### PR TITLE
Use xdg-open as the default browser command on Linux if  available.

### DIFF
--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -30,12 +30,16 @@ http://sourceforge.net/tracker/index.php?func=detail&aid=1681228&group_id=5470&a
 """
 
 if sys.version_info >= (2, 5):
-    # KDE default browser
-    if 'KDE_FULL_SESSION' in os.environ and os.environ['KDE_FULL_SESSION'] == 'true' and webbrowser._iscommand('kfmclient'):
-        webbrowser.register('kfmclient', None, webbrowser.BackgroundBrowser(["kfmclient", "exec", "%s"]), update_tryorder=-1)
-    # GNOME default browser
-    if 'GNOME_DESKTOP_SESSION_ID' in os.environ and webbrowser._iscommand('gnome-open'):
-        webbrowser.register('gnome-open', None, webbrowser.BackgroundBrowser(["gnome-open", "%s"]), update_tryorder=-1)
+    # Cross-platform default tool
+    if webbrowser._iscommand('xdg-open'):
+        webbrowser.register('xdg-open', None, webbrowser.BackgroundBrowser(["xdg-open", "%s"]), update_tryorder=-1)
+    else:
+        # KDE default browser
+        if 'KDE_FULL_SESSION' in os.environ and os.environ['KDE_FULL_SESSION'] == 'true' and webbrowser._iscommand('kfmclient'):
+            webbrowser.register('kfmclient', None, webbrowser.BackgroundBrowser(["kfmclient", "exec", "%s"]), update_tryorder=-1)
+        # GNOME default browser
+        if 'GNOME_DESKTOP_SESSION_ID' in os.environ and webbrowser._iscommand('gnome-open'):
+            webbrowser.register('gnome-open', None, webbrowser.BackgroundBrowser(["gnome-open", "%s"]), update_tryorder=-1)
 
 
 else:


### PR DESCRIPTION
'xdg-open' is a cross-desktop-environment tool that automatically
detects the appropriate web browser; use it if it is available,
preferred over the desktop environment specific tools.

This fixes the browser detection on XFCE and Gnome 3 (which no longer
includes the gnome-open tool).

This change only fixes the code for python >=2.5, I have no way of
testing older versions.
