### PR TITLE
id3/mp4: make supports_tag return True for more tags

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -131,6 +131,9 @@ class ID3File(File):
     }
     __rtipl_roles = dict([(v, k) for k, v in __tipl_roles.iteritems()])
 
+    __other_supported_tags = ("discnumber", "tracknumber",
+                              "totaldiscs", "totaltracks")
+
     def _load(self, filename):
         self.log.debug("Loading file %r", filename)
         file = self._File(encode_filename(filename), ID3=compatid3.CompatID3)
@@ -316,7 +319,9 @@ class ID3File(File):
 
     def supports_tag(self, name):
         return name in self.__rtranslate or name in self.__rtranslate_freetext\
-            or name.startswith('performer:') or name == "discnumber"
+            or name.startswith('performer:')\
+            or name.startswith('lyrics:')\
+            or name in self.__other_supported_tags
 
 
 class MP3File(ID3File):

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -98,6 +98,9 @@ class MP4File(File):
     }
     __r_freeform_tags = dict([(v, k) for k, v in __freeform_tags.iteritems()])
 
+    __other_supported_tags = ("discnumber", "tracknumber",
+                              "totaldiscs", "totaltracks")
+
     def _load(self, filename):
         self.log.debug("Loading file %r", filename)
         file = MP4(encode_filename(filename))
@@ -194,5 +197,6 @@ class MP4File(File):
 
     def supports_tag(self, name):
         return name in self.__r_text_tags or name in self.__r_bool_tags\
-            or name in self.__r_freeform_tags or name == "discnumber"
-
+            or name in self.__r_freeform_tags\
+            or name in self.__other_supported_tags\
+            or name.startswith('lyrics:')


### PR DESCRIPTION
After the comment on #9, I've compared the table at http://wiki.musicbrainz.org/PicardTagMapping and noticed there are a few more tags missing (totaldiscs / totaltracks which, like tracknumber and discnumber, are manipulated manually), so here goes.
