### PR TITLE
basename() filenames in the renaming page if move_files is False

### DIFF
--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -87,6 +87,8 @@ class RenamingOptionsPage(OptionsPage):
                 parser = ScriptParser()
                 parser.eval(script, file.metadata)
             filename = file._make_filename(file.filename, file.metadata, settings)
+            if not settings["move_files"]:
+                return os.path.basename(filename)
             return filename
         except SyntaxError, e: return ""
         except TypeError, e: return ""


### PR DESCRIPTION
This has the disadvantage that the examples are dependent on something that's not on the same options page. I tried merging the move & and rename pages but that makes it really cluttered, especially with the two edit boxes.
