### PR TITLE
Return proper HTTP version in browser integration response.

### DIFF
--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -42,7 +42,7 @@ class BrowserIntegration(QtNetwork.QTcpServer):
     def process_request(self):
         conn = self.sender()
         line = str(conn.readLine())
-        conn.write("HTTP/1.x 200 OK\r\nCache-Control: max-age=0\r\n\r\nNothing to see here.")
+        conn.write("HTTP/1.1 200 OK\r\nCache-Control: max-age=0\r\n\r\nNothing to see here.")
         conn.disconnectFromHost()
         line = line.split()
         self.log.debug("Browser integration request: %r", line)


### PR DESCRIPTION
A small fix to the HTTP response returned by the browser integration. Without it some HTTP libraries can't handle the response.
