### PR TITLE
Add new plugin extension point register_add_plugin_submenu

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -301,6 +301,7 @@ class BaseTreeView(QtGui.QTreeWidget):
             plugin_menus = {}
             plugin_menus['default'] = { '__MENU': plugin_menu }
             plugin_menu.setIcon(self.panel.icon_plugins)
+            menu.addSeparator()
             menu.addMenu(plugin_menu)
 
             for action in plugin_actions:


### PR DESCRIPTION
Add new plugin extension point register_add_plugin_submenu to allow (optionally nested) submenus to be created in the Plugins context menu.

Here's one of the search plugins converted to use submenu support - it makes for a much cleaner menu interface:  https://github.com/brianfreud/Picard-plugins/blob/searchWithSubmenus/SearchEbay.py
