### PR TITLE
Separate clusterlist into a separate plugin registration.

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -59,7 +59,7 @@ def register_cluster_action(action):
     _cluster_actions.register(action.__module__, action)
 
 def register_clusterlist_action(action):
-    _cluster_actions.register(action.__module__, action)
+    _clusterlist_actions.register(action.__module__, action)
 
 def register_track_action(action):
     _track_actions.register(action.__module__, action)


### PR DESCRIPTION
This is a pretty minor change in impact, given that no plugins currently exist which actually intend to do anything from the plugin menu for the parent "Clusters" item.  This change makes it so that register_cluster_action does not also end up creating plugin menu items in that menu item (the clusterlist item).  The negative impact of such behaviour can be seen if you look in that item's plugin menu while using the submenu-supporting search plugin along with https://github.com/musicbrainz/picard/pull/34 .  Instead, this now adds a register_clusterlist_action so that there's more granular control, if there was some reason you did want something to be in that specific menu item's plugin menu, or in the typical case, where you do _not_ want "cluster" actions to also end up dumped into that menu.

(Note, the submenu patch already has this type of granular control for menu submenus; this patch simply gives the same sort of granular control for menu actions.)
