### PR TITLE
Silence errors that flood the logs when an accoustid fingerprint has no match returned.

### DIFF
--- a/picard/acoustid.py
+++ b/picard/acoustid.py
@@ -89,13 +89,16 @@ class AcoustIDClient(QtCore.QObject):
         recording_list_el = puid_el.append_child('recording_list')
         acoustid_id = None
 
-        results = document.response[0].results[0].children.get('result')
-        if results:
-            result = results[0]
-            acoustid_id = result.id[0].text
-            if 'recordings' in result.children:
-                for recording in result.recordings[0].recording:
-                    parse_recording(recording)
+        try:
+            results = document.response[0].results[0].children.get('result')
+            if results:
+                result = results[0]
+                acoustid_id = result.id[0].text
+                if 'recordings' in result.children:
+                    for recording in result.recordings[0].recording:
+                        parse_recording(recording)
+        except AttributeError:
+            pass
 
         if acoustid_id is not None:
             file.metadata['acoustid_id'] = acoustid_id


### PR DESCRIPTION
When an accoustid fingerprint lookup request fails, due to there being no match at the server, each one generates a lot of error text in the logs:

Traceback (most recent call last):
  File "./picard/webservice.py", line 209, in _process_reply
    handler(xml_handler.document, reply, error)
  File "./picard/acoustid.py", line 92, in _on_lookup_finished
    results = document.response[0].results[0].children.get('result')
  File "./picard/webservice.py", line 76, in __getattr__
    raise AttributeError, name
AttributeError: response

This isn't really useful; we know exactly why the lookup failed, and it's entirely the expected behaviour by Picard.  So this patch silences that error.  If a lookup fails because there is no match, then there really is no error, but rather, we tried, we failed to find a match, and all is as expected.  There is not, however, a code bug which should then expose the failure to the logs.  (And typically, if you're doing a batch lookup, this creates a LOT of useless log text.)
