### PR TITLE
Merge/convert old patch

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -115,6 +115,8 @@ class File(LockableObject, Item):
         self.metadata.copy(metadata)
         self.metadata['~extension'] = extension[1:].lower()
         self.metadata['~length'] = format_time(self.metadata.length)
+        self.metadata['Duration (file)'] = format_time(self.metadata.length)
+        self.metadata['~TLEN'] = str(self.metadata.length)
         if 'title' not in self.metadata:
             self.metadata['title'] = filename
         if 'tracknumber' not in self.metadata:

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -85,6 +85,7 @@ class ID3File(File):
         'TIT3': 'subtitle',
         'TSST': 'discsubtitle',
         'TEXT': 'lyricist',
+        'TLEN': 'length',
         'TCMP': 'compilation',
         'TDRC': 'date',
         'TDOR': 'originaldate',

--- a/picard/track.py
+++ b/picard/track.py
@@ -60,6 +60,10 @@ class Track(DataObject, Item):
             return
         file.copy_metadata(self.metadata)
         file.metadata['~extension'] = file.orig_metadata['~extension']
+        file.metadata['~length'] = format_time(file.metadata.length)
+        file.metadata['Duration (server)'] = format_time(file.metadata.length)
+        file.metadata['Duration (file)'] = file.saved_metadata['Duration (file)']
+        self.metadata['~TLEN'] = str(file.metadata.length)
         file.metadata.changed = True
         file.update(signal=False)
         self.update()


### PR DESCRIPTION
This merges in a patch I submitted 2 years ago in track which never made it in, save for the one line.  It adds the ID3 TLEN field, as well as duration for the local file, and duration for that listing on the server. 

I've ported it to the current code.  (But see notes at the end, down below...). 

Ref: http://bugs.musicbrainz.org/ticket/5626
Ref: http://forums.musicbrainz.org/viewtopic.php?id=1999

Also, counter to my comment from 2011-03-12 06:59:59, it does seem that WMA has an optional Duration field, though anywhere I can find mention of how that might be calculated/stored, it seems to be only in reference to ID3-tagged WMAs.

This is not yet ready for prime time, but I don't know how to do more with it, and I think the remaining issues might be simple ones which someone who knows this code better could maybe fix in a few moments.  :D  Having the different durations (TLEN (aka file duration) and length on the server) is quite useful, and there has been demand for having TLEN tagged by Picard.  Note that TLEN != Picard's current "length", as TLEN is ms-accurate, not just second-accurate.

1) I renamed "durationlocal" and "durationserver" to "Duration (file)" and "Duration (server)" because the original names look horrible now that the tag names are on the main window, rather than mainly just in naming strings/taggerscript.  But the new names are themselves really terrible for naming strings/taggerscript.  I don't know how to use "durationlocal" but display "Duration (file)". 

2) Duration (file) and duration (server) both work fine.  TLEN seems to work fine as well, and kid3 sees it, but I'm not completely sure that it's actually being done correctly to create a TLEN tag - the translation bit that has since been added to id3.py confuses me as to quite how that bit should go in.

It's intended that server duration be a taggerscript/naming string-only variable, not one written to the file.  It's also intended that TLEN be written, but "durationlocal" be the taggerscript/naming string-only variable, and for it to display as "Duration (file)".  I'm also not locked into "Duration (file)" and "Duration (server)"; those just make the most sense to me atm.  The patched Picard fully functional based on the patch&code of 2 years ago - v0.12 I think? - but porting it to 1.0.dev is a little beyond me.
