### PR TITLE
Correct localization

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -63,7 +63,7 @@ class TagCounter(dict):
             if missing > 0:
                 return ungettext("(missing from %d item)", "(missing from %d items)", missing) % missing
             else:
-                return _("(different across %d items)") % self.objects
+                return ungettext("(different across %d item)", "(different across %d item)", self.objects) % self.objects
         return None
 
 


### PR DESCRIPTION
"(different across %d items)" is still subject to plural forms even this string doesn't use a singular form -- there can be differences in other languages.
