### PR TITLE
"Heard and Mc Donald Islands" -> "Heard and McDonald Islands"

### DIFF
--- a/picard/const.py
+++ b/picard/const.py
@@ -128,7 +128,7 @@ RELEASE_COUNTRIES = {
     u'HU': N_('Hungary'),
     u'HK': N_('Hong Kong'),
     u'HN': N_('Honduras'),
-    u'HM': N_('Heard and Mc Donald Islands'),
+    u'HM': N_('Heard and McDonald Islands'),
     u'VE': N_('Venezuela'),
     u'PR': N_('Puerto Rico'),
     u'PW': N_('Palau'),


### PR DESCRIPTION
That's apparently the official way of writing it anyway. See e.g. the official site of the islands: http://www.heardisland.aq/
