### PR TITLE
Try to fix crashes when opening files

### DIFF
--- a/picard/musicdns/avcodec.c
+++ b/picard/musicdns/avcodec.c
@@ -60,7 +60,6 @@ decode(PyObject *self, PyObject *args)
 #else
     AVFormatContext *format_context = avformat_alloc_context();
 #endif
-    av_alloc_format_context
     AVCodecContext *codec_context;
     AVCodec *codec;
     PyObject *filename;


### PR DESCRIPTION
**Very important**: My C skill is barely existing, I also have no clue about FFMPEG, I only tried to fix a crash I've experienced. I have no idea when this crash has been introduced, whether it's being experienced by somebody else other than me or whether this proposed patch actually fixes the problem in any way or makes it worse. All I can say, it worked for me and I would like to make developers aware of this problem and I'd be happy if someone (@lalinsky ;-)) came up with a better patch or some obvious explanation for the crashes I'm seeing.

Now to the actual problem: I've experienced a crash every time I've added a file without MusicBrainz metadata to Picard (auto-analyze is on). I could trace the problem down to [this line](http://git.videolan.org/?p=ffmpeg.git;a=blob;f=libavformat/utils.c;h=9164cd01afdc6e46386309ea82f3c1964db71905;hb=8c0c0e9eb3341fe42a2a9315cef5af21e94c4855#l639) in `libavformat` and tried to fix the problem with the code in this pull request. This happened on Ubuntu 12.04, with daily Picard packages from PPA and also with locally compiled Picard. I also tried different `ffmpeg` versions, from Ubuntu's 0.8.1 to 0.8.3 from Ubuntu Updates up to 0.10.4 from someone's PPA. In each case I've had a crash in the same code line.
