### PR TITLE
Add filename related parameters for file naming scripts

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -474,6 +474,13 @@ class File(LockableObject, Item):
         if hasattr(file.info, 'bits_per_sample') and file.info.bits_per_sample:
             metadata['~#bits_per_sample'] = file.info.bits_per_sample
         metadata['~format'] = self.__class__.__name__.replace('File', '')
+        self._add_path_to_metadata(metadata)
+
+    def _add_path_to_metadata(self, metadata):
+        metadata['~dirname'] = os.path.dirname(self.filename)
+        filename = os.path.basename(self.filename)
+        metadata['~filename'], metadata['~extension'] = os.path.splitext(
+                os.path.basename(self.filename))
 
     def get_state(self):
         return self._state

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -35,6 +35,7 @@ class WAVFile(File):
         metadata['~#sample_rate'] = f.getframerate()
         metadata.length = 1000 * f.getnframes() / f.getframerate()
         metadata['~format'] = 'Microsoft WAVE'
+        self._add_path_to_metadata(metadata)
         return metadata
 
     def _save(self, filename, metadata, settings):


### PR DESCRIPTION
As requested in http://tickets.musicbrainz.org/browse/PICARD-278 (and a personal use case :P), I've added a ~filename tag. Since I'd like to use a file naming scheme that actually depends on the path and not the filename, I've added ~dirname as well. And ~extension, because maybe someone finds it useful and it wasn't any additional work.
