### PR TITLE
Load TXXX frames that conflict with Picard tags into the ~id3:TXXX namespace

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -188,12 +188,19 @@ class ID3File(File):
                     if role in self.__tipl_roles and name:
                         metadata.add(self.__tipl_roles[role], name)
             elif frameid == 'TXXX':
-                if frame.desc in self.__translate_freetext:
-                    name = self.__translate_freetext[frame.desc]
-                else:
-                    name = str(frame.desc.lower())
-                    if name in self.__rtranslate and name not in self.__rtranslate_freetext:
-                        name = '~id3:TXXX:' + name
+                name = frame.desc
+                if name in self.__translate_freetext:
+                    name = self.__translate_freetext[name]
+                elif ((name in self.__rtranslate) !=
+                        (name in self.__rtranslate_freetext)):
+                    # If the desc of a TXXX frame conflicts with the name of a
+                    # Picard tag, load it into ~id3:TXXX:desc rather than desc.
+                    #
+                    # This basically performs an XOR, making sure that 'name'
+                    # is in __rtranslate or __rtranslate_freetext, but not
+                    # both. (Being in both implies we support reading it both
+                    # ways.) Currently, the only tag in both is license.
+                    name = '~id3:TXXX:' + name
                 for text in frame.text:
                     metadata.add(name, unicode(text))
             elif frameid == 'USLT':


### PR DESCRIPTION
### Problem

Consider foo.mp3, which contains TXXX=album=foo and TALB=bar. If you load foo.mp3 into Picard, the original value of the "album" tag will be "foo; bar", because Picard merges the values from both frames into one tag.

"Clear existing tags" is disabled. If you match the mp3 to a track and save, everything will look fine, but if you reload the file, it'll display "foo; bar" as the original value again.
### Solution

If the description of a TXXX frame conflicts with the name of a Picard tag, load the TXXX value into ~id3:TXXX:tag_name instead of tag_name.
### Consequences

If foo.mp3 **only** contains TXXX=album=foo and **no** TALB frame, Picard won't load anything into the "album" tag. This could be bad, because Picard won't be able to use the information for lookups.

However, loading TXXX=album=foo into "album" when it doesn't conflict with TALB can cause worse confusion. If foo.mp3 is matched to a track where album=foo, the interface won't indicate any changes, which is false. The file has no TALB frame, and users will be confused when other software can't read their tags which Picard said were correct.
