### PR TITLE
CAA types selection: replace free text input with a list with checkboxes

### DIFF
--- a/picard/coverartarchive.py
+++ b/picard/coverartarchive.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2013 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# list of types from http://musicbrainz.org/doc/Cover_Art/Types
+# order of declaration is preserved in selection box
+CAA_TYPES = [
+    {'name': "front",   'title': N_("Front")},
+    {'name': "back",    'title': N_("Back")},
+    {'name': "booklet", 'title': N_("Booklet")},
+    {'name': "medium",  'title': N_("Medium")},
+    {'name': "tray",    'title': N_("Tray")},
+    {'name': "obi",     'title': N_("Obi")},
+    {'name': "spine",   'title': N_("Spine")},
+    {'name': "track",   'title': N_("Track")},
+    {'name': "sticker", 'title': N_("Sticker")},
+    {'name': "other",   'title': N_("Other")},
+    {'name': "unknown", 'title': N_("Unknown")}, # pseudo type, used for the no type case
+]
+
+CAA_TYPES_SEPARATOR = ' '  #separator to use when joining/splitting list of types

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -21,6 +21,45 @@ from PyQt4 import QtCore, QtGui
 from picard.config import BoolOption, IntOption, TextOption
 from picard.ui.options import OptionsPage, register_options_page
 from picard.ui.ui_options_cover import Ui_CoverOptionsPage
+from picard.coverartarchive import CAA_TYPES, CAA_TYPES_SEPARATOR
+
+
+class CAATypesSelector(object):
+    def __init__(self, widget, enabled_types=''):
+        self.widget = widget
+        self._enabled_types = enabled_types.split(CAA_TYPES_SEPARATOR)
+        self._items = {}
+        self._populate()
+
+    def _populate(self):
+        for name, typ in list((i['name'], i) for i in CAA_TYPES):
+            enabled = name in self._enabled_types
+            self._add_item(typ, enabled=enabled)
+
+    def _add_item(self, typ, enabled=False):
+        item = QtGui.QListWidgetItem(self.widget)
+        item.setText(typ['title'])
+        tooltip = u"CAA: %(name)s" % typ
+        item.setToolTip(tooltip)
+        if enabled:
+            state = QtCore.Qt.Checked
+        else:
+            state = QtCore.Qt.Unchecked
+        item.setCheckState(state)
+        self._items[item] = typ
+
+    def get_selected_types(self):
+        types = []
+        for item, typ in self._items.iteritems():
+            if item.checkState() == QtCore.Qt.Checked:
+                types.append(typ['name'])
+        return types
+
+    def get_selected_types_as_string(self):
+        return CAA_TYPES_SEPARATOR.join(self.get_selected_types())
+
+    def __str__(self):
+        return self.get_selected_types_as_string()
 
 
 class CoverOptionsPage(OptionsPage):
@@ -67,7 +106,10 @@ class CoverOptionsPage(OptionsPage):
         self.ui.gb_caa.setEnabled(self.config.setting["ca_provider_use_caa"])
 
         self.ui.cb_image_size.setCurrentIndex(self.config.setting["caa_image_size"])
-        self.ui.le_image_types.setText(self.config.setting["caa_image_types"])
+        widget = self.ui.caa_types_selector_1
+        self._selector = CAATypesSelector(widget, self.config.setting["caa_image_types"])
+        self.config.setting["caa_image_types"] = \
+                self._selector.get_selected_types_as_string()
         self.ui.cb_approved_only.setChecked(self.config.setting["caa_approved_only"])
         self.ui.cb_type_as_filename.setChecked(self.config.setting["caa_image_type_as_filename"])
         self.connect(self.ui.caprovider_caa, QtCore.SIGNAL("toggled(bool)"),
@@ -88,7 +130,8 @@ class CoverOptionsPage(OptionsPage):
             self.ui.caprovider_whitelist.isChecked()
         self.config.setting["caa_image_size"] =\
             self.ui.cb_image_size.currentIndex()
-        self.config.setting["caa_image_types"] = self.ui.le_image_types.text()
+        self.config.setting["caa_image_types"] = \
+            self._selector.get_selected_types_as_string()
         self.config.setting["caa_approved_only"] =\
             self.ui.cb_approved_only.isChecked()
         self.config.setting["caa_image_type_as_filename"] = \

--- a/picard/ui/ui_options_cover.py
+++ b/picard/ui/ui_options_cover.py
@@ -2,8 +2,8 @@
 
 # Form implementation generated from reading ui file 'ui/options_cover.ui'
 #
-# Created: Tue Nov 20 18:25:21 2012
-#      by: PyQt4 UI code generator 4.9.5
+# Created: Tue Jan 22 12:56:46 2013
+#      by: PyQt4 UI code generator 4.9.6
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -12,7 +12,16 @@ from PyQt4 import QtCore, QtGui
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
 
 class Ui_CoverOptionsPage(object):
     def setupUi(self, CoverOptionsPage):
@@ -89,12 +98,22 @@ class Ui_CoverOptionsPage(object):
         self.label_2 = QtGui.QLabel(self.gb_caa)
         self.label_2.setObjectName(_fromUtf8("label_2"))
         self.verticalLayout_3.addWidget(self.label_2)
-        self.le_image_types = QtGui.QLineEdit(self.gb_caa)
-        self.le_image_types.setObjectName(_fromUtf8("le_image_types"))
-        self.verticalLayout_3.addWidget(self.le_image_types)
-        self.caa_types_help = QtGui.QLabel(self.gb_caa)
-        self.caa_types_help.setObjectName(_fromUtf8("caa_types_help"))
-        self.verticalLayout_3.addWidget(self.caa_types_help)
+        self.caa_types_selector_1 = QtGui.QListWidget(self.gb_caa)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.caa_types_selector_1.sizePolicy().hasHeightForWidth())
+        self.caa_types_selector_1.setSizePolicy(sizePolicy)
+        self.caa_types_selector_1.setMaximumSize(QtCore.QSize(16777215, 80))
+        self.caa_types_selector_1.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.caa_types_selector_1.setTabKeyNavigation(True)
+        self.caa_types_selector_1.setProperty("showDropIndicator", False)
+        self.caa_types_selector_1.setAlternatingRowColors(True)
+        self.caa_types_selector_1.setSelectionMode(QtGui.QAbstractItemView.NoSelection)
+        self.caa_types_selector_1.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
+        self.caa_types_selector_1.setVerticalScrollMode(QtGui.QAbstractItemView.ScrollPerPixel)
+        self.caa_types_selector_1.setObjectName(_fromUtf8("caa_types_selector_1"))
+        self.verticalLayout_3.addWidget(self.caa_types_selector_1)
         self.cb_approved_only = QtGui.QCheckBox(self.gb_caa)
         self.cb_approved_only.setObjectName(_fromUtf8("cb_approved_only"))
         self.verticalLayout_3.addWidget(self.cb_approved_only)
@@ -113,8 +132,18 @@ class Ui_CoverOptionsPage(object):
         self.retranslateUi(CoverOptionsPage)
         QtCore.QObject.connect(self.save_images_to_tags, QtCore.SIGNAL(_fromUtf8("clicked(bool)")), self.cb_embed_front_only.setEnabled)
         QtCore.QMetaObject.connectSlotsByName(CoverOptionsPage)
-        CoverOptionsPage.setTabOrder(self.save_images_to_tags, self.save_images_to_files)
+        CoverOptionsPage.setTabOrder(self.save_images_to_tags, self.cb_embed_front_only)
+        CoverOptionsPage.setTabOrder(self.cb_embed_front_only, self.save_images_to_files)
         CoverOptionsPage.setTabOrder(self.save_images_to_files, self.cover_image_filename)
+        CoverOptionsPage.setTabOrder(self.cover_image_filename, self.save_images_overwrite)
+        CoverOptionsPage.setTabOrder(self.save_images_overwrite, self.caprovider_amazon)
+        CoverOptionsPage.setTabOrder(self.caprovider_amazon, self.caprovider_cdbaby)
+        CoverOptionsPage.setTabOrder(self.caprovider_cdbaby, self.caprovider_caa)
+        CoverOptionsPage.setTabOrder(self.caprovider_caa, self.caprovider_whitelist)
+        CoverOptionsPage.setTabOrder(self.caprovider_whitelist, self.cb_image_size)
+        CoverOptionsPage.setTabOrder(self.cb_image_size, self.caa_types_selector_1)
+        CoverOptionsPage.setTabOrder(self.caa_types_selector_1, self.cb_approved_only)
+        CoverOptionsPage.setTabOrder(self.cb_approved_only, self.cb_type_as_filename)
 
     def retranslateUi(self, CoverOptionsPage):
         self.rename_files.setTitle(_("Location"))
@@ -134,7 +163,6 @@ class Ui_CoverOptionsPage(object):
         self.cb_image_size.setItemText(1, _("500 px"))
         self.cb_image_size.setItemText(2, _("Full size"))
         self.label_2.setText(_("Download only images of the following types:"))
-        self.caa_types_help.setText(_("Types are separated by spaces, and are not case-sensitive."))
         self.cb_approved_only.setText(_("Download only approved images"))
         self.cb_type_as_filename.setText(_("Use the first image type as the filename. This will not change the filename of front images."))
 

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -167,14 +167,41 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="le_image_types"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="caa_types_help">
-        <property name="text">
-         <string>Types are separated by spaces, and are not case-sensitive.</string>
+       <widget class="QListWidget" name="caa_types_selector_1">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-       </widget>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>80</height>
+         </size>
+        </property>
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAsNeeded</enum>
+        </property>
+        <property name="tabKeyNavigation">
+         <bool>true</bool>
+        </property>
+        <property name="showDropIndicator" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="verticalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="cb_approved_only">
@@ -216,8 +243,18 @@
  </widget>
  <tabstops>
   <tabstop>save_images_to_tags</tabstop>
+  <tabstop>cb_embed_front_only</tabstop>
   <tabstop>save_images_to_files</tabstop>
   <tabstop>cover_image_filename</tabstop>
+  <tabstop>save_images_overwrite</tabstop>
+  <tabstop>caprovider_amazon</tabstop>
+  <tabstop>caprovider_cdbaby</tabstop>
+  <tabstop>caprovider_caa</tabstop>
+  <tabstop>caprovider_whitelist</tabstop>
+  <tabstop>cb_image_size</tabstop>
+  <tabstop>caa_types_selector_1</tabstop>
+  <tabstop>cb_approved_only</tabstop>
+  <tabstop>cb_type_as_filename</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
Free text input was simple, but it can't be translated, and isn't very user-friendly.
This patch introduces a CAA types selector, with translatable titles and descriptions.

Upgrade is seamless since the whole list is still saved/load as a simple string using
space as separator, with english lowercased names of each type.

Descriptions were taken from http://musicbrainz.org/doc/Cover_Art/Types

Define missing tabstops for Cover Art options UI
Regenerate picard/ui/ui_options_cover.py with pyuic 4.9.6
