### PR TITLE
IGNORE: Better handling of metadata image types 

### DIFF
--- a/picard/coverart.py
+++ b/picard/coverart.py
@@ -81,10 +81,17 @@ AMAZON_SERVER = {
 AMAZON_IMAGE_PATH = '/images/P/%s.%s.%sZZZZZZZ.jpg'
 AMAZON_ASIN_URL_REGEX = re.compile(r'^http://(?:www.)?(.*?)(?:\:[0-9]+)?/.*/([0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)')
 
+def _mk_image_filename(image):
+    settings = QObject.config.setting
+    filename = settings["cover_image_filename"]
+    if not image.is_main_cover and settings["caa_image_type_as_filename"]:
+        filename = "-".join(image.types)
+    return filename
 
 def _coverart_downloaded(album, metadata, release, try_list, imagedata, data, http, error):
     album._requests -= 1
-    imagetype = imagedata["type"]
+    imagetypes = imagedata["types"]
+    is_front = False
 
     if error or len(data) < 1000:
         if error:
@@ -93,20 +100,19 @@ def _coverart_downloaded(album, metadata, release, try_list, imagedata, data, ht
         QObject.tagger.window.set_statusbar_message(N_("Coverart %s downloaded"),
                 http.url().toString())
         mime = mimetype.get_from_data(data, default="image/jpeg")
-        filename = None
-        if imagetype != 'front' and QObject.config.setting["caa_image_type_as_filename"]:
-                filename = imagetype
-        metadata.add_image(mime, data, filename, imagedata["description"],
-                           imagetype)
+        imagetypes = imagedata["types"]
+        img = metadata.add_image(mime, data, _mk_image_filename, None, imagedata["description"],
+                           imagetypes)
+        is_front = img.is_front
         for track in album._new_tracks:
-            track.metadata.add_image(mime, data, filename,
-                                     imagedata["description"], imagetype)
+            track.metadata.add_image(mime, data, _mk_image_filename, None,
+                                     imagedata["description"], imagetypes)
 
     # If the image already was a front image, there might still be some
     # other front images in the try_list - remove them.
-    if imagetype == 'front':
+    if is_front:
         for item in try_list[:]:
-            if item['type'] == 'front' and 'archive.org' not in item['host']:
+            if 'front' in item['types'] and 'archive.org' not in item['host']:
                 # Hosts other than archive.org only provide front images
                 try_list.remove(item)
     _walk_try_list(album, metadata, release, try_list)
@@ -130,10 +136,9 @@ def _caa_json_downloaded(album, metadata, release, try_list, data, http, error):
                     continue
                 imagetypes = map(unicode.lower, image["types"])
                 for imagetype in imagetypes:
-                    if imagetype == "front":
-                        caa_front_found = True
                     if imagetype in caa_types:
                         _caa_append_image_to_trylist(try_list, image)
+                        caa_front_found = "front" in imagetypes
                         break
 
     if error or not caa_front_found:
@@ -154,7 +159,7 @@ def _caa_append_image_to_trylist(try_list, imagedata):
         url = QUrl(imagedata["image"])
     else:
         url = QUrl(imagedata["thumbnails"][thumbsize])
-    _try_list_append_image_url(try_list, url, imagedata["types"][0], imagedata["comment"])
+    _try_list_append_image_url(try_list, url, imagedata["types"], imagedata["comment"])
 
 
 def coverart(album, metadata, release, try_list=None):
@@ -252,8 +257,8 @@ def _process_asin_relation(try_list, relation):
         _try_list_append_image_url(try_list, QUrl("http://%s:%s" % (host, path_m)))
 
 
-def _try_list_append_image_url(try_list, parsedUrl, imagetype="front", description=""):
-    QObject.log.debug("Adding %s image %s", imagetype, parsedUrl)
+def _try_list_append_image_url(try_list, parsedUrl, imagetypes=[u"front"], description=""):
+    QObject.log.debug("Adding %s image %s", ",".join(imagetypes), parsedUrl)
     path = str(parsedUrl.encodedPath())
     if parsedUrl.hasQuery():
         path += '?' + parsedUrl.encodedQuery()
@@ -261,6 +266,6 @@ def _try_list_append_image_url(try_list, parsedUrl, imagetype="front", descripti
         'host': str(parsedUrl.host()),
         'port': parsedUrl.port(80),
         'path': str(path),
-        'type': imagetype.lower(),
+        'types': map(unicode.lower, imagetypes),
         'description': description,
     })

--- a/picard/file.py
+++ b/picard/file.py
@@ -326,25 +326,19 @@ class File(QtCore.QObject, Item):
         """Save the cover images to disk."""
         if not metadata.images:
             return
-        default_filename = self._make_image_filename(
-            settings["cover_image_filename"], dirname, metadata, settings)
         overwrite = settings["save_images_overwrite"]
         counters = defaultdict(lambda: 0)
         for image in metadata.images:
-            filename = image["filename"]
-            data = image["data"]
-            mime = image["mime"]
-            if filename is None:
-                filename = default_filename
-            else:
-                filename = self._make_image_filename(filename, dirname, metadata, settings)
+            mime = image.mime
+            filename = self._make_image_filename(image.filename, dirname, metadata, settings)
             image_filename = filename
             ext = mimetype.get_extension(mime, ".jpg")
             if counters[filename] > 0:
                 image_filename = "%s (%d)" % (filename, counters[filename])
             counters[filename] = counters[filename] + 1
+            datalen = len(image.data)
             while os.path.exists(image_filename + ext) and not overwrite:
-                if os.path.getsize(image_filename + ext) == len(data):
+                if os.path.getsize(image_filename + ext) == datalen:
                     self.log.debug("Identical file size, not saving %r", image_filename)
                     break
                 image_filename = "%s (%d)" % (filename, counters[filename])
@@ -355,7 +349,7 @@ class File(QtCore.QObject, Item):
                 if not os.path.isdir(new_dirname):
                     os.makedirs(new_dirname)
                 f = open(image_filename + ext, "wb")
-                f.write(data)
+                f.write(image.data)
                 f.close()
 
     def _move_additional_files(self, old_filename, new_filename, settings):

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -142,10 +142,10 @@ class APEv2File(File):
             tags[str(name)] = values
         if settings['save_images_to_tags']:
             for image in metadata.images:
-                if "front" == image["type"]:
+                if image.is_main_cover:
                     cover_filename = 'Cover Art (Front)'
-                    cover_filename += mimetype.get_extension(image["mime"], '.jpg')
-                    tags['Cover Art (Front)'] = cover_filename + '\0' + image["data"]
+                    cover_filename += mimetype.get_extension(image.mime, '.jpg')
+                    tags['Cover Art (Front)'] = cover_filename + '\0' + image.data
                     break # can't save more than one item with the same name
                         # (mp3tags does this, but it's against the specs)
         tags.save(encode_filename(filename))

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -132,7 +132,7 @@ class ASFFile(File):
                     (mime, data, type, description) = unpack_image(image.value)
                     imagetype = ID3_REVERSE_IMAGE_TYPE_MAP.get(type, "other")
                     metadata.add_image(mime, data, description=description,
-                                       type_=imagetype)
+                                       types=[imagetype])
                 continue
             elif name not in self.__RTRANS:
                 continue
@@ -155,11 +155,10 @@ class ASFFile(File):
         if settings['save_images_to_tags']:
             cover = []
             for image in metadata.images:
-                if self.config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if self.config.setting["save_only_front_images_to_tags"] and not image.is_main_cover:
                     continue
-                imagetype = ID3_IMAGE_TYPE_MAP.get(image["type"], 0)
-                tag_data = pack_image(image["mime"], image["data"], imagetype,
-                                      image["description"])
+                imagetype = ID3_IMAGE_TYPE_MAP.get(image.main_type, 0)
+                tag_data = pack_image(image.mime, image.data, imagetype, image.description)
                 cover.append(ASFByteArrayAttribute(tag_data))
             if cover:
                 file.tags['WM/Picture'] = cover

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -270,9 +270,9 @@ class ID3File(File):
             counters = defaultdict(lambda: 0)
             for image in metadata.images:
                 desc = image["description"]
-                if self.config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if self.config.setting["save_only_front_images_to_tags"] and "front" not in image["types"]:
                     continue
-                type_ = ID3_IMAGE_TYPE_MAP.get(image["type"], 0)
+                type_ = ID3_IMAGE_TYPE_MAP.get(image["types"][0], 0)
                 if counters[desc] > 0:
                     if desc:
                         image["description"] = "%s (%i)" % (desc, counters[desc])

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -188,13 +188,13 @@ class MP4File(File):
         if settings['save_images_to_tags']:
             covr = []
             for image in metadata.images:
-                if self.config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if self.config.setting["save_only_front_images_to_tags"] and not image.is_main_cover:
                     continue
-                mime = image["mime"]
+                mime = image.mime
                 if mime == "image/jpeg":
-                    covr.append(MP4Cover(image["data"], MP4Cover.FORMAT_JPEG))
+                    covr.append(MP4Cover(image.data, MP4Cover.FORMAT_JPEG))
                 elif mime == "image/png":
-                    covr.append(MP4Cover(image["data"], MP4Cover.FORMAT_PNG))
+                    covr.append(MP4Cover(image.data, MP4Cover.FORMAT_PNG))
             if covr:
                 file.tags["covr"] = covr
 

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -88,14 +88,14 @@ class VCommentFile(File):
                     imagetype = ID3_REVERSE_IMAGE_TYPE_MAP.get(image.type, "other")
                     metadata.add_image(image.mime, image.data,
                                        description=image.desc,
-                                       type_=imagetype)
+                                       types=[imagetype])
                     continue
                 metadata.add(name, value)
         if self._File == mutagen.flac.FLAC:
             for image in file.pictures:
                 imagetype = ID3_REVERSE_IMAGE_TYPE_MAP.get(image.type, "other")
                 metadata.add_image(image.mime, image.data,
-                                   description=image.desc, type_=imagetype)
+                                   description=image.desc, types=[imagetype])
         # Read the unofficial COVERART tags, for backward compatibillity only
         if not "metadata_block_picture" in file.tags:
             try:
@@ -152,13 +152,13 @@ class VCommentFile(File):
 
         if settings['save_images_to_tags']:
             for image in metadata.images:
-                if self.config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if self.config.setting["save_only_front_images_to_tags"] and not image.is_main_cover:
                     continue
                 picture = mutagen.flac.Picture()
-                picture.data = image["data"]
-                picture.mime = image["mime"]
-                picture.desc = image["description"]
-                picture.type = ID3_IMAGE_TYPE_MAP.get(image["type"], 0)
+                picture.data = image.data
+                picture.mime = image.mime
+                picture.desc = image.description
+                picture.type = ID3_IMAGE_TYPE_MAP.get(image.main_type, 0)
                 if self._File == mutagen.flac.FLAC:
                     file.add_picture(picture)
                 else:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -99,7 +99,7 @@ class CoverArtBox(QtGui.QGroupBox):
         if self.data:
             if pixmap is None:
                 pixmap = QtGui.QPixmap()
-                pixmap.loadFromData(self.data["data"])
+                pixmap.loadFromData(self.data.data)
             if not pixmap.isNull():
                 cover = QtGui.QPixmap(self.shadow)
                 pixmap = pixmap.scaled(121, 121, QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
@@ -113,12 +113,9 @@ class CoverArtBox(QtGui.QGroupBox):
         data = None
         if metadata and metadata.images:
             for image in metadata.images:
-                if image["type"] == "front":
+                if image.is_main_cover:
                     data = image
                     break
-            else:
-                # There's no front image, choose the first one available
-                data = metadata.images[0]
         self.__set_data(data)
         release = None
         if metadata:

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -70,10 +70,9 @@ class InfoDialog(QtGui.QDialog):
         self.ui.info.setText(text)
 
         for image in file.metadata.images:
-            data = image["data"]
             item = QtGui.QListWidgetItem()
             pixmap = QtGui.QPixmap()
-            pixmap.loadFromData(data)
+            pixmap.loadFromData(image.data)
             icon = QtGui.QIcon(pixmap)
             item.setIcon(icon)
             self.ui.artwork_list.addItem(item)


### PR DESCRIPTION
Keep full image type from CAA/MB (ie. front,back,spine)
When option is set to save image to local files, name is build after complete type, ie. front-back-spine.jpg
Introduce main cover concept, since front type wasn't clear enough.
Main cover is:
- first image with front type
- first image if no front found
- there's only one main cover
- it is used in place of "front", even though it is often the same,
  especially when only one image is found
- it is the image displayed by picard for the album

To ease things a new class MetadataImage was added and is now used for Metadata.images elements.
Naming of image files (when saved to local) was modified, and now use a callback
function to generate it (mostly because it depends on main cover and options set), it also helps to clarify code

Info box was improved too, it now displays image type and comment (as well as filename in tooltip), main cover is printed in bold.
![shot](https://f.cloud.github.com/assets/151042/59574/e21dd6ca-5bd3-11e2-8e12-dec5c83394bc.jpg)

Also as a side effect it fixes PICARD 350 (http://tickets.musicbrainz.org/browse/PICARD-350)
