### PR TITLE
CoverArtBox: preserve cover art aspect ratio on drawing

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -101,10 +101,15 @@ class CoverArtBox(QtGui.QGroupBox):
                 pixmap = QtGui.QPixmap()
                 pixmap.loadFromData(self.data["data"])
             if not pixmap.isNull():
+                offx, offy, w, h = (1, 1, 121, 121)
                 cover = QtGui.QPixmap(self.shadow)
-                pixmap = pixmap.scaled(121, 121, QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
+                pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
                 painter = QtGui.QPainter(cover)
-                painter.drawPixmap(1, 1, pixmap)
+                bgcolor = QtGui.QColor.fromRgb(0, 0, 0, 128)
+                painter.fillRect(QtCore.QRectF(offx, offy, w, h), bgcolor)
+                x = offx + (w - pixmap.width()) / 2
+                y = offy + (h - pixmap.height()) / 2
+                painter.drawPixmap(x, y, pixmap)
                 painter.end()
         self.coverArt.setPixmap(cover)
 


### PR DESCRIPTION
Cover is now placed correctly over the cover shadow, aspect ratio
is preserved.
![Capture du 2013-01-11 18:21:15](https://f.cloud.github.com/assets/151042/60558/7cf68946-5c13-11e2-8f3e-8286a3009b4d.png)
![Capture du 2013-01-11 18:20:06](https://f.cloud.github.com/assets/151042/60560/99d5d8a0-5c13-11e2-9948-446cb6701fe4.png)
