### PR TITLE
CAA downloader: fix CAA download of 'unknown' type images

### DIFF
--- a/picard/coverart.py
+++ b/picard/coverart.py
@@ -128,6 +128,8 @@ def _caa_json_downloaded(album, metadata, release, try_list, data, http, error):
             for image in caa_data["images"]:
                 if QObject.config.setting["caa_approved_only"] and not image["approved"]:
                     continue
+                if not image["types"] and 'unknown' in caa_types:
+                    _caa_append_image_to_trylist(try_list, image)
                 imagetypes = map(unicode.lower, image["types"])
                 for imagetype in imagetypes:
                     if imagetype == "front":


### PR DESCRIPTION
When no type is set for an image, CAA is returning an empty list for types.
But Picard user has no way to specify he wants to also download images
of unknown type using the option 'Download only images of the following types'.

I added a special type named 'unknown' and modified _caa_json_downloaded() to
handle this case.
