### PR TITLE
Enable Informations dialog for albums, used to display metadata images.

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -388,6 +388,9 @@ class Album(DataObject, Item):
     def can_refresh(self):
         return True
 
+    def can_view_info(self):
+        return bool(self.loaded and self.metadata and self.metadata.images)
+
     def is_album_like(self):
         return True
 

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -101,3 +101,10 @@ class FileInfoDialog(InfoDialog):
             info.append((_('Channels:'), ch))
         text = '<br/>'.join(map(lambda i: '<b>%s</b><br/>%s' % i, info))
         self.ui.info.setText(text)
+
+
+class AlbumInfoDialog(InfoDialog):
+
+    def __init__(self, album, parent=None):
+        InfoDialog.__init__(self, album, parent)
+        self.setWindowTitle(_("Album Info"))

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -272,6 +272,8 @@ class BaseTreeView(QtGui.QTreeWidget):
             menu.addAction(self.window.analyze_action)
             plugin_actions = list(_file_actions)
         elif isinstance(obj, Album):
+            if can_view_info:
+                menu.addAction(self.window.view_info_action)
             menu.addAction(self.window.browser_lookup_action)
             menu.addSeparator()
             menu.addAction(self.window.refresh_action)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -24,6 +24,7 @@ import os.path
 
 from picard.file import File
 from picard.track import Track
+from picard.album import Album
 from picard.config import Option, BoolOption, TextOption
 from picard.formats import supported_formats
 from picard.ui.coverartbox import CoverArtBox
@@ -32,7 +33,7 @@ from picard.ui.metadatabox import MetadataBox
 from picard.ui.filebrowser import FileBrowser
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.options.dialog import OptionsDialog
-from picard.ui.infodialog import FileInfoDialog
+from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog
 from picard.ui.passworddialog import PasswordDialog
 from picard.util import icontheme, webbrowser2, find_existing_path
 from picard.util.cdrom import get_cdrom_drives
@@ -676,8 +677,12 @@ been merged with that of single artist albums."""),
         return ret == QtGui.QMessageBox.Yes
 
     def view_info(self):
-        file = self.tagger.get_files_from_objects(self.selected_objects)[0]
-        dialog = FileInfoDialog(file, self)
+        if isinstance(self.selected_objects[0], Album):
+            album = self.selected_objects[0]
+            dialog = AlbumInfoDialog(album, self)
+        else:
+            file = self.tagger.get_files_from_objects(self.selected_objects)[0]
+            dialog = FileInfoDialog(file, self)
         dialog.exec_()
 
     def cluster(self):


### PR DESCRIPTION
It is using existing InfoDialog code, moved to a common class.
For now, first tab is just hidden as there is nothing to display in.
In Artwork tab, all metadata images associated with the album are shown.
Slight change in behavior is that pressing Informations button while an album is
selected was showing 1st track information, now it should album info.
