### PR TITLE
Really enable lookup metadata action for cluster list.

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -278,6 +278,11 @@ class ClusterList(list, Item):
     def can_browser_lookup(self):
         return False
 
+    def lookup_metadata(self):
+        for cluster in self:
+            if not cluster.lookup_task:
+                cluster.lookup_metadata()
+
 
 class ClusterDict(object):
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -560,8 +560,10 @@ class Tagger(QtGui.QApplication):
 
     def autotag(self, objects):
         for obj in objects:
-            if isinstance(obj, (File, Cluster)) and not obj.lookup_task:
-                obj.lookup_metadata()
+            if (isinstance(obj, ClusterList)
+                or (isinstance(obj, (File, Cluster))
+                    and not obj.lookup_task)):
+                    obj.lookup_metadata()
 
     # =======================================================================
     #  Clusters


### PR DESCRIPTION
When selecting non-empty cluster list, Lookup action was possible (button enabled, action called), but no real action was taking place.
This patch enables it.
