### PR TITLE
Fix: Global plugins are overwriting User-plugins.

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -160,14 +160,14 @@ class Tagger(QtGui.QApplication):
 
         # Load plugins
         self.pluginmanager = PluginManager()
-        self.user_plugin_dir = os.path.join(self.userdir, "plugins")
-        if not os.path.exists(self.user_plugin_dir):
-            os.makedirs(self.user_plugin_dir)
-        self.pluginmanager.load_plugindir(self.user_plugin_dir)
         if hasattr(sys, "frozen"):
             self.pluginmanager.load_plugindir(os.path.join(os.path.dirname(sys.argv[0]), "plugins"))
         else:
             self.pluginmanager.load_plugindir(os.path.join(os.path.dirname(__file__), "plugins"))
+        self.user_plugin_dir = os.path.join(self.userdir, "plugins")
+        if not os.path.exists(self.user_plugin_dir):
+            os.makedirs(self.user_plugin_dir)
+        self.pluginmanager.load_plugindir(self.user_plugin_dir)
 
         self.acoustidmanager = AcoustIDManager()
         self.browser_integration = BrowserIntegration()


### PR DESCRIPTION
Since the global plugins (from picard/plugins) have been read _after_
the ones in user-plugindir, plugins got overwritten if they have the same
name. Now the user-plugindir is read after the globel one, thus the
user plugins are overwriting the global plugins -- which is more
appropriate.

Signed-off-by: brainz34 brainz34@musicbrainz.org
