### PR TITLE
PICARD-415 make disc lookup faster again

### DIFF
--- a/picard/disc.py
+++ b/picard/disc.py
@@ -45,7 +45,10 @@ class Disc(QtCore.QObject):
             _libdiscid = _openLibrary()
         handle = _libdiscid.discid_new()
         assert handle != 0, "libdiscid: discid_new() returned NULL"
-        res = _libdiscid.discid_read(handle, device or None)
+        try:
+            res = _libdiscid.discid_read_sparse(handle, device or None, 0)
+        except AttributeError:
+            res = _libdiscid.discid_read(handle, device or None)
         if res == 0:
             raise DiscError(_libdiscid.discid_get_error_msg(handle))
         self.id = _libdiscid.discid_get_id(handle)
@@ -129,6 +132,11 @@ def _setPrototypes(libDiscId):
     libDiscId.discid_free.argtypes = (ct.c_void_p, )
 
     libDiscId.discid_read.argtypes = (ct.c_void_p, ct.c_char_p)
+    try:
+        libDiscId.discid_read_sparse.argtypes = (ct.c_void_p, ct.c_char_p,
+                                                 ct.c_uint)
+    except AttributeError:
+        pass
 
     libDiscId.discid_get_error_msg.argtypes = (ct.c_void_p, )
     libDiscId.discid_get_error_msg.restype = ct.c_char_p


### PR DESCRIPTION
This fixes
http://tickets.musicbrainz.org/browse/PICARD-415

Starting with libdiscid 0.3.0 read() reads not only the TOC, but also ISRCs and the MCN.
Reading the TOC is no actual disc access, since the TOC is cached (by the system, not by libdiscid). So read() is now slower than it was using libdiscid 0.2.2.
(I measured 0,5 vs. 3 seconds)

Using read_sparse(), when available, fixes that "performance problem".

Linux is only affected starting with 0.3.1 (when linux isrc support was implemented).
Windows and Mac are currently not affected, since they use an internal libdiscid build, which is 0.2.1 for mac and 0.2.2  for Windows.
