### PR TITLE
Fix: `load_cluster()` does not find existing cluster.

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -587,7 +587,7 @@ class Tagger(QtGui.QApplication):
     def load_cluster(self, name, artist):
         for cluster in self.clusters:
             cm = cluster.metadata
-            if name == cm["album"] and artist == cm["artist"]:
+            if name == cm["album"] and artist == cm["albumartist"]:
                 return cluster
         cluster = Cluster(name, artist)
         self.clusters.append(cluster)


### PR DESCRIPTION
`load_cluster()` uses "artist" for looking up existing clusters, but
`Cluster` does not have a meta-data item "artist".

This bug does not show up when clustering all files at once (which
will be the case most times), as in this case a single cluster will be
calculated and only looked up once. But when clustering files in two
steps, a second cluster will be generated as the first one will not be
found.

Signed-off-by: brainz34 brainz34@musicbrainz.org
