### PR TITLE
Add fpcalc.exe and discid.dll to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build.cfg
 *.dll
 *.so
 locale
+fpcalc.exe
+discid.dll


### PR DESCRIPTION
fpcalc and discid.dll are put in the development directories when you
build the development environment according to the instructions on the
musicbrainz web site - and they should not form part of the repo.
