### PR TITLE
Set Length fields in files and collections to be right justified

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -547,6 +547,7 @@ class TreeItem(QtGui.QTreeWidgetItem):
             obj.item = self
         if sortable:
             self.__lt__ = self._lt
+        self.setTextAlignment(1, QtCore.Qt.AlignRight)
 
     def _lt(self, other):
         column = self.treeWidget().sortColumn()


### PR DESCRIPTION
Sets the alignment for all length fields to be right justified in the files and collections QTreeWidgets.
