### PR TITLE
Handle Performer tags stored in ID3v2.3

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -192,9 +192,13 @@ class ID3File(File):
                     if role or name:
                         metadata.add('performer:%s' % role, name)
             elif frameid == "TIPL":
+                # If file is ID3v2.3, TIPL tag could contain TMCL
+                # so we will test for TMCL values and add to TIPL if not TMCL
                 for role, name in frame.people:
                     if role in self.__tipl_roles and name:
                         metadata.add(self.__tipl_roles[role], name)
+                    else:
+                        metadata.add('performer:%s' % role, name)
             elif frameid == 'TXXX':
                 name = frame.desc
                 if name in self.__translate_freetext:


### PR DESCRIPTION
Performer tags are stored as part of the IPLS tag in ID3v2.3 and this is
put into the TIPL tag when read by mutagen. This fix adds unknown TIPL
roles as Performer tags.
