### PR TITLE
Make track lengths within 1s of each other match

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -104,7 +104,7 @@ class TagDiff:
 
     def __tag_ne(self,tag,orig,new):
         if tag == "~length":
-            return abs(orig-new)>1000
+            return abs(orig-new)>2000
         else:
             return orig!=new
 


### PR DESCRIPTION
Due to minor timing differences when ripping a CD, it is common for
tracks to differ by up to 1s in length.

This commit enhances metadatabox to show lengths +/- 1s as matching.

Note: Means of converting mmm:ss to seconds is not elegant - anyone with
a better solution please say.
