### PR TITLE
Do not rely on Pythons conversion from int to bool when connecting slots

### DIFF
--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -27,7 +27,7 @@ from picard.script import ScriptParser, SyntaxError, UnknownFunction
 from picard.ui.options import OptionsPage, OptionsCheckError, register_options_page
 from picard.ui.ui_options_renaming import Ui_RenamingOptionsPage
 from picard.ui.options.scripting import TaggerScriptSyntaxHighlighter
-from functools import partial
+from picard.util import partial
 
 class RenamingOptionsPage(OptionsPage):
 


### PR DESCRIPTION
The stateChanged signal of QCheckBox emits an int but the setEnabled slots
expect a bool.

This is a fix for [PICARD-417](http://tickets.musicbrainz.org/browse/PICARD-417), I've tested it on a Fedora 13 VM with PyQt 4.7.3 and Qt 4.6.3

The other alternative is using old-style signal and slot syntax but well, that's old stuff.

I'm not sure at which version of PyQt or sip the current code starts to work because I didn't find anything useful in the changelogs - sending this as a pull request if someone has any better idea.
