### PR TITLE
Prevent duplicate record labels in tags.

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -175,7 +175,9 @@ def label_info_from_node(node):
                 if label not in labels:
                     labels.append(label)
             if 'catalog_number' in label_info.children:
-                catalog_numbers.append(label_info.catalog_number[0].text)
+                cat_num = label_info.catalog_number[0].text
+                if cat_num not in catalog_numbers:
+                    catalog_numbers.append(cat_num)
     return (labels, catalog_numbers)
 
 


### PR DESCRIPTION
Picard receives Labels/Catalog Number pairs and separates these into
different tags. Where a two catalog numbers are from the same Label, the
label gets duplicated in the label tag, and this fix prevents that.
