### PR TITLE
When "save_only_front_images_to_tags" is set, save only 1 front image.

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -25,7 +25,7 @@ import mutagen.optimfrog
 import mutagenext.tak
 from picard import config, log
 from picard.file import File
-from picard.metadata import Metadata
+from picard.metadata import Metadata, save_this_image_to_tags
 from picard.util import encode_filename, sanitize_date, mimetype
 from os.path import isfile
 
@@ -144,12 +144,13 @@ class APEv2File(File):
             tags[str(name)] = values
         if config.setting['save_images_to_tags']:
             for image in metadata.images:
-                if "front" == image["type"]:
-                    cover_filename = 'Cover Art (Front)'
-                    cover_filename += mimetype.get_extension(image["mime"], '.jpg')
-                    tags['Cover Art (Front)'] = mutagen.apev2.APEValue(cover_filename + '\0' + image["data"], mutagen.apev2.BINARY)
-                    break # can't save more than one item with the same name
-                        # (mp3tags does this, but it's against the specs)
+                if not save_this_image_to_tags(image):
+                    continue
+                cover_filename = 'Cover Art (Front)'
+                cover_filename += mimetype.get_extension(image["mime"], '.jpg')
+                tags['Cover Art (Front)'] = mutagen.apev2.APEValue(cover_filename + '\0' + image["data"], mutagen.apev2.BINARY)
+                break # can't save more than one item with the same name
+                      # (mp3tags does this, but it's against the specs)
         tags.save(encode_filename(filename))
 
 class MusepackFile(APEv2File):

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -19,9 +19,9 @@
 
 from picard import config, log
 from picard.file import File
-from picard.formats.id3 import ID3_IMAGE_TYPE_MAP, ID3_REVERSE_IMAGE_TYPE_MAP
+from picard.formats.id3 import image_type_from_id3_num, image_type_as_id3_num
 from picard.util import encode_filename
-from picard.metadata import Metadata
+from picard.metadata import Metadata, save_this_image_to_tags
 from mutagen.asf import ASF, ASFByteArrayAttribute
 import struct
 
@@ -131,9 +131,11 @@ class ASFFile(File):
             if name == 'WM/Picture':
                 for image in values:
                     (mime, data, type, description) = unpack_image(image.value)
-                    imagetype = ID3_REVERSE_IMAGE_TYPE_MAP.get(type, "other")
-                    metadata.add_image(mime, data, description=description,
-                                       type_=imagetype)
+                    extras = {
+                        'desc': description,
+                        'type': image_type_from_id3_num(type)
+                    }
+                    metadata.add_image(mime, data, extras=extras)
                 continue
             elif name not in self.__RTRANS:
                 continue
@@ -156,11 +158,11 @@ class ASFFile(File):
         if config.setting['save_images_to_tags']:
             cover = []
             for image in metadata.images:
-                if config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if not save_this_image_to_tags(image):
                     continue
-                imagetype = ID3_IMAGE_TYPE_MAP.get(image["type"], 0)
-                tag_data = pack_image(image["mime"], image["data"], imagetype,
-                                      image["description"])
+                tag_data = pack_image(image["mime"], image["data"],
+                                      image_type_as_id3_num(image['type']),
+                                      image['desc'])
                 cover.append(ASFByteArrayAttribute(tag_data))
             if cover:
                 file.tags['WM/Picture'] = cover

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -20,7 +20,7 @@
 from mutagen.mp4 import MP4, MP4Cover
 from picard import config, log
 from picard.file import File
-from picard.metadata import Metadata
+from picard.metadata import Metadata, save_this_image_to_tags
 from picard.util import encode_filename
 
 class MP4File(File):
@@ -188,7 +188,7 @@ class MP4File(File):
         if config.setting['save_images_to_tags']:
             covr = []
             for image in metadata.images:
-                if config.setting["save_only_front_images_to_tags"] and image["type"] != "front":
+                if not save_this_image_to_tags(image):
                     continue
                 mime = image["mime"]
                 if mime == "image/jpeg":

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -17,6 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import os
 from PyQt4.QtCore import QObject
 from picard import config
 from picard.plugin import ExtensionPoint
@@ -26,6 +27,20 @@ from picard.mbxml import artist_credit_from_node
 
 MULTI_VALUED_JOINER = '; '
 
+def is_front_image(image):
+    # CAA has a flag for "front" image, use it in priority
+    caa_front = image.get('front', None)
+    if caa_front is None:
+        #no caa front flag, use type instead
+        return (image['type'] == 'front')
+    return caa_front
+
+def save_this_image_to_tags(image):
+    if not config.setting["save_only_front_images_to_tags"]:
+        return True
+    if is_front_image(image):
+        return True
+    return False
 
 class Metadata(dict):
     """List of metadata items with dict-like access."""
@@ -43,22 +58,25 @@ class Metadata(dict):
         self.images = []
         self.length = 0
 
-    def add_image(self, mime, data, filename=None, description="", type_="front"):
+    def add_image(self, mime, data, filename=None, extras=None):
         """Adds the image ``data`` to this Metadata object.
 
         Arguments:
         mime -- The mimetype of the image
         data -- The image data
         filename -- The image filename, without an extension
-        description -- A description for the image
-        type_ -- The image type - this should be a lower-cased name from
-                 http://musicbrainz.org/doc/Cover_Art/Types
+        extras -- extra informations about image as dict
+            'desc' : image description or comment, default to ''
+            'type' : main type as a string, default to 'front'
+            'front': if set, CAA front flag is true for this image
         """
         imagedict = {'mime': mime,
                      'data': data,
                      'filename': filename,
-                     'description': description,
-                     'type': type_}
+                     'type': 'front',
+                     'desc': ''}
+        if extras is not None:
+            imagedict.update(extras)
         self.images.append(imagedict)
 
     def remove_image(self, index):

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -23,6 +23,7 @@ from picard import config, log
 from picard.album import Album
 from picard.track import Track
 from picard.file import File
+from picard.metadata import is_front_image
 from picard.util import webbrowser2, encode_filename
 
 
@@ -119,7 +120,7 @@ class CoverArtBox(QtGui.QGroupBox):
         data = None
         if metadata and metadata.images:
             for image in metadata.images:
-                if image["type"] == "front":
+                if is_front_image(image):
                     data = image
                     break
             else:

--- a/picard/ui/ui_options_cover.py
+++ b/picard/ui/ui_options_cover.py
@@ -148,7 +148,7 @@ class Ui_CoverOptionsPage(object):
     def retranslateUi(self, CoverOptionsPage):
         self.rename_files.setTitle(_("Location"))
         self.save_images_to_tags.setText(_("Embed cover images into tags"))
-        self.cb_embed_front_only.setText(_("Embed only front images"))
+        self.cb_embed_front_only.setText(_("Only embed a front image"))
         self.save_images_to_files.setText(_("Save cover images as separate files"))
         self.label_3.setText(_("Use the following file name for images:"))
         self.save_images_overwrite.setText(_("Overwrite the file if it already exists"))

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -33,7 +33,7 @@
       <item>
        <widget class="QCheckBox" name="cb_embed_front_only">
         <property name="text">
-         <string>Embed only front images</string>
+         <string>Only embed a front image</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Introduce helpers to clarify and fix code:
- is_front_image()
- save_this_image_to_tags()
- image_type_from_id3_num()
- image_type_as_id3_num()

Fixes:
- honor "save_only_front_images_to_tags" option for apev2 format too
- save only caa front image to tags when "save_only_front_images_to_tags" is set
  and image source is CAA, use 'front' flag from json.
  Other sources should have only 1 front image anyways.
