### PR TITLE
Make Picard search box smart enough to detect mbids.

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -66,7 +66,7 @@ class FileLookup(object):
         possible.
         """
         uuid = '[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}'
-        entity_type = '(?:artist|release-group|release|track|label)'
+        entity_type = '(?:release-group|release|recording|work|artist|label|url|area|track)'
         regex = r"\b(%s)?\W*(%s)" % (entity_type, uuid)
         m = re.search(regex, string, re.IGNORECASE)
         if m is None:


### PR DESCRIPTION
If a release mbid is given (search type = Album) it will try to load it as
when using web browser tagger link.

If string looks like a known entity (artist, release-group, label, track)
it will open browser on corresponding url.

Examples:
Select box on Album + "abb7caf1-ac93-48e1-a066-60caad07e1a7" -> load release (http://musicbrainz.org/release/abb7caf1-ac93-48e1-a066-60caad07e1a7)

Select box on anything + "http://musicbrainz.org/artist/c19ff12b-058f-44a8-b245-b0efb4752925" -> open browser on Artist page
"ARTIST := c19ff12b-058f-44a8-b245-b0efb4752925 !!" -> open Artist page
