### PR TITLE
Fixes sending username/password in utf-8

### DIFF
--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -165,8 +165,8 @@ class XmlWebService(QtCore.QObject):
         log.debug("%s http://%s:%d%s", method, host, port, path)
         url = QUrl.fromEncoded("http://%s:%d%s" % (host, port, path))
         if mblogin:
-            url.setUserName(config.setting["username"])
-            url.setPassword(config.setting["password"])
+            url.setUserName(config.setting["username"].encode('utf-8'))
+            url.setPassword(config.setting["password"].encode('utf-8'))
         request = QtNetwork.QNetworkRequest(url)
         if cacheloadcontrol is not None:
             request.setAttribute(QtNetwork.QNetworkRequest.CacheLoadControlAttribute,


### PR DESCRIPTION
The webservice requires utf-8 encoding. Just sending the stored authentication gives 401 Unauthorized when using special characters.
