### PR TITLE
Add @throttle decorator to reduce the number of GUI updates

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -36,7 +36,7 @@ from picard.ui.options.dialog import OptionsDialog
 from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog
 from picard.ui.infostatus import InfoStatus
 from picard.ui.passworddialog import PasswordDialog
-from picard.util import icontheme, webbrowser2, find_existing_path
+from picard.util import icontheme, webbrowser2, find_existing_path, throttle
 from picard.util.cdrom import get_cdrom_drives
 from picard.plugin import ExtensionPoint
 
@@ -220,6 +220,7 @@ class MainWindow(QtGui.QMainWindow):
         self.tagger.listen_port_changed.connect(self.update_statusbar_listen_port)
         self.update_statusbar_stats()
 
+    @throttle(250)
     def update_statusbar_stats(self):
         """Updates the status bar information."""
         self.infostatus.setFiles(len(self.tagger.files))
@@ -734,6 +735,7 @@ been merged with that of single artist albums."""),
     def browser_lookup(self):
         self.tagger.browser_lookup(self.selected_objects[0])
 
+    @throttle(100)
     def update_actions(self):
         can_remove = False
         can_save = False

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -25,7 +25,7 @@ from picard.album import Album
 from picard.cluster import Cluster
 from picard.track import Track
 from picard.file import File
-from picard.util import partial, format_time
+from picard.util import partial, format_time, throttle
 from picard.util.tags import display_tag_name
 from picard.ui.edittagdialog import EditTagDialog
 from picard.metadata import MULTI_VALUED_JOINER
@@ -327,6 +327,7 @@ class MetadataBox(QtGui.QTableWidget):
         self.objects = objects
         self.selection_mutex.unlock()
 
+    @throttle(100)
     def update(self):
         if self.editing:
             return

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 import unicodedata
+from time import time
 from PyQt4 import QtCore
 from encodings import rot_13;
 from string import Template
@@ -336,3 +337,39 @@ def parse_amazon_url(url):
     if match is not None:
         return match.groupdict()
     return None
+
+
+def throttle(interval):
+    """
+    Throttle a function so that it will only execute once per ``interval``
+    (specified in milliseconds).
+    """
+    mutex = QtCore.QMutex()
+
+    def decorator(func):
+        def later(*args, **kwargs):
+            mutex.lock()
+            func(*args, **kwargs)
+            decorator.prev = time()
+            decorator.is_ticking = False
+            mutex.unlock()
+
+        def throttled_func(*args, **kwargs):
+            if decorator.is_ticking:
+                return
+            mutex.lock()
+            now = time()
+            r = interval - (now-decorator.prev)*1000.0
+            if r <= 0:
+                func(*args, **kwargs)
+                decorator.prev = now
+            else:
+                QtCore.QTimer.singleShot(r, partial(later, *args, **kwargs))
+                decorator.is_ticking = True
+            mutex.unlock()
+
+        return throttled_func
+
+    decorator.prev = 0
+    decorator.is_ticking = False
+    return decorator


### PR DESCRIPTION
This basically ensures that, if a function that updates the GUI is called many times in a certain interval, it'll only execute once. I explain why I wrote this in https://github.com/musicbrainz/picard/pull/108#issuecomment-19221509.

The decorator executes its function in the same thread as it was called, so there shouldn't be any surprises there.

I haven't made any performance measurements, but drag-selecting albums "feels" a lot less laggy, and so does removing a bunch of them. Logging statements showed that it blocks a _lot_ of calls in those scenarios.

The intervals I picked are somewhat arbitrary, but feel right to me.

This was tested on Mac and Windows.
