### PR TITLE
Fix performed vocals relationship with no vocal type set

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -55,7 +55,8 @@ def _decamelcase(text):
 
 _REPLACE_MAP = {}
 _EXTRA_ATTRS = ['guest', 'additional', 'minor']
-def _parse_attributes(attrs):
+_BLANK_SPECIAL_RELTYPES = {'vocal': 'vocals'}
+def _parse_attributes(attrs, reltype):
     attrs = [_decamelcase(_REPLACE_MAP.get(a, a)) for a in attrs]
     prefix = ' '.join([a for a in attrs if a in _EXTRA_ATTRS])
     attrs = [a for a in attrs if a not in _EXTRA_ATTRS]
@@ -64,7 +65,7 @@ def _parse_attributes(attrs):
     elif len(attrs) == 1:
         attrs = attrs[0]
     else:
-        attrs = ''
+        attrs = _BLANK_SPECIAL_RELTYPES.get(reltype, '')
     return ' '.join([prefix, attrs]).strip().lower()
 
 
@@ -79,7 +80,7 @@ def _relations_to_metadata(relation_lists, m):
                 if 'attribute_list' in relation.children:
                     attribs = [a.text for a in relation.attribute_list[0].attribute]
                 if reltype in ('vocal', 'instrument', 'performer'):
-                    name = 'performer:' + _parse_attributes(attribs)
+                    name = 'performer:' + _parse_attributes(attribs, reltype)
                 elif reltype == 'mix-DJ' and len(attribs) > 0:
                     if not hasattr(m, "_djmix_ars"):
                         m._djmix_ars = {}


### PR DESCRIPTION
This fixes a regression since e16b2533c where picard saves vocal ARs
with no type set as generic "performer" ars; appearing in the UI like
    Performer []: Some Vocalist
    Performer [guest]: Some Guest Vocalist

Add special handling for the vocal relationship type to use a fallback
string if there is no vocal type set. The fallback string is "vocals"
(earlier versions of picard used "vocal"), for consistency with the
current vocal type strings, which look like "lead vocals", "background
vocals", etc.
