### PR TITLE
Fix issue with date format yyyy-mm

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -474,11 +474,11 @@ class ID3Metadata(Metadata):
     def __id3v23_date(self, name, values):
         # id3v23 can only save TDOR dates in yyyy format (cf. id3v24 and MB who provides dates in yyyy-mm-dd format)
         # mutagen cannot handle id3v23 dates which are yyyy-mm rather than yyyy or yyyy-mm-dd
-        if (!config.setting["write_id3v23"]):
+        if not config.setting["write_id3v23"]:
             return values
-        elif (name == "originaldate"):
+        elif name == "originaldate":
             return [v[:4] for v in values]
-        elif (name == "date"):
+        elif name == "date":
             return [self.__fix_date_mm(v) for v in values]
         else:
             return values


### PR DESCRIPTION
MB sometimes gives dates in form yyyy-mm. Mutagen cannot save id3v23
dates in this format and truncates them to yyyy. Then they don't match
when the file is reloaded.

This fix detects New metadata dates in this format and truncates them.
