### PR TITLE
Fix a TypeError, str vs unicode.

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -83,7 +83,7 @@ class CoverOptionsPage(OptionsPage):
         config.BoolOption("setting", "caa_approved_only", False),
         config.BoolOption("setting", "caa_image_type_as_filename", False),
         config.IntOption("setting", "caa_image_size", 2),
-        config.TextOption("setting", "caa_image_types", "front"),
+        config.TextOption("setting", "caa_image_types", u"front"),
     ]
 
     def __init__(self, parent=None):


### PR DESCRIPTION
E: 139836956702464 21:25:09 Traceback (most recent call last):
  File "./picard/album.py", line 133, in _parse_release
    run_album_metadata_processors(self, m, release_node)
  File "./picard/metadata.py", line 334, in run_album_metadata_processors
    processor(tagger, metadata, release)
  File "./picard/coverart.py", line 178, in coverart
    config.setting["caa_image_types"].split())
TypeError: descriptor 'lower' requires a 'unicode' object but received a 'str'
