### PR TITLE
Add support for loading coverart from local files.

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -317,6 +317,8 @@ class Album(DataObject, Item):
 
     def _add_file(self, track, file):
         self._files += 1
+        if len(self.metadata.images) == 0 and len(file.metadata.images) > 0:
+            self.metadata.images.extend(file.metadata.images[:])
         self.update(update_tracks=False)
 
     def _remove_file(self, track, file):

--- a/picard/resources.py
+++ b/picard/resources.py
@@ -2,7 +2,7 @@
 
 # Resource object code
 #
-# Created: Mon 3. Jun 11:55:41 2013
+# Created: Thu Jun 27 12:18:25 2013
 #      by: The Resource Compiler for PyQt (Qt v4.8.4)
 #
 # WARNING! All changes made in this file will be lost!

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -276,7 +276,33 @@ class Tagger(QtGui.QApplication):
                     self.analyze([file])
             elif config.setting['analyze_new_files'] and file.can_analyze():
                 self.analyze([file])
+            if config.setting['load_local_coverart']:
+                self.load_local_coverart(file)
 
+    def load_local_coverart(self, file):
+        coverart_filename = config.setting["local_coverart_filename"]
+        (root, ext) = os.path.splitext(coverart_filename)
+        if ext == '.jpg' or ext == '.jpeg':
+            filename = os.path.join(os.path.dirname(file.filename), coverart_filename)
+            filename = encode_filename(filename)
+            if os.path.exists(filename):
+                try:
+                    fin = open(filename, "rb")
+                    jpgImage = fin.read()
+                    fin.close
+                except IOError:
+                    file.tagger.log.error("Unable to load coverart from: %s" % filename)
+                    raise
+                file.metadata.add_image('image/jpeg', jpgImage)
+                file.tagger.log.debug("Added local image from %s for %s" %
+                                      (filename, file.filename))
+            else:
+                file.tagger.log.debug("No local coverart file named: %s", coverart_filename)
+        else:
+            file.tagger.log.error("Local coverart must be a jpeg file, not: %s",
+                                  coverart_filename)
+        
+        
     def move_files(self, files, target):
         if isinstance(target, (Track, Cluster)):
             for file in files:

--- a/picard/track.py
+++ b/picard/track.py
@@ -52,6 +52,7 @@ class Track(DataObject, Item):
         if file not in self.linked_files:
             self.linked_files.append(file)
             self.num_linked_files += 1
+        self.metadata.images.extend(file.metadata.images[:])
         self.album._add_file(self, file)
         self.update_file_metadata(file)
 

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -84,6 +84,8 @@ class CoverOptionsPage(OptionsPage):
         config.BoolOption("setting", "caa_image_type_as_filename", False),
         config.IntOption("setting", "caa_image_size", 2),
         config.TextOption("setting", "caa_image_types", "front"),
+        config.BoolOption("setting", "load_local_coverart", False),
+        config.TextOption("setting", "local_coverart_filename", "Folder.jpg"),
     ]
 
     def __init__(self, parent=None):
@@ -114,6 +116,8 @@ class CoverOptionsPage(OptionsPage):
         self.ui.cb_type_as_filename.setChecked(config.setting["caa_image_type_as_filename"])
         self.connect(self.ui.caprovider_caa, QtCore.SIGNAL("toggled(bool)"),
                 self.ui.gb_caa.setEnabled)
+        self.ui.load_local_coverart.setChecked(config.setting["load_local_coverart"])
+        self.ui.local_coverart_filename.setText(config.setting["local_coverart_filename"])
 
     def save(self):
         config.setting["save_images_to_tags"] = self.ui.save_images_to_tags.isChecked()
@@ -138,6 +142,10 @@ class CoverOptionsPage(OptionsPage):
             self.ui.cb_type_as_filename.isChecked()
 
         config.setting["save_images_overwrite"] = self.ui.save_images_overwrite.isChecked()
+
+        config.setting["load_local_coverart"] = self.ui.load_local_coverart.isChecked()
+        config.setting["local_coverart_filename"] = \
+            unicode(self.ui.local_coverart_filename.text())
 
     def update_filename(self):
         enabled = self.ui.save_images_to_files.isChecked()

--- a/picard/ui/ui_options_cover.py
+++ b/picard/ui/ui_options_cover.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/options_cover.ui'
 #
-# Created: Tue Jan 22 12:56:46 2013
+# Created: Thu Jun 27 12:27:36 2013
 #      by: PyQt4 UI code generator 4.9.6
 #
 # WARNING! All changes made in this file will be lost!
@@ -50,6 +50,15 @@ class Ui_CoverOptionsPage(object):
         self.cover_image_filename = QtGui.QLineEdit(self.rename_files)
         self.cover_image_filename.setObjectName(_fromUtf8("cover_image_filename"))
         self.vboxlayout.addWidget(self.cover_image_filename)
+        self.load_local_coverart = QtGui.QCheckBox(self.rename_files)
+        self.load_local_coverart.setObjectName(_fromUtf8("load_local_coverart"))
+        self.vboxlayout.addWidget(self.load_local_coverart)
+        self.label_4 = QtGui.QLabel(self.rename_files)
+        self.label_4.setObjectName(_fromUtf8("label_4"))
+        self.vboxlayout.addWidget(self.label_4)
+        self.local_coverart_filename = QtGui.QLineEdit(self.rename_files)
+        self.local_coverart_filename.setObjectName(_fromUtf8("local_coverart_filename"))
+        self.vboxlayout.addWidget(self.local_coverart_filename)
         self.save_images_overwrite = QtGui.QCheckBox(self.rename_files)
         self.save_images_overwrite.setObjectName(_fromUtf8("save_images_overwrite"))
         self.vboxlayout.addWidget(self.save_images_overwrite)
@@ -135,7 +144,9 @@ class Ui_CoverOptionsPage(object):
         CoverOptionsPage.setTabOrder(self.save_images_to_tags, self.cb_embed_front_only)
         CoverOptionsPage.setTabOrder(self.cb_embed_front_only, self.save_images_to_files)
         CoverOptionsPage.setTabOrder(self.save_images_to_files, self.cover_image_filename)
-        CoverOptionsPage.setTabOrder(self.cover_image_filename, self.save_images_overwrite)
+        CoverOptionsPage.setTabOrder(self.cover_image_filename, self.load_local_coverart)
+        CoverOptionsPage.setTabOrder(self.load_local_coverart, self.local_coverart_filename)
+        CoverOptionsPage.setTabOrder(self.local_coverart_filename, self.save_images_overwrite)
         CoverOptionsPage.setTabOrder(self.save_images_overwrite, self.caprovider_amazon)
         CoverOptionsPage.setTabOrder(self.caprovider_amazon, self.caprovider_cdbaby)
         CoverOptionsPage.setTabOrder(self.caprovider_cdbaby, self.caprovider_caa)
@@ -151,6 +162,8 @@ class Ui_CoverOptionsPage(object):
         self.cb_embed_front_only.setText(_("Only embed a front image"))
         self.save_images_to_files.setText(_("Save cover images as separate files"))
         self.label_3.setText(_("Use the following file name for images:"))
+        self.load_local_coverart.setText(_("Load coverart from local files"))
+        self.label_4.setText(_("Use the following file name to load local coverart:"))
         self.save_images_overwrite.setText(_("Overwrite the file if it already exists"))
         self.groupBox.setTitle(_("Coverart Providers"))
         self.caprovider_amazon.setText(_("Amazon"))

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -55,6 +55,23 @@
        <widget class="QLineEdit" name="cover_image_filename"/>
       </item>
       <item>
+       <widget class="QCheckBox" name="load_local_coverart">
+        <property name="text">
+         <string>Load coverart from local files</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Use the following file name to load local coverart:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="local_coverart_filename"/>
+      </item>
+      <item>
        <widget class="QCheckBox" name="save_images_overwrite">
         <property name="text">
          <string>Overwrite the file if it already exists</string>
@@ -246,6 +263,8 @@
   <tabstop>cb_embed_front_only</tabstop>
   <tabstop>save_images_to_files</tabstop>
   <tabstop>cover_image_filename</tabstop>
+  <tabstop>load_local_coverart</tabstop>
+  <tabstop>local_coverart_filename</tabstop>
   <tabstop>save_images_overwrite</tabstop>
   <tabstop>caprovider_amazon</tabstop>
   <tabstop>caprovider_cdbaby</tabstop>


### PR DESCRIPTION
I have coverart that I'm unlikely to ever upload to e.g. the Cover Art
Archive.  This commit teaches picard to load it and add it to files.

Loading local cover art, and the name of the cover art file, are
managed by config options.

When a file is loaded, picard now searches for a local cover art file
in the same directory.

If a file is found it is added to the file's metadata.  When the file
becomes associated with a track, the file's images are added to the
track's images.  If the track's album's metadata has no associated
images, the file's image is also added to the album's metadata.
