### PR TITLE
Add '/' to _escape_lucune_query in webservice.py

### DIFF
--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -43,7 +43,7 @@ USER_AGENT_STRING = 'MusicBrainz%%20Picard-%s' % PICARD_VERSION_STR
 
 
 def _escape_lucene_query(text):
-    return re.sub(r'([+\-&|!(){}\[\]\^"~*?:\\])', r'\\\1', text)
+    return re.sub(r'([+\-&|!(){}\[\]\^"~*?:\\/])', r'\\\1', text)
 
 
 def _wrap_xml_metadata(data):


### PR DESCRIPTION
Due to Lucene 4 updates, this is necessary.
