### PR TITLE
Correctly catch IOError

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -205,7 +205,7 @@ class PluginManager(QtCore.QObject):
                 plugin = self.load_plugin(plugin_name, USER_PLUGIN_DIR)
                 if plugin is not None:
                     self.plugin_installed.emit(plugin, False)
-            except OSError, IOError:
+            except (OSError, IOError):
                 log.debug("Unable to copy %s to plugin folder %s" % (path, USER_PLUGIN_DIR))
 
     def enabled(self, name):


### PR DESCRIPTION
except OSError, IOError does not catch IOError but will overwrite IOError with
catched exception. See [1] for detauls.

[1] http://docs.python.org/2/whatsnew/2.6.html#pep-3110-exception-handling-changes

Signed-off-by: Sebastian Ramacher sramacher@debian.org
