### PR TITLE
Update MusicBrainz to support writing the individual artist names to the...

### DIFF
--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -115,6 +115,8 @@ class ASFFile(File):
         'musicbrainz_discid': 'MusicBrainz/Disc Id',
         'musicbrainz_workid': 'MusicBrainz/Work Id',
         'musicbrainz_releasegroupid': 'MusicBrainz/Release Group Id',
+        'musicbrainz_albumartistnames': 'MusicBrainz/Album Artist Names',
+        'musicbrainz_artistnames': 'MusicBrainz/Artist Names',
         'musicip_puid': 'MusicIP/PUID',
         'releasestatus': 'MusicBrainz/Album Status',
         'releasetype': 'MusicBrainz/Album Type',

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -146,6 +146,8 @@ class ID3File(File):
         'MusicBrainz Work Id': 'musicbrainz_workid',
         'MusicBrainz Release Group Id': 'musicbrainz_releasegroupid',
         'MusicBrainz Album Release Country': 'releasecountry',
+        'MusicBrainz Artist Names': 'musicbrainz_artistnames',
+        'MusicBrainz Album Artist Names': 'musicbrainz_albumartistnames',
         'MusicIP PUID': 'musicip_puid',
         'Acoustid Fingerprint': 'acoustid_fingerprint',
         'Acoustid Id': 'acoustid_id',

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -77,6 +77,8 @@ class MP4File(File):
         "----:com.apple.iTunes:MusicBrainz TRM Id": "musicbrainz_trmid",
         "----:com.apple.iTunes:MusicBrainz Work Id": "musicbrainz_workid",
         "----:com.apple.iTunes:MusicBrainz Release Group Id": "musicbrainz_releasegroupid",
+        "----:com.apple.iTunes:MusicBrainz Album Artist Names": "musicbrainz_albumartistnames",
+        "----:com.apple.iTunes:MusicBrainz Artist Names": "musicbrainz_artistnames",
         "----:com.apple.iTunes:Acoustid Fingerprint": "acoustid_fingerprint",
         "----:com.apple.iTunes:Acoustid Id": "acoustid_id",
         "----:com.apple.iTunes:ASIN": "asin",

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -58,6 +58,8 @@ TAG_NAMES = {
     'musicbrainz_releasegroupid': N_('MusicBrainz Release Group Id'),
     'musicbrainz_discid': N_('MusicBrainz Disc Id'),
     'musicbrainz_sortname': N_('MusicBrainz Sort Name'),
+    'musicbrainz_artistnames': N_('MusicBrainz Artist Names'),
+    'musicbrainz_albumartistnames': N_('MusicBrainz Release Artist Names'),
     'musicip_puid': N_('MusicIP PUID'),
     'musicip_fingerprint': N_('MusicIP Fingerprint'),
     'acoustid_id': N_('AcoustID'),


### PR DESCRIPTION
... tags.

This helps clients which scan MB tagged music in an offline mode to correctly index the artists until they can be resolved online. For example when scanning MB tagged music today all of the MusicBrainz IDs have a 1-1 mapping with ID3 tags except the artists:
MusicBrainzAlbumID -> Album Name
MusicBrainzArtistID[s] -> Artist
That means if we're building a database of artists and we hit a track with multiple artists we see 2 MusicBrainz Artist IDs, but only 1 Artist Name. It is therefore impossible to show a good default for the Artist IDs without looking them up online. This helps clients to correctly index the music even without access to MusicBrainz itself.
