### PR TITLE
Add 'Audio' to the categories in the .desktop file

### DIFF
--- a/picard.desktop
+++ b/picard.desktop
@@ -6,5 +6,5 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Icon=picard
-Categories=AudioVideo;AudioVideoEditing;
+Categories=AudioVideo;Audio;AudioVideoEditing;
 MimeType=audio/x-mp3;audio/ogg;audio/mpeg;application/ogg;audio/x-flac;audio/x-flac+ogg;audio/x-vorbis+ogg;audio/x-speex+ogg;audio/x-oggflac;audio/x-musepack;audio/x-tta;audio/x-ms-wma;audio/x-wavpack;


### PR DESCRIPTION
As per http://blogs.gnome.org/hughsie/2013/09/03/broken-desktop-files/ it should have both 'AudioVideo' and one or both of 'Audio' or 'Video' in order to be categorized correctly.
