### PR TITLE
Track featured artists don't indicate compilation

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -232,8 +232,6 @@ class Album(DataObject, Item):
                 track.metadata["~totalalbumtracks"] = totalalbumtracks
                 if len(artists) > 1:
                     track.metadata["compilation"] = "1"
-                else:
-                    track.metadata["compilation"] = "0"
 
             del self._release_node
             self._tracks_loaded = True

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -328,6 +328,8 @@ def release_group_to_metadata(node, m, release_group=None):
         elif name == 'secondary_type_list':
             add_secondary_release_types(nodes[0], m)
     m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
+    if u'compilation' in m.getall('~secondaryreleasetype'):
+        m['compilation'] = "1"
 
 
 def add_secondary_release_types(node, m):


### PR DESCRIPTION
This fix only uses primary track artist to determine whether an album is a compilation. Featured artists no longer influence this.

Fixes http://forums.musicbrainz.org/viewtopic.php?id=4504
