### PR TITLE
Fix NatAlbum not yet created error

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -178,6 +178,7 @@ class NonAlbumTrack(Track):
         self.metadata.copy(self.album.metadata)
         self.metadata["title"] = u"[loading track information]"
         self.loaded = False
+        self.tagger.create_nats()
         self.tagger.nats.update(True)
         mblogin = False
         inc = ["artist-credits", "artists", "aliases"]


### PR DESCRIPTION
I was getting errors where self.tagger.nats had not been set when self.tagger.nats.update was called. So this additional line ensures that NatAlbum has been created.
