### PR TITLE
PICARD-259: Allow tagger script to access file metadata

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -257,13 +257,16 @@ class Album(DataObject, Item):
                 if len(artists) > 1:
                     track.metadata["~multiartist"] = "1"
 
-                track.orig_metadata.copy(track.metadata)
 
             del self._release_node
             self._tracks_loaded = True
 
         if not self._requests:
-            # Prepare parser for user's script
+            # Save the track original metadata
+            for track in self._new_tracks:
+                track.orig_metadata.copy(track.metadata)
+
+            # Run the user's script over the tracks and album metadata
             if config.setting["enable_tagger_scripts"]:
                 for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
                     if s_enabled and s_text:

--- a/picard/album.py
+++ b/picard/album.py
@@ -256,6 +256,9 @@ class Album(DataObject, Item):
                 track.metadata["~totalalbumtracks"] = totalalbumtracks
                 if len(artists) > 1:
                     track.metadata["~multiartist"] = "1"
+
+                track.orig_metadata.copy(track.metadata)
+
             del self._release_node
             self._tracks_loaded = True
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -50,6 +50,7 @@ class Track(DataObject, Item):
         self.linked_files = []
         self.num_linked_files = 0
         self.metadata = Metadata()
+        self.orig_metadata = Metadata()
         self._track_artists = []
 
     def __repr__(self):
@@ -65,8 +66,20 @@ class Track(DataObject, Item):
     def update_file_metadata(self, file):
         if file not in self.linked_files:
             return
-        file.copy_metadata(self.metadata)
+        file.copy_metadata(self.orig_metadata)
         file.metadata['~extension'] = file.orig_metadata['~extension']
+
+        # Re-run tagger scripts with updated metadata
+        if config.setting["enable_tagger_scripts"]:
+            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
+                if s_enabled and s_text:
+                    parser = ScriptParser()
+                    try:
+                        parser.eval(script, file.metadata)
+                    except:
+                        log.error(traceback.format_exc())
+                    file.metadata.strip_whitespace()
+
         file.metadata.changed = True
         file.update(signal=False)
         self.update()
@@ -275,16 +288,17 @@ class NonAlbumTrack(Track):
         recording_to_metadata(recording, m, self)
         self._customize_metadata()
         run_track_metadata_processors(self.album, m, None, recording)
+        self.orig_metadata.copy(m)
+
         if config.setting["enable_tagger_scripts"]:
             for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
                 if s_enabled and s_text:
                     parser = ScriptParser()
                     try:
-                        parser.eval(s_text, m)
+                        parser.eval(script, m)
                     except:
                         log.error(traceback.format_exc())
                     m.strip_whitespace()
-
         self.loaded = True
         if self.callback:
             self.callback()

--- a/picard/track.py
+++ b/picard/track.py
@@ -80,8 +80,8 @@ class Track(DataObject, Item):
                 if s_enabled and s_text:
                     parser = ScriptParser()
                     try:
-                        parser.eval(script, file.metadata)
-                        parser.eval(script, self.metadata)
+                        parser.eval(s_text, file.metadata)
+                        parser.eval(s_text, self.metadata)
                     except:
                         log.error(traceback.format_exc())
                     file.metadata.strip_whitespace()
@@ -110,7 +110,7 @@ class Track(DataObject, Item):
                 if s_enabled and s_text:
                     parser = ScriptParser()
                     try:
-                        parser.eval(script, self.metadata)
+                        parser.eval(s_text, self.metadata)
                     except:
                         log.error(traceback.format_exc())
                     self.metadata.strip_whitespace()
@@ -318,7 +318,7 @@ class NonAlbumTrack(Track):
                 if s_enabled and s_text:
                     parser = ScriptParser()
                     try:
-                        parser.eval(script, m)
+                        parser.eval(s_text, m)
                     except:
                         log.error(traceback.format_exc())
                     m.strip_whitespace()


### PR DESCRIPTION
This moves the taggerscript evaluation to happen when a file is matched (i.e. when a file is added to a track), where it has access to the both the file metadata _and_ the track metadata.

In order to make the UI work correctly, track.metadata has the tagger script run at load time, but a copy of the pre-tagger-script metadata is saved in track.orig_metadata. At file matching time, the metadata is copied from the track.orig_metadata to the file, and the tagger script is re-run in a context that has file information present.
