### PR TITLE
Add Travis configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,6 @@ install:
   - python setup.py build_locales -i
 # Run the tests!
 script: "python setup.py test"
+# Tell people that tests were run
+notifications:
+  irc: "chat.freenode.net#musicbrainz-devel"


### PR DESCRIPTION
This adds a `.travis.yml` to the repository, allowing forkers (and the project itself!) to let [Travis](https://travis-ci.org/) run the tests against the pushed code and pull requests.

Example of Travis integration with Picard: https://travis-ci.org/Freso/picard

Some notes:
- It's only testing Python 2.7. I wanted to have both 2.6 and 2.7 in the testing matrix, but since it's _much_ more manageable to install PyQt4 via `apt-get`, I opted for that instead of having to build it "manually" for Py 2.6. If it's really desired, it can be added later.
