### PR TITLE
Add error exception...

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -166,6 +166,9 @@ class Album(DataObject, Item):
                 except:
                     error = True
                     self.error_append(traceback.format_exc())
+        except:
+            # error = True
+            self.error_append(traceback.format_exc())
         finally:
             self._requests -= 1
             if parsed or error:


### PR DESCRIPTION
... for try which doesn't have an exception handler.

To be honest, I am not sure why this code is in a try which will just
hide error conditions which should probably be handled explicitly.

However rather than remove the try, I am assuming that in the distant
past this was added to handle some sort of error, and so I am adding an
except clause to log any error condition rather than remove the try and
have a crash.
