### PR TITLE
Centralize Picard urls in PICARD_URLS dict.

### DIFF
--- a/picard/const.py
+++ b/picard/const.py
@@ -47,6 +47,19 @@ FPCALC_NAMES = ['fpcalc', 'pyfpcalc']
 CAA_HOST = "coverartarchive.org"
 CAA_PORT = 80
 
+#URLs
+PICARD_URLS = {
+    'documentation':    "http://musicbrainz.org/doc/Picard_Documentation",
+    'troubleshooting':  "http://musicbrainz.org/doc/Picard_Troubleshooting",
+    'home':             "http://musicbrainz.org/doc/MusicBrainz_Picard",
+    'doc_options':      "http://musicbrainz.org/doc/Picard_Documentation/Options",
+    'plugins':          "http://musicbrainz.org/doc/Picard_Plugins",
+    'forum':            "http://forums.musicbrainz.org/viewforum.php?id=2",
+    'donate':           "http://metabrainz.org/donate",
+    'chromaprint':      "http://acoustid.org/chromaprint#download",
+    'acoustid_apikey':  "http://acoustid.org/api-key",
+}
+
 # Various Artists MBID
 VARIOUS_ARTISTS_ID = '89ad4ac3-39f7-470e-963a-56509c546377'
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -657,7 +657,7 @@ class MainWindow(QtGui.QMainWindow):
         dialog.exec_()
 
     def show_help(self):
-        webbrowser2.open("http://musicbrainz.org/doc/Picard_Documentation")
+        webbrowser2.goto('documentation')
 
     def show_log(self):
         from picard.ui.logview import LogView
@@ -685,13 +685,13 @@ been merged with that of single artist albums."""),
             QtGui.QMessageBox.Ok)
 
     def open_bug_report(self):
-        webbrowser2.open("http://musicbrainz.org/doc/Picard_Troubleshooting")
+        webbrowser2.goto('troubleshooting')
 
     def open_support_forum(self):
-        webbrowser2.open("http://forums.musicbrainz.org/viewforum.php?id=2")
+        webbrowser2.goto('forum')
 
     def open_donation_page(self):
-        webbrowser2.open('http://metabrainz.org/donate')
+        webbrowser2.goto('donate')
 
     def save(self):
         """Tell the tagger to save the selected objects."""

--- a/picard/ui/options/about.py
+++ b/picard/ui/options/about.py
@@ -20,6 +20,7 @@
 from mutagen import version_string as mutagen_version
 from PyQt4.QtCore import PYQT_VERSION_STR as pyqt_version
 from picard import PICARD_VERSION_STR_SHORT
+from picard.const import PICARD_URLS
 from picard.formats import supported_formats
 from picard.ui.options import OptionsPage, register_options_page
 from picard.ui.ui_options_about import Ui_AboutOptionsPage
@@ -44,7 +45,9 @@ class AboutOptionsPage(OptionsPage):
             "version": PICARD_VERSION_STR_SHORT,
             "mutagen-version": mutagen_version,
             "pyqt-version": pyqt_version,
-            "discid-version": discid_version or _("is not installed")
+            "discid-version": discid_version or _("is not installed"),
+            "picard-doc-url": PICARD_URLS['home'],
+            "picard-donate-url": PICARD_URLS['donate'],
         }
 
         formats = []
@@ -70,10 +73,10 @@ Discid %(discid-version)s
 <p align="center"><strong>Supported formats</strong><br/>%(formats)s</p>
 <p align="center"><strong>Please donate</strong><br/>
 Thank you for using Picard. Picard relies on the MusicBrainz database, which is operated by the MetaBrainz Foundation with the help of thousands of volunteers. If you like this application please consider donating to the MetaBrainz Foundation to keep the service running.</p>
-<p align="center"><a href="http://metabrainz.org/donate">Donate now!</a></p>
+<p align="center"><a href="%(picard-donate-url)s">Donate now!</a></p>
 <p align="center"><strong>Credits</strong><br/>
 <small>Copyright © 2004-2011 Robert Kaye, Lukáš Lalinský and others%(translator-credits)s</small></p>
-<p align="center"><a href="http://musicbrainz.org/doc/MusicBrainz_Picard">http://musicbrainz.org/doc/MusicBrainz_Picard</a></p>
+<p align="center"><a href="%(picard-doc-url)s">%(picard-doc-url)s</a></p>
 """) % args
         self.ui.label.setOpenExternalLinks(True)
         self.ui.label.setText(text)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -112,7 +112,7 @@ class OptionsDialog(QtGui.QDialog):
             self.ui.pages_stack.setCurrentWidget(page)
 
     def help(self):
-        webbrowser2.open('http://musicbrainz.org/doc/Picard_Documentation/Options')
+        webbrowser2.goto('doc_options')
 
     def accept(self):
         for page in self.pages:

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -84,10 +84,10 @@ class FingerprintingOptionsPage(OptionsPage):
             self.ui.acoustid_fpcalc.setText(path)
 
     def acoustid_fpcalc_download(self):
-        webbrowser2.open("http://acoustid.org/chromaprint#download")
+        webbrowser2.goto('chromaprint')
 
     def acoustid_apikey_get(self):
-        webbrowser2.open("http://acoustid.org/api-key")
+        webbrowser2.goto('acoustid_apikey')
 
 
 register_options_page(FingerprintingOptionsPage)

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -23,7 +23,7 @@ import sys
 from PyQt4 import QtCore, QtGui
 from picard import config
 from picard.const import USER_PLUGIN_DIR
-from picard.util import encode_filename
+from picard.util import encode_filename, webbrowser2
 from picard.ui.options import OptionsPage, register_options_page
 from picard.ui.ui_options_plugins import Ui_PluginsOptionsPage
 
@@ -151,7 +151,7 @@ class PluginsOptionsPage(OptionsPage):
         QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.loader % USER_PLUGIN_DIR, QtCore.QUrl.TolerantMode))
 
     def open_plugin_site(self):
-        QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://musicbrainz.org/doc/Picard_Plugins", QtCore.QUrl.TolerantMode))
+        webbrowser2.goto('plugins')
 
     def mimeTypes(self):
         return ["text/uri-list"]

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -21,6 +21,7 @@ import os
 import sys
 import webbrowser
 from PyQt4 import QtGui
+from picard.const import PICARD_URLS
 
 """
 A webbrowser extension that respects user's preferred browser on each
@@ -86,3 +87,6 @@ def open(url):
         webbrowser.open(url)
     except webbrowser.Error as e:
         QtGui.QMessageBox.critical(None, _("Web Browser Error"), _("Error while launching a web browser:\n\n%s") % (e,))
+
+def goto(url_id):
+    open(PICARD_URLS[url_id])


### PR DESCRIPTION
Introduce `webbrowser2.goto()`, which open picard urls by id.
