### PR TITLE
Set QApplication.applicationName and organizationName

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -19,6 +19,9 @@
 
 import re
 
+
+PICARD_APP_NAME = "Picard"
+PICARD_ORG_NAME = "MusicBrainz"
 PICARD_VERSION = (1, 2, 0, 'final', 0)
 
 

--- a/picard/config.py
+++ b/picard/config.py
@@ -19,7 +19,8 @@
 
 from operator import itemgetter
 from PyQt4 import QtCore
-from picard import PICARD_VERSION, version_to_string, version_from_string, log
+from picard import (PICARD_APP_NAME, PICARD_ORG_NAME, PICARD_VERSION,
+                    version_to_string, version_from_string, log)
 from picard.util import LockableObject, rot13
 
 
@@ -74,7 +75,7 @@ class Config(QtCore.QSettings):
 
     def __init__(self):
         """Initializes the configuration."""
-        QtCore.QSettings.__init__(self, "MusicBrainz", "Picard")
+        QtCore.QSettings.__init__(self, PICARD_ORG_NAME, PICARD_APP_NAME)
         self.application = ConfigSection(self, "application")
         self.setting = ConfigSection(self, "setting")
         self.persist = ConfigSection(self, "persist")

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -45,7 +45,8 @@ import picard.resources
 import picard.plugins
 from picard.i18n import setup_gettext
 
-from picard import PICARD_VERSION_STR, log, acoustid, config
+from picard import (PICARD_APP_NAME, PICARD_ORG_NAME, PICARD_VERSION_STR, log,
+                    acoustid, config)
 from picard.album import Album, NatAlbum
 from picard.browser.browser import BrowserIntegration
 from picard.browser.filelookup import FileLookup
@@ -591,6 +592,10 @@ def version():
 
 
 def main(localedir=None, autoupdate=True):
+    # Some libs (ie. Phonon) require those to be set
+    QtGui.QApplication.setApplicationName(PICARD_APP_NAME)
+    QtGui.QApplication.setOrganizationName(PICARD_ORG_NAME)
+
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     opts, args = getopt.getopt(sys.argv[1:], "hvd", ["help", "version", "debug"])
     kwargs = {}


### PR DESCRIPTION
Some libs (ie. Phonon) require those to be set.
