### PR TITLE
Fix encoding of limit parameter value in webservice query (limit=%19)

### DIFF
--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -392,7 +392,7 @@ class XmlWebService(QtCore.QObject):
         query = []
         for name, value in kwargs.items():
             if name == 'limit':
-                filters.append((name, value))
+                filters.append((name, str(value)))
             else:
                 value = _escape_lucene_query(value).strip().lower()
                 if value:


### PR DESCRIPTION
This is a very old bug it seems, it was indirectly introduced by
commit 9092a7abcae5254e581497b346b2167a5e37cb26

The missing str() was causing integer value 25 to be encoded as
ascii char 25, then, after percent encoding, limit=%19 in the search url.

Before the patch: **limit=%19**

```
D: 01:27:12 GET http://musicbrainz.org:80/ws/2/release/?limit=%19&query=release%3A%28sarala%29%20tracks%3A%2812%29%20artist%3A%28hank%20jones%29
```

After the patch: **limit=25**

```
D: 01:40:10 GET http://musicbrainz.org:80/ws/2/release/?limit=25&query=release%3A%28sarala%29%20tracks%3A%2812%29%20artist%3A%28hank%20jones%29
```
