### PR TITLE
PICARD-544: include socket module in exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ try:
     args['options'] = {
         'bdist_nsis': {
             'includes': ['json', 'sip'] + [e.name for e in ext_modules],
-            'excludes': ['ssl', 'socket', 'bz2'],
+            'excludes': ['ssl', 'bz2'],
             'optimize': 2,
         },
     }


### PR DESCRIPTION
This is needed by urllib, which is imported since
26f20228eb95d4b55968e56796228bca7ebcffa7.

See
http://tickets.musicbrainz.org/browse/PICARD-544
