### PR TITLE
transifex.net is deprecated, use transifex.com instead

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,8 @@
 [main]
-host = https://www.transifex.net
+host = https://www.transifex.com
 
 [musicbrainz.picard]
 file_filter = po/<lang>.po
 source_file = po/picard.pot
 source_lang = en
-
+type = PO


### PR DESCRIPTION
http://support.transifex.com/customer/portal/questions/1160404-improve-ssl-security-for-transifex-net
tx client is giving a message about it too

Also add translation type 'PO'.
