### PR TITLE
PICARD-144: use comma instead of spaces to separate plugin names

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -22,7 +22,7 @@ import re
 
 PICARD_APP_NAME = "Picard"
 PICARD_ORG_NAME = "MusicBrainz"
-PICARD_VERSION = (1, 3, 0, 'dev', 2)
+PICARD_VERSION = (1, 3, 0, 'dev', 3)
 
 
 class VersionError(Exception):

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -102,9 +102,17 @@ def upgrade_to_v1_3_0_dev_2():
                     'comma instead of spaces as tag separator (PICARD-536).'))
 
 
+def upgrade_to_v1_3_0_dev_3():
+     if "enabled_plugins" in _s:
+        _s["enabled_plugins"] = re.sub(r"\s+", ",", _s["enabled_plugins"].strip())
+        log.info(_('Config upgrade: convert "enabled_plugins" separator '
+                   'from spaces to comma (PICARD-144).'))
+
+
 def upgrade_config():
     cfg = config._config
     cfg.register_upgrade_hook(upgrade_to_v1_0_0_final_0)
     cfg.register_upgrade_hook(upgrade_to_v1_3_0_dev_1)
     cfg.register_upgrade_hook(upgrade_to_v1_3_0_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v1_3_0_dev_3)
     cfg.run_upgrade_hooks()

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -71,7 +71,7 @@ class ExtensionPoint(object):
         self.__items = filter(lambda i: i[0] != name, self.__items)
 
     def __iter__(self):
-        enabled_plugins = config.setting["enabled_plugins"].split()
+        enabled_plugins = config.setting["enabled_plugins"].split(",")
         for module, item in self.__items:
             if module is None or module in enabled_plugins:
                 yield item

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -64,7 +64,7 @@ class PluginsOptionsPage(OptionsPage):
 
     def load(self):
         plugins = sorted(self.tagger.pluginmanager.plugins, cmp=cmp_plugins)
-        enabled_plugins = config.setting["enabled_plugins"].split()
+        enabled_plugins = config.setting["enabled_plugins"].split(",")
         firstitem = None
         for plugin in plugins:
             enabled = plugin.module_name in enabled_plugins
@@ -108,7 +108,7 @@ class PluginsOptionsPage(OptionsPage):
         for item, plugin in self.items.iteritems():
             if item.checkState(0) == QtCore.Qt.Checked:
                 enabled_plugins.append(plugin.module_name)
-        config.setting["enabled_plugins"] = " ".join(enabled_plugins)
+        config.setting["enabled_plugins"] = ",".join(enabled_plugins)
 
     def change_details(self):
         plugin = self.items[self.ui.plugins.selectedItems()[0]]


### PR DESCRIPTION
Plugin names may contain spaces, so use a separator which is more unlikely to interfere, here comma.

http://tickets.musicbrainz.org/browse/PICARD-144
