### PR TITLE
Ensure setup.py returns non-zero exit code on test failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,9 @@ class picard_test(Command):
 
         tests = unittest.defaultTestLoader.loadTestsFromNames(names)
         t = unittest.TextTestRunner(verbosity=self.verbosity)
-        t.run(tests)
+        testresult = t.run(tests)
+        if not testresult.wasSuccessful():
+            raise SystemExit("At least one test failed.")
 
 
 class picard_build_locales(Command):


### PR DESCRIPTION
It was tested:
https://travis-ci.org/musicbrainz/picard/builds/16811246 (build 189) has a forced error, correctly reported
https://travis-ci.org/musicbrainz/picard/builds/16811309 (build 190) was fixed, correctly reported (buggy commit was removed, branch rebased)
