### PR TITLE
Remove user info from logged urls

### DIFF
--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -227,14 +227,14 @@ class XmlWebService(QtCore.QObject):
         try:
             request, handler, xml, refresh = self._active_requests.pop(reply)
         except KeyError:
-            log.error("Error: Request not found for %s" % str(reply.request().url().toString()))
+            log.error("Request not found for %s" % reply.request().url().toString(QUrl.RemoveUserInfo))
             return
         error = int(reply.error())
         redirect = reply.attribute(QtNetwork.QNetworkRequest.RedirectionTargetAttribute).toUrl()
         fromCache = reply.attribute(QtNetwork.QNetworkRequest.SourceIsFromCacheAttribute).toBool()
         cached = ' (CACHED)' if fromCache else ''
         log.debug("Received reply for %s: HTTP %d (%s) %s",
-                  reply.request().url().toString(),
+                  reply.request().url().toString(QUrl.RemoveUserInfo),
                   reply.attribute(QtNetwork.QNetworkRequest.HttpStatusCodeAttribute).toInt()[0],
                   reply.attribute(QtNetwork.QNetworkRequest.HttpReasonPhraseAttribute).toString(),
                   cached
@@ -242,14 +242,14 @@ class XmlWebService(QtCore.QObject):
         if handler is not None:
             if error:
                 log.error("Network request error for %s: %s (QT code %d, HTTP code %d)",
-                          reply.request().url().toString(),
+                          reply.request().url().toString(QUrl.RemoveUserInfo),
                           reply.errorString(),
                           error,
                           reply.attribute(QtNetwork.QNetworkRequest.HttpStatusCodeAttribute).toInt()[0])
 
             # Redirect if found and not infinite
             if not redirect.isEmpty() and not XmlWebService.urls_equivalent(redirect, reply.request().url()):
-                log.debug("Redirect to %s requested", redirect.toString())
+                log.debug("Redirect to %s requested", redirect.toString(QUrl.RemoveUserInfo))
                 redirect_host = str(redirect.host())
                 redirect_port = redirect.port(80)
 


### PR DESCRIPTION
It is a safety measure as users may publish their logs ie. in bug reports.
