### PR TITLE
Fix coverart drop indication.

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -38,7 +38,7 @@ class ActiveLabel(QtGui.QLabel):
         QtGui.QLabel.__init__(self, *args)
         self.setMargin(0)
         self.setActive(active)
-        self.setAcceptDrops(True)
+        self.setAcceptDrops(False)
 
     def setActive(self, active):
         self.active = active
@@ -52,8 +52,10 @@ class ActiveLabel(QtGui.QLabel):
             self.clicked.emit()
 
     def dragEnterEvent(self, event):
-        if event.mimeData().hasUrls():
-            event.acceptProposedAction()
+        for url in event.mimeData().urls():
+            if url.scheme() in ('http', 'file'):
+                event.acceptProposedAction()
+                break
 
     def dropEvent(self, event):
         accepted = False
@@ -128,6 +130,10 @@ class CoverArtBox(QtGui.QGroupBox):
                 # There's no front image, choose the first one available
                 data = metadata.images[0]
         self.__set_data(data)
+        if item and metadata:
+            self.coverArt.setAcceptDrops(True)
+        else:
+            self.coverArt.setAcceptDrops(False)
         release = None
         if metadata:
             release = metadata.get("musicbrainz_albumid", None)


### PR DESCRIPTION
Disable drop if there is no selected item, and if the scheme is not
supported.
