### PR TITLE
Improve naming character handling in windows

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -44,6 +44,7 @@
  * Add a plugin to add Artist Official Homepage relationships to the website tag (ID3 WOAR tag)
  * Add integrated functions $eq_any, $ne_all, $eq_all, $ne_any, $swapprefix and $delprefix.
  * Add %_performance_live%, %_performance_cover% etc. if track is shown as live, cover etc. in the MB database.
+ * Improved handling of invalid characters in file names under windows
 
 
 Version 1.2 - 2013-03-30

--- a/picard/file.py
+++ b/picard/file.py
@@ -251,13 +251,14 @@ class File(QtCore.QObject, Item):
                 metadata[name] = sanitize_filename(metadata[name])
         format = format.replace("\t", "").replace("\n", "")
         filename = ScriptParser().eval(format, metadata, self)
-        if settings["ascii_filenames"]:
+        ascii = settings["ascii_filenames"]
+        if ascii:
             if isinstance(filename, unicode):
                 filename = unaccent(filename)
             filename = replace_non_ascii(filename)
         # replace incompatible characters
         if settings["windows_compatibility"] or sys.platform == "win32":
-            filename = replace_win32_incompat(filename)
+            filename = replace_win32_incompat(filename, ascii)
         # remove null characters
         filename = filename.replace("\x00", "")
         return filename

--- a/picard/file.py
+++ b/picard/file.py
@@ -215,8 +215,7 @@ class File(QtCore.QObject, Item):
             self.base_filename = os.path.basename(new_filename)
             length = self.orig_metadata.length
             temp_info = {}
-            for info in ('~bitrate', '~sample_rate', '~channels',
-                         '~bits_per_sample', '~format'):
+            for info in PRESERVED_TAGS:
                 temp_info[info] = self.orig_metadata[info]
             # Data is copied from New to Original because New may be a subclass to handle id3v23
             if config.setting["clear_existing_tags"]:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -197,7 +197,7 @@ def strip_non_alnum(string):
 
 
 _re_slashes = re.compile(r'[\\/]', re.UNICODE)
-def sanitize_filename(string, repl="_"):
+def sanitize_filename(string, repl="-"):
     return _re_slashes.sub(repl, string)
 
 

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -166,28 +166,30 @@ def replace_non_ascii(string, repl="_"):
 
 
 # dict has re search term (escaped re characters) as key, and normal string as value.
-_win32_incompat = {
-    '"': "'",
-    r"\*": '+',
-    r": ": ' - ',
-    r":": '-',
-    r"<": '{',
-    r">": '}',
-    r"\?": '_',
-    r"\|": '!',
-    r"\.\/": '/',
-    r"\.\\": '\\',
-    }
+_win32_incompat = [
+    (r'"', r"'"),
+    (r"\*", r"+"),
+    (r": ", r" - "),
+    (r":", r"-"),
+    (r"<", r"{"),
+    (r">", r"}"),
+    (r"\?", r"_"),
+    (r"\|", r"!"),
+    (r"\.\/", r"/"),
+    (r"\.\\", r"\\"),
+    ]
+# Ensure supersets precede subsets
+_win32_incompat.sort(key=lambda x: x[0], reverse=True)
 # when we need to look up replacement character, key has been unescaped - so need to do a double lookup
 _re_dict_unescape = re.compile(r"\\.")
 _win32_dict = {}
-for key in _win32_incompat:
-    _win32_dict[_re_dict_unescape.sub(lambda m: m.group(0)[1:], key)] = key;
-_re_win32_incompat = re.compile('(' + ')|('.join(_win32_incompat.keys()) + ')')
+for i in xrange(0, len(_win32_incompat)):
+    _win32_dict[_re_dict_unescape.sub(lambda m: m.group(0)[1:], _win32_incompat[i][0])] = i;
+_re_win32_incompat = re.compile('(' + ')|('.join([x[0] for x in _win32_incompat]) + ')')
 def replace_win32_incompat(string):
     """Replace win32 filename incompatible characters from ``string`` by
        ``repl``."""
-    return _re_win32_incompat.sub(lambda m: _win32_incompat[_win32_dict[m.group(0)]], string)
+    return _re_win32_incompat.sub(lambda m: _win32_incompat[_win32_dict[m.group(0)]][1], string)
 
 
 _re_non_alphanum = re.compile(r'\W+', re.UNICODE)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -168,13 +168,13 @@ def replace_non_ascii(string, repl="_"):
 # dict has re search term (escaped re characters) as key, and normal string as value.
 _win32_incompat = [
     (r'"', r"'"),
-    (r"\*", r"+"),
+    (r"\*", r"_"),
     (r": ", r" - "),
     (r":", r"-"),
     (r"<", r"{"),
     (r">", r"}"),
     (r"\?", r"_"),
-    (r"\|", r"!"),
+    (r"\|", r"_"),
     (r"\.\/", r"/"),
     (r"\.\\", r"\\"),
     ]

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -164,15 +164,30 @@ def replace_non_ascii(string, repl="_"):
     """Replace non-ASCII characters from ``string`` by ``repl``."""
     return _re_non_ascii.sub(repl, asciipunct(string))
 
-_re_escaped = ['.', '\\', '*', '?', '|']
-_win32_incompat_dict = {'"': "'", '\*': '+', ': ': ' - ', ':': '-', '<': '{', '>': '}', '\?': '_', '\|': '!'}
-_re_win32_incompat = re.compile('(' + ')|('.join(_win32_incompat_dict.keys()) + ')')
+
+# dict has re search term (escaped re characters) as key, and normal string as value.
+_win32_incompat = {
+    '"': "'",
+    r"\*": '+',
+    r": ": ' - ',
+    r":": '-',
+    r"<": '{',
+    r">": '}',
+    r"\?": '_',
+    r"\|": '!',
+    r"\.\/": '/',
+    r"\.\\": '\\',
+    }
+# when we need to look up replacement character, key has been unescaped - so need to do a double lookup
+_re_dict_unescape = re.compile(r"\\.")
+_win32_dict = {}
+for key in _win32_incompat:
+    _win32_dict[_re_dict_unescape.sub(lambda m: m.group(0)[1:], key)] = key;
+_re_win32_incompat = re.compile('(' + ')|('.join(_win32_incompat.keys()) + ')')
 def replace_win32_incompat(string):
     """Replace win32 filename incompatible characters from ``string`` by
        ``repl``."""
-    return _re_win32_incompat.sub(
-        lambda m: _win32_incompat_dict[m.group(0)] if m.group(0) not in _re_escaped else _win32_incompat_dict['\\' + m.group(0)],
-        string)
+    return _re_win32_incompat.sub(lambda m: _win32_incompat[_win32_dict[m.group(0)]], string)
 
 
 _re_non_alphanum = re.compile(r'\W+', re.UNICODE)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,7 +11,7 @@ class ReplaceWin32IncompatTest(unittest.TestCase):
         self.assertEqual(util.replace_win32_incompat("c:\\test\\te\"st/2"),
                              "c-\\test\\te'st/2")
         self.assertEqual(util.replace_win32_incompat("A\"*:<>?|: b"),
-                             "A'+-{}_! - b")
+                             "A'_-{}__ - b")
 
     def test_incorrect(self):
         self.assertNotEqual(util.replace_win32_incompat("c:\\test\\te\"st2"),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,6 +12,8 @@ class ReplaceWin32IncompatTest(unittest.TestCase):
                              "c-\\test\\te'st/2")
         self.assertEqual(util.replace_win32_incompat("A\"*:<>?|: b"),
                              "A'_-{}__ - b")
+        self.assertEqual(util.replace_win32_incompat("A\"*:<>?|: b", False),
+                             u"A\u2033_\ufe13\u226a\u226b\ufe16\u2223\ufe13 b")
 
     def test_incorrect(self):
         self.assertNotEqual(util.replace_win32_incompat("c:\\test\\te\"st2"),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,9 +9,9 @@ class ReplaceWin32IncompatTest(unittest.TestCase):
 
     def test_correct(self):
         self.assertEqual(util.replace_win32_incompat("c:\\test\\te\"st/2"),
-                             "c_\\test\\te_st/2")
-        self.assertEqual(util.replace_win32_incompat("A\"*:<>?|b"),
-                             "A_______b")
+                             "c-\\test\\te'st/2")
+        self.assertEqual(util.replace_win32_incompat("A\"*:<>?|: b"),
+                             "A'+-{}_! - b")
 
     def test_incorrect(self):
         self.assertNotEqual(util.replace_win32_incompat("c:\\test\\te\"st2"),


### PR DESCRIPTION
Rather than replacing all invalid characters with _ this does something
slightly more sophisticated i.e.

```
" -> '
* -> +
:space -> space - space
: -> -
< -> {
> -> }
? -> _
| -> !
```

e.g. a track "Is She Really Going Out With Him?" on album "Daily Mail: Solid Gold, Volume 1: Rocking All Over the World" will be named:

"Daily Mail - Solid Gold, Volume 1 - Rocking All Over the World/Is She Really Going Out With Him_"

rather than

"Daily Mail_ Solid Gold, Volume 1_ Rocking All Over the World/Is She Really Going Out With Him_"

There is probably scope for further tweaking of the replacement list.
