### PR TITLE
Copy language from release if not in track

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -235,6 +235,8 @@ class Album(DataObject, Item):
             for track in self._new_tracks:
                 track.metadata["~totalalbumtracks"] = totalalbumtracks
 
+                if "~releaselanguage" in self._new_metadata and not "language" in track.metadata:
+                    track.metadata["language"] = self._new_metadata["~releaselanguage"]
             del self._release_node
             self._tracks_loaded = True
 


### PR DESCRIPTION
Track languages are taken from the related work, however if the track
does not have a related work then language is not set even if it is set
in the Release.

This fix copies the release language to the track if there is no
language received from a related work.
