### PR TITLE
Fix refresh error when album and track selected.

### DIFF
--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -52,3 +52,6 @@ class Item(object):
 
     def is_album_like(self):
         return False
+
+    def load(self, priority=False, refresh=False):
+        pass


### PR DESCRIPTION
When you have album open and select album and first track and press
Ctrl-R, you get an error when it tries to run load method on track.
