### PR TITLE
Fix throttle decorator function...

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -312,7 +312,7 @@ def throttle(interval):
             else:
                 decorator.args = args
                 decorator.kwargs = kwargs
-                QtCore.QTimer.singleShot(r, partial(later))
+                QtCore.QTimer.singleShot(r, later)
                 decorator.is_ticking = True
             mutex.unlock()
 


### PR DESCRIPTION
... so that it uses args from last call before timer triggers rather than args when timer was set.
