### PR TITLE
Add %_musicbrainz_tracknumber% to fix Picard-527 ...

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -32,7 +32,8 @@
  * New %_absolutetracknumber% variable numbering tracks sequentially regardless of disc structure
    (so you can numbers tracks on multi-disc releases without a disc number)
  * Support dropping image directly from Google image results to cover art box
- * Add %_trackindex% to hold track # as shown on MusicBrainz release web-page e.g. vinyl/cassette style A1, A2, B1, B2
+ * Add %_musicbrainz_tracknumber% to hold track # as shown on MusicBrainz release web-page
+   e.g. vinyl/cassette style A1, A2, B1, B2
 
 
 Version 1.2 - 2013-03-30

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -226,7 +226,7 @@ def track_to_metadata(node, track):
         elif name == 'position':
             m['tracknumber'] = nodes[0].text
         elif name == 'number':
-            m['~trackindex'] = nodes[0].text
+            m['~~musicbrainz_tracknumber'] = nodes[0].text
         elif name == 'length' and nodes[0].text:
             m.length = int(nodes[0].text)
         elif name == 'artist_credit':


### PR DESCRIPTION
... for e.g. Vinyl whose tracks are numbered A1, A2, ..., B1, B2, ...

http://tickets.musicbrainz.org/browse/PICARD-527
