### PR TITLE
URGENT: Fix PR #225 when translate language is not en...

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -129,7 +129,7 @@ def _translate_artist_node(node):
                         transl, translsort = alias.text, alias.attribs["sort_name"]
                         if alias.attribs.get("primary") == "primary":
                             found_primary = True
-        if lang == "en" and not transl:
+        if not transl:
             translsort = node.sort_name[0].text
             transl = translate_from_sortname(node.name[0].text, translsort)
     else:


### PR DESCRIPTION
... and there are no correct locales in the artist sort-name node.

To recreate, in Options / Metadata, set Translate Artist Names to German, put 9c3e896d-a1f0-368e-bf5b-a189e8cea44e in the album search box and click search.

See http://forums.musicbrainz.org/viewtopic.php?pid=25627 for error report.

Fixes PR #225.
