### PR TITLE
Possible minor bugette in plugin.py

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -61,7 +61,7 @@ class ExtensionPoint(object):
         _extension_points.append(self)
 
     def register(self, module, item):
-        if module.startswith("picard.plugins"):
+        if module.startswith("picard.plugins."):
             module = module[15:]
         else:
             module = None


### PR DESCRIPTION
No known instances of this problem but ... if plugin was located in picard.plugins_fake.smurf then module would be set to "fake.smurf" rather than None.
