### PR TITLE
Store ReplayGain info for MP3s in ID3v2 instead of APE tags

### DIFF
--- a/contrib/plugins/replaygain/__init__.py
+++ b/contrib/plugins/replaygain/__init__.py
@@ -130,7 +130,7 @@ class ReplayGainOptionsPage(OptionsPage):
         TextOption("setting", "replaygain_vorbisgain_command", "vorbisgain"),
         TextOption("setting", "replaygain_vorbisgain_options", "-asf"),
         TextOption("setting", "replaygain_mp3gain_command", "mp3gain"),
-        TextOption("setting", "replaygain_mp3gain_options", "-a"),
+        TextOption("setting", "replaygain_mp3gain_options", "-a -s i"),
         TextOption("setting", "replaygain_metaflac_command", "metaflac"),
         TextOption("setting", "replaygain_metaflac_options", "--add-replay-gain"),
         TextOption("setting", "replaygain_wvgain_command", "wvgain"),


### PR DESCRIPTION
It's been supported by mp3gain for years now (http://mp3gain.cvs.sourceforge.net/viewvc/mp3gain/mp3gain/) and the docs say it's the preferred format in Picard: http://musicbrainz.org/doc/MusicBrainz_Picard/Documentation/Options#Tags

Also: http://wiki.hydrogenaudio.org/index.php?title=ReplayGain_1.0_specification#Metadata_format

Ultimately, it'd probably be best if you could set custom options from within the plugin settings in Picard.
