### PR TITLE
Fix sub-menu capability for plugins...

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -370,7 +370,7 @@ class BaseTreeView(QtGui.QTreeWidget):
             plugin_menus = {}
             for action in plugin_actions:
                 action_menu = plugin_menu
-                for index in xrange(1, len(action.MENU)+1):
+                for index in xrange(1, len(action.MENU) + 1):
                     key = tuple(action.MENU[:index])
                     if key in plugin_menus:
                         action_menu = plugin_menus[key]


### PR DESCRIPTION
1. xrange(x, y) goes from x to y-1. If len(MENU) is 1 this is never called. So add 1 to get correct range.
2. Exception handling is typically slower and code is less clear than if we just test for the key existing.

Addresses PICARD-580 http://tickets.musicbrainz.org/browse/PICARD-580.
