### PR TITLE
Include functionality to submit files to MusicBrainz in addrelease.py plugin

### DIFF
--- a/contrib/plugins/addrelease.py
+++ b/contrib/plugins/addrelease.py
@@ -152,7 +152,7 @@ class AddFileAsRecording(AddObjectAsEntity):
         nv = self.add_form_value
         nv("edit-recording.name", track.metadata["title"])
         nv("edit-recording.artist_credit.names.0.artist.name", track.metadata["artist"])
-        nv("edit-recording.length", str(track.metadata.length))
+        nv("edit-recording.length", track.metadata["~length"])
 
 
 class AddFileAsRelease(AddObjectAsEntity):


### PR DESCRIPTION
- This patch abstracts functionality previously grouped all into the `callback()` method of the `AddClusterAsRelease` class into a new parent class, `AddObjectAsEntity`.
- It then proceeds to use this new parent class to foster two new classes: `AddFileAsRecording` and `AddFileAsRelease` that allows for adding files as recordings and releases respectively.

I'm not sure about the updated `PLUGIN_NAME`. Suggestions welcome.
