### PR TITLE
Use Courier as monospace family to work on OS X too

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -92,6 +92,12 @@ class Tagger(QtGui.QApplication):
     __instance = None
 
     def __init__(self, args, localedir, autoupdate, debug=False):
+        # Workaround for https://bugreports.qt-project.org/browse/QTBUG-32789
+        if sys.platform == "win32":
+            QtGui.QFont.insertSubstitution("Monospace", "Courier New")
+        elif sys.platform == "darwin":
+            QtGui.QFont.insertSubstitution("Monospace", "Menlo")
+
         QtGui.QApplication.__init__(self, args)
         self.__class__.__instance = self
 

--- a/picard/ui/ui_options_renaming.py
+++ b/picard/ui/ui_options_renaming.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/options_renaming.ui'
 #
-# Created: Fri Apr  4 14:52:10 2014
+# Created: Fri Apr  4 20:28:09 2014
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -84,7 +84,7 @@ class Ui_RenamingOptionsPage(object):
         self.file_naming_format.setSizePolicy(sizePolicy)
         self.file_naming_format.setMinimumSize(QtCore.QSize(0, 0))
         font = QtGui.QFont()
-        font.setFamily(_fromUtf8("Courier"))
+        font.setFamily(_fromUtf8("Monospace"))
         self.file_naming_format.setFont(font)
         self.file_naming_format.viewport().setProperty("cursor", QtGui.QCursor(QtCore.Qt.IBeamCursor))
         self.file_naming_format.setTabChangesFocus(False)

--- a/picard/ui/ui_options_script.py
+++ b/picard/ui/ui_options_script.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/options_script.ui'
 #
-# Created: Fri Apr  4 14:52:10 2014
+# Created: Fri Apr  4 20:27:01 2014
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -38,7 +38,7 @@ class Ui_ScriptingOptionsPage(object):
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.tagger_script = QtGui.QTextEdit(self.enable_tagger_script)
         font = QtGui.QFont()
-        font.setFamily(_fromUtf8("Courier"))
+        font.setFamily(_fromUtf8("Monospace"))
         self.tagger_script.setFont(font)
         self.tagger_script.setLineWrapMode(QtGui.QTextEdit.NoWrap)
         self.tagger_script.setAcceptRichText(False)

--- a/ui/options_renaming.ui
+++ b/ui/options_renaming.ui
@@ -124,7 +124,7 @@
         </property>
         <property name="font">
          <font>
-          <family>Courier</family>
+          <family>Monospace</family>
          </font>
         </property>
         <property name="cursor" stdset="0">

--- a/ui/options_script.ui
+++ b/ui/options_script.ui
@@ -29,7 +29,7 @@
        <widget class="QTextEdit" name="tagger_script" >
         <property name="font" >
          <font>
-          <family>Courier</family>
+          <family>Monospace</family>
          </font>
         </property>
         <property name="lineWrapMode" >


### PR DESCRIPTION
I have the problem, that the file naming and scripting font on OS X  isn't monospace. 

Is this change sufficient and does it work on other systems too?
