### PR TITLE
Move ID3Metadata functionality to new_metadata property

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -89,6 +89,10 @@ class File(QtCore.QObject, Item):
     def __repr__(self):
         return '<File %r>' % self.base_filename
 
+    @property
+    def new_metadata(self):
+        return self.metadata
+
     def load(self, callback):
         thread.run_task(
             partial(self._load, self.filename),
@@ -214,9 +218,9 @@ class File(QtCore.QObject, Item):
                 temp_info[info] = self.orig_metadata[info]
             # Data is copied from New to Original because New may be a subclass to handle id3v23
             if config.setting["clear_existing_tags"]:
-                self.orig_metadata.copy(self.metadata)
+                self.orig_metadata.copy(self.new_metadata)
             else:
-                self.orig_metadata.update(self.metadata)
+                self.orig_metadata.update(self.new_metadata)
             self.orig_metadata.length = length
             self.orig_metadata['~length'] = format_time(length)
             for k, v in temp_info.items():
@@ -418,17 +422,18 @@ class File(QtCore.QObject, Item):
         return self.similarity == 1.0 and self.state == File.NORMAL
 
     def update(self, signal=True):
-        names = set(self.metadata.keys())
+        new_metadata = self.new_metadata
+        names = set(new_metadata.keys())
         names.update(self.orig_metadata.keys())
         clear_existing_tags = config.setting["clear_existing_tags"]
         for name in names:
             if not name.startswith('~') and self.supports_tag(name):
-                new_values = self.metadata.getall(name)
+                new_values = new_metadata.getall(name)
                 if not (new_values or clear_existing_tags):
                     continue
                 orig_values = self.orig_metadata.getall(name)
                 if orig_values != new_values:
-                    self.similarity = self.orig_metadata.compare(self.metadata)
+                    self.similarity = self.orig_metadata.compare(new_metadata)
                     if self.state in (File.CHANGED, File.NORMAL):
                         self.state = File.CHANGED
                     break

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -56,6 +56,8 @@ class Metadata(dict):
         ('totaltracks', 5),
     ]
 
+    multi_valued_joiner = MULTI_VALUED_JOINER
+
     def __init__(self):
         super(Metadata, self).__init__()
         self.images = []
@@ -252,7 +254,7 @@ class Metadata(dict):
     def get(self, name, default=None):
         values = dict.get(self, name, None)
         if values:
-            return MULTI_VALUED_JOINER.join(values)
+            return self.multi_valued_joiner.join(values)
         else:
             return default
 

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -359,7 +359,7 @@ class MetadataBox(QtGui.QTableWidget):
         clear_existing_tags = config.setting["clear_existing_tags"]
 
         for file in files:
-            new_metadata = file.metadata
+            new_metadata = file.new_metadata
             orig_metadata = file.orig_metadata
             tags = set(new_metadata.keys() + orig_metadata.keys())
 


### PR DESCRIPTION
The problem with `ID3Metadata` is that it changes the behavior of `Metadata` methods in undesirable ways (see PR #273).

Also, if we ever want to display the data as it exists on MusicBrainz somewhere, that's harder without adding new methods to hack around the ones we "broke."

This adds a `new_metadata` property to `File` classes which returns a copy with the values modified as they'd be displayed/saved. This should more composable and less error-prone than overriding `Metadata` methods across the board.

`new_metadata` is kinda vague, but still accurate, and I can't think of anything better at the moment.

Please review thoroughly so I can fix anything I broke. :)
