### PR TITLE
Fix loading MP3s without tags.

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -441,7 +441,7 @@ class MP3File(ID3File):
     def _info(self, metadata, file):
         super(MP3File, self)._info(metadata, file)
         id3version = ''
-        if file.info.layer == 3:
+        if file.tags is not None and file.info.layer == 3:
             id3version = ' - ID3v%d.%d' % (file.tags.version[0], file.tags.version[1])
         metadata['~format'] = 'MPEG-1 Layer %d%s' % (file.info.layer, id3version)
 


### PR DESCRIPTION
This patch is straight forward, it fixes setting the ID3 version when there are no tags at all in a MP3 file. Without this patch MP3 files without any tags cannot be loaded.
