### PR TITLE
Fix clustering sometimes displaying "Various Artists"

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -183,9 +183,10 @@ class Cluster(QtCore.QObject, Item):
         albumDict = ClusterDict()
         tracks = []
         for file in files:
+            artist = file.metadata["albumartist"] or file.metadata["artist"]
             album = file.metadata["album"]
             # For each track, record the index of the artist and album within the clusters
-            tracks.append((artistDict.add(file.metadata["artist"]),
+            tracks.append((artistDict.add(artist),
                            albumDict.add(album)))
 
         artist_cluster_engine = ClusterEngine(artistDict)
@@ -212,11 +213,12 @@ class Cluster(QtCore.QObject, Item):
             for track_id in album:
                 cluster = artist_cluster_engine.getClusterFromId(
                     tracks[track_id][0])
-                cnt = artist_hist.get(cluster, 0) + 1
-                if cnt > artist_max:
-                    artist_max = cnt
-                    artist_id = cluster
-                artist_hist[cluster] = cnt
+                if cluster is not None:
+                    cnt = artist_hist.get(cluster, 0) + 1
+                    if cnt > artist_max:
+                        artist_max = cnt
+                        artist_id = cluster
+                    artist_hist[cluster] = cnt
 
             if artist_id is None:
                 artist_name = u"Various Artists"


### PR DESCRIPTION
Issue has been reported at http://forums.musicbrainz.org/viewtopic.php?id=4911

This fix is twofold:
1. Fixes the bug where the clustering does not select an artist name when there are some artist names appearing only once and those are at the end of the tracklist. An example would be files tagged with the data from http://musicbrainz.org/release/98d4d6d1-68eb-4b2e-859d-fa63fe979509. The track artist "Atjazz & Jullian Gomes" appears four times, all the other artists with featuring only once. Those appearing only once are not counted at all by the clustering, but as there are more track artists not being counted (6 x feat.) than the counted one (4) the clustering used Various Artists instead.
2. Use album artist tag, if present in the files. This is not really related to the reported bug and it only applies to files with the album artist already in the tags, but it should lead to better results for already properly tagged files.

With this patch clusters will only have "Various Artists" set when there is either no artist set at all or all the tracks have different artists track artists (which is ok I guess).
