### PR TITLE
Tweak Standardise Performers

### DIFF
--- a/contrib/plugins/standardise_performers.py
+++ b/contrib/plugins/standardise_performers.py
@@ -22,8 +22,8 @@ Performer [synthesizer]: Lol Creme
 Performer [tambourine]: Graham Gouldman
 </pre>
 '''
-PLUGIN_VERSION = '0.1'
-PLUGIN_API_VERSIONS = ["1.3.0"]
+PLUGIN_VERSION = '0.2'
+PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0"]
 
 import re
 from picard import log


### PR DESCRIPTION
Since we have a try/except block so that this will run on previous versions, tweak the API_VERSIONS so that it will load on these versions of Picard.

Note: This is so I can maintain one copy of the code and add it to the Plugins wiki page.
