### PR TITLE
PICARD-605: Make file loading more resilient

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -290,11 +290,13 @@ class Tagger(QtGui.QApplication):
 
     def _file_loaded(self, file, target=None):
         if file is not None and not file.has_error():
-            recordingid = file.metadata['musicbrainz_recordingid']
+            recordingid = file.metadata.getall('musicbrainz_recordingid')[0] \
+                if 'musicbrainz_recordingid' in file.metadata else ''
             if target is not None:
                 self.move_files([file], target)
             elif not config.setting["ignore_file_mbids"]:
-                albumid = file.metadata['musicbrainz_albumid']
+                albumid = file.metadata.getall('musicbrainz_albumid')[0] \
+                    if 'musicbrainz_albumid' in file.metadata else ''
                 if mbid_validate(albumid):
                     if mbid_validate(recordingid):
                         self.move_file_to_track(file, albumid, recordingid)


### PR DESCRIPTION
Partial solution for [PICARD-605](http://tickets.musicbrainz.org/browse/PICARD-605)

recordingid and albumid should be single-value variables. If they have multiple-values, then use only the first one to make Picard more resilient.
