### PR TITLE
Fix conversion of : to _ in drive letter on windows

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -92,7 +92,8 @@ class Image(object):
             filename = os.path.join(dirname, filename)
         # replace incompatible characters
         if config.setting["windows_compatibility"] or sys.platform == "win32":
-            filename = replace_win32_incompat(filename)
+            drive, rest = os.path.splitdrive(filename)
+            filename = drive + replace_win32_incompat(rest)
         # remove null characters
         filename = filename.replace("\x00", "")
         return encode_filename(filename)


### PR DESCRIPTION
```
D: 19:02:00 Saving cover images to u'D_\\Audio\\Music\\Pop\\ABBA\\ABBA
(1992) Gold - Greatest Hits\\folder'
E: 19:02:00 Traceback (most recent call last):
File "picard\util\thread.pyo", line 46, in run
File "picard\file.pyo", line 197, in _save_and_rename
File "picard\file.pyo", line 326, in _save_images
File "picard\metadata.pyo", line 143, in save
File "os.pyo", line 150, in makedirs
File "os.pyo", line 150, in makedirs
File "os.pyo", line 150, in makedirs
File "os.pyo", line 150, in makedirs
File "os.pyo", line 150, in makedirs
File "os.pyo", line 157, in makedirs
WindowsError: [Error 5] Access is denied: u'D_'
```
