### PR TITLE
make_and_add_image(): prevent hash conflict in rare cases

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -188,6 +188,10 @@ class Metadata(dict):
         """
         m = md5()
         m.update(data)
+        # ensure we have no hash conflict, even if data is the same
+        # ie. CAA can have the same image uploaded twice with different types
+        for p in (mime, filename, comment, types, is_front):
+            m.update(repr(p))
         datahash = m.hexdigest()
         QObject.tagger.images.lock()
         image = QObject.tagger.images[datahash]


### PR DESCRIPTION
Include all parameters in hash calculation to prevent misbehavior
- CAA can have same data for 2 or more images (ie. same image uploaded twice with different types)
- adding few strings to hash calculation doesn't cost much
- results in case of cache key conflict are very unpredictable

See https://github.com/musicbrainz/picard/pull/232#discussion_r12419523
