### PR TITLE
Improve acoustid matching

### DIFF
--- a/picard/acoustid.py
+++ b/picard/acoustid.py
@@ -94,8 +94,7 @@ class AcoustIDClient(QtCore.QObject):
 
         doc = XmlNode()
         metadata_el = doc.append_child('metadata')
-        acoustid_el = metadata_el.append_child('acoustid')
-        recording_list_el = acoustid_el.append_child('recording_list')
+        recording_list_el = metadata_el.append_child('recording_list')
 
         if error:
             mparms = {

--- a/picard/acoustid.py
+++ b/picard/acoustid.py
@@ -49,7 +49,7 @@ class AcoustIDClient(QtCore.QObject):
 
         def make_artist_credit_node(parent, artists):
             artist_credit_el = parent.append_child('artist_credit')
-            for i, artist in enumerate(artists):
+            for artist in artists:
                 name_credit_el = artist_credit_el.append_child('name_credit')
                 artist_el = name_credit_el.append_child('artist')
                 artist_el.append_child('id').text = artist.id[0].text
@@ -76,6 +76,8 @@ class AcoustIDClient(QtCore.QObject):
                     release_el.attribs['id'] = release.id[0].text
                     release_group_el = release_el.append_child('release_group')
                     release_group_el.attribs['id'] = release_group.id[0].text
+                    if 'title' in release_group.children:
+                        release_group_el.append_child('title').text = release_group.title[0].text
                     if 'title' in release.children:
                         release_el.append_child('title').text = release.title[0].text
                     else:

--- a/picard/acoustid.py
+++ b/picard/acoustid.py
@@ -55,8 +55,8 @@ class AcoustIDClient(QtCore.QObject):
                 artist_el.append_child('id').text = artist.id[0].text
                 artist_el.append_child('name').text = artist.name[0].text
                 artist_el.append_child('sort_name').text = artist.name[0].text
-                if i > 0:
-                    name_credit_el.attribs['joinphrase'] = '; '
+                if 'joinphrase' in artist.children:
+                    name_credit_el.attribs['joinphrase'] = artist.joinphrase[0].text
             return artist_credit_el
 
         def parse_recording(recording):

--- a/picard/file.py
+++ b/picard/file.py
@@ -486,11 +486,7 @@ class File(QtCore.QObject, Item):
             return
 
         try:
-            m = document.metadata[0]
-            if lookuptype == "metadata":
-                tracks = m.recording_list[0].recording
-            elif lookuptype == "acoustid":
-                tracks = m.acoustid[0].recording_list[0].recording
+            tracks = document.metadata[0].recording_list[0].recording
         except (AttributeError, IndexError):
             tracks = None
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -65,8 +65,9 @@ class File(QtCore.QObject, Item):
         "artist": 4,
         "album": 5,
         "length": 10,
+        "tracknumber": 4,
         "totaltracks": 4,
-        "releasetype": 20,
+        "releasetype": 2,
         "releasecountry": 2,
         "format": 2,
     }

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -249,12 +249,28 @@ class Metadata(dict):
 
         if "totaltracks" in self and "totaltracks" in weights:
             a = int(self["totaltracks"])
-            if "title" in weights:
-                b = int(release.medium_list[0].medium[0].track_list[0].count)
-            else:
+            if "track_count" in release.medium_list[0].children:
                 b = int(release.medium_list[0].track_count[0].text)
+            else:
+                b = int(release.medium_list[0].medium[0].track_list[0].count)
             score = 0.0 if a > b else 0.3 if a < b else 1.0
             parts.append((score, weights["totaltracks"]))
+
+        if "tracknumber" in self and "tracknumber" in weights:
+            if "medium" in release.medium_list[0].children:
+                a = int(self["tracknumber"])
+                for medium in release.medium_list[0].medium:
+                    if "track_list" in medium.children \
+                        and "track" in medium.track_list[0].children:
+                        for track in medium.track_list[0].track:
+                            if 'position' in track.children:
+                                b = track.position[0].text
+                                score = 1.0 if a == b else 0
+                                parts.append((score, weights["tracknumber"]))
+                                break
+                        else:
+                            continue
+                        break
 
         preferred_countries = config.setting["preferred_release_countries"]
         preferred_formats = config.setting["preferred_release_formats"]

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -238,7 +238,7 @@ class Metadata(dict):
     def compare_to_release_parts(self, release, weights):
         parts = []
 
-        if "album" in self:
+        if "album" in self and "album" in weights:
             b = release.title[0].text
             parts.append((similarity2(self["album"], b), weights["album"]))
 
@@ -247,7 +247,7 @@ class Metadata(dict):
             b = artist_credit_from_node(release.artist_credit[0])[0]
             parts.append((similarity2(a, b), weights["albumartist"]))
 
-        if "totaltracks" in self:
+        if "totaltracks" in self and "totaltracks" in weights:
             a = int(self["totaltracks"])
             if "title" in weights:
                 b = int(release.medium_list[0].medium[0].track_list[0].count)
@@ -260,7 +260,7 @@ class Metadata(dict):
         preferred_formats = config.setting["preferred_release_formats"]
 
         total_countries = len(preferred_countries)
-        if total_countries:
+        if total_countries and "releasecountry" in weights:
             score = 0.0
             if "country" in release.children:
                 try:
@@ -271,7 +271,7 @@ class Metadata(dict):
             parts.append((score, weights["releasecountry"]))
 
         total_formats = len(preferred_formats)
-        if total_formats:
+        if total_formats and "format" in weights:
             score = 0.0
             subtotal = 0
             for medium in release.medium_list[0].medium:
@@ -304,18 +304,18 @@ class Metadata(dict):
     def compare_to_track(self, track, weights):
         parts = []
 
-        if 'title' in self:
+        if 'title' in self and "title" in weights:
             a = self['title']
             b = track.title[0].text
             parts.append((similarity2(a, b), weights["title"]))
 
-        if 'artist' in self:
+        if 'artist' in self and "artist" in weights:
             a = self['artist']
             b = artist_credit_from_node(track.artist_credit[0])[0]
             parts.append((similarity2(a, b), weights["artist"]))
 
         a = self.length
-        if a > 0 and 'length' in track.children:
+        if a > 0 and 'length' in track.children and "length" in weights:
             b = int(track.length[0].text)
             score = 1.0 - min(abs(a - b), 30000) / 30000.0
             parts.append((score, weights["length"]))


### PR DESCRIPTION
This PR enhances the acoustid matching process as follows:
1. Fix the join-phrase code so that artist string used for comparison is same as used in MB / Picard normally.
   (Previously appending ';' to next node rather than MB provided text to this node.)
2. Add tracknumber to the matching routine. (Note: I do not have sufficient tracks for testing to be able to tweak the values here - I have added this with the same weight as totaltracks.)
3. Check the number of sources for each release returned by acoustid server and eliminate those that have a very small number of sources cf. the maximum. 

Note: This should eliminate false fingerprints, but it will also eliminate true fingerprints of recordings on rarely submitted acoustids. We could perhaps do further checking for e.g. similar artists or similar titles to (say) any recordings which have more than 20% of the maximum and include these back in again. Feedback on this welcome.

This PR was prompted by discussion in a [forum thread](http://forums.musicbrainz.org/viewtopic.php?id=4978).
