### PR TITLE
Fix up albumartist_website plugin debug message

### DIFF
--- a/contrib/plugins/albumartist_website.py
+++ b/contrib/plugins/albumartist_website.py
@@ -119,7 +119,9 @@ class AlbumArtistWebsite:
                 if 'relation_list' in response.metadata[0].artist[0].children:
                     if 'relation' in response.metadata[0].artist[0].relation_list[0].children:
                         return self.artist_process_relations(response.metadata[0].artist[0].relation_list[0].relation)
-        log.error("%s: %r: MusicBrainz artist xml result not in correct format - %s", PLUGIN_NAME, artistId, response)
+            else:
+                log.error("%s: %r: MusicBrainz artist xml result not in correct format - %s",
+                          PLUGIN_NAME, artistId, response)
         return None
 
     def artist_process_relations(self, relations):


### PR DESCRIPTION
Traceback (most recent call last):
  File "picard\webservice.pyo", line 285, in _process_reply
  File "C:\Program Files (x86)\MusicBrainz Picard\plugins\albumartist_website.py", line 95, in website_process
    log.debug("%s: %r: Artist Official Homepages = %s", PLUGIN_NAME, artistId, url)
NameError: global name 'url' is not defined
