### PR TITLE
log.warning('Not enough data...') -> log.debug

### DIFF
--- a/picard/coverart.py
+++ b/picard/coverart.py
@@ -61,7 +61,7 @@ class CoverArt:
         if error:
             self.album.error_append(u'Coverart error: %s' % (unicode(http.errorString())))
         elif len(data) < 1000:
-            log.warning("Not enough data, skipping %s" % coverartimage)
+            log.debug("Not enough data, skipping %s" % coverartimage)
         else:
             self._message(
                 N_("Cover art of type '%(type)s' downloaded for %(albumid)s from %(host)s"),


### PR DESCRIPTION
This message is mostly emitted when attempting to retrieve cover art from amazon, it is returned when amazon url we build doesn't lead to an image (empty document is returned)
Having it as warning is spamming log and worrying the user ;)
