### PR TITLE
PICARD-690: Added a menu option to add 'new' files to tagger

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import signal
 import sys
+import time
 from functools import partial
 from itertools import chain
 
@@ -365,7 +366,7 @@ class Tagger(QtGui.QApplication):
             for file in new_files:
                 file.load(partial(self._file_loaded, target=target))
 
-    def add_directory(self, path):
+    def add_directory(self, path, period):
         ignore_hidden = config.setting["ignore_hidden_files"]
         walk = os.walk(unicode(path))
 
@@ -379,8 +380,14 @@ class Tagger(QtGui.QApplication):
             else:
                 number_of_files = len(files)
                 if number_of_files:
+                    number_of_new_files, new_files = 0, []
+                    for f in files:
+                        filepath = os.path.join(root, f)
+                        if (time.time() - os.path.getctime(filepath)) <= period:
+                            new_files.append(filepath)
+                            number_of_new_files += 1
                     mparms = {
-                        'count': number_of_files,
+                        'count': number_of_new_files,
                         'directory': root,
                     }
                     log.debug("Adding %(count)d files from '%(directory)s'" %
@@ -389,12 +396,14 @@ class Tagger(QtGui.QApplication):
                         ungettext(
                             "Adding %(count)d file from '%(directory)s' ...",
                             "Adding %(count)d files from '%(directory)s' ...",
-                            number_of_files),
+                            number_of_new_files),
                         mparms,
                         translate=None,
                         echo=None
                     )
-                return (os.path.join(root, f) for f in files)
+                    return new_files
+                else:  # The current folder only contains directories
+                    return (os.path.join(root, d) for d in dirs)
 
         def process(result=None, error=None):
             if result:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -380,14 +380,16 @@ class Tagger(QtGui.QApplication):
             else:
                 number_of_files = len(files)
                 if number_of_files:
-                    number_of_new_files, new_files = 0, []
-                    for f in files:
-                        filepath = os.path.join(root, f)
-                        if (time.time() - os.path.getctime(filepath)) <= period:
-                            new_files.append(filepath)
-                            number_of_new_files += 1
+                    new_files = []
+                    if period:
+                        for f in files:
+                            filepath = os.path.join(root, f)
+                            if (time.time() - os.path.getctime(filepath)) <= period:
+                                new_files.append(filepath)
+                    else:
+                        new_files = [os.path.join(root, f) for f in files]
                     mparms = {
-                        'count': number_of_new_files,
+                        'count': len(new_files),
                         'directory': root,
                     }
                     log.debug("Adding %(count)d files from '%(directory)s'" %
@@ -396,14 +398,14 @@ class Tagger(QtGui.QApplication):
                         ungettext(
                             "Adding %(count)d file from '%(directory)s' ...",
                             "Adding %(count)d files from '%(directory)s' ...",
-                            number_of_new_files),
+                            len(new_files)),
                         mparms,
                         translate=None,
                         echo=None
                     )
                     return new_files
                 else:  # The current folder only contains directories
-                    return (os.path.join(root, d) for d in dirs)
+                    return [os.path.join(root, d) for d in dirs]
 
         def process(result=None, error=None):
             if result:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -460,7 +460,7 @@ class BaseTreeView(QtGui.QTreeWidget):
                 if file:
                     files.append(file)
                 elif os.path.isdir(encode_filename(filename)):
-                    BaseTreeView.tagger.add_directory(filename)
+                    BaseTreeView.tagger.add_directory(filename, None)
                 else:
                     new_files.append(filename)
             elif url.scheme() in ("http", "https"):

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -703,7 +703,7 @@ class MainWindow(QtGui.QMainWindow):
                 (N_(u"In the last 24 hours"), 24*60*6)
             ])
             for op in combo_ops.keys():
-                combo.addItem(op)
+                combo.addItem(_(op))
             file_dialog.layout().addWidget(QtGui.QLabel(_(u"Files created:")))
             file_dialog.layout().addWidget(combo)
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -697,7 +697,7 @@ class MainWindow(QtGui.QMainWindow):
             combo = QtGui.QComboBox()
             # combo.setEditable(True) # Todo
             combo_ops = OrderedDict([
-                (N_(u"Anytime"), time.time()),
+                (N_(u"Anytime"), None),
                 (N_(u"In the last hour"), 1*60*60),
                 (N_(u"In the last 5 hours"), 5*60*60),
                 (N_(u"In the last 10 hours"), 10*60*60),

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -700,7 +700,7 @@ class MainWindow(QtGui.QMainWindow):
                 (N_(u"In the last hour"), 1*60*60),
                 (N_(u"In the last 5 hours"), 5*60*60),
                 (N_(u"In the last 10 hours"), 10*60*60),
-                (N_(u"In the last 24 hours"), 24*60*6)
+                (N_(u"In the last 24 hours"), 24*60*60)
             ])
             for op in combo_ops.keys():
                 combo.addItem(_(op))

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -694,18 +694,18 @@ class MainWindow(QtGui.QMainWindow):
             list_view = file_dialog.findChild(QtGui.QListView, "listView")
             list_view.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
             combo = QtGui.QComboBox()
-            # combo.setEditable(True); # Todo
+            # combo.setEditable(True) # Todo
             combo_ops = OrderedDict([
-                ("Anytime", time.time()),
-                ("In the last hour", 1*60*60),
-                ("In the last 5 hours", 5*60*60),
-                ("In the last 10 hours", 10*60*60),
-                ("In the last 24 hours", 24*60*6)
+                (N_(u"Anytime"), time.time()),
+                (N_(u"In the last hour"), 1*60*60),
+                (N_(u"In the last 5 hours"), 5*60*60),
+                (N_(u"In the last 10 hours"), 10*60*60),
+                (N_(u"In the last 24 hours"), 24*60*6)
             ])
             for op in combo_ops.keys():
                 combo.addItem(op)
-            file_dialog.layout().addWidget(QtGui.QLabel("Files created:"));
-            file_dialog.layout().addWidget(combo);
+            file_dialog.layout().addWidget(QtGui.QLabel(_(u"Files created:")))
+            file_dialog.layout().addWidget(combo)
 
             if file_dialog.exec_() == QtGui.QDialog.Accepted:
                 dir_list = file_dialog.selectedFiles()

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -679,6 +679,7 @@ class MainWindow(QtGui.QMainWindow):
         current_directory = find_starting_directory()
 
         dir_list = []
+        period = time.time()
         if not config.setting["toolbar_multiselect"]:
             directory = QtGui.QFileDialog.getExistingDirectory(self, "", current_directory)
             if directory:
@@ -709,7 +710,8 @@ class MainWindow(QtGui.QMainWindow):
 
             if file_dialog.exec_() == QtGui.QDialog.Accepted:
                 dir_list = file_dialog.selectedFiles()
-                new_file_option = combo.currentText()
+                new_file_option = combo.currentIndex()
+                period = combo_ops.items()[new_file_option][1]
 
         if len(dir_list) == 1:
             config.persist["current_directory"] = dir_list[0]
@@ -724,10 +726,6 @@ class MainWindow(QtGui.QMainWindow):
                 N_("Adding multiple directories from '%(directory)s' ..."),
                 {'directory': parent}
             )
-
-        for op, prd in combo_ops.items():
-            if op == new_file_option:
-                period = prd
 
         for directory in dir_list:
             directory = unicode(directory)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -21,6 +21,7 @@ from PyQt4 import QtCore, QtGui
 
 import sys
 import os.path
+import time
 
 from picard import config, log
 from picard.album import Album
@@ -340,6 +341,10 @@ class MainWindow(QtGui.QMainWindow):
         self.add_files_action.setShortcut(QtGui.QKeySequence.Open)
         self.add_files_action.triggered.connect(self.add_files)
 
+        self.add_new_files_action = QtGui.QAction(_("Add &New Files"), self)
+        self.add_new_files_action.setStatusTip(_(u"Add new files to the tagger"))
+        self.add_new_files_action.triggered.connect(self.add_new_files)
+
         self.add_directory_action = QtGui.QAction(icontheme.lookup('folder'), _(u"A&dd Folder..."), self)
         self.add_directory_action.setStatusTip(_(u"Add a folder to the tagger"))
         # TR: Keyboard shortcut for "Add Directory..."
@@ -498,6 +503,7 @@ class MainWindow(QtGui.QMainWindow):
         menu = self.menuBar().addMenu(_(u"&File"))
         menu.addAction(self.add_directory_action)
         menu.addAction(self.add_files_action)
+        menu.addAction(self.add_new_files_action)
         menu.addSeparator()
         menu.addAction(self.play_file_action)
         menu.addAction(self.open_folder_action)
@@ -671,6 +677,20 @@ class MainWindow(QtGui.QMainWindow):
             files = map(unicode, files)
             config.persist["current_directory"] = os.path.dirname(files[0])
             self.tagger.add_files(files)
+
+    def add_new_files(self):
+        """Add new files to the tagger."""
+        files = []
+        period = 5*60*60 # 5 hours
+
+        current_directory = find_starting_directory()
+        for fileName in os.listdir(current_directory):
+            filePath = os.path.join(current_directory, fileName)
+            if (time.time() - os.path.getmtime(filePath)) <= period:
+                # log.debug("%s", filePath)
+                files.append(filePath)
+
+        self.tagger.add_files(files)
 
     def add_directory(self):
         """Add directory to the tagger."""


### PR DESCRIPTION
A file is considered 'new' if it has been modified in the last five hours. This setting can be stored in the config later. Only the starting directory is scanned for new files currently. A context menu option can be added to the treeview to add new files from a folder.
