### PR TITLE
Fix evaluation of script functions with zero arguments.

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -176,9 +176,12 @@ Grammar:
         results = []
         while True:
             result, ch = self.parse_expression(False)
-            if (result):
-                results.append(result)
+            results.append(result)
             if ch == ')':
+                # Only an empty expression as first argument
+                # is the same as no argument given.
+                if len(results) == 1 and results[0] == []:
+                    return []
                 return results
 
     def parse_function(self):
@@ -580,7 +583,7 @@ def func_gte(parser, x, y):
     return ""
 
 
-def func_len(parser, text):
+def func_len(parser, text=""):
     return str(len(text))
 
 
@@ -599,7 +602,7 @@ def func_matchedtracks(parser, arg):
     return "0"
 
 
-def func_firstalphachar(parser, text, nonalpha="#"):
+def func_firstalphachar(parser, text="", nonalpha="#"):
     if len(text) == 0:
         return nonalpha
     firstchar = text[0]
@@ -609,7 +612,7 @@ def func_firstalphachar(parser, text, nonalpha="#"):
         return nonalpha
 
 
-def func_initials(parser, text):
+def func_initials(parser, text=""):
     return "".join(a[:1] for a in text.split(" ") if a[:1].isalpha())
 
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -2,7 +2,7 @@ import unittest
 import picard
 from PyQt4 import QtCore
 from picard import config
-from picard.script import ScriptParser
+from picard.script import ScriptParser, ScriptError, register_script_function
 from picard.metadata import Metadata
 from picard.ui.options.renaming import _DEFAULT_FILE_NAMING_FORMAT
 
@@ -13,9 +13,13 @@ class ScriptParserTest(unittest.TestCase):
             'enabled_plugins': '',
         }
         self.parser = ScriptParser()
+        def func_noargstest(parser):
+            return ""
+        register_script_function(func_noargstest, "noargstest")
 
     def test_cmd_noop(self):
         self.assertEqual(self.parser.eval("$noop()"), "")
+        self.assertEqual(self.parser.eval("$noop(abcdefg)"), "")
 
     def test_cmd_if(self):
         self.assertEqual(self.parser.eval("$if(1,a,b)"), "a")
@@ -181,6 +185,7 @@ class ScriptParserTest(unittest.TestCase):
 
     def test_cmd_len(self):
         self.assertEqual(self.parser.eval("$len(abcdefg)"), "7")
+        self.assertEqual(self.parser.eval("$len(0)"), "1")
         self.assertEqual(self.parser.eval("$len()"), "0")
 
     def test_cmd_firstalphachar(self):
@@ -313,3 +318,10 @@ class ScriptParserTest(unittest.TestCase):
         context['title'] = u'title'
         result = self.parser.eval(_DEFAULT_FILE_NAMING_FORMAT, context)
         self.assertEqual(result, u'artist/title')
+
+    def test_cmd_with_not_arguments(self):
+        try:
+            self.parser.eval("$noargstest()")
+        except ScriptError:
+            self.fail("Function noargs raised ScriptError unexpectedly.")
+        


### PR DESCRIPTION
This fixes the evaluation of script functions with zero arguments (that is the Python function does not take any additional argument despite the `parser`argument).

An example of such a function would be:

```
def is_video(parser):
    """Returns true, if the file processed is a video file."""
    if parser.context['~extension'] in ['m4v', 'wmv', 'ogv', 'oggtheora']:
        return "1"
    else:
        return ""
```

Without the fix the evaluation of that function will fail with `picard.script.ScriptError: Wrong number of arguments for $is_video: Expected 0 - 0, got 1 at position 25, line 2`.
