### PR TITLE
Fixed plugin precedence for the first plugin in plugin list.

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -201,7 +201,7 @@ class PluginManager(QtCore.QObject):
                                      sorted(compatible_versions)]))
                 plugin.compatible = True
                 setattr(picard.plugins, name, plugin_module)
-                if index:
+                if index is not None:
                     self.plugins[index] = plugin
                 else:
                     self.plugins.append(plugin)


### PR DESCRIPTION
If a plugin was in both the system wide and ther user's plugin folder and the plugin was the first in the list the plugin was loaded and listed twice (due to index = 0 evaluating to False).
