### PR TITLE
Allow one to modify default behavior when moving files using a plugin

### DIFF
--- a/contrib/plugins/file_move.py
+++ b/contrib/plugins/file_move.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+PLUGIN_NAME = u"Copy files instead of moving them"
+PLUGIN_AUTHOR = u'Zas'
+PLUGIN_DESCRIPTION = "Replace shutil.move() by shutil.copy2()."
+PLUGIN_VERSION = "0.1"
+PLUGIN_API_VERSIONS = ["1.3.0"]
+
+import shutil
+
+from picard.file import register_file_move
+from picard import log
+
+def _file_move(old, new):
+    log.debug("Copy %r to %r" % (old, new))
+    shutil.copy2(old, new)
+
+register_file_move(_file_move)

--- a/picard/file.py
+++ b/picard/file.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 from PyQt4 import QtCore
 from picard import config, log
 from picard.metadata import Metadata
+from picard.plugin import ExtensionPoint
 from picard.ui.item import Item
 from picard.script import ScriptParser
 from picard.util import (
@@ -48,6 +49,20 @@ from picard.util.textencoding import (
 )
 from picard.util.filenaming import make_short_filename
 from picard.util.tags import PRESERVED_TAGS
+
+
+file_move = ExtensionPoint()
+
+def register_file_move(function):
+    file_move.register(function.__module__, function)
+
+
+def _file_move(old_file, new_file):
+    if file_move:
+        for function in file_move:
+            function(old_file, new_file)
+    else:
+        shutil.move(old_file, new_file)
 
 
 class File(QtCore.QObject, Item):
@@ -326,7 +341,7 @@ class File(QtCore.QObject, Item):
             i += 1
         new_filename = new_filename + ext
         log.debug("Moving file %r => %r", old_filename, new_filename)
-        shutil.move(encode_filename(old_filename), encode_filename(new_filename))
+        _file_move(encode_filename(old_filename), encode_filename(new_filename))
         return new_filename
 
     def _save_images(self, dirname, metadata):
@@ -353,7 +368,7 @@ class File(QtCore.QObject, Item):
                     log.debug("File loaded in the tagger, not moving %r", old_file)
                     continue
                 log.debug("Moving %r to %r", old_file, new_file)
-                shutil.move(old_file, new_file)
+                _file_move(old_file, new_file)
 
     def remove(self, from_parent=True):
         if from_parent and self.parent:

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -83,6 +83,15 @@ class ExtensionPoint(object):
             if module is None or module in enabled_plugins:
                 yield item
 
+    def __nonzero__(self):
+        return bool(self.__items)
+
+    def __len__(self):
+        return len(self.__items)
+
+    def __contains__(self, value):
+        return value in self.__items
+
 
 class PluginWrapper(object):
 


### PR DESCRIPTION
Basically, it adds a plugin hook to replace `shutil.move()` call by whatever the user prefers.
A sample (and simple) plugin was added to `contrib/plugins`

Not ready to be merged, for testing and feedback only.

Related to:
http://tickets.musicbrainz.org/browse/PICARD-623
http://tickets.musicbrainz.org/browse/PICARD-422
