### PR TITLE
[PICARD-519] Fix up hacky resize/restore/save of metadata box columns

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -156,6 +156,7 @@ class MetadataBox(QtGui.QTableWidget):
         self.setColumnCount(3)
         self.setHorizontalHeaderLabels((_("Tag"), _("Original Value"), _("New Value")))
         self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setResizeMode(QtGui.QHeaderView.ResizeToContents)
         self.horizontalHeader().setClickable(False)
         self.verticalHeader().setDefaultSectionSize(21)
         self.verticalHeader().setVisible(False)
@@ -466,6 +467,7 @@ class MetadataBox(QtGui.QTableWidget):
         state = config.persist["metadatabox_header_state"]
         header = self.horizontalHeader()
         header.restoreState(state)
+        header.setResizeMode(QtGui.QHeaderView.Interactive)
 
     def save_state(self):
         header = self.horizontalHeader()


### PR DESCRIPTION
Replace `metadata_box_sizes` option by QByteArray `metadatabox_header_state` and
simply rely on Qt `QHeaderView::restoreState()` and `QHeaderView::saveState()`

This change implies metadata box columns aren't auto resized when changing main window size, but instead scrollbar may appear.

Overall, it is still user-friendly enough and much more reliable.

See http://tickets.musicbrainz.org/browse/PICARD-519
Related to https://github.com/musicbrainz/picard/pull/176
