### PR TITLE
PICARD-631: honour preferred release formats when matching AcoustIds

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -55,6 +55,7 @@
    Performer [piano] and Performer [guitar].
  * Add support for release group cover art fallback (PICARD-418, PICARD-53)
  * Add a clear button to search box
+ * Honour preferred release formats when matching AcoustIds (PICARD-631)
 
 Version 1.2 - 2013-03-30
  * Picard now requires at least Python 2.6

--- a/picard/acoustid.py
+++ b/picard/acoustid.py
@@ -86,6 +86,8 @@ class AcoustIDClient(QtCore.QObject):
                     medium_list_el.attribs['count'] = release.medium_count[0].text
                     for medium in release.mediums[0].medium:
                         medium_el = medium_list_el.append_child('medium')
+                        if 'format' in medium.children:
+                            medium_el.append_child('format').text = medium.format[0].text
                         track_list_el = medium_el.append_child('track_list')
                         track_list_el.attribs['count'] = medium.track_count[0].text
                         for track in medium.tracks[0].track:


### PR DESCRIPTION
`format` wasn't copied to rebuild xml node during acoustid matching

http://tickets.musicbrainz.org/browse/PICARD-631
