### PR TITLE
PICARD-630: linear_combination_of_weights() raises ZeroDivisionError

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -56,6 +56,7 @@
  * Add support for release group cover art fallback (PICARD-418, PICARD-53)
  * Add a clear button to search box
  * Honour preferred release formats when matching AcoustIds (PICARD-631)
+ * Prevent ZeroDivisionError in some rare cases (PICARD-630)
 
 Version 1.2 - 2013-03-30
  * Picard now requires at least Python 2.6

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -336,6 +336,8 @@ def linear_combination_of_weights(parts):
             raise ValueError, "Weight must be greater than or equal to 0.0"
         total += weight
         sum_of_products += value * weight
+    if total == 0.0:
+        return 0.0
     return sum_of_products / total
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -104,7 +104,7 @@ class LinearCombinationTest(unittest.TestCase):
 
     def test_0(self):
         parts = []
-        self.assertRaises(ZeroDivisionError, util.linear_combination_of_weights, parts)
+        self.assertEqual(util.linear_combination_of_weights(parts), 0.0)
 
     def test_1(self):
         parts = [(1.0, 1), (1.0, 1), (1.0, 1)]


### PR DESCRIPTION
It happens in rare cases that the function is called with empty list, so just handle it gracefully, returning 0.0 instead of raising ZeroDivisionError.

http://tickets.musicbrainz.org/browse/PICARD-630
