### PR TITLE
Display main libs versions in debug log

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -78,6 +78,7 @@ from picard.util import (
     check_io_encoding,
     uniqify,
     is_hidden_path,
+    versions,
 )
 from picard.webservice import XmlWebService
 
@@ -135,9 +136,10 @@ class Tagger(QtGui.QApplication):
 
         # Setup logging
         self.debug(debug or "PICARD_DEBUG" in os.environ)
-        log.debug("Starting Picard %s from %r", picard.__version__, os.path.abspath(__file__))
+        log.debug("Starting Picard from %r", os.path.abspath(__file__))
         log.debug("Platform: %s %s %s", platform.platform(),
                   platform.python_implementation(), platform.python_version())
+        log.debug("Versions: %s", versions.as_string())
         if config.storage_type == config.REGISTRY_PATH:
             log.debug("Configuration registry path: %s", config.storage)
         else:

--- a/picard/ui/options/about.py
+++ b/picard/ui/options/about.py
@@ -17,14 +17,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from mutagen import version_string as mutagen_version
-from PyQt4.QtCore import PYQT_VERSION_STR as pyqt_version
-from picard import PICARD_FANCY_VERSION_STR
 from picard.const import PICARD_URLS
 from picard.formats import supported_formats
 from picard.ui.options import OptionsPage, register_options_page
 from picard.ui.ui_options_about import Ui_AboutOptionsPage
-from picard.disc import discid_version
+from picard.util import versions
 
 
 class AboutOptionsPage(OptionsPage):
@@ -42,13 +39,10 @@ class AboutOptionsPage(OptionsPage):
 
     def load(self):
         args = {
-            "version": PICARD_FANCY_VERSION_STR,
-            "mutagen-version": mutagen_version,
-            "pyqt-version": pyqt_version,
-            "discid-version": discid_version or _("is not installed"),
             "picard-doc-url": PICARD_URLS['home'],
             "picard-donate-url": PICARD_URLS['donate'],
         }
+        args.update(versions.as_dict(i18n=True))
 
         formats = []
         for exts, name in supported_formats():

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2006-2014 Lukáš Lalinský
+# Copyright (C) 2014 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from mutagen import version_string as mutagen_version
+from PyQt4.QtCore import PYQT_VERSION_STR as pyqt_version
+from picard import PICARD_FANCY_VERSION_STR
+from picard.disc import discid_version
+
+
+_versions = {
+    "version": PICARD_FANCY_VERSION_STR,
+    "pyqt-version": pyqt_version,
+    "mutagen-version": mutagen_version,
+    "discid-version": discid_version,
+}
+
+_names = {
+    "version": "Picard",
+    "pyqt-version": "PyQt",
+    "mutagen-version": "Mutagen",
+    "discid-version": "Discid",
+}
+
+
+def _value_as_text(value, i18n=False):
+    if not value:
+        value = N_("is not installed")
+        if i18n:
+            return _(value)
+    return value
+
+
+def as_dict(i18n=False):
+    return dict([(key, _value_as_text(value, i18n)) for key, value in
+                 _versions.iteritems()])
+
+
+def as_string(i18n=False, separator=", "):
+    return separator.join([_names[key] + " " + value for key, value in
+                           as_dict(i18n).items()])


### PR DESCRIPTION
We were already displaying pyqt, mutagen and discid versions in About dialog, now they'll be shown in debug log too.
It will help with debug logs provided by users.

**Before** this patch, debug log output starts with:

```
D: 10:38:54 Debug mode on
D: 10:38:54 Starting Picard 1.3.0dev4 from '/home/zas/src/picard_zas/picard/tagger.py'
D: 10:38:54 Platform: Linux-3.13.0-24-generic-x86_64-with-LinuxMint-17-qiana CPython 2.7.6
D: 10:38:54 Configuration file path: /home/zas/.config/MusicBrainz/Picard.conf
```

**After** this patch, debug log output starts with:

```
D: 10:40:04 Debug mode on
D: 10:40:04 Starting Picard from '/home/zas/src/picard_zas/picard/tagger.py'
D: 10:40:04 Platform: Linux-3.13.0-24-generic-x86_64-with-LinuxMint-17-qiana CPython 2.7.6
D: 10:40:04 Versions: Picard 1.3.0dev4, PyQt 4.10.4, Mutagen 1.22, Discid discid 1.1.0 (compat layer from python-libdiscid 0.4.1), libdiscid 0.6.1
D: 10:40:04 Configuration file path: /home/zas/.config/MusicBrainz/Picard.conf
```
