### PR TITLE
PICARD-227: Display read discid in Album info dialog

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -166,4 +166,12 @@ class AlbumInfoDialog(InfoDialog):
             self.ui.info.setText(text + '<hr />')
         else:
             tabWidget.setTabText(tab_index, _("&Info"))
-            self.tab_hide(tab)
+            if "musicbrainz_discid" in album.metadata:
+                info = []
+                info.append((_('Discid:'), album.metadata["musicbrainz_discid"]))
+                text = '<br/>'.join(map(lambda i: '<b>%s</b><br/>%s' %
+                                (cgi.escape(i[0]),
+                                 cgi.escape(i[1])), info))
+                self.ui.info.setText(text)
+            else:
+                self.tab_hide(tab)


### PR DESCRIPTION
If a discid was read via CD Lookup feature, and associated to an album, display
the discid in the Album info dialog (from album's context menu).

http://tickets.musicbrainz.org/browse/PICARD-227