### PR TITLE
Fix the working directory for shortcuts created by the Windows installer

### DIFF
--- a/installer/picard-setup.nsi.in
+++ b/installer/picard-setup.nsi.in
@@ -140,18 +140,21 @@ SubSection "Shortcuts" shortcuts
   
   Section "Startmenu" startmenu
     SetShellVarContext all
+    SetOutPath "$INSTDIR"
     CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}.lnk" "$INSTDIR\picard.exe" \
       "" "" "" SW_SHOWNORMAL "" "${PRODUCT_DESCRIPTION}"
   SectionEnd
   
   Section "Desktop" desktop
     SetShellVarContext all
+    SetOutPath "$INSTDIR"
     CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\picard.exe" \
       "" "" "" SW_SHOWNORMAL "" "${PRODUCT_DESCRIPTION}"
   SectionEnd
   
   Section "Quick Launch" quicklaunch
     SetShellVarContext all
+    SetOutPath "$INSTDIR"
     CreateShortCut "$QUICKLAUNCH\${PRODUCT_NAME}.lnk" "$INSTDIR\picard.exe" \
       "" "" "" SW_SHOWNORMAL "" "${PRODUCT_DESCRIPTION}"
   SectionEnd


### PR DESCRIPTION
In NSIS the working directory for shortcuts is controlled by the SetOutPath variable, see http://nsis.sourceforge.net/Docs/Chapter4.html#createshortcut . In our case this caused the working directory to be set to the "locale" directory.

Fixes [PICARD-649](http://tickets.musicbrainz.org/browse/PICARD-649)
