### PR TITLE
PICARD-659: Set the originalyear tag when loading a release

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -367,6 +367,8 @@ def release_group_to_metadata(node, m, release_group=None):
             m['~releasegroupcomment'] = nodes[0].text
         elif name == 'first_release_date':
             m['originaldate'] = nodes[0].text
+            if m['originaldate']:
+                m['originalyear'] = m['originaldate'][:4]
         elif name == 'tag_list':
             add_folksonomy_tags(nodes[0], release_group)
         elif name == 'user_tag_list':


### PR DESCRIPTION
Another small and straightforward commit. Since Picard now supports both a `originaldate` and `originalyear` field it should also fill both,

In https://github.com/musicbrainz/picard/commit/388b429b0b35b9a1608156b66bb7ec3b1c8e3e51 I actually already used both tags (since ASF tags distinguish between both fields), so this commit is necessary for that to work as intented.
