### PR TITLE
PICARD-661: evaluate tagger script for album art filename

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -30,6 +30,7 @@ from hashlib import md5
 from PyQt4.QtCore import QUrl, QObject, QMutex
 from picard import config, log
 from picard.coverart.utils import translate_caa_type
+from picard.script import ScriptParser
 from picard.util import (
     encode_filename,
     replace_win32_incompat,
@@ -231,6 +232,7 @@ class CoverArtImage:
         return self.types[0]
 
     def _make_image_filename(self, filename, dirname, metadata):
+        filename = ScriptParser().eval(filename, metadata)
         if config.setting["ascii_filenames"]:
             if isinstance(filename, unicode):
                 filename = unaccent(filename)


### PR DESCRIPTION
This was possible in Picard 1.2 but broke with commit 5a2eee348484403bf10d0617ce4dff462db1ad2f

Fixes PICARD-661
