### PR TITLE
Do not run the HiddenFileTest unit tests on Windows.

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+import sys
 import unittest
 from picard import util
 
@@ -73,6 +74,7 @@ class FormatTimeTest(unittest.TestCase):
 
 class HiddenFileTest(unittest.TestCase):
 
+    @unittest.skipUnless(sys.platform != "win32", "non-windows test")
     def test(self):
         self.assertTrue(util.is_hidden('/a/b/.c.mp3'))
         self.assertTrue(util.is_hidden('/a/.b/.c.mp3'))


### PR DESCRIPTION
The unit tests only consider the string and whether any path component starts with a ".". On Windows the dotfiles are not used for hidden files so the tests always fail. To have proper tests on Windows would require to have an actual folder structure with hidden files and folders.

This is an addition to pull request #370
