### PR TITLE
PICARD-663: Renaming paths starting with "[a-z]:" being interpreted as drive names on Windows

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -134,7 +134,7 @@ def replace_win32_incompat(string, repl=u"_"):
     """Replace win32 filename incompatible characters from ``string`` by
        ``repl``."""
     # Don't replace : with _ for windows drive
-    if os.path.isabs(string):
+    if sys.platform == "win32" and os.path.isabs(string):
         drive, rest = ntpath.splitdrive(string)
         return drive + _re_win32_incompat.sub(repl, rest)
     else:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+import sys
 import unittest
 from picard import util
 
@@ -12,15 +13,25 @@ if '_' not in __builtin__.__dict__:
 
 class ReplaceWin32IncompatTest(unittest.TestCase):
 
-    def test_correct(self):
+    @unittest.skipUnless(sys.platform == "win32", "windows test")
+    def test_correct_absolute_win32(self):
         self.assertEqual(util.replace_win32_incompat("c:\\test\\te\"st/2"),
                              "c:\\test\\te_st/2")
         self.assertEqual(util.replace_win32_incompat("c:\\test\\d:/2"),
                              "c:\\test\\d_/2")
+
+    @unittest.skipUnless(sys.platform != "win32", "non-windows test")
+    def test_correct_absolute_non_win32(self):
+        self.assertEqual(util.replace_win32_incompat("/test/te\"st/2"),
+                             "/test/te_st/2")
+        self.assertEqual(util.replace_win32_incompat("/test/d:/2"),
+                             "/test/d_/2")
+
+    def test_correct_relative(self):
         self.assertEqual(util.replace_win32_incompat("A\"*:<>?|b"),
                              "A_______b")
-        self.assertEqual(util.replace_win32_incompat("d:test"),
-                             "d_test")
+        self.assertEqual(util.replace_win32_incompat("d:tes<t"),
+                             "d_tes_t")
 
     def test_incorrect(self):
         self.assertNotEqual(util.replace_win32_incompat("c:\\test\\te\"st2"),


### PR DESCRIPTION
This happens when the evaluated renaming script starts with e.g. "e:" as it happened in the bug report for the artist name `e:o:nity`.

Fixes [PICARD-663](http://tickets.musicbrainz.org/browse/PICARD-663)
