### PR TITLE
Fix errors during configuration update when reading obsolete options.

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -92,7 +92,7 @@ def upgrade_to_v1_3_0_dev_1():
     old_opt = "windows_compatible_filenames"
     new_opt = "windows_compatibility"
     if old_opt in _s:
-        _s[new_opt] = _s.value(old_opt, config.BoolOption)
+        _s[new_opt] = _s.value(old_opt, config.BoolOption, True)
         _s.remove(old_opt)
 
 


### PR DESCRIPTION
This fix makes old confiuration options, for which there is no Option instance in the code anymore, accessible.

Fixes [PICARD-642](http://tickets.musicbrainz.org/browse/PICARD-642).

@mwiencek: Since you reworked the parts of the code that finally led to this, you maybe have some better idea how to implement this.
