### PR TITLE
Removable tags

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -140,11 +140,14 @@ class File(QtCore.QObject, Item):
             values = self.orig_metadata.getall(tag)
             if values:
                 saved_metadata[tag] = values
+        deleted_tags = set(self.metadata.deleted_tags)
         self.metadata.copy(metadata)
+        self.metadata.deleted_tags = deleted_tags
         for tag, values in saved_metadata.iteritems():
             self.metadata.set(tag, values)
 
-        self.metadata["acoustid_id"] = acoustid
+        if acoustid:
+            self.metadata["acoustid_id"] = acoustid
 
     def has_error(self):
         return self.state == File.ERROR

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -224,7 +224,7 @@ class MP4File(File):
 
     def _get_tag_name(self, name):
         if name.startswith('lyrics:'):
-            name = 'lyrics'
+            return 'lyrics'
         if name in self.__r_text_tags:
             return self.__r_text_tags[name]
         elif name in self.__r_bool_tags:

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -209,6 +209,11 @@ class MP4File(File):
         if covr:
             file.tags["covr"] = covr
 
+        for tag in metadata.deleted_tags:
+            real_name = self._get_tag_name(tag)
+            if real_name and real_name in file.tags:
+                del file.tags[real_name]
+
         file.save()
 
     def supports_tag(self, name):
@@ -216,6 +221,26 @@ class MP4File(File):
             or name in self.__r_freeform_tags\
             or name in self.__other_supported_tags\
             or name.startswith('lyrics:')
+
+    def _get_tag_name(self, name):
+        if name.startswith('lyrics:'):
+            name = 'lyrics'
+        if name in self.__r_text_tags:
+            return self.__r_text_tags[name]
+        elif name in self.__r_bool_tags:
+            return self.__r_bool_tags[name]
+        elif name in self.__r_int_tags:
+            return self.__r_int_tags[name]
+        elif name in self.__r_freeform_tags:
+            return self.__r_freeform_tags[name]
+        elif name == "musicip_fingerprint":
+            return "----:com.apple.iTunes:fingerprint"
+        elif name == "tracknumber":
+            return "trkn"
+        elif name == "discnumber":
+            return "disk"
+        else:
+            return None
 
     def _info(self, metadata, file):
         super(MP4File, self)._info(metadata, file)

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -46,6 +46,7 @@ class Metadata(dict):
     def __init__(self):
         super(Metadata, self).__init__()
         self.images = []
+        self.deleted_tags = set()
         self.length = 0
 
     def append_image(self, coverartimage):
@@ -214,11 +215,13 @@ class Metadata(dict):
             self.images = other.images[:]
         if other.length:
             self.length = other.length
+        self.deleted_tags.update(other.deleted_tags)
 
     def clear(self):
         dict.clear(self)
         self.images = []
         self.length = 0
+        self.deleted_tags = set()
 
     def getall(self, name):
         return dict.get(self, name, [])
@@ -235,23 +238,32 @@ class Metadata(dict):
 
     def set(self, name, values):
         dict.__setitem__(self, name, values)
+        if name in self.deleted_tags:
+            self.deleted_tags.remove(name)
 
     def __setitem__(self, name, values):
         if not isinstance(values, list):
             values = [values]
         values = filter(None, map(unicode, values))
         if len(values):
-            dict.__setitem__(self, name, values)
+            self.set(name, values)
         else:
-            self.pop(name, None)
+            self.delete(name)
 
     def add(self, name, value):
         if value or value == 0:
             self.setdefault(name, []).append(value)
+            if name in self.deleted_tags:
+                self.deleted_tags.remove(name)
 
     def add_unique(self, name, value):
         if value not in self.getall(name):
             self.add(name, value)
+
+    def delete(self, name):
+        if name in self:
+            self.pop(name, None)
+        self.deleted_tags.add(name)
 
     def iteritems(self):
         for name, values in dict.iteritems(self):

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -98,11 +98,18 @@ class FormatsTest(unittest.TestCase):
         metadata = Metadata()
         for (key, value) in self.tags.iteritems():
             metadata[key] = value
+        if self.supports_ratings:
+            metadata['~rating'] = 1
         original_metadata = save_and_load_metadata(self.filename, metadata)
         metadata.delete('albumartist')
+        if self.supports_ratings:
+            metadata.delete('~rating')
         new_metadata = save_and_load_metadata(self.filename, metadata)
         self.assertIn('albumartist', original_metadata.keys())
         self.assertNotIn('albumartist', new_metadata.keys())
+        if self.supports_ratings:
+            self.assertIn('~rating', original_metadata.keys())
+            self.assertNotIn('~rating', new_metadata.keys())
 
     def test_ratings(self):
         if not self.original or not self.supports_ratings:

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -92,6 +92,18 @@ class FormatsTest(unittest.TestCase):
             #    print "%r" % loaded_metadata
             self.assertEqual(loaded_metadata[key], value, '%s: %r != %r' % (key, loaded_metadata[key], value))
 
+    def test_delete_tags(self):
+        if not self.original:
+            return
+        metadata = Metadata()
+        for (key, value) in self.tags.iteritems():
+            metadata[key] = value
+        original_metadata = save_and_load_metadata(self.filename, metadata)
+        metadata.delete('albumartist')
+        new_metadata = save_and_load_metadata(self.filename, metadata)
+        self.assertIn('albumartist', original_metadata.keys())
+        self.assertNotIn('albumartist', new_metadata.keys())
+
     def test_ratings(self):
         if not self.original or not self.supports_ratings:
             return


### PR DESCRIPTION
This implements the ability to remove existing tags from within Picard. The user can remove all values of a multivalue tag or delete an entire tag. Deleted tags will be removed from the file on saving.

This fixes both [PICARD-287](http://tickets.musicbrainz.org/browse/PICARD-287) and [PICARD-546](http://tickets.musicbrainz.org/browse/PICARD-546)

**This is work in progress**. The general functionality and the UI is ready, but the deletion requires format specific code I have so far implemented only for MP4 and Vorbis. It still needs to be implemented for ID3, ASF and Ape (that's why the tests are failing).

I would like to gather some early feedback. One thing that is obvious from the changes to formats/mp4.py and formats/vorbis.py that the code required to get the proper tag name introduces some duplication. This requires maybe some more serious refactoring, but I wanted to keep things simple until I have finished the overall implementation.
