### PR TITLE
Handle Gateway Timeout 504 for large releases with track relationships

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -384,7 +384,6 @@ class Album(DataObject, Item):
             require_authentication = True
             inc += ['user-ratings']
         self._requests += 1
-        # print "Release request",self.id,"Inc",inc
         self.load_task = self.tagger.xmlws.get_release_by_id(
             self.id, self._release_request_finished, inc=inc,
             mblogin=require_authentication,

--- a/picard/album.py
+++ b/picard/album.py
@@ -170,7 +170,7 @@ class Album(DataObject, Item):
                 # Gateway timeout error on large release with track relationships
                 # reissue as a priority request without the track relationships.
                 self.gateway_timeout = True
-                log.debug("Server timeout for release %r: retrying request without track relationships", self.id)
+                log.warning("Server timeout for release %r: retrying request without track relationships", self.id)
                 self._release_request(
                     config.setting['release_ars'],
                     False,


### PR DESCRIPTION
Fallback track relationship request to non track relationship request if we receive a Gateway Timeout 504 because release is too big to deliver track-relationships.

This PR is a partial solution for [PICARD-657](http://tickets.musicbrainz.org/browse/PICARD-657).
