### PR TITLE
PICARD-801: fix CoverArtProviderCaaReleaseGroup.enabled()

### DIFF
--- a/picard/coverart/providers/caa_release_group.py
+++ b/picard/coverart/providers/caa_release_group.py
@@ -47,7 +47,7 @@ class CoverArtProviderCaaReleaseGroup(CoverArtProviderCaa):
     coverartimage_thumbnail_class = CaaThumbnailCoverArtImageRg
 
     def enabled(self):
-        return (super(CoverArtProviderCaaReleaseGroup, self).enabled()
+        return (super(CoverArtProviderCaa, self).enabled()
                 and not self.coverart.front_image_found)
 
     @property


### PR DESCRIPTION
The method is using `super(CoverArtProviderCaaReleaseGroup, self).enabled()` which
is wrong, causing it to be skipped when CAA release has no cover artwork available.