### PR TITLE
Mention python2 in shebang

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/tagger.py
+++ b/tagger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os.path
 import sys


### PR DESCRIPTION
Some distributions have switched to Python3 as default. So, /usr/bin/env
python opens up wrong interpreter.
