### PR TITLE
Prevent stale log and history dialogs

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -107,8 +107,8 @@ class MainWindow(QtGui.QMainWindow):
         if not self.show_cover_art_action.isChecked():
             self.cover_art_box.hide()
 
-        self.logDialog = LogView()
-        self.historyDialog = HistoryView()
+        self.logDialog = LogView(self)
+        self.historyDialog = HistoryView(self)
 
         bottomLayout = QtGui.QHBoxLayout()
         bottomLayout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
Need to pass mainwindow as parent to these dialogs so they quit
with the main window. This bug was introduced in -> 3f2f0f3.

Should I create a separate ticket for this. This was the original ticket -> http://tickets.musicbrainz.org/browse/PICARD-804.