### PR TITLE
Quickfix for upstream Mutagen compatibility

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -40,23 +40,23 @@ from urlparse import urlparse
 # Ugly, but... I need to save the text in ISO-8859-1 even if it contains
 # unsupported characters and this better than encoding, decoding and
 # again encoding.
-def patched_EncodedTextSpec_write(self, frame, value):
+def patched_EncodedTextSpec_write(self, config, frame, value):
     try:
         enc, term = self._encodings[frame.encoding]
     except AttributeError:
         enc, term = self.encodings[frame.encoding]
     return value.encode(enc, 'ignore') + term
 
-id3.EncodedTextSpec.write = patched_EncodedTextSpec_write
+id3._specs.EncodedTextSpec.write = patched_EncodedTextSpec_write
 
 
 # One more "monkey patch". The ID3 spec says that multiple text
 # values should be _separated_ by the string terminator, which
 # means that e.g. 'a\x00' are two values, 'a' and ''.
-def patched_MultiSpec_write(self, frame, value):
-    data = self._write_orig(frame, value)
+def patched_MultiSpec_write(self, config, frame, value):
+    data = self._write_orig(config, frame, value)
     spec = self.specs[-1]
-    if isinstance(spec, id3.EncodedTextSpec):
+    if isinstance(spec, id3._specs.EncodedTextSpec):
         try:
             term = spec._encodings[frame.encoding][1]
         except AttributeError:
@@ -66,8 +66,8 @@ def patched_MultiSpec_write(self, frame, value):
     return data
 
 
-id3.MultiSpec._write_orig = id3.MultiSpec.write
-id3.MultiSpec.write = patched_MultiSpec_write
+id3._specs.MultiSpec._write_orig = id3._specs.MultiSpec.write
+id3._specs.MultiSpec.write = patched_MultiSpec_write
 
 
 id3.TCMP = compatid3.TCMP

--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -23,7 +23,11 @@ from struct import pack, unpack
 import mutagen
 from mutagen._util import insert_bytes
 from mutagen.id3 import ID3, Frames, Frames_2_2, TextFrame, TORY, \
-    TYER, TIME, APIC, IPLS, TDAT, BitPaddedInt, MakeID3v1
+    TYER, TIME, APIC, IPLS, TDAT, MakeID3v1
+try:
+    from mutagen import BitPaddedInt
+except ImportError:
+    from mutagen.id3._util import BitPaddedInt
 
 
 class TCMP(TextFrame):


### PR DESCRIPTION
There have been some changes in Mutagen upstream which makes it
incompatible with Picard. For reference, commits in Mutagen
upstream that currently break Picard:

1. https://github.com/quodlibet/mutagen/commit/e6e3fbe34f5946c92be8fb9266e9d27b46d8a700
2. https://github.com/quodlibet/mutagen/commit/2cd8cfdaec88bf896afd46cd03b209d688d3740a

This patch takes care of things for now, but is not a permanent
solution. Also as Mutagen has dropped support for Python 2.6, but Picard
is continuing it, there may be more conflicts in future.