### PR TITLE
Install SVG icon

### DIFF
--- a/resources/img-src/picard.svg
+++ b/resources/img-src/picard.svg
@@ -19,7 +19,7 @@
    enable-background="new 0 0 375 150"
    xml:space="preserve"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="Picard_logo_no_text.svg"><metadata
+   sodipodi:docname="picard.svg"><metadata
      id="metadata8145"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs

--- a/setup.py
+++ b/setup.py
@@ -772,6 +772,7 @@ if py2exe is None and do_py2app is False:
     args['data_files'].append(('share/icons/hicolor/48x48/apps', ['resources/images/48x48/picard.png']))
     args['data_files'].append(('share/icons/hicolor/128x128/apps', ['resources/images/128x128/picard.png']))
     args['data_files'].append(('share/icons/hicolor/256x256/apps', ['resources/images/256x256/picard.png']))
+    args['data_files'].append(('share/icons/hicolor/scalable/apps', ['resources/img-src/picard.svg']))
     args['data_files'].append(('share/applications', ('picard.desktop',)))
 
 


### PR DESCRIPTION
distutils does not seem to have an option to rename data_files on
install, so rename Picard_logo_no_text.svg -> picard.svg.

https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html