### PR TITLE
Make astrcmp indentation consistent

### DIFF
--- a/picard/util/astrcmp.c
+++ b/picard/util/astrcmp.c
@@ -135,9 +135,9 @@ float LevenshteinDistance(const Py_UNICODE * s1, int len1,
 	/* Step 7 */
 	/* Return result */
 
-    result = ((float)1 - ((float)MATRIX(len1, len2) / (float)MAX(len1, len2)));
+	result = ((float)1 - ((float)MATRIX(len1, len2) / (float)MAX(len1, len2)));
 
-    free(matrix);
+	free(matrix);
 
 	return result;
 }
@@ -145,33 +145,33 @@ float LevenshteinDistance(const Py_UNICODE * s1, int len1,
 static PyObject *
 astrcmp(PyObject *self, PyObject *args)
 {
-    PyObject *s1, *s2;
+	PyObject *s1, *s2;
 	float d;
 	const Py_UNICODE *us1, *us2;
 	int len1, len2;
-    PyThreadState *_save;
+	PyThreadState *_save;
 
-    if (!PyArg_ParseTuple(args, "UU", &s1, &s2))
-        return NULL;
+	if (!PyArg_ParseTuple(args, "UU", &s1, &s2))
+		return NULL;
 
 	us1 = PyUnicode_AS_UNICODE(s1);
 	us2 = PyUnicode_AS_UNICODE(s2);
 	len1 = PyUnicode_GetSize(s1);
 	len2 = PyUnicode_GetSize(s2);
 
-    Py_UNBLOCK_THREADS
+	Py_UNBLOCK_THREADS
 	d = LevenshteinDistance(us1, len1, us2, len2);
-    Py_BLOCK_THREADS
-    return Py_BuildValue("f", d);
+	Py_BLOCK_THREADS
+	return Py_BuildValue("f", d);
 }
 
 static PyMethodDef AstrcmpMethods[] = {
-    {"astrcmp", astrcmp, METH_VARARGS, "Compute Levenshtein distance"},
-    {NULL, NULL, 0, NULL}
+	{"astrcmp", astrcmp, METH_VARARGS, "Compute Levenshtein distance"},
+	{NULL, NULL, 0, NULL}
 };
 
 PyMODINIT_FUNC
 initastrcmp(void)
 {
-    (void)Py_InitModule("astrcmp", AstrcmpMethods);
+	(void)Py_InitModule("astrcmp", AstrcmpMethods);
 }


### PR DESCRIPTION
Fixes the gcc 6.1.1 warning:

```
picard/util/astrcmp.c: In function 'astrcmp':
picard/util/astrcmp.c:154:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (!PyArg_ParseTuple(args, "UU", &s1, &s2))
     ^~
picard/util/astrcmp.c:157:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  us1 = PyUnicode_AS_UNICODE(s1);
  ^~~
```
