### PR TITLE
Search for artists from dialog

### DIFF
--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -353,6 +353,35 @@ def medium_to_metadata(node, m):
             m['media'] = nodes[0].text
 
 
+def artist_to_metadata(node, m):
+    """Make meatadata dict from a XML 'artist' node."""
+    for name, nodes in node.children.iteritems():
+        if not nodes:
+            continue
+        if name == "name":
+            m["name"] = nodes[0].text
+        elif name == "area":
+            m["area"] = nodes[0].name[0].text
+        elif name == "gender":
+            m["gender"] = nodes[0].text
+        elif name == "life_span":
+            if "begin" in nodes[0].children:
+                m["begindate"] = nodes[0].begin[0].text
+            if "ended" in nodes[0].children:
+                ended = nodes[0].ended[0].text
+                if ended == "true" and "end" in nodes[0].children:
+                    m["enddate"] = nodes[0].end[0].text
+        elif name == "begin_area":
+            m["beginarea"] = nodes[0].name[0].text
+        elif name == "end_area":
+            m["endarea"] = nodes[0].name[0].text
+
+    try:
+        m["type"] = node.type
+    except AttributeError:
+        pass
+
+
 def release_to_metadata(node, m, album=None):
     """Make metadata dict from a XML 'release' node."""
     m.add_unique('musicbrainz_albumid', node.id)

--- a/picard/mbxml.py
+++ b/picard/mbxml.py
@@ -355,6 +355,7 @@ def medium_to_metadata(node, m):
 
 def artist_to_metadata(node, m):
     """Make meatadata dict from a XML 'artist' node."""
+    m.add_unique("musicbrainz_artistid", node.id)
     for name, nodes in node.children.iteritems():
         if not nodes:
             continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -82,6 +82,11 @@ from picard.util import (
     versions,
 )
 from picard.webservice import XmlWebService
+from picard.ui.searchdialog import (
+    TrackSearchDialog,
+    AlbumSearchDialog,
+    ArtistSearchDialog
+)
 
 
 class Tagger(QtGui.QApplication):
@@ -417,7 +422,21 @@ class Tagger(QtGui.QApplication):
     def search(self, text, type, adv=False):
         """Search on the MusicBrainz website."""
         lookup = self.get_file_lookup()
-        getattr(lookup, type + "Search")(text, adv)
+        if config.setting["builtin_search"]:
+            if type == "track" and not lookup.mbidLookup(text, 'recording'):
+                dialog = TrackSearchDialog(self.window)
+                dialog.search(text)
+                dialog.exec_()
+            elif type == "album" and not lookup.mbidLookup(text, 'release'):
+                dialog = AlbumSearchDialog(self.window)
+                dialog.search(text)
+                dialog.exec_()
+            elif type == "artist" and not lookup.mbidLookup(text, 'artist'):
+                dialog = ArtistSearchDialog(self.window)
+                dialog.search(text)
+                dialog.exec_()
+        else:
+            getattr(lookup, type + "Search")(text, adv)
 
     def collection_lookup(self):
         """Lookup the users collections on the MusicBrainz website."""

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -34,7 +34,11 @@ from picard.ui.filebrowser import FileBrowser
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.options.dialog import OptionsDialog
 from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog, ClusterInfoDialog
-from picard.ui.searchdialog import TrackSearchDialog, AlbumSearchDialog
+from picard.ui.searchdialog import (
+    TrackSearchDialog,
+    AlbumSearchDialog,
+    ArtistSearchDialog
+)
 from picard.ui.infostatus import InfoStatus
 from picard.ui.passworddialog import PasswordDialog
 from picard.ui.logview import LogView, HistoryView
@@ -690,6 +694,11 @@ class MainWindow(QtGui.QMainWindow):
                 dialog.exec_()
             elif type == "album":
                 dialog = AlbumSearchDialog(self)
+                dialog.search(text)
+                dialog.exec_()
+            else:
+                # `type` must be "artist"
+                dialog = ArtistSearchDialog(self)
                 dialog.search(text)
                 dialog.exec_()
         else:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -34,11 +34,6 @@ from picard.ui.filebrowser import FileBrowser
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.options.dialog import OptionsDialog
 from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog, ClusterInfoDialog
-from picard.ui.searchdialog import (
-    TrackSearchDialog,
-    AlbumSearchDialog,
-    ArtistSearchDialog
-)
 from picard.ui.infostatus import InfoStatus
 from picard.ui.passworddialog import PasswordDialog
 from picard.ui.logview import LogView, HistoryView
@@ -687,22 +682,7 @@ class MainWindow(QtGui.QMainWindow):
         """Search for album, artist or track on the MusicBrainz website."""
         text = self.search_edit.text()
         type = self.search_combo.itemData(self.search_combo.currentIndex())
-        if config.setting["builtin_search"]:
-            if type == "track":
-                dialog = TrackSearchDialog(self)
-                dialog.search(text)
-                dialog.exec_()
-            elif type == "album":
-                dialog = AlbumSearchDialog(self)
-                dialog.search(text)
-                dialog.exec_()
-            else:
-                # `type` must be "artist"
-                dialog = ArtistSearchDialog(self)
-                dialog.search(text)
-                dialog.exec_()
-        else:
-            self.tagger.search(text, type, config.setting["use_adv_search_syntax"])
+        self.tagger.search(text, type, config.setting["use_adv_search_syntax"])
 
     def add_files(self):
         """Add files to the tagger."""

--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -493,6 +493,9 @@ class XmlWebService(QtCore.QObject):
     def find_tracks(self, handler, **kwargs):
         return self._find('recording', handler, kwargs)
 
+    def find_artists(self, handler, **kwargs):
+        return self._find('artist', handler, kwargs)
+
     def _browse(self, entitytype, handler, kwargs, inc=[], priority=False, important=False):
         host = config.setting["server_host"]
         port = config.setting["server_port"]


### PR DESCRIPTION
Allow searching for artists from a dialog. I'm not sure whether it will be super useful, but it's better for consistency with other two dialog which are *Album* (PR: https://github.com/metabrainz/picard/pull/486) and *Track* (PR: https://github.com/metabrainz/picard/pull/475). This dialog displays basic information about the artist, and provides an option to look him/her up in web browser.

### Screenshot
![screenshot from 2016-08-20 15-55-42](https://cloud.githubusercontent.com/assets/7776696/17830634/bed8054e-66ee-11e6-9162-dbeeaac1bf68.png)


### Note
This PR is based on rebase of #486. It would be helpful if review upto commit 851b581 be provided there.