### PR TITLE
PICARD-848: Cannot fetch cover art from amazon link contains https scheme.

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -213,7 +213,7 @@ def parse_amazon_url(url):
     """Extract host and asin from an amazon url.
     It returns a dict with host and asin keys on success, None else
     """
-    r = re.compile(r'^(http|https)://(?:www.)?(?P<host>.*?)(?:\:[0-9]+)?/.*/(?P<asin>[0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)')
+    r = re.compile(r'^https?://(?:www.)?(?P<host>.*?)(?:\:[0-9]+)?/.*/(?P<asin>[0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)')
     match = r.match(url)
     if match is not None:
         return match.groupdict()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -213,7 +213,7 @@ def parse_amazon_url(url):
     """Extract host and asin from an amazon url.
     It returns a dict with host and asin keys on success, None else
     """
-    r = re.compile(r'^http://(?:www.)?(?P<host>.*?)(?:\:[0-9]+)?/.*/(?P<asin>[0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)')
+    r = re.compile(r'^(http|https)://(?:www.)?(?P<host>.*?)(?:\:[0-9]+)?/.*/(?P<asin>[0-9B][0-9A-Z]{9})(?:[^0-9A-Z]|$)')
     match = r.match(url)
     if match is not None:
         return match.groupdict()

--- a/test/test_amazon_urls.py
+++ b/test/test_amazon_urls.py
@@ -37,3 +37,15 @@ class ParseAmazonUrlTest(unittest.TestCase):
         expected = None
         r = parse_amazon_url(url)
         self.assertEqual(r, expected)
+
+    def test_6(self):
+        url = 'https://www.amazon.co.jp/gp/product/B00005FMYV'
+        expected = {'asin': 'B00005FMYV', 'host': 'amazon.co.jp'}
+        r = parse_amazon_url(url)
+        self.assertEqual(r, expected)
+
+    def test_7(self):
+        url = 'httpsa://www.amazon.co.jp/gp/product/B00005FMYV'
+        expected = None
+        r = parse_amazon_url(url)
+        self.assertEqual(r, expected)

--- a/test/test_amazon_urls.py
+++ b/test/test_amazon_urls.py
@@ -45,6 +45,7 @@ class ParseAmazonUrlTest(unittest.TestCase):
         self.assertEqual(r, expected)
 
     def test_7(self):
+        #incorrect url scheme
         url = 'httpsa://www.amazon.co.jp/gp/product/B00005FMYV'
         expected = None
         r = parse_amazon_url(url)


### PR DESCRIPTION
Picard 1.3.2 cannot fetch cover art from amazon.
Because, picard can only fetch information from amazon without ssl.

But some releases have an amazon url with https.
This commit fix regex for amazon url parse function.