### PR TITLE
PICARD-408:  Tree selector in Options window is partially obscured, pane too narrow

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -49,7 +49,7 @@ class OptionsDialog(PicardDialog):
 
     options = [
         config.Option("persist", "options_position", QtCore.QPoint()),
-        config.Option("persist", "options_size", QtCore.QSize(560, 400)),
+        config.Option("persist", "options_size", QtCore.QSize(720, 480)),
         config.Option("persist", "options_splitter", QtCore.QByteArray()),
     ]
 

--- a/picard/ui/ui_options.py
+++ b/picard/ui/ui_options.py
@@ -8,12 +8,21 @@ from PyQt4 import QtCore, QtGui
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
-    _fromUtf8 = lambda s: s
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
 
 class Ui_Dialog(object):
     def setupUi(self, Dialog):
         Dialog.setObjectName(_fromUtf8("Dialog"))
-        Dialog.resize(485, 398)
+        Dialog.resize(720, 480)
         self.vboxlayout = QtGui.QVBoxLayout(Dialog)
         self.vboxlayout.setMargin(9)
         self.vboxlayout.setSpacing(6)

--- a/ui/options.ui
+++ b/ui/options.ui
@@ -5,8 +5,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>485</width>
-    <height>398</height>
+    <width>720</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle" >


### PR DESCRIPTION
Changed default size of the options window so that the left tree fits.