### PR TITLE
PICARD-851: Correctly update parent items on save

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -756,7 +756,6 @@ class TrackItem(TreeItem):
             self.setBackground(i, bgcolor)
         if self.isSelected():
             TreeItem.window.update_selection()
-
         if update_album:
             self.parent().update(update_tracks=False)
 

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -775,8 +775,9 @@ class FileItem(TreeItem):
         if self.isSelected():
             TreeItem.window.update_selection()
 
-        if isinstance(self.parent(), TrackItem) and update_track:
-            self.parent().update(update_files=False)
+        parent = self.parent()
+        if isinstance(parent, TrackItem) and update_track:
+            parent.update(update_files=False)
 
     @staticmethod
     def decide_file_icon(file):


### PR DESCRIPTION
When multiple files were linked to the same track and the changes to
the items were saved, the parent album icon didn't update to reflect
the change.

This was because of a buggy item.save() function which led to an update
call to the update() method of files. The files on update did not recu-
rsively call their parent items to be updated too.