### PR TITLE
Add support for nosetests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,10 +107,6 @@ class picard_test(Command):
 
     def run(self):
         import unittest
-        import sip
-
-        sip.setapi("QString", 2)
-        sip.setapi("QVariant", 2)
 
         names = []
         for filename in glob.glob("test/test_*.py"):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,10 @@
 import glob
 import os.path
 
+import sip
+
+sip.setapi("QString", 2)
+sip.setapi("QVariant", 2)
+
 for filename in glob.glob(os.path.join(os.path.dirname(__file__), "test_*.py")):
     __import__("test." + os.path.basename(filename)[:-3])


### PR DESCRIPTION
When the tests are run using nosetests, the Qt uses sip API v1 by
default which causes nosetests to fail when running version_from_string
function which returns a QVariant object instead of a string.