### PR TITLE
PICARD-857: Remove deprecated checks and add…

### DIFF
--- a/picard/util/icontheme.py
+++ b/picard/util/icontheme.py
@@ -30,8 +30,10 @@ else:
         '/usr/share/pixmaps',
     ]
 
-if 'GNOME_DESKTOP_SESSION_ID' in os.environ:
-    _current_theme = os.popen('gconftool-2 -g /desktop/gnome/interface/icon_theme').read().strip() or None
+if 'XDG_CURRENT_DESKTOP' in os.environ and os.environ['XDG_CURRENT_DESKTOP'].lower() == 'gnome':
+    _current_theme = os.popen('gconftool-2 -g /desktop/gnome/interface/icon_theme').read().strip() or os.popen('gsettings get org.gnome.desktop.interface icon-theme').read().strip()[1:-1] or None
+elif 'XDG_CURRENT_DESKTOP' in os.environ and os.environ['XDG_CURRENT_DESKTOP'].lower() == 'unity':
+    _current_theme = os.popen('dconf read /desktop/gnome/interface/icon_theme').read().strip()[1:-1] or None
 elif os.environ.get('KDE_FULL_SESSION'):
     _current_theme = os.popen("kreadconfig --file kdeglobals --group Icons --key Theme --default crystalsvg").read().strip() or None
 else:

--- a/picard/util/icontheme.py
+++ b/picard/util/icontheme.py
@@ -32,13 +32,11 @@ else:
 
 _current_theme = None
 if 'XDG_CURRENT_DESKTOP' in os.environ:
-    if os.environ['XDG_CURRENT_DESKTOP'].lower() == 'gnome':
+    desktop = os.environ['XDG_CURRENT_DESKTOP'].lower()
+    if desktop in ('gnome', 'unity'):
         _current_theme = (os.popen('gconftool-2 -g /desktop/gnome/interface/icon_theme').read().strip()
-                          or os.popen('gsettings get org.gnome.desktop.interface icon-theme').read().strip()[1:-1]
+                          or os.popen('dconf read /org/gnome/desktop/interface/icon-theme').read().strip()[1:-1]
                           or None)
-    elif os.environ['XDG_CURRENT_DESKTOP'].lower() == 'unity':
-        current_theme = (os.popen('dconf read /desktop/gnome/interface/icon_theme').read().strip()[1:-1]
-                         or None)
 elif os.environ.get('KDE_FULL_SESSION'):
     _current_theme = (os.popen("kreadconfig --file kdeglobals --group Icons --key Theme --default crystalsvg").read().strip()
                       or None)

--- a/picard/util/icontheme.py
+++ b/picard/util/icontheme.py
@@ -30,14 +30,19 @@ else:
         '/usr/share/pixmaps',
     ]
 
-if 'XDG_CURRENT_DESKTOP' in os.environ and os.environ['XDG_CURRENT_DESKTOP'].lower() == 'gnome':
-    _current_theme = os.popen('gconftool-2 -g /desktop/gnome/interface/icon_theme').read().strip() or os.popen('gsettings get org.gnome.desktop.interface icon-theme').read().strip()[1:-1] or None
-elif 'XDG_CURRENT_DESKTOP' in os.environ and os.environ['XDG_CURRENT_DESKTOP'].lower() == 'unity':
-    _current_theme = os.popen('dconf read /desktop/gnome/interface/icon_theme').read().strip()[1:-1] or None
+_current_theme = None
+if 'XDG_CURRENT_DESKTOP' in os.environ:
+    if os.environ['XDG_CURRENT_DESKTOP'].lower() == 'gnome':
+        _current_theme = (os.popen('gconftool-2 -g /desktop/gnome/interface/icon_theme').read().strip()
+                          or os.popen('gsettings get org.gnome.desktop.interface icon-theme').read().strip()[1:-1]
+                          or None)
+    elif os.environ['XDG_CURRENT_DESKTOP'].lower() == 'unity':
+        current_theme = (os.popen('dconf read /desktop/gnome/interface/icon_theme').read().strip()[1:-1]
+                         or None)
 elif os.environ.get('KDE_FULL_SESSION'):
-    _current_theme = os.popen("kreadconfig --file kdeglobals --group Icons --key Theme --default crystalsvg").read().strip() or None
-else:
-    _current_theme = None
+    _current_theme = (os.popen("kreadconfig --file kdeglobals --group Icons --key Theme --default crystalsvg").read().strip()
+                      or None)
+
 
 ICON_SIZE_MENU = ('16x16',)
 ICON_SIZE_TOOLBAR = ('22x22',)

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -39,7 +39,7 @@ if sys.version_info >= (2, 5):
         if 'KDE_FULL_SESSION' in os.environ and os.environ['KDE_FULL_SESSION'] == 'true' and webbrowser._iscommand('kfmclient'):
             webbrowser.register('kfmclient', None, webbrowser.BackgroundBrowser(["kfmclient", "exec", "%s"]), update_tryorder=-1)
         # GNOME default browser
-        if 'GNOME_DESKTOP_SESSION_ID' in os.environ and webbrowser._iscommand('gnome-open'):
+        if 'XDG_CURRENT_DESKTOP' in os.environ and os.environ['XDG_CURRENT_DESKTOP'].lower() == 'gnome' and webbrowser._iscommand('gnome-open'):
             webbrowser.register('gnome-open', None, webbrowser.BackgroundBrowser(["gnome-open", "%s"]), update_tryorder=-1)
 
 
@@ -52,7 +52,7 @@ else:
         else:
             webbrowser._tryorder.insert(0, 'kfmclient')
     # GNOME default browser
-    if 'GNOME_DESKTOP_SESSION_ID' in os.environ and webbrowser._iscommand('gnome-open'):
+    if 'DESKTOP_SESSION' in os.environ and os.environ['DESKTOP_SESSION'].lower() == 'gnome' and webbrowser._iscommand('gnome-open'):
         webbrowser.register('gnome-open', None, webbrowser.GenericBrowser("gnome-open '%s' &"))
         if 'BROWSER' in os.environ:
             webbrowser._tryorder.insert(len(os.environ['BROWSER'].split(os.pathsep)), 'gnome-open')


### PR DESCRIPTION
…support for GNOME 3

Gnome 3 recommends using gsettings to get and set values, as a result
gconftool-2 does not return a value in gnome3. Also GNOME_SESSION_ID
as a variable has been deprecated, so the detection of Gnome as a DE
has been changed accordingly.

