### PR TITLE
PICARD-858: Remove apparent non-functionality of the tagger button

### DIFF
--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -67,6 +67,7 @@ class BrowserIntegration(QtNetwork.QTcpServer):
             action, args = line[1].split("?")
             args = [a.split("=", 1) for a in args.split("&")]
             args = dict((a, unicode(QtCore.QUrl.fromPercentEncoding(b))) for (a, b) in args)
+            self.tagger.bring_tagger_front()
             if action == "/openalbum":
                 self.tagger.load_album(args["id"])
             elif action == "/opennat":

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -658,6 +658,11 @@ class Tagger(QtGui.QApplication):
             if obj.can_refresh():
                 obj.load(priority=True, refresh=True)
 
+    def bring_tagger_front(self):
+        self.window.setWindowState(self.window.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+        self.window.raise_()
+        self.window.activateWindow()
+
     @classmethod
     def instance(cls):
         return cls.__instance


### PR DESCRIPTION
While using the 'Lookup in the Browser' option, clicking the tagger button loads the album into Picard but since Picard doesn't come to surface, it looks like as if nothing is happening. This PR just adds a bring_tagger_front() function and makes a call it to it when one clicks on the tagger button. 