### PR TITLE
PICARD-870,873,874: Fix for List options not updating and saving on reset

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -28,55 +28,6 @@ from picard.ui.sortablecheckboxlist import (
 )
 
 
-class ProviderList(SortableCheckboxListWidget):
-
-    def __init__(self, parent=None):
-        self.all_marked = False
-        self.item_marking = []
-        super(ProviderList, self).__init__(parent)
-
-    def addItem(self, item):
-        self.item_marking.append(False)
-        super(ProviderList, self).addItem(item)
-
-    def addItems(self, items):
-        for item in items:
-            self.addItem(item)
-
-    def moveItem(self, from_row, to_row):
-        self.item_marking[from_row], self.item_marking[to_row] = self.item_marking[to_row], self.item_marking[
-            from_row]
-        super(ProviderList, self).moveItem(from_row, to_row)
-
-    def set_item_marking(self, row, value):
-        self.item_marking[row] = value
-
-    def set_all_marked(self, value):
-        self.all_marked = value
-
-    def remove_marked(self):
-        if self.all_marked:
-            for i in reversed(range(len(self._SortableCheckboxListWidget__items))):
-                self._remove(i)
-            self._SortableCheckboxListWidget__items = []
-            self.all_marked = False
-            self.item_marking = []
-        else:
-            indices = []
-            for i in reversed(range(len(self._SortableCheckboxListWidget__items))):
-                if self.item_marking[i]:
-                    indices.append(i)
-                    self._remove(i)
-            self._SortableCheckboxListWidget__items = [i for j, i in enumerate(self._SortableCheckboxListWidget__items)
-                                                       if j not in indices]
-            self.item_marking = [i for j, i in enumerate(self.__item_marking) if j not in indices]
-
-    def _remove(self, row):
-        self.layout().itemAtPosition(row, self._CHECKBOX_POS).widget().setParent(None)
-        self.layout().itemAtPosition(row, self._BUTTON_UP).widget().setParent(None)
-        self.layout().itemAtPosition(row, self._BUTTON_DOWN).widget().setParent(None)
-
-
 class CoverOptionsPage(OptionsPage):
 
     NAME = "cover"
@@ -106,7 +57,7 @@ class CoverOptionsPage(OptionsPage):
         self.ui.setupUi(self)
         self.ui.save_images_to_files.clicked.connect(self.update_filename)
         self.ui.save_images_to_tags.clicked.connect(self.update_save_images_to_tags)
-        self.provider_list_widget = ProviderList()
+        self.provider_list_widget = SortableCheckboxListWidget()
         self.ui.ca_providers_list.insertWidget(0, self.provider_list_widget)
         self.ca_providers = []
 

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -106,6 +106,7 @@ class CoverOptionsPage(OptionsPage):
         self.ui.save_images_to_tags.clicked.connect(self.update_save_images_to_tags)
         self.provider_list_widget = ProviderList()
         self.ui.ca_providers_list.insertWidget(0, self.provider_list_widget)
+        self.ca_providers = []
 
     def load_cover_art_providers(self):
         """Load available providers, initialize provider-specific options, restore state of each
@@ -124,8 +125,7 @@ class CoverOptionsPage(OptionsPage):
             self.provider_list_widget.addItem(SortableCheckboxListItem(title, checked=checked, data=provider.NAME))
 
         def update_providers_options(items):
-            config.setting['ca_providers'] = [(item.data, item.checked)
-                                              for item in items]
+            self.ca_providers = [(item.data, item.checked) for item in items]
         self.provider_list_widget.changed.connect(update_providers_options)
 
     def load(self):
@@ -134,6 +134,7 @@ class CoverOptionsPage(OptionsPage):
         self.ui.save_images_to_files.setChecked(config.setting["save_images_to_files"])
         self.ui.cover_image_filename.setText(config.setting["cover_image_filename"])
         self.ui.save_images_overwrite.setChecked(config.setting["save_images_overwrite"])
+        self.ca_providers = config.setting["ca_providers"]
         self.load_cover_art_providers()
         self.update_all()
 
@@ -143,6 +144,7 @@ class CoverOptionsPage(OptionsPage):
         config.setting["save_images_to_files"] = self.ui.save_images_to_files.isChecked()
         config.setting["cover_image_filename"] = unicode(self.ui.cover_image_filename.text())
         config.setting["save_images_overwrite"] = self.ui.save_images_overwrite.isChecked()
+        config.setting["ca_providers"] = self.ca_providers
 
     def update_all(self):
         self.update_filename()

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -31,12 +31,12 @@ from picard.ui.sortablecheckboxlist import (
 class ProviderList(SortableCheckboxListWidget):
 
     def __init__(self, parent=None):
-        super(ProviderList, self).__init__(parent)
         self._all_marked = False
         self.item_marking = []
+        super(ProviderList, self).__init__(parent)
 
     def addItem(self, item):
-        self.item_markings.append(False)
+        self.item_marking.append(False)
         super(ProviderList,self).addItem(item)
 
     def addItems(self, items):
@@ -44,7 +44,7 @@ class ProviderList(SortableCheckboxListWidget):
             self.addItem(item)
 
     def moveItem(self, from_row, to_row):
-        self.item_markings[from_row], self.item_markings[to_row] = self.item_markings[to_row], self.item_markings[
+        self.item_marking[from_row], self.item_marking[to_row] = self.item_marking[to_row], self.item_marking[
             from_row]
         super(ProviderList,self).moveItem(from_row, to_row)
 
@@ -56,18 +56,18 @@ class ProviderList(SortableCheckboxListWidget):
 
     def remove_marked(self):
         if self._all_marked:
-            for i in reversed(range(len(self.__items))):
+            for i in reversed(range(len(self._SortableCheckboxListWidget__items))):
                 self._remove(i)
-            self.__items = []
+            self._SortableCheckboxListWidget__items = []
             self._all_marked = False
             self.item_marking = []
         else:
             indices = []
-            for i in reversed(range(len(self.__items))):
+            for i in reversed(range(len(self._SortableCheckboxListWidget__items))):
                 if self.item_marking[i]:
                     indices.append(i)
                     self._remove(i)
-            self.__items= [i for j, i in enumerate(self.__items) if j not in indices]
+            self._SortableCheckboxListWidget__items= [i for j, i in enumerate(self._SortableCheckboxListWidget__items) if j not in indices]
             self.item_marking = [i for j, i in enumerate(self.__item_marking) if j not in indices]
 
     def _remove(self, row):

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -31,13 +31,13 @@ from picard.ui.sortablecheckboxlist import (
 class ProviderList(SortableCheckboxListWidget):
 
     def __init__(self, parent=None):
-        self._all_marked = False
+        self.all_marked = False
         self.item_marking = []
         super(ProviderList, self).__init__(parent)
 
     def addItem(self, item):
         self.item_marking.append(False)
-        super(ProviderList,self).addItem(item)
+        super(ProviderList, self).addItem(item)
 
     def addItems(self, items):
         for item in items:
@@ -46,20 +46,20 @@ class ProviderList(SortableCheckboxListWidget):
     def moveItem(self, from_row, to_row):
         self.item_marking[from_row], self.item_marking[to_row] = self.item_marking[to_row], self.item_marking[
             from_row]
-        super(ProviderList,self).moveItem(from_row, to_row)
+        super(ProviderList, self).moveItem(from_row, to_row)
 
     def set_item_marking(self, row, value):
         self.item_marking[row] = value
 
     def set_all_marked(self, value):
-        self._all_marked = value
+        self.all_marked = value
 
     def remove_marked(self):
-        if self._all_marked:
+        if self.all_marked:
             for i in reversed(range(len(self._SortableCheckboxListWidget__items))):
                 self._remove(i)
             self._SortableCheckboxListWidget__items = []
-            self._all_marked = False
+            self.all_marked = False
             self.item_marking = []
         else:
             indices = []
@@ -67,7 +67,8 @@ class ProviderList(SortableCheckboxListWidget):
                 if self.item_marking[i]:
                     indices.append(i)
                     self._remove(i)
-            self._SortableCheckboxListWidget__items= [i for j, i in enumerate(self._SortableCheckboxListWidget__items) if j not in indices]
+            self._SortableCheckboxListWidget__items = [i for j, i in enumerate(self._SortableCheckboxListWidget__items)
+                                                       if j not in indices]
             self.item_marking = [i for j, i in enumerate(self.__item_marking) if j not in indices]
 
     def _remove(self, row):
@@ -109,17 +110,10 @@ class CoverOptionsPage(OptionsPage):
     def load_cover_art_providers(self):
         """Load available providers, initialize provider-specific options, restore state of each
         """
-
+        # Mark and remove previous entries in providers during reset
         self.provider_list_widget.set_all_marked(True)
         self.provider_list_widget.remove_marked()
 
-        '''
-        # Remove current provider items during a reset
-        if self.ui.ca_providers_list.count() > 1:
-            self.ui.ca_providers_list.itemAt(0).widget().setParent(None)
-
-        widget = SortableCheckboxListWidget()
-        '''
         providers = cover_art_providers()
         for provider in providers:
             try:
@@ -133,7 +127,6 @@ class CoverOptionsPage(OptionsPage):
             config.setting['ca_providers'] = [(item.data, item.checked)
                                               for item in items]
         self.provider_list_widget.changed.connect(update_providers_options)
-        # self.ui.ca_providers_list.insertWidget(0, widget)
 
     def load(self):
         self.ui.save_images_to_tags.setChecked(config.setting["save_images_to_tags"])

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -64,9 +64,8 @@ class CoverOptionsPage(OptionsPage):
     def load_cover_art_providers(self):
         """Load available providers, initialize provider-specific options, restore state of each
         """
-        # Mark and remove previous entries in providers during reset
-        self.provider_list_widget.set_all_marked(True)
-        self.provider_list_widget.remove_marked()
+        # Remove previous entries in providers during reset
+        self.provider_list_widget.clear()
 
         providers = cover_art_providers()
         for provider in providers:

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -73,6 +73,8 @@ class ProviderList(SortableCheckboxListWidget):
 
     def _remove(self, row):
         self.layout().itemAtPosition(row, self._CHECKBOX_POS).widget().setParent(None)
+        self.layout().itemAtPosition(row, self._BUTTON_UP).widget().setParent(None)
+        self.layout().itemAtPosition(row, self._BUTTON_DOWN).widget().setParent(None)
 
 
 class CoverOptionsPage(OptionsPage):

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -64,9 +64,6 @@ class CoverOptionsPage(OptionsPage):
     def load_cover_art_providers(self):
         """Load available providers, initialize provider-specific options, restore state of each
         """
-        # Remove previous entries in providers during reset
-        self.provider_list_widget.clear()
-
         providers = cover_art_providers()
         for provider in providers:
             try:
@@ -79,6 +76,11 @@ class CoverOptionsPage(OptionsPage):
         def update_providers_options(items):
             self.ca_providers = [(item.data, item.checked) for item in items]
         self.provider_list_widget.changed.connect(update_providers_options)
+
+    def restore_defaults(self):
+        # Remove previous entries
+        self.provider_list_widget.clear()
+        super(CoverOptionsPage, self).restore_defaults()
 
     def load(self):
         self.ui.save_images_to_tags.setChecked(config.setting["save_images_to_tags"])

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -61,6 +61,10 @@ class CoverOptionsPage(OptionsPage):
     def load_cover_art_providers(self):
         """Load available providers, initialize provider-specific options, restore state of each
         """
+        # Remove current provider items during a reset
+        if self.ui.ca_providers_list.count() > 1:
+            self.ui.ca_providers_list.itemAt(0).widget().setParent(None)
+
         widget = SortableCheckboxListWidget()
         providers = cover_art_providers()
         for provider in providers:

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -158,16 +158,15 @@ class PluginsOptionsPage(OptionsPage):
         self._user_interaction(True)
 
     def _remove_all(self):
-        self._user_interaction(False)
         for i, p in self.items.items():
             idx = self.ui.plugins.indexOfTopLevelItem(i)
             item = self.ui.plugins.takeTopLevelItem(idx)
             del item
         self.items = {}
-        self._user_interaction(True)
 
     def load(self):
         # Remove previous entries during reset
+        self._user_interaction(False)
         self._remove_all()
 
         self._populate()
@@ -185,11 +184,7 @@ class PluginsOptionsPage(OptionsPage):
         self.ui.details.setText("")
         self._user_interaction(False)
         self.save_state()
-        for i, p in self.items.items():
-            idx = self.ui.plugins.indexOfTopLevelItem(i)
-            item = self.ui.plugins.takeTopLevelItem(idx)
-            del item
-        self.items = {}
+        self._remove_all()
         self.tagger.pluginmanager.query_available_plugins(callback=self._reload)
 
     def plugin_installed(self, plugin):

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -131,7 +131,6 @@ class PluginsOptionsPage(OptionsPage):
         else:
             self.ui.plugins.setCurrentItem(self.ui.plugins.topLevelItem(0))
 
-
     def _populate(self):
         self.ui.details.setText("<b>" + _("No plugins installed.") + "</b>")
         self._user_interaction(False)
@@ -158,7 +157,19 @@ class PluginsOptionsPage(OptionsPage):
 
         self._user_interaction(True)
 
+    def _remove_all(self):
+        self._user_interaction(False)
+        for i, p in self.items.items():
+            idx = self.ui.plugins.indexOfTopLevelItem(i)
+            item = self.ui.plugins.takeTopLevelItem(idx)
+            del item
+        self.items = {}
+        self._user_interaction(True)
+
     def load(self):
+        # Remove previous entries during reset
+        self._remove_all()
+
         self._populate()
         self.restore_state()
 

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -164,11 +164,16 @@ class PluginsOptionsPage(OptionsPage):
             del item
         self.items = {}
 
-    def load(self):
-        # Remove previous entries during reset
+    def restore_defaults(self):
+        # Plugin manager has to be updated
+        for plugin in self.tagger.pluginmanager.plugins:
+            plugin.enabled = False
+        # Remove previous entries
         self._user_interaction(False)
         self._remove_all()
+        super(PluginsOptionsPage, self).restore_defaults()
 
+    def load(self):
         self._populate()
         self.restore_state()
 

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -138,6 +138,8 @@ class ReleasesOptionsPage(OptionsPage):
         self.ui.preferred_format_list.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
 
     def load(self):
+        self.ui.preferred_country_list.clear()
+        self.ui.preferred_format_list.clear()
         scores = dict(config.setting["release_type_scores"])
         for (release_type, release_type_slider) in self._release_type_sliders.iteritems():
             release_type_slider.setValue(scores.get(release_type,

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -137,9 +137,15 @@ class ReleasesOptionsPage(OptionsPage):
         self.ui.format_list.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
         self.ui.preferred_format_list.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
 
-    def load(self):
+    def restore_defaults(self):
+        # Clear lists
         self.ui.preferred_country_list.clear()
         self.ui.preferred_format_list.clear()
+        self.ui.country_list.clear()
+        self.ui.format_list.clear()
+        super(ReleasesOptionsPage, self).restore_defaults()
+
+    def load(self):
         scores = dict(config.setting["release_type_scores"])
         for (release_type, release_type_slider) in self._release_type_sliders.iteritems():
             release_type_slider.setValue(scores.get(release_type,

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -376,6 +376,9 @@ class ScriptingOptionsPage(OptionsPage):
     def load(self):
         self.ui.enable_tagger_scripts.setChecked(config.setting["enable_tagger_scripts"])
         self.list_of_scripts = config.setting["list_of_scripts"]
+        # Remove scripts during a reset
+        self.ui.script_list.clear()
+
         for s_pos, s_name, s_enabled, s_text in self.list_of_scripts:
             script = ScriptItem(s_pos, s_name, s_enabled, s_text)
             list_item = QtGui.QListWidgetItem()

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -373,12 +373,16 @@ class ScriptingOptionsPage(OptionsPage):
         except Exception as e:
             raise OptionsCheckError(_("Script Error"), str(e))
 
+    def restore_defaults(self):
+        # Remove existing scripts
+        self.ui.script_list.clear()
+        self.ui.script_name.setText("")
+        self.ui.tagger_script.setText("")
+        super(ScriptingOptionsPage, self).restore_defaults()
+
     def load(self):
         self.ui.enable_tagger_scripts.setChecked(config.setting["enable_tagger_scripts"])
         self.list_of_scripts = config.setting["list_of_scripts"]
-        # Remove scripts during a reset
-        self.ui.script_list.clear()
-
         for s_pos, s_name, s_enabled, s_text in self.list_of_scripts:
             script = ScriptItem(s_pos, s_name, s_enabled, s_text)
             list_item = QtGui.QListWidgetItem()

--- a/picard/ui/sortablecheckboxlist.py
+++ b/picard/ui/sortablecheckboxlist.py
@@ -39,8 +39,6 @@ class SortableCheckboxListWidget(QtGui.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         self.__items = []
-        self.all_marked = False
-        self.item_marking = []
 
     def addItems(self, items):
         for item in items:
@@ -59,8 +57,6 @@ class SortableCheckboxListWidget(QtGui.QWidget):
         to_row = to_row % len(self.__items)
         self.__items[to_row], self.__items[from_row] = \
             self.__items[from_row], self.__items[to_row]
-        self.item_marking[from_row], self.item_marking[to_row] = self.item_marking[to_row], self.item_marking[
-            from_row]
         self.updateRow(to_row)
         self.updateRow(from_row)
         self._emit_changed()
@@ -87,7 +83,6 @@ class SortableCheckboxListWidget(QtGui.QWidget):
 
     def addItem(self, item):
         self.__items.append(item)
-        self.item_marking.append(False)
         row = len(self.__items) - 1
         layout = self.layout()
         layout.addWidget(QtGui.QCheckBox(), row, self._CHECKBOX_POS)
@@ -106,27 +101,10 @@ class SortableCheckboxListWidget(QtGui.QWidget):
         if not self.__no_emit:
             self.changed.emit(self.__items)
 
-    def set_item_marking(self, row, value):
-        self.item_marking[row] = value
-
-    def set_all_marked(self, value):
-        self.all_marked = value
-
-    def remove_marked(self):
-        if self.all_marked:
-            for i in reversed(range(len(self.__items))):
-                self._remove(i)
-            self.__items = []
-            self.all_marked = False
-            self.item_marking = []
-        else:
-            indices = []
-            for i in reversed(range(len(self.__items))):
-                if self.item_marking[i]:
-                    indices.append(i)
-                    self._remove(i)
-            self.__items = [i for j, i in enumerate(self.__items) if j not in indices]
-            self.item_marking = [i for j, i in enumerate(self.item_marking) if j not in indices]
+    def clear(self):
+        for i in reversed(range(len(self.__items))):
+            self._remove(i)
+        self.__items = []
 
     def _remove(self, row):
         self.layout().itemAtPosition(row, self._CHECKBOX_POS).widget().setParent(None)

--- a/picard/ui/sortablecheckboxlist.py
+++ b/picard/ui/sortablecheckboxlist.py
@@ -39,6 +39,8 @@ class SortableCheckboxListWidget(QtGui.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         self.__items = []
+        self.all_marked = False
+        self.item_marking = []
 
     def addItems(self, items):
         for item in items:
@@ -57,6 +59,8 @@ class SortableCheckboxListWidget(QtGui.QWidget):
         to_row = to_row % len(self.__items)
         self.__items[to_row], self.__items[from_row] = \
             self.__items[from_row], self.__items[to_row]
+        self.item_marking[from_row], self.item_marking[to_row] = self.item_marking[to_row], self.item_marking[
+            from_row]
         self.updateRow(to_row)
         self.updateRow(from_row)
         self._emit_changed()
@@ -83,6 +87,7 @@ class SortableCheckboxListWidget(QtGui.QWidget):
 
     def addItem(self, item):
         self.__items.append(item)
+        self.item_marking.append(False)
         row = len(self.__items) - 1
         layout = self.layout()
         layout.addWidget(QtGui.QCheckBox(), row, self._CHECKBOX_POS)
@@ -100,6 +105,33 @@ class SortableCheckboxListWidget(QtGui.QWidget):
     def _emit_changed(self):
         if not self.__no_emit:
             self.changed.emit(self.__items)
+
+    def set_item_marking(self, row, value):
+        self.item_marking[row] = value
+
+    def set_all_marked(self, value):
+        self.all_marked = value
+
+    def remove_marked(self):
+        if self.all_marked:
+            for i in reversed(range(len(self.__items))):
+                self._remove(i)
+            self.__items = []
+            self.all_marked = False
+            self.item_marking = []
+        else:
+            indices = []
+            for i in reversed(range(len(self.__items))):
+                if self.item_marking[i]:
+                    indices.append(i)
+                    self._remove(i)
+            self.__items = [i for j, i in enumerate(self.__items) if j not in indices]
+            self.item_marking = [i for j, i in enumerate(self.item_marking) if j not in indices]
+
+    def _remove(self, row):
+        self.layout().itemAtPosition(row, self._CHECKBOX_POS).widget().setParent(None)
+        self.layout().itemAtPosition(row, self._BUTTON_UP).widget().setParent(None)
+        self.layout().itemAtPosition(row, self._BUTTON_DOWN).widget().setParent(None)
 
 
 class SortableCheckboxListItem(object):


### PR DESCRIPTION
With reference to [Issue 870](https://tickets.metabrainz.org/browse/PICARD-870), Options in Cover Art Providers and taggers scripts were not removing old entries during a reset. This PR simply does that.

https://tickets.metabrainz.org/browse/PICARD-870
https://tickets.metabrainz.org/browse/PICARD-873
https://tickets.metabrainz.org/browse/PICARD-874