### PR TITLE
PICARD-897: Rename "Submit" button to "Submit AcoustIDs".

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -360,7 +360,7 @@ class MainWindow(QtGui.QMainWindow):
         self.save_action.setEnabled(False)
         self.save_action.triggered.connect(self.save)
 
-        self.submit_action = QtGui.QAction(icontheme.lookup('picard-submit'), _(u"S&ubmit"), self)
+        self.submit_action = QtGui.QAction(icontheme.lookup('picard-submit'), _(u"S&ubmit AcoustIDs"), self)
         self.submit_action.setStatusTip(_(u"Submit acoustic fingerprints"))
         self.submit_action.setEnabled(False)
         self.submit_action.triggered.connect(self._on_submit)


### PR DESCRIPTION
The submit button doesn't actually submit any information to MusicBrainz, but instead submits acoustic fingerprint information to AcoustID.org. The title of this button comes up over and over as a point of confusion for new users of Picard, so renaming it to be more precise will hopefully alleviate this point of confusion.

Jira ticket: https://tickets.metabrainz.org/browse/PICARD-897