### PR TITLE
Gitignore scripts/picard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ locale
 .DS_Store
 po/countries/countries.pot
 po/attributes/attributes.pot
+scripts/picard
 .*.sw[a-z]


### PR DESCRIPTION
./scripts/picard gets build with setup.py build, so let's ignore it to make sure it doesn't accidentally get checked into git at some point.