### PR TITLE
PICARD-911: Messagebox wraps and displays title inappropriately

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -172,8 +172,8 @@ class OptionsDialog(PicardDialog):
         message_box = QtGui.QMessageBox()
         message_box.setIcon(QtGui.QMessageBox.Warning)
         message_box.setWindowModality(QtCore.Qt.WindowModal)
-        message_box.setText("Are you sure?")
-        message_box.setInformativeText(msg)
+        message_box.setWindowTitle(_("Confirm Reset"))
+        message_box.setText(_("Are you sure?") + "\n\n" + msg)
         message_box.setStandardButtons(QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
         if message_box.exec_() == QtGui.QMessageBox.Yes:
             function()


### PR DESCRIPTION
Informative text wraps based on size of text

Before
![before](https://cloud.githubusercontent.com/assets/13236096/21991721/b89b3118-dc39-11e6-8a87-da2616c44d7d.png)

After
![after](https://cloud.githubusercontent.com/assets/13236096/21991676/88b9dfe4-dc39-11e6-86a4-ab2312ec6ceb.png)
