### PR TITLE
PICARD-408: Options pane is obscured

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -103,6 +103,9 @@ class OptionsDialog(PicardDialog):
         self.default_item = None
         self.add_pages(None, default_page, self.ui.pages_tree)
 
+        max_top_page_name = self.ui.pages_tree.sizeHintForColumn(0) + 2*self.ui.pages_tree.frameWidth()
+        self.ui.pages_tree.setMinimumWidth(max_top_page_name)
+
         self.ui.pages_tree.setHeaderLabels([""])
         self.ui.pages_tree.header().hide()
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -103,8 +103,11 @@ class OptionsDialog(PicardDialog):
         self.default_item = None
         self.add_pages(None, default_page, self.ui.pages_tree)
 
-        max_top_page_name = self.ui.pages_tree.sizeHintForColumn(0) + 2*self.ui.pages_tree.frameWidth()
-        self.ui.pages_tree.setMinimumWidth(max_top_page_name)
+        # work-around to set optimal option pane width
+        self.ui.pages_tree.expandAll()
+        max_page_name = self.ui.pages_tree.sizeHintForColumn(0) + 2*self.ui.pages_tree.frameWidth()
+        self.ui.pages_tree.collapseAll()
+        self.ui.pages_tree.setMinimumWidth(max_page_name)
 
         self.ui.pages_tree.setHeaderLabels([""])
         self.ui.pages_tree.header().hide()


### PR DESCRIPTION
I know that another [PR](https://github.com/metabrainz/picard/pull/491) already exists for this [issue](https://tickets.metabrainz.org/browse/PICARD-408), I just wanted to put forward this approach. Rather than simply increasing the default options dialog size, I have set the minimum width according to the contents of the pages_tree. 
This allows the splitter to nicely snap at the perfect pane size.
![reszied_pane](https://cloud.githubusercontent.com/assets/13236096/21994348/4890d100-dc45-11e6-95f5-765c59ab9e99.png)
Note that I have expanded all the items to show that it fits, they're not expanded by default.
