### PR TITLE
Do not translate widget names

### DIFF
--- a/picard/ui/searchdialog.py
+++ b/picard/ui/searchdialog.py
@@ -185,14 +185,14 @@ class SearchDialog(PicardDialog):
 
     def setupUi(self, accept_button_title):
         self.verticalLayout = QtGui.QVBoxLayout(self)
-        self.verticalLayout.setObjectName(_("vertical_layout"))
+        self.verticalLayout.setObjectName("vertical_layout")
         self.search_box = SearchBox(self)
-        self.search_box.setObjectName(_("search_box"))
+        self.search_box.setObjectName("search_box")
         self.verticalLayout.addWidget(self.search_box)
         self.center_widget = QtGui.QWidget(self)
-        self.center_widget.setObjectName(_("center_widget"))
+        self.center_widget.setObjectName("center_widget")
         self.center_layout = QtGui.QVBoxLayout(self.center_widget)
-        self.center_layout.setObjectName(_("center_layout"))
+        self.center_layout.setObjectName("center_layout")
         self.center_layout.setContentsMargins(1, 1, 1, 1)
         self.center_widget.setLayout(self.center_layout)
         self.verticalLayout.addWidget(self.center_widget)

--- a/po/picard.pot
+++ b/po/picard.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: picard 1.4.0dev7\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-01-18 11:25+0100\n"
+"POT-Creation-Date: 2017-01-18 12:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
+"Generated-By: Babel 2.3.4\n"
 
 #: picard/acoustid.py:111
 #, python-format
@@ -141,7 +141,7 @@ msgid "Merge"
 msgstr ""
 
 #: picard/config_upgrade.py:78 picard/ui/metadatabox.py:314
-#: picard/ui/ui_options_interface.py:141 picard/ui/options/interface.py:75
+#: picard/ui/options/interface.py:75 picard/ui/ui_options_interface.py:141
 msgid "Remove"
 msgstr ""
 
@@ -1100,22 +1100,6 @@ msgid ""
 " Help</a>)"
 msgstr ""
 
-#: picard/ui/searchdialog.py:188
-msgid "vertical_layout"
-msgstr ""
-
-#: picard/ui/searchdialog.py:190
-msgid "search_box"
-msgstr ""
-
-#: picard/ui/searchdialog.py:193
-msgid "center_widget"
-msgstr ""
-
-#: picard/ui/searchdialog.py:195
-msgid "center_layout"
-msgstr ""
-
 #: picard/ui/searchdialog.py:228
 msgid "<strong>Loading...</strong>"
 msgstr ""
@@ -1144,9 +1128,9 @@ msgstr ""
 msgid "Track Search Results"
 msgstr ""
 
-#: picard/ui/searchdialog.py:324 picard/ui/searchdialog.py:512
-#: picard/ui/searchdialog.py:740 picard/ui/ui_options_plugins.py:138
-#: picard/ui/options/plugins.py:303
+#: picard/ui/options/plugins.py:303 picard/ui/searchdialog.py:324
+#: picard/ui/searchdialog.py:512 picard/ui/searchdialog.py:740
+#: picard/ui/ui_options_plugins.py:138
 msgid "Name"
 msgstr ""
 
@@ -1206,8 +1190,9 @@ msgstr ""
 msgid "File Name"
 msgstr ""
 
-#: picard/ui/ui_cdlookup.py:53 picard/ui/ui_options_cdlookup.py:42
-#: picard/ui/ui_options_cdlookup_select.py:49 picard/ui/options/cdlookup.py:38
+#: picard/ui/options/cdlookup.py:38 picard/ui/ui_cdlookup.py:53
+#: picard/ui/ui_options_cdlookup.py:42
+#: picard/ui/ui_options_cdlookup_select.py:49
 msgid "CD Lookup"
 msgstr ""
 
@@ -1369,7 +1354,7 @@ msgstr ""
 msgid "Get API key..."
 msgstr ""
 
-#: picard/ui/ui_options_folksonomy.py:115 picard/ui/options/folksonomy.py:28
+#: picard/ui/options/folksonomy.py:28 picard/ui/ui_options_folksonomy.py:115
 msgid "Folksonomy Tags"
 msgstr ""
 
@@ -1424,7 +1409,7 @@ msgstr ""
 msgid "Server address:"
 msgstr ""
 
-#: picard/ui/ui_options_general.py:95 picard/ui/options/general.py:88
+#: picard/ui/options/general.py:88 picard/ui/ui_options_general.py:95
 msgid "MusicBrainz Account"
 msgstr ""
 
@@ -1436,7 +1421,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: picard/ui/ui_options_general.py:98 picard/ui/options/general.py:33
+#: picard/ui/options/general.py:33 picard/ui/ui_options_general.py:98
 msgid "General"
 msgstr ""
 
@@ -1528,7 +1513,7 @@ msgstr ""
 msgid "Minimal similarity for cluster lookups:"
 msgstr ""
 
-#: picard/ui/ui_options_metadata.py:101 picard/ui/options/metadata.py:29
+#: picard/ui/options/metadata.py:29 picard/ui/ui_options_metadata.py:101
 msgid "Metadata"
 msgstr ""
 
@@ -1598,7 +1583,7 @@ msgstr ""
 msgid "Listen only on localhost"
 msgstr ""
 
-#: picard/ui/ui_options_plugins.py:137 picard/ui/options/plugins.py:68
+#: picard/ui/options/plugins.py:68 picard/ui/ui_options_plugins.py:137
 msgid "Plugins"
 msgstr ""
 
@@ -2117,7 +2102,7 @@ msgstr ""
 msgid "File Naming"
 msgstr ""
 
-#: picard/ui/options/renaming.py:175 picard/ui/options/scripting.py:404
+#: picard/ui/options/renaming.py:175 picard/ui/options/scripting.py:406
 msgid ""
 "<a href=\"%(picard-doc-scripting-url)s\">Open Scripting Documentation in "
 "your browser</a>"
@@ -2159,15 +2144,15 @@ msgstr ""
 msgid "Scripting"
 msgstr ""
 
-#: picard/ui/options/scripting.py:290
+#: picard/ui/options/scripting.py:292
 msgid "Are you sure you want to remove this script?"
 msgstr ""
 
-#: picard/ui/options/scripting.py:291
+#: picard/ui/options/scripting.py:293
 msgid "Confirm Remove"
 msgstr ""
 
-#: picard/ui/options/scripting.py:374
+#: picard/ui/options/scripting.py:376
 msgid "Script Error"
 msgstr ""
 


### PR DESCRIPTION
Do we need a ticket for this? It is basically just a fixup for the builtin search.

Speaking of that: I could not find a ticket for the builtin search, but I guess we should have one for the release notes, right?