### PR TITLE
PICARD-258: Visual Feedback for coverart changes

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -35,11 +35,11 @@ class ActiveLabel(QtGui.QLabel):
     clicked = QtCore.pyqtSignal()
     imageDropped = QtCore.pyqtSignal(QtCore.QUrl)
 
-    def __init__(self, active=True, *args):
+    def __init__(self, active=True, drops=False, *args):
         QtGui.QLabel.__init__(self, *args)
         self.setMargin(0)
         self.setActive(active)
-        self.setAcceptDrops(False)
+        self.setAcceptDrops(drops)
 
     def setActive(self, active):
         self.active = active
@@ -66,6 +66,7 @@ class ActiveLabel(QtGui.QLabel):
                 self.imageDropped.emit(url)
         if accepted:
             event.acceptProposedAction()
+
 
 class CoverArtThumbnail(ActiveLabel):
 
@@ -137,6 +138,7 @@ class CoverArtThumbnail(ActiveLabel):
     def fetch_remote_image(self, url):
         return self.parent().fetch_remote_image(url)
 
+
 class CoverArtBox(QtGui.QGroupBox):
 
     def __init__(self, parent):
@@ -147,7 +149,7 @@ class CoverArtBox(QtGui.QGroupBox):
         self.setStyleSheet('''QGroupBox{background-color:none;border:1px;}''')
         self.setFlat(True)
         self.item = None
-        self.cover_art_label = QtGui.QLabel('Cover-Art')
+        self.cover_art_label = QtGui.QLabel('')
         self.cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
         self.cover_art = CoverArtThumbnail(False, True, parent)
         self.orig_cover_art_label = QtGui.QLabel('')
@@ -163,6 +165,8 @@ class CoverArtBox(QtGui.QGroupBox):
     def _show(self):
         if self.cover_art.data == self.orig_cover_art.data:
             self.orig_cover_art.setHidden(True)
+            self.cover_art_label.setText('')
+            self.orig_cover_art_label.setText('')
         else:
             self.orig_cover_art.setHidden(False)
             self.cover_art_label.setText('New Cover-Art')

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -80,6 +80,12 @@ class CoverArtThumbnail(ActiveLabel):
         self.clicked.connect(self.open_release_page)
         self.imageDropped.connect(self.fetch_remote_image)
 
+    def __eq__(self, other):
+        if self.data and other.data:
+            return self.data.data == other.data.data
+        else:
+            return False
+
     def show(self):
         self.set_data(self.data, True)
 
@@ -163,7 +169,9 @@ class CoverArtBox(QtGui.QGroupBox):
         self.setLayout(self.layout)
 
     def _show(self):
-        if self.cover_art.data == self.orig_cover_art.data:
+        # We want to show the 2 coverarts only if they are different
+        # and orig_cover_art is not None
+        if getattr(self.orig_cover_art, 'data', None) is None or self.cover_art == self.orig_cover_art:
             self.orig_cover_art.setHidden(True)
             self.cover_art_label.setText('')
             self.orig_cover_art_label.setText('')

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -130,6 +130,12 @@ class CoverArtThumbnail(ActiveLabel):
             self.setToolTip("")
         self.release = release
 
+    def open_release_page(self):
+        lookup = self.tagger.get_file_lookup()
+        lookup.albumLookup(self.release)
+
+    def fetch_remote_image(self, url):
+        return self.parent().fetch_remote_image(url)
 
 
 class CoverArtBox(QtGui.QGroupBox):

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -892,12 +892,14 @@ class MainWindow(QtGui.QMainWindow):
         self.update_actions()
 
         metadata = None
+        orig_metadata = None
         obj = None
 
         if len(objects) == 1:
             obj = list(objects)[0]
             if isinstance(obj, File):
                 metadata = obj.metadata
+                orig_metadata = obj.orig_metadata
                 if obj.state == obj.ERROR:
                     msg = N_("%(filename)s (error: %(error)s)")
                     mparms = {
@@ -914,6 +916,7 @@ class MainWindow(QtGui.QMainWindow):
                 metadata = obj.metadata
                 if obj.num_linked_files == 1:
                     file = obj.linked_files[0]
+                    orig_metadata = file.orig_metadata
                     if file.state == File.ERROR:
                         msg = N_("%(filename)s (%(similarity)d%%) (error: %(error)s)")
                         mparms = {
@@ -934,7 +937,7 @@ class MainWindow(QtGui.QMainWindow):
 
         self.metadata_box.selection_dirty = True
         self.metadata_box.update()
-        self.cover_art_box.set_metadata(metadata, obj)
+        self.cover_art_box.set_metadata(metadata, orig_metadata, obj)
         self.selection_updated.emit(objects)
 
     def show_cover_art(self):


### PR DESCRIPTION
When no new coverart or new coverart has same data as old or after save

![image](https://cloud.githubusercontent.com/assets/16130816/22182811/653bf44a-e0d4-11e6-8ee8-0597327f0475.png)

when different cover arts
![image](https://cloud.githubusercontent.com/assets/16130816/22182818/9626e42a-e0d4-11e6-88b3-ea006893f9ec.png)
