### PR TITLE
Bump minimum Python version to 2.7.9 for Picard 1.4.

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -6,7 +6,7 @@ Dependencies
 
 Before installing Picard, you need to have these:
 
- * Python 2.7 or newer (Picard will not work with Python 3)
+ * Python 2.7.9 or newer (Picard will not work with Python 3)
    http://python.org/download
 
  * PyQt 4.5 or newer

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ import sys
 import subprocess
 from picard import __version__, compat
 
-if sys.version_info < (2, 7):
-    print("*** You need Python 2.7 or higher to use Picard.")
+if sys.version_info < (2, 7, 9):
+    print("*** You need Python 2.7.9 or higher to use Picard.")
 
 
 args = {}


### PR DESCRIPTION
Since the various MetaBrainz projects are increasingly moving to HTTPS-mostly (and hopefully -only before too long!), it would be nice to know that Picard 1.4 won't break because of this anytime soon. Since several of the MetaBrainz sites share an IP address they're relying on SNI for sending the proper certificate. SNI support wasn't added in Python 2.7 before the .9 release, so bumping minimum Python version to this specific one, so that we can be sure that SNI is supported.

I feel like Picard 1.4 might be a bit of an "LTS" type release for us, since there will undoubtedly be some people unhappy with whatever changes we make for Picard 2.0, so I feel like we'll want to make sure it'll work for as long as possible—which includes after musicbrainz.org and acousticbrainz.org going full-HTTPS. For that we'll want SNI, and it's easier to just depend on 2.7.9 rather than add another dependency and change code for that, and we probably don't want to touch Picard either at that time.

Ubuntu Trusty (from April 2014) still ships a pre-2.7.9 Python, but are any other distros of relevance still on this old Python? Ubuntu Trusty is 3 years old soon, and not likely used on a lot of desktops. It probably also ships an old Picard version anyway and isn't likely to pick up Picard 1.4 either.

A slight bit of IRC discussion: https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/3800847/