### PR TITLE
PICARD-945: Demote non-existent plugin warning to info message.

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -234,7 +234,7 @@ class PluginManager(QtCore.QObject):
     def load_plugindir(self, plugindir):
         plugindir = os.path.normpath(plugindir)
         if not os.path.isdir(plugindir):
-            log.warning("Plugin directory %r doesn't exist", plugindir)
+            log.info("Plugin directory %r doesn't exist", plugindir)
             return
         # first, handle eventual plugin updates
         for updatepath in [os.path.join(plugindir, file) for file in


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/PICARD-945

Instead of presenting as a warning if a given plugin directory isn't found, just notify as an info-level message, as per https://chatlogs.metabrainz.org/brainzbot/metabrainz/msg/3802418/ – though demoting to info instead of debug.