### PR TITLE
Fix OS X package

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -92,11 +92,11 @@ class Config(QtCore.QSettings):
 
     """Configuration."""
 
-    def __init__(self):
+    def __init__(self, app):
         """Initializes the configuration."""
 
         QtCore.QSettings.__init__(self, QtCore.QSettings.IniFormat,
-                                  QtCore.QSettings.UserScope, PICARD_ORG_NAME, PICARD_APP_NAME)
+                                  QtCore.QSettings.UserScope, PICARD_ORG_NAME, PICARD_APP_NAME, app)
         # If there are no settings, copy existing settings from old format
         # (registry on windows systems)
         if not self.allKeys():
@@ -241,21 +241,12 @@ class IntListOption(Option):
         return map(int, value)
 
 
-_config = Config()
+config = None
+setting = None
+persist = None
 
-setting = _config.setting
-persist = _config.persist
-
-# http://pyqt.sourceforge.net/Docs/PyQt4/qsettings.html#fileName
-# QString QSettings.fileName (self)
-#
-# Returns the path where settings written using this QSettings object are stored.
-#
-# On Windows, if the format is QSettings.NativeFormat, the return value is a system registry path, not a file path.
-FILE_PATH = 0
-REGISTRY_PATH = 1
-storage = _config.fileName()
-if _config.format() == QtCore.QSettings.NativeFormat and sys.platform == "win32":
-    storage_type = REGISTRY_PATH
-else:
-    storage_type = FILE_PATH
+def _setup(app):
+    global config, setting, persist
+    config = Config(app)
+    setting = config.setting
+    persist = config.persist

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -32,12 +32,11 @@ from picard import (log, config)
 # and modify PICARD_VERSION to match it
 #
 
-_s = config.setting
-
 
 def upgrade_to_v1_0_0_final_0():
     """In version 1.0, the file naming formats for single and various artist releases were merged.
     """
+    _s = config.setting
     def remove_va_file_naming_format(merge=True):
         if merge:
             _s["file_naming_format"] = (
@@ -89,6 +88,7 @@ def upgrade_to_v1_0_0_final_0():
 def upgrade_to_v1_3_0_dev_1():
     """Option "windows_compatible_filenames" was renamed "windows_compatibility" (PICARD-110).
     """
+    _s = config.setting
     old_opt = "windows_compatible_filenames"
     new_opt = "windows_compatibility"
     if old_opt in _s:
@@ -99,6 +99,7 @@ def upgrade_to_v1_3_0_dev_1():
 def upgrade_to_v1_3_0_dev_2():
     """Option "preserved_tags" is now using comma instead of spaces as tag separator (PICARD-536)
     """
+    _s = config.setting
     opt = "preserved_tags"
     if opt in _s:
         _s[opt] = re.sub(r"\s+", ",", _s[opt].strip())
@@ -107,6 +108,7 @@ def upgrade_to_v1_3_0_dev_2():
 def upgrade_to_v1_3_0_dev_3():
     """Options were made to support lists (solving PICARD-144 and others)
     """
+    _s = config.setting
     option_separators = {
         "preferred_release_countries": "  ",
         "preferred_release_formats": "  ",
@@ -122,6 +124,7 @@ def upgrade_to_v1_3_0_dev_3():
 def upgrade_to_v1_3_0_dev_4():
     """Option "release_type_scores" is now a list of tuples
     """
+    _s = config.setting
     def load_release_type_scores(setting):
         scores = []
         values = setting.split()
@@ -143,6 +146,7 @@ def upgrade_to_v1_4_0_dev_2():
     replaced with OAuth tokens
     """
 
+    _s = config.setting
     opts = ["username", "password"]
     for opt in opts:
         _s.remove(opt)
@@ -150,6 +154,7 @@ def upgrade_to_v1_4_0_dev_2():
 
 def upgrade_to_v1_4_0_dev_3():
     """Cover art providers options were moved to a list of tuples"""
+    _s = config.setting
     map = [
         ('ca_provider_use_amazon', 'Amazon'),
         ('ca_provider_use_caa', 'Cover Art Archive'),
@@ -166,6 +171,7 @@ def upgrade_to_v1_4_0_dev_3():
 
 def upgrade_to_v1_4_0_dev_4():
     """Adds trailing comma to default file names for scripts"""
+    _s = config.setting
     _DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
         "$if($ne(%albumartist%,),%album%/)" \
         "$if($gt(%totaldiscs%,1),%discnumber%-,)" \
@@ -190,6 +196,7 @@ def upgrade_to_v1_4_0_dev_5():
 
 def upgrade_to_v1_4_0_dev_6():
     """Adds support for multiple and selective tagger scripts"""
+    _s = config.setting
     DEFAULT_NUMBERED_SCRIPT_NAME = N_("My script %d")
     old_enabled_option = "enable_tagger_script"
     old_script_text_option = "tagger_script"
@@ -208,14 +215,16 @@ def upgrade_to_v1_4_0_dev_6():
 
 def upgrade_to_v1_4_0_dev_7():
     """Option "save_only_front_images_to_tags" was renamed to "embed_only_one_front_image"."""
+    _s = config.setting
     old_opt = "save_only_front_images_to_tags"
     new_opt = "embed_only_one_front_image"
     if old_opt in _s:
         _s[new_opt] = _s.value(old_opt, config.BoolOption, True)
         _s.remove(old_opt)
 
+
 def upgrade_config():
-    cfg = config._config
+    cfg = config.config
     cfg.register_upgrade_hook(upgrade_to_v1_0_0_final_0)
     cfg.register_upgrade_hook(upgrade_to_v1_3_0_dev_1)
     cfg.register_upgrade_hook(upgrade_to_v1_3_0_dev_2)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -107,6 +107,8 @@ class Tagger(QtGui.QApplication):
         QtGui.QApplication.__init__(self, ['MusicBrainz-Picard'] + unparsed_args)
         self.__class__.__instance = self
 
+        config._setup(self)
+
         self._cmdline_files = picard_args.FILE
         self._autoupdate = autoupdate
         self._debug = False
@@ -149,10 +151,7 @@ class Tagger(QtGui.QApplication):
         log.debug("Platform: %s %s %s", platform.platform(),
                   platform.python_implementation(), platform.python_version())
         log.debug("Versions: %s", versions.as_string())
-        if config.storage_type == config.REGISTRY_PATH:
-            log.debug("Configuration registry path: %s", config.storage)
-        else:
-            log.debug("Configuration file path: %s", config.storage)
+        log.debug("Configuration file path: %s", config.config.fileName())
 
         # TODO remove this before the final release
         if sys.platform == "win32":


### PR DESCRIPTION
It seems that if the ini-based config was initialized before creating the app instance, Qt would do a different initialization sequence and some configs would not be loaded. That caused it to not look for plugins in the app bundle.

@zas @mwiencek Can you please review?