### PR TITLE
PICARD-942: Fix explore/play remote folders/files

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -785,6 +785,8 @@ class MainWindow(QtGui.QMainWindow):
         return self.tagger.analyze(self.selected_objects)
 
     def _openUrl(self,url):
+        # Resolves a bug in Qt opening remote URLs - QTBUG-13359
+        # See https://bugreports.qt.io/browse/QTBUG-13359
         if url.startswith("\\\\") or url.startswith("//"):
             return QtCore.QUrl(QtCore.QDir.toNativeSeparators(url))
         else:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -784,17 +784,21 @@ class MainWindow(QtGui.QMainWindow):
                 return
         return self.tagger.analyze(self.selected_objects)
 
+    def _openUrl(self,url):
+        if url.startswith("\\\\") or url.startswith("//"):
+            return QtCore.QUrl(QtCore.QDir.toNativeSeparators(url))
+        else:
+            return QtCore.QUrl.fromLocalFile(url)
+
     def play_file(self):
         files = self.tagger.get_files_from_objects(self.selected_objects)
         for file in files:
-            url = QtCore.QUrl.fromLocalFile(file.filename)
-            QtGui.QDesktopServices.openUrl(url)
+            QtGui.QDesktopServices.openUrl(self._openUrl(file.filename))
 
     def open_folder(self):
         files = self.tagger.get_files_from_objects(self.selected_objects)
         for file in files:
-            url = QtCore.QUrl.fromLocalFile(os.path.dirname(file.filename))
-            QtGui.QDesktopServices.openUrl(url)
+            QtGui.QDesktopServices.openUrl(self._openUrl(os.path.dirname(file.filename)))
 
     def show_analyze_settings_info(self):
         ret = QtGui.QMessageBox.question(self,


### PR DESCRIPTION
Resolves [PICARD-942](https://tickets.metabrainz.org/browse/PICARD-942).

Make "Open Containing Folder" and "Open in Player" work for remote files.

See [QTBUG-13359](https://bugreports.qt.io/browse/QTBUG-13359) for cause and workaround.

Tested on Windows. Needs testing on Mac / Linux.