### PR TITLE
PICARD-951: Always use HTTPS for musicbrainz.org.

### DIFF
--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -74,7 +74,7 @@ class OAuthManager(object):
                   MUSICBRAINZ_OAUTH_CLIENT_ID, "redirect_uri":
                   "urn:ietf:wg:oauth:2.0:oob", "scope": scopes}
         url = build_qurl(host, port, path="/oauth2/authorize",
-                         queryargs=params, mblogin=True)
+                         queryargs=params)
         return str(url.toEncoded())
 
     def set_refresh_token(self, refresh_token, scopes):

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -37,7 +37,7 @@ class GeneralOptionsPage(OptionsPage):
 
     options = [
         config.TextOption("setting", "server_host", MUSICBRAINZ_SERVERS[0]),
-        config.IntOption("setting", "server_port", 80),
+        config.IntOption("setting", "server_port", 443),
         config.TextOption("persist", "oauth_refresh_token", ""),
         config.BoolOption("setting", "analyze_new_files", False),
         config.BoolOption("setting", "ignore_file_mbids", False),

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -395,9 +395,9 @@ def build_qurl(host, port=80, path=None, queryargs=None):
     url.setHost(host)
     url.setPort(port)
     if (# We're contacting a MusicBrainz server
-        (host in MUSICBRAINZ_SERVERS and port == 80) or
+        host in MUSICBRAINZ_SERVERS or
         # Or we're contacting some other server via HTTPS.
-         port == 443):
+        port == 443):
             url.setScheme("https")
             url.setPort(443)
     else:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -394,12 +394,10 @@ def build_qurl(host, port=80, path=None, queryargs=None):
     url = QtCore.QUrl()
     url.setHost(host)
     url.setPort(port)
-    if (# We're contacting a MusicBrainz server
-        host in MUSICBRAINZ_SERVERS or
-        # Or we're contacting some other server via HTTPS.
-        port == 443):
-            url.setScheme("https")
-            url.setPort(443)
+
+    if (host in MUSICBRAINZ_SERVERS or port == 443):
+        url.setScheme("https")
+        url.setPort(443)
     else:
         url.setScheme("http")
 

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -383,12 +383,10 @@ def album_artist_from_path(filename, album, artist):
     return album, artist
 
 
-def build_qurl(host, port=80, path=None, mblogin=False, queryargs=None):
+def build_qurl(host, port=80, path=None, queryargs=None):
     """
     Builds and returns a QUrl object from `host`, `port` and `path` and
     automatically enables HTTPS if necessary.
-
-    Setting `mblogin` to True forces HTTPS on MusicBrainz' servers.
 
     Encoded query arguments can be provided in `queryargs`, a
     dictionary mapping field names to values.
@@ -396,8 +394,8 @@ def build_qurl(host, port=80, path=None, mblogin=False, queryargs=None):
     url = QtCore.QUrl()
     url.setHost(host)
     url.setPort(port)
-    if (# Login is required and we're contacting an MB server
-        (mblogin and host in MUSICBRAINZ_SERVERS and port == 80) or
+    if (# We're contacting a MusicBrainz server
+        (host in MUSICBRAINZ_SERVERS and port == 80) or
         # Or we're contacting some other server via HTTPS.
          port == 443):
             url.setScheme("https")

--- a/picard/webservice.py
+++ b/picard/webservice.py
@@ -189,8 +189,7 @@ class XmlWebService(QtCore.QObject):
     def _start_request_continue(self, method, host, port, path, data, handler, xml,
                                 mblogin=False, cacheloadcontrol=None, refresh=None,
                                 access_token=None, queryargs=None):
-        url = build_qurl(host, port, path=path, mblogin=mblogin,
-                         queryargs=queryargs)
+        url = build_qurl(host, port, path=path, queryargs=queryargs)
         request = QtNetwork.QNetworkRequest(url)
         if mblogin and access_token:
             request.setRawHeader("Authorization", "Bearer %s" % access_token)


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/PICARD-951

MusicBrainz.org is eventually going to go all HTTPS-only, though the webservice for now can still be reached via HTTP. To help the move to HTTPS, this commit makes URLs built via `build_qurl()` always use HTTPS when going to a MusicBrainz server (as defined by the `MUSICBRAINZ_SERVERS` constant).

This also means that the check in the `build_qurl()` function for whether a given page/URL is/requires an authentication for MusicBrainz is now redundant, as we're always using HTTPS on MusicBrainz, regardless of login/authentication status.