### PR TITLE
PICARD-952: Use HTTPS for Cover Art Archive.

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -48,7 +48,7 @@ MUSICBRAINZ_OAUTH_CLIENT_SECRET = 'xIsvXbIuntaLuRRhzuazOA'
 
 # Cover art archive URL and port
 CAA_HOST = "coverartarchive.org"
-CAA_PORT = 80
+CAA_PORT = 443
 
 # URLs
 PICARD_URLS = {


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/PICARD-952

This sets the `CAA_PORT` constant to 443, making the initial lookup to CAA be over HTTPS. However, after the initial lookup, it seems like CAA itself is sending back HTTP redirects for http:// URLs which Picard then follows (as it should). Effectively, this PR just changes the initial CAA lookup to HTTPS, but I'm not sure I can do any better for now/without adding a bunch of exceptions specifically for `coverartarchive.org` to the code.

Without patch:
```fish
(testenv) freso@koume ~/D/M/picard (master)> grep -i coverartarchive ~/tmp/picard-master.log  
D: 16:09:25 WSREQ: Starting another request to ('coverartarchive.org', 80) without delay
D: 16:09:25 Received reply for http://coverartarchive.org:80/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/: HTTP 307 (TEMPORARY REDIRECT) 
D: 16:09:28 Queuing cover art image CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P')
D: 16:09:28 Downloading CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P')
D: 16:09:28 WSREQ: Starting another request to ('coverartarchive.org', 80) without delay
D: 16:09:28 Received reply for http://coverartarchive.org:80/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg: HTTP 307 (TEMPORARY REDIRECT) 
D: 16:09:29 Cover art image stored to metadata: CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P') [w=500 h=500 mime=image/jpeg ext=.jpg datalen=42632 file=/tmp/picardqf40dv.jpg]
```

With patch:
```fish
(testenv) freso@koume ~/D/M/picard (PICARD-952-caa-over-https)> grep -i coverartarchive ~/tmp/picard.log  
D: 16:05:10 WSREQ: Starting another request to ('coverartarchive.org', 443) without delay
D: 16:05:11 Received reply for https://coverartarchive.org:443/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/: HTTP 307 (TEMPORARY REDIRECT) 
D: 16:05:13 Queuing cover art image CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P')
D: 16:05:13 Downloading CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P')
D: 16:05:13 WSREQ: First request to ('coverartarchive.org', 80)
D: 16:05:13 Received reply for http://coverartarchive.org:80/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg: HTTP 307 (TEMPORARY REDIRECT) 
D: 16:05:14 Cover art image stored to metadata: CaaCoverArtImage(url=u'http://coverartarchive.org/release/66cf87ea-6731-4b33-9c93-8ee1e4c9d9f1/15789846591-500.jpg', types=[u'front'], is_front=True, comment=u'P') [w=500 h=500 mime=image/jpeg ext=.jpg datalen=42632 file=/tmp/picard0c97wR.jpg]
```