### PR TITLE
Update links to ticket tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Binary downloads are available [here](http://picard.musicbrainz.org/downloads/).
 Support and issue reporting
 ---------------------------
 
-Please report all bugs and feature requests in the [MusicBrainz issue tracker](http://tickets.musicbrainz.org/browse/PICARD). If you need support in using Picard please read the [documentation](https://picard.musicbrainz.org/docs/) first and have a look at the [MusicBrainz community forums](https://community.metabrainz.org/c/picard).
+Please report all bugs and feature requests in the [MusicBrainz issue tracker](https://tickets.metabrainz.org/browse/PICARD). If you need support in using Picard please read the [documentation](https://picard.musicbrainz.org/docs/) first and have a look at the [MusicBrainz community forums](https://community.metabrainz.org/c/picard).

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -200,7 +200,7 @@ class CoverArtProviderCaa(CoverArtProvider):
     @property
     def _has_suitable_artwork(self):
         # MB web service indicates if CAA has artwork
-        # http://tickets.musicbrainz.org/browse/MBS-4536
+        # https://tickets.metabrainz.org/browse/MBS-4536
         if 'cover_art_archive' not in self.release.children:
             log.debug("No Cover Art Archive information for %s"
                       % self.release.id)

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -47,7 +47,7 @@ class StandardButton(QtGui.QPushButton):
 
 
 # The following code is there to fix
-# http://tickets.musicbrainz.org/browse/PICARD-417
+# https://tickets.metabrainz.org/browse/PICARD-417
 # In some older version of PyQt/sip it's impossible to connect a signal
 # emitting an `int` to a slot expecting a `bool`.
 # By using `enabledSlot` instead we can force python to do the


### PR DESCRIPTION
The URL for the ticket tracker has changed, so let's reflect this in the files.

I realise that the command also changed a number of .po files and that these changes will likely get lost, but that it was likely still less effort to just include them anyway rather than try and weed them out of the commit. However, not all .po files have this line and it isn't included in the .pot either, apparently, so not sure exactly where to change the .po file link properly. Maybe on Transifex somewhere.

Using:
`sed -i 's|http://tickets.musicbrainz.org|https://tickets.metabrainz.org|' $(git grep -l tickets.musicbrainz.)`