### PR TITLE
PICARD-953: Show album with extra tracks unmatched

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -485,6 +485,8 @@ class Album(DataObject, Item):
         for track in self.tracks:
             if not track.is_complete():
                 return False
+        if self.get_num_unmatched_files():
+            return False
         else:
             return True
 


### PR DESCRIPTION
Resolves [PICARD-953](https://tickets.metabrainz.org/browse/PICARD-953).

If an album has unmatched files it is now shown as incomplete even if all album tracks are matched to one file. Although the terminology would suggest that such an album is "complete", in practical terms the album is not perfect because in all likelihood the user needs to select a different release with more tracks.