### PR TITLE
PICARD-958 Better fix for unicode errors when writing to stderr

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -185,7 +185,7 @@ class File(QtCore.QObject, Item):
                 try:
                     os.utime(encoded_old_filename, (info.st_atime, info.st_mtime))
                 except OSError:
-                    log.warning("Couldn't preserve timestamp for %r", old_filename)
+                    log.warning("Couldn't preserve timestamp for %s", old_filename)
         # Rename files
         if config.setting["rename_files"] or config.setting["move_files"]:
             new_filename = self._rename(old_filename, metadata)
@@ -349,7 +349,7 @@ class File(QtCore.QObject, Item):
             new_filename = "%s (%d)" % (tmp_filename, i)
             i += 1
         new_filename = new_filename + ext
-        log.debug("Moving file %r => %r", old_filename, new_filename)
+        log.debug("Moving file %s => %s", old_filename, new_filename)
         shutil.move(encode_filename(old_filename), encode_filename(new_filename))
         return new_filename
 
@@ -389,9 +389,9 @@ class File(QtCore.QObject, Item):
                     old_file = os.path.join(old_path, old_file)
                     # FIXME we shouldn't do this from a thread!
                     if self.tagger.files.get(decode_filename(old_file)):
-                        log.debug("File loaded in the tagger, not moving %r", old_file)
+                        log.debug("File loaded in the tagger, not moving %s", old_file)
                         continue
-                    log.debug("Moving %r to %r", old_file, new_file)
+                    log.debug("Moving %s to %s", old_file, new_file)
                     shutil.move(old_file, new_file)
 
     def remove(self, from_parent=True):

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -57,7 +57,7 @@ class APEv2File(File):
     __rtranslate = dict([(v, k) for k, v in __translate.iteritems()])
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         file = self._File(encode_filename(filename))
         metadata = Metadata()
         if file.tags:

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -144,7 +144,7 @@ class ASFFile(File):
     __RTRANS = dict([(b, a) for a, b in __TRANS.items()])
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         file = ASF(encode_filename(filename))
         metadata = Metadata()
         for name, values in file.tags.items():

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -176,7 +176,7 @@ class ID3File(File):
     }
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         file = self._get_file(encode_filename(filename))
         tags = file.tags or {}
         # upgrade custom 2.3 frames to 2.4
@@ -422,7 +422,7 @@ class ID3File(File):
                         if frame.FrameID in ('TMCL', 'TIPL', 'IPLS'):
                             for people in frame.people:
                                 if people[0] == role:
-                                    frame.people.remove(people)   
+                                    frame.people.remove(people)
                 elif name.startswith('comment:'):
                     desc = name.split(':', 1)[1]
                     if desc.lower()[:4] != 'itun':
@@ -443,7 +443,7 @@ class ID3File(File):
                         if frame.FrameID in ('TIPL', 'IPLS'):
                             for people in frame.people:
                                 if people[0] == role:
-                                    frame.people.remove(people)   
+                                    frame.people.remove(people)
                 elif name == 'musicbrainz_recordingid':
                     for key, frame in tags.items():
                         if frame.FrameID == 'UFID' and frame.owner == 'http://musicbrainz.org':

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -111,7 +111,7 @@ class MP4File(File):
                               "totaldiscs", "totaltracks")
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         file = MP4(encode_filename(filename))
         tags = file.tags
         if tags is None:

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -51,7 +51,7 @@ class VCommentFile(File):
     __rtranslate = dict([(v, k) for k, v in __translate.iteritems()])
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         file = self._File(encode_filename(filename))
         file.tags = file.tags or {}
         metadata = Metadata()

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -30,7 +30,7 @@ class WAVFile(File):
     _File = None
 
     def _load(self, filename):
-        log.debug("Loading file %r", filename)
+        log.debug("Loading file %s", filename)
         f = wave.open(encode_filename(filename), "rb")
         metadata = Metadata()
         metadata['~channels'] = f.getnchannels()

--- a/picard/log.py
+++ b/picard/log.py
@@ -113,7 +113,7 @@ def formatted_log_line(level, time, message, timefmt='hh:mm:ss',
 
 def _stderr_receiver(level, time, msg):
     try:
-        sys.stderr.write(formatted_log_line(level, time, msg + os.linesep))
+        sys.stderr.write("%r%s" % (formatted_log_line(level, time, msg), os.linesep))
     except UnicodeDecodeError:
         import traceback
         traceback.print_exc()

--- a/picard/log.py
+++ b/picard/log.py
@@ -113,7 +113,7 @@ def formatted_log_line(level, time, message, timefmt='hh:mm:ss',
 
 def _stderr_receiver(level, time, msg):
     try:
-        sys.stderr.write("%r%s" % (formatted_log_line(level, time, msg), os.linesep))
+        sys.stderr.write(formatted_log_line(level, time, msg + os.linesep))
     except UnicodeDecodeError:
         import traceback
         traceback.print_exc()

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -207,7 +207,7 @@ class PluginData(PluginShared):
         try:
             return PluginShared.__getattribute__(self, name)
         except AttributeError:
-            log.debug('Attribute %r not found for plugin %r', name, self.module_name)
+            log.debug('Attribute %s not found for plugin %s', name, self.module_name)
             return None
 
     @property
@@ -234,7 +234,7 @@ class PluginManager(QtCore.QObject):
     def load_plugindir(self, plugindir):
         plugindir = os.path.normpath(plugindir)
         if not os.path.isdir(plugindir):
-            log.info("Plugin directory %r doesn't exist", plugindir)
+            log.info("Plugin directory %s doesn't exist", plugindir)
             return
         # first, handle eventual plugin updates
         for updatepath in [os.path.join(plugindir, file) for file in
@@ -246,9 +246,9 @@ class PluginManager(QtCore.QObject):
             if name:
                 self.remove_plugin(name)
                 os.rename(updatepath, path)
-                log.debug('Updating plugin %r (%r))', name, path)
+                log.debug('Updating plugin %s (%s))', name, path)
             else:
-                log.error('Cannot get plugin name from %r', updatepath)
+                log.error('Cannot get plugin name from %s', updatepath)
         # now load found plugins
         names = set()
         for path in [os.path.join(plugindir, file) for file in os.listdir(plugindir)]:
@@ -257,7 +257,7 @@ class PluginManager(QtCore.QObject):
                 name = _plugin_name_from_path(path)
             if name:
                 names.add(name)
-        log.debug("Looking for plugins in directory %r, %d names found",
+        log.debug("Looking for plugins in directory %s, %d names found",
                   plugindir,
                   len(names))
         for name in sorted(names):
@@ -269,7 +269,7 @@ class PluginManager(QtCore.QObject):
         if importer:
             name = module_name
             if not importer.find_module(name):
-                log.error("Failed loading zipped plugin %r", name)
+                log.error("Failed loading zipped plugin %s", name)
                 return None
             module_pathname = importer.get_filename(name)
         else:
@@ -278,7 +278,7 @@ class PluginManager(QtCore.QObject):
                 module_file = info[0]
                 module_pathname = info[1]
             except ImportError:
-                log.error("Failed loading plugin %r", name)
+                log.error("Failed loading plugin %s", name)
                 return None
 
         plugin = None
@@ -286,8 +286,8 @@ class PluginManager(QtCore.QObject):
             index = None
             for i, p in enumerate(self.plugins):
                 if name == p.module_name:
-                    log.warning("Module %r conflict: unregistering previously" \
-                              " loaded %r version %s from %r",
+                    log.warning("Module %s conflict: unregistering previously" \
+                              " loaded %s version %s from %s",
                               p.module_name,
                               p.name,
                               p.version,
@@ -304,7 +304,7 @@ class PluginManager(QtCore.QObject):
                         list(plugin.api_versions)]
             compatible_versions = list(set(versions) & self._api_versions)
             if compatible_versions:
-                log.debug("Loading plugin %r version %s, compatible with API: %s",
+                log.debug("Loading plugin %s version %s, compatible with API: %s",
                           plugin.name,
                           plugin.version,
                           ", ".join([version_to_string(v, short=True) for v in
@@ -320,9 +320,9 @@ class PluginManager(QtCore.QObject):
                             " with this version of Picard."
                             % (plugin.name, plugin.file))
         except VersionError as e:
-            log.error("Plugin %r has an invalid API version string : %s", name, e)
+            log.error("Plugin %s has an invalid API version string : %s", name, e)
         except:
-            log.error("Plugin %r : %s", name, traceback.format_exc())
+            log.error("Plugin %s : %s", name, traceback.format_exc())
         if module_file is not None:
             module_file.close()
         return plugin
@@ -341,14 +341,14 @@ class PluginManager(QtCore.QObject):
     def remove_plugin(self, plugin_name):
         if plugin_name.endswith('.zip'):
             plugin_name = os.path.splitext(plugin_name)[0]
-        log.debug("Remove plugin files and dirs : %r", plugin_name)
+        log.debug("Remove plugin files and dirs : %s", plugin_name)
         dirpath, filepaths = self._get_existing_paths(plugin_name)
         if dirpath:
-            log.debug("Removing directory %r", dirpath)
+            log.debug("Removing directory %s", dirpath)
             shutil.rmtree(dirpath)
         if filepaths:
             for filepath in filepaths:
-                log.debug("Removing file %r", filepath)
+                log.debug("Removing file %s", filepath)
                 os.remove(filepath)
 
     def install_plugin(self, path, overwrite_confirm=None, plugin_name=None,
@@ -387,7 +387,7 @@ class PluginManager(QtCore.QObject):
                             zipfile.flush()
                             os.fsync(zipfile.fileno())
                         os.rename(ziptmp, dst)
-                        log.debug("Plugin saved to %r", dst)
+                        log.debug("Plugin saved to %s", dst)
                     except:
                         try:
                             os.remove(ziptmp)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -147,7 +147,7 @@ class Tagger(QtGui.QApplication):
 
         # Setup logging
         self.debug(picard_args.debug or "PICARD_DEBUG" in os.environ)
-        log.debug("Starting Picard from %r", os.path.abspath(__file__))
+        log.debug("Starting Picard from %s", os.path.abspath(__file__))
         log.debug("Platform: %s %s %s", platform.platform(),
                   platform.python_implementation(), platform.python_version())
         log.debug("Versions: %s", versions.as_string())

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -151,7 +151,7 @@ class Tagger(QtGui.QApplication):
         log.debug("Platform: %s %s %s", platform.platform(),
                   platform.python_implementation(), platform.python_version())
         log.debug("Versions: %s", versions.as_string())
-        log.debug("Configuration file path: %r", config.config.fileName())
+        log.debug("Configuration file path: %s", config.config.fileName())
 
         # TODO remove this before the final release
         if sys.platform == "win32":
@@ -160,12 +160,12 @@ class Tagger(QtGui.QApplication):
             olduserdir = "~/.picard"
         olduserdir = os.path.expanduser(olduserdir)
         if os.path.isdir(olduserdir):
-            log.info("Moving %r to %r", olduserdir, USER_DIR)
+            log.info("Moving %s to %s", olduserdir, USER_DIR)
             try:
                 shutil.move(olduserdir, USER_DIR)
             except:
                 pass
-        log.debug("User directory: %r", os.path.abspath(USER_DIR))
+        log.debug("User directory: %s", os.path.abspath(USER_DIR))
 
         # for compatibility with pre-1.3 plugins
         QtCore.QObject.tagger = self
@@ -356,10 +356,10 @@ class Tagger(QtGui.QApplication):
         for filename in filenames:
             filename = os.path.normpath(os.path.realpath(filename))
             if ignore_hidden and is_hidden(filename):
-                log.debug("File ignored (hidden): %r" % (filename))
+                log.debug("File ignored (hidden): %s" % (filename))
                 continue
             if ignoreregex is not None and ignoreregex.search(filename):
-                log.info("File ignored (matching %r): %r" % (pattern, filename))
+                log.info("File ignored (matching %s): %s" % (pattern, filename))
                 continue
             if filename not in self.files:
                 file = open_file(filename)
@@ -399,7 +399,7 @@ class Tagger(QtGui.QApplication):
                         'count': number_of_files,
                         'directory': root,
                     }
-                    log.debug("Adding %(count)d files from '%(directory)r'" %
+                    log.debug("Adding %(count)d files from '%(directory)s'" %
                               mparms)
                     self.window.set_statusbar_message(
                         ungettext(
@@ -432,7 +432,7 @@ class Tagger(QtGui.QApplication):
                 'count': number_of_files,
                 'directory': path,
             }
-            log.debug("Adding %(count)d files from '%(directory)r'" %
+            log.debug("Adding %(count)d files from '%(directory)s'" %
                       mparms)
             self.window.set_statusbar_message(
                 ungettext(


### PR DESCRIPTION
This replacement fix for PICARD-958 addresses the root cause of unicode errors when writing to stderr, and avoids poluting the error/debug log (which can handle unicode characters) with double `\\` which occur when you format any string with %r.

I have addressed all the relevant log statements that I could find, but it is entirely possible that I have missed some.