### PR TITLE
PICARD-972: Avoid save if file removed

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -226,8 +226,8 @@ class File(QtCore.QObject, Item):
 
     def _saving_finished(self, result=None, error=None):
         # Handle file removed before save
-        # Result is None if save was skipped because file was removed. 
-        if self.state == File.REMOVED and result is not None:
+        # Result is None if save was skipped because file was removed.
+        if self.state == File.REMOVED and result is None:
             return
         old_filename = new_filename = self.filename
         if error is not None:

--- a/picard/file.py
+++ b/picard/file.py
@@ -263,6 +263,9 @@ class File(QtCore.QObject, Item):
             del self.tagger.files[old_filename]
             self.tagger.files[new_filename] = self
 
+        if self.tagger.stopping:
+            log.debug("Save of %r completed before stopping Picard", self.filename)
+
     def _save(self, filename, metadata):
         """Save the metadata."""
         raise NotImplementedError

--- a/picard/file.py
+++ b/picard/file.py
@@ -225,8 +225,9 @@ class File(QtCore.QObject, Item):
             raise OSError
 
     def _saving_finished(self, result=None, error=None):
-        # Handle file removed
-        if self.state == File.REMOVED and not result:
+        # Handle file removed before save
+        # Result is None if save was skipped because file was removed. 
+        if self.state == File.REMOVED and result is not None:
             return
         old_filename = new_filename = self.filename
         if error is not None:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -214,6 +214,7 @@ class Tagger(QtGui.QApplication):
         self.nats = None
         self.window = MainWindow()
         self.exit_cleanup = []
+        self.stopping = False
 
     def register_cleanup(self, func):
         self.exit_cleanup.append(func)


### PR DESCRIPTION
Handles both removal before save starts and removal whilst file is being
saved.

Resolves [PICARD-972](https://tickets.metabrainz.org/browse/PICARD-972).