### PR TITLE
Fix a division by zero exception

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -189,6 +189,8 @@ class Track(DataObject, Item):
             return
         # Convert counts to values from 0 to 100
         maxcount = max(tags.values())
+        if maxcount == 0:
+            return
         taglist = []
         for name, count in tags.items():
             taglist.append((100 * count / maxcount, name))


### PR DESCRIPTION
It seems in some cases, tags was not empty, but max(tags.values()) was 0
which was raising a Division by zero exception a few lines below when
loading some tracks.

An example of the exception fixed:

Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/picard/webservice.py", line 246, in _process_reply
    handler(str(reply.readAll()), reply, error)
  File "/usr/lib64/python2.7/site-packages/picard/coverart/providers/caa.py", line 194, in _caa_json_downloaded
    self.next_in_queue()
  File "/usr/lib64/python2.7/site-packages/picard/coverart/providers/__init__.py", line 81, in next_in_queue
    self.coverart.download_next_in_queue()
  File "/usr/lib64/python2.7/site-packages/picard/coverart/__init__.py", line 145, in download_next_in_queue
    self.album._finalize_loading(None)
  File "/usr/lib64/python2.7/site-packages/picard/album.py", line 223, in _finalize_loading
    track = self._finalize_loading_track(track_node, mm, artists, va, absolutetracknumber)
  File "/usr/lib64/python2.7/site-packages/picard/album.py", line 294, in _finalize_loading_track
    track._customize_metadata()
  File "/usr/lib64/python2.7/site-packages/picard/track.py", line 124, in _customize_metadata
    self._convert_folksonomy_tags_to_genre()
  File "/usr/lib64/python2.7/site-packages/picard/track.py", line 142, in _convert_folksonomy_tags_to_genre
    taglist.append((100 * count / maxcount, name))
ZeroDivisionError: integer division or modulo by zero