### PR TITLE
Fix 'date' to id3 mapping

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -115,7 +115,7 @@ class ID3File(File):
         'TCOP': 'copyright',
         'TPUB': 'label',
         'TDOR': 'originaldate',
-        'TDRC': 'date',
+        'TDRL': 'date',
         'TSSE': 'encodersettings',
         'TSOA': 'albumsort',
         'TSOP': 'artistsort',

--- a/test/test_compatid3.py
+++ b/test/test_compatid3.py
@@ -24,9 +24,9 @@ class UpdateToV23Test(unittest.TestCase):
         self.assertEqual(tags["TSOA"].text, ["foo"])
         self.assertEqual(tags["TSOT"].text, ["foo"])
 
-    def test_tdrc(self):
+    def test_tdrl(self):
         tags = compatid3.CompatID3()
-        tags.add(id3.TDRC(encoding=1, text="2003-04-05 12:03"))
+        tags.add(id3.TDRL(encoding=1, text="2003-04-05 12:03"))
         tags.update_to_v23()
         self.assertEqual(tags["TYER"].text, ["2003"])
         self.assertEqual(tags["TDAT"].text, ["0504"])


### PR DESCRIPTION
According to the [date docs](https://musicbrainz.org/doc/Release/Date), the 'date' tag holds "the date in which a release was made available through some sort of distribution mechanism".

Relevant excerpts from the [id3v2.4 spec](http://id3.org/id3v2.4.0-frames):
 - `TDRC`: "Recording time [...] when the audio was recorded".
 - `TDRL`: "Release time [...] when the audio was first released"
 - `TDOR`: "Original release time [...] when the original recording of the audio was released"

Currently the 'date' tag is mapped to `TDRC` (recording time). This commit changes the mapping to `TDRL` (release time) to bring the two tag types more in line with each other.