### PR TITLE
PICARD-922: Fix inmulti behaviour with multi-values

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -388,29 +388,32 @@ def func_in(parser, text, needle):
 
 
 def func_inmulti(parser, haystack, needle, separator=MULTI_VALUED_JOINER):
-    """Searches for ``needle`` in ``haystack``, supporting a list variable for ``haystack``.
-       If a string is used instead, then a ``separator`` can be used to split it.
-       In both cases, it returns true if the resulting list contains ``needle``."""
+    """Searches for ``needle`` in ``haystack``, supporting a list variable for
+       ``haystack``. If a string is used instead, then a ``separator`` can be
+       used to split it. In both cases, it returns true if the resulting list
+       contains ``needle``."""
 
     needle = needle.eval(parser)
-    if type(text)==ScriptExpression and len(text)==1 and type(text[0])==ScriptVariable:
-        text=text[0]
-    if type(text)==ScriptVariable:
-        if text.name.startswith(u"_"):
-            name = u"~" + text.name[1:]
-        else:
-            name = text.name
-        values=parser.context.getall(name)
+    if (isinstance(haystack, ScriptExpression) and
+            len(haystack) == 1 and
+            isinstance(haystack[0], ScriptVariable)):
+        haystack = haystack[0]
 
-        if needle in values:
-           return "1"
+    if isinstance(haystack, ScriptVariable):
+        if haystack.name.startswith(u"_"):
+            name = u"~" + haystack.name[1:]
         else:
-           return ""
+            name = haystack.name
+        values = parser.context.getall(name)
+
+        return func_in(parser, values, needle)
 
     # I'm not sure if it is actually possible to continue in this code path,
     # but just in case, it's better to have a fallback to correct behaviour
-    text=text.eval(parser)
-    return func_in(parser, text.split(separator) if separator else [text], needle)
+    haystack = haystack.eval(parser)
+    return func_in(parser,
+                   haystack.split(separator) if separator else [haystack],
+                   needle)
 
 
 def func_rreplace(parser, text, old, new):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -370,3 +370,22 @@ class ScriptParserTest(unittest.TestCase):
         self.parser.eval("$unset(performer:*)", context)
         self.assertNotIn('performer:bar', context)
         self.assertNotIn('performer:foo', context)
+
+    def test_cmd_inmulti(self):
+        context = Metadata()
+        self.parser.eval("$set(foo,First; Second; Third)", context)
+        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
+
+        self.parser.eval("$setmulti(foo,First; Second; Third)", context)
+        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")
+

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -6,15 +6,19 @@ from picard.script import ScriptParser, ScriptError, register_script_function
 from picard.metadata import Metadata
 from picard.ui.options.renaming import _DEFAULT_FILE_NAMING_FORMAT
 
+
 class ScriptParserTest(unittest.TestCase):
 
     def setUp(self):
         config.setting = {
             'enabled_plugins': '',
         }
+
         self.parser = ScriptParser()
+
         def func_noargstest(parser):
             return ""
+
         register_script_function(func_noargstest, "noargstest")
 
     def test_cmd_noop(self):
@@ -374,18 +378,29 @@ class ScriptParserTest(unittest.TestCase):
     def test_cmd_inmulti(self):
         context = Metadata()
         self.parser.eval("$set(foo,First; Second; Third)", context)
-        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,Second)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
 
         self.parser.eval("$setmulti(foo,First; Second; Third)", context)
-        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")
-
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")


### PR DESCRIPTION
inmulti arguments where evaluated before inmulti was executed, which
resulted in strings being passed as arguments, which breaks cases in which
the strings in multivalue variables contain the separator used to separate
multiple values (see PICARD-922).
This commit fixes the behaviour of inmulti so arguments are not evaluated
before they're passed, so it can extract the argument value as a list and
work with that.
This fixes https://tickets.metabrainz.org/browse/PICARD-922
