### PR TITLE
PICARD-922: Add inmulti2 function to fix inmulti behaviour with multi-values

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -391,6 +391,16 @@ def func_inmulti(parser, text, value, separator=MULTI_VALUED_JOINER):
     """Splits ``text`` by ``separator``, and returns true if the resulting list contains ``value``."""
     return func_in(parser, text.split(separator) if separator else [text], value)
 
+def func_inmulti2(parser, haystack, needle):
+    """Searches for ``needle`` in the contents of the variable named
+       ``haystack`` . It returns true if the resulting list
+       contains ``needle``."""
+
+    if haystack.startswith("_"):
+        haystack = "~" + haystack[1:]
+    values = parser.context.getall(haystack)
+
+    return func_in(parser, values, needle)
 
 def func_rreplace(parser, text, old, new):
     return re.sub(old, new, text)
@@ -820,6 +830,7 @@ register_script_function(func_gt, "gt")
 register_script_function(func_gte, "gte")
 register_script_function(func_in, "in")
 register_script_function(func_inmulti, "inmulti")
+register_script_function(func_inmulti2, "inmulti2")
 register_script_function(func_copy, "copy")
 register_script_function(func_copymerge, "copymerge")
 register_script_function(func_len, "len")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -370,3 +370,22 @@ class ScriptParserTest(unittest.TestCase):
         self.parser.eval("$unset(performer:*)", context)
         self.assertNotIn('performer:bar', context)
         self.assertNotIn('performer:foo', context)
+
+    def test_cmd_inmulti(self):
+        context = Metadata()
+        self.parser.eval("$set(foo,First; Second; Third)", context)
+        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
+
+        self.parser.eval("$setmulti(foo,First; Second; Third)", context)
+        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "1")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")
+

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -6,15 +6,19 @@ from picard.script import ScriptParser, ScriptError, register_script_function
 from picard.metadata import Metadata
 from picard.ui.options.renaming import _DEFAULT_FILE_NAMING_FORMAT
 
+
 class ScriptParserTest(unittest.TestCase):
 
     def setUp(self):
         config.setting = {
             'enabled_plugins': '',
         }
+
         self.parser = ScriptParser()
+
         def func_noargstest(parser):
             return ""
+
         register_script_function(func_noargstest, "noargstest")
 
     def test_cmd_noop(self):
@@ -374,18 +378,29 @@ class ScriptParserTest(unittest.TestCase):
     def test_cmd_inmulti(self):
         context = Metadata()
         self.parser.eval("$set(foo,First; Second; Third)", context)
-        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,Second)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
 
         self.parser.eval("$setmulti(foo,First; Second; Third)", context)
-        self.assertEqual(self.parser.eval("$in(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
-        self.assertEqual(self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,Second)", context), "1")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
-        self.assertEqual(self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")
-
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,irst; Second; Thi)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,Second)", context), "1")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+        self.assertEqual(
+            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -375,7 +375,7 @@ class ScriptParserTest(unittest.TestCase):
         self.assertNotIn('performer:bar', context)
         self.assertNotIn('performer:foo', context)
 
-    def test_cmd_inmulti(self):
+    def test_cmd_inmulti2(self):
         context = Metadata()
         self.parser.eval("$set(foo,First; Second; Third)", context)
         self.assertEqual(
@@ -385,11 +385,11 @@ class ScriptParserTest(unittest.TestCase):
         self.assertEqual(
             self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,Second)", context), "")
+            self.parser.eval("$inmulti2(foo,Second)", context), "")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+            self.parser.eval("$inmulti2(foo,irst; Second; Thi)", context), "")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "1")
+            self.parser.eval("$inmulti2(foo,First; Second; Third)", context), "1")
 
         self.parser.eval("$setmulti(foo,First; Second; Third)", context)
         self.assertEqual(
@@ -399,8 +399,8 @@ class ScriptParserTest(unittest.TestCase):
         self.assertEqual(
             self.parser.eval("$in(%foo%,First; Second; Third)", context), "1")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,Second)", context), "1")
+            self.parser.eval("$inmulti2(foo,Second)", context), "1")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,irst; Second; Thi)", context), "")
+            self.parser.eval("$inmulti2(foo,irst; Second; Thi)", context), "")
         self.assertEqual(
-            self.parser.eval("$inmulti(%foo%,First; Second; Third)", context), "")
+            self.parser.eval("$inmulti2(foo,First; Second; Third)", context), "")


### PR DESCRIPTION
Add a inmulti2 function which works as inmulti but gets a variable name
as first parameter, instead of the contents of the variable