### PR TITLE
Fix version number in the Windows installer

### DIFF
--- a/scripts/package-win.bat
+++ b/scripts/package-win.bat
@@ -26,7 +26,7 @@ set PATH=%CI_PROJECT_DIR%\e\scripts;%PATH%
 pip install mutagen==%MUTAGEN_VERSION%
 pip install discid==%PYTHON_DISCID_VERSION%
 
-if NOT "%CI_BUILD_TAG%" == "" python setup.py patch_version --platform=win
+if "%CI_BUILD_TAG%" == "" python setup.py patch_version --platform=win
 
 rmdir /S /Q dist build locale
 python setup.py clean


### PR DESCRIPTION
It should be the full version with current time for master builds,
short version for tags.