### PR TITLE
Add .mailmap file.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Frederik “Freso” S. Olesen <freso.dk@gmail.com>
+Lukáš Lalinský <lalinsky@gmail.com>             <lukas@oxygene.sk>
+Sambhav Kothari <sambhavs.email@gmail.com>
+Sophist-UK <github@sodalis.co.uk>
+Suhas <suhas2go@gmail.com>


### PR DESCRIPTION
Consolidate some of the mismatching author and committer name:email pairs in the logs.

See https://git-scm.com/docs/git-shortlog#_mapping_authors

------

I was trying to do some code analysis on the code and the results got somewhat skewed due to mismatching of commits to disparate authors when they were in fact the same author using multiple names and/or e-mail addresses.

@lalinsky, @samj1912, @Sophist-UK, and @suhas2go are you okay with this? Do you want to be credited differently?