### PR TITLE
PICARD-995: Avoid error on OSX invalid file path

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -486,6 +486,7 @@ class BaseTreeView(QtGui.QTreeWidget):
                         log.debug('OSX NSURL path detected. Dropped File is: %r', filename)
                     else:
                         log.error("Unable to get appropriate file path for %r", url.toString(QtCore.QUrl.RemoveUserInfo))
+                        continue
                 else:
                     # Dropping a file from iTunes gives a filename with a NULL terminator
                     filename = os.path.normpath(os.path.realpath(unicode(url.toLocalFile()).rstrip("\0")))


### PR DESCRIPTION
Resolves a minor bug in #631.

If file path is invalid we need to skip the rest of the code in the for loop since filename is not set.

Ticket https://tickets.metabrainz.org/browse/PICARD-995.