### PR TITLE
PICARD-1000: Show album/cluster cover art

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -557,6 +557,19 @@ class Album(DataObject, Item):
             self.tagger.albums[mbid] = self
             self.load(priority=True, refresh=True)
 
+    def update_metadata_images(self):
+        new_images = []
+        for track in self.tracks:
+            for file in list(track.linked_files):
+                for image in file.metadata.images:
+                    if image not in new_images:
+                        new_images.append(image)
+        for file in list(self.unmatched_files.files):
+            for image in file.metadata.images:
+                if image not in new_images:
+                    new_images.append(image)
+        self.metadata.images = new_images
+
 
 class NatAlbum(Album):
 

--- a/picard/album.py
+++ b/picard/album.py
@@ -58,6 +58,7 @@ class Album(DataObject, Item):
     def __init__(self, id, discid=None):
         DataObject.__init__(self, id)
         self.metadata = Metadata()
+        self.orig_metadata = Metadata()
         self.tracks = []
         self.loaded = False
         self.load_task = None
@@ -382,6 +383,10 @@ class Album(DataObject, Item):
     def _add_file(self, track, file):
         self._files += 1
         self.update(update_tracks=False)
+        # Fixme: The next lines can probably be moved to update()
+        for image in file.orig_metadata.images:
+            if image not in self.orig_metadata.images:
+                self.orig_metadata.append_image(image)
 
     def _remove_file(self, track, file):
         self._files -= 1

--- a/picard/album.py
+++ b/picard/album.py
@@ -561,11 +561,15 @@ class Album(DataObject, Item):
             for image in file.metadata.images:
                 if image not in new_images:
                     new_images.append(image)
-            for image in file.orig_metadata.images:
-                if image not in orig_images:
-                    orig_images.append(image)
+            try:
+                for image in file.orig_metadata.images:
+                    if image not in orig_images:
+                        orig_images.append(image)
+            except AttributeError:
+                pass
 
         for track in self.tracks:
+            process_file_images(track)
             for file in list(track.linked_files):
                 process_file_images(file)
         for file in list(self.unmatched_files.files):

--- a/picard/album.py
+++ b/picard/album.py
@@ -383,10 +383,6 @@ class Album(DataObject, Item):
     def _add_file(self, track, file):
         self._files += 1
         self.update(update_tracks=False)
-        # Fixme: The next lines can probably be moved to update()
-        for image in file.orig_metadata.images:
-            if image not in self.orig_metadata.images:
-                self.orig_metadata.append_image(image)
 
     def _remove_file(self, track, file):
         self._files -= 1
@@ -559,16 +555,24 @@ class Album(DataObject, Item):
 
     def update_metadata_images(self):
         new_images = []
+        orig_images = []
         for track in self.tracks:
             for file in list(track.linked_files):
                 for image in file.metadata.images:
                     if image not in new_images:
                         new_images.append(image)
+                for image in file.orig_metadata.images:
+                    if image not in orig_images:
+                        orig_images.append(image)
         for file in list(self.unmatched_files.files):
             for image in file.metadata.images:
                 if image not in new_images:
                     new_images.append(image)
+            for image in file.orig_metadata.images:
+                if image not in orig_images:
+                    orig_images.append(image)
         self.metadata.images = new_images
+        self.orig_metadata.images = orig_images
 
 
 class NatAlbum(Album):

--- a/picard/album.py
+++ b/picard/album.py
@@ -556,21 +556,21 @@ class Album(DataObject, Item):
     def update_metadata_images(self):
         new_images = []
         orig_images = []
-        for track in self.tracks:
-            for file in list(track.linked_files):
-                for image in file.metadata.images:
-                    if image not in new_images:
-                        new_images.append(image)
-                for image in file.orig_metadata.images:
-                    if image not in orig_images:
-                        orig_images.append(image)
-        for file in list(self.unmatched_files.files):
+
+        def process_file_images(file):
             for image in file.metadata.images:
                 if image not in new_images:
                     new_images.append(image)
             for image in file.orig_metadata.images:
                 if image not in orig_images:
                     orig_images.append(image)
+
+        for track in self.tracks:
+            for file in list(track.linked_files):
+                process_file_images(file)
+        for file in list(self.unmatched_files.files):
+            process_file_images(file)
+
         self.metadata.images = new_images
         self.orig_metadata.images = orig_images
 

--- a/picard/album.py
+++ b/picard/album.py
@@ -557,23 +557,23 @@ class Album(DataObject, Item):
         new_images = []
         orig_images = []
 
-        def process_file_images(file):
-            for image in file.metadata.images:
+        def process_images(obj):
+            for image in obj.metadata.images:
                 if image not in new_images:
                     new_images.append(image)
             try:
-                for image in file.orig_metadata.images:
+                for image in obj.orig_metadata.images:
                     if image not in orig_images:
                         orig_images.append(image)
             except AttributeError:
                 pass
 
         for track in self.tracks:
-            process_file_images(track)
+            process_images(track)
             for file in list(track.linked_files):
-                process_file_images(file)
+                process_images(file)
         for file in list(self.unmatched_files.files):
-            process_file_images(file)
+            process_images(file)
 
         self.metadata.images = new_images
         self.orig_metadata.images = orig_images

--- a/picard/album.py
+++ b/picard/album.py
@@ -85,6 +85,11 @@ class Album(DataObject, Item):
             for file in self.unmatched_files.iterfiles():
                 yield file
 
+    def enable_update_metadata_images(self, enabled):
+        self.update_metadata_images_enabled = enabled
+        if enabled:
+            self.update_metadata_images()
+
     def append_album_artist(self, id):
         """Append artist id to the list of album artists
         and return an AlbumArtist instance"""
@@ -256,7 +261,7 @@ class Album(DataObject, Item):
             self._tracks_loaded = True
 
         if not self._requests:
-            self.update_metadata_images_enabled = False
+            self.enable_update_metadata_images(False)
             # Prepare parser for user's script
             if config.setting["enable_tagger_scripts"]:
                 for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
@@ -288,8 +293,8 @@ class Album(DataObject, Item):
             self.loaded = True
             self.status = None
             self.match_files(self.unmatched_files.files)
-            self.update_metadata_images_enabled = True
             self.update()
+            self.enable_update_metadata_images(True)
             self.tagger.window.set_statusbar_message(
                 N_('Album %(id)s loaded: %(artist)s - %(album)s'),
                 {

--- a/picard/album.py
+++ b/picard/album.py
@@ -570,29 +570,48 @@ class Album(DataObject, Item):
     def update_metadata_images(self):
         if not self.update_metadata_images_enabled:
             return
-        new_images = []
-        orig_images = []
 
-        def process_images(obj):
-            for image in obj.metadata.images:
-                if image not in new_images:
-                    new_images.append(image)
-            try:
-                for image in obj.orig_metadata.images:
-                    if image not in orig_images:
-                        orig_images.append(image)
-            except AttributeError:
-                pass
+        class State:
+            new_images = []
+            orig_images = []
+            has_common_new_images = True
+            has_common_orig_images = True
+            first_new_obj = True
+            first_orig_obj = True
+
+        state = State()
+
+        def process_images(state, obj):
+            # Check new images
+            if state.first_new_obj:
+                state.new_images = obj.metadata.images[:]
+                state.first_new_obj = False
+            else:
+                if state.new_images != obj.metadata.images:
+                    state.has_common_new_images = False
+                    state.new_images.extend([image for image in obj.metadata.images if image not in state.new_images])
+            if isinstance(obj, Track):
+                return
+            # Check orig images, but not for Tracks (which don't have orig_metadata)
+            if state.first_orig_obj:
+                state.orig_images = obj.orig_metadata.images[:]
+                state.first_orig_obj = False
+            else:
+                if state.orig_images != obj.orig_metadata.images:
+                    state.has_common_orig_images = False
+                    state.orig_images.extend([image for image in obj.orig_metadata.images if image not in state.orig_images])
 
         for track in self.tracks:
-            process_images(track)
+            process_images(state, track)
             for file in list(track.linked_files):
-                process_images(file)
+                process_images(state, file)
         for file in list(self.unmatched_files.files):
-            process_images(file)
+            process_images(state, file)
 
-        self.metadata.images = new_images
-        self.orig_metadata.images = orig_images
+        self.metadata.images = state.new_images
+        self.metadata.has_common_images = state.has_common_new_images
+        self.orig_metadata.images = state.orig_images
+        self.orig_metadata.has_common_images = state.has_common_orig_images
 
 
 class NatAlbum(Album):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -69,6 +69,9 @@ class Cluster(QtCore.QObject, Item):
             self.metadata.length += file.metadata.length
             file._move(self)
             file.update(signal=False)
+            cover = file.metadata.get_single_front_image()
+            if cover and cover[0] not in self.metadata.images:
+                self.metadata.append_image(cover[0])
         self.files.extend(files)
         self.metadata['totaltracks'] = len(self.files)
         self.item.add_files(files)
@@ -79,6 +82,9 @@ class Cluster(QtCore.QObject, Item):
         self.metadata['totaltracks'] = len(self.files)
         file._move(self)
         file.update(signal=False)
+        cover = file.metadata.get_single_front_image()
+        if cover and cover[0] not in self.metadata.images:
+            self.metadata.append_image(cover[0])
         self.item.add_file(file)
 
     def remove_file(self, file):

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -113,3 +113,6 @@ PLUGINS_API = {
 
 # Default query limit
 QUERY_LIMIT = 25
+
+# Maximum number of covers to draw in a stack in CoverArtThumbnail
+MAX_COVERS_TO_STACK = 4

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -70,6 +70,9 @@ class DataHash:
     def __eq__(self, other):
         return self._hash == other._hash
 
+    def hash(self):
+        return self._hash
+
     def delete_file(self):
         if self._filename:
             try:
@@ -210,6 +213,11 @@ class CoverArtImage:
             return True
         else:
             return False
+
+    def __hash__(self):
+        if self.datahash is None:
+            return 0
+        return hash(self.datahash.hash())
 
     def set_data(self, data):
         """Store image data in a file, if data already exists in such file

--- a/picard/file.py
+++ b/picard/file.py
@@ -54,6 +54,8 @@ from picard.const import QUERY_LIMIT
 
 class File(QtCore.QObject, Item):
 
+    metadata_images_changed = QtCore.pyqtSignal()
+
     UNDEFINED = -1
     PENDING = 0
     NORMAL = 1
@@ -156,6 +158,7 @@ class File(QtCore.QObject, Item):
 
         if acoustid:
             self.metadata["acoustid_id"] = acoustid
+        self.metadata_images_changed.emit()
 
     def has_error(self):
         return self.state == File.ERROR

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -55,6 +55,11 @@ class Metadata(dict):
     def append_image(self, coverartimage):
         self.images.append(coverartimage)
 
+    def set_front_image(self, coverartimage):
+        # First remove all front images
+        self.images[:] = [ img for img in self.images if not img.is_front_image() ]
+        self.images.append(coverartimage)
+
     @property
     def images_to_be_saved_to_tags(self):
         if not config.setting["save_images_to_tags"]:

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -57,7 +57,7 @@ class Metadata(dict):
 
     def set_front_image(self, coverartimage):
         # First remove all front images
-        self.images[:] = [ img for img in self.images if not img.is_front_image() ]
+        self.images[:] = [img for img in self.images if not img.is_front_image()]
         self.images.append(coverartimage)
 
     @property

--- a/picard/track.py
+++ b/picard/track.py
@@ -110,7 +110,7 @@ class Track(DataObject, Item):
         return True
 
     def can_view_info(self):
-        return self.num_linked_files == 1
+        return self.num_linked_files == 1 or self.metadata.images
 
     def column(self, column):
         m = self.metadata

--- a/picard/track.py
+++ b/picard/track.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from functools import partial
+from PyQt4 import QtCore
 from picard import config, log
 from picard.metadata import Metadata, run_track_metadata_processors
 from picard.dataobj import DataObject
@@ -43,6 +44,8 @@ class TrackArtist(DataObject):
 
 
 class Track(DataObject, Item):
+
+    metadata_images_changed = QtCore.pyqtSignal()
 
     def __init__(self, id, album=None):
         DataObject.__init__(self, id)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -227,7 +227,7 @@ class CoverArtBox(QtGui.QGroupBox):
         # We want to show the 2 coverarts only if they are different
         # and orig_cover_art data is set and not the default cd shadow
         if self.orig_cover_art.data is None or self.cover_art == self.orig_cover_art:
-            self.show_details_button.setHidden(len(self.cover_art.related_images) <= 1)
+            self.show_details_button.setHidden(len(self.cover_art.related_images) == 0)
             self.orig_cover_art.setHidden(True)
             self.cover_art_label.setText('')
             self.orig_cover_art_label.setText('')

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -82,6 +82,7 @@ class ActiveLabel(QtGui.QLabel):
 
 
 class CoverArtThumbnail(ActiveLabel):
+    MAX_COVERS_TO_STACK = 4
 
     def __init__(self, active=False, drops=False, pixmap_cache=None, *args, **kwargs):
         super(CoverArtThumbnail, self).__init__(active, drops, *args, **kwargs)
@@ -139,9 +140,9 @@ class CoverArtThumbnail(ActiveLabel):
                 pixmap.loadFromData(self.data[0].data)
                 pixmap = self.decorate_cover(pixmap)
             else:
-                limited = len(self.data) > 4
+                limited = len(self.data) > self.MAX_COVERS_TO_STACK
                 if limited:
-                    data_to_paint = data[:3]
+                    data_to_paint = data[:self.MAX_COVERS_TO_STACK - 1]
                     offset = displacements * len(data_to_paint)
                 else:
                     data_to_paint = data
@@ -170,7 +171,7 @@ class CoverArtThumbnail(ActiveLabel):
                     else:
                         thumb = QtGui.QPixmap()
                         thumb.loadFromData(image.data)
-                    thumb = self.decorate_cover(thumb)  # QtGui.QColor("darkgoldenrod")
+                    thumb = self.decorate_cover(thumb)
                     x, y = (cx - thumb.width() / 2, cy - thumb.height() / 2)
                     painter.drawPixmap(x, y, thumb)
                     cx -= displacements
@@ -211,11 +212,11 @@ class CoverArtThumbnail(ActiveLabel):
             self.setActive(True)
             text = _(u"View release on MusicBrainz")
             if hasattr(metadata, 'has_common_images'):
-                text += '<br />'
                 if has_common_images:
-                    text += _(u'<i>Common images on all tracks</i>')
+                    note = _(u'Common images on all tracks')
                 else:
-                    text += _(u'<i>Tracks contain different images</i>')
+                    note = _(u'Tracks contain different images')
+                text += '<br /><i>%s</i>' % note
             self.setToolTip(text)
         else:
             self.setActive(False)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -145,14 +145,14 @@ class CoverArtThumbnail(ActiveLabel):
                 bgcolor = self.palette().color(QtGui.QPalette.Window)
                 painter = QtGui.QPainter(pixmap)
                 painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
-                x = w / 2
+                x = stack_width - w / 2
                 y = h / 2
-                for image in self.data:
+                for image in reversed(self.data):
                     thumb = QtGui.QPixmap()
                     thumb.loadFromData(image.data)
                     thumb = self.decorate_cover(thumb)
                     painter.drawPixmap(x - thumb.width() / 2, y - thumb.height() / 2, thumb)
-                    x += displacements
+                    x -= displacements
                     y += displacements
                 painter.end()
                 pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -28,6 +28,7 @@ from picard.track import Track
 from picard.file import File
 from picard.util import encode_filename, imageinfo, get_file_path
 from picard.util.lrucache import LRUCache
+from picard.const import MAX_COVERS_TO_STACK
 
 if sys.platform == 'darwin':
     try:
@@ -82,7 +83,6 @@ class ActiveLabel(QtGui.QLabel):
 
 
 class CoverArtThumbnail(ActiveLabel):
-    MAX_COVERS_TO_STACK = 4
 
     def __init__(self, active=False, drops=False, pixmap_cache=None, *args, **kwargs):
         super(CoverArtThumbnail, self).__init__(active, drops, *args, **kwargs)
@@ -140,9 +140,9 @@ class CoverArtThumbnail(ActiveLabel):
                 pixmap.loadFromData(self.data[0].data)
                 pixmap = self.decorate_cover(pixmap)
             else:
-                limited = len(self.data) > self.MAX_COVERS_TO_STACK
+                limited = len(self.data) > MAX_COVERS_TO_STACK
                 if limited:
-                    data_to_paint = data[:self.MAX_COVERS_TO_STACK - 1]
+                    data_to_paint = data[:MAX_COVERS_TO_STACK - 1]
                     offset = displacements * len(data_to_paint)
                 else:
                     data_to_paint = data

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -26,7 +26,8 @@ from picard.album import Album
 from picard.coverart.image import CoverArtImage, CoverArtImageError
 from picard.track import Track
 from picard.file import File
-from picard.util import encode_filename, imageinfo
+from picard.util import encode_filename, imageinfo, get_file_path
+from picard.util.lrucache import LRUCache
 
 if sys.platform == 'darwin':
     try:
@@ -37,38 +38,7 @@ if sys.platform == 'darwin':
         log.warning("Unable to import NSURL, file drag'n'drop might not work correctly")
 
 
-class LRUCache(dict):
-
-    def __init__(self, max_size):
-        self._ordered_keys = []
-        self._max_size = max_size
-
-    def __getitem__(self, key):
-        if key in self:
-            self._ordered_keys.remove(key)
-            self._ordered_keys.insert(0, key)
-        return super(LRUCache, self).__getitem__(key)
-
-    def __setitem__(self, key, value):
-        if key in self:
-            self._ordered_keys.remove(key)
-        self._ordered_keys.insert(0, key)
-
-        r = super(LRUCache, self).__setitem__(key, value)
-
-        if len(self) > self._max_size:
-            item = self._ordered_keys.pop()
-            super(LRUCache, self).__delitem__(item)
-
-        return r
-
-    def __delitem__(self, key):
-        self._ordered_keys.remove(key)
-        super(LRUCache, self).__delitem__(key)
-
-
 class ActiveLabel(QtGui.QLabel):
-
     """Clickable QLabel."""
 
     clicked = QtCore.pyqtSignal()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -195,7 +195,6 @@ class CoverArtThumbnail(ActiveLabel):
         self.related_images = []
         if metadata and metadata.images:
             self.related_images = metadata.images
-            log.debug("%s using images:" % (self.name), metadata.images)
             data = [image for image in metadata.images if image.is_front_image()]
             if not data:
                 # There's no front image, choose the first one available

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -189,7 +189,14 @@ class CoverArtThumbnail(ActiveLabel):
             release = metadata.get("musicbrainz_albumid", None)
         if release:
             self.setActive(True)
-            self.setToolTip(_(u"View release on MusicBrainz"))
+            text = _(u"View release on MusicBrainz")
+            if hasattr(metadata, 'has_common_images'):
+                text += '<br />'
+                if has_common_images:
+                    text += _(u'<i>Common images on all tracks</i>')
+                else:
+                    text += _(u'<i>Tracks contain different images</i>')
+            self.setToolTip(text)
         else:
             self.setActive(False)
             self.setToolTip("")

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -83,9 +83,10 @@ class ActiveLabel(QtGui.QLabel):
 
 class CoverArtThumbnail(ActiveLabel):
 
-    def __init__(self, active=False, drops=False, *args, **kwargs):
+    def __init__(self, active=False, drops=False, name=None, *args, **kwargs):
         super(CoverArtThumbnail, self).__init__(active, drops, *args, **kwargs)
         self.data = None
+        self.name = name
         self.shadow = QtGui.QPixmap(":/images/CoverArtShadow.png")
         self.release = None
         self.setPixmap(self.shadow)
@@ -134,6 +135,8 @@ class CoverArtThumbnail(ActiveLabel):
         self.related_images = []
         if metadata and metadata.images:
             self.related_images = metadata.images
+            print("%s using images:" % (self.name), metadata.images)
+            # TODO: Combine all images to show there are different images in use instead of getting the first one
             for image in metadata.images:
                 if image.is_front_image():
                     data = image
@@ -174,10 +177,10 @@ class CoverArtBox(QtGui.QGroupBox):
         self.item = None
         self.cover_art_label = QtGui.QLabel('')
         self.cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
-        self.cover_art = CoverArtThumbnail(False, True, parent)
+        self.cover_art = CoverArtThumbnail(False, True, "new cover", parent)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.orig_cover_art_label = QtGui.QLabel('')
-        self.orig_cover_art = CoverArtThumbnail(False, False, parent)
+        self.orig_cover_art = CoverArtThumbnail(False, False, "original cover", parent)
         self.orig_cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
         self.orig_cover_art.setHidden(True)
         self.show_details_button = QtGui.QPushButton(_(u'Show more details'), self)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -139,7 +139,8 @@ class CoverArtThumbnail(ActiveLabel):
                 pixmap.loadFromData(self.data[0].data)
                 pixmap = self.decorate_cover(pixmap)
             else:
-                stack_width, stack_height = (w + displacements * (len(self.data) - 1), h + displacements * (len(self.data) - 1))
+                offset = displacements * (len(self.data) - 1)
+                stack_width, stack_height = (w + offset, h + offset)
                 pixmap = QtGui.QPixmap(stack_width, stack_height)
                 bgcolor = self.palette().color(QtGui.QPalette.Window)
                 painter = QtGui.QPainter(pixmap)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -104,6 +104,19 @@ class CoverArtThumbnail(ActiveLabel):
     def show(self):
         self.set_data(self.data, True)
 
+    def decorate_cover(self, pixmap):
+        offx, offy, w, h = (1, 1, 121, 121)
+        cover = QtGui.QPixmap(self.shadow)
+        pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+        painter = QtGui.QPainter(cover)
+        bgcolor = QtGui.QColor.fromRgb(0, 0, 0, 128)
+        painter.fillRect(QtCore.QRectF(offx, offy, w, h), bgcolor)
+        x = offx + (w - pixmap.width()) / 2
+        y = offy + (h - pixmap.height()) / 2
+        painter.drawPixmap(x, y, pixmap)
+        painter.end()
+        return cover
+
     def set_data(self, data, force=False, pixmap=None):
         if not force and self.data == data:
             return
@@ -114,36 +127,46 @@ class CoverArtThumbnail(ActiveLabel):
 
         cover = self.shadow
         if self.data:
+            w, h, displacements = (121, 121, 20)
             if pixmap is None:
-                pixmap = QtGui.QPixmap()
-                pixmap.loadFromData(self.data.data)
-            if not pixmap.isNull():
-                offx, offy, w, h = (1, 1, 121, 121)
-                cover = QtGui.QPixmap(self.shadow)
-                pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
-                painter = QtGui.QPainter(cover)
-                bgcolor = QtGui.QColor.fromRgb(0, 0, 0, 128)
-                painter.fillRect(QtCore.QRectF(offx, offy, w, h), bgcolor)
-                x = offx + (w - pixmap.width()) / 2
-                y = offy + (h - pixmap.height()) / 2
-                painter.drawPixmap(x, y, pixmap)
-                painter.end()
-        self.setPixmap(cover)
+                if len(self.data) == 1:
+                    pixmap = QtGui.QPixmap()
+                    pixmap.loadFromData(self.data[0].data)
+                else:
+                    stack_width, stack_height = (w+displacements*(len(self.data)-1), h+displacements*(len(self.data)-1))
+                    pixmap = QtGui.QPixmap(stack_width, stack_height)
+                    bgcolor = self.palette().color(QtGui.QPalette.Window)
+                    painter = QtGui.QPainter(pixmap)
+                    painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
+                    x = w / 2
+                    y = h / 2
+                    for image in self.data:
+                        thumb = QtGui.QPixmap()
+                        thumb.loadFromData(image.data)
+                        thumb = self.decorate_cover( thumb )
+                        painter.drawPixmap(x - thumb.width()/2, y - thumb.height()/2, thumb)
+                        x += displacements
+                        y += displacements
+                    painter.end()
+                    pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+                    self.setPixmap(pixmap)
+                    pixmap = None
+
+            if pixmap and not pixmap.isNull():
+                cover = self.decorate_cover( pixmap )
+                self.setPixmap(cover)
 
     def set_metadata(self, metadata):
         data = None
         self.related_images = []
         if metadata and metadata.images:
             self.related_images = metadata.images
-            print("%s using images:" % (self.name), metadata.images)
+            log.debug("%s using images:" % (self.name), metadata.images)
             # TODO: Combine all images to show there are different images in use instead of getting the first one
-            for image in metadata.images:
-                if image.is_front_image():
-                    data = image
-                    break
-            else:
+            data = [ image for image in metadata.images if image.is_front_image() ]
+            if not data:
                 # There's no front image, choose the first one available
-                data = metadata.images[0]
+                data = [ metadata.images[0] ]
         self.set_data(data)
         release = None
         if metadata:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -133,7 +133,7 @@ class CoverArtThumbnail(ActiveLabel):
                     pixmap = QtGui.QPixmap()
                     pixmap.loadFromData(self.data[0].data)
                 else:
-                    stack_width, stack_height = (w+displacements*(len(self.data)-1), h+displacements*(len(self.data)-1))
+                    stack_width, stack_height = (w + displacements * (len(self.data) - 1), h + displacements * (len(self.data) - 1))
                     pixmap = QtGui.QPixmap(stack_width, stack_height)
                     bgcolor = self.palette().color(QtGui.QPalette.Window)
                     painter = QtGui.QPainter(pixmap)
@@ -143,8 +143,8 @@ class CoverArtThumbnail(ActiveLabel):
                     for image in self.data:
                         thumb = QtGui.QPixmap()
                         thumb.loadFromData(image.data)
-                        thumb = self.decorate_cover( thumb )
-                        painter.drawPixmap(x - thumb.width()/2, y - thumb.height()/2, thumb)
+                        thumb = self.decorate_cover(thumb)
+                        painter.drawPixmap(x - thumb.width() / 2, y - thumb.height() / 2, thumb)
                         x += displacements
                         y += displacements
                     painter.end()
@@ -153,7 +153,7 @@ class CoverArtThumbnail(ActiveLabel):
                     pixmap = None
 
             if pixmap and not pixmap.isNull():
-                cover = self.decorate_cover( pixmap )
+                cover = self.decorate_cover(pixmap)
                 self.setPixmap(cover)
 
     def set_metadata(self, metadata):
@@ -162,11 +162,10 @@ class CoverArtThumbnail(ActiveLabel):
         if metadata and metadata.images:
             self.related_images = metadata.images
             log.debug("%s using images:" % (self.name), metadata.images)
-            # TODO: Combine all images to show there are different images in use instead of getting the first one
-            data = [ image for image in metadata.images if image.is_front_image() ]
+            data = [image for image in metadata.images if image.is_front_image()]
             if not data:
                 # There's no front image, choose the first one available
-                data = [ metadata.images[0] ]
+                data = [metadata.images[0]]
         self.set_data(data)
         release = None
         if metadata:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -139,7 +139,13 @@ class CoverArtThumbnail(ActiveLabel):
                 pixmap.loadFromData(self.data[0].data)
                 pixmap = self.decorate_cover(pixmap)
             else:
-                offset = displacements * (len(self.data) - 1)
+                limited = len(self.data) > 4
+                if limited:
+                    data_to_paint = data[:3]
+                    offset = displacements * len(data_to_paint)
+                else:
+                    data_to_paint = data
+                    offset = displacements * (len(data_to_paint) - 1)
                 stack_width, stack_height = (w + offset, h + offset)
                 pixmap = QtGui.QPixmap(stack_width, stack_height)
                 bgcolor = self.palette().color(QtGui.QPalette.Window)
@@ -147,9 +153,23 @@ class CoverArtThumbnail(ActiveLabel):
                 painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
                 cx = stack_width - w / 2
                 cy = h / 2
-                for image in reversed(self.data):
-                    thumb = QtGui.QPixmap()
-                    thumb.loadFromData(image.data)
+                if limited:
+                    x, y = (cx - self.shadow.width() / 2, cy - self.shadow.height() / 2)
+                    for i in range(3):
+                        painter.drawPixmap(x, y, self.shadow)
+                        x -= displacements / 3
+                        y += displacements / 3
+                    cx -= displacements
+                    cy += displacements
+                else:
+                    cx = stack_width - w / 2
+                    cy = h / 2
+                for image in reversed(data_to_paint):
+                    if isinstance(image, QtGui.QPixmap):
+                        thumb = image
+                    else:
+                        thumb = QtGui.QPixmap()
+                        thumb.loadFromData(image.data)
                     thumb = self.decorate_cover(thumb)  # QtGui.QColor("darkgoldenrod")
                     x, y = (cx - thumb.width() / 2, cy - thumb.height() / 2)
                     painter.drawPixmap(x, y, thumb)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -126,35 +126,38 @@ class CoverArtThumbnail(ActiveLabel):
             return
 
         cover = self.shadow
-        if self.data:
-            w, h, displacements = (121, 121, 20)
-            if pixmap is None:
-                if len(self.data) == 1:
-                    pixmap = QtGui.QPixmap()
-                    pixmap.loadFromData(self.data[0].data)
-                else:
-                    stack_width, stack_height = (w + displacements * (len(self.data) - 1), h + displacements * (len(self.data) - 1))
-                    pixmap = QtGui.QPixmap(stack_width, stack_height)
-                    bgcolor = self.palette().color(QtGui.QPalette.Window)
-                    painter = QtGui.QPainter(pixmap)
-                    painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
-                    x = w / 2
-                    y = h / 2
-                    for image in self.data:
-                        thumb = QtGui.QPixmap()
-                        thumb.loadFromData(image.data)
-                        thumb = self.decorate_cover(thumb)
-                        painter.drawPixmap(x - thumb.width() / 2, y - thumb.height() / 2, thumb)
-                        x += displacements
-                        y += displacements
-                    painter.end()
-                    pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
-                    self.setPixmap(pixmap)
-                    pixmap = None
+        if not self.data:
+            self.setPixmap(self.shadow)
+            return
 
-            if pixmap and not pixmap.isNull():
-                cover = self.decorate_cover(pixmap)
-                self.setPixmap(cover)
+        w, h, displacements = (121, 121, 20)
+        if pixmap is None:
+            if len(self.data) == 1:
+                pixmap = QtGui.QPixmap()
+                pixmap.loadFromData(self.data[0].data)
+            else:
+                stack_width, stack_height = (w + displacements * (len(self.data) - 1), h + displacements * (len(self.data) - 1))
+                pixmap = QtGui.QPixmap(stack_width, stack_height)
+                bgcolor = self.palette().color(QtGui.QPalette.Window)
+                painter = QtGui.QPainter(pixmap)
+                painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
+                x = w / 2
+                y = h / 2
+                for image in self.data:
+                    thumb = QtGui.QPixmap()
+                    thumb.loadFromData(image.data)
+                    thumb = self.decorate_cover(thumb)
+                    painter.drawPixmap(x - thumb.width() / 2, y - thumb.height() / 2, thumb)
+                    x += displacements
+                    y += displacements
+                painter.end()
+                pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+                self.setPixmap(pixmap)
+                pixmap = None
+
+        if pixmap and not pixmap.isNull():
+            cover = self.decorate_cover(pixmap)
+            self.setPixmap(cover)
 
     def set_metadata(self, metadata):
         data = None

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -26,7 +26,7 @@ from picard.album import Album
 from picard.coverart.image import CoverArtImage, CoverArtImageError
 from picard.track import Track
 from picard.file import File
-from picard.util import encode_filename, imageinfo, get_file_path
+from picard.util import encode_filename, imageinfo
 from picard.util.lrucache import LRUCache
 from picard.const import MAX_COVERS_TO_STACK
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -316,18 +316,23 @@ class CoverArtBox(QtGui.QGroupBox):
             album.metadata.set_front_image(coverartimage)
             for track in album.tracks:
                 track.metadata.set_front_image(coverartimage)
+                track.metadata_images_changed.emit()
             for file in album.iterfiles():
                 file.metadata.set_front_image(coverartimage)
+                file.metadata_images_changed.emit()
                 file.update()
         elif isinstance(self.item, Track):
             track = self.item
             track.metadata.set_front_image(coverartimage)
+            track.metadata_images_changed.emit()
             for file in track.iterfiles():
                 file.metadata.set_front_image(coverartimage)
+                file.metadata_images_changed.emit()
                 file.update()
         elif isinstance(self.item, File):
             file = self.item
             file.metadata.set_front_image(coverartimage)
+            file.metadata_images_changed.emit()
             file.update()
         self.cover_art.set_metadata(self.item.metadata)
         self.show()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -113,10 +113,9 @@ class ActiveLabel(QtGui.QLabel):
 
 class CoverArtThumbnail(ActiveLabel):
 
-    def __init__(self, active=False, drops=False, name=None, pixmap_cache=None, *args, **kwargs):
+    def __init__(self, active=False, drops=False, pixmap_cache=None, *args, **kwargs):
         super(CoverArtThumbnail, self).__init__(active, drops, *args, **kwargs)
         self.data = None
-        self.name = name
         self.shadow = QtGui.QPixmap(":/images/CoverArtShadow.png")
         self.release = None
         self.setPixmap(self.shadow)
@@ -233,10 +232,10 @@ class CoverArtBox(QtGui.QGroupBox):
         self.pixmap_cache = LRUCache(40)
         self.cover_art_label = QtGui.QLabel('')
         self.cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
-        self.cover_art = CoverArtThumbnail(False, True, "new cover", self.pixmap_cache, parent)
+        self.cover_art = CoverArtThumbnail(False, True, self.pixmap_cache, parent)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.orig_cover_art_label = QtGui.QLabel('')
-        self.orig_cover_art = CoverArtThumbnail(False, False, "original cover", self.pixmap_cache, parent)
+        self.orig_cover_art = CoverArtThumbnail(False, False, self.pixmap_cache, parent)
         self.orig_cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
         self.orig_cover_art.setHidden(True)
         self.show_details_button = QtGui.QPushButton(_(u'Show more details'), self)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -317,13 +317,16 @@ class CoverArtBox(QtGui.QGroupBox):
                 track.metadata.set_front_image(coverartimage)
             for file in album.iterfiles():
                 file.metadata.set_front_image(coverartimage)
+                file.update()
         elif isinstance(self.item, Track):
             track = self.item
             track.metadata.set_front_image(coverartimage)
             for file in track.iterfiles():
                 file.metadata.set_front_image(coverartimage)
+                file.update()
         elif isinstance(self.item, File):
             file = self.item
             file.metadata.set_front_image(coverartimage)
+            file.update()
         self.cover_art.set_metadata(self.item.metadata)
         self.show()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -302,6 +302,7 @@ class CoverArtBox(QtGui.QGroupBox):
         try:
             coverartimage = CoverArtImage(
                 url=url.toString(),
+                types=[u'front'],
                 data=data
             )
         except CoverArtImageError as e:
@@ -309,21 +310,18 @@ class CoverArtBox(QtGui.QGroupBox):
             return
         if isinstance(self.item, Album):
             album = self.item
-            album.metadata.append_image(coverartimage)
+            album.metadata.set_front_image(coverartimage)
             for track in album.tracks:
-                track.metadata.append_image(coverartimage)
+                track.metadata.set_front_image(coverartimage)
             for file in album.iterfiles():
-                file.metadata.append_image(coverartimage)
-                file.update()
+                file.metadata.set_front_image(coverartimage)
         elif isinstance(self.item, Track):
             track = self.item
-            track.metadata.append_image(coverartimage)
+            track.metadata.set_front_image(coverartimage)
             for file in track.iterfiles():
-                file.metadata.append_image(coverartimage)
-                file.update()
+                file.metadata.set_front_image(coverartimage)
         elif isinstance(self.item, File):
             file = self.item
-            file.metadata.append_image(coverartimage)
-            file.update()
+            file.metadata.set_front_image(coverartimage)
         self.cover_art.set_metadata(self.item.metadata)
         self.show()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -313,7 +313,7 @@ class CoverArtBox(QtGui.QGroupBox):
             return
         if isinstance(self.item, Album):
             album = self.item
-            album.metadata.set_front_image(coverartimage)
+            album.enable_update_metadata_images(False)
             for track in album.tracks:
                 track.metadata.set_front_image(coverartimage)
                 track.metadata_images_changed.emit()
@@ -321,14 +321,17 @@ class CoverArtBox(QtGui.QGroupBox):
                 file.metadata.set_front_image(coverartimage)
                 file.metadata_images_changed.emit()
                 file.update()
+            album.enable_update_metadata_images(True)
         elif isinstance(self.item, Track):
             track = self.item
+            track.album.enable_update_metadata_images(False)
             track.metadata.set_front_image(coverartimage)
             track.metadata_images_changed.emit()
             for file in track.iterfiles():
                 file.metadata.set_front_image(coverartimage)
                 file.metadata_images_changed.emit()
                 file.update()
+            track.album.enable_update_metadata_images(True)
         elif isinstance(self.item, File):
             file = self.item
             file.metadata.set_front_image(coverartimage)

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -101,8 +101,9 @@ class InfoDialog(PicardDialog):
         self.obj = obj
         self.ui = Ui_InfoDialog()
         self.display_existing_artwork = False
-        if (isinstance(obj, File) and isinstance(obj.parent, Track) or
-                isinstance(obj, Track)):
+        if (isinstance(obj, File)
+            and isinstance(obj.parent, Track)
+            or isinstance(obj, Track)):
             # Display existing artwork only if selected object is track object
             # or linked to a track object
             if getattr(obj, 'orig_metadata', None) is not None:

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -24,6 +24,7 @@ from PyQt4 import QtGui, QtCore
 from picard import log
 from picard.file import File
 from picard.track import Track
+from picard.album import Album
 from picard.coverart.image import CoverArtImageIOError
 from picard.util import format_time, encode_filename, bytes2human, webbrowser2, union_sorted_lists
 from picard.ui import PicardDialog
@@ -101,7 +102,7 @@ class InfoDialog(PicardDialog):
         self.ui = Ui_InfoDialog()
         self.display_existing_artwork = False
         if isinstance(obj, File) and isinstance(obj.parent, Track) or \
-                isinstance(obj, Track):
+                isinstance(obj, Track) or isinstance(obj, Album):
             # Display existing artwork only if selected object is track object
             # or linked to a track object
             if getattr(obj, 'orig_metadata', None) is not None:
@@ -305,7 +306,6 @@ class TrackInfoDialog(InfoDialog):
 
     def _display_info_tab(self):
         tab = self.ui.info_tab
-        track = self.obj
         tabWidget = self.ui.tabWidget
         tab_index = tabWidget.indexOf(tab)
         tabWidget.setTabText(tab_index, _("&Info"))

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -104,7 +104,8 @@ class InfoDialog(PicardDialog):
                 isinstance(obj, Track):
             # Display existing artwork only if selected object is track object
             # or linked to a track object
-            self.display_existing_artwork = True
+            if getattr(obj, 'orig_metadata', None) is not None:
+                self.display_existing_artwork = True
 
         self.ui.setupUi(self)
         self.ui.buttonBox.accepted.connect(self.accept)
@@ -295,6 +296,20 @@ class AlbumInfoDialog(InfoDialog):
         else:
             tabWidget.setTabText(tab_index, _("&Info"))
             self.tab_hide(tab)
+
+class TrackInfoDialog(InfoDialog):
+
+    def __init__(self, track, parent=None):
+        InfoDialog.__init__(self, track, parent)
+        self.setWindowTitle(_("Track Info"))
+
+    def _display_info_tab(self):
+        tab = self.ui.info_tab
+        track = self.obj
+        tabWidget = self.ui.tabWidget
+        tab_index = tabWidget.indexOf(tab)
+        tabWidget.setTabText(tab_index, _("&Info"))
+        self.tab_hide(tab)
 
 
 class ClusterInfoDialog(InfoDialog):

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -101,8 +101,8 @@ class InfoDialog(PicardDialog):
         self.obj = obj
         self.ui = Ui_InfoDialog()
         self.display_existing_artwork = False
-        if isinstance(obj, File) and isinstance(obj.parent, Track) or \
-                isinstance(obj, Track) or isinstance(obj, Album):
+        if (isinstance(obj, File) and isinstance(obj.parent, Track) or
+                isinstance(obj, (Track, Album))):
             # Display existing artwork only if selected object is track object
             # or linked to a track object
             if getattr(obj, 'orig_metadata', None) is not None:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -956,7 +956,6 @@ class MainWindow(QtGui.QMainWindow):
                     self.set_statusbar_message(msg, mparms, echo=None,
                                                history=None)
             elif isinstance(obj, Album):
-                obj.update_metadata_images()
                 metadata = obj.metadata
                 orig_metadata = obj.orig_metadata
             elif obj.can_edit_tags():

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -952,6 +952,10 @@ class MainWindow(QtGui.QMainWindow):
                         }
                     self.set_statusbar_message(msg, mparms, echo=None,
                                                history=None)
+            elif isinstance(obj, Album):
+                obj.update_metadata_images()
+                metadata = obj.metadata
+                orig_metadata = obj.orig_metadata
             elif obj.can_edit_tags():
                 metadata = obj.metadata
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -33,7 +33,7 @@ from picard.ui.metadatabox import MetadataBox
 from picard.ui.filebrowser import FileBrowser
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.options.dialog import OptionsDialog
-from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog, ClusterInfoDialog
+from picard.ui.infodialog import FileInfoDialog, AlbumInfoDialog, TrackInfoDialog, ClusterInfoDialog
 from picard.ui.infostatus import InfoStatus
 from picard.ui.passworddialog import PasswordDialog, ProxyDialog
 from picard.ui.logview import LogView, HistoryView
@@ -842,8 +842,12 @@ class MainWindow(QtGui.QMainWindow):
             cluster = self.selected_objects[0]
             dialog = ClusterInfoDialog(cluster, self)
         else:
-            file = self.tagger.get_files_from_objects(self.selected_objects)[0]
-            dialog = FileInfoDialog(file, self)
+            files = self.tagger.get_files_from_objects(self.selected_objects)
+            if not files and isinstance(self.selected_objects[0], Track):
+                track = self.selected_objects[0]
+                dialog = TrackInfoDialog(track, self)
+            else:
+                dialog = FileInfoDialog(files[0], self)
         dialog.ui.tabWidget.setCurrentIndex(default_tab)
         dialog.exec_()
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -841,13 +841,12 @@ class MainWindow(QtGui.QMainWindow):
         elif isinstance(self.selected_objects[0], Cluster):
             cluster = self.selected_objects[0]
             dialog = ClusterInfoDialog(cluster, self)
+        elif isinstance(self.selected_objects[0], Track):
+            track = self.selected_objects[0]
+            dialog = TrackInfoDialog(track, self)
         else:
-            files = self.tagger.get_files_from_objects(self.selected_objects)
-            if not files and isinstance(self.selected_objects[0], Track):
-                track = self.selected_objects[0]
-                dialog = TrackInfoDialog(track, self)
-            else:
-                dialog = FileInfoDialog(files[0], self)
+            file = self.tagger.get_files_from_objects(self.selected_objects)[0]
+            dialog = FileInfoDialog(file, self)
         dialog.ui.tabWidget.setCurrentIndex(default_tab)
         dialog.exec_()
 

--- a/picard/util/lrucache.py
+++ b/picard/util/lrucache.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2017 Antonio Larrosa <alarrosa@suse.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""
+Helper class to cache items using a Least Recently Used policy.
+
+It's originally used to cache generated pixmaps in the CoverArtBox object
+but it's generic enough to be used for other purposes if necessary.
+The cache will never hold more than max_size items and the item least
+recently used will be discarded.
+
+>>> cache = LRUCache(3)
+>>> cache['item1'] = 'some value'
+>>> cache['item2'] = 'some other value'
+>>> cache['item3'] = 'yet another value'
+>>> cache['item1']
+'some value'
+>>> cache['item4'] = 'This will push item 2 out of the cache'
+>>> cache['item2']
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "lrucache.py", line 48, in __getitem__
+    return super(LRUCache, self).__getitem__(key)
+KeyError: 'item2'
+>>> cache['item5'] = 'This will push item3 out of the cache'
+>>> cache['item3']
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "lrucache.py", line 48, in __getitem__
+    return super(LRUCache, self).__getitem__(key)
+KeyError: 'item3'
+>>> cache['item1']
+'some value'
+"""
+
+
+class LRUCache(dict):
+    def __init__(self, max_size):
+        self._ordered_keys = []
+        self._max_size = max_size
+
+    def __getitem__(self, key):
+        if key in self:
+            self._ordered_keys.remove(key)
+            self._ordered_keys.insert(0, key)
+        return super(LRUCache, self).__getitem__(key)
+
+    def __setitem__(self, key, value):
+        if key in self:
+            self._ordered_keys.remove(key)
+        self._ordered_keys.insert(0, key)
+
+        r = super(LRUCache, self).__setitem__(key, value)
+
+        if len(self) > self._max_size:
+            item = self._ordered_keys.pop()
+            super(LRUCache, self).__delitem__(item)
+
+        return r
+
+    def __delitem__(self, key):
+        self._ordered_keys.remove(key)
+        super(LRUCache, self).__delitem__(key)

--- a/picard/util/lrucache.py
+++ b/picard/util/lrucache.py
@@ -17,40 +17,40 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-"""
-Helper class to cache items using a Least Recently Used policy.
-
-It's originally used to cache generated pixmaps in the CoverArtBox object
-but it's generic enough to be used for other purposes if necessary.
-The cache will never hold more than max_size items and the item least
-recently used will be discarded.
-
->>> cache = LRUCache(3)
->>> cache['item1'] = 'some value'
->>> cache['item2'] = 'some other value'
->>> cache['item3'] = 'yet another value'
->>> cache['item1']
-'some value'
->>> cache['item4'] = 'This will push item 2 out of the cache'
->>> cache['item2']
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "lrucache.py", line 48, in __getitem__
-    return super(LRUCache, self).__getitem__(key)
-KeyError: 'item2'
->>> cache['item5'] = 'This will push item3 out of the cache'
->>> cache['item3']
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "lrucache.py", line 48, in __getitem__
-    return super(LRUCache, self).__getitem__(key)
-KeyError: 'item3'
->>> cache['item1']
-'some value'
-"""
-
 
 class LRUCache(dict):
+    """
+    Helper class to cache items using a Least Recently Used policy.
+
+    It's originally used to cache generated pixmaps in the CoverArtBox object
+    but it's generic enough to be used for other purposes if necessary.
+    The cache will never hold more than max_size items and the item least
+    recently used will be discarded.
+
+    >>> cache = LRUCache(3)
+    >>> cache['item1'] = 'some value'
+    >>> cache['item2'] = 'some other value'
+    >>> cache['item3'] = 'yet another value'
+    >>> cache['item1']
+    'some value'
+    >>> cache['item4'] = 'This will push item 2 out of the cache'
+    >>> cache['item2']
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "lrucache.py", line 48, in __getitem__
+        return super(LRUCache, self).__getitem__(key)
+    KeyError: 'item2'
+    >>> cache['item5'] = 'This will push item3 out of the cache'
+    >>> cache['item3']
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "lrucache.py", line 48, in __getitem__
+        return super(LRUCache, self).__getitem__(key)
+    KeyError: 'item3'
+    >>> cache['item1']
+    'some value'
+    """
+
     def __init__(self, max_size):
         self._ordered_keys = []
         self._max_size = max_size


### PR DESCRIPTION
This PR adds support to show album/cluster cover art on the CoverArtBox.
I think it's better shown with an example, so...
When an album is looked up and the cover image has changed (slightly, but it has change) it shows up as http://i.imgur.com/M6dFXna.png
When one track is selected, and a different cover image is dropped for that track: http://i.imgur.com/W6xfS2L.png
Then when the user clicks on the album... http://i.imgur.com/ITX4e3g.png
Another file from another album (which has a different cover art) is added to track 9 of that album: http://i.imgur.com/jAt7ZLJ.png
And then another file is added to another track and other covers are dropped to other tracks on that album: http://i.imgur.com/XSig6BS.png

https://tickets.metabrainz.org/browse/PICARD-1000