### PR TITLE
PICARD-1005: Fix drag'n'drop behaviour on blank targets

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -336,6 +336,8 @@ class Tagger(QtGui.QApplication):
                 self.analyze([file])
 
     def move_files(self, files, target):
+        if target is None:
+            return
         if isinstance(target, (Track, Cluster)):
             for file in files:
                 file.move(target)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -337,6 +337,7 @@ class Tagger(QtGui.QApplication):
 
     def move_files(self, files, target):
         if target is None:
+            log.debug("Aborting move since target is invalid")
             return
         if isinstance(target, (Track, Cluster)):
             for file in files:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -529,8 +529,6 @@ class BaseTreeView(QtGui.QTreeWidget):
         # text/uri-list
         urls = data.urls()
         if urls:
-            if target is None:
-                target = self.tagger.unmatched_files
             self.drop_urls(urls, target)
             handled = True
         # application/picard.album-list


### PR DESCRIPTION
In case a cluster is moved to the RHS of the windows, it gets moved to
unmatched files. The cluster should instead stay as is since the target is
invalid.