### PR TITLE
Add OSX tests and a build matrix for different linux envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,33 @@
-sudo: required
-services:
-  - docker
+os: linux
+language: python
+python: "2.7"
+virtualenv:
+  system_site_packages: true
+cache:
+  - apt
+  - pip
+env:
+  global:
+    - PIP_INSTALL="pip install"
+  matrix:
+    - DISCID="" MUTAGEN="$PIP_INSTALL mutagen>=1.23"
+    - DISCID="$PIP_INSTALL discid" MUTAGEN="$PIP_INSTALL mutagen>=1.23"
+    - MUTAGEN="$PIP_INSTALL mutagen==1.34"
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.1
+      language: generic
 before_install:
-  - docker build -t picard .
-script: "docker run picard"
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash scripts/setup-osx.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq && sudo apt-get install -qq python-qt4 libdiscid0 libdiscid0-dev; $MUTAGEN; $DISCID; fi
+install:
+  # Set up Picard
+  - python setup.py build_ext -i
+  - python setup.py build_locales -i
+# Run the tests!
+script: "python setup.py test"
+
 # Tell people that tests were run
 notifications:
   irc: "chat.freenode.net#metabrainz"

--- a/scripts/setup-osx.sh
+++ b/scripts/setup-osx.sh
@@ -1,0 +1,11 @@
+brew tap cartr/qt4
+brew tap-pin cartr/qt4
+brew install gettext
+brew link gettext --force
+brew install qt
+brew install pyqt
+brew install libdiscid 
+pip install mutagen
+pip install discid
+pip install py2app
+pip install pyobjc-framework-Cocoa

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,11 @@ import os
 import re
 import sys
 import subprocess
+import sip
+
+sip.setapi("QString", 2)
+sip.setapi("QVariant", 2)
+
 from picard import __version__, compat
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
Replaced the dockerized travis config with the previous one as it tests for more environments and add OSX tests.