### PR TITLE
Fix OSX builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
   DISCID_VERSION: "0.6.1"
   PYTHON_DISCID_VERSION: "1.1.1"
   MUTAGEN_VERSION: "1.36"
+  PY2APP_VERSION: "0.11"
 
 package win:
   stage: package

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -33,15 +33,6 @@ from string import Template
 from functools import partial
 from picard.const import MUSICBRAINZ_SERVERS
 
-if sys.platform == 'darwin':
-    try:
-        from Foundation import NSURL
-        NSURL_IMPORTED = True
-    except ImportError:
-        NSURL_IMPORTED = False
-        from picard import log
-        log.warning("Unable to import NSURL, file drag'n'drop might not work correctly")
-
 
 class LockableObject(QtCore.QObject):
 
@@ -445,21 +436,3 @@ def union_sorted_lists(list1, list2):
         union.extend(list1[i:])
 
     return union
-
-
-def get_file_path(url):
-    # Workaround for https://bugreports.qt.io/browse/QTBUG-40449
-    # OSX Urls follow the NSURL scheme and need to be converted
-    from picard import log
-
-    file_path = ""
-    if sys.platform == 'darwin' and unicode(url.path()).startswith('/.file/id='):
-        if NSURL_IMPORTED:
-            file_path = os.path.normpath(os.path.realpath(unicode(NSURL.URLWithString_(str(url.toString())).filePathURL().path()).rstrip("\0")))
-            log.debug('OSX NSURL path detected. Dropped File is: %r', file_path)
-        else:
-            log.error("Unable to get appropriate file path for %r", url.toString(QtCore.QUrl.RemoveUserInfo))
-    else:
-        # Dropping a file from iTunes gives a filename with a NULL terminator
-        file_path = os.path.normpath(os.path.realpath(unicode(url.toLocalFile()).rstrip("\0")))
-    return file_path

--- a/scripts/package-osx.sh
+++ b/scripts/package-osx.sh
@@ -16,7 +16,7 @@ virtualenv -p python2.7 --system-site-packages e
 
 pip install mutagen==$MUTAGEN_VERSION
 pip install discid==$PYTHON_DISCID_VERSION
-pip install py2app
+pip install py2app==$PY2APP_VERSION
 
 perl -pi -e 's{plugin_dir = (.*)$}{plugin_dir = "/Developer/Applications/Qt/plugins"}' e/lib/python2.7/site-packages/py2app/recipes/sip.py
 


### PR DESCRIPTION
This fixes the failing OSX builds for Picard.

The prime reasons for failing builds were-

1. Circular imports in util.get_file_path
2. Updated py2app version which breaks OSX builds. (Last working version is 0.11)