### PR TITLE
PICARD-1011: Set action toolbar tab order according to custom order

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -647,27 +647,30 @@ class MainWindow(QtGui.QMainWindow):
         hbox.addWidget(self.search_button)
         toolbar.addWidget(search_panel)
 
-
     def set_tab_order(self):
         tab_order = self.setTabOrder
         tw = self.toolbar.widgetForAction
+        prev_action = None
+        current_action = None
+        # Setting toolbar widget tab-orders for accessibility
+        for action in config.setting['toolbar_layout']:
+            if action != 'separator':
+                try:
+                    current_action = tw(getattr(self, action))
+                except AttributeError:
+                    # No need to log warnings since we have already
+                    # done it once in create_toolbar
+                    pass
 
-        # toolbar
-        tab_order(tw(self.add_directory_action), tw(self.add_files_action))
-        tab_order(tw(self.add_files_action), tw(self.play_file_action))
-        tab_order(tw(self.play_file_action), tw(self.save_action))
-        tab_order(tw(self.save_action), tw(self.submit_acoustid_action))
-        tab_order(tw(self.submit_acoustid_action), tw(self.cd_lookup_action))
-        tab_order(tw(self.cd_lookup_action), tw(self.cluster_action))
-        tab_order(tw(self.cluster_action), tw(self.autotag_action))
-        tab_order(tw(self.autotag_action), tw(self.analyze_action))
-        tab_order(tw(self.analyze_action), tw(self.view_info_action))
-        tab_order(tw(self.view_info_action), tw(self.remove_action))
-        tab_order(tw(self.remove_action), tw(self.browser_lookup_action))
-        tab_order(tw(self.browser_lookup_action), self.search_combo)
+            if prev_action is not None and prev_action != current_action:
+                tab_order(prev_action, current_action)
+
+            prev_action = current_action
+
+        tab_order(prev_action, self.search_combo)
         tab_order(self.search_combo, self.search_edit)
         tab_order(self.search_edit, self.search_button)
-        # panels
+        # Panels
         tab_order(self.search_button, self.file_browser)
         tab_order(self.file_browser, self.panel.views[0])
         tab_order(self.panel.views[0], self.panel.views[1])

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -274,6 +274,7 @@ class InterfaceOptionsPage(OptionsPage):
             widget = widget.parent()
         # Call the main window's create toolbar method
         widget.create_action_toolbar()
+        widget.set_tab_order()
 
 
 class ToolbarListItem(QtGui.QListWidgetItem):


### PR DESCRIPTION
With #567 support for customizable toolbars was added.
This commit changes the set_tab_order function to correspond with the
custom toolbar layout dynamically.

See: https://tickets.metabrainz.org/browse/PICARD-1011