### PR TITLE
PICARD-1030: Add cover art context menu and "keep original images" option

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -587,7 +587,6 @@ class Album(DataObject, Item):
         self.update(False)
 
     def keep_original_images(self):
-        print('keep')
         for track in self.tracks:
             track.keep_original_images()
         for file in list(self.unmatched_files.files):

--- a/picard/album.py
+++ b/picard/album.py
@@ -586,6 +586,14 @@ class Album(DataObject, Item):
 
         self.update(False)
 
+    def keep_original_images(self):
+        print('keep')
+        for track in self.tracks:
+            track.keep_original_images()
+        for file in list(self.unmatched_files.files):
+            file.keep_original_images()
+        self.update_metadata_images()
+
 
 class NatAlbum(Album):
 

--- a/picard/album.py
+++ b/picard/album.py
@@ -587,10 +587,12 @@ class Album(DataObject, Item):
         self.update(False)
 
     def keep_original_images(self):
+        self.enable_update_metadata_images(False)
         for track in self.tracks:
             track.keep_original_images()
         for file in list(self.unmatched_files.files):
             file.keep_original_images()
+        self.enable_update_metadata_images(True)
         self.update_metadata_images()
 
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -175,6 +175,10 @@ class File(QtCore.QObject, Item):
             self.metadata["acoustid_id"] = acoustid
         self.metadata_images_changed.emit()
 
+    def keep_original_images(self):
+        self.metadata.images = self.orig_metadata.images
+        self.update()
+
     def has_error(self):
         return self.state == File.ERROR
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -178,6 +178,7 @@ class File(QtCore.QObject, Item):
     def keep_original_images(self):
         self.metadata.images = self.orig_metadata.images[:]
         self.update()
+        self.metadata_images_changed.emit()
 
     def has_error(self):
         return self.state == File.ERROR

--- a/picard/file.py
+++ b/picard/file.py
@@ -176,7 +176,7 @@ class File(QtCore.QObject, Item):
         self.metadata_images_changed.emit()
 
     def keep_original_images(self):
-        self.metadata.images = self.orig_metadata.images
+        self.metadata.images = self.orig_metadata.images[:]
         self.update()
 
     def has_error(self):

--- a/picard/track.py
+++ b/picard/track.py
@@ -228,6 +228,14 @@ class Track(DataObject, Item):
     def update_orig_metadata_images(self):
         update_metadata_images(self)
 
+    def keep_original_images(self):
+        for file in self.linked_files:
+            file.keep_original_images()
+        if self.linked_files:
+            self.update_orig_metadata_images()
+            self.metadata.images = self.orig_metadata.images[:]
+        self.update()
+
 
 class NonAlbumTrack(Track):
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -234,6 +234,8 @@ class Track(DataObject, Item):
         if self.linked_files:
             self.update_orig_metadata_images()
             self.metadata.images = self.orig_metadata.images[:]
+        else:
+            self.metadata.images = []
         self.update()
 
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -380,9 +380,11 @@ class CoverArtBox(QtGui.QGroupBox):
             return
 
         if config.setting["behaviour_on_image_drop"] == 'replace':
-            drop_image = lambda obj: obj.metadata.set_front_image(coverartimage)
+            def drop_image(obj):
+                obj.metadata.set_front_image(coverartimage)
         else:
-            drop_image = lambda obj: obj.metadata.append_image(coverartimage)
+            def drop_image(obj):
+                obj.metadata.append_image(coverartimage)
 
         if isinstance(self.item, Album):
             album = self.item

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -380,21 +380,21 @@ class CoverArtBox(QtGui.QGroupBox):
             return
 
         if config.setting["behaviour_on_image_drop"] == 'replace':
-            def drop_image(obj):
+            def set_image(obj):
                 obj.metadata.set_front_image(coverartimage)
         else:
-            def drop_image(obj):
+            def set_image(obj):
                 obj.metadata.append_image(coverartimage)
 
         if isinstance(self.item, Album):
             album = self.item
             album.enable_update_metadata_images(False)
-            drop_image(album)
+            set_image(album)
             for track in album.tracks:
-                drop_image(track)
+                set_image(track)
                 track.metadata_images_changed.emit()
             for file in album.iterfiles():
-                drop_image(file)
+                set_image(file)
                 file.metadata_images_changed.emit()
                 file.update()
             album.enable_update_metadata_images(True)
@@ -403,10 +403,10 @@ class CoverArtBox(QtGui.QGroupBox):
         elif isinstance(self.item, Track):
             track = self.item
             track.album.enable_update_metadata_images(False)
-            drop_image(track)
+            set_image(track)
             track.metadata_images_changed.emit()
             for file in track.iterfiles():
-                drop_image(file)
+                set_image(file)
                 file.metadata_images_changed.emit()
                 file.update()
             track.album.enable_update_metadata_images(True)
@@ -414,7 +414,7 @@ class CoverArtBox(QtGui.QGroupBox):
             track.album.update(False)
         elif isinstance(self.item, File):
             file = self.item
-            drop_image(file)
+            set_image(file)
             file.metadata_images_changed.emit()
             file.update()
         self.cover_art.set_metadata(self.item.metadata)
@@ -426,13 +426,13 @@ class CoverArtBox(QtGui.QGroupBox):
     def contextMenuEvent(self, event):
         menu = QtGui.QMenu(self)
         if self.show_details_button.isVisible():
-            name = _(u'Show more details')
+            name = _(u'Show more details...')
             show_more_details_action = QtGui.QAction(name, self.parent)
             show_more_details_action.triggered.connect(self.show_cover_art_info)
             menu.addAction(show_more_details_action)
 
         if self.orig_cover_art.isVisible():
-            name = _(u'Use Original Cover Art')
+            name = _(u'Keep original cover art')
             use_orig_value_action = QtGui.QAction(name, self.parent)
             use_orig_value_action.triggered.connect(self.item.keep_original_images)
             menu.addAction(use_orig_value_action)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -448,12 +448,12 @@ class CoverArtBox(QtGui.QGroupBox):
 
         load_image_behavior_group = QtGui.QActionGroup(self.parent, exclusive=True)
         action = load_image_behavior_group.addAction(QtGui.QAction(_(u'Replace front cover art on drop'), self.parent, checkable=True))
-        action.triggered.connect(partial(self.setLoadImageBehavior, behavior='replace'))
+        action.triggered.connect(partial(self.set_load_image_behavior, behavior='replace'))
         if config.setting["load_image_behavior"] == 'replace':
             action.setChecked(True)
         menu.addAction(action)
         action = load_image_behavior_group.addAction(QtGui.QAction(_(u'Append front cover art on drop'), self.parent, checkable=True))
-        action.triggered.connect(partial(self.setLoadImageBehavior, behavior='append'))
+        action.triggered.connect(partial(self.set_load_image_behavior, behavior='append'))
         if config.setting["load_image_behavior"] == 'append':
             action.setChecked(True)
         menu.addAction(action)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -413,16 +413,17 @@ class CoverArtBox(QtGui.QGroupBox):
 
     def contextMenuEvent(self, event):
         menu = QtGui.QMenu(self)
-        name = _(u'Show more details')
-        show_more_details_action = QtGui.QAction(name, self.parent)
-        show_more_details_action.triggered.connect(self.show_cover_art_info)
-        menu.addAction(show_more_details_action)
+        if self.show_details_button.isVisible():
+            name = _(u'Show more details')
+            show_more_details_action = QtGui.QAction(name, self.parent)
+            show_more_details_action.triggered.connect(self.show_cover_art_info)
+            menu.addAction(show_more_details_action)
 
         if self.orig_cover_art.isVisible():
-                name = _(u'Use Original Cover Art')
-                use_orig_value_action = QtGui.QAction(name, self.parent)
-                use_orig_value_action.triggered.connect(self.item.keep_original_images)
-                menu.addAction(use_orig_value_action)
+            name = _(u'Use Original Cover Art')
+            use_orig_value_action = QtGui.QAction(name, self.parent)
+            use_orig_value_action.triggered.connect(self.item.keep_original_images)
+            menu.addAction(use_orig_value_action)
 
         menu.exec_(event.globalPos())
         event.accept()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -379,7 +379,7 @@ class CoverArtBox(QtGui.QGroupBox):
             log.warning("Can't load image: %s" % unicode(e))
             return
 
-        if config.setting["behaviour_on_image_drop"] == 'replace':
+        if config.setting["load_image_behavior"] == 'replace':
             def set_image(obj):
                 obj.metadata.set_front_image(coverartimage)
         else:
@@ -420,8 +420,8 @@ class CoverArtBox(QtGui.QGroupBox):
         self.cover_art.set_metadata(self.item.metadata)
         self.show()
 
-    def setBehaviourOnImageDrop(self, behaviour):
-        config.setting["behaviour_on_image_drop"] = behaviour
+    def set_load_image_behavior(self, behavior):
+        config.setting["load_image_behavior"] = behavior
 
     def contextMenuEvent(self, event):
         menu = QtGui.QMenu(self)
@@ -440,15 +440,15 @@ class CoverArtBox(QtGui.QGroupBox):
         if not menu.isEmpty():
             menu.addSeparator()
 
-        behaviourOnDrop = QtGui.QActionGroup(self.parent, exclusive=True)
-        action = behaviourOnDrop.addAction(QtGui.QAction(_(u'Replace front cover art on drop'), self.parent, checkable=True))
-        action.triggered.connect(partial(self.setBehaviourOnImageDrop, behaviour='replace'))
-        if config.setting["behaviour_on_image_drop"] == 'replace':
+        load_image_behavior_group = QtGui.QActionGroup(self.parent, exclusive=True)
+        action = load_image_behavior_group.addAction(QtGui.QAction(_(u'Replace front cover art on drop'), self.parent, checkable=True))
+        action.triggered.connect(partial(self.setLoadImageBehavior, behavior='replace'))
+        if config.setting["load_image_behavior"] == 'replace':
             action.setChecked(True)
         menu.addAction(action)
-        action = behaviourOnDrop.addAction(QtGui.QAction(_(u'Append front cover art on drop'), self.parent, checkable=True))
-        action.triggered.connect(partial(self.setBehaviourOnImageDrop, behaviour='append'))
-        if config.setting["behaviour_on_image_drop"] == 'append':
+        action = load_image_behavior_group.addAction(QtGui.QAction(_(u'Append front cover art on drop'), self.parent, checkable=True))
+        action.triggered.connect(partial(self.setLoadImageBehavior, behavior='append'))
+        if config.setting["load_image_behavior"] == 'append':
             action.setChecked(True)
         menu.addAction(action)
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -241,10 +241,6 @@ class CoverArtThumbnail(ActiveLabel):
     def fetch_remote_image(self, url):
         return self.parent().fetch_remote_image(url)
 
-    def contextMenuEvent(self, event):
-        print('CoverArtThumbnail.contextMenuEvent', type(self.parent()))
-        return self.parent().contextMenuEvent(event)
-
 
 class CoverArtBox(QtGui.QGroupBox):
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -241,6 +241,10 @@ class CoverArtThumbnail(ActiveLabel):
     def fetch_remote_image(self, url):
         return self.parent().fetch_remote_image(url)
 
+    def contextMenuEvent(self, event):
+        print('CoverArtThumbnail.contextMenuEvent', type(self.parent()))
+        return self.parent().contextMenuEvent(event)
+
 
 class CoverArtBox(QtGui.QGroupBox):
 
@@ -410,3 +414,19 @@ class CoverArtBox(QtGui.QGroupBox):
             file.update()
         self.cover_art.set_metadata(self.item.metadata)
         self.show()
+
+    def contextMenuEvent(self, event):
+        menu = QtGui.QMenu(self)
+        name = _(u'Show more details')
+        show_more_details_action = QtGui.QAction(name, self.parent)
+        show_more_details_action.triggered.connect(self.show_cover_art_info)
+        menu.addAction(show_more_details_action)
+
+        if self.orig_cover_art.isVisible():
+                name = _(u'Use Original Cover Art')
+                use_orig_value_action = QtGui.QAction(name, self.parent)
+                use_orig_value_action.triggered.connect(self.item.keep_original_images)
+                menu.addAction(use_orig_value_action)
+
+        menu.exec_(event.globalPos())
+        event.accept()

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -242,6 +242,14 @@ class CoverArtThumbnail(ActiveLabel):
         return self.parent().fetch_remote_image(url)
 
 
+def set_image_replace(obj, coverartimage):
+    obj.metadata.set_front_image(coverartimage)
+
+
+def set_image_append(obj, coverartimage):
+    obj.metadata.append_image(coverartimage)
+
+
 class CoverArtBox(QtGui.QGroupBox):
 
     def __init__(self, parent):
@@ -380,21 +388,19 @@ class CoverArtBox(QtGui.QGroupBox):
             return
 
         if config.setting["load_image_behavior"] == 'replace':
-            def set_image(obj):
-                obj.metadata.set_front_image(coverartimage)
+            set_image = set_image_replace
         else:
-            def set_image(obj):
-                obj.metadata.append_image(coverartimage)
+            set_image = set_image_append
 
         if isinstance(self.item, Album):
             album = self.item
             album.enable_update_metadata_images(False)
-            set_image(album)
+            set_image(album, coverartimage)
             for track in album.tracks:
-                set_image(track)
+                set_image(track, coverartimage)
                 track.metadata_images_changed.emit()
             for file in album.iterfiles():
-                set_image(file)
+                set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
                 file.update()
             album.enable_update_metadata_images(True)
@@ -403,10 +409,10 @@ class CoverArtBox(QtGui.QGroupBox):
         elif isinstance(self.item, Track):
             track = self.item
             track.album.enable_update_metadata_images(False)
-            set_image(track)
+            set_image(track, coverartimage)
             track.metadata_images_changed.emit()
             for file in track.iterfiles():
-                set_image(file)
+                set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
                 file.update()
             track.album.enable_update_metadata_images(True)
@@ -414,7 +420,7 @@ class CoverArtBox(QtGui.QGroupBox):
             track.album.update(False)
         elif isinstance(self.item, File):
             file = self.item
-            set_image(file)
+            set_image(file, coverartimage)
             file.metadata_images_changed.emit()
             file.update()
         self.cover_art.set_metadata(self.item.metadata)

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -98,6 +98,7 @@ class InterfaceOptionsPage(OptionsPage):
         config.TextOption("setting", "ui_language", u""),
         config.BoolOption("setting", "starting_directory", False),
         config.TextOption("setting", "starting_directory_path", ""),
+        config.TextOption("setting", "behaviour_on_image_drop", "replace"),
         config.ListOption("setting", "toolbar_layout", [
             'add_directory_action',
             'add_files_action',

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -98,7 +98,7 @@ class InterfaceOptionsPage(OptionsPage):
         config.TextOption("setting", "ui_language", u""),
         config.BoolOption("setting", "starting_directory", False),
         config.TextOption("setting", "starting_directory_path", ""),
-        config.TextOption("setting", "behaviour_on_image_drop", "replace"),
+        config.TextOption("setting", "behaviour_on_image_drop", "append"),
         config.ListOption("setting", "toolbar_layout", [
             'add_directory_action',
             'add_files_action',

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -98,7 +98,7 @@ class InterfaceOptionsPage(OptionsPage):
         config.TextOption("setting", "ui_language", u""),
         config.BoolOption("setting", "starting_directory", False),
         config.TextOption("setting", "starting_directory_path", ""),
-        config.TextOption("setting", "behaviour_on_image_drop", "append"),
+        config.TextOption("setting", "load_image_behavior", "append"),
         config.ListOption("setting", "toolbar_layout", [
             'add_directory_action',
             'add_files_action',


### PR DESCRIPTION
This adds a cover art context menu that allows users to select if they want dropped images to replace the current images or they want them to be appended to the current images. The context menu also adds an option to "Keep original images" which allows to ignore downloaded images and keep the original images if users prefer the images they already have.

Fixes [PICARD-1030](https://tickets.metabrainz.org/browse/PICARD-1030)