### PR TITLE
PICARD-1034: Add support for loading and saving TOAL & TOPE id3 frames

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -123,6 +123,7 @@ class ID3File(File):
         'WCOP': 'license',
         'WOAR': 'website',
         'COMM': 'comment',
+        'TOAL': 'originalalbum',
         'TOPE': 'originalartist',
 
         # The following are informal iTunes extensions to id3v2:

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -123,6 +123,7 @@ class ID3File(File):
         'WCOP': 'license',
         'WOAR': 'website',
         'COMM': 'comment',
+        'TOPE': 'originalartist',
 
         # The following are informal iTunes extensions to id3v2:
         'TCMP': 'compilation',
@@ -432,7 +433,7 @@ class ID3File(File):
                         if frame.FrameID in ('TMCL', 'TIPL', 'IPLS'):
                             for people in frame.people:
                                 if people[0] == role:
-                                    frame.people.remove(people)   
+                                    frame.people.remove(people)
                 elif name.startswith('comment:'):
                     desc = name.split(':', 1)[1]
                     if desc.lower()[:4] != 'itun':
@@ -453,7 +454,7 @@ class ID3File(File):
                         if frame.FrameID in ('TIPL', 'IPLS'):
                             for people in frame.people:
                                 if people[0] == role:
-                                    frame.people.remove(people)   
+                                    frame.people.remove(people)
                 elif name == 'musicbrainz_recordingid':
                     for key, frame in tags.items():
                         if frame.FrameID == 'UFID' and frame.owner == 'http://musicbrainz.org':

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -56,7 +56,6 @@ TAG_NAMES = {
     'musicbrainz_trackid': N_('MusicBrainz Track Id'),
     'musicbrainz_albumid': N_('MusicBrainz Release Id'),
     'musicbrainz_artistid': N_('MusicBrainz Artist Id'),
-    'musicbrainz_originalartistid': N_('MusicBrainz Original Artist Id'),
     'musicbrainz_albumartistid': N_('MusicBrainz Release Artist Id'),
     'musicbrainz_workid': N_('MusicBrainz Work Id'),
     'musicbrainz_releasegroupid': N_('MusicBrainz Release Group Id'),
@@ -90,6 +89,9 @@ TAG_NAMES = {
     'artists': N_('Artists'),
     'work': N_('Work'),
     'originalartist': N_('Original Artist'),
+    'musicbrainz_originalartistid': N_('MusicBrainz Original Artist Id'),
+    'originalalbum': N_('Original Album'),
+    'musicbrainz_originalalbumid': N_('MusicBrainz Orignal Release Id'),
 }
 
 PRESERVED_TAGS = [

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -56,6 +56,7 @@ TAG_NAMES = {
     'musicbrainz_trackid': N_('MusicBrainz Track Id'),
     'musicbrainz_albumid': N_('MusicBrainz Release Id'),
     'musicbrainz_artistid': N_('MusicBrainz Artist Id'),
+    'musicbrainz_originalartistid': N_('MusicBrainz Original Artist Id'),
     'musicbrainz_albumartistid': N_('MusicBrainz Release Artist Id'),
     'musicbrainz_workid': N_('MusicBrainz Work Id'),
     'musicbrainz_releasegroupid': N_('MusicBrainz Release Group Id'),

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -88,6 +88,7 @@ TAG_NAMES = {
     '~rating': N_('Rating'),
     'artists': N_('Artists'),
     'work': N_('Work'),
+    'originalartist': N_('Original Artist'),
 }
 
 PRESERVED_TAGS = [


### PR DESCRIPTION
This PR adds support for loading and saving the TOAL and TOPE tags.

It does not add support for populating these from MB - see ticket for details.

Resolves https://tickets.metabrainz.org/browse/PICARD-1034