### PR TITLE
PICARD-1042: Fix missing import for PICARD_APP_NAME

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -50,7 +50,7 @@ from picard.util.textencoding import (
 from picard.util.filenaming import make_short_filename
 from picard.util.tags import PRESERVED_TAGS
 from picard.const import QUERY_LIMIT
-
+from picard import PICARD_APP_NAME
 
 class File(QtCore.QObject, Item):
 


### PR DESCRIPTION
Missing from #658 which resolved https://tickets.metabrainz.org/browse/PICARD-1021

Resolves https://tickets.metabrainz.org/browse/PICARD-1042.