### PR TITLE
PICARD-1034: Add missing definitions for MBIDs for TOAL TOPE

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -144,6 +144,8 @@ class ID3File(File):
         'MusicBrainz Disc Id': 'musicbrainz_discid',
         'MusicBrainz Work Id': 'musicbrainz_workid',
         'MusicBrainz Release Group Id': 'musicbrainz_releasegroupid',
+        'MusicBrainz Original Album Id': 'musicbrainz_originalalbumid',
+        'MusicBrainz Original Artist Id': 'musicbrainz_originalartistid',
         'MusicBrainz Album Release Country': 'releasecountry',
         'MusicIP PUID': 'musicip_puid',
         'Acoustid Fingerprint': 'acoustid_fingerprint',


### PR DESCRIPTION
Support for other formats will be added in PRs for PICARD-1048