### PR TITLE
INSTALL, resources/README: Explicitly refer to python3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ dependencies:
 
 Run the following command to install PyQt5, Mutagen and discid:
 
-    pip install -r requirements.txt
+    pip3 install -r requirements.txt
 
 The binaries for Python, GetText (msgfmt), fpcalc and discid.dll have to be
 in the %PATH% on Windows.
@@ -43,7 +43,7 @@ Installation
 
 After installing the dependencies, you can install Picard by running:
 
-    sudo python setup.py install
+    sudo python3 setup.py install
 
 This will automatically build and install all required Python modules.
 On Windows you need to have Administrator rights, but don't put "sudo"
@@ -60,13 +60,13 @@ If you want to run Picard from the source directory without installing, you
 need to build the C extensions and locales manually:
 
 ```python
-python setup.py build_ext -i
-python setup.py build_locales -i
+python3 setup.py build_ext -i
+python3 setup.py build_locales -i
 ```
 
 And to start Picard use:
 
-    python tagger.py
+    python3 tagger.py
 
 
 Running the Test Suite
@@ -75,4 +75,4 @@ Running the Test Suite
 To run the included tests, follow the instructions for "Running From
 the Source Tree".  Afterward you can run the tests using setup.py:
 
-    python setup.py test
+    python3 setup.py test

--- a/resources/README.md
+++ b/resources/README.md
@@ -12,8 +12,8 @@ For adding a new image into existing resources, follow these steps:
 1. Add image file (like .png) into `resources/images/` and source file (like .svg) into `resources/img-src`.
 2. Generate new .qrc file. This would automatically detect any changes in directory.
 
-    $ python makeqrc.py
+    $ python3 makeqrc.py
 
 3. Create binary of all resources which will be used by Picard.
 
-    $ python compile.py
+    $ python3 compile.py


### PR DESCRIPTION
PEP 394 makes it clear that python should only be used for applications that can
be run with both Python 2 and Python 3, python3 should be used for Python 3.

pip3 is used because that's what Python 3 compatible pip is called on at least
Arch, Debian, Fedora and Ubuntu.