### PR TITLE
PICARD-1061: Use different plugins directory for v2

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -31,7 +31,7 @@ else:
     USER_DIR = os.environ.get("XDG_CONFIG_HOME", "~/.config")
 
 USER_DIR = os.path.join(
-    os.path.expanduser(USER_DIR), "MusicBrainz", "Picard"
+    os.path.expanduser(USER_DIR), "MusicBrainz", "PicardV2"
 )
 
 USER_PLUGIN_DIR = os.path.join(USER_DIR, "plugins")

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -31,10 +31,10 @@ else:
     USER_DIR = os.environ.get("XDG_CONFIG_HOME", "~/.config")
 
 USER_DIR = os.path.join(
-    os.path.expanduser(USER_DIR), "MusicBrainz", "PicardV2"
+    os.path.expanduser(USER_DIR), "MusicBrainz", "Picard"
 )
 
-USER_PLUGIN_DIR = os.path.join(USER_DIR, "plugins")
+USER_PLUGIN_DIR = os.path.join(USER_DIR, "pluginsV2")
 
 # AcoustID client API key
 ACOUSTID_KEY = 'v8pQ6oyB'


### PR DESCRIPTION
Avoid unavoidable Python errors attempting to import plugins which are not designed for Picard v2 and which e.g. try to import PyQt4.