### PR TITLE
PICARD-1063: Fix astrcmp tests if not compiled

### DIFF
--- a/test/test_util_astrcmp.py
+++ b/test/test_util_astrcmp.py
@@ -3,7 +3,6 @@
 import os
 import os.path
 import unittest
-from picard.util.astrcmp import astrcmp_c, astrcmp_py
 
 
 class AstrcmpBase(object):
@@ -20,9 +19,15 @@ class AstrcmpBase(object):
         self.assertAlmostEqual(0.7083333333333333, astrcmp(u"The Great Gig in the Sky", u"Great Gig In The sky"))
 
 
-class AstrcmpCTest(AstrcmpBase, unittest.TestCase):
-    func = astrcmp_c
-
+from picard.util.astrcmp import astrcmp_py
 
 class AstrcmpPyTest(AstrcmpBase, unittest.TestCase):
     func = astrcmp_py
+
+try:
+    from picard.util.astrcmp import astrcmp_c
+
+    class AstrcmpCTest(AstrcmpBase, unittest.TestCase):
+        func = astrcmp_c
+except:
+    pass

--- a/test/test_util_astrcmp.py
+++ b/test/test_util_astrcmp.py
@@ -3,6 +3,12 @@
 import os
 import os.path
 import unittest
+from picard.util.astrcmp import astrcmp_py
+
+try:
+    from picard.util.astrcmp import astrcmp_c
+except ImportError:
+    astrcmp_c = None
 
 
 class AstrcmpBase(object):
@@ -19,15 +25,15 @@ class AstrcmpBase(object):
         self.assertAlmostEqual(0.7083333333333333, astrcmp(u"The Great Gig in the Sky", u"Great Gig In The sky"))
 
 
-from picard.util.astrcmp import astrcmp_py
+class AstrcmpCTest(AstrcmpBase, unittest.TestCase):
+    func = astrcmp_c
+
+    @unittest.skipIf(astrcmp_c is None, "compiled astrcmp.c does not exist")
+    def test_astrcmp(self):
+        super()
+
 
 class AstrcmpPyTest(AstrcmpBase, unittest.TestCase):
     func = astrcmp_py
 
-try:
-    from picard.util.astrcmp import astrcmp_c
 
-    class AstrcmpCTest(AstrcmpBase, unittest.TestCase):
-        func = astrcmp_c
-except:
-    pass


### PR DESCRIPTION
After #689 tests fail if astrcmp is not compiled.

Resolves https://tickets.metabrainz.org/browse/PICARD-1063