### PR TITLE
Reject functions with required keyword-only arguments

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -24,7 +24,7 @@ import re
 import operator
 from functools import reduce
 from collections import namedtuple
-from inspect import getargspec
+from inspect import getfullargspec
 from picard.metadata import Metadata
 from picard.metadata import MULTI_VALUED_JOINER
 from picard.plugin import ExtensionPoint
@@ -292,7 +292,14 @@ def register_script_function(function, name=None, eval_args=True,
     If ``check_argcount`` is ``False`` the number of arguments passed to the
     function will not be verified."""
 
-    args, varargs, keywords, defaults = getargspec(function)
+    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations = getfullargspec(function)
+
+    required_kwonlyargs = len(kwonlyargs)
+    if kwonlydefaults is not None:
+        required_kwonlyargs -= len(kwonlydefaults.keys())
+    if required_kwonlyargs:
+        raise TypeError("Functions with required keyword-only parameters are not supported")
+
     args = len(args) - 1  # -1 for the parser
     varargs = varargs is not None
     defaults = len(defaults) if defaults else 0

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -384,3 +384,17 @@ class ScriptParserTest(unittest.TestCase):
         self.parser.eval("$unset(performer:*)", context)
         self.assertNotIn('performer:bar', context)
         self.assertNotIn('performer:foo', context)
+
+    def test_required_kwonly_parameters(self):
+        def func(a, *, required_kwarg):
+            pass
+
+        with self.assertRaises(TypeError,
+                               msg="Functions with required keyword-only parameters are not supported"):
+            register_script_function(func)
+
+    def test_optional_kwonly_parameters(self):
+        def func(a, *, optional_kwarg=1):
+            pass
+
+        register_script_function(func)


### PR DESCRIPTION
Python 3 / PEP3102 introduced keyword-only arguments, like in

    def foo(a, *, b):
      pass

where `b` can't be set as a positional argument. This can't be expressed in
tagger script, so reject calls to register such functions.

This also gets rid of a DeprecationWarning for inspect.getargspec.