### PR TITLE
patch_version: Use sys.platform as the default platform name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -577,7 +577,7 @@ class picard_patch_version(Command):
     ]
 
     def initialize_options(self):
-        self.platform = 'unknown'
+        self.platform = sys.platform
 
     def finalize_options(self):
         pass


### PR DESCRIPTION
The names which sys.platform uses are not well-known across all users (darwin
for macOS for example), so this doesn't change the values used in the packaging
scripts.