### PR TITLE
Update setup script to allow submitting pip packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,3 +76,12 @@ To run the included tests, follow the instructions for "Running From
 the Source Tree".  Afterward you can run the tests using setup.py:
 
     python3 setup.py test
+
+Packaging
+---------
+
+Picard supports packaging binaries and uploading them to PyPi.
+
+To submit a package run:
+
+    python setup.py sdist upload -r pypi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft po

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,10 @@ except ImportError:
 from distutils import log
 from distutils.command.build import build
 from distutils.command.install import install as install
-from distutils.core import setup, Command, Extension
 from distutils.dep_util import newer
 from distutils.dist import Distribution
 from distutils.spawn import find_executable
+from setuptools import setup, Command, Extension
 
 ext_modules = [
     Extension('picard.util._astrcmp', sources=['picard/util/_astrcmp.c']),
@@ -663,6 +663,7 @@ args2 = {
         'patch_version': picard_patch_version,
     },
     'scripts': ['scripts/picard'],
+    'install_requires': ['PyQt5', 'mutagen'],
 }
 args.update(args2)
 
@@ -779,6 +780,6 @@ if py2exe is None and do_py2app is False:
     args['data_files'].append(('share/icons/hicolor/256x256/apps', ['resources/images/256x256/picard.png']))
     args['data_files'].append(('share/icons/hicolor/scalable/apps', ['resources/img-src/picard.svg']))
     args['data_files'].append(('share/applications', ('picard.desktop',)))
-
+    args['data_files'].append('scripts/picard.in')
 
 setup(**args)


### PR DESCRIPTION
Since all of Picard's requirements are available on pip,
this PR makes changes to the setup script to allow submitting a
distribution file to PyPi. A MANIFEST.in was included to add data dirs.
New packages can be submitted via python setup.py sdist upload -r pypi