### PR TITLE
PICARD-817: Enable high DPI support for Picard

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -105,8 +105,11 @@ class Tagger(QtWidgets.QApplication):
         # can use it to look up the app
         QtWidgets.QApplication.__init__(self, ['MusicBrainz-Picard'] + unparsed_args)
         self.__class__.__instance = self
-
         config._setup(self, picard_args.config_file)
+
+        # Allow High DPI Support
+        self.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+        self.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
         self._cmdline_files = picard_args.FILE
         self._autoupdate = autoupdate


### PR DESCRIPTION
Picard with Qt5 now supports high-dpi displays. To render icons for
higher resolutions, simply add a 2x scaled png files along with the
normal file with the name as image@2x.png

See http://blog.qt.io/blog/2013/04/25/retina-display-support-for-mac-os-ios-and-x11/
for more details

Fixes: https://tickets.metabrainz.org/browse/PICARD-817

To test, you can try `export QT_SCALE_FACTOR=2` and check if the icon is rendered sharply (although picard itself will appear huge)