### PR TITLE
PICARD-1085: Fix multi-directory load on Windows

### DIFF
--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -104,7 +104,7 @@ class MultiDirsSelectDialog(QtWidgets.QFileDialog):
         super(MultiDirsSelectDialog, self).__init__(*args)
         self.setFileMode(self.Directory)
         self.setOption(self.ShowDirsOnly)
-        if sys.platform == "darwin":
+        if sys.platform in ["darwin", "win32"]:
             # The native dialog doesn't allow selecting >1 directory
             self.setOption(self.DontUseNativeDialog)
         for view in self.findChildren((QtWidgets.QListView, QtWidgets.QTreeView)):


### PR DESCRIPTION
On Windows on Qt5 it appears you need to avoid native dialog.

As far as I can tell, this was actually a bug under Qt4 (because native
dialog wasn't used anyway) and it should always have been specified.

I have only added win32 to the exception list. This may be required on
all platforms, but I am unable to test this.

Resolves https://tickets.metabrainz.org/browse/PICARD-1085