### PR TITLE
PICARD-1084: Call Unicode version of GetDriveType

### DIFF
--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -63,7 +63,7 @@ def get_cdrom_drives():
 
     if sys.platform == 'win32':
         GetLogicalDrives = windll.kernel32.GetLogicalDrives
-        GetDriveType = windll.kernel32.GetDriveTypeA
+        GetDriveType = windll.kernel32.GetDriveTypeW
         DRIVE_CDROM = 5
         mask = GetLogicalDrives()
         for i in range(26):


### PR DESCRIPTION
Py3 strings are unicode, so we have to call the Unicode version of GetDriveType.