### PR TITLE
Add the link to the test results to the travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 MusicBrainz Picard
 ==================
-![Build Status](https://travis-ci.org/metabrainz/picard.svg?branch=master)
+[![Build Status](https://travis-ci.org/metabrainz/picard.svg?branch=master)](https://travis-ci.org/metabrainz/picard)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/53a33607234a4c18a11a6207d1173c0c)](https://www.codacy.com/app/MetaBrainz/picard?utm_source=github.com&utm_medium=referral&utm_content=metabrainz/picard&utm_campaign=badger)
 
 [MusicBrainz Picard](http://picard.musicbrainz.org) is a cross-platform (Linux/Mac OS X/Windows) application written in Python and is the official [MusicBrainz](http://musicbrainz.org) tagger.


### PR DESCRIPTION
This is actually the markdown you get from travis, I'm not sure where the one
without the link came from.