### PR TITLE
PICARD-1106: Discard the second return value of QFileDialog.getOpenFileNames

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -306,7 +306,7 @@ class PluginsOptionsPage(OptionsPage):
         self.ui.details.setText("<p>%s</p>" % "<br/>\n".join(text))
 
     def open_plugins(self):
-        files = QtWidgets.QFileDialog.getOpenFileNames(
+        files, _filter = QtWidgets.QFileDialog.getOpenFileNames(
             self,
             "",
             QtCore.QDir.homePath(),


### PR DESCRIPTION
getOpenFileNames was previously called getOpenFileNamesAndFilter (see [0]) and
returns a tuple (filenames, filter). Since we're not interested in the filter,
discard it.

This is similar to other fixes already done for QFileDialogs in mainwindow.py
and fingerprinting.py.

[0] http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html#qfiledialog