### PR TITLE
_patched_shutil_copystat: Support the follow_symlinks keyword argument

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -38,8 +38,8 @@ from itertools import chain
 from operator import attrgetter
 
 
-# A "fix" for http://python.org/sf/1438480
 def _patched_shutil_copystat(src, dst):
+# A "fix" for https://bugs.python.org/issue1438480
     try:
         _orig_shutil_copystat(src, dst)
     except OSError:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -38,10 +38,10 @@ from itertools import chain
 from operator import attrgetter
 
 
-def _patched_shutil_copystat(src, dst):
 # A "fix" for https://bugs.python.org/issue1438480
+def _patched_shutil_copystat(src, dst, *, follow_symlinks=True):
     try:
-        _orig_shutil_copystat(src, dst)
+        _orig_shutil_copystat(src, dst, follow_symlinks=follow_symlinks)
     except OSError:
         pass
 


### PR DESCRIPTION
shutil.copystat supports it and there's some code called by Picard (for example
when trying to install plugins) that passes the argument. Support it to fix
crashes in those cases.