### PR TITLE
Use unittest.mock instead of mock

### DIFF
--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -32,7 +32,7 @@ class WebServiceTest(unittest.TestCase):
         handler = None
         data = None
         self.ws.get(host, port, path, handler)
-        mock_add_task.assert_called()
+        self.assertEqual(1, mock_add_task.call_count)
         self.assertIn(host, mock_add_task.call_args[0])
         self.assertIn(port, mock_add_task.call_args[0])
         self.assertIn("'GET'", repr(mock_add_task.call_args))

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -3,7 +3,7 @@
 import unittest
 from picard import config
 from picard.webservice import WebService
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 PROXY_SETTINGS = {
     "use_proxy": True,


### PR DESCRIPTION
mock is not part of the standard library, only unittest.mock is.