### PR TITLE
Display astrcmp implementation (C or Python) in About and debug log

### DIFF
--- a/picard/util/astrcmp.py
+++ b/picard/util/astrcmp.py
@@ -36,5 +36,7 @@ def astrcmp_py(a,b):
 try:
     from picard.util._astrcmp import astrcmp as astrcmp_c
     astrcmp = astrcmp_c
+    astrcmp_implementation = "C"
 except ImportError:
     astrcmp = astrcmp_py
+    astrcmp_implementation = "Python"

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -23,6 +23,7 @@ from mutagen import version_string as mutagen_version
 from PyQt5.QtCore import PYQT_VERSION_STR as pyqt_version, QT_VERSION_STR
 from picard import PICARD_FANCY_VERSION_STR
 from picard.disc import discid_version
+from picard.util.astrcmp import astrcmp_implementation
 
 
 _versions = OrderedDict([
@@ -31,6 +32,7 @@ _versions = OrderedDict([
     ("qt-version", QT_VERSION_STR),
     ("mutagen-version", mutagen_version),
     ("discid-version", discid_version),
+    ("astrcmp", astrcmp_implementation),
 ])
 
 _names = {
@@ -39,6 +41,7 @@ _names = {
     "qt-version": "Qt",
     "mutagen-version": "Mutagen",
     "discid-version": "Discid",
+    "astrcmp": "astrcmp",
 }
 
 


### PR DESCRIPTION
It can also be displayed using -V command line option along various libs versions