### PR TITLE
Add windows testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+version: 2.0.0.dev{build}
+pull_requests:
+  do_not_increment_build_number: true
+init:
+- cmd: >-
+    ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
+
+    SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+environment:
+  CHROMAPRINT_FPCALC_VERSION: 1.4.2
+  DISCID_VERSION: 0.6.1
+  matrix:
+  - PYTHON: C:\Python36
+    PYTHON_VERSION: 3.6.1
+    PYTHON_ARCH: 32
+  - PYTHON: C:\Python35
+    PYTHON_VERSION: 3.5.3
+    PYTHON_ARCH: 32
+build: off
+test_script:
+- cmd: >-
+    appveyor DownloadFile https://github.com/acoustid/chromaprint/releases/download/v%CHROMAPRINT_FPCALC_VERSION%/chromaprint-fpcalc-%CHROMAPRINT_FPCALC_VERSION%-windows-i686.zip -FileName fpcalc.zip
+
+    7z x fpcalc.zip -y
+
+    copy /Y chromaprint-fpcalc-%CHROMAPRINT_FPCALC_VERSION%-windows-i686\fpcalc.exe %PYTHON%
+
+    appveyor DownloadFile http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/libdiscid-%DISCID_VERSION%-win32.zip -FileName libdiscid.zip
+
+    7z x libdiscid.zip -y
+
+    copy /Y libdiscid-%DISCID_VERSION%-win32\discid.dll %PYTHON%
+
+    pip install -r requirements.txt
+
+    python setup.py test -v
+deploy: off

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -9,7 +9,7 @@ class AcoustIDTest(unittest.TestCase):
 
     def init_test(self, filename):
         self.json_doc = None
-        with open(os.path.join('test', 'data', 'ws_data', filename)) as f:
+        with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
             self.json_doc = json.load(f)
 
 

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -27,7 +27,7 @@ class MBJSONTest(unittest.TestCase):
     def init_test(self, filename):
         config.setting = settings
         self.json_doc = None
-        with open(os.path.join('test', 'data', 'ws_data', filename)) as f:
+        with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
             self.json_doc = json.load(f)
 
 

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -21,7 +21,7 @@ class ReleaseTest(unittest.TestCase):
 
     @staticmethod
     def load_data(filename):
-        with open(os.path.join('test', 'data', 'ws_data', filename)) as f:
+        with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
             return json.load(f)
 
     def setUp(self):


### PR DESCRIPTION
We recently added compatibility for Windows tests.
This is to make sure the tests are working. They were currently facing an encoding issue on reading the test json files.