### PR TITLE
PICARD-1126: Add meaningful error log during lookup requests

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -574,7 +574,8 @@ class File(QtCore.QObject, Item):
         if self.state == File.REMOVED:
             return
         if error:
-            log.error(document)
+            log.error("Network error encountered during the lookup for %s. Error code: %s",
+                       self.filename, error)
         try:
             if lookuptype == "metadata":
                 tracks = document['recordings']


### PR DESCRIPTION
Resolves https://tickets.metabrainz.org/browse/PICARD-1126