### PR TITLE
PICARD-1143: Prevent loading .smbdelete* files

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -367,7 +367,7 @@ class Tagger(QtWidgets.QApplication):
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r" % (filename))
                 continue
-            # Ignore .smbdelete* files which Applie iOS creates by renaming a file when it cannot delete it
+            # Ignore .smbdelete* files which Applie iOS SMB creates by renaming a file when it cannot delete it
             if os.path.basename(filename).startswith(".smbdelete"):
                 log.debug("File ignored (.smbdelete): %r", filename)
                 continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -367,6 +367,9 @@ class Tagger(QtWidgets.QApplication):
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r" % (filename))
                 continue
+            if os.path.basename(filename).startswith(".smbdelete") and is_hidden(filename):
+                log.debug("File ignored (.smbdelete): %r", filename)
+                continue
             if ignoreregex is not None and ignoreregex.search(filename):
                 log.info("File ignored (matching %r): %r" % (pattern, filename))
                 continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -367,7 +367,8 @@ class Tagger(QtWidgets.QApplication):
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r" % (filename))
                 continue
-            if os.path.basename(filename).startswith(".smbdelete") and is_hidden(filename):
+            # Ignore .smbdelete* files which Applie iOS creates by renaming a file when it cannot delete it
+            if os.path.basename(filename).startswith(".smbdelete"):
                 log.debug("File ignored (.smbdelete): %r", filename)
                 continue
             if ignoreregex is not None and ignoreregex.search(filename):


### PR DESCRIPTION
.smbdelete files are temporary versions of files that should have been deleted but cannot be due to  samba bug(?). We should not load these files even if we have ignore-hidden-files unchecked.

Note: I am not running on a Mac and have not tested this code.

This PR resolves [PICARD-1143](https://tickets.metabrainz.org/browse/PICARD-1143).