### PR TITLE
PICARD-1147: Handle media with only data tracks

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -237,9 +237,9 @@ class Album(DataObject, Item):
                     track = self._finalize_loading_track(medium_node['pregap'], mm, artists, va, absolutetracknumber, discpregap)
                     track.metadata['~pregap'] = "1"
 
-                tracklist_node = medium_node['tracks']
                 track_count = medium_node['track-count']
                 if track_count:
+                    tracklist_node = medium_node['tracks']
                     for track_node in tracklist_node:
                         absolutetracknumber += 1
                         track = self._finalize_loading_track(track_node, mm, artists, va, absolutetracknumber, discpregap)


### PR DESCRIPTION
In the JSON representation, these media do not have a 'tracks' element
containing the list of tracks.

@samj1912 I'm not sure if this is intentional in the JSON format and needs to be handled here or in MBS.