### PR TITLE
Only output CD read failure traceback in debug mode

### DIFF
--- a/picard/disc.py
+++ b/picard/disc.py
@@ -46,9 +46,13 @@ class Disc(QtCore.QObject):
         if device is None:
             device = discid.get_default_device()
         log.debug("Reading CD using device: %r", device)
-        disc = discid.read(device)
-        self.id = disc.id
-        self.submission_url = disc.submission_url
+        try:
+            disc = discid.read(device)
+            self.id = disc.id
+            self.submission_url = disc.submission_url
+        except discid.disc.DiscError as e:
+            log.error("Error while reading %r: %s" % (device, str(e)))
+            raise
 
     def lookup(self):
         self.tagger.mb_api.lookup_discid(self.id, self._lookup_finished)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -644,7 +644,8 @@ class Tagger(QtWidgets.QApplication):
         self.set_wait_cursor()
         thread.run_task(
             partial(disc.read, encode_filename(device)),
-            partial(self._lookup_disc, disc))
+            partial(self._lookup_disc, disc),
+            traceback=self._debug)
 
     @property
     def use_acoustid(self):

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -36,26 +36,28 @@ class ProxyToMainEvent(QEvent):
 
 class Runnable(QRunnable):
 
-    def __init__(self, func, next_func):
+    def __init__(self, func, next_func, traceback=True):
         QRunnable.__init__(self)
         self.func = func
         self.next_func = next_func
+        self.traceback = traceback
 
     def run(self):
         try:
             result = self.func()
         except:
             from picard import log
-            log.error(traceback.format_exc())
+            if self.traceback:
+                log.error(traceback.format_exc())
             to_main(self.next_func, error=sys.exc_info()[1])
         else:
             to_main(self.next_func, result=result)
 
 
-def run_task(func, next_func, priority=0, thread_pool=None):
+def run_task(func, next_func, priority=0, thread_pool=None, traceback=True):
     if thread_pool is None:
         thread_pool = QCoreApplication.instance().thread_pool
-    thread_pool.start(Runnable(func, next_func), priority)
+    thread_pool.start(Runnable(func, next_func, traceback), priority)
 
 
 def to_main(func, *args, **kwargs):


### PR DESCRIPTION
It makes the log cleaner, as most of times CD read error is due to CD not inserted.

Without debug mode, output looks like:

```
E: 16:58:00 Error while reading b'/dev/sr1': cannot open device `/dev/sr1'
```

With debug mode:

```
D: 16:58:17 Reading CD using device: b'/dev/sr1'
E: 16:58:17 Error while reading b'/dev/sr1': cannot open device `/dev/sr1'
E: 16:58:17 Traceback (most recent call last):
  File "./picard/util/thread.py", line 47, in run
    result = self.func()
  File "./picard/disc.py", line 55, in read
    raise e
  File "./picard/disc.py", line 50, in read
    disc = discid.read(device)
  File "/home/zas/.virtualenvs/picard2/lib/python3.5/site-packages/discid/disc.py", line 55, in read
    disc.read(device, features)
  File "/home/zas/.virtualenvs/picard2/lib/python3.5/site-packages/discid/disc.py", line 152, in read
    raise DiscError(self._get_error_msg())
discid.disc.DiscError: cannot open device `/dev/sr1'
```
