### PR TITLE
PICARD-1179 Fix release builder logic

### DIFF
--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -77,25 +77,14 @@ class ReleaseGroup(DataObject):
                 "id":      node['id'],
                 "year":    node['date'][:4] if "date" in node else "????",
                 "country": "+".join(countries) if countries
-                    else node['country'] if "country" in node
-                    else "??",
+                    else node.get('country', '') or "??",
                 "format":  media_formats_from_node(node['media']),
                 "label":  ", ".join([' '.join(x.split(' ')[:2]) for x in set(labels)]),
                 "catnum": ", ".join(set(catnums)),
                 "tracks":  "+".join([str(m['track-count']) for m in node['media']]),
-                "barcode":
-                    node['barcode']
-                    if "barcode" in node
-                    and node['barcode'] != ""
-                    else _("[no barcode]"),
-                "packaging":
-                    node['packaging']
-                    if "packaging" in node
-                    else None,
-                "disambiguation":
-                    node['disambiguation']
-                    if "disambiguation" in node
-                    else None,
+                "barcode": node.get('barcode', '') or _('[no barcode]'),
+                "packaging": node.get('packaging', '') or '??',
+                "disambiguation": node.get('disambiguation', ''),
                 "_disambiguate_name": list(),
                 "totaltracks": sum([m['track-count'] for m in node['media']]),
                 "countries": countries,


### PR DESCRIPTION
When releases are built from node, fields are assigned values None at
times which doesn't play well with the string join in a couple of lines
below. This fixes that and reduces code by using default values.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1179](https://tickets.metabrainz.org/browse/PICARD-1179)


