### PR TITLE
run{album,track}_metadata_processors: Correct the first arguments name

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -350,9 +350,9 @@ def register_track_metadata_processor(function, priority=PluginPriority.NORMAL):
     _track_metadata_processors.register(function.__module__, function, priority)
 
 
-def run_album_metadata_processors(tagger, metadata, release):
-    _album_metadata_processors.run(tagger, metadata, release)
+def run_album_metadata_processors(album_object, metadata, release):
+    _album_metadata_processors.run(album_object, metadata, release)
 
 
-def run_track_metadata_processors(tagger, metadata, release, track):
-    _track_metadata_processors.run(tagger, metadata, track, release)
+def run_track_metadata_processors(track_object, metadata, release, track):
+    _track_metadata_processors.run(track_object, metadata, track, release)


### PR DESCRIPTION


# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

According to the history, those passed the Album or Track and not a Tagger object as the first
argument already in Picard 0.15.1.

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)

I didn't make one, since nothing changes and the API is documented in the picard-website repository. Since these are not passed as keyword arguments, there should be no plugin relying on their name.

# Solution

Rename the argument.

# Action

Nothing.
