### PR TITLE
PICARD-1181: slow down only on certain errors (429, 5xx)

### DIFF
--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -479,6 +479,7 @@ class WebService(QtCore.QObject):
                      or error == 403
                     )
                ):
+                slow_down = True
                 retries = request.mark_for_retry()
                 log.debug("Retrying %s (#%d)", url, retries)
                 self.add_task(partial(self._start_request, request), request)
@@ -486,7 +487,8 @@ class WebService(QtCore.QObject):
             elif handler is not None:
                 handler(reply.readAll(), reply, error)
 
-            slow_down = True
+            slow_down = (slow_down or code >= 500)
+
         else:
             redirect = reply.attribute(QtNetwork.QNetworkRequest.RedirectionTargetAttribute)
             fromCache = reply.attribute(QtNetwork.QNetworkRequest.SourceIsFromCacheAttribute)


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Exclude non-(5xx errors and 429) from slow down

# Problem

Queries getting 404s cause unneeded slow down

* JIRA ticket : fix [PICARD-1181](https://tickets.metabrainz.org/browse/PICARD-1181)

# Solution

Set slow down on 5xx errors and few others.

# Action

Review

