### PR TITLE
Fix sorting in SearchDialog

### DIFF
--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -336,7 +336,8 @@ class SearchDialog(PicardDialog):
 
     def accept(self):
         if self.table:
-            row = self.table.selectionModel().selectedRows()[0].row()
+            idx = self.table.selectionModel().selectedRows()[0]
+            row = self.table.itemFromIndex(idx).data(QtCore.Qt.UserRole)
             self.accept_event(row)
         self.save_state()
         QtWidgets.QDialog.accept(self)

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -33,7 +33,7 @@ from picard.metadata import Metadata
 from picard.webservice.api_helpers import escape_lucene_query
 from picard.const import CAA_HOST, CAA_PORT, QUERY_LIMIT
 from picard.coverart.image import CaaThumbnailCoverArtImage
-from picard.ui.searchdialog import SearchDialog, Retry
+from picard.ui.searchdialog import SearchDialog, Retry, BY_NUMBER
 
 
 class CoverWidget(QtWidgets.QWidget):
@@ -331,16 +331,16 @@ class AlbumSearchDialog(SearchDialog):
             self.set_table_item(row, 'name',     release, "album")
             self.set_table_item(row, 'artist',   release, "albumartist")
             self.set_table_item(row, 'format',   release, "format")
-            self.set_table_item(row, 'tracks',   release, "tracks")
+            self.set_table_item(row, 'tracks',   release, "tracks", sort=BY_NUMBER)
             self.set_table_item(row, 'date',     release, "date")
             self.set_table_item(row, 'country',  release, "country")
             self.set_table_item(row, 'labels',   release, "label")
             self.set_table_item(row, 'catnums',  release, "catalognumber")
-            self.set_table_item(row, 'barcode',  release, "barcode")
+            self.set_table_item(row, 'barcode',  release, "barcode", sort=BY_NUMBER)
             self.set_table_item(row, 'language', release, "~releaselanguage")
             self.set_table_item(row, 'type',     release, "releasetype")
             self.set_table_item(row, 'status',   release, "releasestatus")
-            self.set_table_item(row, 'score',    release, "score", conv=int)
+            self.set_table_item(row, 'score',    release, "score", sort=BY_NUMBER)
             self.cover_cells.append(CoverCell(self, release, row, 'cover',
                                               on_show=self.fetch_coverart))
         self.show_table(sort_column='score')

--- a/picard/ui/searchdialog/artist.py
+++ b/picard/ui/searchdialog/artist.py
@@ -23,7 +23,7 @@ from picard import config
 from picard.mbjson import artist_to_metadata
 from picard.metadata import Metadata
 from picard.const import QUERY_LIMIT
-from picard.ui.searchdialog import SearchDialog, Retry
+from picard.ui.searchdialog import SearchDialog, Retry, BY_NUMBER
 
 
 class ArtistSearchDialog(SearchDialog):
@@ -99,7 +99,7 @@ class ArtistSearchDialog(SearchDialog):
             self.set_table_item(row, 'beginarea', artist, "beginarea")
             self.set_table_item(row, 'enddate',   artist, "enddate")
             self.set_table_item(row, 'endarea',   artist, "endarea")
-            self.set_table_item(row, 'score',     artist, "score", conv=int)
+            self.set_table_item(row, 'score',     artist, "score", sort=BY_NUMBER)
         self.show_table(sort_column='score')
 
     def accept_event(self, row):

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -32,7 +32,7 @@ from picard.metadata import Metadata
 from picard.webservice.api_helpers import escape_lucene_query
 from picard.track import Track
 from picard.const import QUERY_LIMIT
-from picard.ui.searchdialog import SearchDialog, Retry
+from picard.ui.searchdialog import SearchDialog, Retry, BY_DURATION, BY_NUMBER
 
 
 class TrackSearchDialog(SearchDialog):
@@ -138,13 +138,13 @@ class TrackSearchDialog(SearchDialog):
             track = obj[0]
             self.table.insertRow(row)
             self.set_table_item(row, 'name',    track, "title")
-            self.set_table_item(row, 'length',  track, "~length")
+            self.set_table_item(row, 'length',  track, "~length", sort=BY_DURATION)
             self.set_table_item(row, 'artist',  track, "artist")
             self.set_table_item(row, 'release', track, "album")
             self.set_table_item(row, 'date',    track, "date")
             self.set_table_item(row, 'country', track, "country")
             self.set_table_item(row, 'type',    track, "releasetype")
-            self.set_table_item(row, 'score',   track, "score", conv=int)
+            self.set_table_item(row, 'score',   track, "score", sort=BY_NUMBER)
         self.show_table(sort_column='score')
 
     def parse_tracks(self, tracks):


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Sorting in SearchDialog wasn't enabled at start, enabling it revealed various issues:
- returned row was incorrect after a re-ordering of rows
- sort order of certain columns was incorrect (Length column of Track search for example), because the default sort key is a string.

# Solution

Subclass QTableWidgetItem and optionnaly set a per-column sort method ('duration' or 'number')
Store row in the data array as UserRole on first column and retrieve it on accept.

# Action

Test & review


