### PR TITLE
PICARD-1175: save and restore CD Lookup dialog and headers states

### DIFF
--- a/picard/ui/ui_cdlookup.py
+++ b/picard/ui/ui_cdlookup.py
@@ -17,7 +17,6 @@ class Ui_Dialog(object):
         self.label.setObjectName("label")
         self.vboxlayout.addWidget(self.label)
         self.release_list = QtWidgets.QTreeWidget(Dialog)
-        self.release_list.setRootIsDecorated(False)
         self.release_list.setObjectName("release_list")
         self.release_list.headerItem().setText(0, "1")
         self.vboxlayout.addWidget(self.release_list)

--- a/ui/cdlookup.ui
+++ b/ui/cdlookup.ui
@@ -29,9 +29,6 @@
    </item>
    <item>
     <widget class="QTreeWidget" name="release_list">
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
      <column>
       <property name="text">
        <string notr="true">1</string>
@@ -103,8 +100,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
+     <x>410</x>
+     <y>227</y>
     </hint>
     <hint type="destinationlabel">
      <x>96</x>
@@ -119,8 +116,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
+     <x>629</x>
+     <y>227</y>
     </hint>
     <hint type="destinationlabel">
      <x>179</x>


### PR DESCRIPTION

# Summary



* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Save CD Lookup dialog size and header state to persist options, and restore them when needed. 

# Problem

Every time a CD lookup is done you have to scroll or make the resulting window larger to see all the information to distinguish releases, especially the catalog number and barcode (as the last columns). The barcode column often is cut off.
Picard should store and remember that window setting (and maybe auto-size the smaller columns).

# Solution

Save CD Lookup dialog size and header state to persist options, and restore them when needed. 

* fix [PICARD-1175](https://tickets.metabrainz.org/browse/PICARD-1175)

