### PR TITLE
[WIP] Improve log view so one can filter out messages based on verbosity or domains

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -26,6 +26,7 @@ from picard.util import find_executable, is_frozen
 from picard.acoustid.json_helpers import parse_recording
 
 
+
 class AcoustIDClient(QtCore.QObject):
 
     def __init__(self):
@@ -48,6 +49,7 @@ class AcoustIDClient(QtCore.QObject):
     def done(self):
         pass
 
+    @log.domain('acoustid')
     def _on_lookup_finished(self, next_func, file, document, http, error):
 
         doc = {}
@@ -58,7 +60,7 @@ class AcoustIDClient(QtCore.QObject):
             }
             log.error(
                 "AcoustID: Lookup network error for '%(filename)s': %(error)r" %
-                mparms, domains='acoustid')
+                mparms)
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID lookup network error for '%(filename)s'!"),
                 mparms,
@@ -77,7 +79,7 @@ class AcoustIDClient(QtCore.QObject):
                             parsed_recording = parse_recording(recording)
                             if parsed_recording is not None:
                                 recording_list.append(parsed_recording)
-                        log.debug("AcoustID: Lookup successful for '%s'", file.filename, domains='acoustid')
+                        log.debug("AcoustID: Lookup successful for '%s'", file.filename)
             else:
                 mparms = {
                     'error': document['error']['message'],
@@ -85,7 +87,7 @@ class AcoustIDClient(QtCore.QObject):
                 }
                 log.error(
                     "AcoustID: Lookup error for '%(filename)s': %(error)r" %
-                    mparms, domains='acoustid')
+                    mparms)
                 self.tagger.window.set_statusbar_message(
                     N_("AcoustID lookup failed for '%(filename)s'!"),
                     mparms,
@@ -106,7 +108,7 @@ class AcoustIDClient(QtCore.QObject):
         if not result:
             log.debug(
                 "AcoustID: lookup returned no result for file '%(filename)s'" %
-                mparms, domains='acoustid'
+                mparms
             )
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID lookup returned no result for file '%(filename)s'"),
@@ -117,7 +119,7 @@ class AcoustIDClient(QtCore.QObject):
             return
         log.debug(
             "AcoustID: looking up the fingerprint for file '%(filename)s'" %
-            mparms, domains='acoustid'
+            mparms
         )
         self.tagger.window.set_statusbar_message(
             N_("Looking up the fingerprint for file '%(filename)s' ..."),
@@ -167,9 +169,7 @@ class AcoustIDClient(QtCore.QObject):
                     "Fingerprint calculator failed exit code = %r, exit status = %r, error = %s",
                     exit_code,
                     exit_status,
-                    process.errorString(),
-                    domains='acoustid'
-                )
+                    process.errorString())
         finally:
             next_func(result)
 
@@ -182,11 +182,7 @@ class AcoustIDClient(QtCore.QObject):
         try:
             self._running -= 1
             self._run_next_task()
-            log.error("Fingerprint calculator failed error = %s (%r)",
-                      process.errorString(),
-                      error,
-                      domains='acoustid'
-                     )
+            log.error("Fingerprint calculator failed error = %s (%r)", process.errorString(), error)
         finally:
             next_func(None)
 
@@ -202,7 +198,7 @@ class AcoustIDClient(QtCore.QObject):
         process.finished.connect(partial(self._on_fpcalc_finished, next_func, file))
         process.error.connect(partial(self._on_fpcalc_error, next_func, file))
         process.start(fpcalc, ["-length", "120", file.filename])
-        log.debug("Starting fingerprint calculator %r %r", fpcalc, file.filename, domains='acoustid')
+        log.debug("Starting fingerprint calculator %r %r", fpcalc, file.filename)
 
     def analyze(self, file, next_func):
         fpcalc_next = partial(self._lookup_fingerprint, next_func, file.filename)

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -58,7 +58,7 @@ class AcoustIDClient(QtCore.QObject):
             }
             log.error(
                 "AcoustID: Lookup network error for '%(filename)s': %(error)r" %
-                mparms)
+                mparms, domains='acoustid')
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID lookup network error for '%(filename)s'!"),
                 mparms,
@@ -77,7 +77,7 @@ class AcoustIDClient(QtCore.QObject):
                             parsed_recording = parse_recording(recording)
                             if parsed_recording is not None:
                                 recording_list.append(parsed_recording)
-                        log.debug("AcoustID: Lookup successful for '%s'", file.filename)
+                        log.debug("AcoustID: Lookup successful for '%s'", file.filename, domains='acoustid')
             else:
                 mparms = {
                     'error': document['error']['message'],
@@ -85,7 +85,7 @@ class AcoustIDClient(QtCore.QObject):
                 }
                 log.error(
                     "AcoustID: Lookup error for '%(filename)s': %(error)r" %
-                    mparms)
+                    mparms, domains='acoustid')
                 self.tagger.window.set_statusbar_message(
                     N_("AcoustID lookup failed for '%(filename)s'!"),
                     mparms,
@@ -106,7 +106,7 @@ class AcoustIDClient(QtCore.QObject):
         if not result:
             log.debug(
                 "AcoustID: lookup returned no result for file '%(filename)s'" %
-                mparms
+                mparms, domains='acoustid'
             )
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID lookup returned no result for file '%(filename)s'"),
@@ -117,7 +117,7 @@ class AcoustIDClient(QtCore.QObject):
             return
         log.debug(
             "AcoustID: looking up the fingerprint for file '%(filename)s'" %
-            mparms
+            mparms, domains='acoustid'
         )
         self.tagger.window.set_statusbar_message(
             N_("Looking up the fingerprint for file '%(filename)s' ..."),
@@ -167,7 +167,9 @@ class AcoustIDClient(QtCore.QObject):
                     "Fingerprint calculator failed exit code = %r, exit status = %r, error = %s",
                     exit_code,
                     exit_status,
-                    process.errorString())
+                    process.errorString(),
+                    domains='acoustid'
+                )
         finally:
             next_func(result)
 
@@ -180,7 +182,11 @@ class AcoustIDClient(QtCore.QObject):
         try:
             self._running -= 1
             self._run_next_task()
-            log.error("Fingerprint calculator failed error = %s (%r)", process.errorString(), error)
+            log.error("Fingerprint calculator failed error = %s (%r)",
+                      process.errorString(),
+                      error,
+                      domains='acoustid'
+                     )
         finally:
             next_func(None)
 
@@ -196,7 +202,7 @@ class AcoustIDClient(QtCore.QObject):
         process.finished.connect(partial(self._on_fpcalc_finished, next_func, file))
         process.error.connect(partial(self._on_fpcalc_error, next_func, file))
         process.start(fpcalc, ["-length", "120", file.filename])
-        log.debug("Starting fingerprint calculator %r %r", fpcalc, file.filename)
+        log.debug("Starting fingerprint calculator %r %r", fpcalc, file.filename, domains='acoustid')
 
     def analyze(self, file, next_func):
         fpcalc_next = partial(self._lookup_fingerprint, next_func, file.filename)

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -74,7 +74,7 @@ class AcoustIDManager(QtCore.QObject):
         if not fingerprints:
             self._check_unsubmitted()
             return
-        log.debug("AcoustID: submitting ...")
+        log.debug("AcoustID: submitting ...", domains='acoustid')
         self.tagger.window.set_statusbar_message(
             N_('Submitting AcoustIDs ...'),
             echo=None
@@ -95,7 +95,7 @@ class AcoustIDManager(QtCore.QObject):
             }
             log.error(
                 "AcoustID: submission failed with error '%(error)s': %(message)s" %
-                mparms)
+                mparms, domains='acoustid')
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID submission failed with error '%(error)s': %(message)s"),
                 mparms,
@@ -103,7 +103,7 @@ class AcoustIDManager(QtCore.QObject):
                 timeout=3000
             )
         else:
-            log.debug('AcoustID: successfully submitted')
+            log.debug('AcoustID: successfully submitted', domains='acoustid')
             self.tagger.window.set_statusbar_message(
                 N_('AcoustIDs successfully submitted.'),
                 echo=None,

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -74,7 +74,7 @@ class AcoustIDManager(QtCore.QObject):
         if not fingerprints:
             self._check_unsubmitted()
             return
-        log.debug("AcoustID: submitting ...", domains='acoustid')
+        log.debug("AcoustID: submitting ...")
         self.tagger.window.set_statusbar_message(
             N_('Submitting AcoustIDs ...'),
             echo=None
@@ -95,7 +95,7 @@ class AcoustIDManager(QtCore.QObject):
             }
             log.error(
                 "AcoustID: submission failed with error '%(error)s': %(message)s" %
-                mparms, domains='acoustid')
+                mparms)
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID submission failed with error '%(error)s': %(message)s"),
                 mparms,
@@ -103,7 +103,7 @@ class AcoustIDManager(QtCore.QObject):
                 timeout=3000
             )
         else:
-            log.debug('AcoustID: successfully submitted', domains='acoustid')
+            log.debug('AcoustID: successfully submitted')
             self.tagger.window.set_statusbar_message(
                 N_('AcoustIDs successfully submitted.'),
                 echo=None,

--- a/picard/log.py
+++ b/picard/log.py
@@ -20,7 +20,7 @@
 import sys
 import os
 import logging
-from collections import deque
+from collections import deque, namedtuple, OrderedDict
 from PyQt5 import QtCore
 from picard.util import thread
 
@@ -141,21 +141,21 @@ def error(message, *args, domains=None):
     main_logger.message(logging.ERROR, message, *args, domains=domains)
 
 
-_log_prefixes = {
-    logging.INFO:    'I',
-    logging.WARNING: 'W',
-    logging.ERROR:   'E',
-    logging.DEBUG:   'D',
-}
+_feat = namedtuple('_feat', ['name', 'prefix', 'fgcolor'])
+
+levels_features = OrderedDict([
+    (logging.INFO,    _feat('Info',    'I', 'black')),
+    (logging.WARNING, _feat('Warning', 'W', 'darkorange')),
+    (logging.ERROR,   _feat('Error',   'E', 'red')),
+    (logging.DEBUG,   _feat('Debug',   'D', 'purple')),
+])
 
 
 def formatted_log_line(message_obj, timefmt='hh:mm:ss',
-                       level_prefixes=None, fmt='%s %s'):
+                       level_prefixes=True, fmt='%s %s'):
     msg = fmt % (message_obj.time.toString(timefmt), message_obj.message)
-    if level_prefixes is None:
-        level_prefixes = _log_prefixes
     if level_prefixes:
-        return "%s: %s" % (level_prefixes[message_obj.level], msg)
+        return "%s: %s" % (levels_features[message_obj.level].prefix, msg)
     else:
         return msg
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -149,8 +149,8 @@ _log_prefixes = {
 
 
 def formatted_log_line(message_obj, timefmt='hh:mm:ss',
-                       level_prefixes=None, format='%s %s'):
-    msg = format % (message_obj.time.toString(timefmt), message_obj.message)
+                       level_prefixes=None, fmt='%s %s'):
+    msg = fmt % (message_obj.time.toString(timefmt), message_obj.message)
     if level_prefixes is None:
         level_prefixes = _log_prefixes
     if level_prefixes:
@@ -163,7 +163,7 @@ def _stderr_receiver(message_obj):
     try:
         sys.stderr.write(formatted_log_line(message_obj) + os.linesep)
     except (UnicodeDecodeError, UnicodeEncodeError):
-        sys.stderr.write(formatted_log_line(message_obj, format='%s %r') + os.linesep)
+        sys.stderr.write(formatted_log_line(message_obj, fmt='%s %r') + os.linesep)
 
 
 main_logger.register_receiver(_stderr_receiver)

--- a/picard/log.py
+++ b/picard/log.py
@@ -21,6 +21,7 @@ import io
 import logging
 import os
 import sys
+import traceback
 
 from collections import deque, namedtuple, OrderedDict
 from functools import partial, wraps

--- a/picard/log.py
+++ b/picard/log.py
@@ -232,17 +232,20 @@ main_logger.addFilter(name_filter)
 
 main_tail = TailLogger(_MAX_TAIL_LEN)
 
+main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s %(funcName)s(): %(message)s'
+main_time_fmt = '%H:%M:%S'
+main_inapp_fmt = main_fmt
+main_inapp_time_fmt = main_time_fmt
+
 main_handler = main_tail.log_handler
-main_formatter = logging.Formatter('%(asctime)s %(message)s', '%H:%M:%S')
+main_formatter = logging.Formatter(main_inapp_fmt, main_inapp_time_fmt)
 main_handler.setFormatter(main_formatter)
 
 main_logger.addHandler(main_handler)
 
 main_console_handler = logging.StreamHandler()
-main_console_formatter = logging.Formatter(
-    '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s %(funcName)s(): %(message)s',
-    '%H:%M:%S'
-)
+main_console_formatter = logging.Formatter(main_fmt, main_time_fmt)
+
 main_console_handler.setFormatter(main_console_formatter)
 
 main_logger.addHandler(main_console_handler)

--- a/picard/log.py
+++ b/picard/log.py
@@ -48,18 +48,21 @@ class LogMessage(object):
         self.domains = domains
 
     def is_shown(self, verbosity=None, show_set=None, hide_set=None):
-        if self.domains:
-            if show_set:
+        show = True
+        if show_set:
+            if not self.domains:
+                show = False
+            else:
                 show_set = _onestr2set(show_set)
                 if self.domains.isdisjoint(show_set):
-                    return False
-            if hide_set:
-                hide_set = _onestr2set(hide_set)
-                if self.domains.intersection(hide_set):
-                    return False
+                    show = False
+        if self.domains and hide_set:
+            hide_set = _onestr2set(hide_set)
+            if self.domains.intersection(hide_set):
+                return False
         if verbosity is not None and self.level not in verbosity:
             return False
-        return True
+        return show
 
     def domains_as_string(self):
         if not self.domains:

--- a/picard/log.py
+++ b/picard/log.py
@@ -230,10 +230,11 @@ main_logger.setLevel(logging.INFO)
 
 def name_filter(record):
     # provide a significant name, because module sucks
-    prefix = os.path.dirname(os.path.normpath(os.path.normcase(__file__)))
-    pathname = os.path.normpath(record.pathname)
-    record.name, _ = os.path.splitext(pathname[len(prefix) + 1:] if
-                                      pathname.startswith(prefix) else pathname)
+    prefix = os.path.dirname(os.path.normcase(_srcfile))
+    name = record.pathname
+    if name.startswith(prefix):
+        name = name[len(prefix) + 1:].replace(os.path.sep, '.').replace('.__init__', '')
+    record.name, _ = os.path.splitext(name)
     return True
 
 
@@ -241,7 +242,7 @@ main_logger.addFilter(name_filter)
 
 main_tail = TailLogger(_MAX_TAIL_LEN)
 
-main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s:%(lineno)d %(funcName)s(): %(message)s'
+main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s.%(funcName)s:%(lineno)d: %(message)s'
 main_time_fmt = '%H:%M:%S'
 main_inapp_fmt = main_fmt
 main_inapp_time_fmt = main_time_fmt

--- a/picard/log.py
+++ b/picard/log.py
@@ -34,7 +34,7 @@ def _onestr2set(domains):
     if isinstance(domains, str):
         # this is a shortcut: allow one to pass a domains as sole
         # argument, but use it as first argument of set
-        return set((str,))
+        return set((domains,))
     else:
         return set(domains)
 
@@ -47,21 +47,25 @@ class LogMessage(object):
         self.message = message
         self.domains = domains
 
-    def is_shown(self, show_set=None, hide_set=None):
-        if show_set:
-            show_set = _onestr2set(show_set)
-            if self.domains.isdisjoint(show_set):
-                return False
-        if hide_set:
-            hide_set = _onestr2set(hide_set)
-            if self.domains.intersection(self._hide):
-                return False
+    def is_shown(self, verbosity=None, show_set=None, hide_set=None):
+        if self.domains:
+            if show_set:
+                show_set = _onestr2set(show_set)
+                if self.domains.isdisjoint(show_set):
+                    return False
+            if hide_set:
+                hide_set = _onestr2set(hide_set)
+                if self.domains.intersection(hide_set):
+                    return False
+        if verbosity is not None and self.level not in verbosity:
+            return False
         return True
 
     def domains_as_string(self):
         if not self.domains:
             return ""
         return "|".join(self.domains)
+
 
 class Logger(object):
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -144,8 +144,10 @@ _log_prefixes = {
 
 
 def formatted_log_line(message_obj, timefmt='hh:mm:ss',
-                       level_prefixes=_log_prefixes, format='%s %s'):
+                       level_prefixes=None, format='%s %s'):
     msg = format % (message_obj.time.toString(timefmt), message_obj.message)
+    if level_prefixes is None:
+        level_prefixes = _log_prefixes
     if level_prefixes:
         return "%s: %s" % (level_prefixes[message_obj.level], msg)
     else:

--- a/picard/log.py
+++ b/picard/log.py
@@ -116,24 +116,29 @@ class OurLogger(logging.getLoggerClass()):
         return kwargs
 
     def log(self, level, msg, *args, **kwargs):
-        kwargs = self._fix_kwargs(kwargs)
-        super().log(level, msg, *args, **kwargs)
+        if self.isEnabledFor(level):
+            kwargs = self._fix_kwargs(kwargs)
+            super()._log(level, msg, args, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
-        kwargs = self._fix_kwargs(kwargs)
-        super().debug(msg, *args, **kwargs)
+        if self.isEnabledFor(logging.DEBUG):
+            kwargs = self._fix_kwargs(kwargs)
+            super()._log(logging.DEBUG, msg, args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        kwargs = self._fix_kwargs(kwargs)
-        super().error(msg, *args, **kwargs)
+        if self.isEnabledFor(logging.ERROR):
+            kwargs = self._fix_kwargs(kwargs)
+            super()._log(logging.ERROR, msg, args, **kwargs)
 
     def warning(self, msg, *args, **kwargs):
-        kwargs = self._fix_kwargs(kwargs)
-        super().warning(msg, *args, **kwargs)
+        if self.isEnabledFor(logging.WARNING):
+            kwargs = self._fix_kwargs(kwargs)
+            super()._log(logging.WARNING, msg, args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        kwargs = self._fix_kwargs(kwargs)
-        super().info(msg, *args, **kwargs)
+        if self.isEnabledFor(logging.INFO):
+            kwargs = self._fix_kwargs(kwargs)
+            super()._log(logging.INFO, msg, args, **kwargs)
 
     def exception(self, msg, *args, exc_info=True, **kwargs):
         self.error(msg, *args, exc_info=exc_info, **kwargs)

--- a/picard/log.py
+++ b/picard/log.py
@@ -230,9 +230,10 @@ main_logger.setLevel(logging.INFO)
 
 def name_filter(record):
     # provide a significant name, because module sucks
-    logpydir = os.path.dirname(os.path.realpath(__file__))
-    pathname = os.path.realpath(record.pathname)
-    record.name, _ = os.path.splitext(os.path.relpath(pathname, logpydir))
+    prefix = os.path.dirname(os.path.normpath(os.path.normcase(__file__)))
+    pathname = os.path.normpath(record.pathname)
+    record.name, _ = os.path.splitext(pathname[len(prefix) + 1:] if
+                                      pathname.startswith(prefix) else pathname)
     return True
 
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -206,6 +206,10 @@ class TailLogger(QtCore.QObject):
     def contents(self, prev=-1):
         return [x for x in self._log_queue if x.pos > prev]
 
+    def clear(self):
+        self._log_queue.clear()
+        self.known_domains = set()
+
 
 # MAIN LOGGER
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -241,7 +241,7 @@ main_logger.addFilter(name_filter)
 
 main_tail = TailLogger(_MAX_TAIL_LEN)
 
-main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s %(funcName)s(): %(message)s'
+main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s:%(lineno)d %(funcName)s(): %(message)s'
 main_time_fmt = '%H:%M:%S'
 main_inapp_fmt = main_fmt
 main_inapp_time_fmt = main_time_fmt

--- a/picard/log.py
+++ b/picard/log.py
@@ -67,9 +67,11 @@ class LogMessage(object):
         return "|".join(self.domains)
 
 
-class Logger(object):
+class Logger(QtCore.QObject):
+    domains_updated = QtCore.pyqtSignal()
 
     def __init__(self, maxlen=0):
+        super().__init__()
         self._receivers = []
         self.maxlen = maxlen
         self.known_domains = set()
@@ -92,7 +94,10 @@ class Logger(object):
             return
         if domains is not None:
             domains = _onestr2set(domains)
+            count = len(self.known_domains)
             self.known_domains.update(domains)
+            if count != len(self.known_domains):
+                self.domains_updated.emit()
         if not isinstance(message, str):
             message = repr(message)
         if args:

--- a/picard/log.py
+++ b/picard/log.py
@@ -19,15 +19,11 @@
 
 import sys
 import os
+import logging
 from collections import deque
 from PyQt5 import QtCore
 from picard.util import thread
 
-
-LOG_INFO = 1
-LOG_WARNING = 2
-LOG_ERROR = 4
-LOG_DEBUG = 8
 
 
 def _onestr2set(domains):
@@ -93,7 +89,7 @@ class Logger(QtCore.QObject):
         self._receivers.remove(receiver)
 
     def message(self, level, message, *args, domains=None):
-        if not self.log_level(level):
+        if level < self.log_level:
             return
         if domains is not None:
             domains = _onestr2set(domains)
@@ -116,38 +112,40 @@ class Logger(QtCore.QObject):
                 import traceback
                 traceback.print_exc()
 
-    def log_level(self, level):
-        return True
-
 
 # main logger
-log_levels = LOG_INFO | LOG_WARNING | LOG_ERROR
 
 main_logger = Logger(50000)
-main_logger.log_level = lambda level: log_levels & level
+main_logger.log_level = logging.INFO
+
+def debug_mode(enabled):
+    if enabled:
+        main_logger.log_level = logging.DEBUG
+    else:
+        main_logger.log_level = logging.INFO
 
 
 def debug(message, *args, domains=None):
-    main_logger.message(LOG_DEBUG, message, *args, domains=domains)
+    main_logger.message(logging.DEBUG, message, *args, domains=domains)
 
 
 def info(message, *args, domains=None):
-    main_logger.message(LOG_INFO, message, *args, domains=domains)
+    main_logger.message(logging.INFO, message, *args, domains=domains)
 
 
 def warning(message, *args, domains=None):
-    main_logger.message(LOG_WARNING, message, *args, domains=domains)
+    main_logger.message(logging.WARNING, message, *args, domains=domains)
 
 
 def error(message, *args, domains=None):
-    main_logger.message(LOG_ERROR, message, *args, domains=domains)
+    main_logger.message(logging.ERROR, message, *args, domains=domains)
 
 
 _log_prefixes = {
-    LOG_INFO: 'I',
-    LOG_WARNING: 'W',
-    LOG_ERROR: 'E',
-    LOG_DEBUG: 'D',
+    logging.INFO:    'I',
+    logging.WARNING: 'W',
+    logging.ERROR:   'E',
+    logging.DEBUG:   'D',
 }
 
 
@@ -174,8 +172,8 @@ main_logger.register_receiver(_stderr_receiver)
 
 # history of status messages
 history_logger = Logger(50000)
-history_logger.log_level = lambda level: log_levels & level
+history_logger.log_level = logging.INFO
 
 
 def history_info(message, *args):
-    history_logger.message(LOG_INFO, message, *args)
+    history_logger.message(logging.INFO, message, *args)

--- a/picard/log.py
+++ b/picard/log.py
@@ -132,6 +132,8 @@ class OurLogger(logging.getLoggerClass()):
         kwargs = self._fix_kwargs(kwargs)
         super().info(msg, *args, **kwargs)
 
+    # copied from https://github.com/python/cpython/blob/3.5/Lib/logging/__init__.py#L1353-L1381
+    # see https://stackoverflow.com/questions/4957858/how-to-write-own-logging-methods-for-own-logging-levels
     def findCaller(self, stack_info=False):
         """
         Find the stack frame of the caller so that we can note the source

--- a/picard/log.py
+++ b/picard/log.py
@@ -28,6 +28,9 @@ from functools import partial, wraps
 from PyQt5 import QtCore
 
 
+_MAX_TAIL_LEN = 10**6
+
+
 def domain(*domains):
     def wrapper(f):
         @wraps(f)
@@ -223,7 +226,7 @@ def name_filter(record):
 
 main_logger.addFilter(name_filter)
 
-main_tail = TailLogger(100000)
+main_tail = TailLogger(_MAX_TAIL_LEN)
 
 main_handler = main_tail.log_handler
 main_formatter = logging.Formatter('%(asctime)s %(message)s', '%H:%M:%S')
@@ -253,7 +256,7 @@ error = main_logger.error
 history_logger = logging.getLogger('history')
 history_logger.setLevel(logging.INFO)
 
-history_tail = TailLogger(100000)
+history_tail = TailLogger(_MAX_TAIL_LEN)
 
 history_handler = history_tail.log_handler
 history_formatter = logging.Formatter('%(asctime)s - %(message)s')

--- a/picard/log.py
+++ b/picard/log.py
@@ -25,131 +25,40 @@ from PyQt5 import QtCore
 from picard.util import thread
 
 
-def _onestr2set(domains):
+def debug_mode(enabled):
+    if enabled:
+        main_logger.setLevel(logging.DEBUG)
+    else:
+        main_logger.setLevel(logging.INFO)
+
+
+def main_logger_wrapper(level, message, *args, domains=None):
     if not domains:
-        return set()
+        domains = set()
     elif isinstance(domains, str):
         # this is a shortcut: allow one to pass a domains as sole
         # argument, but use it as first argument of set
-        return set((domains,))
+        domains = set((domains,))
     else:
-        return set(domains)
-
-
-class LogMessage(object):
-
-    def __init__(self, level, time, message, domains):
-        self.level = level
-        self.time = time
-        self.message = message
-        self.domains = domains
-
-    def is_shown(self, verbosity=None, show_set=None, hide_set=None):
-        show = True
-        if show_set:
-            if not self.domains:
-                show = False
-            else:
-                show_set = _onestr2set(show_set)
-                if self.domains.isdisjoint(show_set):
-                    show = False
-        if self.domains and hide_set:
-            hide_set = _onestr2set(hide_set)
-            if self.domains.intersection(hide_set):
-                return False
-        if verbosity is not None and self.level not in verbosity:
-            return False
-        return show
-
-    def domains_as_string(self):
-        if not self.domains:
-            return ""
-        return "|".join(self.domains)
-
-
-class Logger(QtCore.QObject):
-    domains_updated = QtCore.pyqtSignal()
-
-    def __init__(self, maxlen=0):
-        super().__init__()
-        self._receivers = []
-        self.maxlen = maxlen
-        self.known_domains = set()
-        self.reset()
-
-    def reset(self):
-        if self.maxlen > 0:
-            self.entries = deque(maxlen=self.maxlen)
-        else:
-            self.entries = []
-
-    def register_receiver(self, receiver):
-        self._receivers.append(receiver)
-
-    def unregister_receiver(self, receiver):
-        self._receivers.remove(receiver)
-
-    def message(self, level, message, *args, domains=None):
-        if level < self.log_level:
-            return
-        if domains is not None:
-            domains = _onestr2set(domains)
-            count = len(self.known_domains)
-            self.known_domains.update(domains)
-            if count != len(self.known_domains):
-                self.domains_updated.emit()
-        if not isinstance(message, str):
-            message = repr(message)
-        if args:
-            message = message % args
-        time = QtCore.QTime.currentTime()
-        message = "%s" % (message,)
-        message_obj = LogMessage(level, time, message, domains)
-        self.entries.append(message_obj)
-        for func in self._receivers:
-            try:
-                thread.to_main(func, message_obj)
-            except:
-                import traceback
-                traceback.print_exc()
-
-
-# main logger
-
-main_logger = Logger(50000)
-main_logger.log_level = logging.INFO
-
-
-def debug_mode(enabled):
-    if enabled:
-        main_logger.log_level = logging.DEBUG
-    else:
-        main_logger.log_level = logging.INFO
-
-
-def n_main_logger_wrapper(level, message, *args, domains=None):
-    n_main_logger.log(level, message, *args,
-                      extra={'domains': _onestr2set(domains)})
+        domains = set(domains)
+    main_logger.log(level, message, *args,
+                    extra={'domains': domains})
 
 
 def debug(message, *args, domains=None):
-    main_logger.message(logging.DEBUG, message, *args, domains=domains)
-    n_main_logger_wrapper(logging.DEBUG, message, *args, domains=domains)
+    main_logger_wrapper(logging.DEBUG, message, *args, domains=domains)
 
 
 def info(message, *args, domains=None):
-    main_logger.message(logging.INFO, message, *args, domains=domains)
-    n_main_logger_wrapper(logging.INFO, message, *args, domains=domains)
+    main_logger_wrapper(logging.INFO, message, *args, domains=domains)
 
 
 def warning(message, *args, domains=None):
-    main_logger.message(logging.WARNING, message, *args, domains=domains)
-    n_main_logger_wrapper(logging.WARNING, message, *args, domains=domains)
+    main_logger_wrapper(logging.WARNING, message, *args, domains=domains)
 
 
 def error(message, *args, domains=None):
-    main_logger.message(logging.ERROR, message, *args, domains=domains)
-    n_main_logger_wrapper(logging.ERROR, message, *args, domains=domains)
+    main_logger_wrapper(logging.ERROR, message, *args, domains=domains)
 
 
 _feat = namedtuple('_feat', ['name', 'prefix', 'fgcolor'])
@@ -160,15 +69,6 @@ levels_features = OrderedDict([
     (logging.ERROR,   _feat('Error',   'E', 'red')),
     (logging.DEBUG,   _feat('Debug',   'D', 'purple')),
 ])
-
-
-def formatted_log_line(message_obj, timefmt='hh:mm:ss',
-                       level_prefixes=True, fmt='%s %s'):
-    msg = fmt % (message_obj.time.toString(timefmt), message_obj.message)
-    if level_prefixes:
-        return "%s: %s" % (levels_features[message_obj.level].prefix, msg)
-    else:
-        return msg
 
 
 # COMMON CLASSES
@@ -220,32 +120,32 @@ class TailLogger(QtCore.QObject):
 # MAIN LOGGER
 
 
-n_main_logger = logging.getLogger('main')
+main_logger = logging.getLogger('main')
 
-n_main_logger.setLevel(logging.DEBUG)
+main_logger.setLevel(logging.INFO)
 
-n_main_tail = TailLogger(100000)
+main_tail = TailLogger(100000)
 
-n_main_handler = n_main_tail.log_handler
-n_main_formatter = logging.Formatter('%(asctime)s %(message)s', '%H:%M:%S')
-n_main_handler.setFormatter(n_main_formatter)
+main_handler = main_tail.log_handler
+main_formatter = logging.Formatter('%(asctime)s %(message)s', '%H:%M:%S')
+main_handler.setFormatter(main_formatter)
 
-n_main_logger.addHandler(n_main_handler)
+main_logger.addHandler(main_handler)
 
-n_main_console_handler = logging.StreamHandler()
-n_main_console_formatter = logging.Formatter(
+main_console_handler = logging.StreamHandler()
+main_console_formatter = logging.Formatter(
     '%(levelname).1s: %(asctime)s,%(msecs)03d %(message)s',
     '%H:%M:%S'
 )
-n_main_console_handler.setFormatter(n_main_console_formatter)
+main_console_handler.setFormatter(main_console_formatter)
 
-n_main_logger.addHandler(n_main_console_handler)
+main_logger.addHandler(main_console_handler)
 
 # HISTORY LOGGING
 
 
 history_logger = logging.getLogger('history')
-history_logger.setLevel(logging.DEBUG)
+history_logger.setLevel(logging.INFO)
 
 history_tail = TailLogger(100000)
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -37,7 +37,7 @@ def domain(*domains):
         def caller(*args, **kwargs):
             log = sys.modules['picard.log']
             saved = {}
-            methods = ('debug', 'info', 'error', 'warning')
+            methods = ('debug', 'info', 'error', 'warning', 'exception')
             for method in methods:
                 saved[method] = getattr(log, method)
                 setattr(log, method, partial(
@@ -134,6 +134,9 @@ class OurLogger(logging.getLoggerClass()):
     def info(self, msg, *args, **kwargs):
         kwargs = self._fix_kwargs(kwargs)
         super().info(msg, *args, **kwargs)
+
+    def exception(self, msg, *args, exc_info=True, **kwargs):
+        self.error(msg, *args, exc_info=exc_info, **kwargs)
 
     # copied from https://github.com/python/cpython/blob/3.5/Lib/logging/__init__.py#L1353-L1381
     # see https://stackoverflow.com/questions/4957858/how-to-write-own-logging-methods-for-own-logging-levels
@@ -255,6 +258,7 @@ debug = main_logger.debug
 info = main_logger.info
 warning = main_logger.warning
 error = main_logger.error
+exception = main_logger.exception
 
 
 # HISTORY LOGGING

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -48,6 +48,9 @@ _PLUGIN_PACKAGE_SUFFIX = ".picard"
 _PLUGIN_PACKAGE_SUFFIX_LEN = len(_PLUGIN_PACKAGE_SUFFIX)
 
 
+_domains = {'plugins'}
+
+
 def _plugin_name_from_path(path):
     path = os.path.normpath(path)
     file = os.path.basename(path)
@@ -227,7 +230,8 @@ class PluginData(PluginShared):
         try:
             return PluginShared.__getattribute__(self, name)
         except AttributeError:
-            log.debug('Attribute %r not found for plugin %r', name, self.module_name)
+            log.debug('Attribute %r not found for plugin %r', name,
+                      self.module_name, domains=_domains)
             return None
 
     @property
@@ -253,7 +257,8 @@ class PluginManager(QtCore.QObject):
     def load_plugindir(self, plugindir):
         plugindir = os.path.normpath(plugindir)
         if not os.path.isdir(plugindir):
-            log.info("Plugin directory %r doesn't exist", plugindir)
+            log.info("Plugin directory %r doesn't exist", plugindir,
+                     domains=_domains)
             return
         # first, handle eventual plugin updates
         for updatepath in [os.path.join(plugindir, file) for file in
@@ -265,9 +270,11 @@ class PluginManager(QtCore.QObject):
             if name:
                 self.remove_plugin(name)
                 os.rename(updatepath, path)
-                log.debug('Updating plugin %r (%r))', name, path)
+                log.debug('Updating plugin %r (%r))', name, path,
+                          domains=_domains)
             else:
-                log.error('Cannot get plugin name from %r', updatepath)
+                log.error('Cannot get plugin name from %r', updatepath,
+                          domains=_domains)
         # now load found plugins
         names = set()
         for path in [os.path.join(plugindir, file) for file in os.listdir(plugindir)]:
@@ -278,7 +285,8 @@ class PluginManager(QtCore.QObject):
                 names.add(name)
         log.debug("Looking for plugins in directory %r, %d names found",
                   plugindir,
-                  len(names))
+                  len(names),
+                  domains=_domains)
         for name in sorted(names):
             self.load_plugin(name, plugindir)
 
@@ -288,7 +296,7 @@ class PluginManager(QtCore.QObject):
         if importer:
             name = module_name
             if not importer.find_module(name):
-                log.error("Failed loading zipped plugin %r", name)
+                log.error("Failed loading zipped plugin %r", name, domains=_domains)
                 return None
             module_pathname = importer.get_filename(name)
         else:
@@ -297,7 +305,7 @@ class PluginManager(QtCore.QObject):
                 module_file = info[0]
                 module_pathname = info[1]
             except ImportError:
-                log.error("Failed loading plugin %r", name)
+                log.exception("Failed loading plugin %r", name, domains=_domains)
                 return None
 
         plugin = None
@@ -305,12 +313,15 @@ class PluginManager(QtCore.QObject):
             index = None
             for i, p in enumerate(self.plugins):
                 if name == p.module_name:
-                    log.warning("Module %r conflict: unregistering previously" \
-                              " loaded %r version %s from %r",
-                              p.module_name,
-                              p.name,
-                              p.version,
-                              p.file)
+                    log.warning(
+                        "Module %r conflict: unregistering previously" \
+                        " loaded %r version %s from %r",
+                        p.module_name,
+                        p.name,
+                        p.version,
+                        p.file,
+                        domains=_domains
+                    )
                     _unregister_module_extensions(name)
                     index = i
                     break
@@ -328,7 +339,7 @@ class PluginManager(QtCore.QObject):
                           plugin.name,
                           plugin.version,
                           ", ".join([version_to_string(v, short=True) for v in
-                                     sorted(compatible_versions)]))
+                                     sorted(compatible_versions)]), domains=_domains)
                 plugin.compatible = True
                 setattr(picard.plugins, name, plugin_module)
                 if index is not None:
@@ -337,12 +348,13 @@ class PluginManager(QtCore.QObject):
                     self.plugins.append(plugin)
             else:
                 log.warning("Plugin '%s' from '%s' is not compatible"
-                            " with this version of Picard."
-                            % (plugin.name, plugin.file))
+                            " with this version of Picard.",
+                            plugin.name, plugin.file, domains=_domains)
         except VersionError as e:
-            log.error("Plugin %r has an invalid API version string : %s", name, e)
-        except:
-            log.error("Plugin %r : %s", name, traceback.format_exc())
+            log.exception("Plugin %r has an invalid API version string : %s",
+                          name, e, domains=_domains)
+        except Exception as e:
+            log.exception("Plugin %r exception : %s", name, e, domains=_domains)
         if module_file is not None:
             module_file.close()
         return plugin
@@ -361,18 +373,18 @@ class PluginManager(QtCore.QObject):
     def remove_plugin(self, plugin_name):
         if plugin_name.endswith('.zip'):
             plugin_name = os.path.splitext(plugin_name)[0]
-        log.debug("Remove plugin files and dirs : %r", plugin_name)
+        log.debug("Remove plugin files and dirs : %r", plugin_name, domains=_domains)
         dirpath, filepaths = self._get_existing_paths(plugin_name)
         if dirpath:
             if os.path.islink(dirpath):
-                log.debug("Removing symlink %r", dirpath)
+                log.debug("Removing symlink %r", dirpath, domains=_domains)
                 os.remove(dirpath)
             elif os.path.isdir(dirpath):
-                log.debug("Removing directory %r", dirpath)
+                log.debug("Removing directory %r", dirpath, domains=_domains)
                 shutil.rmtree(dirpath)
         if filepaths:
             for filepath in filepaths:
-                log.debug("Removing file %r", filepath)
+                log.debug("Removing file %r", filepath, domains=_domains)
                 os.remove(filepath)
 
     def install_plugin(self, path, action, overwrite_confirm=None, plugin_name=None,
@@ -409,7 +421,7 @@ class PluginManager(QtCore.QObject):
                             zipfile.flush()
                             os.fsync(zipfile.fileno())
                         os.rename(ziptmp, dst)
-                        log.debug("Plugin saved to %r", dst)
+                        log.debug("Plugin saved to %r", dst, domains=_domains)
                     except:
                         try:
                             os.remove(ziptmp)
@@ -437,7 +449,8 @@ class PluginManager(QtCore.QObject):
                 else:
                     self.plugin_updated.emit(plugin_name, False)
             except (OSError, IOError):
-                log.warning("Unable to copy %s to plugin folder %s" % (path, USER_PLUGIN_DIR))
+                log.warning("Unable to copy %s to plugin folder %s",
+                            path, USER_PLUGIN_DIR, domains=_domains)
 
     def query_available_plugins(self, callback=None):
         self.tagger.webservice.get(

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -235,11 +235,11 @@ class Tagger(QtWidgets.QApplication):
         if self._debug == debug:
             return
         if debug:
-            log.log_levels = log.log_levels | log.LOG_DEBUG
+            log.debug_mode(True)
             log.debug("Debug mode on")
         else:
             log.debug("Debug mode off")
-            log.log_levels = log.log_levels & ~log.LOG_DEBUG
+            log.debug_mode(False)
         self._debug = debug
 
     def move_files_to_album(self, files, albumid=None, album=None):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -66,20 +66,20 @@ class LogViewCommon(PicardDialog):
 
     def _display(self):
         self._setup_formats()
-        for level, time, msg in self.logger.entries:
-            self._add_entry(level, time, msg)
+        for message_obj in self.logger.entries:
+            self._add_entry(message_obj)
         self.logger.register_receiver(self._add_entry)
 
-    def _add_entry(self, level, time, msg):
+    def _add_entry(self, message_obj):
         self.textCursor.movePosition(QtGui.QTextCursor.End)
-        self.textCursor.insertText(self._formatted_log_line(level, time, msg),
-                                   self._format(level))
+        self.textCursor.insertText(self._formatted_log_line(message_obj),
+                                   self._format(message_obj.level))
         self.textCursor.insertBlock()
         sb = self.browser.verticalScrollBar()
         sb.setValue(sb.maximum())
 
-    def _formatted_log_line(self, level, time, msg):
-        return log.formatted_log_line(level, time, msg)
+    def _formatted_log_line(self, message_obj):
+        return log.formatted_log_line(message_obj)
 
     def closeEvent(self, event):
         self.logger.unregister_receiver(self._add_entry)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -17,6 +17,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+
+import os
+
 from collections import OrderedDict
 from functools import partial
 
@@ -213,8 +216,34 @@ class LogView(LogViewCommon):
         self.hbox.addWidget(self.clear_log_button)
         self.clear_log_button.clicked.connect(self._clear_log_do)
 
+        self.save_log_as_button = QtWidgets.QPushButton(_("Save As..."))
+        self.hbox.addWidget(self.save_log_as_button)
+        self.save_log_as_button.clicked.connect(self._save_log_as_do)
+
         logger.domains_updated.connect(self.menu_domains_rebuild)
         self.display()
+
+    def _save_log_as_do(self):
+        path, ok =  QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            caption=_("Save Log View to File"),
+            filter=_("Text Files (*.txt *.TXT)"),
+            options=QtWidgets.QFileDialog.DontConfirmOverwrite
+        )
+        if ok and path:
+            if os.path.isfile(path):
+                reply = QtWidgets.QMessageBox.question(
+                    self,
+                    _("Save Log View to File"),
+                    _("File already exists, do you really want to save to this file?"),
+                     QtWidgets.QMessageBox.Yes |  QtWidgets.QMessageBox.No
+                )
+                if reply != QtWidgets.QMessageBox.Yes:
+                    return
+
+            writer = QtGui.QTextDocumentWriter(path)
+            success = writer.write(self.doc)
+            # FIXME: handle errors
 
     def set_domains_menu_can_update(self, can_update):
         self.domains_menu_can_update = can_update

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -69,7 +69,7 @@ class LogViewCommon(LogViewDialog):
         super().__init__(*args, **kwargs)
 
     def show(self):
-        self.display(True)
+        self.display(clear=True)
         super().show()
 
     def _updated(self):
@@ -249,8 +249,8 @@ class LogView(LogViewCommon):
             self.hl_text = new_hl_text
             self.display()
 
-    def display(self, *args, **kwargs):
-        super().display(*args, **kwargs)
+    def display(self, clear=False):
+        super().display(clear=clear)
         if self.hl_text:
             self.highlight(self.hl_text)
 

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -18,6 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+import logging
 import os
 
 from collections import OrderedDict
@@ -30,7 +31,7 @@ from picard.ui import PicardDialog
 
 class LogViewCommon(PicardDialog):
 
-    default_verbosity = {log.LOG_INFO, log.LOG_WARNING, log.LOG_ERROR, log.LOG_DEBUG}
+    default_verbosity = {logging.INFO, logging.WARNING, logging.ERROR, logging.DEBUG}
 
     def __init__(self, title, logger, w=740, h=340, parent=None):
         PicardDialog.__init__(self, parent)
@@ -66,10 +67,10 @@ class LogViewCommon(PicardDialog):
         self.textFormatError.setFont(font)
         self.textFormatError.setForeground(QtGui.QColor('red'))
         self.formats = {
-            log.LOG_INFO: self.textFormatInfo,
-            log.LOG_WARNING: self.textFormatWarning,
-            log.LOG_ERROR: self.textFormatError,
-            log.LOG_DEBUG: self.textFormatDebug,
+            logging.INFO: self.textFormatInfo,
+            logging.WARNING: self.textFormatWarning,
+            logging.ERROR: self.textFormatError,
+            logging.DEBUG: self.textFormatDebug,
         }
 
     def _format(self, level):
@@ -156,10 +157,10 @@ class LogView(LogViewCommon):
     ]
 
     _log_level_names = OrderedDict([
-        (log.LOG_INFO,      N_('Info')),
-        (log.LOG_WARNING,   N_('Warning')),
-        (log.LOG_ERROR,     N_('Error')),
-        (log.LOG_DEBUG,     N_('Debug')),
+        (logging.INFO,      N_('Info')),
+        (logging.WARNING,   N_('Warning')),
+        (logging.ERROR,     N_('Error')),
+        (logging.DEBUG,     N_('Debug')),
     ])
 
     def __init__(self, parent=None):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -18,10 +18,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import logging
 import os
 
-from collections import OrderedDict
 from functools import partial
 
 from PyQt5 import QtCore, QtGui, QtWidgets
@@ -120,7 +118,8 @@ class LogViewCommon(LogViewDialog):
         if self.hl_text:
             self.highlight(self.hl_text, cursor)
 
-    def _formatted_log_line(self, message_obj):
+    @staticmethod
+    def _formatted_log_line(message_obj):
         return log.formatted_log_line(message_obj)
 
     def closeEvent(self, event):
@@ -314,7 +313,8 @@ class HistoryView(LogViewCommon):
         self.restoreWindowState("historyview_position", "historyview_size")
         self.display()
 
-    def _formatted_log_line(self, message_obj):
+    @staticmethod
+    def _formatted_log_line(message_obj):
         return log.formatted_log_line(message_obj, level_prefixes=False)
 
     def closeEvent(self, event):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -208,6 +208,11 @@ class LogView(LogViewCommon):
         self.highlight_button = QtWidgets.QPushButton(_("Highlight"))
         self.hbox.addWidget(self.highlight_button)
         self.highlight_button.clicked.connect(self._highlight_do)
+
+        self.clear_log_button = QtWidgets.QPushButton(_("Clear Log"))
+        self.hbox.addWidget(self.clear_log_button)
+        self.clear_log_button.clicked.connect(self._clear_log_do)
+
         logger.domains_updated.connect(self.menu_domains_rebuild)
         self.display()
 
@@ -232,10 +237,14 @@ class LogView(LogViewCommon):
             act.triggered.connect(partial(self._show_only_domains_changed, domain))
             self.show_only_domains_menu.addAction(act)
 
-
     def show(self):
         self.menu_domains_rebuild()
         super().show()
+
+    def _clear_log_do(self):
+        self.logger.reset()
+        self.menu_domains_rebuild()
+        self.display()
 
     def _highlight_do(self):
         self.hl_text = self.highlight_text.text()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import OrderedDict
+from functools import partial
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 from picard import config, log
@@ -24,6 +26,8 @@ from picard.ui import PicardDialog
 
 
 class LogViewCommon(PicardDialog):
+
+    default_verbosity = {log.LOG_INFO, log.LOG_WARNING, log.LOG_ERROR, log.LOG_DEBUG}
 
     def __init__(self, title, logger, w=740, h=340, parent=None):
         PicardDialog.__init__(self, parent)
@@ -37,7 +41,8 @@ class LogViewCommon(PicardDialog):
         self.browser.setDocument(self.doc)
         self.vbox = QtWidgets.QVBoxLayout(self)
         self.vbox.addWidget(self.browser)
-        self._display()
+        self._setup_formats()
+        self.verbosity = self.default_verbosity
 
     def _setup_formats(self):
         font = QtGui.QFont()
@@ -64,13 +69,20 @@ class LogViewCommon(PicardDialog):
     def _format(self, level):
         return self.formats[level]
 
-    def _display(self):
-        self._setup_formats()
+    def display(self):
+        try:
+            self.logger.unregister_receiver(self._add_entry)
+        except ValueError:
+            pass
+        self.doc.clear()
+        self.textCursor.movePosition(QtGui.QTextCursor.Start)
         for message_obj in self.logger.entries:
             self._add_entry(message_obj)
         self.logger.register_receiver(self._add_entry)
 
     def _add_entry(self, message_obj):
+        if message_obj.level not in self.verbosity:
+            return
         self.textCursor.movePosition(QtGui.QTextCursor.End)
         self.textCursor.insertText(self._formatted_log_line(message_obj),
                                    self._format(message_obj.level))
@@ -103,24 +115,58 @@ class LogView(LogViewCommon):
     options = [
         config.Option("persist", "logview_position", QtCore.QPoint()),
         config.Option("persist", "logview_size", QtCore.QSize(560, 400)),
+        config.Option("persist", "logview_verbosity", LogViewCommon.default_verbosity)
     ]
+
+    _log_level_names = OrderedDict([
+        (log.LOG_INFO,      N_('Info')),
+        (log.LOG_WARNING,   N_('Warning')),
+        (log.LOG_ERROR,     N_('Error')),
+        (log.LOG_DEBUG,     N_('Debug')),
+    ])
 
     def __init__(self, parent=None):
         title = _("Log")
         logger = log.main_logger
         LogViewCommon.__init__(self, title, logger, parent=parent)
+        self.verbosity = config.persist['logview_verbosity']
         self.restoreWindowState("logview_position", "logview_size")
+        self.hbox = QtWidgets.QHBoxLayout(self)
+        self.vbox.addLayout(self.hbox)
+
         cb = QtWidgets.QCheckBox(_('Debug mode'), self)
         cb.setChecked(QtCore.QObject.tagger._debug)
         cb.stateChanged.connect(self.toggleDebug)
-        self.vbox.addWidget(cb)
+        self.hbox.addWidget(cb)
+
+        self.verbosity_menu = QtWidgets.QMenu(self)
+        for level, label in self._log_level_names.items():
+            act = QtWidgets.QAction(_(label), self.verbosity_menu)
+            act.setCheckable(True)
+            act.setChecked(level in self.verbosity)
+            act.triggered.connect(partial(self._verbosity_changed, level))
+            self.verbosity_menu.addAction(act)
+
+        self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"))
+        self.verbosity_menu_button.setMenu(self.verbosity_menu)
+        self.hbox.addWidget(self.verbosity_menu_button)
+
+        self.display()
 
     def toggleDebug(self, state):
         QtCore.QObject.tagger.debug(state == QtCore.Qt.Checked)
 
     def closeEvent(self, event):
+        config.persist['logview_verbosity'] = self.verbosity
         self.saveWindowState("logview_position", "logview_size")
         event.accept()
+
+    def _verbosity_changed(self, level, checked):
+        if checked:
+            self.verbosity.add(level)
+        else:
+            self.verbosity.discard(level)
+        self.display()
 
 
 class HistoryView(LogViewCommon):
@@ -135,6 +181,7 @@ class HistoryView(LogViewCommon):
         logger = log.history_logger
         LogViewCommon.__init__(self, title, logger, parent=parent)
         self.restoreWindowState("historyview_position", "historyview_size")
+        self.display()
 
     def _formatted_log_line(self, message_obj):
         return log.formatted_log_line(message_obj, level_prefixes=False)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -31,8 +31,6 @@ from picard.ui import PicardDialog
 
 class LogViewCommon(PicardDialog):
 
-    default_verbosity = {logging.INFO, logging.WARNING, logging.ERROR, logging.DEBUG}
-
     def __init__(self, title, logger, w=740, h=340, parent=None):
         PicardDialog.__init__(self, parent)
         self.logger = logger
@@ -46,7 +44,7 @@ class LogViewCommon(PicardDialog):
         self.vbox = QtWidgets.QVBoxLayout(self)
         self.vbox.addWidget(self.browser)
         self._setup_formats()
-        self.verbosity = self.default_verbosity
+        self.verbosity = set(log.levels_features)
         self.hidden_domains = set()
         self.show_only_domains = set()
         self.hl_text = ''
@@ -141,7 +139,7 @@ class LogView(LogViewCommon):
     options = [
         config.Option("persist", "logview_position", QtCore.QPoint()),
         config.Option("persist", "logview_size", QtCore.QSize(560, 400)),
-        config.Option("persist", "logview_verbosity", LogViewCommon.default_verbosity)
+        config.Option("persist", "logview_verbosity", set(log.levels_features)),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -136,8 +136,8 @@ class HistoryView(LogViewCommon):
         LogViewCommon.__init__(self, title, logger, parent=parent)
         self.restoreWindowState("historyview_position", "historyview_size")
 
-    def _formatted_log_line(self, level, time, msg):
-        return log.formatted_log_line(level, time, msg, level_prefixes=False)
+    def _formatted_log_line(self, message_obj):
+        return log.formatted_log_line(message_obj, level_prefixes=False)
 
     def closeEvent(self, event):
         self.saveWindowState("historyview_position", "historyview_size")

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -62,11 +62,14 @@ class LogViewCommon(PicardDialog):
     def _format(self, level):
         return self.formats[level]
 
-    def display(self):
+    def _unregister_add_entry(self):
         try:
             self.logger.unregister_receiver(self._add_entry)
         except ValueError:
             pass
+
+    def display(self):
+        self._unregister_add_entry()
         self.doc.clear()
         self.textCursor.movePosition(QtGui.QTextCursor.Start)
         for message_obj in self.logger.entries:
@@ -100,7 +103,7 @@ class LogViewCommon(PicardDialog):
         return log.formatted_log_line(message_obj)
 
     def closeEvent(self, event):
-        self.logger.unregister_receiver(self._add_entry)
+        self._unregister_add_entry()
         return QtWidgets.QDialog.closeEvent(self, event)
 
     def saveWindowState(self, position, size):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -52,26 +52,14 @@ class LogViewCommon(PicardDialog):
         self.hl_text = ''
 
     def _setup_formats(self):
+        self.formats = {}
         font = QtGui.QFont()
         font.setFamily("Monospace")
-        self.textFormatInfo = QtGui.QTextCharFormat()
-        self.textFormatInfo.setFont(font)
-        self.textFormatInfo.setForeground(QtGui.QColor('black'))
-        self.textFormatDebug = QtGui.QTextCharFormat()
-        self.textFormatDebug.setFont(font)
-        self.textFormatDebug.setForeground(QtGui.QColor('purple'))
-        self.textFormatWarning = QtGui.QTextCharFormat()
-        self.textFormatWarning.setFont(font)
-        self.textFormatWarning.setForeground(QtGui.QColor('darkorange'))
-        self.textFormatError = QtGui.QTextCharFormat()
-        self.textFormatError.setFont(font)
-        self.textFormatError.setForeground(QtGui.QColor('red'))
-        self.formats = {
-            logging.INFO: self.textFormatInfo,
-            logging.WARNING: self.textFormatWarning,
-            logging.ERROR: self.textFormatError,
-            logging.DEBUG: self.textFormatDebug,
-        }
+        for level, feat in log.levels_features.items():
+            text_fmt = QtGui.QTextCharFormat()
+            text_fmt.setFont(font)
+            text_fmt.setForeground(QtGui.QColor(feat.fgcolor))
+            self.formats[level] = text_fmt
 
     def _format(self, level):
         return self.formats[level]
@@ -156,13 +144,6 @@ class LogView(LogViewCommon):
         config.Option("persist", "logview_verbosity", LogViewCommon.default_verbosity)
     ]
 
-    _log_level_names = OrderedDict([
-        (logging.INFO,      N_('Info')),
-        (logging.WARNING,   N_('Warning')),
-        (logging.ERROR,     N_('Error')),
-        (logging.DEBUG,     N_('Debug')),
-    ])
-
     def __init__(self, parent=None):
         title = _("Log")
         logger = log.main_logger
@@ -178,8 +159,8 @@ class LogView(LogViewCommon):
         self.hbox.addWidget(cb)
 
         self.verbosity_menu = QtWidgets.QMenu(self)
-        for level, label in self._log_level_names.items():
-            act = QtWidgets.QAction(_(label), self.verbosity_menu)
+        for level, feat in log.levels_features.items():
+            act = QtWidgets.QAction(_(feat.name), self.verbosity_menu)
             act.setCheckable(True)
             act.setChecked(level in self.verbosity)
             act.triggered.connect(partial(self._verbosity_changed, level))

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -325,15 +325,18 @@ class LogView(LogViewCommon):
     def is_shown(self, logitem):
         if logitem.level not in self.verbosity:
             return False
-        show_set = self.show_only_domains
-        hide_set = self.hidden_domains
-        show = True
-        if show_set and (not logitem.domains or
-                         logitem.domains.isdisjoint(show_set)):
-            show = False
-        if hide_set and logitem.domains and logitem.domains.intersection(hide_set):
-            return False
-        return show
+        shown = False
+        # show by default if items has no domains defined
+        if not logitem.domains:
+            shown = True
+        else:
+            # show if item has domains and they arent all in hidden domains
+            shown = not logitem.domains.intersection(self.hidden_domains)
+        # if shown and show_only_domains is non empty, check if at least one is
+        # in both sets
+        if shown and self.show_only_domains:
+            shown = logitem.domains and logitem.domains.intersection(self.show_only_domains)
+        return shown
 
     def _add_entry(self, logitem):
         if not self.is_shown(logitem):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -239,9 +239,9 @@ class LogView(LogViewCommon):
         super().show()
 
     def _clear_log_do(self):
-        self.logger.reset()
+        self.log_tail.clear()
         self.menu_domains_rebuild()
-        self.display()
+        self.display(clear=True)
 
     def _highlight_do(self):
         new_hl_text = self.highlight_text.text()

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -278,7 +278,7 @@ class WebService(QtCore.QObject):
         self.manager.setCache(cache)
         log.debug("NetworkDiskCache dir: %s", cache.cacheDirectory())
         log.debug("NetworkDiskCache size: %s / %s", cache.cacheSize(),
-                  cache.maximumCacheSize())
+                  cache.maximumCacheSize(), domains = ('ws', 'network_cache'))
 
     def setup_proxy(self):
         proxy = QtNetwork.QNetworkProxy()
@@ -329,7 +329,9 @@ class WebService(QtCore.QObject):
         # merge with base url (to cover the possibility of the URL being relative)
         redirect = url.resolved(redirect)
         if not WebService.urls_equivalent(redirect, reply.request().url()):
-            log.debug("Redirect to %s requested", redirect.toString(QUrl.RemoveUserInfo))
+            log.debug("Redirect to %s requested",
+                      redirect.toString(QUrl.RemoveUserInfo), domains = ('ws',
+                                                                         'queries'))
             redirect_host = string_(redirect.host())
             redirect_port = self.url_port(redirect)
             redirect_query = dict(QUrlQuery(redirect).queryItems(QUrl.FullyEncoded))
@@ -349,8 +351,9 @@ class WebService(QtCore.QObject):
                      cacheloadcontrol=request.attribute(QtNetwork.QNetworkRequest.CacheLoadControlAttribute))
         else:
             log.error("Redirect loop: %s",
-                      reply.request().url().toString(QUrl.RemoveUserInfo)
-                      )
+                      reply.request().url().toString(QUrl.RemoveUserInfo),
+                      domains = ('ws', 'queries')
+            )
             request.handler(reply.readAll(), reply, error)
 
     def _handle_reply(self, reply, request):
@@ -369,7 +372,7 @@ class WebService(QtCore.QObject):
             errstr = reply.errorString()
             url = reply.request().url().toString(QUrl.RemoveUserInfo)
             log.error("Network request error for %s: %s (QT code %d, HTTP code %d)",
-                      url, errstr, error, code)
+                      url, errstr, error, code, domains = ('ws', 'queries'))
             if (not request.max_retries_reached()
                 and (code == 503
                      or code == 429
@@ -442,7 +445,7 @@ class WebService(QtCore.QObject):
         request = WSPostRequest(host, port, path, handler, parse_response_type=parse_response_type,
                             data=data, mblogin=mblogin, queryargs=queryargs,
                             priority=priority, important=important)
-        log.debug("POST-DATA %r", data)
+        log.debug("POST-DATA %r", data, domains = ('ws', 'post-data'))
         func = partial(self._start_request, request)
         return self.add_task(func, request)
 

--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -72,11 +72,7 @@ CONGESTION_SSTHRESH = defaultdict(lambda: 0)
 # Storage of last request times per host key
 LAST_REQUEST_TIMES = defaultdict(lambda: 0)
 
-
-@log.domain('ws', 'ratecontrol')
-def _dbug(message, hostkey, *args):
-    log.debug('%s: ' + message, hostkey, *args)
-
+_domains = {'ws', 'ratecontrol'}
 
 def set_minimum_delay(hostkey, delay_ms):
     """Set the minimun delay between requests
@@ -93,6 +89,7 @@ def current_delay(hostkey):
     return REQUEST_DELAY[hostkey]
 
 
+@log.domain(*_domains)
 def get_delay_to_next_request(hostkey):
     """Calculate delay to next request to hostkey (host, port)
        returns a tuple (wait, delay) where:
@@ -107,20 +104,21 @@ def get_delay_to_next_request(hostkey):
 
     interval = REQUEST_DELAY[hostkey]
     if not interval:
-        _dbug("Starting another request without delay", hostkey)
+        log.debug("%s: Starting another request without delay", hostkey)
         return (False, 0)
     last_request = LAST_REQUEST_TIMES[hostkey]
     if not last_request:
-        _dbug("First request", hostkey)
+        log.debug("%s: First request", hostkey)
         _remember_request_time(hostkey)  # set it on first run
         return (False, interval)
     elapsed = (time.time() - last_request) * 1000
     if elapsed >= interval:
-        _dbug("Last request was %d ms ago, starting another one", hostkey, elapsed)
+        log.debug("%s: Last request was %d ms ago, starting another one",
+                  hostkey, elapsed)
         return (False, interval)
     delay = int(math.ceil(interval - elapsed))
-    _dbug("Last request was %d ms ago, waiting %d ms before starting another one",
-          hostkey, elapsed, delay)
+    log.debug("%s: Last request was %d ms ago, waiting %d ms before starting another one",
+              hostkey, elapsed, delay)
     return (True, delay)
 
 
@@ -136,7 +134,8 @@ def increment_requests(hostkey):
     _remember_request_time(hostkey)
     # Increment the number of unack'd requests on sending a new one
     CONGESTION_UNACK[hostkey] += 1
-    _dbug("Incrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
+    log.debug("%s: Incrementing requests to: %d", hostkey,
+              CONGESTION_UNACK[hostkey], domains=_domains)
 
 
 def decrement_requests(hostkey):
@@ -144,7 +143,7 @@ def decrement_requests(hostkey):
     """
     assert(CONGESTION_UNACK[hostkey] > 0)
     CONGESTION_UNACK[hostkey] -= 1
-    _dbug("Decrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
+    log.debug("%s: Decrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey], domains=_domains)
 
 
 def copy_minimal_delay(from_hostkey, to_hostkey):
@@ -154,8 +153,13 @@ def copy_minimal_delay(from_hostkey, to_hostkey):
     if (from_hostkey in REQUEST_DELAY_MINIMUM
             and to_hostkey not in REQUEST_DELAY_MINIMUM):
         REQUEST_DELAY_MINIMUM[to_hostkey] = REQUEST_DELAY_MINIMUM[from_hostkey]
-        _dbug("Copy minimun delay from %s, setting it to %dms",
-              to_hostkey, from_hostkey, REQUEST_DELAY_MINIMUM[to_hostkey])
+        log.debug(
+            "%s: Copy minimun delay from %s, setting it to %dms",
+            to_hostkey,
+            from_hostkey,
+            REQUEST_DELAY_MINIMUM[to_hostkey],
+            domains=_domains
+        )
 
 
 def adjust(hostkey, slow_down):
@@ -186,12 +190,14 @@ def _slow_down(hostkey):
     CONGESTION_SSTHRESH[hostkey] = int(CONGESTION_WINDOW_SIZE[hostkey] / 2.0)
     CONGESTION_WINDOW_SIZE[hostkey] = 1.0
 
-    _dbug('slowdown; delay: %dms -> %dms; ssthresh: %d; cws: %.3f',
-          hostkey,
-          REQUEST_DELAY[hostkey],
-          delay,
-          CONGESTION_SSTHRESH[hostkey],
-          CONGESTION_WINDOW_SIZE[hostkey])
+    log.debug(
+        '%s: slowdown; delay: %dms -> %dms; ssthresh: %d; cws: %.3f',
+        hostkey,
+        REQUEST_DELAY[hostkey],
+        delay,
+        CONGESTION_SSTHRESH[hostkey],
+        CONGESTION_WINDOW_SIZE[hostkey], domains=_domains
+    )
 
     REQUEST_DELAY[hostkey] = delay
 
@@ -218,13 +224,16 @@ def _out_of_backoff(hostkey):
 
     if (REQUEST_DELAY[hostkey] != delay
         or CONGESTION_WINDOW_SIZE[hostkey] != cws):
-        _dbug('oobackoff; delay: %dms -> %dms; %s; window size %.3f -> %.3f',
-              hostkey,
-              REQUEST_DELAY[hostkey],
-              delay,
-              phase,
-              CONGESTION_WINDOW_SIZE[hostkey],
-              cws)
+        log.debug(
+            '%s: oobackoff; delay: %dms -> %dms; %s; window size %.3f -> %.3f',
+            hostkey,
+            REQUEST_DELAY[hostkey],
+            delay,
+            phase,
+            CONGESTION_WINDOW_SIZE[hostkey],
+            cws,
+            domains=_domains
+        )
 
         CONGESTION_WINDOW_SIZE[hostkey] = cws
         REQUEST_DELAY[hostkey] = delay

--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -73,9 +73,9 @@ CONGESTION_SSTHRESH = defaultdict(lambda: 0)
 LAST_REQUEST_TIMES = defaultdict(lambda: 0)
 
 
+@log.domain('ws', 'ratecontrol')
 def _dbug(message, hostkey, *args):
-    log.debug('ratecontrol: %s: '+ message, hostkey, *args, domains = ('ws',
-                                                                       'ratecontrol'))
+    log.debug('%s: ' + message, hostkey, *args)
 
 
 def set_minimum_delay(hostkey, delay_ms):

--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -74,7 +74,8 @@ LAST_REQUEST_TIMES = defaultdict(lambda: 0)
 
 
 def _dbug(message, hostkey, *args):
-    log.debug('ratecontrol: %s: '+ message, hostkey, *args)
+    log.debug('ratecontrol: %s: '+ message, hostkey, *args, domains = ('ws',
+                                                                       'ratecontrol'))
 
 
 def set_minimum_delay(hostkey, delay_ms):


### PR DESCRIPTION


# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Application log view is really user-friendly, but underlying log system neither.
To improve it, few features will be added:
- log "domains", allowing devs to regroup logs in sets
- log verbosity filtering in log view
- log domains filtering in log view
- log highlighting in log view
- saving current log to file

Related to [PICARD-1185](https://tickets.metabrainz.org/browse/PICARD-1185)

# Solution

- log "domains" are implemented, every `log.(error|warn|debug|info)()` now accepts an optional set of domains using `domains` kv parameter
- log messages are stored in a list of `MessageObj`, which has `domains` and `level` properties
- log verbosity can be set through a menu in log view
- log domains can be hidden through a menu in log view
- user-defined text can be highlighted in log view


![capture du 2018-02-04 18-19-43](https://user-images.githubusercontent.com/151042/35780447-d4b1eec0-09db-11e8-8d9b-c0341dfcd746.png)

# Action

Review & test, the code is still very experimental, feedback welcome

