### PR TITLE
Rework logging system and in-app log view

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -29,7 +29,7 @@ from PyQt5 import QtCore
 
 _MAX_TAIL_LEN = 10**6
 
-VERBOSITY_DEFAULT = logging.INFO
+VERBOSITY_DEFAULT = logging.WARNING
 
 
 def debug_mode(enabled):

--- a/picard/log.py
+++ b/picard/log.py
@@ -17,113 +17,206 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import sys
+import io
+import logging
 import os
-from collections import deque
+import sys
+import traceback
+
+from collections import deque, namedtuple, OrderedDict
 from PyQt5 import QtCore
-from picard.util import thread
 
 
-LOG_INFO = 1
-LOG_WARNING = 2
-LOG_ERROR = 4
-LOG_DEBUG = 8
+_MAX_TAIL_LEN = 10**6
+
+VERBOSITY_DEFAULT = logging.INFO
 
 
-class Logger(object):
-
-    def __init__(self, maxlen=0):
-        self._receivers = []
-        self.maxlen = maxlen
-        self.reset()
-
-    def reset(self):
-        if self.maxlen > 0:
-            self.entries = deque(maxlen=self.maxlen)
-        else:
-            self.entries = []
-
-    def register_receiver(self, receiver):
-        self._receivers.append(receiver)
-
-    def unregister_receiver(self, receiver):
-        self._receivers.remove(receiver)
-
-    def message(self, level, message, *args):
-        if not self.log_level(level):
-            return
-        if not isinstance(message, str):
-            message = repr(message)
-        if args:
-            message = message % args
-        time = QtCore.QTime.currentTime()
-        message = "%s" % (message,)
-        self.entries.append((level, time, message))
-        for func in self._receivers:
-            try:
-                thread.to_main(func, level, time, message)
-            except:
-                import traceback
-                traceback.print_exc()
-
-    def log_level(self, level):
-        return True
-
-
-# main logger
-log_levels = LOG_INFO | LOG_WARNING | LOG_ERROR
-
-main_logger = Logger(50000)
-main_logger.log_level = lambda level: log_levels & level
-
-
-def debug(message, *args):
-    main_logger.message(LOG_DEBUG, message, *args)
-
-
-def info(message, *args):
-    main_logger.message(LOG_INFO, message, *args)
-
-
-def warning(message, *args):
-    main_logger.message(LOG_WARNING, message, *args)
-
-
-def error(message, *args):
-    main_logger.message(LOG_ERROR, message, *args)
-
-
-_log_prefixes = {
-    LOG_INFO: 'I',
-    LOG_WARNING: 'W',
-    LOG_ERROR: 'E',
-    LOG_DEBUG: 'D',
-}
-
-
-def formatted_log_line(level, time, message, timefmt='hh:mm:ss',
-                       level_prefixes=_log_prefixes, format='%s %s'):
-    msg = format % (time.toString(timefmt), message)
-    if level_prefixes:
-        return "%s: %s" % (level_prefixes[level], msg)
+def debug_mode(enabled):
+    if enabled:
+        main_logger.setLevel(logging.DEBUG)
     else:
-        return msg
+        main_logger.setLevel(VERBOSITY_DEFAULT)
 
 
-def _stderr_receiver(level, time, msg):
-    try:
-        sys.stderr.write(formatted_log_line(level, time, msg) + os.linesep)
-    except (UnicodeDecodeError, UnicodeEncodeError):
-        sys.stderr.write(formatted_log_line(level, time, msg, format='%s %r') + os.linesep)
+_feat = namedtuple('_feat', ['name', 'prefix', 'fgcolor'])
+
+levels_features = OrderedDict([
+    (logging.ERROR,   _feat('Error',   'E', 'red')),
+    (logging.WARNING, _feat('Warning', 'W', 'darkorange')),
+    (logging.INFO,    _feat('Info',    'I', 'black')),
+    (logging.DEBUG,   _feat('Debug',   'D', 'purple')),
+])
 
 
-main_logger.register_receiver(_stderr_receiver)
+# COMMON CLASSES
 
 
-# history of status messages
-history_logger = Logger(50000)
-history_logger.log_level = lambda level: log_levels & level
+TailLogTuple = namedtuple(
+    'TailLogTuple', ['pos', 'message', 'level'])
+
+
+def _DummyFn(*args, **kwargs):
+    """Placeholder function.
+
+    Raises:
+        NotImplementedError
+    """
+    _, _ = args, kwargs
+    raise NotImplementedError()
+
+
+# _srcfile is used when walking the stack to check when we've got the first
+# caller stack frame, by skipping frames whose filename is that of this
+# module's source. It therefore should contain the filename of this module's
+# source file.
+_srcfile = os.path.normcase(_DummyFn.__code__.co_filename)
+if hasattr(sys, '_getframe'):
+    def currentframe():
+        return sys._getframe(3)
+else:  # pragma: no cover
+    def currentframe():
+        """Return the frame object for the caller's stack frame."""
+        try:
+            raise Exception
+        except Exception:
+            return sys.exc_info()[2].tb_frame.f_back
+
+
+class OurLogger(logging.getLoggerClass()):
+
+
+    # copied from https://github.com/python/cpython/blob/3.5/Lib/logging/__init__.py#L1353-L1381
+    # see https://stackoverflow.com/questions/4957858/how-to-write-own-logging-methods-for-own-logging-levels
+    def findCaller(self, stack_info=False):
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        """
+        f = currentframe()
+        # On some versions of IronPython, currentframe() returns None if
+        # IronPython isn't run with -X:Frames.
+        if f is not None:
+            f = f.f_back
+        rv = "(unknown file)", 0, "(unknown function)", None
+        while hasattr(f, "f_code"):
+            co = f.f_code
+            filename = os.path.normcase(co.co_filename)
+            if filename == _srcfile:
+                f = f.f_back
+                continue
+            sinfo = None
+            if stack_info:
+                sio = io.StringIO()
+                sio.write('Stack (most recent call last):\n')
+                traceback.print_stack(f, file=sio)
+                sinfo = sio.getvalue()
+                if sinfo[-1] == '\n':
+                    sinfo = sinfo[:-1]
+                sio.close()
+            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+            break
+        return rv
+
+
+class TailLogHandler(logging.Handler):
+
+    def __init__(self, log_queue, tail_logger):
+        super().__init__()
+        self.log_queue = log_queue
+        self.tail_logger = tail_logger
+        self.pos = 0
+
+    def emit(self, record):
+        self.log_queue.append(
+            TailLogTuple(
+                self.pos,
+                self.format(record),
+                record.levelno
+            )
+        )
+        self.pos += 1
+        self.tail_logger.updated.emit()
+
+
+class TailLogger(QtCore.QObject):
+    updated = QtCore.pyqtSignal()
+
+    def __init__(self, maxlen):
+        super().__init__()
+        self._log_queue = deque(maxlen=maxlen)
+        self.log_handler = TailLogHandler(self._log_queue, self)
+
+    def contents(self, prev=-1):
+        return [x for x in self._log_queue if x.pos > prev]
+
+    def clear(self):
+        self._log_queue.clear()
+
+
+# MAIN LOGGER
+
+logging.setLoggerClass(OurLogger)
+
+main_logger = logging.getLogger('main')
+
+main_logger.setLevel(logging.INFO)
+
+
+def name_filter(record):
+    # provide a significant name, because module sucks
+    prefix = os.path.dirname(os.path.normcase(_srcfile))
+    name = record.pathname
+    if name.startswith(prefix):
+        name = name[len(prefix) + 1:].replace(os.path.sep, '.').replace('.__init__', '')
+    record.name, _ = os.path.splitext(name)
+    return True
+
+
+main_logger.addFilter(name_filter)
+
+main_tail = TailLogger(_MAX_TAIL_LEN)
+
+main_fmt = '%(levelname).1s: %(asctime)s,%(msecs)03d %(name)s.%(funcName)s:%(lineno)d: %(message)s'
+main_time_fmt = '%H:%M:%S'
+main_inapp_fmt = main_fmt
+main_inapp_time_fmt = main_time_fmt
+
+main_handler = main_tail.log_handler
+main_formatter = logging.Formatter(main_inapp_fmt, main_inapp_time_fmt)
+main_handler.setFormatter(main_formatter)
+
+main_logger.addHandler(main_handler)
+
+main_console_handler = logging.StreamHandler()
+main_console_formatter = logging.Formatter(main_fmt, main_time_fmt)
+
+main_console_handler.setFormatter(main_console_formatter)
+
+main_logger.addHandler(main_console_handler)
+
+
+debug = main_logger.debug
+info = main_logger.info
+warning = main_logger.warning
+error = main_logger.error
+exception = main_logger.exception
+log = main_logger.log
+
+# HISTORY LOGGING
+
+
+history_logger = logging.getLogger('history')
+history_logger.setLevel(logging.INFO)
+
+history_tail = TailLogger(_MAX_TAIL_LEN)
+
+history_handler = history_tail.log_handler
+history_formatter = logging.Formatter('%(asctime)s - %(message)s')
+history_handler.setFormatter(history_formatter)
+
+history_logger.addHandler(history_handler)
 
 
 def history_info(message, *args):
-    history_logger.message(LOG_INFO, message, *args)
+    history_logger.info(message, *args)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -232,15 +232,13 @@ class Tagger(QtWidgets.QApplication):
             f()
 
     def debug(self, debug):
-        if self._debug == debug:
-            return
+        self._debug = debug
         if debug:
-            log.log_levels = log.log_levels | log.LOG_DEBUG
+            log.debug_mode(True)
             log.debug("Debug mode on")
         else:
-            log.debug("Debug mode off")
-            log.log_levels = log.log_levels & ~log.LOG_DEBUG
-        self._debug = debug
+            log.info("Debug mode off")
+            log.debug_mode(False)
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -26,6 +26,7 @@ sip.setapi("QVariant", 2)
 from PyQt5 import QtGui, QtCore, QtWidgets
 
 import argparse
+import logging
 import os.path
 import platform
 import re
@@ -99,6 +100,8 @@ class Tagger(QtWidgets.QApplication):
 
     __instance = None
 
+    _debug = False
+
     def __init__(self, picard_args, unparsed_args, localedir, autoupdate):
 
         # Use the new fusion style from PyQt5 for a modern and consistent look
@@ -117,7 +120,12 @@ class Tagger(QtWidgets.QApplication):
 
         self._cmdline_files = picard_args.FILE
         self._autoupdate = autoupdate
-        self._debug = False
+
+        self.debug(
+            picard_args.debug
+            or "PICARD_DEBUG" in os.environ
+            or config.setting['log_verbosity'] == logging.DEBUG
+        )
 
         # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
         # It's a valid reference, but its start() method doesn't work.
@@ -152,7 +160,6 @@ class Tagger(QtWidgets.QApplication):
             signal.signal(signal.SIGTERM, self.signal)
 
         # Setup logging
-        self.debug(picard_args.debug or "PICARD_DEBUG" in os.environ)
         log.debug("Starting Picard from %r", os.path.abspath(__file__))
         log.debug("Platform: %s %s %s", platform.platform(),
                   platform.python_implementation(), platform.python_version())

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -35,11 +35,12 @@ class LogViewDialog(PicardDialog):
         self.setWindowFlags(QtCore.Qt.Window)
         self.resize(w, h)
         self.setWindowTitle(title)
-        self.doc = QtGui.QTextDocument(self)
+        self.doc = QtGui.QTextDocument()
         self.textCursor = QtGui.QTextCursor(self.doc)
-        self.browser = QtWidgets.QTextBrowser(self)
+        self.browser = QtWidgets.QTextBrowser()
         self.browser.setDocument(self.doc)
-        self.vbox = QtWidgets.QVBoxLayout(self)
+        self.vbox = QtWidgets.QVBoxLayout()
+        self.setLayout(self.vbox)
         self.vbox.addWidget(self.browser)
 
     def saveWindowState(self, position, size):
@@ -157,28 +158,28 @@ class LogView(LogViewCommon):
         self.hl_text = ''
         self.hl = None
 
-        self.hbox = QtWidgets.QHBoxLayout(self)
+        self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
         # Verbosity
         if QtCore.QObject.tagger._debug:
             self.verbosity = logging.DEBUG
-        self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"), self)
+        self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"))
         self.hbox.addWidget(self.verbosity_menu_button)
 
-        self.verbosity_menu = VerbosityMenu(self)
+        self.verbosity_menu = VerbosityMenu()
         self.verbosity_menu.set_verbosity(self.verbosity)
         self.verbosity_menu.verbosity_changed.connect(self._verbosity_changed)
         self.verbosity_menu_button.setMenu(self.verbosity_menu)
 
         # highlight input
-        self.highlight_text = QtWidgets.QLineEdit(self)
+        self.highlight_text = QtWidgets.QLineEdit()
         self.highlight_text.setPlaceholderText(_("String to highlight"))
         self.highlight_text.textEdited.connect(self._highlight_text_edited)
         self.hbox.addWidget(self.highlight_text)
 
         # highlight button
-        self.highlight_button = QtWidgets.QPushButton(_("Highlight"), self)
+        self.highlight_button = QtWidgets.QPushButton(_("Highlight"))
         self.hbox.addWidget(self.highlight_button)
         self.highlight_button.setDefault(True)
         self.highlight_button.setEnabled(False)
@@ -187,22 +188,20 @@ class LogView(LogViewCommon):
         self.highlight_text.returnPressed.connect(self.highlight_button.click)
 
         # clear highlight button
-        self.clear_highlight_button = QtWidgets.QPushButton(_("Clear Highlight"), self)
+        self.clear_highlight_button = QtWidgets.QPushButton(_("Clear Highlight"))
         self.hbox.addWidget(self.clear_highlight_button)
         self.clear_highlight_button.setEnabled(False)
         self.clear_highlight_button.clicked.connect(self._clear_highlight_do)
 
         # clear log
-        self.clear_log_button = QtWidgets.QPushButton(_("Clear Log"), self)
+        self.clear_log_button = QtWidgets.QPushButton(_("Clear Log"))
         self.hbox.addWidget(self.clear_log_button)
         self.clear_log_button.clicked.connect(self._clear_log_do)
 
         # save as
-        self.save_log_as_button = QtWidgets.QPushButton(_("Save As..."), self)
+        self.save_log_as_button = QtWidgets.QPushButton(_("Save As..."))
         self.hbox.addWidget(self.save_log_as_button)
         self.save_log_as_button.clicked.connect(self._save_log_as_do)
-
-        # ------
 
 
     def _clear_highlight_do(self):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -144,13 +144,13 @@ class LogView(LogViewCommon):
         config.Option("persist", "logview_position", QtCore.QPoint()),
         config.Option("persist", "logview_size", QtCore.QSize(
             LogViewCommon.WIDTH, LogViewCommon.HEIGHT)),
-        config.Option("persist", "logview_verbosity", log.VERBOSITY_DEFAULT),
+        config.IntOption("setting", "log_verbosity", log.VERBOSITY_DEFAULT),
     ]
 
     def __init__(self, parent=None):
         super().__init__(log.main_tail, _("Log"), w=self.WIDTH,
                          h=self.HEIGHT, parent=parent)
-        self.verbosity = config.persist['logview_verbosity']
+        self.verbosity = config.setting['log_verbosity']
         self.restoreWindowState("logview_position", "logview_size")
 
         self._setup_formats()
@@ -296,12 +296,12 @@ class LogView(LogViewCommon):
         self.verbosity_menu.set_verbosity(self.verbosity)
 
     def closeEvent(self, event):
-        config.persist['logview_verbosity'] = self.verbosity
         self.saveWindowState("logview_position", "logview_size")
         super().closeEvent(event)
 
     def _verbosity_changed(self, level):
         if level != self.verbosity:
+            config.setting['log_verbosity'] = level
             QtCore.QObject.tagger.debug(level == logging.DEBUG)
             self.verbosity = level
             self.display(clear=True)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -18,16 +18,20 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+import logging
+import os
+
+from functools import partial
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 from picard import config, log
 from picard.ui import PicardDialog
 
 
-class LogViewCommon(PicardDialog):
+class LogViewDialog(PicardDialog):
 
-    def __init__(self, title, logger, w=740, h=340, parent=None):
-        PicardDialog.__init__(self, parent)
-        self.logger = logger
+    def __init__(self, title, w, h, parent=None):
+        super().__init__(parent)
         self.setWindowFlags(QtCore.Qt.Window)
         self.resize(w, h)
         self.setWindowTitle(title)
@@ -37,53 +41,6 @@ class LogViewCommon(PicardDialog):
         self.browser.setDocument(self.doc)
         self.vbox = QtWidgets.QVBoxLayout(self)
         self.vbox.addWidget(self.browser)
-        self._display()
-
-    def _setup_formats(self):
-        font = QtGui.QFont()
-        font.setFamily("Monospace")
-        self.textFormatInfo = QtGui.QTextCharFormat()
-        self.textFormatInfo.setFont(font)
-        self.textFormatInfo.setForeground(QtGui.QColor('black'))
-        self.textFormatDebug = QtGui.QTextCharFormat()
-        self.textFormatDebug.setFont(font)
-        self.textFormatDebug.setForeground(QtGui.QColor('purple'))
-        self.textFormatWarning = QtGui.QTextCharFormat()
-        self.textFormatWarning.setFont(font)
-        self.textFormatWarning.setForeground(QtGui.QColor('darkorange'))
-        self.textFormatError = QtGui.QTextCharFormat()
-        self.textFormatError.setFont(font)
-        self.textFormatError.setForeground(QtGui.QColor('red'))
-        self.formats = {
-            log.LOG_INFO: self.textFormatInfo,
-            log.LOG_WARNING: self.textFormatWarning,
-            log.LOG_ERROR: self.textFormatError,
-            log.LOG_DEBUG: self.textFormatDebug,
-        }
-
-    def _format(self, level):
-        return self.formats[level]
-
-    def _display(self):
-        self._setup_formats()
-        for level, time, msg in self.logger.entries:
-            self._add_entry(level, time, msg)
-        self.logger.register_receiver(self._add_entry)
-
-    def _add_entry(self, level, time, msg):
-        self.textCursor.movePosition(QtGui.QTextCursor.End)
-        self.textCursor.insertText(self._formatted_log_line(level, time, msg),
-                                   self._format(level))
-        self.textCursor.insertBlock()
-        sb = self.browser.verticalScrollBar()
-        sb.setValue(sb.maximum())
-
-    def _formatted_log_line(self, level, time, msg):
-        return log.formatted_log_line(level, time, msg)
-
-    def closeEvent(self, event):
-        self.logger.unregister_receiver(self._add_entry)
-        return QtWidgets.QDialog.closeEvent(self, event)
 
     def saveWindowState(self, position, size):
         pos = self.pos()
@@ -97,48 +54,271 @@ class LogViewCommon(PicardDialog):
             self.move(pos)
         self.resize(config.persist[size])
 
+    def closeEvent(self, event):
+        return super().closeEvent(event)
+
+
+class LogViewCommon(LogViewDialog):
+    WIDTH = 570
+    HEIGHT = 400
+
+    def __init__(self, log_tail, *args, **kwargs):
+        self.displaying = False
+        self.prev = -1
+        self.log_tail = log_tail
+        self.log_tail.updated.connect(self._updated)
+        super().__init__(*args, **kwargs)
+
+    def show(self):
+        self.display(clear=True)
+        super().show()
+
+    def _updated(self):
+        if self.displaying:
+            return
+        self.display()
+
+    def display(self, clear=False):
+        self.displaying = True
+        if clear:
+            self.prev = -1
+            self.doc.clear()
+            self.textCursor.movePosition(QtGui.QTextCursor.Start)
+        for logitem in self.log_tail.contents(self.prev):
+            self._add_entry(logitem)
+            self.prev = logitem.pos
+        self.displaying = False
+
+    def _add_entry(self, logitem):
+        self.textCursor.movePosition(QtGui.QTextCursor.End)
+        self.textCursor.insertText(logitem.message)
+        self.textCursor.insertBlock()
+        sb = self.browser.verticalScrollBar()
+        sb.setValue(sb.maximum())
+
+
+class Highlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, string, parent=None):
+        super().__init__(parent)
+
+        self.fmt = QtGui.QTextCharFormat()
+        self.fmt.setBackground(QtCore.Qt.lightGray)
+
+        self.reg = QtCore.QRegExp()
+        self.reg.setPatternSyntax(QtCore.QRegExp.Wildcard)
+        self.reg.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.reg.setPattern(string)
+
+    def highlightBlock(self, text):
+        expression = self.reg
+        index = expression.indexIn(text)
+        while index >= 0:
+            length = expression.matchedLength()
+            self.setFormat(index, length, self.fmt)
+            index = expression.indexIn(text, index + length)
+
+
+class VerbosityMenu(QtWidgets.QMenu):
+    verbosity_changed = QtCore.pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+
+        self.action_group = QtWidgets.QActionGroup(self)
+        self.action_group .setExclusive(True)
+        self.actions = {}
+        for level, feat in log.levels_features.items():
+            act = QtWidgets.QAction(_(feat.name), self, checkable=True)
+            act.triggered.connect(partial(self.verbosity_changed.emit, level))
+            self.action_group.addAction(act)
+            self.addAction(act)
+            self.actions[level] = act
+
+    def set_verbosity(self, level):
+        self.actions[level].setChecked(True)
+
 
 class LogView(LogViewCommon):
 
     options = [
         config.Option("persist", "logview_position", QtCore.QPoint()),
-        config.Option("persist", "logview_size", QtCore.QSize(560, 400)),
+        config.Option("persist", "logview_size", QtCore.QSize(
+            LogViewCommon.WIDTH, LogViewCommon.HEIGHT)),
+        config.Option("persist", "logview_verbosity", log.VERBOSITY_DEFAULT),
     ]
 
     def __init__(self, parent=None):
-        title = _("Log")
-        logger = log.main_logger
-        LogViewCommon.__init__(self, title, logger, parent=parent)
+        super().__init__(log.main_tail, _("Log"), w=self.WIDTH,
+                         h=self.HEIGHT, parent=parent)
+        self.verbosity = config.persist['logview_verbosity']
         self.restoreWindowState("logview_position", "logview_size")
-        cb = QtWidgets.QCheckBox(_('Debug mode'), self)
-        cb.setChecked(QtCore.QObject.tagger._debug)
-        cb.stateChanged.connect(self.toggleDebug)
-        self.vbox.addWidget(cb)
 
-    def toggleDebug(self, state):
-        QtCore.QObject.tagger.debug(state == QtCore.Qt.Checked)
+        self._setup_formats()
+        self.hl_text = ''
+        self.hl = None
+
+        self.hbox = QtWidgets.QHBoxLayout(self)
+        self.vbox.addLayout(self.hbox)
+
+        # Verbosity
+        if QtCore.QObject.tagger._debug:
+            self.verbosity = logging.DEBUG
+        self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"), self)
+        self.hbox.addWidget(self.verbosity_menu_button)
+
+        self.verbosity_menu = VerbosityMenu(self)
+        self.verbosity_menu.set_verbosity(self.verbosity)
+        self.verbosity_menu.verbosity_changed.connect(self._verbosity_changed)
+        self.verbosity_menu_button.setMenu(self.verbosity_menu)
+
+        # highlight input
+        self.highlight_text = QtWidgets.QLineEdit(self)
+        self.highlight_text.setPlaceholderText(_("String to highlight"))
+        self.highlight_text.textEdited.connect(self._highlight_text_edited)
+        self.hbox.addWidget(self.highlight_text)
+
+        # highlight button
+        self.highlight_button = QtWidgets.QPushButton(_("Highlight"), self)
+        self.hbox.addWidget(self.highlight_button)
+        self.highlight_button.setDefault(True)
+        self.highlight_button.setEnabled(False)
+        self.highlight_button.clicked.connect(self._highlight_do)
+
+        self.highlight_text.returnPressed.connect(self.highlight_button.click)
+
+        # clear highlight button
+        self.clear_highlight_button = QtWidgets.QPushButton(_("Clear Highlight"), self)
+        self.hbox.addWidget(self.clear_highlight_button)
+        self.clear_highlight_button.setEnabled(False)
+        self.clear_highlight_button.clicked.connect(self._clear_highlight_do)
+
+        # clear log
+        self.clear_log_button = QtWidgets.QPushButton(_("Clear Log"), self)
+        self.hbox.addWidget(self.clear_log_button)
+        self.clear_log_button.clicked.connect(self._clear_log_do)
+
+        # save as
+        self.save_log_as_button = QtWidgets.QPushButton(_("Save As..."), self)
+        self.hbox.addWidget(self.save_log_as_button)
+        self.save_log_as_button.clicked.connect(self._save_log_as_do)
+
+        # ------
+
+
+    def _clear_highlight_do(self):
+        self.highlight_text.setText('')
+        self.highlight_button.setEnabled(False)
+        self._highlight_do()
+
+    def _highlight_text_edited(self, text):
+        if text and self.hl_text != text:
+            self.highlight_button.setEnabled(True)
+        else:
+            self.highlight_button.setEnabled(False)
+        if not text:
+            self.clear_highlight_button.setEnabled(bool(self.hl))
+
+    def _highlight_do(self):
+        new_hl_text = self.highlight_text.text()
+        if new_hl_text != self.hl_text:
+            self.hl_text = new_hl_text
+            if self.hl is not None:
+                self.hl.setDocument(None)
+                self.hl = None
+            if self.hl_text:
+                self.hl = Highlighter(self.hl_text, parent=self.doc)
+            self.clear_highlight_button.setEnabled(bool(self.hl))
+
+    def _setup_formats(self):
+        self.formats = {}
+        font = QtGui.QFont()
+        font.setFamily("Monospace")
+        for level, feat in log.levels_features.items():
+            text_fmt = QtGui.QTextCharFormat()
+            text_fmt.setFont(font)
+            text_fmt.setForeground(QtGui.QColor(feat.fgcolor))
+            self.formats[level] = text_fmt
+
+    def _format(self, level):
+        return self.formats[level]
+
+    def _save_log_as_do(self):
+        path, ok = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            caption=_("Save Log View to File"),
+            filter=_("Text Files (*.txt *.TXT)"),
+            options=QtWidgets.QFileDialog.DontConfirmOverwrite
+        )
+        if ok and path:
+            if os.path.isfile(path):
+                reply = QtWidgets.QMessageBox.question(
+                    self,
+                    _("Save Log View to File"),
+                    _("File already exists, do you really want to save to this file?"),
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+                )
+                if reply != QtWidgets.QMessageBox.Yes:
+                    return
+
+            writer = QtGui.QTextDocumentWriter(path)
+            success = writer.write(self.doc)
+            # FIXME: handle errors
+
+    def show(self):
+        self.highlight_text.setFocus(QtCore.Qt.OtherFocusReason);
+        super().show()
+
+    def _clear_log_do(self):
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            _("Clear Log"),
+            _("Are you sure you want to clear the log?"),
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+        )
+        if reply != QtWidgets.QMessageBox.Yes:
+            return
+        self.log_tail.clear()
+        self.display(clear=True)
+
+    def is_shown(self, logitem):
+        return logitem.level >= self.verbosity
+
+    def _add_entry(self, logitem):
+        if not self.is_shown(logitem):
+            return
+        fmt = self.textCursor.blockCharFormat()
+        self.textCursor.setBlockCharFormat(self._format(logitem.level))
+        super()._add_entry(logitem)
+        self.textCursor.setBlockCharFormat(fmt)
+
+    def _set_verbosity(self, level):
+        self.verbosity = level
+        self.verbosity_menu.set_verbosity(self.verbosity)
 
     def closeEvent(self, event):
+        config.persist['logview_verbosity'] = self.verbosity
         self.saveWindowState("logview_position", "logview_size")
-        event.accept()
+        super().closeEvent(event)
+
+    def _verbosity_changed(self, level):
+        if level != self.verbosity:
+            QtCore.QObject.tagger.debug(level == logging.DEBUG)
+            self.verbosity = level
+            self.display(clear=True)
 
 
 class HistoryView(LogViewCommon):
-
     options = [
         config.Option("persist", "historyview_position", QtCore.QPoint()),
-        config.Option("persist", "historyview_size", QtCore.QSize(560, 400)),
+        config.Option("persist", "historyview_size", QtCore.QSize(LogViewCommon.WIDTH,
+                                                                  LogViewCommon.HEIGHT)),
     ]
 
     def __init__(self, parent=None):
-        title = _("Activity History")
-        logger = log.history_logger
-        LogViewCommon.__init__(self, title, logger, parent=parent)
+        super().__init__(log.history_tail, _("Activity History"), w=self.WIDTH,
+                         h=self.HEIGHT, parent=parent)
         self.restoreWindowState("historyview_position", "historyview_size")
-
-    def _formatted_log_line(self, level, time, msg):
-        return log.formatted_log_line(level, time, msg, level_prefixes=False)
 
     def closeEvent(self, event):
         self.saveWindowState("historyview_position", "historyview_size")
-        event.accept()
+        super().closeEvent(event)


### PR DESCRIPTION
- use standard logging module as backend
- implement a circular buffer handler for in-app log view
- use default logging levels
- debug mode is now tied to verbosity
- default log format changed, adding source/lineno infos and milliseconds precision
- history log changed to logging/circular buffer handler too
 
- log view was changed accordingly
- Save As button added
- Clear Log (only the in-memory buffer and the view) button added, with confirmation dialog
- Highlight text and button added
- Verbosity toggling menu added
- Debug mode check box removed (replaced by verbosity = Debug)

Replace https://github.com/metabrainz/picard/pull/830

