### PR TITLE
PICARD-1192: Add .txt extension in path if no extension is there

### DIFF
--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -248,6 +248,8 @@ class LogView(LogViewCommon):
             filter=_("Text Files (*.txt *.TXT)"),
             options=QtWidgets.QFileDialog.DontConfirmOverwrite
         )
+        if not path.endswith('.txt') and not path.endswith('.TXT'):
+            path = path + '.txt'
         if ok and path:
             if os.path.isfile(path):
                 reply = QtWidgets.QMessageBox.question(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Currently if you click on save as option in log dialog. And if you doesn't specify .txt or .TXT format it will not save that file
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1192](https://tickets.metabrainz.org/browse/PICARD-1192)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
I simply check the file and if there isn't any .txt or .TXT extension add '.txt' extension
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

