### PR TITLE
Handle caa_image_size option change in an upgrade hook, bump version to 2.0.0dev3

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -22,7 +22,7 @@ import re
 
 PICARD_ORG_NAME = "MusicBrainz"
 PICARD_APP_NAME = "Picard"
-PICARD_VERSION = (2, 0, 0, 'dev', 2)
+PICARD_VERSION = (2, 0, 0, 'dev', 3)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -222,6 +222,25 @@ def upgrade_to_v1_4_0_dev_7():
         _s.remove(old_opt)
 
 
+def upgrade_to_v2_0_0_dev_3():
+    """Option "caa_image_size" value has different meaning."""
+    _s = config.setting
+    opt = "caa_image_size"
+    if opt in _s:
+        # caa_image_size option was storing index of a combobox item as size
+        # therefore it depends on items order and/or number, which is bad
+        # To keep the option as is, values >= 250 are stored for thumbnails and -1 is
+        # used for full size.
+        _CAA_SIZE_COMPAT = {
+            0: 250,
+            1: 500,
+            2: -1,
+        }
+        value = _s[opt]
+        if value in _CAA_SIZE_COMPAT:
+            _s[opt] = _CAA_SIZE_COMPAT[value]
+
+
 def upgrade_config():
     cfg = config.config
     cfg.register_upgrade_hook(upgrade_to_v1_0_0_final_0)
@@ -235,4 +254,5 @@ def upgrade_config():
     cfg.register_upgrade_hook(upgrade_to_v1_4_0_dev_5)
     cfg.register_upgrade_hook(upgrade_to_v1_4_0_dev_6)
     cfg.register_upgrade_hook(upgrade_to_v1_4_0_dev_7)
+    cfg.register_upgrade_hook(upgrade_to_v2_0_0_dev_3)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -35,19 +35,6 @@ from picard.ui.util import StandardButton
 from picard.util import webbrowser2, load_json
 
 
-
-
-# note: caa_image_size option was storing index of a combobox item as size
-# therefore it depends on items order and/or number, which is bad
-# To keep the option as is, values >= 250 are stored for thumbnails and -1 is
-# used for full size. This trick avoids a hook for compatibility
-
-_CAA_SIZE_COMPAT = {
-    0: 250,
-    1: 500,
-    2: -1,
-}
-
 CaaSizeItem = namedtuple('CaaSizeItem', ['thumbnail', 'label'])
 
 _CAA_THUMBNAIL_SIZE_MAP = OrderedDict([
@@ -196,8 +183,6 @@ class ProviderOptionsCaa(ProviderOptions):
             self.ui.cb_image_size.addItem(_(item.label), userData=item_id)
 
         size = config.setting["caa_image_size"]
-        if size in _CAA_SIZE_COMPAT:
-            size = _CAA_SIZE_COMPAT[size]
         index = self.ui.cb_image_size.findData(size)
         if index < 0:
             index = self.ui.cb_image_size.findData(_CAA_IMAGE_SIZE_DEFAULT)


### PR DESCRIPTION
Suggested by sambhav in https://github.com/metabrainz/picard/pull/833/files#r167294289

It also fixes the issue reported at https://tickets.metabrainz.org/browse/PICARD-1189?focusedCommentId=45336&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-45336

