### PR TITLE
Set default paths to standard locations

### DIFF
--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -21,15 +21,19 @@
 import os
 import sys
 from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import QStandardPaths
 from picard import config
 from picard.formats import supported_formats
 from picard.util import find_existing_path
 
 
+_default_current_browser_path = QStandardPaths.writableLocation(QStandardPaths.HomeLocation)
+
+
 class FileBrowser(QtWidgets.QTreeView):
 
     options = [
-        config.TextOption("persist", "current_browser_path", ""),
+        config.TextOption("persist", "current_browser_path", _default_current_browser_path),
         config.BoolOption("persist", "show_hidden_files", False),
     ]
 

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -20,6 +20,7 @@
 import os.path
 from functools import partial
 from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import QStandardPaths
 from picard import config
 from picard.util import icontheme
 from picard.ui.options import OptionsPage, register_options_page
@@ -27,6 +28,9 @@ from picard.ui.ui_options_interface import Ui_InterfaceOptionsPage
 from picard.ui.util import enabledSlot
 from picard.const import UI_LANGUAGES
 import locale
+
+
+_default_starting_dir = QStandardPaths.writableLocation(QStandardPaths.HomeLocation)
 
 
 class InterfaceOptionsPage(OptionsPage):
@@ -96,7 +100,7 @@ class InterfaceOptionsPage(OptionsPage):
         config.BoolOption("setting", "quit_confirmation", True),
         config.TextOption("setting", "ui_language", ""),
         config.BoolOption("setting", "starting_directory", False),
-        config.TextOption("setting", "starting_directory_path", ""),
+        config.TextOption("setting", "starting_directory_path", _default_starting_dir),
         config.TextOption("setting", "load_image_behavior", "append"),
         config.ListOption("setting", "toolbar_layout", [
             'add_directory_action',

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -22,6 +22,7 @@ import os.path
 import sys
 from functools import partial
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import QStandardPaths
 from PyQt5.QtGui import QPalette
 from picard import config
 from picard.const import PICARD_URLS
@@ -39,6 +40,10 @@ _DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
     "$if($ne(%albumartist%,),$num(%tracknumber%,2) ,)" \
     "$if(%_multiartist%,%artist% - ,)" \
     "%title%"
+
+
+_default_music_dir = QStandardPaths.writableLocation(QStandardPaths.MusicLocation)
+
 
 class RenamingOptionsPage(OptionsPage):
 
@@ -58,7 +63,7 @@ class RenamingOptionsPage(OptionsPage):
             _DEFAULT_FILE_NAMING_FORMAT,
         ),
         config.BoolOption("setting", "move_files", False),
-        config.TextOption("setting", "move_files_to", ""),
+        config.TextOption("setting", "move_files_to", _default_music_dir),
         config.BoolOption("setting", "move_additional_files", False),
         config.TextOption("setting", "move_additional_files_pattern", "*.jpg *.png"),
         config.BoolOption("setting", "delete_empty_dirs", True),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

Set default paths to standard locations

# Problem

Default paths are quite unpredictable, for example, the "Move files to" points to current directory (.) which leads to unexpected behaviour if not changed before moving files.
Picard behaviour is different from most apps in this regard.

# Solution


Since Qt5.0, QStandardPaths provide standard locations for all systems, use it.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

