### PR TITLE
Do not show un-supported DSF tags in UI

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -625,6 +625,10 @@ class DSFFile(ID3File):
             tags.update_to_v24()
             tags.save(filename, v2_version=4)
 
+    def supports_tag(self, name):
+        return (super().supports_tag(name)
+                and name not in ['albumsort', 'artistsort', 'discsubtitle', 'titlesort'])
+
 
 if mutagen.aiff:
     class AiffFile(ID3File):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

PR #835 added support for DSF tags(\o/), but users are still shown unsupported tags in the UI. This fixes that.

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

