### PR TITLE
PICARD-1201: Add -N/--no-restore option to not restore persisted sizes and positions

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -101,6 +101,7 @@ class Tagger(QtWidgets.QApplication):
     __instance = None
 
     _debug = False
+    _no_restore = False
 
     def __init__(self, picard_args, unparsed_args, localedir, autoupdate):
 
@@ -120,6 +121,7 @@ class Tagger(QtWidgets.QApplication):
 
         self._cmdline_files = picard_args.FILE
         self._autoupdate = autoupdate
+        self._no_restore = picard_args.no_restore
 
         self.debug(
             picard_args.debug
@@ -772,6 +774,8 @@ def process_picard_args():
                         help="location of the configuration file")
     parser.add_argument("-d", "--debug", action='store_true',
                         help="enable debug-level logging")
+    parser.add_argument("-N", "--no-restore", action='store_true',
+                        help="do not restore positions and/or sizes")
     parser.add_argument('-v', '--version', action='store_true',
                         help="display version information and exit")
     parser.add_argument("-V", "--long-version", action='store_true',

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -27,6 +27,7 @@ from picard.mbjson import (
     label_info_from_node,
     release_dates_and_countries_from_node,
 )
+from picard.util import restore_method
 
 
 class CDLookupDialog(PicardDialog):
@@ -94,12 +95,14 @@ class CDLookupDialog(PicardDialog):
         self.save_state()
         QtWidgets.QDialog.reject(self)
 
+    @restore_method
     def restore_state(self):
         size = config.persist[self.dialog_window_size]
         if size:
             self.resize(size)
             log.debug("restore_state: %s" % self.dialog_window_size)
 
+    @restore_method
     def restore_header_state(self):
         header = self.ui.release_list.header()
         state = config.persist[self.dialog_header_state]

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -26,7 +26,7 @@ from picard.album import Album, NatAlbum
 from picard.cluster import Cluster, ClusterList, UnclusteredFiles
 from picard.file import File
 from picard.track import Track, NonAlbumTrack
-from picard.util import encode_filename, icontheme
+from picard.util import encode_filename, icontheme, restore_method
 from picard.plugin import ExtensionPoint
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.collectionmenu import CollectionMenu
@@ -129,6 +129,7 @@ class MainPanel(QtWidgets.QSplitter):
         for view in self.views:
             view.save_state()
 
+    @restore_method
     def restore_state(self):
         self.restoreState(config.persist["splitter_state"])
 
@@ -408,6 +409,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         menu.exec_(event.globalPos())
         event.accept()
 
+    @restore_method
     def restore_state(self):
         sizes = config.persist[self.view_sizes.name]
         header = self.header()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -26,6 +26,7 @@ from functools import partial
 from PyQt5 import QtCore, QtGui, QtWidgets
 from picard import config, log
 from picard.ui import PicardDialog
+from picard.util import restore_method
 
 
 class LogViewDialog(PicardDialog):
@@ -49,6 +50,7 @@ class LogViewDialog(PicardDialog):
             config.persist[position] = pos
         config.persist[size] = self.size()
 
+    @restore_method
     def restoreWindowState(self, position, size):
         pos = config.persist[position]
         if pos.x() > 0 and pos.y() > 0:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -46,7 +46,7 @@ from picard.ui.util import (
     ButtonLineEdit,
     MultiDirsSelectDialog
 )
-from picard.util import icontheme, webbrowser2, throttle, thread
+from picard.util import icontheme, webbrowser2, throttle, thread, restore_method
 from picard.util.cdrom import discid, get_cdrom_drives
 from picard.plugin import ExtensionPoint
 
@@ -202,6 +202,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.panel.save_state()
         self.metadata_box.save_state()
 
+    @restore_method
     def restoreWindowState(self):
         self.restoreState(config.persist["window_state"])
         pos = config.persist["window_position"]

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -26,7 +26,7 @@ from picard.album import Album
 from picard.cluster import Cluster
 from picard.track import Track
 from picard.file import File
-from picard.util import format_time, throttle, thread, uniqify
+from picard.util import format_time, throttle, thread, uniqify, restore_method
 from picard.util.tags import display_tag_name
 from picard.ui.edittagdialog import EditTagDialog
 from picard.metadata import MULTI_VALUED_JOINER
@@ -553,6 +553,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         font.setItalic(italic)
         item.setFont(font)
 
+    @restore_method
     def restore_state(self):
         state = config.persist["metadatabox_header_state"]
         header = self.horizontalHeader()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -19,7 +19,7 @@
 
 from PyQt5 import QtCore, QtWidgets
 from picard import config
-from picard.util import webbrowser2
+from picard.util import webbrowser2, restore_method
 from picard.ui import PicardDialog, HashableTreeWidgetItem
 from picard.ui.util import StandardButton
 from picard.ui.options import (
@@ -157,6 +157,7 @@ class OptionsDialog(PicardDialog):
         config.persist["options_size"] = self.size()
         config.persist["options_splitter"] = self.ui.splitter.saveState()
 
+    @restore_method
     def restoreWindowState(self):
         pos = config.persist["options_position"]
         if pos.x() > 0 and pos.y() > 0:

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -24,6 +24,7 @@ from picard.script import ScriptParser
 from picard.ui import HashableListWidgetItem
 from picard.ui.options import OptionsPage, OptionsCheckError, register_options_page
 from picard.ui.ui_options_script import Ui_ScriptingOptionsPage
+from picard.util import restore_method
 
 
 DEFAULT_NUMBERED_SCRIPT_NAME = N_("My script %d")
@@ -402,8 +403,7 @@ class ScriptingOptionsPage(OptionsPage):
         if last_selected_script:
             last_selected_script.setSelected(True)
 
-        # Preserve previous splitter position
-        self.ui.splitter.restoreState(config.persist["scripting_splitter"])
+        self.restore_state()
 
         args = {
             "picard-doc-scripting-url": PICARD_URLS['doc_scripting'],
@@ -411,6 +411,11 @@ class ScriptingOptionsPage(OptionsPage):
         text = _('<a href="%(picard-doc-scripting-url)s">Open Scripting'
                  ' Documentation in your browser</a>') % args
         self.ui.scripting_doc_link.setText(text)
+
+    @restore_method
+    def restore_state(self):
+        # Preserve previous splitter position
+        self.ui.splitter.restoreState(config.persist["scripting_splitter"])
 
     def save(self):
         config.setting["enable_tagger_scripts"] = self.ui.enable_tagger_scripts.isChecked()

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -24,7 +24,7 @@ from collections import namedtuple, OrderedDict
 from picard import config, log
 from picard.ui import PicardDialog
 from picard.ui.util import StandardButton, ButtonLineEdit
-from picard.util import icontheme, throttle
+from picard.util import icontheme, throttle, restore_method
 
 
 class ResultTable(QtWidgets.QTableWidget):
@@ -347,6 +347,7 @@ class SearchDialog(PicardDialog):
         self.save_state()
         QtWidgets.QDialog.reject(self)
 
+    @restore_method
     def restore_state(self):
         size = config.persist[self.dialog_window_size]
         if size:
@@ -355,6 +356,7 @@ class SearchDialog(PicardDialog):
             self.search_box.restore_checkbox_state()
         log.debug("restore_state: %s" % self.dialog_window_size)
 
+    @restore_method
     def restore_table_header_state(self):
         header = self.table.horizontalHeader()
         state = config.persist[self.dialog_header_state]

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -24,6 +24,7 @@ from picard import config
 from picard.ui.util import StandardButton
 from picard.ui import PicardDialog
 from picard.ui.ui_tagsfromfilenames import Ui_TagsFromFileNamesDialog
+from picard.util import restore_method
 from picard.util.tags import display_tag_name
 
 
@@ -143,6 +144,7 @@ class TagsFromFileNamesDialog(PicardDialog):
             config.persist["tags_from_filenames_position"] = pos
         config.persist["tags_from_filenames_size"] = self.size()
 
+    @restore_method
     def restoreWindowState(self):
         pos = config.persist["tags_from_filenames_position"]
         if pos.x() > 0 and pos.y() > 0:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -489,5 +489,10 @@ def load_json(data):
 def parse_json(reply):
     return load_json(reply.readAll())
 
+def restore_method(func):
+    def func_wrapper(*args, **kwargs):
+       if not QtCore.QObject.tagger._no_restore:
+           return func(*args, **kwargs)
+    return func_wrapper
 
 builtins.__dict__['string_'] = convert_to_string


### PR DESCRIPTION
It is useful for:
- users having UI issues on startup (too small, too big, out of screen, etc...)
- devs for testing purposes

Fix [PICARD-1201](https://tickets.metabrainz.org/browse/PICARD-1201)