### PR TITLE
PICARD-1204: Read and dump values to QSettings only when necessary

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -37,14 +37,14 @@ class ConfigSection(LockableObject):
         self.__qt_config = config
         self.__config = {}
         self.__name = name
-        self.load_keys()
+        self.__load_keys()
 
     def __qt_keys(self):
         prefix = self.__name + '/'
         return filter(lambda key: key.startswith(prefix),
                       self.__qt_config.allKeys())
 
-    def load_keys(self):
+    def __load_keys(self):
         for key in self.__qt_keys():
             self.__config[key] = self.__qt_config.value(key)
 
@@ -63,12 +63,12 @@ class ConfigSection(LockableObject):
         finally:
             self.unlock()
 
-    def __contains__(self, key):
-        key = "%s/%s" % (self.__name, key)
+    def __contains__(self, name):
+        key = self.__name + '/' + name
         return key in self.__config
 
-    def remove(self, key):
-        key = "%s/%s" % (self.__name, key)
+    def remove(self, name):
+        key = self.__name + '/' + name
         self.lock_for_write()
         try:
             if key in self.__config:
@@ -77,14 +77,14 @@ class ConfigSection(LockableObject):
         finally:
             self.unlock()
 
-    def raw_value(self, key):
+    def raw_value(self, name):
         """Return an option value without any type conversion."""
-        value = self.__config["%s/%s" % (self.__name, key)]
+        value = self.__config[self.__name + '/' + name]
         return value
 
     def value(self, name, option_type, default=None):
         """Return an option value converted to the given Option type."""
-        key = "%s/%s" % (self.__name, name)
+        key = self.__name + '/' + name
         self.lock_for_read()
         try:
             if key in self.__config:

--- a/picard/config.py
+++ b/picard/config.py
@@ -40,13 +40,17 @@ class ConfigSection(LockableObject):
         self.load_keys()
         self.__qt_config.parent().register_cleanup(self.dump_keys)
 
+    def __qt_keys(self):
+        return filter(lambda key: key.startswith('%s/' % self.__name),
+                      self.__qt_config.allKeys())
+
     def load_keys(self):
-        for key in self.__qt_config.allKeys():
+        for key in self.__qt_keys():
             self.__config[key] = self.__qt_config.value(key)
 
     def dump_keys(self):
         log.debug('Dumping config(%s) to file.', self.__name)
-        for key in self.__qt_config.allKeys():
+        for key in self.__qt_keys():
             if key not in self.__config:
                 self.__qt_config.remove(key)
         for key, value in self.__config.items():


### PR DESCRIPTION
Reading and dumping too often from QSettings causes picard to lock up.
This makes sure we only read on start and dump on change.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1204](https://tickets.metabrainz.org/browse/PICARD-1204)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

