### PR TITLE
Generic class to save/restore dialog geometry, code simplification

### DIFF
--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -31,11 +31,12 @@ from picard.util import restore_method
 
 
 class CDLookupDialog(PicardDialog):
-    dialog_window_size = "cdlookupdialog_window_size"
+
+    defaultsize = QtCore.QSize(720, 360)
+    autorestore = False
     dialog_header_state = "cdlookupdialog_header_state"
 
     options = [
-        config.Option("persist", dialog_window_size, QtCore.QSize(720, 360)),
         config.Option("persist", dialog_header_state, QtCore.QByteArray())
     ]
 
@@ -49,7 +50,6 @@ class CDLookupDialog(PicardDialog):
         self.ui.release_list.setAlternatingRowColors(True)
         self.ui.release_list.setHeaderLabels([_("Album"), _("Artist"), _("Date"), _("Country"),
                                               _("Labels"), _("Catalog #s"), _("Barcode")])
-        self.restore_state()
         if self.releases:
             def myjoin(l):
                 return "\n".join(l)
@@ -75,48 +75,31 @@ class CDLookupDialog(PicardDialog):
         self.ui.release_list.sortByColumn(3, QtCore.Qt.AscendingOrder)
         self.ui.release_list.sortByColumn(2, QtCore.Qt.DescendingOrder)
         self.ui.lookup_button.clicked.connect(self.lookup)
+        self.restore_geometry()
         self.restore_header_state()
-
-    def save_and_accept(self):
-        self.save_state()
-        QtWidgets.QDialog.accept(self)
+        self.finished.connect(self.save_header_state)
 
     def accept(self):
         release_id = self.ui.release_list.currentItem().data(0, QtCore.Qt.UserRole)
         self.tagger.load_album(release_id, discid=self.disc.id)
-        self.save_and_accept()
+        super().accept()
 
     def lookup(self):
         lookup = self.tagger.get_file_lookup()
         lookup.disc_lookup(self.disc.submission_url)
-        self.save_and_accept()
-
-    def reject(self):
-        self.save_state()
-        QtWidgets.QDialog.reject(self)
-
-    @restore_method
-    def restore_state(self):
-        size = config.persist[self.dialog_window_size]
-        if size:
-            self.resize(size)
-            log.debug("restore_state: %s" % self.dialog_window_size)
+        super().accept()
 
     @restore_method
     def restore_header_state(self):
-        header = self.ui.release_list.header()
-        state = config.persist[self.dialog_header_state]
-        if state:
-            header.restoreState(state)
-            log.debug("restore_state: %s" % self.dialog_header_state)
-
-    def save_state(self):
         if self.ui.release_list:
-            self.save_header_state()
-            log.debug("save_state: %s" % self.dialog_window_size)
-        config.persist[self.dialog_window_size] = self.size()
+            header = self.ui.release_list.header()
+            state = config.persist[self.dialog_header_state]
+            if state:
+                header.restoreState(state)
+                log.debug("restore_state: %s" % self.dialog_header_state)
 
     def save_header_state(self):
-        state = self.ui.release_list.header().saveState()
-        config.persist[self.dialog_header_state] = state
-        log.debug("save_state: %s" % self.dialog_header_state)
+        if self.ui.release_list:
+            state = self.ui.release_list.header().saveState()
+            config.persist[self.dialog_header_state] = state
+            log.debug("save_state: %s" % self.dialog_header_state)

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -25,6 +25,9 @@ from picard.ui.ui_edittagdialog import Ui_EditTagDialog
 
 class EditTagDialog(PicardDialog):
 
+    defaultsize = None
+    autorestore = False
+
     def __init__(self, window, tag):
         super().__init__(window)
         self.ui = Ui_EditTagDialog()
@@ -55,6 +58,7 @@ class EditTagDialog(PicardDialog):
         self.ui.remove_value.clicked.connect(self.remove_value)
         self.value_list.itemChanged.connect(self.value_edited)
         self.value_list.itemSelectionChanged.connect(self.value_selection_changed)
+        self.restore_geometry()
 
     def edit_value(self):
         item = self.value_list.currentItem()
@@ -175,4 +179,4 @@ class EditTagDialog(PicardDialog):
             obj.update()
         self.window.ignore_selection_changes = False
         self.window.update_selection()
-        QtWidgets.QDialog.accept(self)
+        super().accept()

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -97,6 +97,9 @@ class ArtworkTable(QtWidgets.QTableWidget):
 
 class InfoDialog(PicardDialog):
 
+    defaultsize = QtCore.QSize(665, 436)
+    autorestore = False
+
     def __init__(self, obj, parent=None):
         super().__init__(parent)
         self.obj = obj
@@ -131,14 +134,13 @@ class InfoDialog(PicardDialog):
         self.ui.artwork_table = ArtworkTable(self.display_existing_artwork)
         self.ui.artwork_table.setObjectName("artwork_table")
         self.ui.vboxlayout1.addWidget(self.ui.artwork_table)
-        if self.display_existing_artwork:
-            self.resize(665, 436)
         self.setTabOrder(self.ui.tabWidget, self.ui.artwork_table)
         self.setTabOrder(self.ui.artwork_table, self.ui.buttonBox)
 
         self.setWindowTitle(_("Info"))
         self.artwork_table = self.ui.artwork_table
         self._display_tabs()
+        self.restore_geometry()
 
     def _display_tabs(self):
         self._display_info_tab()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -47,9 +47,10 @@ from picard.ui.options import (
 
 class OptionsDialog(PicardDialog):
 
+    defaultsize = QtCore.QSize(560, 400)
+    autorestore = False
+
     options = [
-        config.Option("persist", "options_position", QtCore.QPoint()),
-        config.Option("persist", "options_size", QtCore.QSize(560, 400)),
         config.Option("persist", "options_splitter", QtCore.QByteArray()),
     ]
 
@@ -119,6 +120,7 @@ class OptionsDialog(PicardDialog):
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)
 
         self.restoreWindowState()
+        self.finished.connect(self.saveWindowState)
 
         for page in self.pages:
             page.load()
@@ -143,26 +145,14 @@ class OptionsDialog(PicardDialog):
                 return
         for page in self.pages:
             page.save()
-        self.saveWindowState()
-        QtWidgets.QDialog.accept(self)
-
-    def closeEvent(self, event):
-        self.saveWindowState()
-        event.accept()
+        super().accept()
 
     def saveWindowState(self):
-        pos = self.pos()
-        if not pos.isNull():
-            config.persist["options_position"] = pos
-        config.persist["options_size"] = self.size()
         config.persist["options_splitter"] = self.ui.splitter.saveState()
 
     @restore_method
     def restoreWindowState(self):
-        pos = config.persist["options_position"]
-        if pos.x() > 0 and pos.y() > 0:
-            self.move(pos)
-        self.resize(config.persist["options_size"])
+        self.restore_geometry()
         self.ui.splitter.restoreState(config.persist["options_splitter"])
 
     def restore_all_defaults(self):

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -158,6 +158,8 @@ def to_seconds(timestr):
 
 class SearchDialog(PicardDialog):
 
+    defaultsize = QtCore.QSize(720, 360)
+    autorestore = False
     scrolled = pyqtSignal()
 
     def __init__(self, parent, accept_button_title, show_search=True):
@@ -172,6 +174,7 @@ class SearchDialog(PicardDialog):
         # matching label as values
         self.columns = None
         self.sorting_enabled = True
+        self.finished.connect(self.save_state)
 
     @property
     def columns(self):
@@ -340,21 +343,13 @@ class SearchDialog(PicardDialog):
             idx = self.table.selectionModel().selectedRows()[0]
             row = self.table.itemFromIndex(idx).data(QtCore.Qt.UserRole)
             self.accept_event(row)
-        self.save_state()
-        QtWidgets.QDialog.accept(self)
-
-    def reject(self):
-        self.save_state()
-        QtWidgets.QDialog.reject(self)
+        super().accept()
 
     @restore_method
     def restore_state(self):
-        size = config.persist[self.dialog_window_size]
-        if size:
-            self.resize(size)
+        self.restore_geometry()
         if self.show_search:
             self.search_box.restore_checkbox_state()
-        log.debug("restore_state: %s" % self.dialog_window_size)
 
     @restore_method
     def restore_table_header_state(self):
@@ -368,8 +363,6 @@ class SearchDialog(PicardDialog):
     def save_state(self):
         if self.table:
             self.save_table_header_state()
-        config.persist[self.dialog_window_size] = self.size()
-        log.debug("save_state: %s" % self.dialog_window_size)
 
     def save_table_header_state(self):
         state = self.table.horizontalHeader().saveState()

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -117,11 +117,9 @@ class CoverCell:
 
 class AlbumSearchDialog(SearchDialog):
 
-    dialog_window_size = "albumsearchdialog_window_size"
     dialog_header_state = "albumsearchdialog_header_state"
 
     options = [
-        config.Option("persist", dialog_window_size, QtCore.QSize(720, 360)),
         config.Option("persist", dialog_header_state, QtCore.QByteArray())
     ]
 

--- a/picard/ui/searchdialog/artist.py
+++ b/picard/ui/searchdialog/artist.py
@@ -28,11 +28,9 @@ from picard.ui.searchdialog import SearchDialog, Retry, BY_NUMBER
 
 class ArtistSearchDialog(SearchDialog):
 
-    dialog_window_size = "artistsearchdialog_window_size"
     dialog_header_state = "artistsearchdialog_header_state"
 
     options = [
-        config.Option("persist", dialog_window_size, QtCore.QSize(720, 360)),
         config.Option("persist", dialog_header_state, QtCore.QByteArray())
     ]
 

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -37,11 +37,9 @@ from picard.ui.searchdialog import SearchDialog, Retry, BY_DURATION, BY_NUMBER
 
 class TrackSearchDialog(SearchDialog):
 
-    dialog_window_size = "tracksearchdialog_window_size"
     dialog_header_state = "tracksearchdialog_header_state"
 
     options = [
-        config.Option("persist", dialog_window_size, QtCore.QSize(720, 360)),
         config.Option("persist", dialog_header_state, QtCore.QByteArray())
     ]
 

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -24,16 +24,15 @@ from picard import config
 from picard.ui.util import StandardButton
 from picard.ui import PicardDialog
 from picard.ui.ui_tagsfromfilenames import Ui_TagsFromFileNamesDialog
-from picard.util import restore_method
 from picard.util.tags import display_tag_name
 
 
 class TagsFromFileNamesDialog(PicardDialog):
 
+    defaultsize = QtCore.QSize(560, 400)
+
     options = [
         config.TextOption("persist", "tags_from_filenames_format", ""),
-        config.Option("persist", "tags_from_filenames_position", QtCore.QPoint()),
-        config.Option("persist", "tags_from_filenames_size", QtCore.QSize(560, 400)),
     ]
 
     def __init__(self, files, parent=None):
@@ -64,7 +63,6 @@ class TagsFromFileNamesDialog(PicardDialog):
         self.ui.buttonbox.rejected.connect(self.reject)
         self.ui.preview.clicked.connect(self.preview)
         self.ui.files.setHeaderLabels([_("File Name")])
-        self.restoreWindowState()
         self.files = files
         self.items = []
         for file in files:
@@ -127,26 +125,4 @@ class TagsFromFileNamesDialog(PicardDialog):
                 file.metadata[name] = value
             file.update()
         config.persist["tags_from_filenames_format"] = self.ui.format.currentText()
-        self.saveWindowState()
-        QtWidgets.QDialog.accept(self)
-
-    def reject(self):
-        self.saveWindowState()
-        QtWidgets.QDialog.reject(self)
-
-    def closeEvent(self, event):
-        self.saveWindowState()
-        event.accept()
-
-    def saveWindowState(self):
-        pos = self.pos()
-        if not pos.isNull():
-            config.persist["tags_from_filenames_position"] = pos
-        config.persist["tags_from_filenames_size"] = self.size()
-
-    @restore_method
-    def restoreWindowState(self):
-        pos = config.persist["tags_from_filenames_position"]
-        if pos.x() > 0 and pos.y() > 0:
-            self.move(pos)
-        self.resize(config.persist["tags_from_filenames_size"])
+        super().accept()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Simplify save/restoration of dialog geometry, using standard Qt saveGeometry() and restoreGeometry()

# Problem

A lot of code duplication, lack of checks for valid positions and/or sizes, plus various small issues.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1093](https://tickets.metabrainz.org/browse/PICARD-1093)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Implement a generic class managing most of it.
http://doc.qt.io/qt-5/restoring-geometry.html


<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

