### PR TITLE
Allow tagger script to access file metadata

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -260,6 +260,9 @@ class Album(DataObject, Item):
             self._tracks_loaded = True
 
         if not self._requests:
+            for track in self._new_tracks:
+                track.orig_metadata.copy(track.metadata)
+
             self.enable_update_metadata_images(False)
             # Prepare parser for user's script
             if config.setting["enable_tagger_scripts"]:

--- a/picard/script.py
+++ b/picard/script.py
@@ -25,6 +25,7 @@ import operator
 from functools import reduce
 from collections import namedtuple
 from inspect import getfullargspec
+from picard import config
 from picard.metadata import Metadata
 from picard.metadata import MULTI_VALUED_JOINER
 from picard.plugin import ExtensionPoint
@@ -282,6 +283,13 @@ Grammar:
         if key not in ScriptParser._cache:
             ScriptParser._cache[key] = self.parse(script, True)
         return ScriptParser._cache[key].eval(self)
+
+def enabled_tagger_scripts_texts():
+    """Returns an iterator over the enabled tagger scripts.
+    For each script, you'll get a tuple consisting of the script name and text"""
+    if not config.setting["enable_tagger_scripts"]:
+        return []
+    return [ (s_name, s_text) for _s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"] if s_enabled and s_text]
 
 
 def register_script_function(function, name=None, eval_args=True,

--- a/picard/track.py
+++ b/picard/track.py
@@ -25,7 +25,7 @@ from picard.metadata import Metadata, run_track_metadata_processors
 from picard.dataobj import DataObject
 from picard.util.textencoding import asciipunct
 from picard.mbjson import recording_to_metadata
-from picard.script import ScriptParser
+from picard.script import ScriptParser, enabled_tagger_scripts_texts
 from picard.const import VARIOUS_ARTISTS_ID, SILENCE_TRACK_TITLE, DATA_TRACK_TITLE
 from picard.ui.item import Item
 from picard.util.imagelist import update_metadata_images
@@ -76,17 +76,15 @@ class Track(DataObject, Item):
         self.metadata.copy(file.metadata)
 
         # Re-run tagger scripts with updated metadata
-        if config.setting["enable_tagger_scripts"]:
-            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
-                if s_enabled and s_text:
-                    parser = ScriptParser()
-                    try:
-                        parser.eval(s_text, file.metadata)
-                        parser.eval(s_text, self.metadata)
-                    except:
-                        log.error(traceback.format_exc())
-                    file.metadata.strip_whitespace()
-                    self.metadata.strip_whitespace()
+        for s_name, s_text in enabled_tagger_scripts_texts():
+            parser = ScriptParser()
+            try:
+                parser.eval(s_text, file.metadata)
+                parser.eval(s_text, self.metadata)
+            except:
+                log.exception("Failed to run tagger script %s on file", s_name)
+            file.metadata.strip_whitespace()
+            self.metadata.strip_whitespace()
 
         file.metadata.changed = True
         file.update(signal=False)
@@ -107,15 +105,13 @@ class Track(DataObject, Item):
             self.metadata.copy(self.orig_metadata)
 
         # Restore to non-associated state
-        if config.setting["enable_tagger_scripts"]:
-            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
-                if s_enabled and s_text:
-                    parser = ScriptParser()
-                    try:
-                        parser.eval(s_text, self.metadata)
-                    except:
-                        log.error(traceback.format_exc())
-                    self.metadata.strip_whitespace()
+        for s_name, s_text in enabled_tagger_scripts_texts():
+            parser = ScriptParser()
+            try:
+                parser.eval(s_text, self.metadata)
+            except:
+                log.exception("Failed to run tagger script %s on track", s_name)
+            self.metadata.strip_whitespace()
 
         self.update()
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -71,8 +71,23 @@ class Track(DataObject, Item):
     def update_file_metadata(self, file):
         if file not in self.linked_files:
             return
-        file.copy_metadata(self.metadata)
+        file.copy_metadata(self.orig_metadata)
         file.metadata['~extension'] = file.orig_metadata['~extension']
+        self.metadata.copy(file.metadata)
+
+        # Re-run tagger scripts with updated metadata
+        if config.setting["enable_tagger_scripts"]:
+            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
+                if s_enabled and s_text:
+                    parser = ScriptParser()
+                    try:
+                        parser.eval(s_text, file.metadata)
+                        parser.eval(s_text, self.metadata)
+                    except:
+                        log.error(traceback.format_exc())
+                    file.metadata.strip_whitespace()
+                    self.metadata.strip_whitespace()
+
         file.metadata.changed = True
         file.update(signal=False)
         self.update()
@@ -85,6 +100,23 @@ class Track(DataObject, Item):
         file.copy_metadata(file.orig_metadata)
         self.album._remove_file(self, file)
         file.metadata_images_changed.disconnect(self.update_orig_metadata_images)
+
+        if self.num_linked_files > 0:
+            self.metadata.copy(self.linked_files[-1].orig_metadata)
+        else:
+            self.metadata.copy(self.orig_metadata)
+
+        # Restore to non-associated state
+        if config.setting["enable_tagger_scripts"]:
+            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
+                if s_enabled and s_text:
+                    parser = ScriptParser()
+                    try:
+                        parser.eval(s_text, self.metadata)
+                    except:
+                        log.error(traceback.format_exc())
+                    self.metadata.strip_whitespace()
+
         self.update()
 
     def update(self):
@@ -295,15 +327,7 @@ class NonAlbumTrack(Track):
         recording_to_metadata(recording, m, self)
         self._customize_metadata()
         run_track_metadata_processors(self.album, m, None, recording)
-        if config.setting["enable_tagger_scripts"]:
-            for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:
-                if s_enabled and s_text:
-                    parser = ScriptParser()
-                    try:
-                        parser.eval(s_text, m)
-                    except:
-                        log.error(traceback.format_exc())
-                    m.strip_whitespace()
+        self.orig_metadata.copy(m)
 
         self.loaded = True
         if self.callback:


### PR DESCRIPTION
Fixes PICARD-259 (and associated sub-tickets)

This moves the taggerscript evaluation to happen when a file is matched (i.e. when a file is added to a track), where it has access to the both the file metadata *and* the track metadata.

In order to ensure that the titles in the user interface are correct, this is done by saving an extra copy of the original musicbrainz metadata in track.orig_metadata. The taggerscript is run as per normal
on track.metadata, but the file matching will use track.orig_metadata and re-run the taggerscript on the merged data.

This is an updated version of the code previously submitted as #170 

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

* JIRA ticket (_optional_): [PICARD-259](https://tickets.metabrainz.org/browse/PICARD-259)
