### PR TITLE
Info dialog cleanup

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -258,7 +258,7 @@ def format_file_info(file_):
         else:
             ch = string_(ch)
         info.append((_('Channels:'), ch))
-    return '<br/>'.join(map(lambda i: '<b>%s</b><br/>%s' %
+    return '<br/>'.join(map(lambda i: '<b>%s</b> %s' %
                             (htmlescape(i[0]),
                              htmlescape(i[1])), info))
 

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -30,6 +30,7 @@ from picard.util import (format_time, encode_filename,
                          union_sorted_lists, htmlescape)
 from picard.ui import PicardDialog
 from picard.ui.ui_infodialog import Ui_InfoDialog
+from picard.ui.util import StandardButton
 
 
 class ArtworkCoverWidget(QtWidgets.QWidget):
@@ -113,8 +114,9 @@ class InfoDialog(PicardDialog):
             self.existing_images = []
             self.display_existing_artwork = False
         self.ui.setupUi(self)
+        self.ui.buttonBox.addButton(
+            StandardButton(StandardButton.CLOSE), QtWidgets.QDialogButtonBox.AcceptRole)
         self.ui.buttonBox.accepted.connect(self.accept)
-        self.ui.buttonBox.rejected.connect(self.reject)
 
         # Add the ArtworkTable to the ui
         self.ui.artwork_table = ArtworkTable(self.display_existing_artwork)

--- a/picard/ui/ui_infodialog.py
+++ b/picard/ui/ui_infodialog.py
@@ -22,7 +22,7 @@ class Ui_InfoDialog(object):
         self.info_scroll.setObjectName("info_scroll")
         self.scrollAreaWidgetContents = QtWidgets.QWidget()
         self.scrollAreaWidgetContents.setEnabled(True)
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 493, 334))
+        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 493, 358))
         self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
         self.verticalLayoutLabel = QtWidgets.QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayoutLabel.setContentsMargins(0, 0, 0, 0)
@@ -44,7 +44,7 @@ class Ui_InfoDialog(object):
         self.tabWidget.addTab(self.artwork_tab, "")
         self.verticalLayout.addWidget(self.tabWidget)
         self.buttonBox = QtWidgets.QDialogButtonBox(InfoDialog)
-        self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Cancel|QtWidgets.QDialogButtonBox.Ok)
+        self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.NoButton)
         self.buttonBox.setObjectName("buttonBox")
         self.verticalLayout.addWidget(self.buttonBox)
 

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -28,11 +28,13 @@ class StandardButton(QtWidgets.QPushButton):
     OK = 0
     CANCEL = 1
     HELP = 2
+    CLOSE = 4
 
     __types = {
         OK: (N_('&Ok'), 'SP_DialogOkButton'),
         CANCEL: (N_('&Cancel'), 'SP_DialogCancelButton'),
         HELP: (N_('&Help'), 'SP_DialogHelpButton'),
+        CLOSE: (N_('Clos&e'), 'SP_DialogCloseButton'),
     }
 
     def __init__(self, btntype):

--- a/ui/infodialog.ui
+++ b/ui/infodialog.ui
@@ -35,7 +35,7 @@
             <x>0</x>
             <y>0</y>
             <width>493</width>
-            <height>334</height>
+            <height>358</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayoutLabel">
@@ -65,15 +65,14 @@
       <attribute name="title">
        <string>A&amp;rtwork</string>
       </attribute>
-      <layout class="QVBoxLayout">
-      </layout>
+      <layout class="QVBoxLayout"/>
      </widget>
     </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::NoButton</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Before:
![capture du 2018-03-06 10-46-00](https://user-images.githubusercontent.com/151042/37027776-994d301a-2132-11e8-9e8b-c5ef1ea188ae.png)

After:
![capture du 2018-03-06 11-35-10](https://user-images.githubusercontent.com/151042/37027777-9972cd16-2132-11e8-9f2f-b37f6417fdeb.png)

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

