### PR TITLE
PICARD-1206: force style for GroupBox::title

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -118,6 +118,9 @@ class Tagger(QtWidgets.QApplication):
         # Allow High DPI Support
         self.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
         self.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+        super().setStyleSheet(
+            'QGroupBox::title { /* PICARD-1206, Qt bug workaround */ }'
+        )
 
         self._cmdline_files = picard_args.FILE
         self._autoupdate = autoupdate


### PR DESCRIPTION
It is a workaround for a Qt bug, resulting on partially truncated group box titles.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1206](https://tickets.metabrainz.org/browse/PICARD-1206)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

