### PR TITLE
Remove un-needed guard clauses for mutagen imports

### DIFF
--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -94,8 +94,7 @@ from picard.formats.id3 import (
     MP3File,
     TrueAudioFile,
 )
-if AiffFile:
-    register_format(AiffFile)
+register_format(AiffFile)
 register_format(DSFFile)
 register_format(MP3File)
 register_format(TrueAudioFile)
@@ -121,28 +120,20 @@ from picard.formats.vorbis import (
     OggAudioFile,
     OggVideoFile,
     OggOpusFile,
-    with_opus,
 )
 register_format(FLACFile)
 register_format(OggFLACFile)
 register_format(OggSpeexFile)
 register_format(OggVorbisFile)
-if with_opus:
-    register_format(OggOpusFile)
+register_format(OggOpusFile)
 register_format(OggAudioFile)
 register_format(OggVideoFile)
 
-try:
-    from picard.formats.mp4 import MP4File
-    register_format(MP4File)
-except ImportError:
-    pass
+from picard.formats.mp4 import MP4File
+register_format(MP4File)
 
-try:
-    from picard.formats.asf import ASFFile
-    register_format(ASFFile)
-except ImportError:
-    pass
+from picard.formats.asf import ASFFile
+register_format(ASFFile)
 
 from picard.formats.wav import WAVFile
 register_format(WAVFile)

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -21,10 +21,7 @@ import mutagen.apev2
 import mutagen.dsf
 import mutagen.mp3
 import mutagen.trueaudio
-try:
-    import mutagen.aiff
-except ImportError:
-    mutagen.aiff = None
+import mutagen.aiff
 
 import re
 from collections import defaultdict
@@ -635,16 +632,12 @@ class DSFFile(ID3File):
                                  'titlesort'})
 
 
-if mutagen.aiff:
-    class AiffFile(DSFFile):
+class AiffFile(DSFFile):
 
-        """AIFF file."""
-        EXTENSIONS = [".aiff", ".aif", ".aifc"]
-        NAME = "Audio Interchange File Format (AIFF)"
-        _File = mutagen.aiff.AIFF
+    """AIFF file."""
+    EXTENSIONS = [".aiff", ".aif", ".aifc"]
+    NAME = "Audio Interchange File Format (AIFF)"
+    _File = mutagen.aiff.AIFF
 
-        def _get_file(self, filename):
-            return mutagen.aiff.AIFF(filename)
-
-else:
-    AiffFile = None
+    def _get_file(self, filename):
+        return mutagen.aiff.AIFF(filename)

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -25,12 +25,8 @@ import mutagen.oggflac
 import mutagen.oggspeex
 import mutagen.oggtheora
 import mutagen.oggvorbis
-try:
-    from mutagen.oggopus import OggOpus
-    with_opus = True
-except ImportError:
-    OggOpus = None
-    with_opus = False
+import mutagen.oggopus
+
 from picard import config, log
 from picard.coverart.image import TagCoverArtImage, CoverArtImageError
 from picard.file import File
@@ -330,7 +326,7 @@ class OggOpusFile(VCommentFile):
     """Ogg Opus file."""
     EXTENSIONS = [".opus"]
     NAME = "Ogg Opus"
-    _File = OggOpus
+    _File = mutagen.oggopus.OggOpus
 
     def _info(self, metadata, file):
         super()._info(metadata, file)


### PR DESCRIPTION
Since Picard 2.0 picard uses a min. mutagen version 1.39. These are not
needed anymore.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

