### PR TITLE
PICARD-1213: Correct the order of movement in coverart providers

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -71,6 +71,7 @@ class CoverOptionsPage(OptionsPage):
                 title = provider.NAME
             checked = is_provider_enabled(provider.NAME)
             self.provider_list_widget.addItem(SortableCheckboxListItem(title, checked=checked, data=provider.NAME))
+        self.provider_list_widget.disable_last_down_btn()
 
         def update_providers_options(items):
             self.ca_providers = [(item.data, item.checked) for item in items]

--- a/picard/ui/sortablecheckboxlist.py
+++ b/picard/ui/sortablecheckboxlist.py
@@ -51,6 +51,8 @@ class SortableCheckboxListWidget(QtWidgets.QWidget):
         checkbox.stateChanged.connect(partial(self.checkbox_toggled, row))
         up.clicked.connect(partial(self.move_button_clicked, row, up=True))
         down.clicked.connect(partial(self.move_button_clicked, row, up=False))
+        if row == 0:
+            up.setEnabled(False)
 
     def moveItem(self, from_row, to_row):
         to_row = to_row % len(self.__items)
@@ -109,6 +111,9 @@ class SortableCheckboxListWidget(QtWidgets.QWidget):
         self.layout().itemAtPosition(row, self._CHECKBOX_POS).widget().setParent(None)
         self.layout().itemAtPosition(row, self._BUTTON_UP).widget().setParent(None)
         self.layout().itemAtPosition(row, self._BUTTON_DOWN).widget().setParent(None)
+
+    def disable_last_down_btn(self):
+        self.layout().itemAtPosition(len(self.__items) - 1, self._BUTTON_DOWN).widget().setEnabled(False)
 
 
 class SortableCheckboxListItem(object):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When you move top element of coverart providers. It is swapping it's position with last element. This implies that the least prior provider has now become most prior provider. Similar for lower most element.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

# JIRA ticket : [PICARD-1213](https://tickets.metabrainz.org/browse/PICARD-1213)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Disable the up button for top row and disable the down button for lowest row.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

