### PR TITLE
PICARD-1220: Add keyboard shortcut to delete scripts in options page.

### DIFF
--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -232,6 +232,14 @@ class ScriptingOptionsPage(OptionsPage):
         self.last_selected_script_pos = 0
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 2)
+        self.shortcut = QtWidgets.QShortcut(self.ui.script_list)
+        self.shortcut.setKey(QtGui.QKeySequence.Delete)
+        self.shortcut.activated.connect(self.processor_delete_item)
+
+    def processor_delete_item(self):
+        items = self.ui.script_list.selectedItems()
+        if items:
+            self.remove_from_list_of_scripts(self.ui.script_list.row(items[0]))
 
     def script_name_changed(self):
         items = self.ui.script_list.selectedItems()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
JIRA [PICARD-1220](https://tickets.metabrainz.org/browse/PICARD-1220)
# Solution
In options > Scripting. On pressing delete key, the script will be removed.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
