### PR TITLE
PICARD-1229: Use the right shebang in the main executable

### DIFF
--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!%(python)s
 from picard.tagger import main; main('%(localedir)s', %(autoupdate)s)
 

--- a/setup.py
+++ b/setup.py
@@ -266,7 +266,7 @@ class picard_build(build):
     def run(self):
         if 'bdist_nsis' not in sys.argv:  # somebody shoot me please
             log.info('generating scripts/%s from scripts/picard.in', PACKAGE_NAME)
-            generate_file('scripts/picard.in', 'scripts/' + PACKAGE_NAME, {'localedir': self.localedir, 'autoupdate': not self.disable_autoupdate})
+            generate_file('scripts/picard.in', 'scripts/' + PACKAGE_NAME, {'localedir': self.localedir, 'autoupdate': not self.disable_autoupdate, 'python': sys.executable})
         build.run(self)
 
 


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* Use the right shebang in the main executable

# Problem

* JIRA ticket: [PICARD-1229](https://tickets.metabrainz.org/browse/PICARD-1229)

On most platforms, the unversioned "python" executable still points to Python 2.

As a result, the `env python` shebang will always give a Python 2 interpreter on those platforms.

But when installing Picard with `python3 setup.py install`, then a Python 3 interpreter needs to be used to run the script.

# Solution

This change sets the shebang for the installed script to the Python executable used to run the setup.py script.