### PR TITLE
PICARD-1226: Fix font size issues occuring while resizing plugin option page. 

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -86,6 +86,8 @@ class PluginsOptionsPage(OptionsPage):
         super().__init__(parent)
         self.ui = Ui_PluginsOptionsPage()
         self.ui.setupUi(self)
+        #fix for PICARD-1226, QT bug (https://bugreports.qt.io/browse/QTBUG-22572) workaround
+        self.ui.plugins.setStyleSheet('')
         self.items = {}
         self.ui.plugins.itemSelectionChanged.connect(self.change_details)
         self.ui.plugins.mimeTypes = self.mimeTypes


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
While resizing the plugin option page, font size in plugin names changes.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1226](https://tickets.metabrainz.org/browse/PICARD-1226)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Just force set the style sheet for qtreewidget.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
before
![bug1](https://user-images.githubusercontent.com/14358616/37516438-154bdc30-2934-11e8-9d45-caa1d2038d85.png)

after 
![solve](https://user-images.githubusercontent.com/14358616/37516446-248ec2fc-2934-11e8-86ae-b4b1dafe6eb2.png)


