### PR TITLE
PICARD-1221: Handle exception on loading incompatible plugins

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -281,7 +281,10 @@ class PluginManager(QtCore.QObject):
                   plugindir,
                   len(names))
         for name in sorted(names):
-            self.load_plugin(name, plugindir)
+            try:
+                self.load_plugin(name, plugindir)
+            except Exception as e:
+                log.error('Unable to load plugin: %s.\nError occured: %s', name, e)
 
     def load_plugin(self, name, plugindir):
         module_file = None
@@ -432,7 +435,12 @@ class PluginManager(QtCore.QObject):
                             shutil.rmtree(dst)
                     shutil.copytree(path, dst)
                 if action != PLUGIN_ACTION_UPDATE:
-                    installed_plugin = self.load_plugin(zip_plugin or plugin_name, USER_PLUGIN_DIR)
+                    try:
+                        installed_plugin = self.load_plugin(zip_plugin or plugin_name, USER_PLUGIN_DIR)
+                    except Exception as e:
+                        log.error('Unable to load plugin: %s.\nError occured: %s', name, e)
+                        installed_plugin = None
+
                     if installed_plugin is not None:
                         self.plugin_installed.emit(installed_plugin, False)
                 else:


### PR DESCRIPTION
Picard crashes with an 'Unable to execute tagger script' message due to py2 syntax.
This fixes the crash by catching the exception and logging an error message saying that Picard is unable to load a specific plugin.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1221](https://tickets.metabrainz.org/browse/PICARD-1221)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

