### PR TITLE
CD Lookup dialog: use explicit button labels and key accels

### DIFF
--- a/picard/ui/ui_cdlookup.py
+++ b/picard/ui/ui_cdlookup.py
@@ -50,7 +50,7 @@ class Ui_Dialog(object):
         _translate = QtCore.QCoreApplication.translate
         Dialog.setWindowTitle(_("CD Lookup"))
         self.label.setText(_("The following releases on MusicBrainz match the CD:"))
-        self.ok_button.setText(_("OK"))
-        self.lookup_button.setText(_("Lookup manually"))
-        self.cancel_button.setText(_("Cancel"))
+        self.ok_button.setText(_("&Load into Picard"))
+        self.lookup_button.setText(_("Lookup in &Browser"))
+        self.cancel_button.setText(_("&Cancel"))
 

--- a/ui/cdlookup.ui
+++ b/ui/cdlookup.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
+    <layout class="QHBoxLayout" name="hboxlayout">
      <property name="spacing">
       <number>6</number>
      </property>
@@ -45,7 +45,7 @@
       <number>0</number>
      </property>
      <item>
-      <spacer>
+      <spacer name="hspacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -63,21 +63,21 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>OK</string>
+        <string>&amp;Load into Picard</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="lookup_button">
        <property name="text">
-        <string>Lookup manually</string>
+        <string>Lookup in &amp;Browser</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="cancel_button">
        <property name="text">
-        <string>Cancel</string>
+        <string>&amp;Cancel</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Improve button labels in CD Lookup dialog


# Problem

Buttons are labelled "OK" and "Lookup manually": it isn't obvious what they do

![capture du 2018-03-20 11-10-47](https://user-images.githubusercontent.com/151042/37648796-394485e8-2c30-11e8-964f-f7d14d0f44e7.png)

# Solution

Use explicit labels, re-using what it is used in other dialogs.
Replace "OK" with "Load into Picard" (already used in In-app Search Dialog)
Replace "Lookup manually" with "Lookup in Browser" (already used in different dialogs)
Add accel keys (&)

![capture du 2018-03-20 11-09-06](https://user-images.githubusercontent.com/151042/37648787-365243d4-2c30-11e8-969b-cfbf30290b25.png)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

