### PR TITLE
PICARD-1252: properly escape strings used to build a regexp

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -789,7 +789,8 @@ def _delete_prefix(parser, text, *prefixes):
     if not prefixes:
         prefixes = ('A', 'The')
     text = text.strip()
-    match = re.match('(' + r'\s+)|('.join(prefixes) + r'\s+)', text)
+    rx = '(' + r'\s+)|('.join(map(re.escape, prefixes)) + r'\s+)'
+    match = re.match(rx, text)
     if match:
         pref = match.group()
         return text[len(pref):], pref.strip()


### PR DESCRIPTION

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

An exception is raised because of invalid regexp

# Problem

If argument contains '*' (or any other re reserved and unescaped character), an invalid regexp can be build, leading to an exception

* JIRA ticket : [PICARD-1252](https://tickets.metabrainz.org/browse/PICARD-1252)

# Solution

Just use `re.escape()` on each argument before using them.
