### PR TITLE
PICARD-1253: Fix coverart image file save on platforms that support and OSX

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -32,6 +32,7 @@ from picard import config, log
 from picard.coverart.utils import translate_caa_type
 from picard.script import ScriptParser
 from picard.util import (
+    decode_filename,
     encode_filename,
     replace_win32_incompat,
     imageinfo
@@ -315,11 +316,11 @@ class CoverArtImage:
 
     def _next_filename(self, filename, counters):
         if counters[filename]:
-            new_filename = b"%b (%d)" % (filename, counters[filename])
+            new_filename = "%s (%d)" % (decode_filename(filename), counters[filename])
         else:
             new_filename = filename
         counters[filename] += 1
-        return new_filename
+        return encode_filename(new_filename)
 
     def _is_write_needed(self, filename):
         if (os.path.exists(filename)


### PR DESCRIPTION

The bug was being caused when encode_filename returns a string object on a platform that supports unicode filenames. To deal with it, simply call decode_filename, create a new filename and encode it again.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1253](https://tickets.metabrainz.org/browse/PICARD-1253)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

