### PR TITLE
Non-string (dict) tag values (ISRC)

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -86,7 +86,8 @@ class TagCounter(dict):
             if tag == "~length":
                 msg = format_time(self.get(tag, 0))
             else:
-                msg = MULTI_VALUED_JOINER.join(self[tag])
+                # ensure values are strings, e.g. 'ISRC' tag can be a dict
+                msg = MULTI_VALUED_JOINER.join([str(x) for x in self[tag]])
 
             if count > 0 and missing > 0:
                 return (msg + " " + (ngettext("(missing from %d item)", "(missing from %d items)", missing) % missing), True)


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

The `ISRC` tag value was a dict (`{'id': 'GBBTF9300123'}`) for [ad516208-e732-4ac4-b9d0-4618d440a9ec](https://musicbrainz.org/recording/ad516208-e732-4ac4-b9d0-4618d440a9ec), so the `.join(self[tag])` line choked with a `TypeError: sequence item 0: expected str instance, dict found`.

# Solution

I added a conversion of everything to string. But that's only in the display. Clicking to edit crashes, but at least I can tag my files now.

I have no idea how a dict ended up here. This should probably be handled at another level (data parsing?). Sorry for using a PR as a more of a bug report, I'm too lazy to get a JIRA account.