### PR TITLE
PICARD-1122: Preffered release type settings are exclusive and should be inclusive

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -198,7 +198,7 @@ class Metadata(dict):
             score = 0.0
             other_score = type_scores.get('Other', 0.5)
             if 'release-group' in release and 'primary-type' in release['release-group']:
-                types_found = release['release-group']['primary-type']
+                types_found = [release['release-group']['primary-type']]
                 if 'secondary-types' in release['release-group']:
                     types_found += release['release-group']['secondary-types']
                 for release_type in types_found:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
This pull request fixes the the preferred release type functionality

# Problem
Prior to this, picard only used the primary release type and ignored the secondary release type. This algorithm improves on that by incorporating the secondary release types and averaging the weights of all the types
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1122](https://tickets.metabrainz.org/browse/PICARD-1122)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

# Solution
The algorithm gathers all the release types found in the release (both primary and secondary) into a list, adds their respective scores (from the user's settings) together and then divides that score by the number of types there are in total, thus averaging all the scores.

It is important to note that the preffered release types only works with lookups, and not with acousticid fingerprinting. It would be an improvement for the preffered release types to work in both cases but to implement this, it must be determined why fingerprinting does not return release types data while tag based lookup does
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
The changes are pep-8 compliant and have been tested successfully. No further action should be necessary. 

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

