### PR TITLE
PICARD-1277 (workaround): translate_caa_type: Return the input if the type is unknown

### DIFF
--- a/picard/const/attributes.py
+++ b/picard/const/attributes.py
@@ -16,6 +16,7 @@ MB_ATTRIBUTES = {
     'DB:cover_art_archive.art_type/name:011': 'Poster',
     'DB:cover_art_archive.art_type/name:012': 'Liner',
     'DB:cover_art_archive.art_type/name:013': 'Watermark',
+    'DB:cover_art_archive.art_type/name:014': 'Raw/Unedited',
     'DB:medium_format/name:001': 'CD',
     'DB:medium_format/name:002': 'DVD',
     'DB:medium_format/name:003': 'SACD',

--- a/picard/coverart/utils.py
+++ b/picard/coverart/utils.py
@@ -39,4 +39,5 @@ def translate_caa_type(name):
     if name == 'unknown':
         return _(CAA_TYPES_TR[name])
     else:
-        return gettext_attr(CAA_TYPES_TR[name], "cover_art_type")
+        title = CAA_TYPES_TR.get(name, name)
+        return gettext_attr(title, "cover_art_type")

--- a/test/test_coverart_utils.py
+++ b/test/test_coverart_utils.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# coding: utf-8
+import os.path
+import shutil
+import tempfile
+import unittest
+
+from picard.coverart.utils import translate_caa_type
+from picard.i18n import setup_gettext
+
+
+class CaaTypeTranslationTest(unittest.TestCase):
+    def setUp(self):
+        # we are using temporary locales for tests
+        self.tmp_path = tempfile.mkdtemp()
+        self.localedir = os.path.join(self.tmp_path, 'locale')
+        self.addCleanup(shutil.rmtree, self.tmp_path)
+        setup_gettext(self.localedir, "C")
+
+    def test_translating_unknown_types_returns_input(self):
+        testtype = "ThisIsAMadeUpCoverArtTypeName"
+        self.assertEqual(translate_caa_type(testtype), testtype)


### PR DESCRIPTION
# Summary

That can happen if a new cover art type is added in MB that Picard doesn't yet
know about. Instead of raising a KeyError (and crashing), just return the raw
type, which is good enough until we have something better to show.

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

See above.

* JIRA ticket (_optional_): [PICARD-1277](https://tickets.metabrainz.org/browse/PICARD-1277)

# Solution
See above.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Backport this to 1.4.something? Otherwise all users on older releases (Debian, Ubuntu, ...) will not be able to load albums with new cover art types.