### PR TITLE
PICARD-1273: Add an option to exclude new cover art type "Raw / Unedited"

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -72,6 +72,61 @@ _CAA_THUMBNAIL_SIZE_MAP = OrderedDict([
 
 _CAA_IMAGE_SIZE_DEFAULT = 500
 
+_CAA_IMAGE_TYPE_DEFAULT_INCLUDE = [ 'front', ]
+_CAA_IMAGE_TYPE_DEFAULT_EXCLUDE = [ 'raw/unedited', 'watermark', ]
+
+
+def make_list_box():
+    """Make standard list box for CAA image type selection dialog."""
+    list_box = QtWidgets.QListWidget()
+    list_box.setFixedSize(QtCore.QSize(150, 250))
+    list_box.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+    list_box.setSortingEnabled(True)
+    list_box.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+    return list_box
+
+def make_arrow_button(label, command):
+    """Make standard arrow button for CAA image type selection dialog."""
+    item = QtWidgets.QPushButton(label)
+    item.clicked.connect(command)
+    item.setFixedSize(QtCore.QSize(35, 20))
+    return item
+
+def make_arrows_column(list_add, list_add_all, list_remove, list_remove_all, reverse=False):
+    """Make standard arrow buttons column for CAA image type selection dialog."""
+    _spacer_item = QtWidgets.QSpacerItem(20, 20, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+    arrows = QtWidgets.QWidget()
+    arrows_layout = QtWidgets.QVBoxLayout()
+    arrows.setLayout(arrows_layout)
+    arrows_layout.addItem(QtWidgets.QSpacerItem(_spacer_item))
+    arrows_layout.addWidget(make_arrow_button('>' if reverse else '<', list_add))
+    arrows_layout.addWidget(make_arrow_button('>>' if reverse else '<<', list_add_all))
+    arrows_layout.addWidget(make_arrow_button('<' if reverse else '>', list_remove))
+    arrows_layout.addWidget(make_arrow_button('<<' if reverse else '>>', list_remove_all))
+    arrows_layout.addItem(QtWidgets.QSpacerItem(_spacer_item))
+    return arrows
+
+def move_item(item, list1, list2):
+    """Move the specified item from one listbox to another.  Used in the CAA image type selection dialog."""
+    clone = item.clone()
+    list2.addItem(clone)
+    list1.takeItem(list1.row(item))
+
+def move_selected_items(list1, list2):
+    """Move the selected item from one listbox to another.  Used in the CAA image type selection dialog."""
+    for item in list1.selectedItems():
+        move_item(item, list1, list2)
+
+def move_all_items(list1, list2):
+    """Move all items from one listbox to another.  Used in the CAA image type selection dialog."""
+    while list1.count():
+        item = list1.item(0)
+        move_item(item, list1, list2)
+
+def clear_listbox_focus(list_to_clear):
+    """Clear all item selections in the specified listbox."""
+    list_to_clear.clearSelection()
+
 
 def caa_url_fallback_list(desired_size, thumbnails):
     """List of thumbnail urls equal or smaller than size, in size decreasing order
@@ -95,14 +150,15 @@ def caa_url_fallback_list(desired_size, thumbnails):
 
 
 class CAATypesSelectorDialog(QtWidgets.QDialog):
-    _columns = 3        # Number of main display columns
-    _subcolumns = 3     # Number of columns comprising a main display column (i.e.: label, combobox, spacer)
-    _spacer_width = 35  # Width of the spacer columns in pixels
+    """Display dialog box to select the CAA image types to include and exclude from download and use."""
 
-    # Combo box index definitions
-    IDX_INCLUDE_TYPE = 0
-    IDX_IGNORE_TYPE = 1
-    IDX_EXCLUDE_TYPE = 2
+    # Dictionary of standard image type names by translated image type title
+    #   key:    image type title displayed in list boxes (translated by i18n)
+    #   value:  standard image type name
+    #
+    # This is used to return the include and exclude lists containing standard image
+    # type names based on the titles displayed in the list boxes in the dialog.
+    image_types_by_display_title = {}
 
     def __init__(self, parent=None, types_include=None, types_exclude=None):
         if types_include is None:
@@ -112,38 +168,80 @@ class CAATypesSelectorDialog(QtWidgets.QDialog):
         super().__init__(parent)
 
         self.setWindowTitle(_("Cover art types"))
-        self._items = {}
         self.layout = QtWidgets.QVBoxLayout(self)
+
+        # Populate display title / standard name dictionary
+        for caa_type in CAA_TYPES:
+            name = caa_type['name']
+            title = _(caa_type['title'])
+            self.image_types_by_display_title[title] = name
+
+        # Create list boxes for dialog
+        self.list_include = make_list_box()
+        self.list_exclude = make_list_box()
+        self.list_ignore = make_list_box()
+
+        # Populate list boxes from current settings
+        self.fill_lists(types_include, types_exclude)
+
+        self.list_include.clicked.connect(self.focus_set_include)
+        self.list_exclude.clicked.connect(self.focus_set_exclude)
+        self.list_ignore.clicked.connect(self.focus_set_ignore)
+
+        # Add instructions to the dialog box
+        instructions = QtWidgets.QLabel()
+        instructions.setText(_("Please select the contents of the image type 'Include' and 'Exclude' lists."))
+        instructions.setWordWrap(True)
+        instructions.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.layout.addWidget(instructions)
 
         grid = QtWidgets.QWidget()
         gridlayout = QtWidgets.QGridLayout()
-        # Set up spacer columns between type selection columns
-        spacer_column_index = self._subcolumns - 1  # index of first spacer column
-        while spacer_column_index < self._columns * self._subcolumns - 1:
-            gridlayout.setColumnMinimumWidth(spacer_column_index, self._spacer_width)
-            spacer_column_index += self._subcolumns
         grid.setLayout(gridlayout)
 
-        for index, caa_type in enumerate(CAA_TYPES):
-            row = index // self._columns
-            column = (index % self._columns) * self._subcolumns
-            name = caa_type["name"]
-            item = QtWidgets.QLabel()
-            item.setText(translate_caa_type(name))
-            gridlayout.addWidget(item, row, column)
-            column += 1
-            item = QtWidgets.QComboBox()
-            item.addItems([ _('Include'), _('Ignore'), _('Exclude'),])
-            if name in types_include:
-                item.setCurrentIndex(self.IDX_INCLUDE_TYPE) # Include coverart type
-            elif name in types_exclude:
-                item.setCurrentIndex(self.IDX_EXCLUDE_TYPE) # Exclude coverart type
-            else:
-                item.setCurrentIndex(self.IDX_IGNORE_TYPE)  # Ignore coverart type
-            self._items[item] = caa_type
-            gridlayout.addWidget(item, row, column)
+        row = 0
+        column = 0
+        item = QtWidgets.QLabel()
+        item.setText(_("Include types list"))
+        gridlayout.addWidget(item, row, column)
+
+        column = 4
+        item = QtWidgets.QLabel()
+        item.setText(_("Exclude types list"))
+        gridlayout.addWidget(item, row, column)
+
+        row = 1
+        column = 0
+        gridlayout.addWidget(self.list_include, row, column)
+
+        column = 1
+        self.arrows_include = make_arrows_column(self.add_include, self.add_include_all, self.remove_include, self.remove_include_all)
+        gridlayout.addWidget(self.arrows_include, row, column)
+
+        column = 2
+        gridlayout.addWidget(self.list_ignore, row, column)
+
+        column = 3
+        self.arrows_exclude = make_arrows_column(self.add_exclude, self.add_exclude_all, self.remove_exclude, self.remove_exclude_all, reverse=True)
+        gridlayout.addWidget(self.arrows_exclude, row, column)
+
+        column = 4
+        gridlayout.addWidget(self.list_exclude, row, column)
 
         self.layout.addWidget(grid)
+
+        # Add usage explanation to the dialog box
+        instructions = QtWidgets.QLabel()
+        instructions.setText(_(
+            "CAA images with an image type found in the 'Include' list will be downloaded and used "
+            "UNLESS they also have an image type found in the 'Exclude' list. Images with types "
+            "found in the 'Exclude' list will NEVER be used. Image types not appearing in the 'Include' "
+            "or 'Exclude' lists will not be considered when determining whether or not to download and "
+            "use a CAA image.\n")
+        )
+        instructions.setWordWrap(True)
+        instructions.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.layout.addWidget(instructions)
 
         self.buttonbox = QtWidgets.QDialogButtonBox(self)
         self.buttonbox.setOrientation(QtCore.Qt.Horizontal)
@@ -155,12 +253,13 @@ class CAATypesSelectorDialog(QtWidgets.QDialog):
             StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.HelpRole)
 
         extrabuttons = [
-            (N_("I&nclude all"), self.checkall),
-            (N_("E&xclude all"), self.uncheckall),
-            (N_("I&gnore all"), self.ignoreall),
+            (N_("I&nclude all"), self.include_all),
+            (N_("E&xclude all"), self.exclude_all),
+            (N_("C&lear all"), self.clear_all),
+            (N_("Restore &Defaults"), self.reset_to_defaults),
         ]
         for label, callback in extrabuttons:
-            button = QtWidgets.QPushButton(_(label))
+            button = QtWidgets.QPushButton(label)
             button.setSizePolicy(
                 QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Expanding)
             self.buttonbox.addButton(button, QtWidgets.QDialogButtonBox.ActionRole)
@@ -172,29 +271,134 @@ class CAATypesSelectorDialog(QtWidgets.QDialog):
         self.buttonbox.rejected.connect(self.reject)
         self.buttonbox.helpRequested.connect(self.help)
 
+        self.fix_buttons()
+
+    def fill_lists(self, includes, excludes):
+        """Fill dialog listboxes.
+
+        First clears the contents of the three listboxes, and then populates the listboxes
+        from the dictionary of translated standard CAA types, using the provided 'includes'
+        and 'excludes' lists to determine the appropriate list for each type.
+
+        Arguments:
+            includes -- list of standard image types to place in the "Include" listbox
+            excludes -- list of standard image types to place in the "Exclude" listbox
+        """
+        self.list_include.clear()
+        self.list_exclude.clear()
+        self.list_ignore.clear()
+        for title in self.image_types_by_display_title:
+            name = self.image_types_by_display_title[title]
+            if name in includes:
+                self.list_include.addItem(title)
+            elif name in excludes:
+                self.list_exclude.addItem(title)
+            else:
+                self.list_ignore.addItem(title)
+
     def help(self):
         webbrowser2.goto('doc_cover_art_types')
 
-    def uncheckall(self):
-        self._set_checked_all(2)
+    def add_include(self):
+        move_selected_items(self.list_ignore, self.list_include)
+        self.fix_buttons()
 
-    def checkall(self):
-        self._set_checked_all(0)
+    def remove_include(self):
+        move_selected_items(self.list_include, self.list_ignore)
+        self.fix_buttons()
 
-    def ignoreall(self):
-        self._set_checked_all(1)
+    def add_include_all(self):
+        move_all_items(self.list_ignore, self.list_include)
+        self.fix_buttons()
 
-    def _set_checked_all(self, value):
-        for item in self._items.keys():
-            item.setCurrentIndex(value)
+    def remove_include_all(self):
+        move_all_items(self.list_include, self.list_ignore)
+        self.fix_buttons()
+
+    def add_exclude(self):
+        move_selected_items(self.list_ignore, self.list_exclude)
+        self.fix_buttons()
+
+    def remove_exclude(self):
+        move_selected_items(self.list_exclude, self.list_ignore)
+        self.fix_buttons()
+
+    def add_exclude_all(self):
+        move_all_items(self.list_ignore, self.list_exclude)
+        self.fix_buttons()
+
+    def remove_exclude_all(self):
+        move_all_items(self.list_exclude, self.list_ignore)
+        self.fix_buttons()
+
+    def include_all(self):
+        move_all_items(self.list_ignore, self.list_include)
+        move_all_items(self.list_exclude, self.list_include)
+        self.fix_buttons()
+
+    def exclude_all(self):
+        move_all_items(self.list_ignore, self.list_exclude)
+        move_all_items(self.list_include, self.list_exclude)
+        self.fix_buttons()
+
+    def clear_all(self):
+        move_all_items(self.list_include, self.list_ignore)
+        move_all_items(self.list_exclude, self.list_ignore)
+        self.fix_buttons()
 
     def get_selected_types_include(self):
-        return [typ['name'] for item, typ in self._items.items() if
-                item.currentIndex() == self.IDX_INCLUDE_TYPE] or ['front']
+        return [self.image_types_by_display_title[self.list_include.item(index).text()] for index in range(self.list_include.count())] or ['front']
 
     def get_selected_types_exclude(self):
-        return [typ['name'] for item, typ in self._items.items() if
-                item.currentIndex() == self.IDX_EXCLUDE_TYPE] or ['none']
+        return [self.image_types_by_display_title[self.list_exclude.item(index).text()] for index in range(self.list_exclude.count())] or ['none']
+
+    def focus_set_include(self):
+        clear_listbox_focus(self.list_exclude)
+        clear_listbox_focus(self.list_ignore)
+        self.fix_buttons()
+
+    def focus_set_exclude(self):
+        clear_listbox_focus(self.list_include)
+        clear_listbox_focus(self.list_ignore)
+        self.fix_buttons()
+
+    def focus_set_ignore(self):
+        clear_listbox_focus(self.list_include)
+        clear_listbox_focus(self.list_exclude)
+        self.fix_buttons()
+
+    def focus_clear_all(self):
+        clear_listbox_focus(self.list_include)
+        clear_listbox_focus(self.list_exclude)
+        clear_listbox_focus(self.list_ignore)
+        self.fix_buttons()
+
+    def reset_to_defaults(self):
+        self.fill_lists(_CAA_IMAGE_TYPE_DEFAULT_INCLUDE, _CAA_IMAGE_TYPE_DEFAULT_EXCLUDE)
+        self.fix_buttons()
+
+    def fix_buttons(self):
+        has_items_include = self.list_include.count()
+        has_items_exclude = self.list_exclude.count()
+        has_items_ignore = self.list_ignore.count()
+
+        has_selected_include = True if self.list_include.selectedItems() else False
+        has_selected_exclude = True if self.list_exclude.selectedItems() else False
+        has_selected_ignore = True if self.list_ignore.selectedItems() else False
+
+        # "Include" list buttons
+        buttons = self.arrows_include.findChildren(QtWidgets.QPushButton)
+        buttons[0].setEnabled(has_items_ignore and has_selected_ignore)     # '<'
+        buttons[1].setEnabled(has_items_ignore)                             # '<<'
+        buttons[2].setEnabled(has_items_include and has_selected_include)   # '>'
+        buttons[3].setEnabled(has_items_include)                            # '>>'
+
+        # "Exclude" list buttons
+        buttons = self.arrows_exclude.findChildren(QtWidgets.QPushButton)
+        buttons[0].setEnabled(has_items_ignore and has_selected_ignore)     # '>'
+        buttons[1].setEnabled(has_items_ignore)                             # '>>'
+        buttons[2].setEnabled(has_items_exclude and has_selected_exclude)   # '<'
+        buttons[3].setEnabled(has_items_exclude)                            # '<<'
 
     @staticmethod
     def run(parent=None, types_include=None, types_exclude=None):
@@ -218,9 +422,9 @@ class ProviderOptionsCaa(ProviderOptions):
         config.BoolOption("setting", "caa_image_type_as_filename", False),
         config.IntOption("setting", "caa_image_size",
                          _CAA_IMAGE_SIZE_DEFAULT),
-        config.ListOption("setting", "caa_image_types", ["front"]),
+        config.ListOption("setting", "caa_image_types", _CAA_IMAGE_TYPE_DEFAULT_INCLUDE),
         config.BoolOption("setting", "caa_restrict_image_types", True),
-        config.ListOption("setting", "caa_image_types_to_omit", ["raw/unedited"]),
+        config.ListOption("setting", "caa_image_types_to_omit", _CAA_IMAGE_TYPE_DEFAULT_EXCLUDE),
     ]
 
     _options_ui = Ui_CaaOptions
@@ -405,7 +609,7 @@ class CoverArtProviderCaa(CoverArtProvider):
                         if types and self.caa_types_to_omit:
                             types = not set(image["types"]).intersection(
                                 set(self.caa_types_to_omit))
-                        log.debug('CAA Image %s: %s  %s' % ('accepted' if types else 'rejected', image['image'], image['types'],))
+                        log.debug('CAA image %s: %s  %s' % ('accepted' if types else 'rejected', image['image'], image['types'],))
                     else:
                         types = True
                     if types:

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -111,8 +111,6 @@ class ArrowButton(QtWidgets.QPushButton):
     ARROW_BUTTON_HEIGHT = 20
 
     def __init__(self, label, command=None, parent=None):
-        if label is None:
-            label = '.'
         super().__init__(label, parent=parent)
         if command is not None:
             self.clicked.connect(command)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: This change provides the user with the option of excluding selected cover art types from downloading from CAA.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
[STYLE-980](https://tickets.metabrainz.org/browse/STYLE-980) has added a new cover art style "Raw / Unedited".  Although beneficial for identifying and allowing better images for archival purposes, the images within this type are generally not suitable for tagging purposes.  Picard currently allows the user to select the types of images to download from CAA, but does not provide the ability to exclude selected image types from being downloaded.

* JIRA ticket: [PICARD-1273](https://tickets.metabrainz.org/browse/PICARD-1273): Add an option to exclude new cover art type "Raw / Unedited"
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
This change adds new user settings to indicate whether selected image types should be excluded from downloads from CAA and the list of image types to be excluded, similar to the option to only include selected image types.  Additional logic is applied to the list of images selected for download, and any images with a type intersecting the user's "exclusion" type list are removed from the download list.

Generally speaking, the current logic for determining whether to download an image is (where the image is downloaded when "types" evaluates to True):

    if self.restrict_types:
        # only keep enabled caa types
        types = set(image["types"]).intersection(
            set(self.caa_types))
    else:
        types = True

This change adds a further check for exclusion, as:

    if self.restrict_types:
        # only keep enabled caa types
        types = set(image["types"]).intersection(
            set(self.caa_types))
    else:
        types = True
    if types and self.omit_types:
        # omit selected caa types
        types = not set(image["types"]).intersection(
            set(self.caa_types_to_omit))



# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Currently, it appears that CAA does not return the new "Raw/Unedited" type in the list of image types associated with an image.  This is described (with an example) in [CAA-113](https://tickets.metabrainz.org/browse/CAA-113): CAA does not return "Raw/Unedited" in image type array.  This will need to be addressed before the proposed changes will work.
