### PR TITLE
PICARD-1302, PICARD-1303, PICARD-1304: Fix crashes

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -150,10 +150,13 @@ class Metadata(dict):
         except (ValueError, KeyError):
             pass
         else:
-            if "title" in weights:
-                b = release['media'][0]['track-count']
-            else:
-                b = release['track-count']
+            try:
+                if "title" in weights:
+                    b = release['media'][0]['track-count']
+                else:
+                    b = release['track-count']
+            except KeyError:
+                b = 0
             score = 0.0 if a > b else 0.3 if a < b else 1.0
             parts.append((score, weights["totaltracks"]))
 
@@ -172,7 +175,7 @@ class Metadata(dict):
             parts.append((score, weights["releasecountry"]))
 
         total_formats = len(preferred_formats)
-        if total_formats:
+        if total_formats and 'media' in release:
             score = 0.0
             subtotal = 0
             for medium in release['media']:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -355,7 +355,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 port = 443
             else:
                 port = 80
-            self.tagger.webservice.get(string_(url.encodedHost()), url.port(port), string_(path),
+            self.tagger.webservice.get(url.host(), url.port(port), string_(path),
                                   partial(self.on_remote_image_fetched, url, fallback_data=fallback_data),
                                   parse_response_type=None,
                                   priority=True, important=True)
@@ -369,11 +369,12 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
     def on_remote_image_fetched(self, url, data, reply, error, fallback_data=None):
         mime = reply.header(QtNetwork.QNetworkRequest.ContentTypeHeader)
+        url_query = QtCore.QUrlQuery(url.query())
         if mime in ('image/jpeg', 'image/png'):
             self.load_remote_image(url, mime, data)
-        elif url.hasQueryItem("imgurl"):
+        elif url_query.hasQueryItem("imgurl"):
             # This may be a google images result, try to get the URL which is encoded in the query
-            url = QtCore.QUrl(url.queryItemValue("imgurl"))
+            url = QtCore.QUrl(url_query.queryItemValue("imgurl"))
             self.fetch_remote_image(url)
         else:
             log.warning("Can't load remote image with MIME-Type %s", mime)

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -19,6 +19,7 @@
 
 from collections import namedtuple
 import os.path
+import re
 import traceback
 from PyQt5 import QtGui, QtCore, QtWidgets
 from picard import log
@@ -357,7 +358,12 @@ class ClusterInfoDialog(InfoDialog):
             try:
                 return int(item.tracknumber)
             except:
-                return item.tracknumber or 0
+                try:
+                    # This allows to parse values like '3' but also '3/10'
+                    m = re.search('^\d+', item.tracknumber)
+                    return int(m.group(0))
+                except:
+                    return 0
 
         lines = ["%s %s - %s (%s)" % item for item in sorted(tracklist, key=sorttracknum)]
         info.append("<b>%s</b><br />%s" % (_('Tracklist:'),

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -357,7 +357,7 @@ class ClusterInfoDialog(InfoDialog):
             try:
                 return int(item.tracknumber)
             except:
-                return item.tracknumber
+                return item.tracknumber or 0
 
         lines = ["%s %s - %s (%s)" % item for item in sorted(tracklist, key=sorttracknum)]
         info.append("<b>%s</b><br />%s" % (_('Tracklist:'),

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -357,12 +357,12 @@ class ClusterInfoDialog(InfoDialog):
         def sorttracknum(item):
             try:
                 return int(item.tracknumber)
-            except:
+            except ValueError:
                 try:
                     # This allows to parse values like '3' but also '3/10'
                     m = re.search('^\d+', item.tracknumber)
                     return int(m.group(0))
-                except:
+                except AttributeError:
                     return 0
 
         lines = ["%s %s - %s (%s)" % item for item in sorted(tracklist, key=sorttracknum)]


### PR DESCRIPTION
# Summary

Fix two crashes.

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

- Fix crash when using drag&drop from Google Images to the coverartbox widget due to code not being fully ported from Qt4 to Qt5.
- Fix crash due to KeyError exceptions when trying to match a cluster with a release that doesn't have any track in musicbrainz.
- Fix crash when a cluster has a file with track number and a file without any track number information and the user opens the info dialog on the cluster.

# Solution

- Ported code to Qt5
- Catch and handle exceptions properly
- Treat files with no track number as having track number 0.