### PR TITLE
PICARD-1207: Fix handling paths with unicode characters on python3

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -206,12 +206,11 @@ class File(QtCore.QObject, Item):
             return None
         new_filename = old_filename
         if not config.setting["dont_write_tags"]:
-            encoded_old_filename = encode_filename(old_filename)
-            info = os.stat(encoded_old_filename)
+            info = os.stat(old_filename)
             self._save(old_filename, metadata)
             if config.setting["preserve_timestamps"]:
                 try:
-                    os.utime(encoded_old_filename, (info.st_atime, info.st_mtime))
+                    os.utime(old_filename, (info.st_atime, info.st_mtime))
                 except OSError:
                     log.warning("Couldn't preserve timestamp for %r", old_filename)
         # Rename files
@@ -222,7 +221,7 @@ class File(QtCore.QObject, Item):
             self._move_additional_files(old_filename, new_filename)
         # Delete empty directories
         if config.setting["delete_empty_dirs"]:
-            dirname = encode_filename(os.path.dirname(old_filename))
+            dirname = os.path.dirname(old_filename)
             try:
                 self._rmdir(dirname)
                 head, tail = os.path.split(dirname)
@@ -380,17 +379,17 @@ class File(QtCore.QObject, Item):
             return old_filename
 
         new_dirname = os.path.dirname(new_filename)
-        if not os.path.isdir(encode_filename(new_dirname)):
+        if not os.path.isdir(new_dirname):
             os.makedirs(new_dirname)
         tmp_filename = new_filename
         i = 1
         while (not pathcmp(old_filename, new_filename + ext) and
-               os.path.exists(encode_filename(new_filename + ext))):
+               os.path.exists(new_filename + ext)):
             new_filename = "%s (%d)" % (tmp_filename, i)
             i += 1
         new_filename = new_filename + ext
         log.debug("Moving file %r => %r", old_filename, new_filename)
-        shutil.move(encode_filename(old_filename), encode_filename(new_filename))
+        shutil.move(old_filename, new_filename)
         return new_filename
 
     def _save_images(self, dirname, metadata):
@@ -408,18 +407,18 @@ class File(QtCore.QObject, Item):
 
     def _move_additional_files(self, old_filename, new_filename):
         """Move extra files, like playlists..."""
-        old_path = encode_filename(os.path.dirname(old_filename))
-        new_path = encode_filename(os.path.dirname(new_filename))
-        patterns = encode_filename(config.setting["move_additional_files_pattern"])
+        old_path = os.path.dirname(old_filename)
+        new_path = os.path.dirname(new_filename)
+        patterns = config.setting["move_additional_files_pattern"]
         patterns = [string_(p.strip()) for p in patterns.split() if p.strip()]
         try:
-            names = list(map(encode_filename, os.listdir(old_path)))
+            names = os.listdir(old_path)
         except os.error:
             log.error("Error: {} directory not found".naming_format(old_path))
             return
         filtered_names = [name for name in names if name[0] != "."]
         for pattern in patterns:
-            pattern_regex = re.compile(encode_filename(fnmatch.translate(pattern)), re.IGNORECASE)
+            pattern_regex = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
             file_names = names
             if pattern[0] != '.':
                 file_names = filtered_names

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import os.path
+import picard.formats
+import unittest
+import shutil
+from contextlib import suppress
+
+from PyQt5 import QtCore
+from picard import config
+from tempfile import mkdtemp
+from test.test_formats import FakeTagger
+
+
+settings = {
+    'enabled_plugins': '',
+    'move_files': True,
+    'move_additional_files': True,
+    'move_additional_files_pattern': 'cover.jpg',
+}
+
+
+class TestFileSystem(unittest.TestCase):
+
+    def setUp(self):
+        self.src_directory = mkdtemp()
+        self.tgt_directory = mkdtemp()
+        QtCore.QObject.tagger = FakeTagger()
+        config.setting = settings.copy()
+
+    def tearDown(self):
+        shutil.rmtree(self.src_directory)
+        shutil.rmtree(self.tgt_directory)
+
+    def _set_up_src_file(self, filename, src_rel_path):
+        """Copy filename to the src directory under src_rel_path."""
+        path = os.path.join(self.src_directory, src_rel_path)
+        shutil.copy(filename, path)
+        return path
+
+    def _set_up_tgt_filename(self, tgt_rel_path):
+        """Return the absolute path to tgt_rel_path in the tgt directory."""
+        return os.path.join(self.tgt_directory, tgt_rel_path)
+
+    def _prepare_files(self, src_rel_path='', tgt_rel_path=''):
+        """Prepare src files and tgt filenames for a test."""
+        with suppress(FileExistsError):
+            os.mkdir(os.path.join(self.src_directory, src_rel_path))
+
+        # Prepare the source directory structure under self.src_directory
+        # .../<src_rel_path>/test.mp3
+        # .../<src_rel_path>/cover.jpg
+
+        old_filename = self._set_up_src_file(os.path.join('test', 'data', 'test.mp3'),
+                                             os.path.join(src_rel_path, 'test.mp3'))
+        old_additional_filename = self._set_up_src_file(os.path.join('test', 'data', 'mb.jpg'),
+                                                        os.path.join(src_rel_path, 'cover.jpg'))
+
+        with suppress(FileExistsError):
+            os.mkdir(os.path.join(self.tgt_directory, tgt_rel_path))
+
+        # Prepare the target filenames under self.tgt_directory
+        # .../<tgt_rel_path>/test.mp3
+        # .../<tgt_rel_path>/cover.jpg
+
+        new_filename = self._set_up_tgt_filename(os.path.join(tgt_rel_path, 'test.mp3'))
+
+        new_additional_filename = self._set_up_tgt_filename(os.path.join(tgt_rel_path, 'cover.jpg'))
+
+        return (old_filename, old_additional_filename, new_filename, new_additional_filename)
+
+    def test_move_additional_files_source_unicode(self):
+        files = self._prepare_files(src_rel_path='música')
+        (old_filename, old_additional_filename, new_filename, new_additional_filename) = files
+
+        f = picard.formats.open_(old_filename)
+        f._move_additional_files(old_filename, new_filename)
+
+        self.assertTrue(os.path.isfile(new_additional_filename))
+        self.assertFalse(os.path.isfile(old_additional_filename))
+
+    def test_move_additional_files_target_unicode(self):
+        files = self._prepare_files(tgt_rel_path='música')
+        (old_filename, old_additional_filename, new_filename, new_additional_filename) = files
+
+        f = picard.formats.open_(old_filename)
+        f._move_additional_files(old_filename, new_filename)
+
+        self.assertTrue(os.path.isfile(new_additional_filename))
+        self.assertFalse(os.path.isfile(old_additional_filename))

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -39,6 +39,7 @@ class FakeTagger(QtCore.QObject):
         QtCore.QObject.log = log
         self.tagger_stats_changed.connect(self.emit)
         self.exit_cleanup = []
+        self.files = {}
 
     def register_cleanup(self, func):
         self.exit_cleanup.append(func)


### PR DESCRIPTION
# Summary

Fix a crash moving additional files when their full path contains non-ascii characters.

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem
When moving additional files, the call to ```encode_filename``` encodes the path to the original filename converting the variable from str to bytes, provoking the next exception . ```shutil.move``` only accepts strings (the documentation don't specifically mention that for ```shutil.move```, but it does for [```copy```](https://docs.python.org/3/library/shutil.html#shutil.copy), ```copyfile```, ```copymode```, etc. and the error makes clear the same is true for ```shutil.move```)

Traceback (most recent call last):
  File "./picard/util/thread.py", line 47, in run
    result = self.func()
  File "./picard/file.py", line 222, in _save_and_rename
    self._move_additional_files(old_filename, new_filename)
  File "./picard/file.py", line 435, in _move_additional_files
    shutil.move(old_file, new_file)
  File "/usr/x86_64-pc-linux-gnu/lib/python3.6/shutil.py", line 551, in move
    if _destinsrc(src, dst):
  File "/usr/x86_64-pc-linux-gnu/lib/python3.6/shutil.py", line 565, in _destinsrc
    if not src.endswith(os.path.sep):
TypeError: endswith first arg must be bytes or a tuple of bytes, not str

* JIRA ticket: [PICARD-1207](https://tickets.metabrainz.org/browse/PICARD-1207)

# Solution

I removed the calls to ```encode_filename``` in ```file.py```, which convert the strings to bytes and breaks the call to ```shutil.move``` which require a string to be passed (as mentioned above).

Also, other functions like ```os.path.dirname```, ```os.path.isdir```, ```os.stat```, ```os.utime``` ... allow to be passed a string, instead of the encoded path in a bytes variable. So I removed the use of ```encode_filename``` for all cases that either require or allow a string to be passed so we don't do unnecessary processing neither.