### PR TITLE
PICARD-1305: Fix crash when the file doesn't belong to an album

### DIFF
--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -197,10 +197,11 @@ class TrackSearchDialog(SearchDialog):
                 # No files associated. Just a normal search.
                 self.tagger.load_album(track["musicbrainz_albumid"])
         else:
-            if self.file_:
+            if self.file_ and getattr(self.file_.parent, 'album', None):
                 album = self.file_.parent.album
-                self.tagger.move_file_to_nat(track["musicbrainz_recordingid"])
+                self.tagger.move_file_to_nat(self.file_, track["musicbrainz_recordingid"], node)
                 if album._files == 0:
                     self.tagger.remove_album(album)
             else:
                 self.tagger.load_nat(track["musicbrainz_recordingid"], node)
+                self.tagger.move_file_to_nat(self.file_, track["musicbrainz_recordingid"], node)


### PR DESCRIPTION
If the file doesn't belong to an album, we have to load a NAT and then move the file there. Also fix the call to self.tagger.move_file_to_nat which was missing a parameter (the file to move)

# Summary

Fix a picard crash when the "search for a similar track" dialog is opened and a recording with no album
is selected.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* Load a recording as a NAT correctly when the recording doesn't have an album.

# Problem

Picard crashes with the following backtrace when a recording like https://musicbrainz.org/recording/7f7dfdc4-c5ed-45b3-9363-a403ddff8445 is selected in the search dialog. 

Traceback (most recent call last): 
 File "/usr/lib64/python3.6/site-packages/picard/ui/searchdialog/_init_.py", line 345, in accept 
   self.accept_event(row) 
 File "/usr/lib64/python3.6/site-packages/picard/ui/searchdialog/track.py", line 172, in accept_event 
   self.load_selection(arg) 
 File "/usr/lib64/python3.6/site-packages/picard/ui/searchdialog/track.py", line 201, in load_selection 
   album = self.file_.parent.album 
AttributeError: 'Cluster' object has no attribute 'album'
Aborted (core dumped)

This can be reproduced with any file by opening the dialog and changing the query to "track:(la vie en rose) artist:(Emilie Simon)" and selecting the first result.

* JIRA ticket (_optional_): [PICARD-1305](https://tickets.metabrainz.org/browse/PICARD-1305)

# Solution

Check if the file parent contains an album attribute before accesing it, and falling back to loading the recording as a nat and assigning the file to it if there's no album.