### PR TITLE
PICARD-1306: Fix crash opening the options dialog if cwd doesn't exist

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -369,7 +369,13 @@ class File(QtCore.QObject, Item):
                 if sys.platform == "darwin":
                     new_filename = unicodedata.normalize("NFD", new_filename)
 
-        return os.path.realpath(os.path.join(new_dirname, new_filename))
+        new_path = os.path.join(new_dirname, new_filename)
+        try:
+            return os.path.realpath(new_path)
+        except FileNotFoundError:
+            # os.path.realpath can fail if cwd doesn't exist
+            return new_path
+
 
     def _rename(self, old_filename, metadata):
         new_filename, ext = os.path.splitext(

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -23,6 +23,7 @@ import struct
 import sys
 import unicodedata
 from picard.util import _io_encoding, decode_filename, encode_filename
+from PyQt5.QtCore import QStandardPaths
 
 
 def _get_utf16_length(text):
@@ -301,7 +302,12 @@ def make_short_filename(basedir, relpath, win_compat=False, relative_to=""):
     """
     # only deal with absolute paths. it saves a lot of grief,
     # and is the right thing to do, even for renames.
-    basedir = os.path.abspath(basedir)
+    try:
+        basedir = os.path.abspath(basedir)
+    except FileNotFoundError:
+        # os.path.abspath raises an exception if basedir is a relative path and
+        # cwd doesn't exist anymore
+        basedir = QStandardPaths.writableLocation(QStandardPaths.MusicLocation)
     # also, make sure the relative path is clean
     relpath = os.path.normpath(relpath)
     if win_compat and relative_to:


### PR DESCRIPTION
# Summary

picard crashes when opening the options dialog if the cwd doesn't exist

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

The way to reproduce it:

```
mkdir foo
cd foo
picard .
```
Now on a different terminal, do ```rmdir foo```

And on Picard, open the Options dialog. Picard will crash due to a call to os.getcwd() raising an exception inside os.path.abspath/realpath .

* JIRA ticket: [PICARD-1306](https://tickets.metabrainz.org/browse/PICARD-1306)

# Solution

Handle FileNotFoundError exceptions raised from os.path.abspath and
os.path.realpath used by the options dialog for the examples in the
file naming tab.