### PR TITLE
PICARD-1314: originalalbum/originalartist mappings for APE and ASF

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -66,6 +66,7 @@ class APEv2File(File):
         "MUSICBRAINZ_ALBUMTYPE": "releasetype",
         "musicbrainz_trackid": "musicbrainz_recordingid",
         "musicbrainz_releasetrackid": "musicbrainz_trackid",
+        "Original Artist": "originalartist",
     }
     __rtranslate = dict([(v, k) for k, v in __translate.items()])
 

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -97,6 +97,8 @@ class ASFFile(File):
         'artist': 'Author',
         'albumartist': 'WM/AlbumArtist',
         'date': 'WM/Year',
+        'originalalbum': 'WM/OriginalAlbumTitle',
+        'originalartist': 'WM/OriginalArtist',
         'originaldate': 'WM/OriginalReleaseTime',
         'originalyear': 'WM/OriginalReleaseYear',
         'composer': 'WM/Composer',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Curently the tags originalalbum and originalartist are not fully mapped to supported tagging formats. This PR tries to improve the situation for WMA and APE.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1314](https://tickets.metabrainz.org/browse/PICARD-1314)
* JIRA ticket (_optional_): [PICARD-1407](https://tickets.metabrainz.org/browse/PICARD-1407)
* JIRA ticket (_optional_): [PICARD-1408](https://tickets.metabrainz.org/browse/PICARD-1408)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
I think uncontroversial changes are:
- ASF: Map to `WM/OriginalAlbumTitle` and `WM/OriginalArtist`
- Ape: Map `originalartist` to `Original Artist`

Supported this way by Media Monkey, Jaikoz. See

- http://www.jthink.net/jaudiotagger/tagmapping.html
- https://www.mediamonkey.com/sw/webhelp/frame/index.html?abouttrackproperties.htm
- https://help.mp3tag.de/main_tags.html