### PR TITLE
PICARD-1319: Provide cover art metadata in cover art naming script

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -38,6 +38,7 @@ from picard import (
     log,
 )
 from picard.coverart.utils import translate_caa_type
+from picard.metadata import Metadata
 from picard.script import ScriptParser
 from picard.util import (
     decode_filename,
@@ -261,7 +262,15 @@ class CoverArtImage:
         # TODO: do something better than randomly using the first in the list
         return self.types[0]
 
-    def _make_image_filename(self, filename, dirname, metadata):
+    def _make_image_filename(self, filename, dirname, _metadata):
+        metadata = Metadata()
+        metadata.copy(_metadata)
+        metadata["coverart_maintype"] = self.maintype
+        metadata["coverart_comment"] = self.comment
+        if self.is_front:
+            metadata.add_unique("coverart_types", "front")
+        for cover_type in self.types:
+            metadata.add_unique("coverart_types", cover_type)
         filename = ScriptParser().eval(filename, metadata)
         if config.setting["ascii_filenames"]:
             if isinstance(filename, str):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Allow the file naming script for cover art to access additional metadata about the cover art itself, such as types, maintype and comment. This will allow e.g. the filename to be based upon the image type.

* JIRA ticket (_optional_): [PICARD-1319](https://tickets.metabrainz.org/browse/PICARD-1319)



# Solution

Add the following additional metadata variables for the cover ar file name script:

- `coverart_maintype`: The main type of the artwork as determined by `CoverArtImage.maintype`
- ` coverart_types`: Full multivalue list of all types
- ` coverart_comment`: The cover art comment

This will allow something like this:

```
$if($eq(%coverart_maintype%,front),AlbumArt,%album%_%coverart_maintype%)
```

# Action

With this change we can discuss to also remove the CAA option "Use the first image type as the filename", since setting the file name to just `%coverart_maintype%` is equivalent to this.

