### PR TITLE
PICARD-1245: Add an option to save grouping and work compatible with iTunes

### DIFF
--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -26,6 +26,10 @@ from mutagen.id3 import (
 )
 
 
+class GRP1(TextFrame):
+    pass
+
+
 class TCMP(TextFrame):
     pass
 
@@ -60,6 +64,7 @@ class CompatID3(ID3):
         if args:
             known_frames = dict(Frames)
             known_frames.update(dict(Frames_2_2))
+            known_frames["GRP1"] = GRP1
             known_frames["TCMP"] = TCMP
             known_frames["TSO2"] = TSO2
             known_frames["TSOC"] = TSOC

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -52,6 +52,7 @@ class TagsOptionsPage(OptionsPage):
         config.BoolOption("setting", "remove_id3_from_flac", False),
         config.BoolOption("setting", "remove_ape_from_mp3", False),
         config.BoolOption("setting", "tpe2_albumartist", False),
+        config.BoolOption("setting", "itunes_compatible_grouping", False),
         config.BoolOption("setting", "dont_write_tags", False),
         config.BoolOption("setting", "preserve_timestamps", False),
     ]
@@ -86,6 +87,7 @@ class TagsOptionsPage(OptionsPage):
         self.ui.id3v23_join_with.setEditText(config.setting["id3v23_join_with"])
         self.ui.remove_ape_from_mp3.setChecked(config.setting["remove_ape_from_mp3"])
         self.ui.remove_id3_from_flac.setChecked(config.setting["remove_id3_from_flac"])
+        self.ui.itunes_compatible_grouping.setChecked(config.setting["itunes_compatible_grouping"])
         self.ui.preserved_tags.setText(config.setting["preserved_tags"])
         self.update_encodings()
 
@@ -107,6 +109,7 @@ class TagsOptionsPage(OptionsPage):
             config.setting["id3v2_encoding"] = "utf-8"
         config.setting["remove_ape_from_mp3"] = self.ui.remove_ape_from_mp3.isChecked()
         config.setting["remove_id3_from_flac"] = self.ui.remove_id3_from_flac.isChecked()
+        config.setting["itunes_compatible_grouping"] = self.ui.itunes_compatible_grouping.isChecked()
         config.setting["preserved_tags"] = self.ui.preserved_tags.text()
         self.tagger.window.enable_tag_saving_action.setChecked(not config.setting["dont_write_tags"])
 

--- a/picard/ui/ui_options_tags.py
+++ b/picard/ui/ui_options_tags.py
@@ -8,7 +8,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_TagsOptionsPage(object):
     def setupUi(self, TagsOptionsPage):
         TagsOptionsPage.setObjectName("TagsOptionsPage")
-        TagsOptionsPage.resize(539, 474)
+        TagsOptionsPage.resize(539, 476)
         self.vboxlayout = QtWidgets.QVBoxLayout(TagsOptionsPage)
         self.vboxlayout.setObjectName("vboxlayout")
         self.write_tags = QtWidgets.QCheckBox(TagsOptionsPage)
@@ -121,6 +121,9 @@ class Ui_TagsOptionsPage(object):
         self.id3v23_join_with.setItemText(2, " / ")
         self.hbox_id3v23_join_with.addWidget(self.id3v23_join_with)
         self.vboxlayout2.addLayout(self.hbox_id3v23_join_with)
+        self.itunes_compatible_grouping = QtWidgets.QCheckBox(self.tag_compatibility)
+        self.itunes_compatible_grouping.setObjectName("itunes_compatible_grouping")
+        self.vboxlayout2.addWidget(self.itunes_compatible_grouping)
         self.write_id3v1 = QtWidgets.QCheckBox(self.tag_compatibility)
         self.write_id3v1.setObjectName("write_id3v1")
         self.vboxlayout2.addWidget(self.write_id3v1)
@@ -163,5 +166,6 @@ class Ui_TagsOptionsPage(object):
         self.enc_iso88591.setText(_("ISO-8859-1"))
         self.label_id3v23_join_with.setText(_("Join multiple ID3v2.3 tags with:"))
         self.id3v23_join_with.setToolTip(_("<html><head/><body><p>Default is \'/\' to maintain compatibility with previous Picard releases.</p><p>New alternatives are \';_\' or \'_/_\' or type your own. </p></body></html>"))
+        self.itunes_compatible_grouping.setText(_("Save iTunes compatible grouping and work"))
         self.write_id3v1.setText(_("Also include ID3v1 tags in the files"))
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -59,14 +59,23 @@ class FakeTagger(QtCore.QObject):
         pass
 
 
+def save_metadata(filename, metadata):
+    f = picard.formats.open_(filename)
+    f._save(filename, metadata)
+
+
+def load_metadata(filename):
+    f = picard.formats.open_(filename)
+    return f._load(filename)
+
+
 def save_and_load_metadata(filename, metadata):
     """Save new metadata to a file and load it again."""
     f = picard.formats.open_(filename)
     loaded_metadata = f._load(filename)
     f._copy_loaded_metadata(loaded_metadata)
     f._save(filename, metadata)
-    f = picard.formats.open_(filename)
-    loaded_metadata = f._load(filename)
+    loaded_metadata = load_metadata(filename)
     return loaded_metadata
 
 
@@ -366,7 +375,6 @@ class CommonTests:
 
         @skipUnlessTestfile
         def test_id3v23_simple_tags(self):
-
             config.setting['write_id3v23'] = True
             metadata = Metadata()
             for (key, value) in self.tags.items():
@@ -375,39 +383,41 @@ class CommonTests:
             for (key, value) in self.tags.items():
                 self.assertEqual(loaded_metadata[key], value, '%s: %r != %r' % (key, loaded_metadata[key], value))
 
-        @skipUnlessTestfile
-        def test_standard_grouping(self):
+        @property
+        def itunes_grouping_metadata(self):
             metadata = Metadata()
             metadata['grouping'] = 'The Grouping'
             metadata['work'] = 'The Work'
+            return metadata
+
+        @skipUnlessTestfile
+        def test_standard_grouping(self):
+            metadata = self.itunes_grouping_metadata
+
+            config.setting['itunes_compatible_grouping'] = False
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
+
             self.assertEqual(loaded_metadata['grouping'], metadata['grouping'])
             self.assertEqual(loaded_metadata['work'], metadata['work'])
 
         @skipUnlessTestfile
         def test_itunes_compatible_grouping(self):
+            metadata = self.itunes_grouping_metadata
 
             config.setting['itunes_compatible_grouping'] = True
-            metadata = Metadata()
-            metadata['grouping'] = 'The Grouping'
-            metadata['work'] = 'The Work'
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
+
             self.assertEqual(loaded_metadata['grouping'], metadata['grouping'])
             self.assertEqual(loaded_metadata['work'], metadata['work'])
 
         @skipUnlessTestfile
         def test_always_read_grp1(self):
+            metadata = self.itunes_grouping_metadata
 
-            metadata = Metadata()
-            metadata['grouping'] = 'The Grouping'
-            metadata['work'] = 'The Work'
             config.setting['itunes_compatible_grouping'] = True
-            f = picard.formats.open_(self.filename)
-            f._save(self.filename, metadata)
-
+            save_metadata(self.filename, metadata)
             config.setting['itunes_compatible_grouping'] = False
-            f = picard.formats.open_(self.filename)
-            loaded_metadata = f._load(self.filename)
+            loaded_metadata = load_metadata(self.filename)
 
             self.assertIn(metadata['grouping'], loaded_metadata['grouping'])
             self.assertIn(metadata['work'], loaded_metadata['grouping'])
@@ -415,17 +425,12 @@ class CommonTests:
 
         @skipUnlessTestfile
         def test_always_read_txxx_work(self):
+            metadata = self.itunes_grouping_metadata
 
-            metadata = Metadata()
-            metadata['grouping'] = 'The Grouping'
-            metadata['work'] = 'The Work'
             config.setting['itunes_compatible_grouping'] = False
-            f = picard.formats.open_(self.filename)
-            f._save(self.filename, metadata)
-
+            save_metadata(self.filename, metadata)
             config.setting['itunes_compatible_grouping'] = True
-            f = picard.formats.open_(self.filename)
-            loaded_metadata = f._load(self.filename)
+            loaded_metadata = load_metadata(self.filename)
 
             self.assertIn(metadata['grouping'], loaded_metadata['work'])
             self.assertIn(metadata['work'], loaded_metadata['work'])

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -332,10 +332,6 @@ class CommonTests:
         @skipUnlessTestfile
         def test_performer_duplication(self):
 
-            def reset_id3_ver():
-                config.setting['write_id3v23'] = False
-
-            self.addCleanup(reset_id3_ver)
             config.setting['write_id3v23'] = True
             metadata = Metadata()
             tags = {
@@ -371,10 +367,7 @@ class CommonTests:
         @skipUnlessTestfile
         def test_id3v23_simple_tags(self):
 
-            def reset_to_id3v24():
-                config.setting['write_id3v23'] = False
             config.setting['write_id3v23'] = True
-            self.addCleanup(reset_to_id3v24)
             metadata = Metadata()
             for (key, value) in self.tags.items():
                 metadata[key] = value
@@ -394,10 +387,7 @@ class CommonTests:
         @skipUnlessTestfile
         def test_itunes_compatible_grouping(self):
 
-            def reset_itunes_compatible_grouping():
-                config.setting['itunes_compatible_grouping'] = False
             config.setting['itunes_compatible_grouping'] = True
-            self.addCleanup(reset_itunes_compatible_grouping)
             metadata = Metadata()
             metadata['grouping'] = 'The Grouping'
             metadata['work'] = 'The Work'
@@ -408,9 +398,6 @@ class CommonTests:
         @skipUnlessTestfile
         def test_always_read_grp1(self):
 
-            def reset_itunes_compatible_grouping():
-                config.setting['itunes_compatible_grouping'] = False
-            self.addCleanup(reset_itunes_compatible_grouping)
             metadata = Metadata()
             metadata['grouping'] = 'The Grouping'
             metadata['work'] = 'The Work'
@@ -429,9 +416,6 @@ class CommonTests:
         @skipUnlessTestfile
         def test_always_read_txxx_work(self):
 
-            def reset_itunes_compatible_grouping():
-                config.setting['itunes_compatible_grouping'] = False
-            self.addCleanup(reset_itunes_compatible_grouping)
             metadata = Metadata()
             metadata['grouping'] = 'The Grouping'
             metadata['work'] = 'The Work'

--- a/ui/options_tags.ui
+++ b/ui/options_tags.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>539</width>
-    <height>474</height>
+    <height>476</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
@@ -282,6 +282,13 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="itunes_compatible_grouping">
+        <property name="text">
+         <string>Save iTunes compatible grouping and work</string>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="write_id3v1">


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
For ID3 Picard is currently saving the `grouping` tag to `TIT1` and `work` to `TXXX:Work`. Originally iTunes actually used `TIT1` for grouping, but later repurposed `TIT1` to be used for the work name. For `grouping` they introduced the non-standard frame `GRP1`.

The result is that files tagged with Picard will show up wrong in iTunes: If you save the `grouping` tag it will instead be displayed as work name and saving `work` will actually not show up in iTunes at all.

The re-purposing of `TIT1` makes it difficult to deal with this in a generic manner. A lot of software followed Apple's original approach to use `TIT1` for grouping, so we can not simply change this to `GRP1`. Also using `TIT1` seems to be closer to the ID3 standard.

# Solution

This PR adds an option `itunes_compatible_grouping` to Tags -> Tag compatibility to change how Picard saves the tags `grouping` and `work` to ID3:

| itunes_compatible_grouping | False (default) | True   |
| -------------------------------------|--------------------|---------|
| grouping                                | TIT1                | GRP1 |
| work                                      | TXXX:Work      | TIT1 |

The default is disabled, which equals the existing behavior. The following screenshots demonstrate the result in iTunes. With standard settings the `grouping` tag will actually be displayed as the work name in iTunes, the `work` tag will not be displayed:

![standard-grouping](https://user-images.githubusercontent.com/29852/44590868-75fceb80-a7bc-11e8-8d3f-b435daaf6df5.png)

When enabling itunes_compatible_grouping both the work name and grouping will display correctly in iTunes:

![itunes-compatible-grouping](https://user-images.githubusercontent.com/29852/44590955-a3499980-a7bc-11e8-9f7e-e8adef45518d.png)
