### PR TITLE
PICARD-1321: Fix CD drive selection on Linux

### DIFF
--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -52,7 +52,7 @@ LINUX_CDROM_INFO = '/proc/sys/dev/cdrom/info'
 # if get_cdrom_drives() lists ALL drives available on the machine
 if sys.platform == 'win32':
     AUTO_DETECT_DRIVES = True
-elif sys.platform == 'linux2' and QFile.exists(LINUX_CDROM_INFO):
+elif sys.platform == 'linux' and QFile.exists(LINUX_CDROM_INFO):
     AUTO_DETECT_DRIVES = True
 else:
     # There might be more drives we couldn't detect
@@ -77,7 +77,7 @@ def get_cdrom_drives():
                 if GetDriveType(drive) == DRIVE_CDROM:
                     drives.append(drive)
 
-    elif sys.platform == 'linux2' and QFile.exists(LINUX_CDROM_INFO):
+    elif sys.platform == 'linux' and QFile.exists(LINUX_CDROM_INFO):
         # Read info from /proc/sys/dev/cdrom/info
         cdinfo = QFile(LINUX_CDROM_INFO)
         if cdinfo.open(QIODevice.ReadOnly | QIODevice.Text):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

In Picard 2 the CD drive selection is broken due to wrong check for the platform. Hence Picard falls back to show only a simple input for the device name.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1321](https://tickets.metabrainz.org/browse/PICARD-1321)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
In Python 3 sys.platform is 'linux' and no longer 'linux2'


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

