### PR TITLE
PICARD-1323: Restore all defaults resets CAA types

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -428,6 +428,11 @@ class ProviderOptionsCaa(ProviderOptions):
         self.ui.restrict_images_types.clicked.connect(self.update_caa_types)
         self.ui.select_caa_types.clicked.connect(self.select_caa_types)
 
+    def restore_defaults(self):
+        self.caa_image_types = _CAA_IMAGE_TYPE_DEFAULT_INCLUDE
+        self.caa_image_types_to_omit = _CAA_IMAGE_TYPE_DEFAULT_EXCLUDE
+        super().restore_defaults()
+
     def load(self):
         self.ui.cb_image_size.clear()
         for item_id, item in _CAA_THUMBNAIL_SIZE_MAP.items():
@@ -444,6 +449,8 @@ class ProviderOptionsCaa(ProviderOptions):
         self.ui.cb_type_as_filename.setChecked(config.setting["caa_image_type_as_filename"])
         self.ui.restrict_images_types.setChecked(
             config.setting["caa_restrict_image_types"])
+        self.caa_image_types = config.setting["caa_image_types"]
+        self.caa_image_types_to_omit = config.setting["caa_image_types_to_omit"]
         self.update_caa_types()
 
     def save(self):
@@ -457,6 +464,8 @@ class ProviderOptionsCaa(ProviderOptions):
             self.ui.cb_type_as_filename.isChecked()
         config.setting["caa_restrict_image_types"] = \
             self.ui.restrict_images_types.isChecked()
+        config.setting["caa_image_types"] = self.caa_image_types
+        config.setting["caa_image_types_to_omit"] = self.caa_image_types_to_omit
 
     def update_caa_types(self):
         enabled = self.ui.restrict_images_types.isChecked()
@@ -464,10 +473,10 @@ class ProviderOptionsCaa(ProviderOptions):
 
     def select_caa_types(self):
         (types, types_to_omit, ok) = CAATypesSelectorDialog.run(
-            self, config.setting["caa_image_types"], config.setting["caa_image_types_to_omit"])
+            self, self.caa_image_types, self.caa_image_types_to_omit)
         if ok:
-            config.setting["caa_image_types"] = types
-            config.setting["caa_image_types_to_omit"] = types_to_omit
+            self.caa_image_types = types
+            self.caa_image_types_to_omit = types_to_omit
 
 
 class CoverArtProviderCaa(CoverArtProvider):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


Using "Restore all defaults" doe snot reset the selected CAA cover art types.

Furthermore the CAA cover art types are saved immediately to settings after saving, no matter if the user closes the options dialog with "Make it so!" or "Cancel"


<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1323](https://tickets.metabrainz.org/browse/PICARD-1323)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
1. Make the CAA options page restore_defaults method also reset the CAA types
2. When closing the CAA types dialog don't immediately persist the selected types to settings but do so only if the options are actually saved
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

