### PR TITLE
PICARD-1267: Fixed Exception on Windows 10 when setting locale

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -43,15 +43,16 @@ def setup_gettext(localedir, ui_language=None, logger=None):
         from ctypes import windll
         try:
             current_locale = locale.windows_locale[windll.kernel32.GetUserDefaultUILanguage()]
+            current_locale += '.' + locale.getpreferredencoding()
             locale.setlocale(locale.LC_ALL, current_locale)
-        except KeyError:
+        except KeyError as e:
             os.environ["LANG"] = locale.getdefaultlocale()[0]
             try:
                 current_locale = locale.setlocale(locale.LC_ALL, "")
-            except:
-                pass
-        except:
-            pass
+            except Exception as e:
+                logger(e)
+        except Exception as e:
+            logger(e)
     elif not ui_language:
         if sys.platform == "darwin":
             try:
@@ -64,7 +65,7 @@ def setup_gettext(localedir, ui_language=None, logger=None):
         try:
             current_locale = locale.setlocale(locale.LC_ALL, "")
         except:
-            pass
+            logger(e)
     logger("Using locale %r", current_locale)
     try:
         logger("Loading gettext translation, localedir=%r", localedir)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Sometimes Picard crashes without further output on Windows 10. The only output is in the Windows event logs, and that doesn't tell much. The crash can be traced back to the call of `locale.setlocale`.

In the issue this is reported only for running from source, but I could also reproduce this when building an installer and running that. But at the same time recent builds (exactly same branch) from Appveyor work.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1267](https://tickets.metabrainz.org/browse/PICARD-1267)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

The attached change of using `locale + '.' + locale.getpreferredencoding()` fixes the issue for me.

This is also consistent with the non-win32 specific call to `setlocale` before.

I am not sure what the root cause is, because this worked on my system just yesterday and I never had this before. I did do cleanup the source dir though and did a clean build, maybe this changed something.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

- [x] will test an Appveyor build of this change: Test successful

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

