### PR TITLE
[2.0.x] PICARD-1322: Fix crash when using "Restore all defaults"

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -71,7 +71,7 @@ class CoverOptionsPage(OptionsPage):
 
     def restore_defaults(self):
         # Remove previous entries
-        self.provider_list_widget.clear()
+        self.ui.ca_providers_list.clear()
         super().restore_defaults()
 
     def ca_providers(self):


### PR DESCRIPTION
Backports the following commits to 2.0.x:
 - PICARD-1322: Fix crash when using "Restore all defaults" (#931)