### PR TITLE
PICARD-1329: Fix saving iTunNORM tags to ID3

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -358,9 +358,9 @@ class ID3File(File):
                     tmcl.people.append([role, value])
             elif name.startswith('comment:'):
                 desc = name.split(':', 1)[1]
-                if desc.lower()[:4] == "itun":
+                if desc.lower()[:4] == 'itun':
                     tags.delall('COMM:' + desc)
-                    tags.add(id3.COMM(encoding=0, desc=desc, lang='eng', text=[v + b'\x00' for v in values]))
+                    tags.add(id3.COMM(encoding=0, desc=desc, lang='eng', text=[v + '\x00' for v in values]))
                 else:
                     tags.add(id3.COMM(encoding=encoding, desc=desc, lang='eng', text=values))
             elif name.startswith('lyrics:') or name == 'lyrics':

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -436,6 +436,15 @@ class CommonTests:
             self.assertIn(metadata['work'], loaded_metadata['work'])
             self.assertEqual(loaded_metadata['grouping'], '')
 
+        @skipUnlessTestfile
+        def test_save_itunnorm_tag(self):
+            config.setting['clear_existing_tags'] = True
+            iTunNORM = '00001E86 00001E86 0000A2A3 0000A2A3 000006A6 000006A6 000078FA 000078FA 00000211 00000211'
+            metadata = Metadata()
+            metadata['comment:iTunNORM'] = iTunNORM
+            new_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertEqual(new_metadata['comment:iTunNORM'], iTunNORM)
+
 
 class FLACTest(CommonTests.FormatsTest):
     testfile = 'test.flac'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard fails to save ID3 tags that contain an iTunNORM comment, see https://community.metabrainz.org/t/cant-convert-bytes-object-to-str-implicitly/396592
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1329](https://tickets.metabrainz.org/browse/PICARD-1329)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

