### PR TITLE
Fix isort config to not skip __init__.py files (but few)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -19,5 +19,6 @@ multi_line_output=3
 order_by_type=True
 sections=FUTURE,STDLIB,THIRDPARTY,QT,LOCALFOLDER,RESOURCES,PICARD_UI
 skip_glob=**/picard/ui/ui_*.py
-skip=./tagger.py,picard/const/attributes.py,picard/const/countries.py,picard/resources.py,scripts/picard.in
+skip=./tagger.py,picard/const/attributes.py,picard/const/countries.py,picard/resources.py,scripts/picard.in,picard/const/__init__.py,picard/formats/__init__.py,picard/coverart/providers/__init__.py
+not_skip=__init__.py
 use_parentheses=1

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -19,7 +19,6 @@
 
 import re
 
-
 PICARD_ORG_NAME = "MusicBrainz"
 PICARD_APP_NAME = "Picard"
 PICARD_VERSION = (2, 0, 5, 'dev', 1)

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -19,11 +19,19 @@
 
 from collections import deque
 from functools import partial
+
 from PyQt5 import QtCore
-from picard import config, log
-from picard.const import FPCALC_NAMES
-from picard.util import find_executable, is_frozen
+
+from picard import (
+    config,
+    log,
+)
 from picard.acoustid.json_helpers import parse_recording
+from picard.const import FPCALC_NAMES
+from picard.util import (
+    find_executable,
+    is_frozen,
+)
 
 
 class AcoustIDClient(QtCore.QObject):

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -23,15 +23,23 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from functools import partial
 import traceback
 
-from picard.coverart.providers import cover_art_providers, CoverArtProvider
-
-from functools import partial
-from picard import config, log
-from picard.coverart.image import (CoverArtImageIOError,
-                                   CoverArtImageIdentificationError)
 from PyQt5.QtCore import QObject
+
+from picard import (
+    config,
+    log,
+)
+from picard.coverart.image import (
+    CoverArtImageIdentificationError,
+    CoverArtImageIOError,
+)
+from picard.coverart.providers import (
+    CoverArtProvider,
+    cover_art_providers,
+)
 
 
 class CoverArt:

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -19,8 +19,13 @@
 
 
 import uuid
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+
 from picard import config
-from PyQt5 import QtCore, QtWidgets
 from picard.util import restore_method
 
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -18,7 +18,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import re
+
 from PyQt5 import QtWidgets
+
 from picard import config
 from picard.plugin import ExtensionPoint
 

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -18,13 +18,34 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from PyQt5 import QtGui, QtCore, QtNetwork, QtWidgets
+from collections import (
+    OrderedDict,
+    namedtuple,
+)
+
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtNetwork,
+    QtWidgets,
+)
 from PyQt5.QtCore import pyqtSignal
-from collections import namedtuple, OrderedDict
-from picard import config, log
+
+from picard import (
+    config,
+    log,
+)
+from picard.util import (
+    icontheme,
+    restore_method,
+    throttle,
+)
+
 from picard.ui import PicardDialog
-from picard.ui.util import StandardButton, ButtonLineEdit
-from picard.util import icontheme, throttle, restore_method
+from picard.ui.util import (
+    ButtonLineEdit,
+    StandardButton,
+)
 
 
 class ResultTable(QtWidgets.QTableWidget):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -17,22 +17,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+import builtins
 import html
 import json
-import os
 import ntpath
+import os
 import re
+from string import Template
 import sys
+from time import time
 import unicodedata
-import builtins
+
+from PyQt5 import QtCore
+
+# Required for compatibility with lastfmplus which imports this from here rather than loading it direct.
+from picard.const import MUSICBRAINZ_SERVERS
+
 if sys.platform == 'win32':
     from ctypes import windll
 
-from time import time
-from PyQt5 import QtCore
-from string import Template
-# Required for compatibility with lastfmplus which imports this from here rather than loading it direct.
-from picard.const import MUSICBRAINZ_SERVERS
 
 # These variables are set by pyinstaller if running from a packaged build
 # See http://pyinstaller.readthedocs.io/en/stable/runtime-information.html

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -24,22 +24,40 @@
 Asynchronous web service.
 """
 
-import sys
-import time
+from collections import (
+    defaultdict,
+    deque,
+    namedtuple,
+)
+from functools import partial
+import math
 import os.path
 import platform
-import math
-from collections import deque, defaultdict, namedtuple
-from functools import partial
-from PyQt5 import QtCore, QtNetwork
-from PyQt5.QtCore import QUrl, QStandardPaths, QUrlQuery
-from picard import (PICARD_APP_NAME,
-                    PICARD_ORG_NAME,
-                    PICARD_VERSION_STR,
-                    config,
-                    log)
+import sys
+import time
+
+from PyQt5 import (
+    QtCore,
+    QtNetwork,
+)
+from PyQt5.QtCore import (
+    QStandardPaths,
+    QUrl,
+    QUrlQuery,
+)
+
+from picard import (
+    PICARD_APP_NAME,
+    PICARD_ORG_NAME,
+    PICARD_VERSION_STR,
+    config,
+    log,
+)
 from picard.oauth import OAuthManager
-from picard.util import build_qurl, parse_json
+from picard.util import (
+    build_qurl,
+    parse_json,
+)
 from picard.util.xml import parse_xml
 from picard.webservice import ratecontrol
 

--- a/test/test_versioncompare.py
+++ b/test/test_versioncompare.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+
 from picard.util import compare_version_tuples
 
 
@@ -214,4 +215,3 @@ class CompareVersionsTest(unittest.TestCase):
     def test_compare_version_52(self):
         a, b, r = (1, 0, 0, 'final', 0), (1, 0, 0, 'dev', 1), -1
         self.assertEqual(compare_version_tuples(a, b), r)
-


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Some files were forgotten during last isort pass, because isort ignores `__init__.py` files per default.

# Solution

Fix config file to include those but few exceptions.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

