### PR TITLE
Deprecate string_() and related cleanup

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -139,7 +139,7 @@ class AcoustIDClient(QtCore.QObject):
             file.acoustid_length = length
             self.tagger.acoustidmanager.add(file, None)
             params['fingerprint'] = fingerprint
-            params['duration'] = string_(length)
+            params['duration'] = str(length)
         else:
             fp_type, recordingid = result
             params['recordingid'] = recordingid
@@ -157,7 +157,7 @@ class AcoustIDClient(QtCore.QObject):
             self._run_next_task()
             process = self.sender()
             if exit_code == 0 and exit_status == 0:
-                output = string_(process.readAllStandardOutput())
+                output = bytes(process.readAllStandardOutput()).decode()
                 duration = None
                 fingerprint = None
                 for line in output.splitlines():

--- a/picard/album.py
+++ b/picard/album.py
@@ -268,7 +268,7 @@ class Album(DataObject, Item):
                         track = self._finalize_loading_track(track_node, mm, artists, va, absolutetracknumber, discpregap)
                         track.metadata['~datatrack'] = "1"
 
-            totalalbumtracks = string_(absolutetracknumber)
+            totalalbumtracks = str(absolutetracknumber)
 
             for track in self._new_tracks:
                 track.metadata["~totalalbumtracks"] = totalalbumtracks

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -65,7 +65,7 @@ class BrowserIntegration(QtNetwork.QTcpServer):
 
     def _process_request(self):
         conn = self.sender()
-        line = string_(conn.readLine())
+        line = bytes(conn.readLine()).decode()
         conn.write(b"HTTP/1.1 200 OK\r\nCache-Control: max-age=0\r\n\r\nNothing to see here.")
         conn.disconnectFromHost()
         line = line.split()
@@ -73,7 +73,7 @@ class BrowserIntegration(QtNetwork.QTcpServer):
         if line[0] == "GET" and "?" in line[1]:
             action, args = line[1].split("?")
             args = [a.split("=", 1) for a in args.split("&")]
-            args = dict((a, string_(QtCore.QUrl.fromPercentEncoding(b.encode('ascii')))) for (a, b) in args)
+            args = dict((a, QtCore.QUrl.fromPercentEncoding(b.encode('ascii'))) for (a, b) in args)
             self.tagger.bring_tagger_front()
             if action == "/openalbum":
                 self.tagger.load_album(args["id"])

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -47,7 +47,7 @@ class FileLookup(object):
         if self.local_port:
             params['tport'] = self.local_port
         url = build_qurl(self.server, self.port, path=path, queryargs=params)
-        return url.toEncoded()
+        return bytes(url.toEncoded()).decode()
 
     def _build_launch(self, path, params=None):
         if params is None:

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -227,7 +227,7 @@ class Cluster(QtCore.QObject, Item):
         self.lookup_task = self.tagger.mb_api.find_releases(self._lookup_finished,
             artist=self.metadata['albumartist'],
             release=self.metadata['album'],
-            tracks=string_(len(self.files)),
+            tracks=str(len(self.files)),
             limit=QUERY_LIMIT)
 
     def clear_lookup_task(self):

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -153,11 +153,11 @@ class CoverArtImage:
 
     def parse_url(self, url):
         self.url = QUrl(url)
-        self.host = string_(self.url.host())
+        self.host = self.url.host()
         self.port = self.url.port(80)
-        self.path = string_(self.url.path(QUrl.FullyEncoded))
+        self.path = self.url.path(QUrl.FullyEncoded)
         if self.url.hasQuery():
-            self.path += '?' + string_(self.url.query(QUrl.FullyEncoded))
+            self.path += '?' + self.url.query(QUrl.FullyEncoded)
 
     @property
     def source(self):

--- a/picard/file.py
+++ b/picard/file.py
@@ -130,7 +130,7 @@ class File(QtCore.QObject, Item):
         if self.state != File.PENDING or self.tagger.stopping:
             return
         if error is not None:
-            self.error = string_(error)
+            self.error = str(error)
             self.state = self.ERROR
             from picard.formats import supported_extensions
             file_name, file_extension = os.path.splitext(self.base_filename)
@@ -153,7 +153,7 @@ class File(QtCore.QObject, Item):
         if 'tracknumber' not in metadata:
             tracknumber = tracknum_from_filename(self.base_filename)
             if tracknumber != -1:
-                tracknumber = string_(tracknumber)
+                tracknumber = str(tracknumber)
                 metadata['tracknumber'] = tracknumber
                 if metadata['title'] == filename:
                     stripped_filename = filename.lstrip('0')
@@ -264,7 +264,7 @@ class File(QtCore.QObject, Item):
             return
         old_filename = new_filename = self.filename
         if error is not None:
-            self.error = string_(error)
+            self.error = str(error)
             self.set_state(File.ERROR, update=True)
         else:
             self.filename = new_filename = result
@@ -425,8 +425,9 @@ class File(QtCore.QObject, Item):
         """Move extra files, like playlists..."""
         old_path = os.path.dirname(old_filename)
         new_path = os.path.dirname(new_filename)
-        patterns = config.setting["move_additional_files_pattern"]
-        patterns = [string_(p.strip()) for p in patterns.split() if p.strip()]
+        patterns = [p for p in [p.strip() for p in
+                                config.setting["move_additional_files_pattern"].split()]
+                    if p]
         try:
             names = os.listdir(old_path)
         except os.error:
@@ -658,7 +659,7 @@ class File(QtCore.QObject, Item):
             release=metadata['album'],
             tnum=metadata['tracknumber'],
             tracks=metadata['totaltracks'],
-            qdur=string_(metadata.length // 2000),
+            qdur=str(metadata.length // 2000),
             isrc=metadata['isrc'],
             limit=QUERY_LIMIT)
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -425,16 +425,16 @@ class File(QtCore.QObject, Item):
         """Move extra files, like playlists..."""
         old_path = os.path.dirname(old_filename)
         new_path = os.path.dirname(new_filename)
-        patterns = [p for p in [p.strip() for p in
-                                config.setting["move_additional_files_pattern"].split()]
-                    if p]
         try:
             names = os.listdir(old_path)
         except os.error:
             log.error("Error: {} directory not found".naming_format(old_path))
             return
         filtered_names = [name for name in names if name[0] != "."]
-        for pattern in patterns:
+        for pattern in config.setting["move_additional_files_pattern"].split():
+            pattern = pattern.strip()
+            if not pattern:
+                continue
             pattern_regex = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
             file_names = names
             if pattern[0] != '.':

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -169,7 +169,7 @@ class APEv2File(File):
                 name = name.title()
             temp.setdefault(name, []).append(value)
         for name, values in temp.items():
-            tags[string_(name)] = values
+            tags[str(name)] = values
         for image in metadata.images_to_be_saved_to_tags:
             cover_filename = 'Cover Art (Front)'
             cover_filename += image.extension
@@ -185,7 +185,7 @@ class APEv2File(File):
     def _remove_deleted_tags(self, metadata, tags):
         """Remove the tags from the file that were deleted in the UI"""
         for tag in metadata.deleted_tags:
-            real_name = string_(self._get_tag_name(tag))
+            real_name = self._get_tag_name(tag)
             if real_name in ('Lyrics', 'Comment', 'Performer'):
                 tag_type = re.compile(r"\(%s\)" % tag.split(':', 1)[1])
                 for item in tags.get(real_name):
@@ -276,7 +276,10 @@ class OptimFROGFile(APEv2File):
     def _info(self, metadata, file):
         super()._info(metadata, file)
         # mutagen.File.filename can be either a bytes or str object
-        if string_(file.filename.lower()).endswith(".ofs"):
+        filename = file.filename
+        if isinstance(filename, bytes):
+            filename = filename.decode()
+        if filename.lower().endswith(".ofs"):
             metadata['~format'] = "OptimFROG DualStream Audio"
         else:
             metadata['~format'] = "OptimFROG Lossless Audio"

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -185,14 +185,14 @@ class ASFFile(File):
                 continue
             elif name == 'WM/SharedUserRating':
                 # Rating in WMA ranges from 0 to 99, normalize this to the range 0 to 5
-                values[0] = int(round(int(string_(values[0])) / 99.0 * (config.setting['rating_steps'] - 1)))
+                values[0] = int(round(int(str(values[0])) / 99.0 * (config.setting['rating_steps'] - 1)))
             elif name == 'WM/PartOfSet':
-                disc = string_(values[0]).split("/")
+                disc = str(values[0]).split("/")
                 if len(disc) > 1:
                     metadata["totaldiscs"] = disc[1]
                     values[0] = disc[0]
             name = self.__RTRANS[name]
-            values = [string_(value) for value in values if value]
+            values = [str(value) for value in values if value]
             if values:
                 metadata[name] = values
         self._info(metadata, file)

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -84,7 +84,7 @@ def image_type_as_id3_num(texttype):
 
 
 def types_from_id3(id3type):
-    return [string_(image_type_from_id3_num(id3type))]
+    return [image_type_from_id3_num(id3type)]
 
 
 class ID3File(File):
@@ -216,19 +216,19 @@ class ID3File(File):
                 if frameid.startswith('T') or frameid == 'GRP1':
                     for text in frame.text:
                         if text:
-                            metadata.add(name, string_(text))
+                            metadata.add(name, str(text))
                 elif frameid == 'COMM':
                     for text in frame.text:
                         if text:
-                            metadata.add('%s:%s' % (name, frame.desc), string_(text))
+                            metadata.add('%s:%s' % (name, frame.desc), str(text))
                 else:
-                    metadata.add(name, string_(frame))
+                    metadata.add(name, str(frame))
             elif frameid == 'TIT1':
                 itunes_compatible = config.setting['itunes_compatible_grouping']
                 name = 'work' if itunes_compatible else 'grouping'
                 for text in frame.text:
                     if text:
-                        metadata.add(name, string_(text))
+                        metadata.add(name, str(text))
             elif frameid == "TMCL":
                 for role, name in frame.people:
                     if role or name:
@@ -256,12 +256,12 @@ class ID3File(File):
                     # ways.) Currently, the only tag in both is license.
                     name = '~id3:TXXX:' + name
                 for text in frame.text:
-                    metadata.add(name, string_(text))
+                    metadata.add(name, str(text))
             elif frameid == 'USLT':
                 name = 'lyrics'
                 if frame.desc:
                     name += ':%s' % frame.desc
-                metadata.add(name, string_(frame.text))
+                metadata.add(name, str(frame.text))
             elif frameid == 'UFID' and frame.owner == 'http://musicbrainz.org':
                 metadata['musicbrainz_recordingid'] = frame.data.decode('ascii', 'ignore')
             elif frameid in self.__tag_re_parse.keys():
@@ -289,7 +289,7 @@ class ID3File(File):
             elif frameid == 'POPM':
                 # Rating in ID3 ranges from 0 to 255, normalize this to the range 0 to 5
                 if frame.email == config.setting['rating_user_email']:
-                    rating = string_(int(round(frame.rating / 255.0 * (config.setting['rating_steps'] - 1))))
+                    rating = str(int(round(frame.rating / 255.0 * (config.setting['rating_steps'] - 1))))
                     metadata.add('~rating', rating)
 
         if 'date' in metadata:

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -136,7 +136,7 @@ class MP4File(File):
                 metadata.add(self.__bool_tags[name], values and '1' or '0')
             elif name in self.__int_tags:
                 for value in values:
-                    metadata.add(self.__int_tags[name], string_(value))
+                    metadata.add(self.__int_tags[name], str(value))
             elif name in self.__freeform_tags:
                 for value in values:
                     value = value.decode("utf-8", "replace").strip("\x00")
@@ -147,11 +147,11 @@ class MP4File(File):
                     if value.startswith("MusicMagic Fingerprint"):
                         metadata.add("musicip_fingerprint", value[22:])
             elif name == "trkn":
-                metadata["tracknumber"] = string_(values[0][0])
-                metadata["totaltracks"] = string_(values[0][1])
+                metadata["tracknumber"] = str(values[0][0])
+                metadata["totaltracks"] = str(values[0][1])
             elif name == "disk":
-                metadata["discnumber"] = string_(values[0][0])
-                metadata["totaldiscs"] = string_(values[0][1])
+                metadata["discnumber"] = str(values[0][0])
+                metadata["totaldiscs"] = str(values[0][1])
             elif name == "covr":
                 for value in values:
                     if value.imageformat not in (value.FORMAT_JPEG,

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -95,7 +95,7 @@ class VCommentFile(File):
                     if email != config.setting['rating_user_email']:
                         continue
                     name = '~rating'
-                    value = string_(int(round((float(value) * (config.setting['rating_steps'] - 1)))))
+                    value = str(int(round((float(value) * (config.setting['rating_steps'] - 1)))))
                 elif name == "fingerprint" and value.startswith("MusicMagic Fingerprint"):
                     name = "musicip_fingerprint"
                     value = value[22:]
@@ -185,7 +185,7 @@ class VCommentFile(File):
                     name = 'rating:%s' % config.setting['rating_user_email']
                 else:
                     name = 'rating'
-                value = string_(float(value) / (config.setting['rating_steps'] - 1))
+                value = str(float(value) / (config.setting['rating_steps'] - 1))
             # don't save private tags
             elif name.startswith("~"):
                 continue

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -308,7 +308,7 @@ def media_formats_from_node(node):
         count = formats_count[medium_format]
         medium_format = RELEASE_FORMATS.get(medium_format, medium_format)
         if count > 1:
-            medium_format = string_(count) + "×" + medium_format
+            medium_format = str(count) + "×" + medium_format
         formats.append(medium_format)
     return " + ".join(formats)
 

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -302,7 +302,7 @@ class Metadata(dict):
     def __setitem__(self, name, values):
         if not isinstance(values, list):
             values = [values]
-        values = [string_(value) for value in values if value]
+        values = [str(value) for value in values if value]
         if len(values):
             self.set(name, values)
         elif name in self:

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -84,7 +84,7 @@ class OAuthManager(object):
                   "urn:ietf:wg:oauth:2.0:oob", "scope": scopes}
         url = build_qurl(host, port, path="/oauth2/authorize",
                          queryargs=params)
-        return string_(url.toEncoded())
+        return bytes(url.toEncoded()).decode()
 
     def set_refresh_token(self, refresh_token, scopes):
         log.debug("OAuth: got refresh_token %s with scopes %s", refresh_token, scopes)
@@ -112,7 +112,7 @@ class OAuthManager(object):
         url_query.addQueryItem("client_id", MUSICBRAINZ_OAUTH_CLIENT_ID)
         url_query.addQueryItem("client_secret", MUSICBRAINZ_OAUTH_CLIENT_SECRET)
         url.setQuery(url_query.query(QUrl.FullyEncoded))
-        data = string_(url.query())
+        data = url.query()
         self.webservice.post(host, port, path, data,
                         partial(self.on_refresh_access_token_finished, callback),
                         parse_response_type=None, mblogin=True, priority=True, important=True)
@@ -145,7 +145,7 @@ class OAuthManager(object):
         url_query.addQueryItem("client_secret", MUSICBRAINZ_OAUTH_CLIENT_SECRET)
         url_query.addQueryItem("redirect_uri", "urn:ietf:wg:oauth:2.0:oob")
         url.setQuery(url_query.query(QUrl.FullyEncoded))
-        data = string_(url.query())
+        data = url.query()
         self.webservice.post(host, port, path, data,
                         partial(self.on_exchange_authorization_code_finished, scopes, callback),
                         parse_response_type=None, mblogin=True, priority=True, important=True)

--- a/picard/script.py
+++ b/picard/script.py
@@ -94,7 +94,7 @@ class ScriptFunction(object):
                 raise ScriptError(
                     "Wrong number of arguments for $%s: Expected %s, got %i at position %i, line %i"
                     % (name,
-                       string_(argnum_bound.lower)
+                       str(argnum_bound.lower)
                         if argnum_bound.upper is None
                         else "%i - %i" % (argnum_bound.lower, argnum_bound.upper),
                        argcount,
@@ -329,7 +329,7 @@ def register_script_function(function, name=None, eval_args=True,
 
 
 def _compute_int(operation, *args):
-    return string_(reduce(operation, map(int, args)))
+    return str(reduce(operation, map(int, args)))
 
 
 def _compute_logic(operation, *args):
@@ -683,7 +683,7 @@ def func_gte(parser, x, y):
 
 
 def func_len(parser, text=""):
-    return string_(len(text))
+    return str(len(text))
 
 
 def func_lenmulti(parser, multi, separator=MULTI_VALUED_JOINER):
@@ -700,7 +700,7 @@ def func_performer(parser, pattern="", join=", "):
 
 def func_matchedtracks(parser, arg):
     if parser.file and parser.file.parent:
-        return string_(parser.file.parent.album.get_num_matched_tracks())
+        return str(parser.file.parent.album.get_num_matched_tracks())
     return "0"
 
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -337,8 +337,7 @@ class Tagger(QtWidgets.QApplication):
         if isinstance(event, thread.ProxyToMainEvent):
             event.run()
         elif event.type() == QtCore.QEvent.FileOpen:
-            f = string_(event.file())
-            self.add_files([f])
+            self.add_files([event.file()])
             # We should just return True here, except that seems to
             # cause the event's sender to get a -9874 error, so
             # apparently there's some magic inside QFileOpenEvent...
@@ -553,7 +552,7 @@ class Tagger(QtWidgets.QApplication):
                 metadata["album"],
                 metadata["title"],
                 metadata["tracknumber"],
-                '' if item.is_album_like() else string_(metadata.length),
+                '' if item.is_album_like() else str(metadata.length),
                 item.filename if isinstance(item, File) else '')
 
     def get_files_from_objects(self, objects, save=False):

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -77,7 +77,7 @@ class HashableTreeWidgetItem(QtWidgets.QTreeWidgetItem):
         return self.id == other.id
 
     def __hash__(self):
-        return hash(string_(self.id))
+        return hash(str(self.id))
 
 
 class HashableListWidgetItem(QtWidgets.QListWidgetItem):
@@ -90,4 +90,4 @@ class HashableListWidgetItem(QtWidgets.QListWidgetItem):
         return self.id == other.id
 
     def __hash__(self):
-        return hash(string_(self.id))
+        return hash(str(self.id))

--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -41,7 +41,7 @@ class CollectionMenu(QtWidgets.QMenu):
         self.clear()
         for id_, collection in sorted(user_collections.items(),
                                      key=lambda k_v:
-                                     (locale.strxfrm(string_(k_v[1])), k_v[0])):
+                                     (locale.strxfrm(str(k_v[1])), k_v[0])):
             action = QtWidgets.QWidgetAction(self)
             action.setDefaultWidget(CollectionCheckBox(self, collection))
             self.addAction(action)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -368,7 +368,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 port = 443
             else:
                 port = 80
-            self.tagger.webservice.get(url.host(), url.port(port), string_(path),
+            self.tagger.webservice.get(url.host(), url.port(port), path,
                                   partial(self.on_remote_image_fetched, url, fallback_data=fallback_data),
                                   parse_response_type=None,
                                   priority=True, important=True)

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -106,7 +106,7 @@ class EditTagDialog(PicardDialog):
             tag_names.removeItem(tag_names.findText(self.tag, flags))
 
         row = tag_names.findText(tag, flags)
-        self.tag = string_(tag)
+        self.tag = tag
         if row <= 0:
             if tag:
                 # add custom tags to the QComboBox immediately

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -264,7 +264,7 @@ def format_file_info(file_):
     if '~sample_rate' in file_.orig_metadata:
         info.append((_('Sample rate:'), '%s Hz' % file_.orig_metadata['~sample_rate']))
     if '~bits_per_sample' in file_.orig_metadata:
-        info.append((_('Bits per sample:'), string_(file_.orig_metadata['~bits_per_sample'])))
+        info.append((_('Bits per sample:'), str(file_.orig_metadata['~bits_per_sample'])))
     if '~channels' in file_.orig_metadata:
         ch = file_.orig_metadata['~channels']
         if ch == '1':

--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -67,13 +67,13 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self.label4.setToolTip(t4)
 
     def setFiles(self, num):
-        self.val1.setText(string_(num))
+        self.val1.setText(str(num))
 
     def setAlbums(self, num):
-        self.val2.setText(string_(num))
+        self.val2.setText(str(num))
 
     def setPendingFiles(self, num):
-        self.val3.setText(string_(num))
+        self.val3.setText(str(num))
 
     def setPendingRequests(self, num):
         if num <= 0:
@@ -81,4 +81,4 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         else:
             enabled = QtGui.QIcon.Normal
         self.label4.setPixmap(self.icon_download.pixmap(self._size, enabled))
-        self.val4.setText(string_(num))
+        self.val4.setText(str(num))

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -456,7 +456,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
     def save_state(self):
         cols = range(self.numHeaderSections - 1)
-        sizes = " ".join(string_(self.header().sectionSize(i)) for i in cols)
+        sizes = " ".join(str(self.header().sectionSize(i)) for i in cols)
         config.persist[self.view_sizes.name] = sizes
 
     def supportedDropActions(self):
@@ -489,7 +489,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         for item in items:
             obj = item.obj
             if isinstance(obj, Album):
-                album_ids.append(string_(obj.id))
+                album_ids.append(obj.id)
             elif obj.iterfiles:
                 files.extend([url(f.filename) for f in obj.iterfiles()])
         mimeData = QtCore.QMimeData()
@@ -552,7 +552,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         if albums:
             if isinstance(self, FileTreeView) and target is None:
                 target = self.tagger.unclustered_files
-            albums = [self.tagger.load_album(id) for id in string_(albums).split("\n")]
+            albums = [self.tagger.load_album(id) for id in bytes(albums).decode().split("\n")]
             self.tagger.move_files(self.tagger.get_files_from_objects(albums), target)
             handled = True
         return handled

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -479,7 +479,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                 tag_diff.add(name, orig_values, new_values, True, removed)
 
             tag_diff.add("~length",
-                         string_(orig_metadata.length), string_(new_metadata.length), False)
+                         str(orig_metadata.length), str(new_metadata.length), False)
 
         for track in tracks:
             if track.num_linked_files == 0:
@@ -487,7 +487,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                     if not name.startswith("~"):
                         tag_diff.add(name, values, values, True)
 
-                length = string_(track.metadata.length)
+                length = str(track.metadata.length)
                 tag_diff.add("~length", length, length, False)
 
                 tag_diff.objects += 1

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -87,7 +87,7 @@ class OptionsPage(QtWidgets.QWidget):
             try:
                 re.compile(regex_edit.text())
             except re.error as e:
-                raise OptionsCheckError(_("Regex Error"), string_(e))
+                raise OptionsCheckError(_("Regex Error"), str(e))
 
         def live_checker(text):
             regex_error.setStyleSheet("")

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -126,7 +126,7 @@ class FingerprintingOptionsPage(OptionsPage):
     def _on_acoustid_fpcalc_check_finished(self, exit_code, exit_status):
         process = self.sender()
         if exit_code == 0 and exit_status == 0:
-            output = string_(process.readAllStandardOutput())
+            output = bytes(process.readAllStandardOutput()).decode()
             if output.startswith("fpcalc version"):
                 self._acoustid_fpcalc_set_success(output.strip())
             else:

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -228,7 +228,7 @@ class ReleasesOptionsPage(OptionsPage):
         data = []
         for i in range(list1.count()):
             item = list1.item(i)
-            data.append(string_(item.data(QtCore.Qt.UserRole)))
+            data.append(item.data(QtCore.Qt.UserRole))
         config.setting[setting] = data
 
 

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -204,7 +204,7 @@ class RenamingOptionsPage(OptionsPage):
         try:
             parser.eval(self.ui.file_naming_format.toPlainText())
         except Exception as e:
-            raise OptionsCheckError("", string_(e))
+            raise OptionsCheckError("", str(e))
         if self.ui.rename_files.isChecked():
             if not self.ui.file_naming_format.toPlainText().strip():
                 raise OptionsCheckError("", _("The file naming format must not be empty."))

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -394,7 +394,7 @@ class ScriptingOptionsPage(OptionsPage):
         try:
             parser.eval(self.ui.tagger_script.toPlainText())
         except Exception as e:
-            raise OptionsCheckError(_("Script Error"), string_(e))
+            raise OptionsCheckError(_("Script Error"), str(e))
 
     def restore_defaults(self):
         # Remove existing scripts

--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -84,7 +84,7 @@ class RatingWidget(QtWidgets.QWidget):
 
     def _update_track(self):
         track = self._track
-        track.metadata["~rating"] = string_(self._rating)
+        track.metadata["~rating"] = str(self._rating)
         if config.setting["submit_ratings"]:
             ratings = {("recording", track.id): self._rating}
             self.tagger.mb_api.submit_ratings(ratings, None)

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -58,7 +58,7 @@ class ScriptsMenu(QtWidgets.QMenu):
                 msg = N_('Script error in "%(script)s": %(message)s')
                 mparms = {
                     'script': s_name,
-                    'message': string_(e),
+                    'message': str(e),
                 }
                 self.tagger.window.set_statusbar_message(msg, mparms)
 

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -186,7 +186,7 @@ class AlbumSearchDialog(SearchDialog):
         query = {
             "artist": metadata["albumartist"],
             "release": metadata["album"],
-            "tracks": string_(len(cluster.files))
+            "tracks": str(len(cluster.files))
         }
 
         # Generate query to be displayed to the user (in search box).

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -90,7 +90,7 @@ class TrackSearchDialog(SearchDialog):
             'release': metadata['album'],
             'tnum': metadata['tracknumber'],
             'tracks': metadata['totaltracks'],
-            'qdur': string_(metadata.length // 2000),
+            'qdur': str(metadata.length // 2000),
             'isrc': metadata['isrc'],
         }
 

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -418,7 +418,7 @@ def build_qurl(host, port=80, path=None, queryargs=None):
     if queryargs is not None:
         url_query = QtCore.QUrlQuery()
         for k, v in queryargs.items():
-            url_query.addQueryItem(k, string_(v))
+            url_query.addQueryItem(k, str(v))
         url.setQuery(url_query)
     return url
 

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -453,7 +453,7 @@ def union_sorted_lists(list1, list2):
     return union
 
 
-def convert_to_string(obj):
+def __convert_to_string(obj):
     """Appropriately converts the input `obj` to a string.
 
     Args:
@@ -471,6 +471,15 @@ def convert_to_string(obj):
         return str(obj)
 
 
+def convert_to_string(obj):
+    from picard import log
+    log.warning("string_() and convert_to_string() are deprecated, do not use")
+    return __convert_to_string(obj)
+
+
+builtins.__dict__['string_'] = convert_to_string
+
+
 def htmlescape(string):
     return html.escape(string, quote=False)
 
@@ -486,7 +495,7 @@ def load_json(data):
         dict: Response data as a python dict
 
     """
-    return json.loads(convert_to_string(data))
+    return json.loads(__convert_to_string(data))
 
 
 def parse_json(reply):
@@ -498,7 +507,6 @@ def restore_method(func):
            return func(*args, **kwargs)
     return func_wrapper
 
-builtins.__dict__['string_'] = convert_to_string
 
 
 def compare_version_tuples(version1, version2):

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -83,8 +83,10 @@ def get_cdrom_drives():
         if cdinfo.open(QIODevice.ReadOnly | QIODevice.Text):
             drive_names = []
             drive_audio_caps = []
-            line = string_(cdinfo.readLine())
-            while line:
+            while True:
+                line = bytes(cdinfo.readLine()).decode()
+                if not line:
+                    break
                 if ":" in line:
                     key, values = line.split(':')
                     if key == 'drive name':
@@ -92,7 +94,6 @@ def get_cdrom_drives():
                     elif key == 'Can play audio':
                         drive_audio_caps = [v == '1' for v in values.split()]
                         break  # no need to continue past this line
-                line = string_(cdinfo.readLine())
             # Show only drives that are capable of playing audio
             for index, drive in enumerate(drive_names):
                 if drive_audio_caps[index]:

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -32,7 +32,7 @@ in PyQt and also adds a utility function for opening Picard URLS.
 
 def open(url):
     try:
-        webbrowser.open(string_(url))
+        webbrowser.open(url)
     except webbrowser.Error as e:
         QtWidgets.QMessageBox.critical(None, _("Web Browser Error"), _("Error while launching a web browser:\n\n%s") % (e,))
 

--- a/picard/util/xml.py
+++ b/picard/util/xml.py
@@ -71,7 +71,7 @@ def parse_xml(response):
 
             for i in range(attrs.count()):
                 attr = attrs.at(i)
-                node.attribs[_node_name(attr.name())] = string_(attr.value())
+                node.attribs[_node_name(attr.name())] = attr.value()
 
             current_node.append_child(_node_name(stream.name()), node)
             path.append(current_node)

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -69,9 +69,9 @@ USER_AGENT_STRING = '%s-%s/%s (%s;%s-%s)' % (PICARD_ORG_NAME, PICARD_APP_NAME,
                                              platform.platform(),
                                              platform.python_implementation(),
                                              platform.python_version())
-CLIENT_STRING = string_(QUrl.toPercentEncoding('%s %s-%s' % (PICARD_ORG_NAME,
-                                                         PICARD_APP_NAME,
-                                                         PICARD_VERSION_STR)))
+CLIENT_STRING = bytes(QUrl.toPercentEncoding('%s %s-%s' % (PICARD_ORG_NAME,
+                                                           PICARD_APP_NAME,
+                                                           PICARD_VERSION_STR))).decode()
 
 
 
@@ -169,7 +169,7 @@ class WSRequest(QtNetwork.QNetworkRequest):
 
     def _update_authorization_header(self):
         if self.mblogin and self.access_token:
-            self.setRawHeader(b"Authorization", ("Bearer %s" % string_(self.access_token)).encode('utf-8'))
+            self.setRawHeader(b"Authorization", ("Bearer %s" % self.access_token).encode('utf-8'))
         else:
             self.setRawHeader(b"Authorization", b"")
 
@@ -348,12 +348,12 @@ class WebService(QtCore.QObject):
         redirect = url.resolved(redirect)
         if not WebService.urls_equivalent(redirect, reply.request().url()):
             log.debug("Redirect to %s requested", redirect.toString(QUrl.RemoveUserInfo))
-            redirect_host = string_(redirect.host())
+            redirect_host = redirect.host()
             redirect_port = self.url_port(redirect)
             redirect_query = dict(QUrlQuery(redirect).queryItems(QUrl.FullyEncoded))
             redirect_path = redirect.path()
 
-            original_host = string_(url.host())
+            original_host = url.host()
             original_port = self.url_port(url)
             original_host_key = (original_host, original_port)
             redirect_host_key = (redirect_host, redirect_port)

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -150,8 +150,8 @@ class MBAPIHelper(APIHelper):
             filters.append(("query", query))
         queryargs = {}
         for name, value in filters:
-            value = QUrl.toPercentEncoding(string_(value))
-            queryargs[string_(name)] = value
+            queryargs[name] = bytes(QUrl.toPercentEncoding(str(value))).decode()
+
         path_list = [entitytype]
         return self.get(path_list, handler, queryargs=queryargs,
                             priority=True, important=True, mblogin=False,
@@ -236,8 +236,8 @@ class AcoustIdAPIHelper(APIHelper):
         args['clientversion'] = PICARD_VERSION_STR
         args['format'] = format_
         for name, value in args.items():
-            value = string_(QUrl.toPercentEncoding(value))
-            filters.append('%s=%s' % (string_(name), value))
+            value = bytes(QUrl.toPercentEncoding(value)).decode()
+            filters.append('%s=%s' % (name, value))
         return '&'.join(filters)
 
     def query_acoustid(self, handler, **args):
@@ -249,10 +249,10 @@ class AcoustIdAPIHelper(APIHelper):
         path_list = ['submit']
         args = {'user': config.setting["acoustid_apikey"]}
         for i, submission in enumerate(submissions):
-            args['fingerprint.%d' % i] = string_(submission.fingerprint)
-            args['duration.%d' % i] = string_(submission.duration)
-            args['mbid.%d' % i] = string_(submission.recordingid)
+            args['fingerprint.%d' % i] = submission.fingerprint
+            args['duration.%d' % i] = str(submission.duration)
+            args['mbid.%d' % i] = submission.recordingid
             if submission.puid:
-                args['puid.%d' % i] = string_(submission.puid)
+                args['puid.%d' % i] = submission.puid
         body = self._encode_acoustid_args(args, format_='json')
         return self.post(path_list, body, handler, priority=True, important=False, mblogin=False)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -32,7 +32,7 @@ class BrowserLookupTest(unittest.TestCase):
         for i, type_ in enumerate(lookups):
             lookups[type_]['function']("123")
 
-            url = urlparse(string_(mock_open.call_args[0][0]))
+            url = urlparse(mock_open.call_args[0][0])
             path = url.path.split('/')[1:]
             query_args = parse_qs(url.query)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

About string_():
- that's a builtin aliasing `picard.util.convert_to_string()`
- it does 2 tests before eventually returning `str(arg)` plus the call to the method, that's pretty expensive if not strictly needed
- in many cases, it is unneeded or equivalent to `str()`
- explicit calls to conversion functions are better as they don't hide what is going on
- it was introduced in https://github.com/metabrainz/picard/pull/664 to help the move to Python3


References:
https://github.com/metabrainz/picard/pull/945#discussion_r214912848
https://github.com/metabrainz/picard/pull/945#issuecomment-418523558


# Solution

Use `str()` or `bytes(arg).decode()` or drop it, depending on the case.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

