### PR TITLE
PICARD-105: Allow loading AcoustId recording as NAT

### DIFF
--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -67,15 +67,21 @@ def _make_artist_credit_node(artists):
 
 
 def parse_recording(recording):
-    if 'title' not in recording:  # we have no metadata for this recording
+    if 'id' not in recording:  # we have no metadata for this recording
         return
 
     recording_mb = {
-        'id': recording['id'],
-        'title': recording['title'],
-        'artist-credit': _make_artist_credit_node(recording['artists']),
-        'releases': _make_releases_node(recording)
+        'id': recording['id']
     }
+
+    if 'title' in recording:
+        recording_mb['title'] = recording['title']
+
+    if 'artists' in recording:
+        recording_mb['artist-credit'] = _make_artist_credit_node(recording['artists'])
+
+    if 'releasegroups' in recording:
+        recording_mb['releases'] = _make_releases_node(recording)
 
     if 'duration' in recording:
         try:

--- a/picard/file.py
+++ b/picard/file.py
@@ -634,7 +634,8 @@ class File(QtCore.QObject, Item):
             self.tagger.get_release_group_by_id(rg['id']).loaded_albums.add(release['id'])
             self.tagger.move_file_to_track(self, release['id'], track['id'])
         else:
-            self.tagger.move_file_to_nat(self, track['id'], node=track)
+            node = track if 'title' in track else None
+            self.tagger.move_file_to_nat(self, track['id'], node=node)
 
     def lookup_metadata(self):
         """Try to identify the file using the existing metadata."""

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -222,12 +222,13 @@ class Metadata(dict):
 
         if 'title' in self:
             a = self['title']
-            b = track['title']
+            b = track.get('title', '')
             parts.append((similarity2(a, b), weights["title"]))
 
         if 'artist' in self:
             a = self['artist']
-            b = artist_credit_from_node(track['artist-credit'])[0]
+            artist_credits = track.get('artist-credit', [])
+            b = artist_credit_from_node(artist_credits)[0]
             parts.append((similarity2(a, b), weights["artist"]))
 
         a = self.length


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
For NAT recordings AcoustId returns incomplete results and we have only the recording ID. Allow Picard to load such results as NAT.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-105](https://tickets.metabrainz.org/browse/PICARD-105)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Even with only the recording ID Picard can load a track as NAT. This patch enables this for AcoustId results.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

