### PR TITLE
PICARD-1340: fix display of Mono/Stereo for channels in info dialog

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -267,12 +267,10 @@ def format_file_info(file_):
         info.append((_('Bits per sample:'), string_(file_.orig_metadata['~bits_per_sample'])))
     if '~channels' in file_.orig_metadata:
         ch = file_.orig_metadata['~channels']
-        if ch == 1:
+        if ch == '1':
             ch = _('Mono')
-        elif ch == 2:
+        elif ch == '2':
             ch = _('Stereo')
-        else:
-            ch = string_(ch)
         info.append((_('Channels:'), ch))
     return '<br/>'.join(map(lambda i: '<b>%s</b> %s' %
                             (htmlescape(i[0]),


### PR DESCRIPTION
ch is a string

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

In Info Dialog, Picard displayed Mono/Stereo for 1 or 2 channels, it was broken at some point
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Comparing int to string doesn't work, and thus the number of channels was displayed in all cases

* JIRA ticket (_optional_): [PICARD-1340](https://tickets.metabrainz.org/browse/PICARD-1340)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Compare to "1" and "2"
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

