### PR TITLE
PICARD-1339: Remove O(n^2) complexity when deleting files

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -114,6 +114,8 @@ class Cluster(QtCore.QObject, Item):
         self.item.remove_file(file)
         if not self.special and self.get_num_files() == 0:
             self.tagger.remove_cluster(self)
+
+    def finalize_remove_files(self):
         self.update_metadata_images()
         self._update_related_album()
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -604,12 +604,17 @@ class Tagger(QtWidgets.QApplication):
 
     def remove_files(self, files, from_parent=True):
         """Remove files from the tagger."""
+        parents = set()
         for file in files:
             if file.filename in self.files:
                 file.clear_lookup_task()
                 self._acoustid.stop_analyze(file)
                 del self.files[file.filename]
                 file.remove(from_parent)
+                parents.add(file.parent)
+        if from_parent:
+            for parent in parents:
+                parent.finalize_remove_files()
 
     def remove_album(self, album):
         """Remove the specified album."""

--- a/picard/track.py
+++ b/picard/track.py
@@ -100,6 +100,8 @@ class Track(DataObject, Item):
         file.copy_metadata(file.orig_metadata, preserve_deleted=False)
         self.album._remove_file(self, file)
         file.metadata_images_changed.disconnect(self.update_orig_metadata_images)
+
+    def finalize_remove_files(self):
         self.update()
 
     def update(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Removing files from Picard takes a long time if many files are loaded. This is especially noticeable when deleting unclustered files. On my system with approx. 3700 unclustered files deletion goes at a rate of 180 files per 10 seconds. While delting such a large number of files Picard's UI is unresponsive.

The reason for this is mainly the call to `update_metadata_images()`, which itself iterates over all files in a cluster.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1339](https://tickets.metabrainz.org/browse/PICARD-1339)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This change basically makes sure calls to update_metadata_images are done only once per cluster / track when multiple files get removed. Since update_metadata_images iterates over all files inside a cluster doing this after deletion reduces the complexity significantly.

With the changes on my system the deletion of 3700 unclustered files happens almost instantly.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

