### PR TITLE
Fix pyinstaller complaining about empty DEST

### DIFF
--- a/picard.spec
+++ b/picard.spec
@@ -51,16 +51,16 @@ fpcalc_name = 'fpcalc'
 if os_name == 'Windows':
     fpcalc_name = 'fpcalc.exe'
     binaries += [
-        ('discid.dll', ''),
-        ('ssleay32.dll', ''),
-        ('libeay32.dll', ''),
+        ('discid.dll', '.'),
+        ('ssleay32.dll', '.'),
+        ('libeay32.dll', '.'),
     ]
 
 if os_name == 'Darwin':
-    binaries += [('libdiscid.0.dylib', '')]
+    binaries += [('libdiscid.0.dylib', '.')]
 
 if os.path.isfile(fpcalc_name):
-    binaries += [(fpcalc_name, '')]
+    binaries += [(fpcalc_name, '.')]
 
 
 a = Analysis(['tagger.py'],


### PR DESCRIPTION
It is enforced by pyinstaller 3.4

Empty DEST not allowed when adding binary and data files. Maybe you want to used '.'.
Caused by 'discid.dll'.

https://github.com/pyinstaller/pyinstaller/issues/3066

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

appveyor checks are failing since pyinstaller 3.4
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

