### PR TITLE
PICARD-1281: Drop deprecated CFBundleGetInfoString from info.plist

### DIFF
--- a/picard.spec
+++ b/picard.spec
@@ -106,7 +106,6 @@ if platform.system() == 'Darwin':
         'NSPrincipalClass': 'NSApplication',
         'CFBundleName': 'Picard',
         'CFBundleDisplayName': 'MusicBrainz Picard',
-        'CFBundleGetInfoString': 'Audio file tagger',
         'CFBundleIdentifier': 'org.musicbrainz.picard',
         'CFBundleVersion': macos_picard_version,
         'CFBundleShortVersionString': macos_picard_short_version,


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/PICARD-1281
http://www.openradar.me/8600732
