### PR TITLE
PICARD-1346: Fix exception with move additional files

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -427,11 +427,11 @@ class File(QtCore.QObject, Item):
         old_path = os.path.dirname(old_filename)
         new_path = os.path.dirname(new_filename)
         try:
-            names = os.listdir(old_path)
+            names = set(os.listdir(old_path))
         except os.error:
             log.error("Error: {} directory not found".naming_format(old_path))
             return
-        filtered_names = [name for name in names if name[0] != "."]
+        filtered_names = {name for name in names if name[0] != "."}
         for pattern in config.setting["move_additional_files_pattern"].split():
             pattern = pattern.strip()
             if not pattern:
@@ -440,9 +440,10 @@ class File(QtCore.QObject, Item):
             file_names = names
             if pattern[0] != '.':
                 file_names = filtered_names
-            for old_file in file_names:
+            for old_file in set(file_names):
                 if pattern_regex.match(old_file):
-                    file_names.remove(old_file)
+                    names.discard(old_file)
+                    filtered_names.discard(old_file)
                     new_file = os.path.join(new_path, old_file)
                     old_file = os.path.join(old_path, old_file)
                     # FIXME we shouldn't do this from a thread!

--- a/picard/file.py
+++ b/picard/file.py
@@ -442,6 +442,7 @@ class File(QtCore.QObject, Item):
                 file_names = filtered_names
             for old_file in file_names:
                 if pattern_regex.match(old_file):
+                    file_names.remove(old_file)
                     new_file = os.path.join(new_path, old_file)
                     old_file = os.path.join(old_path, old_file)
                     # FIXME we shouldn't do this from a thread!

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -87,3 +87,15 @@ class TestFileSystem(unittest.TestCase):
 
         self.assertTrue(os.path.isfile(new_additional_filename))
         self.assertFalse(os.path.isfile(old_additional_filename))
+
+    def test_move_additional_files_duplicate_patterns(self):
+        files = self._prepare_files()
+        (old_filename, old_additional_filename, new_filename, new_additional_filename) = files
+
+        config.setting['move_additional_files_pattern'] = 'cover.jpg *.jpg'
+
+        f = picard.formats.open_(old_filename)
+        f._move_additional_files(old_filename, new_filename)
+
+        self.assertTrue(os.path.isfile(new_additional_filename))
+        self.assertFalse(os.path.isfile(old_additional_filename))


### PR DESCRIPTION
When multiple patterns for move additional files matched the same file an exception was thrown when attempting to move the files again after it already had been moved.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1346](https://tickets.metabrainz.org/browse/PICARD-1346)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

