### PR TITLE
PICARD-1358: Use native Qt style for macOS

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -188,6 +188,10 @@ class Tagger(QtWidgets.QApplication):
             signal.signal(signal.SIGINT, self.signal)
             signal.signal(signal.SIGTERM, self.signal)
 
+        if sys.platform == "darwin":
+            # On macOS it is not common that the global menu shows icons
+            self.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus)
+
         # Setup logging
         log.debug("Starting Picard from %r", os.path.abspath(__file__))
         log.debug("Platform: %s %s %s", platform.platform(),

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -129,7 +129,8 @@ class Tagger(QtWidgets.QApplication):
 
         # Use the new fusion style from PyQt5 for a modern and consistent look
         # across all OSes.
-        self.setStyle('Fusion')
+        if sys.platform != "darwin":
+            self.setStyle('Fusion')
 
         # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
         # can use it to look up the app

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 import datetime
 from functools import partial
 import os.path
+import sys
 
 from PyQt5 import (
     QtCore,
@@ -126,6 +127,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.create_statusbar()
         self.create_toolbar()
         self.create_menus()
+
+        if sys.platform == "darwin":
+            self.setUnifiedTitleAndToolBarOnMac(True)
+            self.toolbar.setMovable(False)
+            self.search_toolbar.setMovable(False)
 
         mainLayout = QtWidgets.QSplitter(QtCore.Qt.Vertical)
         mainLayout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

On macOS Picard currently looks alien because it does not use native styling.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1358](https://tickets.metabrainz.org/browse/PICARD-1358)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This PR makes the following changes:

- Disable the Fusion style for macOS
- Unify title and toolbar on macOS (so it blends together instead of appearing as two distinct areas)
- Disable icons for the menu. It is very uncommon that a macOS application provides icons there

The results look like this:

![screenshot 2018-09-25 at 12 24 17](https://user-images.githubusercontent.com/29852/46015068-98429b80-c0d1-11e8-85f2-8df184aec2c4.png)
![screenshot 2018-09-25 at 12 25 31](https://user-images.githubusercontent.com/29852/46015069-98429b80-c0d1-11e8-87d0-80ef6ccdf67f.png)

The old look:

![screenshot 2018-09-25 at 14 42 56](https://user-images.githubusercontent.com/29852/46015074-a1336d00-c0d1-11e8-9185-56c34a1c55c9.png)
![screenshot 2018-09-25 at 14 43 40](https://user-images.githubusercontent.com/29852/46015075-a1336d00-c0d1-11e8-9d5d-a527f341f02b.png)

I purposefully only set this for macOS for now. On my Linux with GNOME 3 Picard used the exact same styling when I removed `setStyle('Fusion')`, and I was not in the mood to test a dozen other DEs. But I think the general styling is ok in most cases. It could still make sense to not set this explicitly, e.g. on KDE which uses explicit Qt styling this could make a difference. But maybe we should tackle that separately, since it needs some testing across different desktop environments and themes.

On Windows I think the Fusion look is close enough to the "native" look, but looks a bit more modern (Qt's Windows look looks a bit dated. Here is a side by side comparison, native Windows look left, Fusion right:

![virtualbox_windows 10 devel_25_09_2018_14_54_40](https://user-images.githubusercontent.com/29852/46015616-0471cf00-c0d3-11e8-9abf-de3bf932a686.png)



<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

