### PR TITLE
PICARD-664: Render the first dragged row as drag representation

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -479,6 +479,11 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         if items:
             drag = QtGui.QDrag(self)
             drag.setMimeData(self.mimeData(items))
+            # Render the first selected element as drag representation
+            rectangle = self.visualItemRect(items[0])
+            pixmap = QtGui.QPixmap(rectangle.width(), rectangle.height())
+            self.viewport().render(pixmap, QtCore.QPoint(), QtGui.QRegion(rectangle))
+            drag.setPixmap(pixmap)
             drag.exec_(QtCore.Qt.MoveAction)
 
     def mimeData(self, items):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard is not showing a proper drag indicator when dragging items from the tree views. On Linux and Windows nothing is shown, on just the usually useless first part (truncated) of the file URL is displayed (e.g. "file:///MyHD/...").

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-664](https://tickets.metabrainz.org/browse/PICARD-664)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Render the first selected item's row as a drag image. Here is how it looks like in action:

![peek 2018-09-25 14-59](https://user-images.githubusercontent.com/29852/46015873-ad202e80-c0d3-11e8-9216-7f4eca572fe1.gif)

Tested on all Windows, Mac and Linux


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

