### PR TITLE
PICARD-1285: Add Close Window menu entry for macOS

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -377,6 +377,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.add_directory_action.setShortcut(QtGui.QKeySequence(_("Ctrl+D")))
         self.add_directory_action.triggered.connect(self.add_directory)
 
+        if sys.platform == "darwin":
+            self.close_window_action = QtWidgets.QAction(_("Close Window"), self)
+            self.close_window_action.setShortcut(QtGui.QKeySequence(_("Ctrl+W")))
+            self.close_window_action.triggered.connect(self.close_active_window)
+
         self.save_action = QtWidgets.QAction(icontheme.lookup('document-save'), _("&Save"), self)
         self.save_action.setStatusTip(_("Save selected files"))
         # TR: Keyboard shortcut for "Save"
@@ -575,6 +580,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         menu = self.menuBar().addMenu(_("&File"))
         menu.addAction(self.add_directory_action)
         menu.addAction(self.add_files_action)
+        if sys.platform == "darwin":
+            menu.addAction(self.close_window_action)
         menu.addSeparator()
         menu.addAction(self.play_file_action)
         menu.addAction(self.open_folder_action)
@@ -822,6 +829,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
             for directory in dir_list:
                 self.tagger.add_directory(directory)
+
+    def close_active_window(self):
+        print("close_active_window")
+        self.tagger.activeWindow().close()
 
     def show_about(self):
         self.show_options("about")

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -123,6 +123,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         icon.addFile(":/images/256x256/picard.png", QtCore.QSize(256, 256))
         self.setWindowIcon(icon)
 
+        self.show_close_window = sys.platform == "darwin"
+
         self.create_actions()
         self.create_statusbar()
         self.create_toolbar()
@@ -377,7 +379,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.add_directory_action.setShortcut(QtGui.QKeySequence(_("Ctrl+D")))
         self.add_directory_action.triggered.connect(self.add_directory)
 
-        if sys.platform == "darwin":
+        if self.show_close_window:
             self.close_window_action = QtWidgets.QAction(_("Close Window"), self)
             self.close_window_action.setShortcut(QtGui.QKeySequence(_("Ctrl+W")))
             self.close_window_action.triggered.connect(self.close_active_window)
@@ -580,7 +582,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         menu = self.menuBar().addMenu(_("&File"))
         menu.addAction(self.add_directory_action)
         menu.addAction(self.add_files_action)
-        if sys.platform == "darwin":
+        if self.show_close_window:
             menu.addAction(self.close_window_action)
         menu.addSeparator()
         menu.addAction(self.play_file_action)
@@ -831,7 +833,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 self.tagger.add_directory(directory)
 
     def close_active_window(self):
-        print("close_active_window")
         self.tagger.activeWindow().close()
 
     def show_about(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Usually windows on macOS can be closed via a "Close Window" command, which is available both in the "File" menu and the keyboard shortcut ⌘W. This PR adds such a menu action to Picard on macOS
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1285](https://tickets.metabrainz.org/browse/PICARD-1285)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
While the change in this PR allows closing utility windows like activity protocol and debug log as well as the main window, it does not work as expected with the preferences window. This can be considered a bug caused by the fact that the preferences window is a modal dialog, which in Qt causes the menu items to get disabled. The issue is tracked at [PICARD-1282](https://tickets.metabrainz.org/browse/PICARD-1282). Still this PR provides the general functionality and is a prerequisite to fix PICARD-1282
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

