### PR TITLE
PICARD-1368: Correctly set log levels

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -33,11 +33,12 @@ _MAX_TAIL_LEN = 10**6
 VERBOSITY_DEFAULT = logging.WARNING
 
 
-def debug_mode(enabled):
-    if enabled:
-        main_logger.setLevel(logging.DEBUG)
-    else:
-        main_logger.setLevel(VERBOSITY_DEFAULT)
+def set_level(level):
+    main_logger.setLevel(level)
+
+
+def get_effective_level():
+    return main_logger.getEffectiveLevel()
 
 
 _feat = namedtuple('_feat', ['name', 'prefix', 'fgcolor'])

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -150,11 +150,10 @@ class Tagger(QtWidgets.QApplication):
         self._no_restore = picard_args.no_restore
         self._no_plugins = picard_args.no_plugins
 
-        self.debug(
-            picard_args.debug
-            or "PICARD_DEBUG" in os.environ
-            or config.setting['log_verbosity'] == logging.DEBUG
-        )
+        self.set_log_level(config.setting['log_verbosity'])
+
+        if picard_args.debug or "PICARD_DEBUG" in os.environ:
+            self.set_log_level(logging.DEBUG)
 
         # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
         # It's a valid reference, but its start() method doesn't work.
@@ -261,14 +260,9 @@ class Tagger(QtWidgets.QApplication):
         for f in self.exit_cleanup:
             f()
 
-    def debug(self, debug):
-        self._debug = debug
-        if debug:
-            log.debug_mode(True)
-            log.debug("Debug mode on")
-        else:
-            log.info("Debug mode off")
-            log.debug_mode(False)
+    def set_log_level(self, level):
+        self._debug = level == logging.DEBUG
+        log.set_level(level)
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -19,7 +19,6 @@
 
 
 from functools import partial
-import logging
 import os
 
 from PyQt5 import (
@@ -138,7 +137,7 @@ class LogView(LogViewCommon):
 
     def __init__(self, parent=None):
         super().__init__(log.main_tail, _("Log"), parent=parent)
-        self.verbosity = config.setting['log_verbosity']
+        self.verbosity = log.get_effective_level()
 
         self._setup_formats()
         self.hl_text = ''
@@ -147,9 +146,6 @@ class LogView(LogViewCommon):
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
-        # Verbosity
-        if QtCore.QObject.tagger._debug:
-            self.verbosity = logging.DEBUG
         self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"))
         self.hbox.addWidget(self.verbosity_menu_button)
 
@@ -287,7 +283,7 @@ class LogView(LogViewCommon):
     def _verbosity_changed(self, level):
         if level != self.verbosity:
             config.setting['log_verbosity'] = level
-            QtCore.QObject.tagger.debug(level == logging.DEBUG)
+            QtCore.QObject.tagger.set_log_level(level)
             self.verbosity = level
             self.display(clear=True)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1368](https://tickets.metabrainz.org/browse/PICARD-1368)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Previously, despite having the option to set one of 4 log levels, it was only
possible to toggle between WARNING and DEBUG, because log.debug_mode only set
either logging.DEBUG or VERBOSITY_DEFAULT (logging.WARNING). Now we correctly
pass the selected log level to log.set_level.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

