### PR TITLE
PICARD-1374: Fix a crash when parsing an incomplete regular expresion being written

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -445,7 +445,7 @@ def func_rreplace(parser, text, old, new):
     try:
         return re.sub(old, new, text)
     except re.error:
-        return ""
+        return text
 
 
 def func_rsearch(parser, text, pattern):

--- a/picard/script.py
+++ b/picard/script.py
@@ -442,11 +442,17 @@ def func_inmulti(parser, haystack, needle, separator=MULTI_VALUED_JOINER):
 
 
 def func_rreplace(parser, text, old, new):
-    return re.sub(old, new, text)
+    try:
+        return re.sub(old, new, text)
+    except re.error:
+        return ""
 
 
 def func_rsearch(parser, text, pattern):
-    match = re.search(pattern, text)
+    try:
+        match = re.search(pattern, text)
+    except re.error:
+        return ""
     if match:
         try:
             return match.group(1)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Fix a crash when parsing an incomplete regular expresion that is still being written

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

* **Describe this change in 1-2 sentences**:
This patch catches the re exceptions for $rsearch and $rreplace so
picard doesn't crash.

# Problem

If you write $rsearch(text,) in the file naming script window and then move the cursor between the comma and the closing parenthesis and start writing a regular expression like [a-z], picard crashes as soon as the '[' character is entered, since it tries to parse the regular expression and the re module raises an exception.

* JIRA ticket (_optional_): [PICARD-1374](https://tickets.metabrainz.org/browse/PICARD-1374)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Catch the exception and just return as if the text didn't match

