### PR TITLE
PICARD-1313: Unregister extension points when uninstalling a plugin

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -397,7 +397,7 @@ class PluginManager(QtCore.QObject):
                     if os.path.isfile(update):
                         log.debug("Removing file %r", update)
                         os.remove(update)
-
+        _unregister_module_extensions(plugin_name)
         self.plugins = [ p for p in self.plugins if p.module_name != plugin_name]
 
     def remove_plugin(self, plugin_name, with_update=False):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Fixes a crash when uninstalling a plugin which provides an option page, the re-installing it again.

# Problem
After re-installing the previously installed plugin, opening the options would crash, since the option page is now registered twice.

The issue was introduced with the reworked option page in PICARD-1313. In general extension points should be deregistered when uninstalling a plugin. The specific crash described above was only for `register_options_page`, but similar issues might happen with other extension points.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1313](https://tickets.metabrainz.org/browse/PICARD-1313)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

