### PR TITLE
PICARD-1379: Fix PyUnicode_GetSize deprecation warning in astrcmp

### DIFF
--- a/picard/util/_astrcmp.c
+++ b/picard/util/_astrcmp.c
@@ -1,5 +1,6 @@
 /*
  * Picard, the next-generation MusicBrainz tagger
+ * Copyright (C) 2018 Philipp Wolfer
  * Copyright (C) 2006 Lukáš Lalinský
  * Copyright (C) 2003 Benbuck Nason
  *
@@ -56,8 +57,8 @@
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MATRIX(a, b) matrix[(b) * (len1 + 1) + (a)]
 
-float LevenshteinDistance(const Py_UNICODE * s1, int len1,
-	                      const Py_UNICODE * s2, int len2)
+float LevenshteinDistance(int k1, const Py_UNICODE * s1, Py_ssize_t len1,
+	                      int k2, const Py_UNICODE * s2, Py_ssize_t len2)
 {
 	int *matrix, index1, index2;
 	float result;
@@ -87,14 +88,14 @@ float LevenshteinDistance(const Py_UNICODE * s1, int len1,
 
 	for (index1 = 1; index1 <= len1; index1++)
 	{
-		Py_UNICODE s1_current = s1[index1 - 1];
+		Py_UCS4 s1_current = PyUnicode_READ(k1, s1, index1 - 1);
 
 		/* Step 4 */
 		/* Loop through second string */
 
 		for (index2 = 1; index2 <= len2; index2++)
 		{
-			Py_UNICODE s2_current = s2[index2 - 1];
+			Py_UCS4 s2_current = PyUnicode_READ(k2, s2, index2 - 1);
 
 			/* Step 5 */
 			/* Calculate cost of this iteration
@@ -119,9 +120,9 @@ float LevenshteinDistance(const Py_UNICODE * s1, int len1,
 			if (index1 > 2 && index2 > 2)
 			{
 				int trans = MATRIX(index1 - 2, index2 - 2) + 1;
-				if (s1[index1 - 2] != s2_current)
+				if (PyUnicode_READ(k1, s1, index1 - 2) != s2_current)
 					trans++;
-				if (s1_current != s2[index2 - 2])
+				if (s1_current != PyUnicode_READ(k2, s2, index2 - 2))
 					trans++;
 				if (cell > trans)
 					cell = trans;
@@ -147,20 +148,23 @@ astrcmp(PyObject *self, PyObject *args)
 {
 	PyObject *s1, *s2;
 	float d;
-	const Py_UNICODE *us1, *us2;
-	int len1, len2;
+	const void *ud1, *ud2;
+	int k1, k2;
+	Py_ssize_t len1, len2;
 	PyThreadState *_save;
 
 	if (!PyArg_ParseTuple(args, "UU", &s1, &s2))
 		return NULL;
 
-	us1 = PyUnicode_AS_UNICODE(s1);
-	us2 = PyUnicode_AS_UNICODE(s2);
+	k1 = PyUnicode_KIND(s1);
+	k2 = PyUnicode_KIND(s2);
+	ud1 = PyUnicode_DATA(s1);
+	ud2 = PyUnicode_DATA(s2);
 	len1 = PyUnicode_GetLength(s1);
 	len2 = PyUnicode_GetLength(s2);
 
 	Py_UNBLOCK_THREADS
-	d = LevenshteinDistance(us1, len1, us2, len2);
+	d = LevenshteinDistance(k1, ud1, len1, k2, ud2, len2);
 	Py_BLOCK_THREADS
 	return Py_BuildValue("f", d);
 }

--- a/picard/util/_astrcmp.c
+++ b/picard/util/_astrcmp.c
@@ -88,6 +88,7 @@ float LevenshteinDistance(int k1, const Py_UNICODE * s1, Py_ssize_t len1,
 
 	for (index1 = 1; index1 <= len1; index1++)
 	{
+		Py_UCS4 s1_previous = 0;
 		Py_UCS4 s1_current = PyUnicode_READ(k1, s1, index1 - 1);
 
 		/* Step 4 */
@@ -95,6 +96,7 @@ float LevenshteinDistance(int k1, const Py_UNICODE * s1, Py_ssize_t len1,
 
 		for (index2 = 1; index2 <= len2; index2++)
 		{
+			Py_UCS4 s2_previous = 0;
 			Py_UCS4 s2_current = PyUnicode_READ(k2, s2, index2 - 1);
 
 			/* Step 5 */
@@ -120,16 +122,19 @@ float LevenshteinDistance(int k1, const Py_UNICODE * s1, Py_ssize_t len1,
 			if (index1 > 2 && index2 > 2)
 			{
 				int trans = MATRIX(index1 - 2, index2 - 2) + 1;
-				if (PyUnicode_READ(k1, s1, index1 - 2) != s2_current)
+				if (s1_previous != s2_current)
 					trans++;
-				if (s1_current != PyUnicode_READ(k2, s2, index2 - 2))
+				if (s1_current != s2_previous)
 					trans++;
 				if (cell > trans)
 					cell = trans;
 			}
 
 			MATRIX(index1, index2) = cell;
+			s2_previous = s2_current;
 		}
+
+		s1_previous = s1_current;
 	}
 
 

--- a/picard/util/_astrcmp.c
+++ b/picard/util/_astrcmp.c
@@ -22,8 +22,8 @@
  *
  * Approximate string comparison
  *
- * This work is based on the Levenshtein Metric or "edit distance", which is 
- * well known, simple, and seems to be unencumbered by any usage restrictions. 
+ * This work is based on the Levenshtein Metric or "edit distance", which is
+ * well known, simple, and seems to be unencumbered by any usage restrictions.
  * For more information on the Levenshtein Distance you can refer to the web,
  * e.g. http://www.merriampark.com/ld.htm
  *
@@ -112,10 +112,10 @@ float LevenshteinDistance(const Py_UNICODE * s1, int len1,
 
 			/* Step 6a */
 			/* Also cover transposition. This step is taken from:
-			   Berghel, Hal ; Roach, David : "An Extension of Ukkonen's 
+			   Berghel, Hal ; Roach, David : "An Extension of Ukkonen's
 			   Enhanced Dynamic Programming ASM Algorithm"
 			   (http://berghel.net/publications/asm/asm.php) */
-			
+
 			if (index1 > 2 && index2 > 2)
 			{
 				int trans = MATRIX(index1 - 2, index2 - 2) + 1;
@@ -156,8 +156,8 @@ astrcmp(PyObject *self, PyObject *args)
 
 	us1 = PyUnicode_AS_UNICODE(s1);
 	us2 = PyUnicode_AS_UNICODE(s2);
-	len1 = PyUnicode_GetSize(s1);
-	len2 = PyUnicode_GetSize(s2);
+	len1 = PyUnicode_GetLength(s1);
+	len2 = PyUnicode_GetLength(s2);
 
 	Py_UNBLOCK_THREADS
 	d = LevenshteinDistance(us1, len1, us2, len2);
@@ -179,7 +179,7 @@ static struct PyModuleDef AstrcmpModule =
     AstrcmpMethods
 };
 
-PyMODINIT_FUNC 
+PyMODINIT_FUNC
 PyInit__astrcmp(void)
 {
     return PyModule_Create(&AstrcmpModule);

--- a/test/test_util_astrcmp.py
+++ b/test/test_util_astrcmp.py
@@ -29,7 +29,7 @@ class AstrcmpCTest(AstrcmpBase, unittest.TestCase):
 
     @unittest.skipIf(astrcmp_c is None, "The _astrcmp C extension module has not been compiled")
     def test_astrcmp(self):
-        super()
+        super().test_astrcmp()
 
 
 class AstrcmpPyTest(AstrcmpBase, unittest.TestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Use `PyUnicode_GetLength` instead of deprecated `PyUnicode_GetSize`. Requires Python >= 3.3, but we list Python 3.5 as the minimum anyway.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1379](https://tickets.metabrainz.org/browse/PICARD-1379)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

