### PR TITLE
Use locale.format_string instead of locale.format

### DIFF
--- a/picard/util/bytes2human.py
+++ b/picard/util/bytes2human.py
@@ -80,7 +80,7 @@ def short_string(number, multiple, scale=1):
     else:
         fmt = '%%0.%df' % scale
         num = nr
-    fmtnum = locale.format(fmt, num)
+    fmtnum = locale.format_string(fmt, num)
     return _("%s " + unit) % fmtnum
 
 


### PR DESCRIPTION


# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

locale.format is deprecated in favor of locale.format_string since Python 3.7.
locale.format_string is exactly like it with less limitations. This makes a few warnings during tests disappear.

