### PR TITLE
PICARD-637: Allow $matchedtracks any number of args 

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -706,7 +706,8 @@ def func_performer(parser, pattern="", join=", "):
     return join.join(values)
 
 
-def func_matchedtracks(parser, arg):
+def func_matchedtracks(parser, *args):
+    # only works in file naming scripts, always returns zero in tagging scripts
     if parser.file and parser.file.parent:
         return str(parser.file.parent.album.get_num_matched_tracks())
     return "0"
@@ -922,7 +923,7 @@ register_script_function(func_copymerge, "copymerge")
 register_script_function(func_len, "len")
 register_script_function(func_lenmulti, "lenmulti", eval_args=False)
 register_script_function(func_performer, "performer")
-register_script_function(func_matchedtracks, "matchedtracks")
+register_script_function(func_matchedtracks, "matchedtracks", eval_args=False)
 register_script_function(func_is_complete, "is_complete")
 register_script_function(func_firstalphachar, "firstalphachar")
 register_script_function(func_initials, "initials")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1,4 +1,5 @@
 from test.picardtestcase import PicardTestCase
+from unittest.mock import MagicMock
 
 from picard import config
 from picard.metadata import Metadata
@@ -26,7 +27,7 @@ class ScriptParserTest(PicardTestCase):
 
         register_script_function(func_noargstest, "noargstest")
 
-    def assertScriptResultEquals(self, script, expected, context=None):
+    def assertScriptResultEquals(self, script, expected, context=None, file=None):
         """Asserts that evaluating `script` returns `expected`.
 
 
@@ -35,7 +36,7 @@ class ScriptParserTest(PicardTestCase):
             expected: The expected result
             context: A Metadata object with pre-set tags or None
         """
-        actual = self.parser.eval(script, context=context)
+        actual = self.parser.eval(script, context=context, file=file)
         self.assertEqual(actual,
                          expected,
                          "'%s' evaluated to '%s', expected '%s'"
@@ -465,6 +466,14 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lenmulti(%foo%,:)", "4", context)
         self.assertScriptResultEquals("$lenmulti(%bar%,:)", "4", context)
         self.assertScriptResultEquals("$lenmulti(%foo%.,:)", "4", context)
+
+    def test_matchedtracks(self):
+        file = MagicMock()
+        file.parent.album.get_num_matched_tracks.return_value = 42
+        self.assertScriptResultEquals("$matchedtracks()", "42", file=file)
+        self.assertScriptResultEquals("$matchedtracks()", "0")
+        # The following only is possible for backward compatibility, arg is unused
+        self.assertScriptResultEquals("$matchedtracks(arg)", "0")
 
     def test_required_kwonly_parameters(self):
         def func(a, *, required_kwarg):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

`$matchedtracks()` currently requires an argument (this is historic baggage, at some point tagger script did not support functions without argument). This is a resubmission of PR #367 by @Sophist-UK, please see the discussions there for details. I just added unit tests.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-637](https://tickets.metabrainz.org/browse/PICARD-637)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

