### PR TITLE
PICARD-1338: More resilient webservice

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -86,4 +86,5 @@ else:
 # Keep those ordered
 api_versions = [
     "2.0",
+    "2.1"
 ]

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -44,7 +44,6 @@ from picard.const import (
     USER_PLUGIN_DIR,
 )
 import picard.plugins
-from picard.util import load_json
 
 _suffixes = [s[0] for s in imp.get_suffixes()]
 _package_entries = ["__init__.py", "__init__.pyc", "__init__.pyo"]
@@ -479,7 +478,6 @@ class PluginManager(QtCore.QObject):
             PLUGINS_API['port'],
             PLUGINS_API['endpoint']['plugins'],
             partial(self._plugins_json_loaded, callback=callback),
-            parse_response_type=None,
             priority=True,
             important=True
         )
@@ -496,8 +494,11 @@ class PluginManager(QtCore.QObject):
             )
             self._available_plugins = []
         else:
-            self._available_plugins = [PluginData(data, key) for key, data in
-                                       load_json(response)['plugins'].items()]
+            try:
+                self._available_plugins = [PluginData(data, key) for key, data in
+                                           response['plugins'].items()]
+            except (AttributeError, KeyError, TypeError):
+                self._available_plugins = []
         if callback:
             callback()
 

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -263,21 +263,25 @@ class AlbumSearchDialog(SearchDialog):
             return
 
         front = None
-        for image in data["images"]:
-            if image["front"]:
-                front = image
-                break
+        try:
+            for image in data["images"]:
+                if image["front"]:
+                    front = image
+                    break
 
-        if front:
-            url = front["thumbnails"]["small"]
-            coverartimage = CaaThumbnailCoverArtImage(url=url)
-            cover_cell.fetch_task = self.tagger.webservice.download(
-                coverartimage.host,
-                coverartimage.port,
-                coverartimage.path,
-                partial(self._cover_downloaded, cover_cell)
-            )
-        else:
+            if front:
+                url = front["thumbnails"]["small"]
+                coverartimage = CaaThumbnailCoverArtImage(url=url)
+                cover_cell.fetch_task = self.tagger.webservice.download(
+                    coverartimage.host,
+                    coverartimage.port,
+                    coverartimage.path,
+                    partial(self._cover_downloaded, cover_cell)
+                )
+            else:
+                cover_cell.not_found()
+        except (AttributeError, KeyError, TypeError):
+            log.error("Error reading CAA response", exc_info=True)
             cover_cell.not_found()
 
     def _cover_downloaded(self, cover_cell, data, http, error):

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -44,7 +44,6 @@ from picard.mbjson import (
     release_to_metadata,
 )
 from picard.metadata import Metadata
-from picard.util import load_json
 from picard.webservice.api_helpers import escape_lucene_query
 
 from picard.ui.searchdialog import (
@@ -242,7 +241,7 @@ class AlbumSearchDialog(SearchDialog):
             return
         cell.fetched = True
         caa_path = "/release/%s" % cell.release["musicbrainz_albumid"]
-        cell.fetch_task = self.tagger.webservice.download(
+        cell.fetch_task = self.tagger.webservice.get(
             CAA_HOST,
             CAA_PORT,
             caa_path,
@@ -263,14 +262,8 @@ class AlbumSearchDialog(SearchDialog):
             cover_cell.not_found()
             return
 
-        try:
-            caa_data = load_json(data)
-        except ValueError:
-            cover_cell.not_found()
-            return
-
         front = None
-        for image in caa_data["images"]:
+        for image in data["images"]:
             if image["front"]:
                 front = image
                 break
@@ -282,7 +275,7 @@ class AlbumSearchDialog(SearchDialog):
                 coverartimage.host,
                 coverartimage.port,
                 coverartimage.path,
-                partial(self._cover_downloaded, cover_cell),
+                partial(self._cover_downloaded, cover_cell)
             )
         else:
             cover_cell.not_found()

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -418,8 +418,10 @@ class WebService(QtCore.QObject):
                     try:
                         document = request.response_parser(reply)
                     except Exception as e:
-                        log.error("Unable to parse the response. %s", e)
+                        url = reply.request().url().toString(QUrl.RemoveUserInfo)
+                        log.error("Unable to parse the response for %s: %s", url, e)
                         document = reply.readAll()
+                        error = e
                     finally:
                         handler(document, reply, error)
                 else:

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -93,7 +93,8 @@ class WSRequest(QNetworkRequest):
 
     def __init__(self, method, host, port, path, handler, parse_response_type=None, data=None,
                  mblogin=False, cacheloadcontrol=None, refresh=False,
-                 queryargs=None, priority=False, important=False):
+                 queryargs=None, priority=False, important=False,
+                 request_mimetype=None):
         """
         Args:
             method: HTTP method.  One of ``GET``, ``POST``, ``PUT``, or ``DELETE``.
@@ -115,6 +116,7 @@ class WSRequest(QNetworkRequest):
             retries: Current retry attempt number.
             priority: Indicates that this is a high priority request.
             important: Indicates that this is an important request.
+            request_mimetype: Set the Content-Type header.
         """
         url = build_qurl(host, port, path=path, queryargs=queryargs)
         super().__init__(url)
@@ -134,6 +136,7 @@ class WSRequest(QNetworkRequest):
         self.parse_response_type = parse_response_type
         self.response_parser = None
         self.response_mimetype = None
+        self.request_mimetype = request_mimetype
         self.data = data
         self.mblogin = mblogin
         self.cacheloadcontrol = cacheloadcontrol
@@ -164,7 +167,9 @@ class WSRequest(QNetworkRequest):
                 self.setRawHeader(b"Accept", self.response_mimetype.encode('utf-8'))
 
         if self.data:
-                self.setHeader(QNetworkRequest.ContentTypeHeader, "application/x-www-form-urlencoded")
+            if not self.request_mimetype:
+                self.request_mimetype = self.response_mimetype or "application/x-www-form-urlencoded"
+            self.setHeader(QNetworkRequest.ContentTypeHeader, self.request_mimetype)
 
     def _update_authorization_header(self):
         authorization = b""
@@ -242,9 +247,6 @@ class WSPostRequest(WSRequest):
 
     def _init_headers(self):
         super()._init_headers(high_prio_no_cache=True)
-        if self.host == config.setting["server_host"] and self.response_mimetype:
-            self.setHeader(QNetworkRequest.ContentTypeHeader,
-                            "%s; charset=utf-8" % self.response_mimetype)
 
 
 class WebService(QtCore.QObject):
@@ -450,17 +452,19 @@ class WebService(QtCore.QObject):
         return self.add_request(request)
 
     def post(self, host, port, path, data, handler, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
-             priority=False, important=False, mblogin=True, queryargs=None):
+             priority=False, important=False, mblogin=True, queryargs=None, request_mimetype=None):
         request = WSPostRequest(host, port, path, handler, parse_response_type=parse_response_type,
                             data=data, mblogin=mblogin, queryargs=queryargs,
-                            priority=priority, important=important)
+                            priority=priority, important=important,
+                            request_mimetype=request_mimetype)
         log.debug("POST-DATA %r", data)
         return self.add_request(request)
 
     def put(self, host, port, path, data, handler, priority=True, important=False, mblogin=True,
-            queryargs=None):
+            queryargs=None, request_mimetype=None):
         request = WSPutRequest(host, port, path, handler, data=data, mblogin=mblogin,
-                            queryargs=queryargs, priority=priority, important=important)
+                               queryargs=queryargs, priority=priority,
+                               important=important, request_mimetype=request_mimetype)
         return self.add_request(request)
 
     def delete(self, host, port, path, handler, priority=True, important=False, mblogin=True,

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -67,18 +67,20 @@ class APIHelper(object):
                  refresh=refresh, queryargs=queryargs, parse_response_type=parse_response_type)
 
     def post(self, path_list, data, handler, priority=False, important=False,
-                 mblogin=True, queryargs=None, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE):
+                 mblogin=True, queryargs=None, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
+                 request_mimetype=None):
         path = self.api_path + "/".join(path_list)
         return self._webservice.post(self.host, self.port, path, data, handler,
                   priority=priority, important=important, mblogin=mblogin,
-                  queryargs=queryargs, parse_response_type=parse_response_type)
+                  queryargs=queryargs, parse_response_type=parse_response_type,
+                  request_mimetype=request_mimetype)
 
     def put(self, path_list, data, handler, priority=True, important=False,
-                mblogin=True, queryargs=None):
+                mblogin=True, queryargs=None, request_mimetype=None):
         path = self.api_path + "/".join(path_list)
         return self._webservice.put(self.host, self.port, path, data, handler,
                  priority=priority, important=important, mblogin=mblogin,
-                 queryargs=queryargs)
+                 queryargs=queryargs, request_mimetype=request_mimetype)
 
     def delete(self, path_list, handler, priority=True, important=False,
                    mblogin=True, queryargs=None):
@@ -243,7 +245,8 @@ class AcoustIdAPIHelper(APIHelper):
     def query_acoustid(self, handler, **args):
         path_list = ['lookup']
         body = self._encode_acoustid_args(args)
-        return self.post(path_list, body, handler, priority=False, important=False, mblogin=False)
+        return self.post(path_list, body, handler, priority=False, important=False,
+                         mblogin=False, request_mimetype="application/x-www-form-urlencoded")
 
     def submit_acoustid_fingerprints(self, submissions, handler):
         path_list = ['submit']
@@ -255,4 +258,5 @@ class AcoustIdAPIHelper(APIHelper):
             if submission.puid:
                 args['puid.%d' % i] = submission.puid
         body = self._encode_acoustid_args(args, format_='json')
-        return self.post(path_list, body, handler, priority=True, important=False, mblogin=False)
+        return self.post(path_list, body, handler, priority=True, important=False,
+                         mblogin=False, request_mimetype="application/x-www-form-urlencoded")

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -106,7 +106,7 @@ class VersionsTest(PicardTestCase):
 
         len_api_versions = len(api_versions)
         if len_api_versions > 1:
-            for i in xrange(len_api_versions - 1):
+            for i in range(len_api_versions - 1):
                 a = version_from_string(api_versions[i])
                 b = version_from_string(api_versions[i+1])
                 self.assertLess(a, b)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
This PR aims to make the webservice and code that uses it more error tolerant. Most web service requests Picard currently makes operate under the assumption of a successful response with a valid response body. Hence a broken response by the server, e.g. changed JSON structure or sending HTML instead of expected JSON, in many cases lead to Picard crashing.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1338](https://tickets.metabrainz.org/browse/PICARD-1338)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

This PR provides the following changes:

- When using `parse_response_type` to let the web service module handle the parsing of JSON or XML responses any parsing error is treated as an error in the request and an error object is passed to the callback. This frees the caller from checking if the response data was parsed or not. See also https://github.com/metabrainz/picard-plugins/pull/173#issuecomment-434222461
- Change callers of the webservice to use `parse_response_type` instead of custom JSON parsing
- Make sure callers of the webservice handle error responses and catch errors when processing the response body
- Replaced magic code in `WSPostRequest` which set a different Content-Type header on requests if host was musicbrainz.org and `parse_response_type` was set. Replaced this by more generic logic and the ability to set a custom `request_mimetype`

I tested all the requests I touched as good as I could, also made sure the changes do not affect any request performing plugin. Parts of this PR are backwards incompatible, e.g. callers of `post` which use a different request then response mime type will have to set the request mime type explicitly. But luckily we have only read access in existing known plugins.

I introduced API version 2.1 so plugins can choose to target the new API explicitly. However, I think at this point it is still save to say we still support API 2.0.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

