### PR TITLE
PICARD-1068: Save work tag for MP4 as ©wrk

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -62,6 +62,7 @@ class MP4File(File):
         "tvsh": "show",
         "purl": "podcasturl",
         "\xa9mvn": "movement",
+        "\xa9wrk": "work",
     }
     __r_text_tags = dict([(v, k) for k, v in __text_tags.items()])
 

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -125,6 +125,7 @@ TAGS = {
     'totaltracks': '10',
     'tracknumber': '2',
     'website': 'http://example.com',
+    'work': 'Foo'
 }
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard does not save the `work` tag to MP4, even though there is a work tag in MP4 (which is displayed in iTunes and others) and we already save the tag to MP3 in a way that is also interpreted by iTunes and others in the same field (see #928).

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1068](https://tickets.metabrainz.org/browse/PICARD-1068)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

This adds support for writing `©wrk` to MP4 to get a result like this in iTunes:

![grafik](https://user-images.githubusercontent.com/29852/48311787-539d9180-e5a5-11e8-9636-107761aa6846.png)

Note that this is already possible for MP3, so it is just consistent to support it for MP4 as well.

Previous attempt to support this ended in discussions about what MusicBrainz data should be stored there, because the work as defined in MusicBrainz is often not what you actually want to write to this tag. But I think this is a separate discussion.

Together with #928 and #1029 this will give rather complete support for "classical music" tags as interpreted by popular players like iTunes and MusicBee. Furthermore support for this is consistent between MP3 and MP4.

If the default behavior of writing the direct MB work is not sufficient for the user they can use scripting or plugins to get more sophisticated data. E.g. the work name can be split into work and movement according to the classical track title guidelines, or a plugin like Classical Extras can be used to also fetch parent works. But for all this to work it is important that Picard actually writes the tags to the files.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

