### PR TITLE
PICARD-1320: Fix text color for modified files for dark themes

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -144,7 +144,7 @@ class MainPanel(QtWidgets.QSplitter):
         }
         FileItem.file_colors = {
             File.NORMAL: TreeItem.text_color,
-            File.CHANGED: config.setting["color_modified"],
+            File.CHANGED: TreeItem.text_color,
             File.PENDING: config.setting["color_pending"],
             File.ERROR: config.setting["color_error"],
         }
@@ -240,7 +240,6 @@ class MainPanel(QtWidgets.QSplitter):
 class BaseTreeView(QtWidgets.QTreeWidget):
 
     options = [
-        config.Option("setting", "color_modified", QtGui.QColor(QtGui.QPalette.WindowText)),
         config.Option("setting", "color_saved", QtGui.QColor(0, 128, 0)),
         config.Option("setting", "color_error", QtGui.QColor(200, 0, 0)),
         config.Option("setting", "color_pending", QtGui.QColor(128, 128, 128)),


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
With dark theme modified files are shown with black text on dark background.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The text color for modified files was supposed to be theme aware, but generating the color failed. Creating a QColor object from a QPalette ColorRole does not work (maybe it worked in Qt4). The result was always a black color.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1320](https://tickets.metabrainz.org/browse/PICARD-1320)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Switch the text color to use the color for foreground text. When the "color_modified" option gets initialized we don't have access to the current palette, so I decided to remove the "color_modified" config option entirely, as it defaulted to the standard foreground text color anyway and we don't make use of these options currently anyway.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

