### PR TITLE
PICARD-1060: Fix collections menu not looking and behaving like a normal menu

### DIFF
--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -2,6 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 # Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2018 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -36,9 +37,11 @@ class CollectionMenu(QtWidgets.QMenu):
     def __init__(self, albums, *args):
         super().__init__(*args)
         self.ids = set(a.id for a in albums)
+        self._ignore_update = False
         self.update_collections()
 
     def update_collections(self):
+        self._ignore_update = True
         self.clear()
         self.actions = []
         for id_, collection in sorted(user_collections.items(),
@@ -48,6 +51,7 @@ class CollectionMenu(QtWidgets.QMenu):
             action.setDefaultWidget(CollectionMenuItem(self, collection))
             self.addAction(action)
             self.actions.append(action)
+        self._ignore_update = False
         self.addSeparator()
         self.refresh_action = self.addAction(_("Refresh List"))
         self.hovered.connect(self.update_highlight)
@@ -62,15 +66,21 @@ class CollectionMenu(QtWidgets.QMenu):
             self.refresh_list()
 
     def update_highlight(self, action):
+        if self._ignore_update:
+            return
         for a in self.actions:
             a.defaultWidget().set_active(a == action)
 
     def update_active_action_for_widget(self, widget):
+        if self._ignore_update:
+            return
         for action in self.actions:
             action_widget = action.defaultWidget()
             is_active = action_widget ==  widget
             if is_active:
+                self._ignore_hover = True
                 self.setActiveAction(action)
+                self._ignore_hover = False
             action_widget.set_active(is_active)
 
 

--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -95,9 +95,12 @@ class CollectionMenuItem(QtWidgets.QWidget):
     def _setup_layout(self, menu, collection):
         layout = QtWidgets.QVBoxLayout(self)
         style = self.style()
-        lmargin = style.pixelMetric(QtWidgets.QStyle.PM_LayoutLeftMargin)
-        rmargin = style.pixelMetric(QtWidgets.QStyle.PM_LayoutRightMargin)
-        layout.setContentsMargins(lmargin, 0, rmargin, 0)
+        layout.setContentsMargins(
+            style.pixelMetric(QtWidgets.QStyle.PM_LayoutLeftMargin),
+            style.pixelMetric(QtWidgets.QStyle.PM_FocusFrameVMargin),
+            style.pixelMetric(QtWidgets.QStyle.PM_LayoutRightMargin),
+            style.pixelMetric(QtWidgets.QStyle.PM_FocusFrameVMargin),
+            )
         self.checkbox = CollectionCheckBox(self, menu, collection)
         layout.addWidget(self.checkbox)
 

--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -91,6 +91,7 @@ class CollectionMenuItem(QtWidgets.QWidget):
         self.menu = menu
         self.active = False
         self._setup_layout(menu, collection)
+        self._setup_colors()
 
     def _setup_layout(self, menu, collection):
         layout = QtWidgets.QVBoxLayout(self)
@@ -103,8 +104,17 @@ class CollectionMenuItem(QtWidgets.QWidget):
         self.checkbox = CollectionCheckBox(self, menu, collection)
         layout.addWidget(self.checkbox)
 
+    def _setup_colors(self):
+        palette = self.palette()
+        self.text_color = palette.text().color()
+        self.highlight_color = palette.highlightedText().color()
+
     def set_active(self, active):
         self.active = active
+        palette = self.palette()
+        textcolor = self.highlight_color if active else self.text_color
+        palette.setColor(QtGui.QPalette.WindowText, textcolor)
+        self.checkbox.setPalette(palette)
 
     def enterEvent(self, e):
         self.menu.update_active_action_for_widget(self)
@@ -121,7 +131,6 @@ class CollectionMenuItem(QtWidgets.QWidget):
             option.state |= QtWidgets.QStyle.State_Enabled
         if self.active:
             option.state |= QtWidgets.QStyle.State_Selected
-        option.text = self.checkbox.label()
         painter.drawControl(QtWidgets.QStyle.CE_MenuItem, option)
 
 
@@ -158,10 +167,3 @@ class CollectionCheckBox(QtWidgets.QCheckBox):
     def label(self):
         c = self.collection
         return ngettext("%s (%i release)", "%s (%i releases)", c.size) % (c.name, c.size)
-
-    def paintEvent(self, e):
-        painter = QtWidgets.QStylePainter(self)
-        option = QtWidgets.QStyleOptionButton()
-        self.initStyleOption(option)
-        option.text = None
-        painter.drawControl(QtWidgets.QStyle.CE_CheckBox, option)


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The collection sub menu currently does not display and behave like a normal menu. Mainly the menu items render without margins and do not highlight on activation.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1060](https://tickets.metabrainz.org/browse/PICARD-1060)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
The reason for the differences is that we render those menu items with a custom widget which we need for the tri-state checkboxes.

Implement the necessary changes to render with margin and background highlighting. Capture the mouse over and menu item activated events to properly mark mouse overed items as active and render active items with background.

I tested this on Gnome and KDE (KDE with a light and a dark theme). In both cases the menu rendered exactly as e.g. the "other versions" menu.

Since we strictly set the Fusion theme this should reliable work. I have not tested with any other theme. I have also not yet tested on macOS, but even there it should be at least an improvement to the really broken rendering we currently have. The highlight color or margins might be off, though.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

