### PR TITLE
PICARD-1415: Fix opening UNC paths on Windows

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -889,12 +889,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return self.tagger.analyze(self.selected_objects)
 
     def _openUrl(self, url):
-        # Resolves a bug in Qt opening remote URLs - QTBUG-13359
-        # See https://bugreports.qt.io/browse/QTBUG-13359
-        if url.startswith("\\\\") or url.startswith("//"):
-            return QtCore.QUrl(QtCore.QDir.toNativeSeparators(url))
-        else:
-            return QtCore.QUrl.fromLocalFile(url)
+        return QtCore.QUrl.fromLocalFile(url)
 
     def play_file(self):
         files = self.tagger.get_files_from_objects(self.selected_objects)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Network / UNC paths on Windows cannot be opened, affects open containing folder and open in player actions.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1415](https://tickets.metabrainz.org/browse/PICARD-1415)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Remove an older workaround for a similar problem which is no linger required in Qt5 and actually breaks this functionality.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

