### PR TITLE
PICARD-1417: Do not show plugins that are incompatible

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -34,6 +34,7 @@ from PyQt5 import QtCore
 
 from picard import (
     VersionError,
+    api_versions,
     config,
     log,
     version_from_string,
@@ -494,9 +495,11 @@ class PluginManager(QtCore.QObject):
             )
             self._available_plugins = []
         else:
+            supported_versions = set(api_versions)
             try:
                 self._available_plugins = [PluginData(data, key) for key, data in
-                                           response['plugins'].items()]
+                                           response['plugins'].items()
+                                           if supported_versions.intersection(data['api_versions'])]
             except (AttributeError, KeyError, TypeError):
                 self._available_plugins = []
         if callback:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard is showing plugins even if they are incompatible with currently supported API versions. This fix checks the compatibility and ignores incompatible plugins when loading the list.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1417](https://tickets.metabrainz.org/browse/PICARD-1417)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
There is also the proposal to filter this already server side, see [PW-27](https://tickets.metabrainz.org/projects/PW/issues/PW-27). That also would require some client changes, but additionally provide some complication server side with caching of different API version combinations. I'm actually in favor of applying this simple client side fix so we have something in place for the next release. We can still later do the server side change.

The advantage of having this in with the next release is that it will then already be easier to deprecate older API versions in follow up releases without causing trouble on plugin installation for existing installs.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

