### PR TITLE
PICARD-1418: Setup default Qt translations

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -23,6 +23,8 @@ import locale
 import os.path
 import sys
 
+from PyQt5.QtCore import QLocale
+
 builtins.__dict__['N_'] = lambda a: a
 
 
@@ -65,6 +67,7 @@ def setup_gettext(localedir, ui_language=None, logger=None):
             except Exception as e:
                 logger(e)
     os.environ['LANGUAGE'] = os.environ['LANG'] = current_locale
+    QLocale.setDefault(QLocale(current_locale))
     logger("Using locale %r", current_locale)
     try:
         logger("Loading gettext translation, localedir=%r", localedir)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -816,5 +816,16 @@ def main(localedir=None, autoupdate=True):
         return longversion()
 
     tagger = Tagger(picard_args, unparsed_args, localedir, autoupdate)
+
+    # Initialize Qt default translations
+    translator = QtCore.QTranslator()
+    locale = QtCore.QLocale()
+    translation_path = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.TranslationsPath)
+    log.debug("Looking for Qt locale %s in %s", locale.name(), translation_path)
+    if translator.load(locale, "qt_", directory=translation_path):
+        tagger.installTranslator(translator)
+    else:
+        log.warning('Error loading Qt locale %s', locale.name())
+
     tagger.startTimer(1000)
     sys.exit(tagger.run())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The keyboard shortcuts currently do not show up localized, so e.g. German users also see "Ctrl+S" for saving files, but actually should see it localized "Strg+S". Same is true for default dialogs, e.g. file open dialogs currently always show up with English button labels.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1418](https://tickets.metabrainz.org/browse/PICARD-1418)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Setup default Qt translations. This makes sure standard dialogs and keyboard shortcut hints show up in the user selected language.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

