### PR TITLE
PICARD-1341: Fix cluster sorting by disc and track number

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -696,14 +696,14 @@ class File(QtCore.QObject, Item):
 
     def _get_tracknumber(self):
         try:
-            return self.metadata["tracknumber"]
+            return int(self.metadata["tracknumber"])
         except:
             return 0
     tracknumber = property(_get_tracknumber, doc="The track number as an int.")
 
     def _get_discnumber(self):
         try:
-            return self.metadata["discnumber"]
+            return int(self.metadata["discnumber"])
         except:
             return 0
     discnumber = property(_get_discnumber, doc="The disc number as an int.")

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,0 +1,28 @@
+from test.picardtestcase import PicardTestCase
+
+from picard.file import File
+
+
+class DataObjectTest(PicardTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.file = File('somepath/somefile.mp3')
+
+    def test_filename(self):
+        self.assertEqual('somepath/somefile.mp3', self.file.filename)
+        self.assertEqual('somefile.mp3', self.file.base_filename)
+
+    def test_tracknumber(self):
+        self.assertEqual(0, self.file.tracknumber)
+        self.file.metadata['tracknumber'] = '42'
+        self.assertEqual(42, self.file.tracknumber)
+        self.file.metadata['tracknumber'] = 'FOURTYTWO'
+        self.assertEqual(0, self.file.tracknumber)
+
+    def test_discnumber(self):
+        self.assertEqual(0, self.file.discnumber)
+        self.file.metadata['discnumber'] = '42'
+        self.assertEqual(42, self.file.discnumber)
+        self.file.metadata['discnumber'] = 'FOURTYTWO'
+        self.assertEqual(0, self.file.discnumber)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When clustering files they are supposed to be ordered by disc and tracknumber. But since all metadata in Picard 2.0 is returned as strings this breaks the sorting.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1341](https://tickets.metabrainz.org/browse/PICARD-1341)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Convert numbers to int. The `file.discnumber` and `file.tracknumber` properties where supposed to return integers before, as can be seen by the default 0 getting returned.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
It might be worth discussing to support more representations of tracknumbers here, like e.g. vinyl numbering ('A1', 'A2'), strings in the form `"3/42"` or even latin numbers. But I think this would be part of a separate issue and require all of Picard supporting this. For here I wanted to focus on fixing the regression.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

