### PR TITLE
PICARD-421: Set inc=user-collections for album loading when authentic…

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -375,6 +375,9 @@ class Album(DataObject, Item):
         require_authentication = False
         inc = ['release-groups', 'media', 'recordings', 'artist-credits',
                'artists', 'aliases', 'labels', 'isrcs', 'collections']
+        if self.tagger.webservice.oauth_manager.is_authorized():
+            require_authentication = True
+            inc += ['user-collections']
         if config.setting['release_ars'] or config.setting['track_ars']:
             inc += ['artist-rels', 'release-rels', 'url-rels', 'recording-rels', 'work-rels']
             if config.setting['track_ars']:


### PR DESCRIPTION
…ated

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Load user's private collections for releases.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard does not load user's private collections when loading releases, except if ratings or "only use my tags" are enabled.

Picard must set inc?user-collections explicitly as implemented in https://tickets.metabrainz.org/browse/MBS-6152

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-421](https://tickets.metabrainz.org/browse/PICARD-421)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

