### PR TITLE
PICARD-1398: Fix installing locales when running setup.py bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,8 +160,9 @@ class picard_install(install):
     def finalize_options(self):
         install.finalize_options(self)
         if self.install_locales is None:
-            self.install_locales = '$base/share/locale'
-            self._expand_attrs(['install_locales'])
+            self.install_locales = os.path.join(self.install_data, 'share', 'locale')
+            if self.root and self.install_locales.startswith(self.root):
+                self.install_locales = self.install_locales[len(self.root):]
         self.install_locales = os.path.normpath(self.install_locales)
         self.localedir = self.install_locales
         # can't use set_undefined_options :/


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Builds for Snap package do not contain locale files.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Snap packages use `setup.py bdist_wheel` for generating the package. Currently the way our locale files are built causes them to be not included in the data package of the wheel.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1398](https://tickets.metabrainz.org/browse/PICARD-1398)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fix installation of locale files to be in the proper data file used by the setuptools. This ensures not matter how the final packaging works the locale files will be included.

For now only tested locally with normal setup.py install and bdist_wheel commands. Before merging I want to test the CI builds for Win and Mac.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

