### PR TITLE
PICARD-1430: On MB auth errors allow the user to start the oAuth flow

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -288,6 +288,7 @@ class Tagger(QtWidgets.QApplication):
         else:
             callback(False)
 
+    @classmethod
     def on_mb_login_finished(self, callback, successful):
         if successful:
             load_user_collections()

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -278,11 +278,15 @@ class Tagger(QtWidgets.QApplication):
             self.webservice.oauth_manager.exchange_authorization_code(
                 authorization_code, scopes,
                 partial(self.on_mb_authorization_finished, callback))
+        else:
+            callback(False)
 
     def on_mb_authorization_finished(self, callback, successful):
         if successful:
             self.webservice.oauth_manager.fetch_username(
                 partial(self.on_mb_login_finished, callback))
+        else:
+            callback(False)
 
     def on_mb_login_finished(self, callback, successful):
         if successful:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1091,10 +1091,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
                 QtWidgets.QMessageBox.Yes)
             if ret == QtWidgets.QMessageBox.Yes:
-                pass
+                self.tagger.mb_login(self.on_mb_login_finished)
         else:
             dialog = PasswordDialog(authenticator, reply, parent=self)
             dialog.exec_()
+
+    def on_mb_login_finished(self, successful):
+        log.debug('MusicBrainz authentication finished: %s', successful)
 
     def show_proxy_dialog(self, proxy, authenticator):
         dialog = ProxyDialog(authenticator, proxy, parent=self)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1096,6 +1096,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             dialog = PasswordDialog(authenticator, reply, parent=self)
             dialog.exec_()
 
+    @classmethod
     def on_mb_login_finished(self, successful):
         log.debug('MusicBrainz authentication finished: %s', successful)
 

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -21,12 +21,10 @@ from PyQt5 import QtCore
 from PyQt5.QtWidgets import QInputDialog
 
 from picard import config
-from picard.collection import load_user_collections
 from picard.const import (
     MUSICBRAINZ_SERVERS,
     PROGRAM_UPDATE_LEVELS,
 )
-from picard.util import webbrowser2
 
 from picard.ui.options import (
     OptionsPage,
@@ -106,33 +104,18 @@ class GeneralOptionsPage(OptionsPage):
             self.ui.logout.hide()
 
     def login(self):
-        scopes = "profile tag rating collection submit_isrc submit_barcode"
-        authorization_url = self.tagger.webservice.oauth_manager.get_authorization_url(scopes)
-        webbrowser2.open(authorization_url)
-        authorization_code, ok = QInputDialog.getText(self,
-            _("MusicBrainz Account"), _("Authorization code:"))
-        if ok:
-            self.tagger.webservice.oauth_manager.exchange_authorization_code(
-                authorization_code, scopes, self.on_authorization_finished)
+        self.tagger.mb_login(self.on_login_finished, self)
 
     def restore_defaults(self):
         super().restore_defaults()
         self.logout()
 
-    def on_authorization_finished(self, successful):
-        if successful:
-            self.tagger.webservice.oauth_manager.fetch_username(
-                self.on_login_finished)
-
     def on_login_finished(self, successful):
         self.update_login_logout()
-        if successful:
-            load_user_collections()
 
     def logout(self):
-        self.tagger.webservice.oauth_manager.revoke_tokens()
+        self.tagger.mb_logout()
         self.update_login_logout()
-        load_user_collections()
 
 
 register_options_page(GeneralOptionsPage)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Currently if a request to MB requires authentication and the user is not authorized or has invalid oauth tokens set a dialog will be shown asking the user to authenticate with "Yes" / "No" buttons. But currently there is no implementation behind clicking "Yes", so nothing will happen.

This fix changes this by initiating the oAuth flow allowing the user to directly authenticate instead of going to the options.

One issue remains: The request causing this issue still fails. The QNetworkAccessManager.authenticationRequired signal requires to either set credentials before the signal returns or the request will fail with an AuthenticationRequiredError.

To my knowledge Qt does not provide an asynchroneous way to handle authentication, see also https://bugreports.qt.io/browse/QTBUG-16251

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1430](https://tickets.metabrainz.org/browse/PICARD-1430)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

