### PR TITLE
PICARD-1450: Fix language labels for zh_CN and zh_TW

### DIFF
--- a/picard/const/languages.py
+++ b/picard/const/languages.py
@@ -71,6 +71,6 @@ UI_LANGUAGES = [
     #(u'ta', u'தமிழ்', N_(u'Tamil')),
     (u'tr', u'Türkçe', N_(u'Turkish')),
     (u'uk', u'Украї́нська мо́ва', N_(u'Ukrainian')),
-    (u'zh_CN', u'中文', N_(u'Chinese')),
-    (u'zh_TW', u'傳統中文', N_(u'Traditional Chinese')),
+    (u'zh_CN', u'中文（中国大陆）', N_(u'Chinese (China)')),
+    (u'zh_TW', u'中文（台灣）', N_(u'Chinese (Taiwan)')),
 ]


### PR DESCRIPTION
zh_CN (Chinese (China)) should read "中文（中国大陆）" not "中文".
zh_TW (Chinese (Taiwan)) should read "中文（台灣）" not “傳統中文".

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1450](https://tickets.metabrainz.org/browse/PICARD-1450)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

