### PR TITLE
PICARD-1453: Fix drop events on coverartbox

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -66,10 +66,12 @@ class ActiveLabel(QtWidgets.QLabel):
         if self.active and event.button() == QtCore.Qt.LeftButton:
             self.clicked.emit()
 
-    def dragEnterEvent(self, event):
+    @staticmethod
+    def dragEnterEvent(event):
         event.acceptProposedAction()
 
-    def dragMoveEvent(self, event):
+    @staticmethod
+    def dragMoveEvent(event):
         event.acceptProposedAction()
 
     def dropEvent(self, event):

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -69,6 +69,9 @@ class ActiveLabel(QtWidgets.QLabel):
     def dragEnterEvent(self, event):
         event.acceptProposedAction()
 
+    def dragMoveEvent(self, event):
+        event.acceptProposedAction()
+
     def dropEvent(self, event):
         accepted = False
         # Chromium includes the actual data of the dragged image in the drop event. This


### PR DESCRIPTION
It seems at some point it has become neccessary to accept
dragMoveEvents as well as dragEnterEvents in order to
let Qt know that we want to receive drop events.

# Summary

Fix drop events on coverartbox which were previously ignored by what appears to be a behaviour change in Qt.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

When dragging  a file from a file manager (or an image from the browser) and dropping it over the CoverArtBox, ActiveLabel.dragEnterEvent is correctly called and it's accepting the event, but ActiveLabel.dropEvent is not called at all because some logic looks to be preventing it.


* JIRA ticket: [PICARD-1453](https://tickets.metabrainz.org/browse/PICARD-1453)

# Solution

It seems at some point it has become necessary to also accept the dragMoveEvent in order to Qt to call the dropEvent method, which is what this pull request does.

