### PR TITLE
PICARD-1470: Make Qt locale loading warning less visible

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -858,7 +858,7 @@ def main(localedir=None, autoupdate=True):
     if translator.load(locale, "qtbase_", directory=translation_path):
         tagger.installTranslator(translator)
     else:
-        log.warning('Error loading Qt locale %s', locale.name())
+        log.debug('Qt locale %s not available', locale.name())
 
     tagger.startTimer(1000)
     sys.exit(tagger.run())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
For locales that are not available for Qt Picard currently shows a warning like:

    W: 08:47:12,788 /usr/lib/python3.7/site-packages/picard/tagger.main:861: Error loading Qt locale sv_SE

This actually shows up a lot, since Qt has not that many locales included. If I look at the avilable Qt locales on my system this is only ar, bg, ca, cs, da, de, en, es, fa, fi, fr, gd, gl, he.

But the warning confuses users and makes them think something is broken.

Reduce the log level of this warning and reword it to be less scary.


<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1470](https://tickets.metabrainz.org/browse/PICARD-1470)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

