### PR TITLE
PICARD-323: Fix discid for multidisc releases

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -79,7 +79,7 @@ class Album(DataObject, Item):
 
     release_group_loaded = QtCore.pyqtSignal()
 
-    def __init__(self, album_id):
+    def __init__(self, album_id, discid=None):
         DataObject.__init__(self, album_id)
         self.metadata = Metadata()
         self.orig_metadata = Metadata()
@@ -91,6 +91,8 @@ class Album(DataObject, Item):
         self._requests = 0
         self._tracks_loaded = False
         self._discids = set()
+        if discid:
+            self._discids.add(discid)
         self._after_load_callbacks = []
         self.unmatched_files = Cluster(_("Unmatched Files"), special=True, related_album=self, hide_if_empty=True)
         self.errors = []
@@ -370,7 +372,7 @@ class Album(DataObject, Item):
 
         return track
 
-    def load(self, priority=False, refresh=False, discid=None):
+    def load(self, priority=False, refresh=False):
         if self._requests:
             log.info("Not reloading, some requests are still active.")
             return
@@ -390,8 +392,6 @@ class Album(DataObject, Item):
         self._new_tracks = []
         self._requests = 1
         self.errors = []
-        if discid:
-            self._discids.add(discid)
         require_authentication = False
         inc = ['release-groups', 'media', 'discids', 'recordings', 'artist-credits',
                'artists', 'aliases', 'labels', 'isrcs', 'collections']

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -606,10 +606,10 @@ class Tagger(QtWidgets.QApplication):
             log.debug("Album %s already loaded.", album_id)
             album.add_discid(discid)
             return album
-        album = Album(album_id)
+        album = Album(album_id, discid=discid)
         self.albums[album_id] = album
         self.album_added.emit(album)
-        album.load(discid=discid)
+        album.load()
         return album
 
     def load_nat(self, nat_id, node=None):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -605,10 +605,10 @@ class Tagger(QtWidgets.QApplication):
         if album:
             log.debug("Album %s already loaded.", album_id)
             return album
-        album = Album(album_id, discid=discid)
+        album = Album(album_id)
         self.albums[album_id] = album
         self.album_added.emit(album)
-        album.load()
+        album.load(discid=discid)
         return album
 
     def load_nat(self, nat_id, node=None):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -604,6 +604,7 @@ class Tagger(QtWidgets.QApplication):
         album = self.albums.get(album_id)
         if album:
             log.debug("Album %s already loaded.", album_id)
+            album.add_discid(discid)
             return album
         album = Album(album_id)
         self.albums[album_id] = album


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
On disc lookup set the disc ID only for the tracks on the disc being looked up.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The feature of Picard to set the disc ID used for a disc lookup on the loaded metadata was from a time when releases had only a single medium. It set the disc ID for all tracks, regardless on whether they are on the looked up disc or not.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-323](https://tickets.metabrainz.org/browse/PICARD-323)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Handle multiple disc IDs and set them only for tracks on the looked up disc. The following changes have been made:

1. Album handles a list of disc IDs
2. A new hidden variable `~musicbrainz_discids` is set on the tracks, holding all disc IDs MusicBrainz has stored for the corresponding medium
3. On lookup the tag `musicbrainz_discid` is set only for the affected tracks
4. Looking up a disc for an already loaded album adds the disc ID to the loaded album. That allows the user to also insert e.g. disc 2 and add it's disc ID to the tags after they have loaded the album using disc 1
5. The changes also fix the bug that re-loading an album lost the disc ID.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

