### PR TITLE
PICARD-1242: Consider AcoustId source count

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -80,10 +80,12 @@ class AcoustIDClient(QtCore.QObject):
                     if results:
                         result = results[0]
                         file.metadata['acoustid_id'] = result['id']
-                        if 'recordings' in result:
+                        if 'recordings' in result and result['recordings']:
+                            max_sources = max([r['sources'] for r in result['recordings']])
                             for recording in result['recordings']:
                                 parsed_recording = parse_recording(recording)
                                 if parsed_recording is not None:
+                                    parsed_recording['score'] = recording['sources'] / max_sources * 100
                                     recording_list.append(parsed_recording)
                             log.debug("AcoustID: Lookup successful for '%s'", file.filename)
                 else:
@@ -135,7 +137,7 @@ class AcoustIDClient(QtCore.QObject):
             mparms,
             echo=None
         )
-        params = dict(meta='recordings releasegroups releases tracks compress')
+        params = dict(meta='recordings releasegroups releases tracks compress sources')
         if result[0] == 'fingerprint':
             fp_type, fingerprint, length = result
             file.acoustid_fingerprint = fingerprint

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -81,11 +81,11 @@ class AcoustIDClient(QtCore.QObject):
                         result = results[0]
                         file.metadata['acoustid_id'] = result['id']
                         if 'recordings' in result and result['recordings']:
-                            max_sources = max([r['sources'] for r in result['recordings']])
+                            max_sources = max([r.get('sources', 1) for r in result['recordings']] + [1])
                             for recording in result['recordings']:
                                 parsed_recording = parse_recording(recording)
                                 if parsed_recording is not None:
-                                    parsed_recording['score'] = recording['sources'] / max_sources * 100
+                                    parsed_recording['score'] = recording.get('sources', 1) / max_sources * 100
                                     recording_list.append(parsed_recording)
                             log.debug("AcoustID: Lookup successful for '%s'", file.filename)
                 else:

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -137,7 +137,10 @@ class Metadata(dict):
         linear combination of weights that the metadata matches a certain album.
         """
         parts = self.compare_to_release_parts(release, weights)
-        return (linear_combination_of_weights(parts), release)
+        sim = linear_combination_of_weights(parts)
+        if 'score' in release:
+            sim *= release['score'] / 100
+        return (sim, release)
 
     def compare_to_release_parts(self, release, weights):
         parts = []
@@ -253,6 +256,8 @@ class Metadata(dict):
         for release in releases:
             release_parts = self.compare_to_release_parts(release, weights)
             sim = linear_combination_of_weights(parts + release_parts)
+            if 'score' in track:
+                sim *= track['score'] / 100
             if sim > result[0]:
                 rg = release['release-group'] if "release-group" in release else None
                 result = (sim, rg, release, track)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Take the number of sources for a AcoustId into account when selecting the best match. This gives better matches in cases where an AcoustId is also attached to the wrong recording.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

AcoustId tracks the number of sources for each linked MB recording. A higher number usually gives a higher confidence that this AcoustId is linked to the correct release, but Picard does currently not consider this.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1242](https://tickets.metabrainz.org/browse/PICARD-1242)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Calculate a score for recordings based on the sources relative to the recording with the most sources. E.g. if there are two recordings linked, one with 30 and one with 10 sources, the first one will get a score of 100 (percent), the second one of 33.

This score will be used when comparing recordings for the best match.

As this scoring roughly is the same as the search scoring MB provides for search results, this PR also makes use of this and utilizes MB search scores the same way.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

This should be properly tested as it affects search results as well (hopefully making them a bit better).

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

