### PR TITLE
PICARD-1473: Fix AcoustId lookup with existing fingerprint

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -61,10 +61,11 @@ class AcoustIDClient(QtCore.QObject):
         if error:
             mparms = {
                 'error': http.errorString(),
+                'body': document,
                 'filename': file.filename,
             }
             log.error(
-                "AcoustID: Lookup network error for '%(filename)s': %(error)r" %
+                "AcoustID: Lookup network error for '%(filename)s': %(error)r, %(body)s" %
                 mparms)
             self.tagger.window.set_statusbar_message(
                 N_("AcoustID lookup network error for '%(filename)s'!"),

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -216,7 +216,8 @@ class AcoustIDClient(QtCore.QObject):
             # use cached fingerprint
             fingerprints = file.metadata.getall('acoustid_fingerprint')
             if fingerprints:
-                fpcalc_next(result=('fingerprint', fingerprints[0], 0))
+                length = int(file.metadata.length / 1000)
+                fpcalc_next(result=('fingerprint', fingerprints[0], length))
                 return
         # calculate the fingerprint
         task = (file, fpcalc_next)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
When using existing fingerprint for AcoustId lookup properly set the duration parameter.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
If a file already contains a fingerprint, Picard will use this for AcoustId lookup instead of calling fpcalc. In this case Picard was submitting a parameter `duration=0`, which caused a 400 error from AcoustId:

```json
{"status": "error", "error": {"message": "missing required parameter \"duration\"", "code": 2}}
```


<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1473](https://tickets.metabrainz.org/browse/PICARD-1473)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Submit a proper duration
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

