### PR TITLE
CI: Do not fail the build if macOS upload to transfer.sh fails

### DIFF
--- a/scripts/package-osx.sh
+++ b/scripts/package-osx.sh
@@ -45,7 +45,7 @@ hdiutil create -volname "MusicBrainz Picard $VERSION" -srcfolder 'MusicBrainz Pi
 [ "$codesign" = '1' ] && codesign --keychain picard.keychain --verify --verbose --sign 'Developer ID Application: MetaBrainz Foundation Inc.' "$dmg"
 if [ -n "$UPLOAD_OSX" ]
 then
-    curl -v --fail --upload-file "$dmg" https://transfer.sh/
+    curl -v --upload-file "$dmg" https://transfer.sh/
     # Required for a newline between the outputs
     echo -e "\n"
     md5 -r "$dmg"

--- a/scripts/package-osx.sh
+++ b/scripts/package-osx.sh
@@ -45,7 +45,7 @@ hdiutil create -volname "MusicBrainz Picard $VERSION" -srcfolder 'MusicBrainz Pi
 [ "$codesign" = '1' ] && codesign --keychain picard.keychain --verify --verbose --sign 'Developer ID Application: MetaBrainz Foundation Inc.' "$dmg"
 if [ -n "$UPLOAD_OSX" ]
 then
-    curl -v --upload-file "$dmg" https://transfer.sh/
+    curl -v --retry 6 --retry-delay 10 --upload-file "$dmg" https://transfer.sh/
     # Required for a newline between the outputs
     echo -e "\n"
     md5 -r "$dmg"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Do not fail the build if macOS upload to transfer.sh fails.

As discussed with @zas on IRC we do not really care in most cases if this fails, but it currently quite often fails with server errors from transfer.sh. We still want this functionality though, as sometimes you need to access the build binaries for pull requests. If it failed and we find out we need it restarting the build is usually a quick solution.

This basically reverts https://github.com/metabrainz/picard/pull/1085

The general approach that errors in package-osx.sh should fail the build still is true
