### PR TITLE
PICARD-1474: Fix version information in Windows installer exe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ build_script:
 
     pyinstaller --noconfirm picard.spec
 
-    makensis.exe installer\picard-setup.nsi
+    makensis.exe /INPUTCHARSET UTF8 installer\picard-setup.nsi
 
 artifacts:
 - path: installer/*.exe

--- a/installer/picard-setup.nsi.in
+++ b/installer/picard-setup.nsi.in
@@ -77,13 +77,14 @@ ReserveFile "${NSISDIR}\Plugins\x86-unicode\InstallOptions.dll"
 !insertmacro MUI_LANGUAGE "English"
 
 ; Adds info to installer
-VIProductVersion "0.12.0.0"
+VIProductVersion "%(file_version)s"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "${PRODUCT_NAME}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "Comments" "${PRODUCT_DESCRIPTION}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "${PRODUCT_PUBLISHER}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "© ${PRODUCT_PUBLISHER} under the GNU GPLv2."
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Installation for ${PRODUCT_NAME}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "%(version)s"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "%(version)s"
 
 ; Install
 Section !Required req

--- a/setup.py
+++ b/setup.py
@@ -216,11 +216,12 @@ class picard_build(build):
         if platform.system() == 'Windows':
             # Temporarily setting it to this value to generate a nice name for Windows app
             args['name'] = 'MusicBrainz Picard'
+            file_version = PICARD_VERSION[0:3] + PICARD_VERSION[4:]
+            args['file_version'] = '.'.join([str(v) for v in file_version])
             generate_file('installer/picard-setup.nsi.in', 'installer/picard-setup.nsi', args)
-            version = str(PICARD_VERSION[0:3] + PICARD_VERSION[4:])
             version_args = {
-                'filevers': version,
-                'prodvers': version,
+                'filevers': str(file_version),
+                'prodvers': str(file_version),
             }
             generate_file('win-version-info.txt.in', 'win-version-info.txt', {**args, **version_args})
             args['name'] = 'picard'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Show proper version string in file properties of Windows install .exe file.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Looking at the file properties of the Windows installer show outdated version string, since that was hard coded.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1474](https://tickets.metabrainz.org/browse/PICARD-1474)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Set the version accordingly.

Before and after:

![grafik](https://user-images.githubusercontent.com/29852/52955252-7e5d6a00-338c-11e9-8a0a-59a79c06f7b8.png)

Some notes:

1. `VIProductVersion` actually is shown as "File version" ("Dateiversion" in the screenshot) in the properties dialog. This must be defined.
2. `VIProductVersion` must be in the format `0.0.0.0`, only digits allowed
3. You need to specify both `FileVersion` and `ProductVersion` in the version metadata. These are strings. `ProductVersion` is shown in the dialog as "Product version", I don't know how `FileVersion` is used, but it needs to be present and is not shown as `File Version` in the dialog
4. There is some kind of encoding issue in the Copyright field. We can fix that by putting that string into a separate file and enabling Unicode support.. I am working on a translation of the installer, which will take care of this (but don't expect this too soon).




<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

