### PR TITLE
PICARD-729: NAT error handling

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -329,6 +329,7 @@ class Tagger(QtWidgets.QApplication):
             self.nats = NatAlbum()
             self.albums["NATS"] = self.nats
             self.album_added.emit(self.nats)
+            self.nats.item.setExpanded(True)
         return self.nats
 
     def move_file_to_nat(self, file, recordingid, node=None):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -664,6 +664,16 @@ class Tagger(QtWidgets.QApplication):
             self.nats = None
         self.album_removed.emit(album)
 
+    def remove_nat(self, track):
+        """Remove the specified non-album track."""
+        log.debug("Removing %r", track)
+        self.remove_files(self.get_files_from_objects([track]))
+        self.nats.tracks.remove(track)
+        if not self.nats.tracks:
+            self.remove_album(self.nats)
+        else:
+            self.nats.update(True)
+
     def remove_cluster(self, cluster):
         """Remove the specified cluster."""
         if not cluster.special:
@@ -681,6 +691,8 @@ class Tagger(QtWidgets.QApplication):
         for obj in objects:
             if isinstance(obj, File):
                 files.append(obj)
+            elif isinstance(obj, NonAlbumTrack):
+                self.remove_nat(obj)
             elif isinstance(obj, Track):
                 files.extend(obj.linked_files)
             elif isinstance(obj, Album):

--- a/picard/track.py
+++ b/picard/track.py
@@ -298,6 +298,9 @@ class NonAlbumTrack(Track):
                                            priority=priority,
                                            refresh=refresh)
 
+    def can_remove(self):
+        return True
+
     def _recording_request_finished(self, recording, http, error):
         if error:
             self._set_error(http.errorString())

--- a/picard/track.py
+++ b/picard/track.py
@@ -75,6 +75,7 @@ class Track(DataObject, Item):
         self.num_linked_files = 0
         self.metadata = Metadata()
         self.orig_metadata = Metadata()
+        self.error = None
         self._track_artists = []
 
     def __repr__(self):
@@ -281,6 +282,7 @@ class NonAlbumTrack(Track):
     def load(self, priority=False, refresh=False):
         self.metadata.copy(self.album.metadata)
         self.status = _("[loading recording information]")
+        self.error = None
         self.loaded = False
         self.album.update(True)
         mblogin = False
@@ -315,6 +317,7 @@ class NonAlbumTrack(Track):
     def _set_error(self, error):
         log.error("%r", error)
         self.status = _("[could not load recording %s]") % self.id
+        self.error = error
         self.album.update(True)
 
     def _parse_recording(self, recording):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -708,11 +708,12 @@ class AlbumItem(TreeItem):
             newnum = len(album.tracks)
             if oldnum > newnum:  # remove old items
                 for i in range(oldnum - newnum):
-                    self.takeChild(newnum - 1)
+                    self.takeChild(newnum)
                 oldnum = newnum
             # update existing items
             for i in range(oldnum):
                 item = self.child(i)
+                item.setSelected(False)
                 track = album.tracks[i]
                 item.obj = track
                 track.item = item

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -172,6 +172,7 @@ class MainPanel(QtWidgets.QSplitter):
         TrackItem.icon_audio = QtGui.QIcon(":/images/track-audio.png")
         TrackItem.icon_video = QtGui.QIcon(":/images/track-video.png")
         TrackItem.icon_data = QtGui.QIcon(":/images/track-data.png")
+        TrackItem.icon_error = icontheme.lookup('dialog-error', icontheme.ICON_SIZE_MENU)
         FileItem.icon_file = QtGui.QIcon(":/images/file.png")
         FileItem.icon_file_pending = QtGui.QIcon(":/images/file-pending.png")
         FileItem.icon_error = icontheme.lookup('dialog-error', icontheme.ICON_SIZE_MENU)
@@ -797,7 +798,11 @@ class TrackItem(TreeItem):
                         items.append(item)
                     self.addChildren(items)
             self.setExpanded(True)
-        self.setIcon(0, icon)
+        if track.error:
+            self.setIcon(0, TrackItem.icon_error)
+            self.setToolTip(0, track.error)
+        else:
+            self.setIcon(0, icon)
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, track.column(column[1]))
             self.setForeground(i, color)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fix handling of non-album tracks in error case and make it generally more usable.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

If loading of a NAT fails it is stuck with the "[loading track information]" message. It does never display any error. Also it is not possible to remove any NAT, you can only remove the entire "non-album tracks" pseudo album.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-729](https://tickets.metabrainz.org/browse/PICARD-729)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

The core changes to fix PICARD-729 are:
- Show an actual error state with error icon, error details in tooltip and message "could not load recording"
- Allow removing single NATs

I also did some general cleanup that improve the usability of this feature:
- The NATs pseudo album is loaded always expanded, otherwise newly added NATs are not visible to the user
- Change the message "[loading track information]" to "[loading recording information]"
- Made the "[loading recording information]" localizable

The following animation demonstrates the changes:
![peek 2019-02-20 21-47](https://user-images.githubusercontent.com/29852/53123559-ae0d9d00-3559-11e9-93a1-b2c5eb2bd475.gif)


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Do we need a ticket for the auto expanded NATs and the localized error message? I considered these changes rather minor

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

