### PR TITLE
PICARD-1178: Support comparing cover images with only one type

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -121,6 +121,8 @@ class CoverArtImage:
     # formats may have types associated with cover art, but some other sources
     # don't provide such information
     support_types = False
+    # Indicates that the source supports multiple types per image.
+    support_multi_types = False
     # `is_front` has to be explicitly set, it is used to handle CAA is_front
     # indicator
     is_front = None
@@ -211,8 +213,11 @@ class CoverArtImage:
 
     def __eq__(self, other):
         if self and other:
-            if self.types and other.types:
-                return (self.datahash, self.types) == (other.datahash, other.types)
+            if self.support_types and other.support_types:
+                if self.support_multi_types and other.support_multi_types:
+                    return (self.datahash, self.types) == (other.datahash, other.types)
+                else:
+                    return (self.datahash, self.maintype) == (other.datahash, other.maintype)
             else:
                 return self.datahash == other.datahash
         elif not self and not other:
@@ -360,6 +365,7 @@ class CaaCoverArtImage(CoverArtImage):
     """Image from Cover Art Archive"""
 
     support_types = True
+    support_multi_types = True
     sourceprefix = "CAA"
 
     def __init__(self, url, types=None, is_front=False, comment='', data=None):
@@ -385,11 +391,13 @@ class TagCoverArtImage(CoverArtImage):
     """Image from file tags"""
 
     def __init__(self, file, tag=None, types=None, is_front=None,
-                 support_types=False, comment='', data=None):
+                 support_types=False, comment='', data=None,
+                 support_multi_types=False):
         super().__init__(url=None, types=types, comment=comment, data=data)
         self.sourcefile = file
         self.tag = tag
         self.support_types = support_types
+        self.support_multi_types = support_multi_types
         if is_front is not None:
             self.is_front = is_front
 
@@ -420,10 +428,12 @@ class CoverArtImageFromFile(CoverArtImage):
     sourceprefix = 'LOCAL'
 
     def __init__(self, filepath, types=None, is_front=None,
-                 support_types=False, comment='', data=None):
+                 support_types=False, comment='', data=None,
+                 support_multi_types=False):
         super().__init__(url=None, types=types, comment=comment, data=data)
         self.filepath = filepath
         self.support_types = support_types
+        self.support_multi_types = support_multi_types
         if is_front is not None:
             self.is_front = is_front
 

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import struct
 import unittest
 
 from PyQt5 import QtCore
@@ -36,3 +37,8 @@ class PicardTestCase(unittest.TestCase):
     def setUp(self):
         QtCore.QObject.tagger = FakeTagger()
         config.setting = {}
+
+
+def create_fake_png(extra):
+    """Creates fake PNG data that satisfies Picard's internal image type detection"""
+    return b'\x89PNG\x0D\x0A\x1A\x0A' + (b'a' * 4) + b'IHDR' + struct.pack('>LL', 100, 100) + extra

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# coding: utf-8
+from test.picardtestcase import (
+    PicardTestCase,
+    create_fake_png,
+)
+
+from picard.coverart.image import CoverArtImage
+
+
+def create_image(extra_data, types=None, support_types=False,
+                 support_multi_types=False):
+    image = CoverArtImage(
+        data=create_fake_png(extra_data),
+        types=types,
+    )
+    image.support_types = support_types
+    image.support_multi_types = support_multi_types
+    return image
+
+
+class CoverArtImageTest(PicardTestCase):
+    def test_is_front_image_no_types(self):
+        image = create_image(b'a')
+        self.assertTrue(image.is_front_image())
+        image.can_be_saved_to_metadata = False
+        self.assertFalse(image.is_front_image())
+
+    def test_is_front_image_types_supported(self):
+        image = create_image(b'a', types=["booklet", "front"], support_types=True)
+        self.assertTrue(image.is_front_image())
+        image.is_front = False
+        self.assertFalse(image.is_front_image())
+        image = create_image(b'a', support_types=True)
+        self.assertFalse(image.is_front_image())
+
+    def test_is_front_image_no_types_supported(self):
+        image = create_image(b'a', types=["back"], support_types=False)
+        self.assertTrue(image.is_front_image())
+
+    def test_maintype(self):
+        self.assertEqual("front", create_image(b'a').maintype)
+        self.assertEqual("front", create_image(b'a', support_types=True).maintype)
+        self.assertEqual("front", create_image(b'a', types=["back", "front"], support_types=True).maintype)
+        self.assertEqual("back", create_image(b'a', types=["back", "medium"], support_types=True).maintype)
+        self.assertEqual("front", create_image(b'a', types=["back", "medium"], support_types=False).maintype)
+
+    def test_compare_without_type(self):
+        image1 = create_image(b'a', types=["front"])
+        image2 = create_image(b'a', types=["back"])
+        image3 = create_image(b'a', types=["back"], support_types=True)
+        image4 = create_image(b'b', types=["front"])
+
+        self.assertEqual(image1, image2)
+        self.assertEqual(image1, image3)
+        self.assertNotEqual(image1, image4)
+
+    def test_compare_with_primary_type(self):
+        image1 = create_image(b'a', types=["front"], support_types=True)
+        image2 = create_image(b'a', types=["front", "booklet"], support_types=True, support_multi_types=True)
+        image3 = create_image(b'a', types=["back"], support_types=True)
+        image4 = create_image(b'b', types=["front"], support_types=True)
+        image5 = create_image(b'a', types=[], support_types=True)
+        image6 = create_image(b'a', types=[], support_types=True)
+
+        self.assertEqual(image1, image2)
+        self.assertNotEqual(image1, image3)
+        self.assertNotEqual(image1, image4)
+        self.assertNotEqual(image3, image5)
+        self.assertEqual(image5, image6)
+
+    def test_compare_with_multiple_types(self):
+        image1 = create_image(b'a', types=["front"], support_types=True, support_multi_types=True)
+        image2 = create_image(b'a', types=["front", "booklet"], support_types=True, support_multi_types=True)
+        image3 = create_image(b'a', types=["front", "booklet"], support_types=True, support_multi_types=True)
+        image4 = create_image(b'b', types=["front", "booklet"], support_types=True, support_multi_types=True)
+
+        self.assertNotEqual(image1, image2)
+        self.assertEqual(image2, image3)
+        self.assertNotEqual(image2, image4)

--- a/test/test_formats.py
+++ b/test/test_formats.py
@@ -766,34 +766,24 @@ class TestCoverArt(PicardTestCase):
     def _test_cover_art(self, filename):
         self._set_up(filename)
         try:
+            source_types = ["front", "booklet"]
             # Use reasonable large data > 64kb.
             # This checks a mutagen error with ASF files.
-            tests = {
-                'jpg': {
-                    'mime': 'image/jpeg',
-                    'data': self.jpegdata + b"a" * 1024 * 128
-                },
-                'png': {
-                    'mime': 'image/png',
-                    'data': self.pngdata + b"a" * 1024 * 128
-                },
-            }
-            for t in tests:
+            tests = [
+                CoverArtImage(data=self.jpegdata + b"a" * 1024 * 128, types=source_types),
+                CoverArtImage(data=self.pngdata + b"a" * 1024 * 128, types=source_types),
+            ]
+            for test in tests:
                 f = picard.formats.open_(self.filename)
                 metadata = Metadata()
-                imgdata = tests[t]['data']
-                metadata.append_image(
-                    CoverArtImage(
-                        data=imgdata
-                    )
-                )
+                metadata.append_image(test)
                 f._save(self.filename, metadata)
 
                 f = picard.formats.open_(self.filename)
                 loaded_metadata = f._load(self.filename)
                 image = loaded_metadata.images[0]
-                self.assertEqual(image.mimetype, tests[t]['mime'])
-                self.assertEqual(image.data, imgdata)
+                self.assertEqual(test.mimetype, image.mimetype)
+                self.assertEqual(test, image)
         finally:
             self._tear_down()
 

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import struct
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    create_fake_png,
+)
 
 from picard.album import Album
 from picard.cluster import Cluster
@@ -13,11 +15,6 @@ from picard.util.imagelist import (
     remove_metadata_images,
     update_metadata_images,
 )
-
-
-def create_fake_png(extra):
-    """Creates fake PNG data that satisfies Picard's internal image type detection"""
-    return b'\x89PNG\x0D\x0A\x1A\x0A' + (b'a' * 4) + b'IHDR' + struct.pack('>LL', 100, 100) + extra
 
 
 def create_test_files():


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixes issues where files where shown as modified when loading again and comparing against cover art with more than one type.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Cover art images that have both "front" and another type will cause files been shown as modified if they are saved and reloaded. Reason ist that only the front type gets stored, but comparison with the original image with more types than fails.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1178](https://tickets.metabrainz.org/browse/PICARD-1178)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

The following cases can happen:

- Format does not support cover art (this is currently only the case for formats that don't support tagging at all, which means currently WAV and MIDI)
- Format supports cover art, but no types (MP4, APE)
- Format supports cover art with exactly one type (ID3, ASF/WMA, FLAC, Vorbis)
- Format supports cover art with multiple types (currently none)

Case 1. is a non-issue, case 2. is already supported, since we indicate whether loaded cover art supports types or not. Case 3. is currently broken and case 4. is hypothetical.

Implemented a new attribute `CoverArtImage.support_multi_types` which indicates whether an image supports more than one type. Off by default (except for CAA). Only compare all types if both compared images have `support_multi_types == True`, else compare only the `maintype`.

This way we both fix the issue and are prepared for the multi-type case (which currently would only apply when comparing images from cover art sources that support multiple types).

Added tests for `CoverArtImage`, extended tests for formats to consider this case and tested manually with all supported formats.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

