### PR TITLE
PICARD-1480: Remove unneeded ButtonLineEdit

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -77,7 +77,6 @@ from picard.ui.searchdialog.album import AlbumSearchDialog
 from picard.ui.searchdialog.track import TrackSearchDialog
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.util import (
-    ButtonLineEdit,
     MultiDirsSelectDialog,
     find_starting_directory,
 )
@@ -699,7 +698,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.search_combo.addItem(_("Artist"), "artist")
         self.search_combo.addItem(_("Track"), "track")
         hbox.addWidget(self.search_combo, 0)
-        self.search_edit = ButtonLineEdit(search_panel)
+        self.search_edit = QtWidgets.QLineEdit(search_panel)
+        self.search_edit.setClearButtonEnabled(True)
         self.search_edit.returnPressed.connect(self.trigger_search_action)
         self.search_edit.textChanged.connect(self.enable_search)
         hbox.addWidget(self.search_edit, 0)

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -43,7 +43,6 @@ from picard.util import (
 
 from picard.ui import PicardDialog
 from picard.ui.util import (
-    ButtonLineEdit,
     StandardButton,
 )
 
@@ -85,7 +84,7 @@ class SearchBox(QtWidgets.QWidget):
         self.setupUi()
 
     def focus_in_event(self, event):
-        # When focus is on search edit box (ButtonLineEdit), need to disable
+        # When focus is on search edit box, need to disable
         # dialog's accept button. This would avoid closing of dialog when user
         # hits enter.
         parent = self.parent()
@@ -99,7 +98,8 @@ class SearchBox(QtWidgets.QWidget):
         self.search_row_layout = QtWidgets.QHBoxLayout(self.search_row_widget)
         self.search_row_layout.setContentsMargins(1, 1, 1, 1)
         self.search_row_layout.setSpacing(1)
-        self.search_edit = ButtonLineEdit(self.search_row_widget)
+        self.search_edit = QtWidgets.QLineEdit(self.search_row_widget)
+        self.search_edit.setClearButtonEnabled(True)
         self.search_edit.returnPressed.connect(self.trigger_search_action)
         self.search_edit.textChanged.connect(self.enable_search)
         self.search_edit.setFocusPolicy(QtCore.Qt.StrongFocus)

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -76,35 +76,6 @@ def find_starting_directory():
     return find_existing_path(path)
 
 
-class ButtonLineEdit(QtWidgets.QLineEdit):
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        self.clear_button = QtWidgets.QToolButton(self)
-        self.clear_button.setVisible(False)
-        self.clear_button.setCursor(QtCore.Qt.PointingHandCursor)
-        self.clear_button.setFocusPolicy(QtCore.Qt.NoFocus)
-        fallback_icon = icontheme.lookup('edit-clear', icontheme.ICON_SIZE_TOOLBAR)
-        self.clear_button.setIcon(QtGui.QIcon.fromTheme("edit-clear",
-                                                        fallback_icon))
-        self.clear_button.setStyleSheet(
-            "QToolButton { background: transparent; border: none;} QToolButton QWidget { color: black;}")
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.addWidget(self.clear_button, 0, QtCore.Qt.AlignRight)
-
-        layout.setSpacing(0)
-        self.clear_button.setToolTip(_("Clear entry"))
-        self.clear_button.clicked.connect(self.clear)
-        self.textChanged.connect(self._update_clear_button)
-        self._margins = self.getTextMargins()
-
-    def _update_clear_button(self, text):
-        self.clear_button.setVisible(text != "")
-        left, top, right, bottom = self._margins
-        self.setTextMargins(left, top, right + self.clear_button.width(), bottom)
-
-
 class MultiDirsSelectDialog(QtWidgets.QFileDialog):
 
     """Custom file selection dialog which allows the selection


### PR DESCRIPTION
QLineEdit has a clearButtonEnabled property since 5.2 which is meant for this purpose.
It also fixes an issue with clear button icon size

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1480](https://tickets.metabrainz.org/browse/PICARD-1480)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

