### PR TITLE
Better handling of missing libdiscid, catching OSError

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,28 +4,27 @@ MusicBrainz Picard Installation
 Dependencies
 ------------
 
-Before installing Picard, you need to have these:
+Before installing Picard, you need to check you have following dependencies installed.
+
+Required:
 
 * [Python 3.5 or newer](http://python.org/download)
-
 * [PyQt 5.7.1 or newer](http://www.riverbankcomputing.co.uk/software/pyqt/download)
-
 * [Mutagen 1.37 or newer](https://bitbucket.org/lazka/mutagen/downloads)
-
 * gettext:
   * [Windows](http://gnuwin32.sourceforge.net/packages/gettext.htm)
-
 * a compiler
   * Windows should work with [Visual C++ 2008 Express](http://go.microsoft.com/?linkid=7729279)
 
-* [chromaprint](http://acoustid.org/chromaprint) (optional)
-  For fingerprinting (scanning) files
+Optional but recommended:
 
-* [python-discid or python-libdiscid](https://python-discid.readthedocs.org/) (optional)
-  Required for CD lookups.
-  Depends on [libdiscid](http://musicbrainz.org/doc/libdiscid)
-  Due to slowdowns in reading the CD TOC, using libdiscid versions
-  0.3.0 - 0.4.1 is not recommended.
+* [chromaprint](http://acoustid.org/chromaprint)
+  * Required for fingerprinting (scanning) files
+* [python-discid](https://python-discid.readthedocs.org/) or [python-libdiscid](https://pypi.org/project/python-libdiscid/)
+  * Required for CD lookups.
+  * Depends on [libdiscid](http://musicbrainz.org/doc/libdiscid)
+   Note: Due to slowdowns in reading the CD TOC, using libdiscid versions
+   0.3.0 - 0.4.1 is not recommended.
 
 We recommend you use [pip](https://pip.pypa.io/en/stable/) to install the Python
 dependencies:
@@ -34,8 +33,8 @@ Run the following command to install PyQt5, Mutagen and discid:
 
     pip3 install -r requirements.txt
 
-The binaries for Python, GetText (msgfmt), fpcalc and discid.dll have to be
-in the %PATH% on Windows.
+The binaries for Python, GetText (`msgfmt`), `fpcalc` and `discid.dll` have to be
+in the `%PATH%` on Windows.
 
 
 Installation
@@ -46,8 +45,9 @@ After installing the dependencies, you can install Picard by running:
     sudo python3 setup.py install
 
 This will automatically build and install all required Python modules.
-On Windows you need to have Administrator rights, but don't put "sudo"
+On Windows you need to have Administrator rights, but don't put `sudo`
 in front of the command.
+
 To start Picard now you can use:
 
     picard
@@ -59,10 +59,8 @@ Running From the Source Tree
 If you want to run Picard from the source directory without installing, you
 need to build the C extensions and locales manually:
 
-```python
-python3 setup.py build_ext -i
-python3 setup.py build_locales -i
-```
+    python3 setup.py build_ext -i
+    python3 setup.py build_locales -i
 
 And to start Picard use:
 

--- a/picard/disc.py
+++ b/picard/disc.py
@@ -26,7 +26,7 @@ except ImportError:
     try:
         # use python-discid (http://python-discid.readthedocs.org/en/latest/)
         import discid
-    except ImportError:
+    except (ImportError, OSError):
         discid = None
 
 import traceback

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     try:
         import discid
-    except ImportError:
+    except (ImportError, OSError):
         discid = None
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Picard cannot run without this patch and missing `libdiscid` and `python-libdiscid`.

It falls back on `discid` module, but when this one is trying to load `libdiscid` it fails with:
`OSError: libdiscid.so.0: cannot open shared object file: No such file or directory`

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

According to https://python-discid.readthedocs.io/en/latest/install/#dependencies

*The module discid cannot be imported without Libdiscid >= 0.2.2 installed.
If you want to use it as optional dependency, import the module only when
needed or catch the OSError when libdiscid is not found.*

So catch OSError and define discid to None.
After that, Picard runs but emits a warning:
`W: 10:54:37,425 picard/ui/mainwindow.create_actions:465: CDROM: discid library not found - Lookup CD functionality disabled`
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

