### PR TITLE
_move_additional_files(): return asap if same directory

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -407,6 +407,11 @@ class File(QtCore.QObject, Item):
 
     def _move_additional_files(self, old_filename, new_filename):
         """Move extra files, like images, playlists..."""
+        new_path = os.path.dirname(new_filename)
+        old_path = os.path.dirname(old_filename)
+        if new_path == old_path:
+            # skip, same directory, nothing to move
+            return
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()
         for pattern in patterns.split():
@@ -418,8 +423,6 @@ class File(QtCore.QObject, Item):
             pattern_regexes.add((pattern_regex, match_hidden))
         if not pattern_regexes:
             return
-        new_path = os.path.dirname(new_filename)
-        old_path = os.path.dirname(old_filename)
         moves = set()
         try:
             # TODO: use with statement with python 3.6+


### PR DESCRIPTION
If old file and new file are in the same directory, there's no need to move any additionnal files

Apparently, the code wasn't really taking care of this,
since its introduction in https://github.com/metabrainz/picard/commit/6d4dc078aeff5a57f6fb9eaf568e96fb9a2eda20

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

