### PR TITLE
PICARD-1490: Fix local cover art loading on Windows

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -174,7 +174,7 @@ class CoverArt:
         # local files
         if coverartimage.url and coverartimage.url.scheme() == 'file':
             try:
-                path = coverartimage.url.path()
+                path = coverartimage.url.toLocalFile()
                 with open(path, 'rb') as file:
                     self._set_metadata(coverartimage, file.read())
             except IOError as ioexcept:

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -431,7 +431,7 @@ class LocalFileCoverArtImage(CoverArtImage):
 
     def __init__(self, filepath, types=None, comment='',
                  support_types=False, support_multi_types=False):
-        url = 'file://' + filepath
+        url = QUrl.fromLocalFile(filepath).toString()
         super().__init__(url=url, types=types, comment=comment)
         self.support_types = support_types
         self.support_multi_types = support_multi_types

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -100,3 +100,8 @@ class LocalFileCoverArtImageTest(PicardTestCase):
         image = LocalFileCoverArtImage(path, support_multi_types=True)
         self.assertFalse(image.support_types)
         self.assertTrue(image.support_multi_types)
+
+    def test_windows_path(self):
+        path = 'C:\\Music\\somefile.mp3'
+        image = LocalFileCoverArtImage(path)
+        self.assertEqual(image.url.toLocalFile(), 'C:/Music/somefile.mp3')

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # coding: utf-8
+import unittest
+
 from test.picardtestcase import (
     PicardTestCase,
     create_fake_png,
 )
-
+from picard.const.sys import IS_WIN
 from picard.coverart.image import (
     CoverArtImage,
     LocalFileCoverArtImage,
@@ -101,6 +103,7 @@ class LocalFileCoverArtImageTest(PicardTestCase):
         self.assertFalse(image.support_types)
         self.assertTrue(image.support_multi_types)
 
+    @unittest.skipUnless(IS_WIN, "windows test")
     def test_windows_path(self):
         path = 'C:\\Music\\somefile.mp3'
         image = LocalFileCoverArtImage(path)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Local cover art providers fails loading images on Windows. The issue was introduced in https://github.com/metabrainz/picard/pull/1111, the way the path was converted to QUrl and back was implemented to naively.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1490](https://tickets.metabrainz.org/browse/PICARD-1490)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

