### PR TITLE
Metadata class: inherit from MutableMapping instead of dict

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -284,8 +284,10 @@ class Metadata(MutableMapping):
         self.clear()
         self.update(other)
 
-    def update(self, other):
-        if isinstance(other, self.__class__):
+    def update(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], self.__class__):
+            # update from Metadata object
+            other = args[0]
             for k, v in other._store.items():
                 self._store[k] = v[:]
             if other.images:
@@ -296,8 +298,13 @@ class Metadata(MutableMapping):
             # Remove deleted tags from UI on save
             for tag in other.deleted_tags:
                 del self[tag]
-        elif isinstance(other, dict):
-            for k, v in other.items():
+        elif len(args) == 1 and isinstance(args[0], MutableMapping):
+            # update from MutableMapping (ie. dict)
+            for k, v in args[0].items():
+                self[k] = v
+        else:
+            # update from a dict-like constructor parameters
+            for k, v in dict(*args, **kwargs).items():
                 self[k] = v
 
     def clear(self):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -305,10 +305,13 @@ class Metadata(MutableMapping):
             # update from MutableMapping (ie. dict)
             for k, v in args[0].items():
                 self[k] = v
-        else:
+        elif args or kwargs:
             # update from a dict-like constructor parameters
             for k, v in dict(*args, **kwargs).items():
                 self[k] = v
+        else:
+            # no argument, raise TypeError to mimic dict.update()
+            raise TypeError("descriptor 'update' of '%s' object needs an argument" % self.__class__.__name__)
 
     def clear(self):
         self._store.clear()

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -285,20 +285,23 @@ class Metadata(MutableMapping):
         self.update(other)
 
     def update(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], self.__class__):
+        one_arg = len(args) == 1
+        if one_arg and isinstance(args[0], self.__class__):
             # update from Metadata object
             other = args[0]
-            for k, v in other._store.items():
-                self._store[k] = v[:]
+
+            for k, v in other.rawitems():
+                self.set(k, v[:])
+
+            for tag in other.deleted_tags:
+                del self[tag]
+
             if other.images:
                 self.images = other.images[:]
             if other.length:
                 self.length = other.length
 
-            # Remove deleted tags from UI on save
-            for tag in other.deleted_tags:
-                del self[tag]
-        elif len(args) == 1 and isinstance(args[0], MutableMapping):
+        elif one_arg and isinstance(args[0], MutableMapping):
             # update from MutableMapping (ie. dict)
             for k, v in args[0].items():
                 self[k] = v

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -409,7 +409,7 @@ class Metadata(MutableMapping):
         return "%s(%r, deleted_tags=%r, length=%r, images=%r)" % (self.__class__.__name__, self._store, self.deleted_tags, self.length, self.images)
 
     def __str__(self):
-        return ("store: %r\ndeleted: %r\nimages: %r\nlength: %r" % (self._store, self.deleted_tags, self.images, self.length))
+        return ("store: %r\ndeleted: %r\nimages: %r\nlength: %r" % (self._store, self.deleted_tags, [str(img) for img in self.images], self.length))
 
 
 _album_metadata_processors = PluginFunctions()

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -14,10 +14,11 @@ from picard.coverart.image import (
 
 
 def create_image(extra_data, types=None, support_types=False,
-                 support_multi_types=False):
+                 support_multi_types=False, comment=None):
     image = CoverArtImage(
         data=create_fake_png(extra_data),
         types=types,
+        comment=comment
     )
     image.support_types = support_types
     image.support_multi_types = support_multi_types

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -34,6 +34,10 @@ class MetadataTest(PicardTestCase):
         self.metadata.set("multi3", self.multi3)
         self.metadata["~hidden"] = "hidden-value"
 
+        self.metadata_d1 = Metadata({'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''})
+        self.metadata_d2 = Metadata({'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'})
+        self.metadata_d3 = Metadata({'c': 3, 'd': ['u', 'w'], 'x': 'p'})
+
     def tearDown(self):
         pass
 
@@ -196,8 +200,7 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(m.length, 1234)
 
     def test_metadata_mapping_del(self):
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''}
-        m = Metadata(d)
+        m = self.metadata_d1
         self.assertEqual(m.getraw('a'), ['b'])
         self.assertNotIn('a', m.deleted_tags)
 
@@ -209,26 +212,19 @@ class MetadataTest(PicardTestCase):
         self.assertIn('a', m.deleted_tags)
 
     def test_metadata_mapping_iter(self):
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''}
-        m = Metadata(d)
-        l = set(m)
+        l = set(self.metadata_d1)
         self.assertEqual(l, {'a', 'c', 'd'})
 
     def test_metadata_mapping_keys(self):
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''}
-        m = Metadata(d)
-        l = set(m.keys())
+        l = set(self.metadata_d1.keys())
         self.assertEqual(l, {'a', 'c', 'd'})
 
     def test_metadata_mapping_values(self):
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''}
-        m = Metadata(d)
-        l = set(m.values())
+        l = set(self.metadata_d1.values())
         self.assertEqual(l, {'b', '2', 'x; y'})
 
     def test_metadata_mapping_len(self):
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': ''}
-        m = Metadata(d)
+        m = self.metadata_d1
         self.assertEqual(len(m), 3)
         del m['x']
         self.assertEqual(len(m), 3)
@@ -236,81 +232,63 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(len(m), 2)
         #TODO: test with cover art images
 
+    def _check_mapping_update(self, m):
+        self.assertEqual(m['a'], 'b')
+        self.assertEqual(m['c'], '3')
+        self.assertEqual(m.getraw('d'), ['u', 'w'])
+        self.assertEqual(m['x'], '')
+        self.assertIn('x', m.deleted_tags)
+
     def test_metadata_mapping_update(self):
         # update from Metadata
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
-
-        d2 = {'c': 3, 'd': ['u', 'w'], 'x': 'p'}
-        m2 = Metadata(d2)
+        m = self.metadata_d2
+        m2 = self.metadata_d3
 
         del m2['x']
         m.update(m2)
-        self.assertEqual(m['a'], 'b')
-        self.assertEqual(m['c'], '3')
-        self.assertEqual(m['x'], '')
-        self.assertIn('x', m.deleted_tags)
-        self.assertEqual(m.getraw('d'), ['u', 'w'])
+        self._check_mapping_update(m)
 
     def test_metadata_mapping_update_dict(self):
         # update from dict
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         d2 = {'c': 3, 'd': ['u', 'w'], 'x': ''}
 
         m.update(d2)
-        self.assertEqual(m['a'], 'b')
-        self.assertEqual(m['c'], '3')
-        self.assertEqual(m.getraw('d'), ['u', 'w'])
-        self.assertEqual(m['x'], '')
-        self.assertIn('x', m.deleted_tags)
+        self._check_mapping_update(m)
 
     def test_metadata_mapping_update_tuple(self):
         # update from tuple
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         d2 = (('c', 3), ('d', ['u', 'w']), ('x', ''))
 
         m.update(d2)
-        self.assertEqual(m['a'], 'b')
-        self.assertEqual(m['c'], '3')
-        self.assertEqual(m.getraw('d'), ['u', 'w'])
-        self.assertEqual(m['x'], '')
-        self.assertIn('x', m.deleted_tags)
+        self._check_mapping_update(m)
 
     def test_metadata_mapping_update_dictlike(self):
         # update from kwargs
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         m.update(c=3, d=['u', 'w'], x='')
-        self.assertEqual(m['a'], 'b')
-        self.assertEqual(m['c'], '3')
-        self.assertEqual(m.getraw('d'), ['u', 'w'])
-        self.assertEqual(m['x'], '')
-        self.assertIn('x', m.deleted_tags)
+        self._check_mapping_update(m)
 
     def test_metadata_mapping_update_noparam(self):
         # update without parameter
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         m.update()
         self.assertEqual(m['a'], 'b')
 
     def test_metadata_mapping_update_intparam(self):
         # update without parameter
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         self.assertRaises(TypeError, m.update, 123)
 
     def test_metadata_mapping_update_strparam(self):
         # update without parameter
-        d = {'a': 'b', 'c': 2, 'd': ['x', 'y'], 'x': 'z'}
-        m = Metadata(d)
+        m = self.metadata_d2
 
         self.assertRaises(ValueError, m.update, 'abc')
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -299,3 +299,16 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(m['tag2'], 'b')
         m.update(tag2='')
         self.assertIn('tag2', m.deleted_tags)
+
+    def test_metadata_mapping_update_kw_del(self):
+        m = Metadata(tag1='a', tag2='b')
+        del m['tag1']
+
+        m2 = Metadata(tag1='c', tag2='d')
+        del m2['tag2']
+
+        m.update(m2)
+        self.assertEqual(m['tag1'], 'c')
+        self.assertNotIn('tag2', m)
+        self.assertNotIn('tag1', m.deleted_tags)
+        self.assertIn('tag2', m.deleted_tags)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from test.picardtestcase import PicardTestCase
+from test.test_coverart_image import create_image
 
 from picard import config
 from picard.metadata import (
@@ -312,3 +313,20 @@ class MetadataTest(PicardTestCase):
         self.assertNotIn('tag2', m)
         self.assertNotIn('tag1', m.deleted_tags)
         self.assertIn('tag2', m.deleted_tags)
+
+    def test_metadata_mapping_images(self):
+        image1 = create_image(b'A', comment='A')
+        image2 = create_image(b'B', comment='B')
+
+        m1 = Metadata(a='b', length=1234, images=[image1])
+        self.assertEqual(m1.images[0], image1)
+
+        m1.append_image(image2)
+        self.assertEqual(m1.images[1], image2)
+
+        m1.remove_image(0)
+        self.assertEqual(m1.images[0], image2)
+
+        m2 = Metadata(a='c', length=4567, images=[image1])
+        m1.update(m2)
+        self.assertEqual(m1.images[0], image1)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -277,7 +277,7 @@ class MetadataTest(PicardTestCase):
         # update without parameter
         m = self.metadata_d2
 
-        m.update()
+        self.assertRaises(TypeError, m.update)
         self.assertEqual(m['a'], 'b')
 
     def test_metadata_mapping_update_intparam(self):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -231,7 +231,6 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(len(m), 3)
         del m['c']
         self.assertEqual(len(m), 2)
-        #TODO: test with cover art images
 
     def _check_mapping_update(self, m):
         self.assertEqual(m['a'], 'b')
@@ -320,6 +319,7 @@ class MetadataTest(PicardTestCase):
 
         m1 = Metadata(a='b', length=1234, images=[image1])
         self.assertEqual(m1.images[0], image1)
+        self.assertEqual(len(m1), 2) # one tag, one image
 
         m1.append_image(image2)
         self.assertEqual(m1.images[1], image2)
@@ -330,3 +330,7 @@ class MetadataTest(PicardTestCase):
         m2 = Metadata(a='c', length=4567, images=[image1])
         m1.update(m2)
         self.assertEqual(m1.images[0], image1)
+
+        m1.remove_image(0)
+        self.assertEqual(len(m1), 1) # one tag, zero image
+        self.assertFalse(m1.images)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -212,6 +212,14 @@ class MetadataTest(PicardTestCase):
         self.assertRaises(KeyError, m.getraw, 'a')
         self.assertIn('a', m.deleted_tags)
 
+        # NOTE: historic behavior of Metadata.delete()
+        # an attempt to delete an non-existing tag, will add it to the list
+        # of deleted tags
+        # so this will not raise a KeyError
+        # as is it differs from dict or even defaultdict behavior
+        del m['unknown']
+        self.assertIn('unknown', m.deleted_tags)
+
     def test_metadata_mapping_iter(self):
         l = set(self.metadata_d1)
         self.assertEqual(l, {'a', 'c', 'd'})


### PR DESCRIPTION
Inheriting from `dict` is rather messy, so let's inherit from `collections.abc.MutableMapping` instead which is meant for that.

The conversion isn't that easy, and some tests were dependent on `dict` methods.

But the move has a lot of advantages:
- much cleaner
- `del metadata['tag']` is working
- `Metadata([('tag', 'value')])` can be used to create the object from an iterable
- `Metadata([('tag', 'value'), ('ignoreme': '')]` or `Metadata(tag='value', ignoreme='')` are equivalent to:
```python
m = Metadata()
m['tag'] = 'value'
```
- `metadata.keys()` and `metadata.values()` are working as expected
- `len(metadata)` is returning number of tags plus number of images (as ` __bool__` somehow was doing)
- a method `getraw()` was added, because none of `__getitem__()`, `get()`, `getall()` were actually raising a `KeyError` (as they all have default value), which forced to use `dict.get()` method in some tests.
- `metadata.update()` accepts dict-like syntax:
```python
m = Metadata(tag1='a', tag2='b')
m.update(tag1='c')
m.update(tag2='')
```
will lead to:
```
store: {'tag1': ['c']}
deleted: {'tag2'}
```
It will prolly need more work and testing, but it could help to simplify a lot of code.