### PR TITLE
PICARD-1493: Fixed opening message box during 1.0 config upgrade

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -70,20 +70,19 @@ def upgrade_to_v1_0_0_final_0():
                 "cs%,1),%discnumber%-,)$num(%tracknumber%,2) %artist% - "
                 "%title%"):
 
-            answer = msgbox.question(msgbox,
-                _("Various Artists file naming scheme removal"),
-                _("The separate file naming scheme for various artists "
-                    "albums has been removed in this version of Picard.\n"
-                    "You currently do not use this option, but have a "
-                    "separate file naming scheme defined.\n"
-                    "Do you want to remove it or merge it with your file "
-                    "naming scheme for single artist albums?"),
-                _("Merge"), _("Remove"))
-
-            if answer:
-                remove_va_file_naming_format(merge=False)
-            else:
-                remove_va_file_naming_format()
+            msgbox.setWindowTitle(_("Various Artists file naming scheme removal"))
+            msgbox.setText(_("The separate file naming scheme for various artists "
+                "albums has been removed in this version of Picard.\n"
+                "You currently do not use this option, but have a "
+                "separate file naming scheme defined.\n"
+                "Do you want to remove it or merge it with your file "
+                "naming scheme for single artist albums?"))
+            msgbox.setIcon(QtWidgets.QMessageBox.Question)
+            merge_button = msgbox.addButton(_('Merge'), QtWidgets.QMessageBox.AcceptRole)
+            msgbox.addButton(_('Remove'), QtWidgets.QMessageBox.DestructiveRole)
+            msgbox.exec()
+            merge = msgbox.clickedButton() == merge_button
+            remove_va_file_naming_format(merge=merge)
         else:
             # default format, disabled
             remove_va_file_naming_format(merge=False)


### PR DESCRIPTION
Using QMessageBox.question with custom buttons is not supported in Qt5. Use custom implementation.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1493](https://tickets.metabrainz.org/browse/PICARD-1493)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

