### PR TITLE
Cleanup missing clear existing tags setting fix

### DIFF
--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -33,6 +33,7 @@ from picard.script import (
     ScriptError,
     ScriptParser,
 )
+from picard.util.settingsoverride import SettingsOverride
 
 from picard.ui.options import (
     OptionsCheckError,
@@ -138,15 +139,15 @@ class RenamingOptionsPage(OptionsPage):
         self.update_examples()
 
     def _example_to_filename(self, file):
-        settings = {
+        settings = SettingsOverride(config.setting, {
             'ascii_filenames': self.ui.ascii_filenames.isChecked(),
-            'clear_existing_tags': config.setting['clear_existing_tags'],
             'file_naming_format': self.ui.file_naming_format.toPlainText(),
             'move_files': self.ui.move_files.isChecked(),
             'move_files_to': os.path.normpath(self.ui.move_files_to.text()),
             'rename_files': self.ui.rename_files.isChecked(),
             'windows_compatibility': self.ui.windows_compatibility.isChecked(),
-        }
+        })
+
         try:
             if config.setting["enable_tagger_scripts"]:
                 for s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"]:

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -139,14 +139,14 @@ class RenamingOptionsPage(OptionsPage):
 
     def _example_to_filename(self, file):
         settings = {
-            'windows_compatibility': self.ui.windows_compatibility.isChecked(),
             'ascii_filenames': self.ui.ascii_filenames.isChecked(),
-            'rename_files': self.ui.rename_files.isChecked(),
-            'move_files': self.ui.move_files.isChecked(),
-            'use_va_format': False,  # TODO remove
-            'file_naming_format': self.ui.file_naming_format.toPlainText(),
-            'move_files_to': os.path.normpath(self.ui.move_files_to.text()),
             'clear_existing_tags': config.setting['clear_existing_tags'],
+            'file_naming_format': self.ui.file_naming_format.toPlainText(),
+            'move_files': self.ui.move_files.isChecked(),
+            'move_files_to': os.path.normpath(self.ui.move_files_to.text()),
+            'rename_files': self.ui.rename_files.isChecked(),
+            'use_va_format': False,  # TODO remove
+            'windows_compatibility': self.ui.windows_compatibility.isChecked(),
         }
         try:
             if config.setting["enable_tagger_scripts"]:

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -145,7 +145,6 @@ class RenamingOptionsPage(OptionsPage):
             'move_files': self.ui.move_files.isChecked(),
             'move_files_to': os.path.normpath(self.ui.move_files_to.text()),
             'rename_files': self.ui.rename_files.isChecked(),
-            'use_va_format': False,  # TODO remove
             'windows_compatibility': self.ui.windows_compatibility.isChecked(),
         }
         try:

--- a/picard/util/settingsoverride.py
+++ b/picard/util/settingsoverride.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2019 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from collections.abc import MutableMapping
+
+
+class SettingsOverride(MutableMapping):
+    """ This class can be used to override config temporarly
+        Basically it returns config[key] if key isn't found in internal dict
+
+        Typical usage:
+
+        settings = SettingsOverride(config.setting)
+        settings["option"] = "value"
+    """
+
+    def __init__(self, orig_settings, *args, **kwargs):
+        self.orig_settings = orig_settings
+        self._dict = dict()
+        for k, v in dict(*args, **kwargs).items():
+            self[k] = v
+
+    def __getitem__(self, key):
+        try:
+            return self._dict[key]
+        except KeyError:
+            return self.orig_settings[key]
+
+    def __setitem__(self, key, value):
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        try:
+            del self._dict[key]
+        except KeyError:
+            pass
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __repr__(self):
+        d = self.orig_settings.copy()
+        d.update(self._dict)
+        return repr(d)

--- a/test/test_settingsoverride.py
+++ b/test/test_settingsoverride.py
@@ -1,0 +1,51 @@
+from test.picardtestcase import PicardTestCase
+
+from picard import config
+from picard.util.settingsoverride import SettingsOverride
+
+
+class SettingsOverrideTest(PicardTestCase):
+
+    def setUp(self):
+        self.config = {'key1': 'origval1', 'key2': 'origval2'}
+        config.setting = self.config.copy()
+        self.new_settings = {'key1': 'newval2'}
+
+    def test_read_orig_settings(self):
+        override = SettingsOverride(config.setting, self.new_settings)
+        self.assertEqual(override['key1'], 'newval2')
+        self.assertEqual(override['key2'], 'origval2')
+        with self.assertRaises(KeyError):
+            x = override['key3']
+
+    def test_read_orig_settings_kw(self):
+        override = SettingsOverride(config.setting, key1='newval2')
+        self.assertEqual(override['key1'], 'newval2')
+        self.assertEqual(override['key2'], 'origval2')
+
+    def test_write_orig_settings(self):
+        override = SettingsOverride(config.setting, self.new_settings)
+        override['key1'] = 'newval3'
+        self.assertEqual(override['key1'], 'newval3')
+        self.assertEqual(config.setting['key1'], 'origval1')
+
+        override['key2'] = 'newval4'
+        self.assertEqual(override['key2'], 'newval4')
+        self.assertEqual(config.setting['key2'], 'origval2')
+
+        override['key3'] = 'newval5'
+        self.assertEqual(override['key3'], 'newval5')
+        with self.assertRaises(KeyError):
+            x = config.setting['key3']
+
+    def test_del_orig_settings(self):
+        override = SettingsOverride(config.setting, self.new_settings)
+
+        override['key1'] = 'newval3'
+        self.assertEqual(override['key1'], 'newval3')
+        del override['key1']
+        self.assertEqual(override['key1'], 'origval1')
+
+        self.assertEqual(override['key2'], 'origval2')
+        del override['key2']
+        self.assertEqual(override['key2'], 'origval2')


### PR DESCRIPTION
A bug was introduced recently in https://github.com/metabrainz/picard/commit/04dcd4691bd57f2e24f2054e47e666ab843d891d
It was fixed in https://github.com/metabrainz/picard/commit/4990cef589496cabf0613bee4b6b2bac6a11797c

This PR is a cleanup of this fix