### PR TITLE
Format the list of user collections with pformat

### DIFF
--- a/picard/collection.py
+++ b/picard/collection.py
@@ -18,6 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from functools import partial
+from pprint import pformat
 
 from PyQt5 import QtCore
 
@@ -133,7 +134,7 @@ def load_user_collections(callback=None):
             for collection_id in old_collections:
                 del user_collections[collection_id]
 
-            log.debug("User collections: %r", [(k, v.name) for k, v in user_collections.items()])
+            log.debug("User collections:\n%s", pformat([(k, v.name) for k, v in user_collections.items()]))
         if callback:
             callback()
 


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The list of users collections logged in debug mode was unreadable for large lists of collections due to the way it was formatted without linebreaks etc.:

```
D: 23:03:50,114 /home/wieland/dev/picard/picard/collection.request_finished:136: User collections: [('03448598-16f0-4a40-af3f-ffa9fb1457f8', 'Collection 2'), ('040d316f-9d0b-401d-aa73-7d5c09e32476', 'Collection 1')]
```

# Solution

Use pprint.pformat to get

```
D: 23:07:29,343 /home/wieland/dev/picard/picard/collection.request_finished:137: User collections:
[('03448598-16f0-4a40-af3f-ffa9fb1457f8', 'Collection 1'),
 ('040d316f-9d0b-401d-aa73-7d5c09e32476', 'Collection 2')]
```

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

