### PR TITLE
Log the key of an option that can't be read

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -106,7 +106,7 @@ class ConfigSection(LockableObject):
                 return option_type.convert(self.raw_value(name))
             return default
         except Exception:
-            log.error('Error reading option value', exc_info=True)
+            log.error('Error reading the value of option "%s"', key, exc_info=True)
             return default
         finally:
             self.unlock()


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->


<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Previously, the error message was really unhelpful:

```
E: 23:14:22,253 /home/wieland/dev/picard/picard/config.value:109: Error reading option value
Traceback (most recent call last):
  File "/home/wieland/dev/picard/picard/config.py", line 106, in value
    return option_type.convert(self.raw_value(name))
TypeError: 'NoneType' object is not iterable
```

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


Now the key of the option is included, making it actually possible to look it up
in the config file:

```
E: 23:15:49,421 /home/wieland/dev/picard/picard/config.value:109: Error reading the value of option "setting/preferred_release_countries"
Traceback (most recent call last):
  File "/home/wieland/dev/picard/picard/config.py", line 106, in value
    return option_type.convert(self.raw_value(name))
TypeError: 'NoneType' object is not iterable
```

# Action
