### PR TITLE
PICARD-1501: Use QDesktopServices to open cover images instead of webbrowser2

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -38,8 +38,7 @@ from picard.util import (
     encode_filename,
     format_time,
     htmlescape,
-    union_sorted_lists,
-    webbrowser2,
+    union_sorted_lists
 )
 
 from picard.ui import PicardDialog
@@ -243,7 +242,8 @@ class InfoDialog(PicardDialog):
             return
         filename = data.tempfile_filename
         if filename:
-            webbrowser2.open("file://" + filename)
+            url = QtCore.QUrl.fromLocalFile(filename)
+            QtGui.QDesktopServices.openUrl(url)
 
 
 def format_file_info(file_):


### PR DESCRIPTION
QDesktopServices takes care of honoring the user configuration so
when opening an image, the user preferred external app is used
instead of always using a web browser.

Fixes PICARD-1501

# Summary

Use QDesktopServices to open cover images instead of webbrowser2

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

If a user configures the desktop to open images with a given application, it's unexpected that Picard uses a web browser instead.

* JIRA ticket: [PICARD-1501](https://tickets.metabrainz.org/browse/PICARD-1501)

# Solution

Use QDesktopServices instead of using webbrowser2 to open the image file.
