### PR TITLE
PICARD-1503: fix CDROM device containing ampersand (&)

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -747,7 +747,7 @@ class Tagger(QtWidgets.QApplication):
     def lookup_cd(self, action):
         """Reads CD from the selected drive and tries to lookup the DiscID on MusicBrainz."""
         if isinstance(action, QtWidgets.QAction):
-            device = action.text()
+            device = action.data()
         elif config.setting["cd_lookup_device"] != '':
             device = config.setting["cd_lookup_device"].split(",", 1)[0]
         else:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -471,6 +471,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 self.cd_lookup_action.setEnabled(True)
                 for drive in drives:
                     action = self.cd_lookup_menu.addAction(drive)
+                    action.setData(drive)
                     if drive == shortcut_drive:
                         # Clear existing shortcode on main action and assign it to sub-action
                         self.cd_lookup_action.setShortcut(QtGui.QKeySequence())


### PR DESCRIPTION
Patch by Philipp Hahn

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

device name is set using Action text, which contains & accelerator
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket : [PICARD-1503](https://tickets.metabrainz.org/browse/PICARD-1503)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Pass device name as QAction data
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

