### PR TITLE
PICARD-1502: Call setDesktopFileName before creating QApplication

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -22,6 +22,8 @@ import re
 
 PICARD_ORG_NAME = "MusicBrainz"
 PICARD_APP_NAME = "Picard"
+PICARD_APP_ID = "org.musicbrainz.Picard"
+PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
 PICARD_VERSION = (2, 2, 0, 'dev', 1)
 
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -38,6 +38,7 @@ from PyQt5 import (
 
 from picard import (
     PICARD_APP_NAME,
+    PICARD_DESKTOP_NAME,
     PICARD_FANCY_VERSION_STR,
     PICARD_ORG_NAME,
     acoustid,
@@ -141,7 +142,6 @@ class Tagger(QtWidgets.QApplication):
         # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
         # can use it to look up the app
         super().__init__(['MusicBrainz-Picard'] + unparsed_args)
-        self.setDesktopFileName('org.musicbrainz.Picard.desktop')
         self.__class__.__instance = self
         config._setup(self, picard_args.config_file)
 
@@ -886,6 +886,7 @@ def main(localedir=None, autoupdate=True):
     # Some libs (ie. Phonon) require those to be set
     QtWidgets.QApplication.setApplicationName(PICARD_APP_NAME)
     QtWidgets.QApplication.setOrganizationName(PICARD_ORG_NAME)
+    QtWidgets.QApplication.setDesktopFileName(PICARD_DESKTOP_NAME)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Follow up to PICARD-1502, `QApplication.setDesktopFileName` is a static method intended to be called before QApplication is created (just like e.g. `setApplicationName`)
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1502](https://tickets.metabrainz.org/browse/PICARD-1502)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
We could reuse `PICARD_APP_ID` elsewhere, e.g. in setup.py. We duplicate this string a lot. Will submit a separate PR.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

