### PR TITLE
Fix crash when saving after "keep original cover art.

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -203,7 +203,7 @@ class File(QtCore.QObject, Item):
         self.metadata_images_changed.emit()
 
     def keep_original_images(self):
-        self.metadata.images = self.orig_metadata.images[:]
+        self.metadata.images = self.orig_metadata.images.copy()
         self.update()
         self.metadata_images_changed.emit()
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -48,6 +48,7 @@ from picard.script import (
     enabled_tagger_scripts_texts,
 )
 from picard.util.imagelist import (
+    ImageList,
     add_metadata_images,
     remove_metadata_images,
     update_metadata_images,
@@ -261,9 +262,9 @@ class Track(DataObject, Item):
             file.keep_original_images()
         self.update_orig_metadata_images()
         if self.linked_files:
-            self.metadata.images = self.orig_metadata.images[:]
+            self.metadata.images = self.orig_metadata.images.copy()
         else:
-            self.metadata.images = []
+            self.metadata.images = ImageList()
         self.update()
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This fixes a saving error after "keep original metadata" or after files have been moved around.

Reason is that the `ImageList` in `metadata.images` gets turned into a regular list under some circumstances. This was introduced in recent metadata refactorings.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

