### PR TITLE
PICARD-1517: Fix running matchedtracks()/is_complete() on clusters

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -710,14 +710,17 @@ def func_performer(parser, pattern="", join=", "):
 
 def func_matchedtracks(parser, *args):
     # only works in file naming scripts, always returns zero in tagging scripts
-    if parser.file and parser.file.parent:
+    file = parser.file
+    if file and file.parent and hasattr(file.parent, 'album'):
         return str(parser.file.parent.album.get_num_matched_tracks())
     return "0"
 
 
 def func_is_complete(parser):
-    if (parser.file and parser.file.parent
-            and parser.file.parent.album.is_complete()):
+    # only works in file naming scripts, always returns zero in tagging scripts
+    file = parser.file
+    if (file and file.parent and hasattr(file.parent, 'album')
+            and file.parent.album.is_complete()):
         return "1"
     return "0"
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from test.picardtestcase import PicardTestCase
 
 from picard import config
+from picard.cluster import Cluster
 from picard.const import DEFAULT_FILE_NAMING_FORMAT
 from picard.metadata import Metadata
 from picard.script import (
@@ -508,6 +509,28 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$matchedtracks()", "0")
         # The following only is possible for backward compatibility, arg is unused
         self.assertScriptResultEquals("$matchedtracks(arg)", "0")
+
+    def test_matchedtracks_with_cluster(self):
+        file = MagicMock()
+        cluster = Cluster(name="Test")
+        cluster.files.append(file)
+        file.parent = cluster
+        self.assertScriptResultEquals("$matchedtracks()", "0", file=file)
+
+    def test_is_complete(self):
+        file = MagicMock()
+        file.parent.album.is_complete.return_value = True
+        self.assertScriptResultEquals("$is_complete()", "1", file=file)
+        file.parent.album.is_complete.return_value = False
+        self.assertScriptResultEquals("$is_complete()", "0", file=file)
+        self.assertScriptResultEquals("$is_complete()", "0")
+
+    def test_is_complete_with_cluster(self):
+        file = MagicMock()
+        cluster = Cluster(name="Test")
+        cluster.files.append(file)
+        file.parent = cluster
+        self.assertScriptResultEquals("$is_complete()", "0", file=file)
 
     def test_required_kwonly_parameters(self):
         def func(a, *, required_kwarg):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Having the scripting functions is_complete() or matchedtracks() in naming script and saving a cluster causes an exception.

See also https://community.metabrainz.org/t/problem-on-right-click-cluster-and-save/426786

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1517](https://tickets.metabrainz.org/browse/PICARD-1517)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

