### PR TITLE
PICARD-1506: Provide empty config for tests

### DIFF
--- a/test/data/test.ini
+++ b/test/data/test.ini
@@ -1,0 +1,4 @@
+[application]
+version=2.0.0
+
+[setting]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,6 +41,7 @@ class TestPicardConfigCommon(PicardTestCase):
         super().setUp()
         self.tmp_directory = mkdtemp()
         self.configpath = os.path.join(self.tmp_directory, 'test.ini')
+        shutil.copy(os.path.join('test', 'data', 'test.ini'), self.configpath)
         self.config = Config.from_file(None, self.configpath)
         self.config.application["version"] = "testing"
         logging.disable(logging.ERROR)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Currently Picard's test cases can be affected by existing user configuration and might fail.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1506](https://tickets.metabrainz.org/browse/PICARD-1506)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
For tests provide an empty config file.

I am not entirely sure what is happening and I could not find anything in the Qt docs at https://doc.qt.io/qt-5/qsettings.html#QSettings-3

But if there is no empty config file Qt seems to initialize the specified config file path with a copy of the application's config. I can easily reproduce what @Freso reported on PICARD-1506, and providing an empty file solves the issue for me.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

