### PR TITLE
PICARD-1529: Avoid loaded NATs getting assigned cover art from other NATs

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -257,27 +257,14 @@ class Metadata(MutableMapping):
                 result = SimMatchTrack(similarity=sim, releasegroup=rg, release=release, track=track)
         return result
 
-    def copy(self, other):
+    def copy(self, other, copy_images=True):
         self.clear()
-        self.update(other)
+        self._update_from_metadata(other, copy_images)
 
     def update(self, *args, **kwargs):
         one_arg = len(args) == 1
         if one_arg and isinstance(args[0], self.__class__):
-            # update from Metadata object
-            other = args[0]
-
-            for k, v in other.rawitems():
-                self.set(k, v[:])
-
-            for tag in other.deleted_tags:
-                del self[tag]
-
-            if other.images:
-                self.images = other.images.copy()
-            if other.length:
-                self.length = other.length
-
+            self._update_from_metadata(args[0])
         elif one_arg and isinstance(args[0], MutableMapping):
             # update from MutableMapping (ie. dict)
             for k, v in args[0].items():
@@ -289,6 +276,18 @@ class Metadata(MutableMapping):
         else:
             # no argument, raise TypeError to mimic dict.update()
             raise TypeError("descriptor 'update' of '%s' object needs an argument" % self.__class__.__name__)
+
+    def _update_from_metadata(self, other, copy_images=True):
+        for k, v in other.rawitems():
+            self.set(k, v[:])
+
+        for tag in other.deleted_tags:
+            del self[tag]
+
+        if copy_images and other.images:
+            self.images = other.images.copy()
+        if other.length:
+            self.length = other.length
 
     def clear(self):
         self._store.clear()

--- a/picard/track.py
+++ b/picard/track.py
@@ -329,9 +329,7 @@ class NonAlbumTrack(Track):
         return super().column(column)
 
     def load(self, priority=False, refresh=False):
-        images = self.metadata.images
-        self.metadata.copy(self.album.metadata)
-        self.metadata.images = images
+        self.metadata.copy(self.album.metadata, copy_images=False)
         self.status = _("[loading recording information]")
         self.error = None
         self.loaded = False

--- a/picard/track.py
+++ b/picard/track.py
@@ -329,7 +329,9 @@ class NonAlbumTrack(Track):
         return super().column(column)
 
     def load(self, priority=False, refresh=False):
+        images = self.metadata.images
         self.metadata.copy(self.album.metadata)
+        self.metadata.images = images
         self.status = _("[loading recording information]")
         self.error = None
         self.loaded = False

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -145,6 +145,7 @@ class MetadataTest(PicardTestCase):
         self.assertIn("single1", m.deleted_tags)
         self.assertEqual("single2-value", m["single2"])
         self.assertEqual(self.metadata.deleted_tags, m.deleted_tags)
+        self.assertEqual(self.metadata.images, m.images)
 
         self.metadata["old"] = "old-value"
         for (key, value) in self.metadata.rawitems():

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -108,32 +108,18 @@ class MetadataTest(PicardTestCase):
         m["old"] = "old-value"
         self.metadata.delete("single1")
         m.copy(self.metadata)
-
+        self.assertEqual(self.metadata._store, m._store)
         self.assertEqual(self.metadata.deleted_tags, m.deleted_tags)
         self.assertEqual(self.metadata.length, m.length)
         self.assertEqual(self.metadata.images, m.images)
 
-        for (key, value) in self.metadata.rawitems():
-            self.assertIn(key, m)
-            self.assertEqual(value, m.getraw(key))
-        for (key, value) in m.rawitems():
-            self.assertIn(key, self.metadata)
-            self.assertEqual(value, self.metadata.getraw(key))
-
     def test_metadata_copy_without_images(self):
         m = Metadata()
         m.copy(self.metadata, copy_images=False)
-
+        self.assertEqual(self.metadata._store, m._store)
         self.assertEqual(self.metadata.deleted_tags, m.deleted_tags)
         self.assertEqual(self.metadata.length, m.length)
         self.assertEqual(ImageList(), m.images)
-
-        for (key, value) in self.metadata.rawitems():
-            self.assertIn(key, m)
-            self.assertEqual(value, m.getraw(key))
-        for (key, value) in m.rawitems():
-            self.assertIn(key, self.metadata)
-            self.assertEqual(value, self.metadata.getraw(key))
 
     def test_metadata_update(self):
         m = Metadata()
@@ -148,12 +134,7 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(self.metadata.images, m.images)
 
         self.metadata["old"] = "old-value"
-        for (key, value) in self.metadata.rawitems():
-            self.assertIn(key, m)
-            self.assertEqual(value, m.getraw(key))
-        for (key, value) in m.rawitems():
-            self.assertIn(key, self.metadata)
-            self.assertEqual(value, self.metadata.getraw(key))
+        self.assertEqual(self.metadata._store, m._store)
 
     def test_metadata_clear(self):
         self.metadata.clear()

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -7,6 +7,7 @@ from picard.metadata import (
     MULTI_VALUED_JOINER,
     Metadata,
 )
+from picard.util.imagelist import ImageList
 from picard.util.tags import PRESERVED_TAGS
 
 
@@ -101,6 +102,38 @@ class MetadataTest(PicardTestCase):
         self.metadata["single1"] = "value1"
         self.assertIn("single1", self.metadata)
         self.assertNotIn("single1", self.metadata.deleted_tags)
+
+    def test_metadata_copy(self):
+        m = Metadata()
+        m["old"] = "old-value"
+        self.metadata.delete("single1")
+        m.copy(self.metadata)
+
+        self.assertEqual(self.metadata.deleted_tags, m.deleted_tags)
+        self.assertEqual(self.metadata.length, m.length)
+        self.assertEqual(self.metadata.images, m.images)
+
+        for (key, value) in self.metadata.rawitems():
+            self.assertIn(key, m)
+            self.assertEqual(value, m.getraw(key))
+        for (key, value) in m.rawitems():
+            self.assertIn(key, self.metadata)
+            self.assertEqual(value, self.metadata.getraw(key))
+
+    def test_metadata_copy_without_images(self):
+        m = Metadata()
+        m.copy(self.metadata, copy_images=False)
+
+        self.assertEqual(self.metadata.deleted_tags, m.deleted_tags)
+        self.assertEqual(self.metadata.length, m.length)
+        self.assertEqual(ImageList(), m.images)
+
+        for (key, value) in self.metadata.rawitems():
+            self.assertIn(key, m)
+            self.assertEqual(value, m.getraw(key))
+        for (key, value) in m.rawitems():
+            self.assertIn(key, self.metadata)
+            self.assertEqual(value, self.metadata.getraw(key))
 
     def test_metadata_update(self):
         m = Metadata()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary


When loading already tagged NAT files into Picard which contain embedded cover art, the first loaded file loads normally, but every additional loaded file gets the cover art of all previously loaded files attached.

See discussion at https://community.metabrainz.org/t/album-modified-and-complete-on-every-load-but-no-modifications/432044

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1529](https://tickets.metabrainz.org/browse/PICARD-1529)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Preserve the file images instead of applying images from `NatAlbum`.

A few considerations:

1. I thought about removing `self.metadata.copy(self.album.metadata)` completely, as by default this does not provide any additional metadata. But having the ability to set tags for all NATs on the `NatAlbum` level has some use cases for people who want specific tags for all NATs.

2. I also considered removing display and handling of cover art on the `NatAlbum`, but I think having the `NatAlbum` display the different cover art has some value in the UI as you can easily see whether your NATs have cover art or not.
 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

