### PR TITLE
PICARD-1533: Set Qt.AA_EnableHighDpiScaling before application gets created

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -146,9 +146,6 @@ class Tagger(QtWidgets.QApplication):
         self.__class__.__instance = self
         config._setup(self, picard_args.config_file)
 
-        # Allow High DPI Support
-        self.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
-        self.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
         super().setStyleSheet(
             'QGroupBox::title { /* PICARD-1206, Qt bug workaround */ }'
         )
@@ -889,6 +886,10 @@ def main(localedir=None, autoupdate=True):
     QtWidgets.QApplication.setApplicationName(PICARD_APP_NAME)
     QtWidgets.QApplication.setOrganizationName(PICARD_ORG_NAME)
     QtWidgets.QApplication.setDesktopFileName(PICARD_DESKTOP_NAME)
+
+    # Allow High DPI Support
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1533](https://tickets.metabrainz.org/browse/PICARD-1533)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

