### PR TITLE
unittest.assertEquals() is deprecated in favor of assertEqual()

### DIFF
--- a/test/test_util_lrucache.py
+++ b/test/test_util_lrucache.py
@@ -10,7 +10,7 @@ class LRUCacheTest(PicardTestCase):
     def test_simple_getset(self):
         lrucache = LRUCache(3)
         lrucache['test'] = 1
-        self.assertEquals(lrucache['test'], 1)
+        self.assertEqual(lrucache['test'], 1)
         self.assertIn('test', lrucache._ordered_keys)
 
     def test_simple_del(self):
@@ -33,23 +33,23 @@ class LRUCacheTest(PicardTestCase):
         lrucache['test1'] = 1
         lrucache['test2'] = 2
         lrucache['test3'] = 3
-        self.assertEquals(len(lrucache._ordered_keys), 3)
-        self.assertEquals('test3', lrucache._ordered_keys[0])
-        self.assertEquals('test2', lrucache._ordered_keys[1])
-        self.assertEquals('test1', lrucache._ordered_keys[2])
+        self.assertEqual(len(lrucache._ordered_keys), 3)
+        self.assertEqual('test3', lrucache._ordered_keys[0])
+        self.assertEqual('test2', lrucache._ordered_keys[1])
+        self.assertEqual('test1', lrucache._ordered_keys[2])
         v = lrucache['test2']
-        self.assertEquals('test2', lrucache._ordered_keys[0])
-        self.assertEquals('test3', lrucache._ordered_keys[1])
-        self.assertEquals('test1', lrucache._ordered_keys[2])
+        self.assertEqual('test2', lrucache._ordered_keys[0])
+        self.assertEqual('test3', lrucache._ordered_keys[1])
+        self.assertEqual('test1', lrucache._ordered_keys[2])
         lrucache['test1'] = 4
-        self.assertEquals('test1', lrucache._ordered_keys[0])
-        self.assertEquals('test2', lrucache._ordered_keys[1])
-        self.assertEquals('test3', lrucache._ordered_keys[2])
+        self.assertEqual('test1', lrucache._ordered_keys[0])
+        self.assertEqual('test2', lrucache._ordered_keys[1])
+        self.assertEqual('test3', lrucache._ordered_keys[2])
 
     def test_dict_like_init(self):
         lrucache = LRUCache(3, [('test1', 1), ('test2', 2)])
-        self.assertEquals(lrucache['test1'], 1)
-        self.assertEquals(lrucache['test2'], 2)
+        self.assertEqual(lrucache['test1'], 1)
+        self.assertEqual(lrucache['test2'], 2)
 
     def test_get_keyerror(self):
         lrucache = LRUCache(3)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

https://docs.python.org/3/library/unittest.html#deprecated-aliases

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

