### PR TITLE
PICARD-1546: Truncate tracks in Other Releases menu when too many media

### DIFF
--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -69,11 +69,16 @@ class ReleaseGroup(DataObject):
         except (TypeError, KeyError):
             releases = []
 
+        max_tracks = 10
         for node in releases:
             labels, catnums = label_info_from_node(node['label-info'])
 
             countries = countries_from_node(node)
 
+            if len(node['media']) > max_tracks:
+                tracks = "+".join([str(m['track-count']) for m in node['media'][:max_tracks]]) + '+…'
+            else:
+                tracks = "+".join([str(m['track-count']) for m in node['media']])
             formats = []
             for medium in node['media']:
                 if "format" in medium:
@@ -86,7 +91,7 @@ class ReleaseGroup(DataObject):
                 "format":  media_formats_from_node(node['media']),
                 "label":  ", ".join([' '.join(x.split(' ')[:2]) for x in set(labels)]),
                 "catnum": ", ".join(set(catnums)),
-                "tracks":  "+".join([str(m['track-count']) for m in node['media']]),
+                "tracks": tracks,
                 "barcode": node.get('barcode', '') or _('[no barcode]'),
                 "packaging": node.get('packaging', '') or '??',
                 "disambiguation": node.get('disambiguation', ''),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When releases have a lot of media the list of number of tracks can be far too long for clean display

* JIRA ticket (_optional_): [PICARD-1546](https://tickets.metabrainz.org/browse/PICARD-1546)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Truncate it if > 10

![Capture du 2019-07-01 13-44-05](https://user-images.githubusercontent.com/151042/60434309-26baef00-9c07-11e9-9eb7-9c55ddb2484b.png)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

