### PR TITLE
Switch import of install from distutils to setuptools to support --single-version-externally-managed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import datetime
 from distutils import log
 from distutils.command.build import build
-from setuptools.command.install import install as install
 from distutils.dep_util import newer
 from distutils.spawn import find_executable
 import glob
@@ -20,6 +19,7 @@ from setuptools import (
     Extension,
     setup,
 )
+from setuptools.command.install import install as install
 from setuptools.dist import Distribution
 
 from picard import (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import datetime
 from distutils import log
 from distutils.command.build import build
-from distutils.command.install import install as install
+from setuptools.command.install import install as install
 from distutils.dep_util import newer
 from distutils.spawn import find_executable
 import glob


### PR DESCRIPTION

# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

I'm trying to update the (quite out of date) OpenBSD port of picard. Our process uses the --single-version-externally-managed option to install. The distutils version of install doesn't support it, but the main setuptools version of install does.

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)


# Solution

Change from importing install from distutils.commands.install to setuptools.commands.install

# Action



