### PR TITLE
Add test *.aac files to MANIFEST.in 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ recursive-include scripts *.in
 graft ui
 recursive-include resources *.py
 
+recursive-include test *.aac
 recursive-include test *.aiff
 recursive-include test *.ape
 recursive-include test *.asf


### PR DESCRIPTION
Add test *.aac files to MANIFEST.in so that source tarball for PyPI has all the data files for the tests.

# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

A subset of the regression tests fail when I run them on OpenBSD. Most of them fail due to the test-apev2.aac is missing from the test/data/ directory from the PyPI tarball. Looks like aac files were forgotten from the MANIFEST.in file. Adding them puts them in the tarball generated by python3 setup.py sdist.

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)


# Solution

This simple change to MANIFEST.in should include those files for future source tarballs.

# Action

No other actions.
