### PR TITLE
PICARD-1549: Fixed pip install on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,3 +38,10 @@ include *.md
 include *.txt
 
 recursive-include resources/images *.png
+
+recursive-include installer *.in
+recursive-include installer *.ini
+recursive-include installer/images *.bmp
+recursive-include installer/images *.ico
+recursive-include installer/images *.svg
+recursive-include installer/languages *.nsh

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,6 @@ from picard import (
     PICARD_VERSION,
     __version__,
 )
-from picard.const.sys import (
-    IS_LINUX,
-    IS_WIN,
-)
 
 
 if sys.version_info < (3, 5):
@@ -222,7 +218,7 @@ class picard_build(build):
     def run(self):
         log.info('generating scripts/%s from scripts/picard.in', PACKAGE_NAME)
         generate_file('scripts/picard.in', 'scripts/' + PACKAGE_NAME, {'localedir': self.localedir, 'autoupdate': not self.disable_autoupdate})
-        if IS_WIN:
+        if sys.platform == 'win32':
             # Temporarily setting it to this value to generate a nice name for Windows app
             args['name'] = 'MusicBrainz Picard'
             file_version = PICARD_VERSION[0:3] + PICARD_VERSION[4:]
@@ -234,7 +230,7 @@ class picard_build(build):
             }
             generate_file('win-version-info.txt.in', 'win-version-info.txt', {**args, **version_args})
             args['name'] = 'picard'
-        elif IS_LINUX:
+        elif sys.platform == 'linux':
             self.run_command('build_appdata')
         build.run(self)
 
@@ -746,7 +742,7 @@ args['data_files'] = [
 args['data_files'].append(('share/icons/hicolor/scalable/apps', ['resources/img-src/%s.svg' % PICARD_APP_ID]))
 args['data_files'].append(('share/applications', [PICARD_DESKTOP_NAME]))
 
-if IS_LINUX:
+if sys.platform == 'linux':
     args['data_files'].append(('share/metainfo', [APPDATA_FILE]))
 
 setup(**args)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
As reported https://stackoverflow.com/questions/56737424/how-to-fix-error-option-single-version-externally-managed-not-recognized/56740829 trying to install Picard via pip on Windows currently fails.

There are actually multiple independent issues:

1. `setup.py` install tries to generate the installer config from `installer/picard-setup.nsi.in`, but it's not included in the source
2. `setup.py` (indirectly) depends on PyQt5
3. Our `setup.py` does not support `--single-version-externally-managed`, this is already fixed in #1210
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1549](https://tickets.metabrainz.org/browse/PICARD-1549)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

1. Include the installer files in the source distribution. I think that makes sense to allow the full functionality Picard's setup.py provides, including building the Windows installer if wanted. @mineo What is your opinion on that?

2. Remove the dependency on PyQt5 from `setup.py`. This was indirectly by importing from `picard.const.sys`, because `picard.const` depends on PyQt5.

@zas What is your opinion on that second part? IMHO `picard.const` should not depend on PyQt5, but this is difficult to change now. I tried moving the `USER_DIR` and `USER_PLUGIN_DIR` constants elsewhere, but this could break plugins (at least classical extras does import `USER_DIR`). In the end I figured those simple `IS_WIN` / `IS_LINUX` constants as a simplification of a simple `sys.platform` comparison are not worse the trouble and there is more benefit in having `setup.py` not rely on Picard's internal abstractions like this.

With the above changes I was able to run a successful `pip install .` from Picard source on Windows.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

