### PR TITLE
PICARD-1556: Ignore empty track numbers in default naming script

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -24,7 +24,7 @@ PICARD_ORG_NAME = "MusicBrainz"
 PICARD_APP_NAME = "Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = (2, 2, 0, 'dev', 3)
+PICARD_VERSION = (2, 2, 0, 'dev', 4)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -157,7 +157,6 @@ def upgrade_to_v1_3_0_dev_4(config):
             pass
 
 
-
 def upgrade_to_v1_4_0_dev_2(config):
     """Options "username" and "password" are removed and
     replaced with OAuth tokens
@@ -186,7 +185,7 @@ def upgrade_to_v1_4_0_dev_3(config):
     _s['ca_providers'] = newopts
 
 
-OLD_DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
+OLD_DEFAULT_FILE_NAMING_FORMAT_v1_3 = "$if2(%albumartist%,%artist%)/" \
     "$if($ne(%albumartist%,),%album%/)" \
     "$if($gt(%totaldiscs%,1),%discnumber%-,)" \
     "$if($ne(%albumartist%,),$num(%tracknumber%,2) ,)" \
@@ -197,7 +196,7 @@ OLD_DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
 def upgrade_to_v1_4_0_dev_4(config):
     """Adds trailing comma to default file names for scripts"""
     _s = config.setting
-    if _s["file_naming_format"] == OLD_DEFAULT_FILE_NAMING_FORMAT:
+    if _s["file_naming_format"] == OLD_DEFAULT_FILE_NAMING_FORMAT_v1_3:
         _s["file_naming_format"] = DEFAULT_FILE_NAMING_FORMAT
 
 
@@ -273,6 +272,21 @@ def upgrade_to_v2_2_0_dev_3(config):
             tags = ["-" + e.strip().lower() for e in _s[old_opt].split(',')]
             _s[new_opt] = "\n".join(tags)
         _s.remove(old_opt)
+
+
+OLD_DEFAULT_FILE_NAMING_FORMAT_v2_1 = "$if2(%albumartist%,%artist%)/" \
+    "$if($ne(%albumartist%,),%album%/,)" \
+    "$if($gt(%totaldiscs%,1),%discnumber%-,)" \
+    "$if($ne(%albumartist%,),$num(%tracknumber%,2) ,)" \
+    "$if(%_multiartist%,%artist% - ,)" \
+    "%title%"
+
+
+def upgrade_to_v2_2_0_dev_4(config):
+    """Improved default file naming script"""
+    _s = config.setting
+    if _s["file_naming_format"] == OLD_DEFAULT_FILE_NAMING_FORMAT_v2_1:
+        _s["file_naming_format"] = DEFAULT_FILE_NAMING_FORMAT
 
 
 def rename_option(config, old_opt, new_opt, option_type, default):

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -141,9 +141,9 @@ PROGRAM_UPDATE_LEVELS = OrderedDict(
 
 
 DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
-    "$if($ne(%albumartist%,),%album%/,)" \
+    "$if(%albumartist%,%album%/,)" \
     "$if($gt(%totaldiscs%,1),%discnumber%-,)" \
-    "$if($ne(%albumartist%,),$num(%tracknumber%,2) ,)" \
+    "$if($and(%albumartist%,%tracknumber%),$num(%tracknumber%,2) ,)" \
     "$if(%_multiartist%,%artist% - ,)" \
     "%title%"
 

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -140,8 +140,8 @@ PROGRAM_UPDATE_LEVELS = OrderedDict(
 )
 
 
-DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/" \
-    "$if(%albumartist%,%album%/,)" \
+DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/\n" \
+    "$if(%albumartist%,%album%/,)\n" \
     "$if($gt(%totaldiscs%,1),%discnumber%-,)" \
     "$if($and(%albumartist%,%tracknumber%),$num(%tracknumber%,2) ,)" \
     "$if(%_multiartist%,%artist% - ,)" \

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -26,7 +26,8 @@ from picard.config import (
     TextOption,
 )
 from picard.config_upgrade import (
-    OLD_DEFAULT_FILE_NAMING_FORMAT,
+    OLD_DEFAULT_FILE_NAMING_FORMAT_v1_3,
+    OLD_DEFAULT_FILE_NAMING_FORMAT_v2_1,
     upgrade_to_v1_0_0_final_0,
     upgrade_to_v1_3_0_dev_1,
     upgrade_to_v1_3_0_dev_2,
@@ -40,6 +41,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_0_0_dev_3,
     upgrade_to_v2_1_0_dev_1,
     upgrade_to_v2_2_0_dev_3,
+    upgrade_to_v2_2_0_dev_4,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -151,7 +153,7 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v1_4_0_dev_4(self.config)
         self.assertEqual('xxx', self.config.setting['file_naming_format'])
 
-        self.config.setting['file_naming_format'] = OLD_DEFAULT_FILE_NAMING_FORMAT
+        self.config.setting['file_naming_format'] = OLD_DEFAULT_FILE_NAMING_FORMAT_v1_3
         upgrade_to_v1_4_0_dev_4(self.config)
         self.assertEqual(DEFAULT_FILE_NAMING_FORMAT, self.config.setting['file_naming_format'])
 
@@ -232,3 +234,14 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_2_0_dev_3(self.config)
         self.assertNotIn('ignore_genres', self.config.setting)
         self.assertEqual(self.config.setting['genres_filter'], "-a\n-b\n-c")
+
+    def test_upgrade_to_v2_2_0_dev_4(self):
+        TextOption("setting", "file_naming_format", "")
+
+        self.config.setting['file_naming_format'] = 'xxx'
+        upgrade_to_v2_2_0_dev_4(self.config)
+        self.assertEqual('xxx', self.config.setting['file_naming_format'])
+
+        self.config.setting['file_naming_format'] = OLD_DEFAULT_FILE_NAMING_FORMAT_v2_1
+        upgrade_to_v2_2_0_dev_4(self.config)
+        self.assertEqual(DEFAULT_FILE_NAMING_FORMAT, self.config.setting['file_naming_format'])

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -372,10 +372,10 @@ class ScriptParserTest(PicardTestCase):
         context['tracknumber'] = 8
         context['title'] = u'title'
         result = self.parser.eval(DEFAULT_FILE_NAMING_FORMAT, context)
-        self.assertEqual(result, u'albumartist/album/1-08 title')
+        self.assertEqual(result, u'albumartist/\nalbum/\n1-08 title')
         context['~multiartist'] = '1'
         result = self.parser.eval(DEFAULT_FILE_NAMING_FORMAT, context)
-        self.assertEqual(result, u'albumartist/album/1-08 artist - title')
+        self.assertEqual(result, u'albumartist/\nalbum/\n1-08 artist - title')
 
     def test_default_NAT_filenaming(self):
         context = Metadata()
@@ -383,7 +383,7 @@ class ScriptParserTest(PicardTestCase):
         context['album'] = u'[non-album tracks]'
         context['title'] = u'title'
         result = self.parser.eval(DEFAULT_FILE_NAMING_FORMAT, context)
-        self.assertEqual(result, u'artist/title')
+        self.assertEqual(result, u'artist/\n\ntitle')
 
     def test_cmd_with_not_arguments(self):
         self.parser.eval("$noargstest()")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
If there is no track number in metadata the default script will still write "00" to the file name.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1556](https://tickets.metabrainz.org/browse/PICARD-1556)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Check for tracknumber being set in the default script.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

