### PR TITLE
PICARD-1564: AcoustId metadata parsing must not set "track" field

### DIFF
--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -37,7 +37,6 @@ def _make_releases_node(recording):
                 medium_mb = {}
                 if 'format' in medium:
                     medium_mb['format'] = medium['format']
-                medium_mb['track'] = {}
                 medium_mb['track-count'] = medium['track_count']
                 release_mb['media'].append(medium_mb)
             release_list.append(release_mb)

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -41,7 +41,7 @@ class RecordingTest(AcoustIDTest):
         self.assertEqual(parsed_recording['id'], '017830c1-d1cf-46f3-8801-aaaa0a930223')
         self.assertEqual(parsed_recording['length'], 225000)
         self.assertEqual(parsed_recording['title'], 'Nina')
-        self.assertEqual(release['media'], [{'track': {}, 'format': 'CD', 'track-count': 12}])
+        self.assertEqual(release['media'], [{'format': 'CD', 'track-count': 12}])
         self.assertEqual(release['title'], 'x')
         self.assertEqual(release['id'], 'a2b25883-306f-4a53-809a-a234737c209d')
         self.assertEqual(release['release-group'], {'id': 'c24e5416-cd2e-4cff-851b-5faa78db98a2'})


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1564](https://tickets.metabrainz.org/browse/PICARD-1564)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Avoid setting unused field when parsing AcoustId medium info.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

