### PR TITLE
PICARD-1282: Allow closing all dialogs on macOS with ⌘W

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -217,7 +217,9 @@ class CAATypesSelectorDialog(PicardDialog):
             types_exclude = []
 
         self.setWindowTitle(_("Cover art types"))
+        self.setWindowModality(QtCore.Qt.WindowModal)
         self.layout = QtWidgets.QVBoxLayout(self)
+        self.layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
 
         # Create list boxes for dialog
         self.list_include = ListBox()

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -56,6 +56,7 @@ from picard.coverart.utils import (
 )
 from picard.util import webbrowser2
 
+from picard.ui import PicardDialog
 from picard.ui.ui_provider_options_caa import Ui_CaaOptions
 from picard.ui.util import StandardButton
 
@@ -199,7 +200,7 @@ class ListBox(QtWidgets.QListWidget):
             yield self.item(index).data(role)
 
 
-class CAATypesSelectorDialog(QtWidgets.QDialog):
+class CAATypesSelectorDialog(PicardDialog):
     """Display dialog box to select the CAA image types to include and exclude from download and use.
 
     Keyword Arguments:

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -26,6 +26,7 @@ from PyQt5 import (
 )
 
 from picard import config
+from picard.const.sys import IS_MACOS
 from picard.util import restore_method
 
 
@@ -62,6 +63,13 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     def __init__(self, parent=None):
         super().__init__(parent, self.flags)
+
+    def keyPressEvent(self, event):
+        if (IS_MACOS and event.modifiers() & QtCore.Qt.ControlModifier
+            and event.key() == QtCore.Qt.Key_W):
+            self.close()
+        else:
+            super().keyPressEvent(event)
 
 
 # With py3, QObjects are no longer hashable unless they have

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -177,6 +177,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.logDialog = LogView(self)
         self.historyDialog = HistoryView(self)
+        self.optionsDialog = None
 
         bottomLayout = QtWidgets.QHBoxLayout()
         bottomLayout.setContentsMargins(0, 0, 0, 0)
@@ -928,8 +929,15 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.show_options("about")
 
     def show_options(self, page=None):
-        dialog = OptionsDialog(page, self)
-        dialog.exec_()
+        if not self.optionsDialog:
+            self.optionsDialog = OptionsDialog(page, self)
+            self.optionsDialog.finished.connect(self.on_options_closed)
+        self.optionsDialog.show()
+        self.optionsDialog.raise_()
+        self.optionsDialog.activateWindow()
+
+    def on_options_closed(self):
+        self.optionsDialog = None
 
     def show_help(self):
         webbrowser2.goto('documentation')

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -86,6 +86,7 @@ class OptionsDialog(PicardDialog):
 
     def __init__(self, default_page=None, parent=None):
         super().__init__(parent)
+        self.setWindowModality(QtCore.Qt.ApplicationModal)
 
         from picard.ui.ui_options import Ui_Dialog
         self.ui = Ui_Dialog()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -288,6 +288,7 @@ class ToolbarListItem(QtWidgets.QListWidgetItem):
 class AddActionDialog(PicardDialog):
     def __init__(self, action_list, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.setWindowModality(QtCore.Qt.WindowModal)
 
         layout = QtWidgets.QVBoxLayout(self)
 

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -31,6 +31,7 @@ from picard import config
 from picard.const import UI_LANGUAGES
 from picard.util import icontheme
 
+from picard.ui import PicardDialog
 from picard.ui.moveable_list_view import MoveableListView
 from picard.ui.options import (
     OptionsPage,
@@ -284,7 +285,7 @@ class ToolbarListItem(QtWidgets.QListWidgetItem):
         self.action_name = action_name
 
 
-class AddActionDialog(QtWidgets.QDialog):
+class AddActionDialog(PicardDialog):
     def __init__(self, action_list, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
On macOS all windows can usually be closed with ⌘W. Qt enables this already for some dialogs, but this does not work for all dialogs we use, most significantly not for the options dialog, but also not for e.g. "Tags from filenames" and smaller dialogs opened inside options.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1282](https://tickets.metabrainz.org/browse/PICARD-1282)
* JIRA ticket (_optional_): [PICARD-1571](https://tickets.metabrainz.org/browse/PICARD-1571)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Enable the ⌘W for all dialogs by implementing it in `PicardDialog` and making sure all dialogs inherit from it.

This PR also addresses the issue that on macOS one could open more then one instance of the options dialog ([PICARD-1571](https://tickets.metabrainz.org/browse/PICARD-1571)), leading to some issues. I could add this as a separate PR (it is a single commit https://github.com/metabrainz/picard/commit/f8eb75596e8090d2f08e9290608dbe7a9f4964d4), but I found it easier to test both changes as one.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

