### PR TITLE
PEP8 fixes, check with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash scripts/package-osx.sh; fi
 
 script:
-- py.test -v --cov=picard --cov-report xml:coverage.xml
+- py.test -v --cov=picard --cov-report xml:coverage.xml test
 - isort --check-only --diff --quiet $(git ls-tree -r --name-only $(git rev-parse HEAD) | grep "\\.py$")
 - flake8 picard
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
   - PIP_INSTALL="pip3 install"
   - INSTALL_DEPS="$PIP_INSTALL -r requirements.txt"
-  - INSTALL_TEST_TOOLS="$PIP_INSTALL pytest pytest-randomly pytest-cov isort==4.3.10"
+  - INSTALL_TEST_TOOLS="$PIP_INSTALL pytest pytest-randomly pytest-cov isort==4.3.10 flake8"
   - CODACY="$PIP_INSTALL codacy-coverage"
   - LIBDISCID="libdiscid0 libdiscid-dev"
   matrix:
@@ -79,6 +79,7 @@ before_install:
 script:
 - py.test -v --cov=picard --cov-report xml:coverage.xml
 - isort --check-only --diff --quiet $(git ls-tree -r --name-only $(git rev-parse HEAD) | grep "\\.py$")
+- flake8 picard
 
 after_success:
 - if [ ! -z "${CODACY_PROJECT_TOKEN}" ]; then $CODACY; python-codacy-coverage -r coverage.xml;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ PYFILES=$(git diff --cached --name-only | grep "\\.py$" | grep --invert-match \
 if [ ! -z "$PYFILES" ]; then
   set -e
   isort --check-only --diff --quiet $PYFILES
+  flake8 $PYFILES
 fi
 ```
 

--- a/picard/collection.py
+++ b/picard/collection.py
@@ -127,7 +127,7 @@ def load_user_collections(callback=None):
                 col_name = node['name']
                 col_size = node['release-count']
                 new_collections.add(col_id)
-                collection = get_user_collection(col_id, col_name, col_size, refresh=True)
+                get_user_collection(col_id, col_name, col_size, refresh=True)
 
             # remove collections which aren't returned by the web service anymore
             old_collections = set(user_collections) - new_collections

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -84,13 +84,13 @@ for k, v in MB_ATTRIBUTES.items():
         RELEASE_SECONDARY_GROUPS[v] = v
 
 # Release countries
-from picard.const.countries import RELEASE_COUNTRIES
+from picard.const.countries import RELEASE_COUNTRIES  # noqa: F401 # pylint: disable=unused-import
 
 # List of available user interface languages
-from picard.const.languages import UI_LANGUAGES
+from picard.const.languages import UI_LANGUAGES  # noqa: F401 # pylint: disable=unused-import
 
 # List of alias locales
-from picard.const.locales import ALIAS_LOCALES
+from picard.const.locales import ALIAS_LOCALES  # noqa: F401 # pylint: disable=unused-import
 
 # List of official musicbrainz servers - must support SSL for mblogin requests (such as collections).
 MUSICBRAINZ_SERVERS = [

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -36,7 +36,7 @@ builtins.__dict__['N_'] = lambda a: a
 def setup_gettext(localedir, ui_language=None, logger=None):
     """Setup locales, load translations, install gettext functions."""
     if not logger:
-        logger = lambda *a, **b: None  # noop
+        logger = lambda *a, **b: None  # noqa: E731
     current_locale = ''
     if ui_language:
         try:

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -33,7 +33,6 @@ _PLUGIN_MODULE_PREFIX_LEN = len(_PLUGIN_MODULE_PREFIX)
 _extension_points = []
 
 
-
 def _unregister_module_extensions(module):
     for ep in _extension_points:
         ep.unregister_module(module)
@@ -206,7 +205,7 @@ class PluginFunctions:
     """
 
     def __init__(self, label=None):
-        self.functions = defaultdict(lambda : ExtensionPoint(label=label))
+        self.functions = defaultdict(lambda: ExtensionPoint(label=label))
 
     def register(self, module, item, priority=PluginPriority.NORMAL):
         self.functions[priority].register(module, item)

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -87,7 +87,7 @@ class ReleaseGroup(DataObject):
                 "id":      node['id'],
                 "year":    node['date'][:4] if "date" in node else "????",
                 "country": "+".join(countries) if countries
-                    else node.get('country', '') or "??",
+                           else node.get('country', '') or "??",
                 "format":  media_formats_from_node(node['media']),
                 "label":  ", ".join([' '.join(x.split(' ')[:2]) for x in set(labels)]),
                 "catnum": ", ".join(set(catnums)),

--- a/picard/script.py
+++ b/picard/script.py
@@ -767,7 +767,7 @@ def func_endswith(parser, text, suffix):
 def func_truncate(parser, text, length):
     try:
         length = int(length)
-    except ValueError as e:
+    except ValueError:
         length = None
     return text[:length].rstrip()
 
@@ -887,7 +887,7 @@ def iswbound(char):
     # from https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/titlecase/titlecase.py
     """ Checks whether the given character is a word boundary """
     category = unicodedata.category(char)
-    return "Zs" == unicodedata.category(char) or "Sk" == unicodedata.category(char) or "P" == unicodedata.category(char)[0]
+    return "Zs" == category or "Sk" == category or "P" == category[0]
 
 
 register_script_function(func_if, "if", eval_args=False)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -98,7 +98,7 @@ from picard.webservice.api_helpers import (
     MBAPIHelper,
 )
 
-import picard.resources  # pylint: disable=unused-import
+import picard.resources  # noqa: F401 # pylint: disable=unused-import
 
 from picard.ui.itemviews import BaseTreeView
 from picard.ui.mainwindow import MainWindow

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -32,7 +32,7 @@ from picard.ui import (
     HashableTreeWidgetItem,
     PicardDialog,
 )
-from picard.ui.options import (  # pylint: disable=unused-import
+from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     OptionsCheckError,
     _pages as page_classes,
     about,

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -51,7 +51,7 @@ class InterfaceOptionsPage(OptionsPage):
     PARENT = None
     SORT_ORDER = 80
     ACTIVE = True
-    SEPARATOR = '—'*5
+    SEPARATOR = '—' * 5
     TOOLBAR_BUTTONS = {
         'add_directory_action': {
             'label': N_('Add Folder'),
@@ -140,7 +140,8 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.ui_language.addItem(_('System default'), '')
         language_list = [(l[0], l[1], _(l[2])) for l in UI_LANGUAGES]
 
-        def fcmp(x): return locale.strxfrm(x[2])
+        def fcmp(x):
+            return locale.strxfrm(x[2])
         for lang_code, native, translation in sorted(language_list, key=fcmp):
             if native and native != translation:
                 name = '%s (%s)' % (translation, native)

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -257,7 +257,8 @@ class ReleasesOptionsPage(OptionsPage):
         else:
             source_list = [(c[0], _(c[1])) for c in source.items()]
 
-        def fcmp(x): return strxfrm(x[1])
+        def fcmp(x):
+            return strxfrm(x[1])
         source_list.sort(key=fcmp)
         saved_data = config.setting[setting]
         move = []

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -20,10 +20,7 @@
 import os.path
 import re
 
-from PyQt5 import (
-    QtCore,
-    QtWidgets,
-)
+from PyQt5 import QtWidgets
 
 from picard import config
 from picard.util.tags import display_tag_name

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -146,7 +146,7 @@ def sanitize_date(datestr):
 
 
 _re_win32_incompat = re.compile(r'["*:<>?|]', re.UNICODE)
-def replace_win32_incompat(string, repl="_"):
+def replace_win32_incompat(string, repl="_"):  # noqa: E302
     """Replace win32 filename incompatible characters from ``string`` by
        ``repl``."""
     # Don't replace : with _ for windows drive
@@ -158,13 +158,13 @@ def replace_win32_incompat(string, repl="_"):
 
 
 _re_non_alphanum = re.compile(r'\W+', re.UNICODE)
-def strip_non_alnum(string):
+def strip_non_alnum(string):  # noqa: E302
     """Remove all non-alphanumeric characters from ``string``."""
     return _re_non_alphanum.sub(" ", string).strip()
 
 
 _re_slashes = re.compile(r'[\\/]', re.UNICODE)
-def sanitize_filename(string, repl="_"):
+def sanitize_filename(string, repl="_"):  # noqa: E302
     return _re_slashes.sub(repl, string)
 
 
@@ -224,7 +224,7 @@ def find_executable(*executables):
 
 _mbid_format = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 _re_mbid_val = re.compile(_mbid_format, re.IGNORECASE)
-def mbid_validate(string):
+def mbid_validate(string):  # noqa: E302
     """Test if passed string is a valid mbid
     """
     return _re_mbid_val.match(string) is not None
@@ -595,12 +595,14 @@ def compare_barcodes(barcode1, barcode2):
 
 BestMatch = namedtuple('BestMatch', 'similarity result num_results')
 
+
 def sort_by_similarity(candidates):
     return sorted(
         candidates(),
         reverse=True,
         key=attrgetter('similarity')
     )
+
 
 def find_best_match(candidates, no_match):
     sorted_results = sort_by_similarity(candidates)

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -89,8 +89,9 @@ def _shorten_to_utf16_nfd_length(text, length):
         pass
     return unicodedata.normalize('NFC', newtext)
 
+
 _re_utf8 = re.compile(r'^utf([-_]?8)$', re.IGNORECASE)
-def _shorten_to_bytes_length(text, length):
+def _shorten_to_bytes_length(text, length):  # noqa: E302
     """Truncates a unicode object to the given number of bytes it would take
     when encoded in the "filesystem encoding".
     """
@@ -124,7 +125,7 @@ def _shorten_to_bytes_length(text, length):
 
 
 SHORTEN_BYTES, SHORTEN_UTF16, SHORTEN_UTF16_NFD = 0, 1, 2
-def shorten_filename(filename, length, mode):
+def shorten_filename(filename, length, mode):  # noqa: E302
     """Truncates a filename to the given number of thingies,
     as implied by `mode`.
     """
@@ -145,7 +146,8 @@ def shorten_path(path, length, mode):
     length: Maximum number of code points / bytes allowed in a node.
     mode: One of SHORTEN_BYTES, SHORTEN_UTF16, SHORTEN_UTF16_NFD.
     """
-    def shorten(n, l): return n and shorten_filename(n, l, mode).strip() or ""
+    def shorten(n, l):
+        return n and shorten_filename(n, l, mode).strip() or ""
     dirpath, filename = os.path.split(path)
     fileroot, ext = os.path.splitext(filename)
     return os.path.join(
@@ -192,7 +194,8 @@ def _make_win_short_filename(relpath, reserved=0):
     remaining = MAX_DIRPATH_LEN - reserved
 
     # to make things more readable...
-    def shorten(p, l): return shorten_path(p, l, mode=SHORTEN_UTF16)
+    def shorten(p, l):
+        return shorten_path(p, l, mode=SHORTEN_UTF16)
     xlength = _get_utf16_length
 
     # shorten to MAX_NODE_LEN from the beginning
@@ -274,6 +277,7 @@ def _get_mount_point(target):
             mount = os.path.dirname(mount)
         mounts[target] = mount
     return mount
+
 
 # NOTE: this could be merged with the function above, and get all needed info
 # in a single call, returning the filesystem type as well. (but python's

--- a/picard/util/textencoding.py
+++ b/picard/util/textencoding.py
@@ -68,7 +68,7 @@ import unicodedata
 from picard.util import sanitize_filename
 
 
-#########################  LATIN SIMPLIFICATION ###########################
+# LATIN SIMPLIFICATION
 # The translation tables for punctuation and latin combined-characters are taken from
 # http://unicode.org/repos/cldr/trunk/common/transforms/Latin-ASCII.xml
 # Various bugs and mistakes in this have been ironed out during testing.

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -36,7 +36,7 @@ def open(url):
         webbrowser.open(url)
     except webbrowser.Error as e:
         QtWidgets.QMessageBox.critical(None, _("Web Browser Error"), _("Error while launching a web browser:\n\n%s") % (e,))
-    except TypeError as e:
+    except TypeError:
         if version_info.major == 3 and version_info.minor == 7 and version_info.micro == 0:
             # See https://bugs.python.org/issue31014, webbrowser.open doesn't
             # work on 3.7.0 the first time it's called. The initialization code

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -386,14 +386,13 @@ class WebService(QtCore.QObject):
             log.error("Network request error for %s: %s (QT code %d, HTTP code %d)",
                       url, errstr, error, code)
             if (not request.max_retries_reached()
-                        and (code == 503
-                             or code == 429
-                             # Sometimes QT returns a http status code of 200 even when there
-                             # is a service unavailable error. But it returns a QT error code
-                             # of 403 when this happens
-                             or error == 403
-                             )
-                    ):
+                and (code == 503
+                     or code == 429
+                     # Sometimes QT returns a http status code of 200 even when there
+                     # is a service unavailable error. But it returns a QT error code
+                     # of 403 when this happens
+                     or error == 403
+                     )):
                 slow_down = True
                 retries = request.mark_for_retry()
                 log.debug("Retrying %s (#%d)", url, retries)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,17 @@
 [flake8]
 # E127: continuation line over-indented for visual indent
 # E128: continuation line under-indented for visual indent
+# E129: visually indented line with same indent as next logical line
+# E226: missing whitespace around arithmetic operator
+# E241: multiple spaces after ','
 # E265: block comment should start with ‘# ‘
 # E402: module level import not at top of file
 # E501: line too long (xx > 79 characters)
 # W503: line break occurred before a binary operator
-ignore = E127,E128,E265,E402,E501,W503
+ignore = E127,E128,E129,E226,E241,E265,E402,E501,W503
 builtins = _,N_,ngettext,gettext_attributes,gettext_countries,string_
-exclude = ui_*.py
+exclude = ui_*.py,picard/resources.py
 
 [coverage:run]
 source = picard
-omit = */ui_*.py
+omit = */ui_*.py,picard/resources.py


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
This makes some PEP8 fixes and ensures that at least all source inside `picard/` can be checked with flake8. Adds flake8 source code check to CI.

I added some exceptions for specific cases inline as well as ignoring a few rules globally. The now additionally ignored rules are:

**E226: missing whitespace around arithmetic operator**

While I in general think it is better to have whitespace around arithmetic operators there are cases where it makes sense to omit them. E.g. we often have something like `data[pos:pos+2]`. Adding whitespace here looks a bit off to me (`data[pos:pos + 2]`). Also something like `2*3 + 4*4` reads nicer then `2 * 3 + 4 * 4` as the precedence of the operations is more visible. I think this is even mentioned in the PEP8 docs.

**E241: multiple spaces after ','**

Again, often goo, but we in some places use this to align code nicely. Some examples:

https://github.com/metabrainz/picard/blob/master/picard/ui/searchdialog/album.py#L149
https://github.com/metabrainz/picard/blob/master/picard/ui/searchdialog/album.py#L344
https://github.com/metabrainz/picard/blob/master/picard/const/__init__.py#L52

**E129: visually indented line with same indent as next logical line**
Not too sure about this one. This is for cases like:

```
if (config.setting["caa_image_type_as_filename"]
    and not self.is_front_image()):
    filename = self.maintype
```

While I agree that this sometimes can make it a bit harder to read, I felt like doing some crazy shenanigans with indentation to satisfy the rules was also not that great. I'm open for other opinion, though.

We can always enable rules again in `setup.cfg` if we feel like going a step further. But having these checks run automated already showed that it can uncover some actual bad code. E.g. the line changed in https://github.com/metabrainz/picard/pull/1236/files#diff-49991922d5e1bb94a02cf28bf4619a1eL890 

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

