### PR TITLE
PICARD-1446: Fixed missing expand indicator for releases

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -759,6 +759,9 @@ class AlbumItem(TreeItem):
             self.setText(i, album.column(column[1]))
         if self.isSelected():
             TreeItem.window.update_selection()
+        # Workaround for PICARD-1446: Expand/collapse indicator for the release
+        # is briefly missing on Windows
+        self.emitDataChanged()
 
 
 class TrackItem(TreeItem):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
On windows the expand indicator for a release in the tree view was missing directly after having loaded a release. Any further action, like loading another release or clicking the tree view caused the indicator to appear.

I could not reproduce this on Linux, but on Windows it is a thing even with latest Qt 5.13. But on Windows it is easily reproducible.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1446](https://tickets.metabrainz.org/browse/PICARD-1446)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
After updating the release item force an update by invoking `emitDataChanged()`.

This is more a workaround, basically I think this is a Qt or PyQt bug.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

