### PR TITLE
PICARD-1488: macOS player fixes

### DIFF
--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -279,7 +279,6 @@ class PlaybackProgressSlider(QtWidgets.QWidget):
         self.media_name = ''
         self._position_update = False
 
-        vbox = QtWidgets.QVBoxLayout(self)
         tool_font = QtWidgets.QApplication.font("QToolButton")
 
         self.progress_slider = ClickableSlider(self)
@@ -307,6 +306,8 @@ class PlaybackProgressSlider(QtWidgets.QWidget):
         hbox.addWidget(self.progress_slider)
         hbox.addWidget(self.duration_label)
 
+        vbox = QtWidgets.QVBoxLayout(self)
+        vbox.setSpacing(0)
         vbox.addWidget(slider_container)
         vbox.addWidget(self.media_name_label)
 

--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -31,6 +31,7 @@ from picard import (
     config,
     log,
 )
+from picard.const.sys import IS_MACOS
 from picard.util import (
     format_time,
     icontheme,
@@ -146,17 +147,19 @@ class Player(QtCore.QObject):
     def set_playback_rate(self, playback_rate):
         player = self._player
         player.setPlaybackRate(playback_rate)
-        # Playback rate changes do not affect the current media playback.
-        # Force playback restart to have the rate change applied immediately.
-        player_state = player.state()
-        if player_state != QtMultimedia.QMediaPlayer.StoppedState:
-            position = player.position()
-            player.stop()
-            player.setPosition(position)
-            if player_state == QtMultimedia.QMediaPlayer.PlayingState:
-                player.play()
-            elif player_state == QtMultimedia.QMediaPlayer.PausedState:
-                player.pause()
+        if not IS_MACOS:
+            # Playback rate changes do not affect the current media playback on
+            # Linux and does work unreliable on Windows.
+            # Force playback restart to have the rate change applied immediately.
+            player_state = player.state()
+            if player_state != QtMultimedia.QMediaPlayer.StoppedState:
+                position = player.position()
+                player.stop()
+                player.setPosition(position)
+                if player_state == QtMultimedia.QMediaPlayer.PlayingState:
+                    player.play()
+                elif player_state == QtMultimedia.QMediaPlayer.PausedState:
+                    player.pause()
 
     def _on_error(self, error):
         if error == QtMultimedia.QMediaPlayer.FormatError:

--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -280,6 +280,7 @@ class PlaybackProgressSlider(QtWidgets.QWidget):
         self._position_update = False
 
         vbox = QtWidgets.QVBoxLayout(self)
+        tool_font = QtWidgets.QApplication.font("QToolButton")
 
         self.progress_slider = ClickableSlider(self)
         self.progress_slider.setOrientation(QtCore.Qt.Horizontal)
@@ -290,6 +291,7 @@ class PlaybackProgressSlider(QtWidgets.QWidget):
         self.progress_slider.valueChanged.connect(self.on_value_changed)
         self.media_name_label = QtWidgets.QLabel(self)
         self.media_name_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.media_name_label.setFont(tool_font)
 
         slider_container = QtWidgets.QWidget(self)
         hbox = QtWidgets.QHBoxLayout(slider_container)
@@ -299,6 +301,8 @@ class PlaybackProgressSlider(QtWidgets.QWidget):
         min_duration_width = get_text_width(self.position_label.font(), "8:88")
         self.position_label.setMinimumWidth(min_duration_width)
         self.duration_label.setMinimumWidth(min_duration_width)
+        self.position_label.setFont(tool_font)
+        self.duration_label.setFont(tool_font)
         hbox.addWidget(self.position_label)
         hbox.addWidget(self.progress_slider)
         hbox.addWidget(self.duration_label)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
A couple of optimizations after testing the player on macOS. Most notably this fixes the playback speed changing on macOS (by disabling a workaround which is needed for Linux and Windows).

Also some Layout fixes, which theoretically are also present on other platforms but not as notable there.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1488](https://tickets.metabrainz.org/browse/PICARD-1488)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

