### PR TITLE
PICARD-1524: Fix color chooser getting all buttons colored

### DIFF
--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -53,7 +53,8 @@ class ColorButton(QtWidgets.QPushButton):
         self.setStyleSheet("QPushButton { background-color: %s; }" % self.color.name())
 
     def open_color_dialog(self):
-        new_color = QtWidgets.QColorDialog.getColor(self.color, title=_("Choose a color"), parent=self)
+        new_color = QtWidgets.QColorDialog.getColor(
+            self.color, title=_("Choose a color"), parent=self.parent())
 
         if new_color.isValid():
             self.color = new_color


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Due to the parent buttons stylesheet all buttons in the QColorDialog got colored as well. This happened e.g. on Windows, where no native color chooser is available.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
This is a fun bug in the new color options (#1199). Found this on Windows, although it will happen on every platform where the custom Qt color dialog is used and not a platform native one (e.g. also Linux with KDE, but not on GNOME). The stylesheet `QPushButton { background-color: %s; }` also colors all buttons in the color chooser:

![screenshot-2019-09-01-15-35-40](https://user-images.githubusercontent.com/29852/64077254-b7c54980-ccce-11e9-8ca0-a6ffbe66587c.png)

If you want to experience this on Linux with e.g. GNOME (where otherwise a native dialog is being used), just replace

```
new_color = QtWidgets.QColorDialog.getColor(self.color, title=_("Choose a color"), parent=self)
```

with 

```
dlg = QtWidgets.QColorDialog(self.parent())
dlg.setOption(QtWidgets.QColorDialog.DontUseNativeDialog)
dlg.setWindowModality(QtCore.Qt.WindowModal)
dlg.setCurrentColor(self.color)
dlg.exec_()
new_color = dlg.selectedColor()
```

(This is basically exactly the code that gets executed by `QColorDialog.getColor`, just with `DontUseNativeDialog` getting set).

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1524](https://tickets.metabrainz.org/browse/PICARD-1524)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Not sure if this is the clearest solution, but I just reparented the `QColorDialog` to the parent pf `ColorButton`. I think this is also conceptionally fine, and avoids any stylesheets from `ColorButton` leaking into the dialog.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

