### PR TITLE
PICARD-1590: Fixed thread locking when saving options

### DIFF
--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -26,6 +26,7 @@ from PyQt5 import (
 
 from picard import config
 from picard.util.tags import TAG_NAMES
+from picard.util.thread import to_main
 
 from picard.ui.options import (
     OptionsPage,
@@ -97,7 +98,7 @@ class TagsOptionsPage(OptionsPage):
         clear_existing_tags = self.ui.clear_existing_tags.isChecked()
         if clear_existing_tags != config.setting["clear_existing_tags"]:
             config.setting["clear_existing_tags"] = clear_existing_tags
-            self.tagger.window.metadata_box.update()
+            to_main(self.tagger.window.metadata_box.update)
         config.setting["write_id3v1"] = self.ui.write_id3v1.isChecked()
         config.setting["write_id3v23"] = self.ui.write_id3v23.isChecked()
         config.setting["id3v23_join_with"] = self.ui.id3v23_join_with.currentText()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Avoids some kind of thread lock when saving options.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When saving the options while a file is selected and the `clear_existing_tags` was toggled, Picard could completely freeze up (at least on Linux, I could not reproduce on Windows). The basic cause is the call to `MetadataBox.update`.

To reproduce:

1. Open current master with e.g. `./tagger.py test/data/test.mp3`
2. Select the loaded file (so that the metadatabox shows the metadata of this file)
3. Open Options, toggle Tags > Clear existing tags
4. Save Options

Often the app is now unresponsive. If this does not work, just repeat steps 3. and 4. Usually after not more than 5 tries I can reproduce this. But often it freezes on first try for me.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1590](https://tickets.metabrainz.org/browse/PICARD-1590)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
To be honest I am not entirely sure about the final cause and the solution. But calling `self.tagger.window.metadata_box.update` on the main thread seems to avoid the issue.

I think this is somewhat related that the QDialog itself running code in separate threads. But I really would appreciate some critical review and some better ideas on what is happening. Also if someone can both reproduce the issue

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

