### PR TITLE
PICARD-1591: Error tolerant loading of metadata_block_picture

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -133,8 +133,8 @@ class VCommentFile(File):
                         continue
                     name = "totaldiscs"
                 elif name == "metadata_block_picture":
-                    image = mutagen.flac.Picture(base64.standard_b64decode(value))
                     try:
+                        image = mutagen.flac.Picture(base64.standard_b64decode(value))
                         coverartimage = TagCoverArtImage(
                             file=filename,
                             tag=name,
@@ -143,11 +143,10 @@ class VCommentFile(File):
                             support_types=True,
                             data=image.data,
                         )
-                    except CoverArtImageError as e:
+                    except (CoverArtImageError, TypeError, ValueError, mutagen.flac.error) as e:
                         log.error('Cannot load image from %r: %s' % (filename, e))
                     else:
                         metadata.images.append(coverartimage)
-
                     continue
                 elif name in self.__translate:
                     name = self.__translate[name]
@@ -178,7 +177,7 @@ class VCommentFile(File):
                             tag='COVERART',
                             data=base64.standard_b64decode(data)
                         )
-                    except CoverArtImageError as e:
+                    except (CoverArtImageError, TypeError, ValueError) as e:
                         log.error('Cannot load image from %r: %s' % (filename, e))
                     else:
                         metadata.images.append(coverartimage)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard fails to load files with invalid `metadata_block_picture` tag (e.g. not base64 or the decoded content is not a FLAC picture block).
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1591](https://tickets.metabrainz.org/browse/PICARD-1591)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- Handle exceptions for base64 decoding and FLAC picture block parsing.
- Added tests for errors in cover art and for loading the legacy `COVERART` tag
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

