### PR TITLE
PICARD-1595: Keep cursor position when editing tag names

### DIFF
--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -97,6 +97,8 @@ class EditTagDialog(PicardDialog):
     def tag_changed(self, tag):
         tag_names = self.ui.tag_names
         tag_names.editTextChanged.disconnect(self.tag_changed)
+        line_edit = tag_names.lineEdit()
+        cursor_pos = line_edit.cursorPosition()
         flags = QtCore.Qt.MatchFixedString | QtCore.Qt.MatchCaseSensitive
 
         # if the previous tag was new and has no value, remove it from the QComboBox.
@@ -121,6 +123,7 @@ class EditTagDialog(PicardDialog):
 
         self.enable_all()
         tag_names.setCurrentIndex(row)
+        line_edit.setCursorPosition(cursor_pos)
         self.value_list.clear()
 
         values = self.modified_tags.get(self.tag, None)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
If the user edits the tag name inside the tag edit box, the text cursor always jumps to the end of the input on every keypress.

E.g. if the user wants to edit the tag name "start_abc_end" by replacing the inner "abc" with something else they would place the cursor in the middle of the string. But on every input (removing a character, adding a character) the cursor jumps to the end of the string.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1595](https://tickets.metabrainz.org/browse/PICARD-1595)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Reset the cursor position after updating the `QComboBox` selection.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

