### PR TITLE
PICARD-622: Do not reset horizontal scroll position in main window panes on selection change

### DIFF
--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -102,6 +102,18 @@ class FileBrowser(QtWidgets.QTreeView):
             self.scrollTo(self.currentIndex())
         QtCore.QTimer.singleShot(0, scroll)
 
+    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.EnsureVisible):
+        # QTreeView.scrollTo resets the horizontal scroll position to 0.
+        # Reimplemented to instead scroll to horizontal parent position.
+        level = -1
+        super().scrollTo(index, scrolltype)
+        parent = self.currentIndex().parent()
+        while parent.isValid():
+            parent = parent.parent()
+            level += 1
+        pos_x = max(self.indentation() * level, 0)
+        self.horizontalScrollBar().setValue(pos_x)
+
     def mousePressEvent(self, event):
         index = self.indexAt(event.pos())
         if index.isValid():

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -513,6 +513,14 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             mimeData.setUrls(files)
         return mimeData
 
+    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.EnsureVisible):
+        # QTreeView.scrollTo resets the horizontal scroll position to 0.
+        # Reimplemented to maintain current horizontal scroll position.
+        hscrollbar = self.horizontalScrollBar()
+        xpos = hscrollbar.value()
+        super().scrollTo(index, scrolltype)
+        hscrollbar.setValue(xpos)
+
     @staticmethod
     def drop_urls(urls, target):
         files = []


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary


<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The horizontal scroll position in all three main window panes (file browser, untagged files, tagged files) resets to 0 when selection changes. This is default behavior of `QTreeView.scrollTo`.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-622](https://tickets.metabrainz.org/browse/PICARD-622)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Reimplement `scrollTo` to better handle horizontal scroll position.

- For the file browser, set the horizontal scroll position to the indentation level of the parent. This allows intuitive and easy navigation through deep hierarchies without the need of manually handling the scrolling.
- For the untagged / tagged files panes we don't have deep hierarchies, but potentially large data columns. Just keep the current horizontal scrolling position. Usually if the user needs to scroll horizontally here it means the panes are very narrow but the user probably focuses on a certain column. This behavior ensures the focus on the column is not lost.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
@zas Please try this locally. The behavior is hard to explain, one has to actually use it to see if it "feels good".
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

