### PR TITLE
PICARD-1590: fix thread lockups

### DIFF
--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -26,7 +26,6 @@ from PyQt5 import (
 
 from picard import config
 from picard.util.tags import TAG_NAMES
-from picard.util.thread import to_main
 
 from picard.ui.options import (
     OptionsPage,
@@ -98,7 +97,7 @@ class TagsOptionsPage(OptionsPage):
         clear_existing_tags = self.ui.clear_existing_tags.isChecked()
         if clear_existing_tags != config.setting["clear_existing_tags"]:
             config.setting["clear_existing_tags"] = clear_existing_tags
-            to_main(self.tagger.window.metadata_box.update)
+            self.tagger.window.metadata_box.update()
         config.setting["write_id3v1"] = self.ui.write_id3v1.isChecked()
         config.setting["write_id3v23"] = self.ui.write_id3v23.isChecked()
         config.setting["id3v23_join_with"] = self.ui.id3v23_join_with.currentText()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The issue occurs when writing a config value and directly afterwards reading one. it hangs in reading then .This behavior came with https://github.com/metabrainz/picard/commit/a63cc6bdd1614476c63244e1dce92500dd1219f2 at https://github.com/metabrainz/picard/blob/master/picard/config.py#L94

Here it calls ConfigSection__contains__, which calls ConfigSection._subkeys, which calls QSettings.allKeys(). and allkeys() never returns. Instead of calling .allKeys() you can also call QSettings.contains() or QSettings.sync(), has the same effect of locking up

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1590](https://tickets.metabrainz.org/browse/PICARD-1590)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
 avoid calling allKeys() or contains() on the QSetting instance and instead maintain a own list of loaded config names per section
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

