### PR TITLE
PICARD-1598: Keep selection when updating album in itemview

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -722,18 +722,21 @@ class AlbumItem(TreeItem):
 
     def update(self, update_tracks=True):
         album = self.obj
+        selection_changed = self.isSelected()
         if update_tracks:
             oldnum = self.childCount() - 1
             newnum = len(album.tracks)
             if oldnum > newnum:  # remove old items
                 for i in range(oldnum - newnum):
+                    item = self.child(newnum)
+                    selection_changed |= item.isSelected()
                     self.takeChild(newnum)
                 oldnum = newnum
             # update existing items
             for i in range(oldnum):
                 item = self.child(i)
-                item.setSelected(False)
                 track = album.tracks[i]
+                selection_changed |= item.isSelected() and item.obj != track
                 item.obj = track
                 track.item = item
                 item.update(update_album=False)
@@ -765,8 +768,8 @@ class AlbumItem(TreeItem):
                 self.setToolTip(0, _("Album unchanged"))
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, album.column(column[1]))
-        if self.isSelected():
-            TreeItem.window.update_selection()
+        if selection_changed:
+            TreeItem.window.panel.update_current_view()
         # Workaround for PICARD-1446: Expand/collapse indicator for the release
         # is briefly missing on Windows
         self.emitDataChanged()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
This fixes an issue with the metadata box loosing its content when an album in the right pane gets updated while a track is selected. See the screencast in https://tickets.metabrainz.org/browse/PICARD-1598
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1598](https://tickets.metabrainz.org/browse/PICARD-1598)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
The problem was introduced in https://github.com/metabrainz/picard/commit/98769b01e04eb7e3a41953991f08eec4a4e07bf0, where I added a call to `item.setSelected(False)`.

The issue this call tried to solve was that if you removed a non-album track the main window could still have it in its selected objects, which could lead to a crash when deleting another NAT without hanging the selection first. Deselecting the updated item caused the main window to update its selection.

This is now better fixed by actually triggering an update to the selection. To not cause useless updates care is taken to only perform this update when there is a relevant change to a selected item:

- A selected item gets removed
- A selected item gets re-assigned to a different track

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

