### PR TITLE
Fixed names of parameters for run_track_metadata_processors

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -401,7 +401,7 @@ class Album(DataObject, Item):
 
         # Run track metadata plugins
         try:
-            run_track_metadata_processors(self, tm, self._release_node, track_node)
+            run_track_metadata_processors(self, tm, track_node, self._release_node)
         except BaseException:
             self.error_append(traceback.format_exc())
 

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -405,5 +405,5 @@ def run_album_metadata_processors(album_object, metadata, release):
     _album_metadata_processors.run(album_object, metadata, release)
 
 
-def run_track_metadata_processors(track_object, metadata, release, track):
-    _track_metadata_processors.run(track_object, metadata, track, release)
+def run_track_metadata_processors(album_object, metadata, track, release=None):
+    _track_metadata_processors.run(album_object, metadata, track, release)

--- a/picard/track.py
+++ b/picard/track.py
@@ -374,7 +374,7 @@ class NonAlbumTrack(Track):
         recording_to_metadata(recording, m, self)
         self.orig_metadata.copy(m)
         self._customize_metadata()
-        run_track_metadata_processors(self.album, m, None, recording)
+        run_track_metadata_processors(self.album, m, recording)
         for s_name, s_text in enabled_tagger_scripts_texts():
             parser = ScriptParser()
             try:


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixed the first parameter name of `run_track_metadata_processors` from `track_object` to `album_object`, because this is what gets actually passed here.

Also switched the parameters `track` and `release` around to match the order for the public API.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

