### PR TITLE
PICARD-456: Do not remove empty standard directories

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -611,3 +611,20 @@ def find_best_match(candidates, no_match):
     else:
         result = no_match
     return BestMatch(similarity=result.similarity, result=result, num_results=len(sorted_results))
+
+
+def get_qt_enum(cls, enum):
+    """
+    List all the names of attributes inside a Qt enum.
+
+    Example:
+        >>> from PyQt5.Qt import Qt
+        >>> print(get_qt_enum(Qt, Qt.CoordinateSystem))
+        ['DeviceCoordinates', 'LogicalCoordinates']
+    """
+    values = []
+    for key in dir(cls):
+        value = getattr(cls, key)
+        if isinstance(value, enum):
+            values.append(key)
+    return values

--- a/picard/util/emptydir.py
+++ b/picard/util/emptydir.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2006 Lukáš Lalinský
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import os
+import os.path
+import shutil
+
+from PyQt5.QtCore import QStandardPaths
+
+from picard.util import get_qt_enum
+
+
+# Files not considered relevant for a directory. If a directory has only
+# some of these files inside it is still considered empty and can be deleted.
+JUNK_FILES = set([".DS_Store", "desktop.ini", "Desktop.ini", "Thumbs.db"])
+
+# Special file system locations Picard should never delete.
+PROTECTED_DIRECTORIES = set()
+for location in get_qt_enum(QStandardPaths, QStandardPaths.StandardLocation):
+    value = getattr(QStandardPaths, location)
+    for path in QStandardPaths.standardLocations(value):
+        PROTECTED_DIRECTORIES.add(os.path.realpath(path))
+
+
+class SkipRemoveDir(Exception):
+    pass
+
+
+def is_empty_dir(path, ignored_files=None):
+    """
+    Checks if a directory is considered empty.
+
+    Args:
+        path: Path to directory to check.
+        ignored_files: List of files to ignore. I only some of those files is
+                       inside the directory it is still considered empty.
+
+    Returns:
+        True if path is considered an empty directory
+        False if path is not considered an empty directory
+
+    Raises:
+        NotADirectoryError: path is not a directory
+    """
+    if ignored_files is None:
+        ignored_files = JUNK_FILES
+    return not set(os.listdir(path)) - set(ignored_files)
+
+
+def rm_empty_dir(path):
+    """
+    Delete a directory if it is considered empty by is_empty_dir and if it
+    is not considered a special directory (e.g. the users home dir or ~/Desktop).
+
+    Args:
+        path: Path to directory to remove.
+
+    Raises:
+        NotADirectoryError: path is not a directory
+        SkipRemoveDir: path was not deleted because it is either not empty
+                       or considered a special directory.
+    """
+    if os.path.realpath(path) in PROTECTED_DIRECTORIES:
+        raise SkipRemoveDir('%s is a protected directory' % path)
+    elif not is_empty_dir(path):
+        raise SkipRemoveDir('%s is not empty' % path)
+    else:
+        shutil.rmtree(path)

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+import os.path
+from tempfile import (
+    mkdtemp,
+    mkstemp,
+)
+import unittest
+
+from picard.util import emptydir
+
+
+class EmptyDirTest(unittest.TestCase):
+
+    def test_is_empty_dir_really_empty(self):
+        dir = _create_temp_dir()
+        self.assertTrue(emptydir.is_empty_dir(dir))
+
+    def test_is_empty_dir_only_junk_files(self):
+        dir = _create_temp_dir(extra_files=emptydir.JUNK_FILES)
+        self.assertTrue(len(os.listdir(dir)) > 0)
+        self.assertTrue(emptydir.is_empty_dir(dir))
+
+    def test_is_empty_dir_not_empty(self):
+        dir = _create_temp_dir(extra_files=['.notempty'])
+        self.assertEqual(1, len(os.listdir(dir)))
+        self.assertFalse(emptydir.is_empty_dir(dir))
+
+    def test_is_empty_dir_custom_ignore_files(self):
+        ignored_files = ['.empty']
+        dir = _create_temp_dir(extra_files=ignored_files)
+        self.assertEqual(1, len(os.listdir(dir)))
+        self.assertTrue(emptydir.is_empty_dir(dir, ignored_files=ignored_files))
+
+    def test_is_empty_dir_not_empty_child_dir(self):
+        dir = _create_temp_dir(extra_dirs=['childdir'])
+        self.assertEqual(1, len(os.listdir(dir)))
+        self.assertFalse(emptydir.is_empty_dir(dir))
+
+    def test_is_empty_dir_on_file(self):
+        fd, file_ = mkstemp()
+        self.assertRaises(NotADirectoryError, emptydir.is_empty_dir, file_)
+
+
+class RmEmptyDirTest(unittest.TestCase):
+
+    def test_rm_empty_dir_really_empty(self):
+        dir = _create_temp_dir()
+        self.assertTrue(os.path.isdir(dir))
+        emptydir.rm_empty_dir(dir)
+        self.assertFalse(os.path.exists(dir))
+
+    def test_rm_empty_dir_only_junk_files(self):
+        dir = _create_temp_dir(extra_files=emptydir.JUNK_FILES)
+        self.assertTrue(os.path.isdir(dir))
+        emptydir.rm_empty_dir(dir)
+        self.assertFalse(os.path.exists(dir))
+
+    def test_rm_empty_dir_not_empty(self):
+        dir = _create_temp_dir(['.notempty'])
+        self.assertEqual(1, len(os.listdir(dir)))
+        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, dir)
+
+    def test_rm_empty_dir_is_special(self):
+        dir = _create_temp_dir()
+        orig_portected_dirs = emptydir.PROTECTED_DIRECTORIES
+        emptydir.PROTECTED_DIRECTORIES.add(dir)
+        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, dir)
+        emptydir.PROTECTED_DIRECTORIES = orig_portected_dirs
+
+    def test_is_empty_dir_on_file(self):
+        fd, file_ = mkstemp()
+        self.assertRaises(NotADirectoryError, emptydir.rm_empty_dir, file_)
+
+
+def _create_temp_dir(extra_files=(), extra_dirs=()):
+    dir = mkdtemp()
+    for f in extra_files:
+        open(os.path.join(dir, f), 'a').close()
+    for f in extra_dirs:
+        os.mkdir(os.path.join(dir, f))
+    return dir

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -64,7 +64,7 @@ class RmEmptyDirTest(unittest.TestCase):
     def test_rm_empty_dir_is_special(self):
         dir = _create_temp_dir()
         orig_portected_dirs = emptydir.PROTECTED_DIRECTORIES
-        emptydir.PROTECTED_DIRECTORIES.add(dir)
+        emptydir.PROTECTED_DIRECTORIES.add(os.path.realpath(dir))
         self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, dir)
         emptydir.PROTECTED_DIRECTORIES = orig_portected_dirs
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -311,3 +311,13 @@ class SortBySimilarity(unittest.TestCase):
         self.assertEqual(best_match.result.name, 'no_match')
         self.assertEqual(best_match.similarity, -1)
         self.assertEqual(best_match.num_results, 0)
+
+
+class GetQtEnum(unittest.TestCase):
+
+    def test_get_qt_enum(self):
+        from PyQt5.QtCore import QStandardPaths
+        values = util.get_qt_enum(QStandardPaths, QStandardPaths.LocateOption)
+        self.assertIn('LocateFile', values)
+        self.assertIn('LocateDirectory', values)
+        self.assertNotIn('DesktopLocation', values)


### PR DESCRIPTION
This protects standard directories like e.g. ~/Desktop being deleted if empty.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Folders considered "special", such as the Desktop, default Music or other media folders or even configuration folders, could get deleted by the "Remove empty directories" option. This PR fixes this.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-456](https://tickets.metabrainz.org/browse/PICARD-456)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Exclude directories listed in `QStandardPaths`. When comparing also resolve symlinks.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

