### PR TITLE
travisci: Upload macOS artifacts to S3

### DIFF
--- a/scripts/package-osx.sh
+++ b/scripts/package-osx.sh
@@ -45,13 +45,19 @@ mv 'MusicBrainz Picard.tmp' 'MusicBrainz Picard.app'
 dmg="MusicBrainz Picard $VERSION.dmg"
 hdiutil create -volname "MusicBrainz Picard $VERSION" -srcfolder 'MusicBrainz Picard.app' -ov -format UDBZ "$dmg"
 [ "$CODESIGN" = '1' ] && codesign --keychain $KEYCHAIN_PATH --verify --verbose --sign "$CERTIFICATE_NAME" "$dmg"
-if [ -n "$UPLOAD_OSX" ]
-then
-    set +e
+md5 -r "$dmg"
+if [ -n "$UPLOAD_OSX" ]; then
     # make upload failures non fatal
-    curl -v --retry 6 --retry-delay 10 --max-time 180 --upload-file "$dmg" https://transfer.sh/
+    set +e
+    # Set $AWS_ARTIFACTS_BUCKET, $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY for AWS S3 upload to work
+    if [ -n "$AWS_ARTIFACTS_BUCKET" ] && [ -n "$AWS_ACCESS_KEY_ID" ]; then
+      pip3 install --upgrade awscli
+      aws s3 cp --acl public-read "$dmg" "s3://${AWS_ARTIFACTS_BUCKET}/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/$dmg"
+    else
+      # Fall back to transfer.sh
+      curl -v --retry 6 --retry-delay 10 --max-time 180 --upload-file "$dmg" https://transfer.sh/
+    fi
     set -e
     # Required for a newline between the outputs
     echo -e "\n"
-    md5 -r "$dmg"
 fi

--- a/scripts/package-osx.sh
+++ b/scripts/package-osx.sh
@@ -51,7 +51,7 @@ if [ -n "$UPLOAD_OSX" ]; then
     set +e
     # Set $AWS_ARTIFACTS_BUCKET, $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY for AWS S3 upload to work
     if [ -n "$AWS_ARTIFACTS_BUCKET" ] && [ -n "$AWS_ACCESS_KEY_ID" ]; then
-      pip3 install --upgrade awscli
+      # pip3 install --upgrade awscli
       aws s3 cp --acl public-read "$dmg" "s3://${AWS_ARTIFACTS_BUCKET}/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/$dmg"
     else
       # Fall back to transfer.sh


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

This uploads the macOS build artifacts to a S3 bucket instead of using transfer.sh

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

`transfer.sh` is frequently blocking builds and is very unreliable. Also we don't control how long artifacts are available and we have no single place to check for the latest artifacts.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-XXX](https://tickets.metabrainz.org/browse/PICARD-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Setup uploading artifacts to a S3 bucket.

For this to work we need to set the following variables in Travis CI:

- `AWS_ARTIFACTS_BUCKET`
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

I have already setup a bucket for this and I would be fine with keeping this, but it could make senseto use a bucket created via a MetaBrainz AWS account. It just should be using credentials that have write access to the `AWS_ARTIFACTS_BUCKET` bucket and this bucket only. Also the bucket must be world readable for everyone to be able to download the builds.

For now the dmg images will be placed in `https://s3.eu-central-1.amazonaws.com/artifacts.picard.uploadedlobster.com/metabrainz/picard/${TRAVIS_BUILD_NUMBER}/`

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

