### PR TITLE
PICARD-1608: Allow removal of "non-album tracks" pseudo-album again

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -681,6 +681,8 @@ class Tagger(QtWidgets.QApplication):
     def remove_album(self, album):
         """Remove the specified album."""
         log.debug("Removing %r", album)
+        if album.id not in self.albums:
+            return
         album.stop_loading()
         self.remove_files(self.get_files_from_objects([album]))
         del self.albums[album.id]
@@ -722,7 +724,7 @@ class Tagger(QtWidgets.QApplication):
                 self.remove_nat(obj)
             elif isinstance(obj, Track):
                 files.extend(obj.linked_files)
-            elif isinstance(obj, Album) and not isinstance(obj, NatAlbum):
+            elif isinstance(obj, Album):
                 self.window.set_statusbar_message(
                     N_("Removing album %(id)s: %(artist)s - %(album)s"),
                     {


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If a folder “[non-album tracks]” is available at the third pane, it can only be removed, if it’s empty. 
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Directly removing the NAT pseudo-album broke with c6815c4fada5f6f006673d21cecf870f88cc932c. This commit fixed the issue, that removing both the non-album tracks album and the last NAT track would cause a crash, since removal of the NAT album was attempted twice.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1608](https://tickets.metabrainz.org/browse/PICARD-1608)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Allow direct removal of the NAT album, but ensure duplicate calls to remove_album() do not crash.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

