### PR TITLE
PICARD-1609: Show actual runtime version of Qt

### DIFF
--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -42,7 +42,7 @@ _versions = OrderedDict([
     ("mutagen-version", mutagen_version),
     ("discid-version", discid_version),
     ("astrcmp", astrcmp_implementation),
-    ("SSL", QSslSocket.sslLibraryVersionString())
+    ("ssl-version", QSslSocket.sslLibraryVersionString())
 ])
 
 _names = {
@@ -53,7 +53,7 @@ _names = {
     "mutagen-version": "Mutagen",
     "discid-version": "Discid",
     "astrcmp": "astrcmp",
-    "SSL": "SSL",
+    "ssl-version": "SSL",
 }
 
 

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -25,7 +25,7 @@ from mutagen import version_string as mutagen_version
 
 from PyQt5.QtCore import (
     PYQT_VERSION_STR as pyqt_version,
-    QT_VERSION_STR,
+    qVersion,
 )
 from PyQt5.QtNetwork import QSslSocket
 
@@ -38,7 +38,7 @@ _versions = OrderedDict([
     ("version", PICARD_FANCY_VERSION_STR),
     ("python-version", python_version()),
     ("pyqt-version", pyqt_version),
-    ("qt-version", QT_VERSION_STR),
+    ("qt-version", qVersion()),
     ("mutagen-version", mutagen_version),
     ("discid-version", discid_version),
     ("astrcmp", astrcmp_implementation),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Use `qVersion()` instead of `QT_VERSION_STR`
    
  This shows the proper runtime version of Qt being used instead of the Qt version PyQt was built against.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1609](https://tickets.metabrainz.org/browse/PICARD-1609)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

