### PR TITLE
PICARD-1619: grey out cover art providers list if cover art is disabled

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -101,14 +101,21 @@ class CoverOptionsPage(OptionsPage):
         self.update_filename()
         self.update_save_images_to_tags()
 
+    def update_ca_providers_groupbox_state(self):
+        files_enabled = self.ui.save_images_to_files.isChecked()
+        tags_enabled = self.ui.save_images_to_tags.isChecked()
+        self.ui.ca_providers_groupbox.setEnabled(files_enabled or tags_enabled)
+
     def update_filename(self):
         enabled = self.ui.save_images_to_files.isChecked()
         self.ui.cover_image_filename.setEnabled(enabled)
         self.ui.save_images_overwrite.setEnabled(enabled)
+        self.update_ca_providers_groupbox_state()
 
     def update_save_images_to_tags(self):
         enabled = self.ui.save_images_to_tags.isChecked()
         self.ui.cb_embed_front_only.setEnabled(enabled)
+        self.update_ca_providers_groupbox_state()
 
 
 register_options_page(CoverOptionsPage)


### PR DESCRIPTION
If none of save images to tags or save images to files is enabled, cover art is totally disabled, greying out ca providers list somehow make it more obvious.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1619](https://tickets.metabrainz.org/browse/PICARD-1619)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
![Capture du 2019-10-01 15-26-07](https://user-images.githubusercontent.com/151042/65966166-0564db80-e460-11e9-8fad-ab248f8d176b.png)
![Capture du 2019-10-01 15-25-01](https://user-images.githubusercontent.com/151042/65966172-06960880-e460-11e9-8d22-e9bfc8fb1926.png)
![Capture du 2019-10-01 15-24-33](https://user-images.githubusercontent.com/151042/65966174-072e9f00-e460-11e9-82a1-e8afc340eda5.png)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

