### PR TITLE
PICARD-118: Portable Windows version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,20 +35,28 @@ install:
     pip3 install -r requirements-build.txt
     pip3 install -r requirements-win.txt
 
-build_script:
+before_build:
 - cmd: |
     appveyor DownloadFile https://github.com/acoustid/chromaprint/releases/download/v%CHROMAPRINT_FPCALC_VERSION%/chromaprint-fpcalc-%CHROMAPRINT_FPCALC_VERSION%-windows-x86_64.zip -FileName fpcalc.zip
     7z x fpcalc.zip -y
     copy /Y chromaprint-fpcalc-%CHROMAPRINT_FPCALC_VERSION%-windows-x86_64\fpcalc.exe fpcalc.exe
     IF "%APPVEYOR_REPO_TAG%" == "false" python setup.py patch_version --platform=python%PYTHON_VERSION%
+
+build_script:
+- cmd: |
     python setup.py build
     python setup.py build_ext -i
+- cmd: |
+    echo "Building Windows installer..."
     pyinstaller --noconfirm --clean picard.spec
     REM Workaround for https://github.com/pyinstaller/pyinstaller/issues/4429
     IF EXIST dist\picard\PyQt5\translations move dist\picard\PyQt5\translations dist\picard\PyQt5\Qt
     del /F /Q dist\picard\libcrypto-1_1.dll
     del /F /Q dist\picard\libssl-1_1.dll
     makensis.exe /INPUTCHARSET UTF8 installer\picard-setup.nsi
+- cmd: |
+    echo "Building portable exe..."
+    pyinstaller --noconfirm --clean --onefile picard.spec
 
 test_script:
 - ps: |
@@ -64,6 +72,8 @@ for:
       - TEST_PIP_INSTALL: true
   install:
     echo Skipped install
+  before_build:
+    echo Skipped before_build
   build_script:
     pip3 install .
   test_script:
@@ -71,6 +81,7 @@ for:
 
 artifacts:
 - path: installer/*.exe
+- path: dist/*.exe
 deploy:
 - provider: GitHub
   auth_token:

--- a/picard.spec
+++ b/picard.spec
@@ -8,7 +8,14 @@ import sys
 # Get the version and build a CFBundleVersion compatible version
 # of it according to Apple dev documentation
 sys.path.append('.')
-from picard import PICARD_APP_ID, PICARD_VERSION
+from picard import (
+    PICARD_APP_ID,
+    PICARD_APP_NAME,
+    PICARD_ORG_NAME,
+    PICARD_VERSION,
+    PICARD_VERSION_STR_SHORT,
+)
+
 pv = [str(x) for x in PICARD_VERSION]
 macos_picard_version = '.'.join(pv[:3])
 macos_picard_short_version = macos_picard_version
@@ -71,6 +78,8 @@ if os.path.isfile(fpcalc_name):
 runtime_hooks = []
 if sys.platform == 'win32':
     runtime_hooks.append('scripts/picard-winconsole-hook.py')
+if '--onefile' in sys.argv:
+    runtime_hooks.append('scripts/picard-portable-hook.py')
 
 
 a = Analysis(['tagger.py'],
@@ -90,42 +99,60 @@ pyz = PYZ(a.pure, a.zipped_data,
           cipher=block_cipher)
 
 
-exe = EXE(pyz,
-          a.scripts,
-          exclude_binaries=True,
-          # Avoid name clash between picard executable and picard module folder
-          name='picard' if os_name == 'Windows' else 'picard-run',
-          debug=False,
-          strip=False,
-          upx=False,
-          icon='picard.ico',
-          version='win-version-info.txt',
-          console=False)
+if '--onefile' in sys.argv:
+    exe = EXE(pyz,
+              a.scripts,
+              a.binaries,
+              a.zipfiles,
+              a.datas,
+              name='{}-{}-{}'.format(PICARD_ORG_NAME,
+                                     PICARD_APP_NAME,
+                                     PICARD_VERSION_STR_SHORT),
+              debug=False,
+              strip=False,
+              upx=False,
+              icon='picard.ico',
+              version='win-version-info.txt',
+              console=False)
+
+else:
+    exe = EXE(pyz,
+              a.scripts,
+              exclude_binaries=True,
+              # Avoid name clash between picard executable and picard module folder
+              name='picard' if os_name == 'Windows' else 'picard-run',
+              debug=False,
+              strip=False,
+              upx=False,
+              icon='picard.ico',
+              version='win-version-info.txt',
+              console=False)
 
 
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=False,
-               name='picard')
+    coll = COLLECT(exe,
+                   a.binaries,
+                   a.zipfiles,
+                   a.datas,
+                   strip=False,
+                   upx=False,
+                   name='picard')
 
 
-if os_name == 'Darwin':
-    info_plist = {
-        'NSHighResolutionCapable': 'True',
-        'NSPrincipalClass': 'NSApplication',
-        'CFBundleName': 'Picard',
-        'CFBundleDisplayName': 'MusicBrainz Picard',
-        'CFBundleIdentifier': PICARD_APP_ID,
-        'CFBundleVersion': macos_picard_version,
-        'CFBundleShortVersionString': macos_picard_short_version,
-        'LSMinimumSystemVersion': '10.12',
-    }
-    app = BUNDLE(coll,
-                 name='MusicBrainz Picard.app',
-                 icon='picard.icns',
-                 bundle_identifier=None,
-                 info_plist=info_plist
-                 )
+    if os_name == 'Darwin':
+        info_plist = {
+            'NSHighResolutionCapable': 'True',
+            'NSPrincipalClass': 'NSApplication',
+            'CFBundleName': PICARD_APP_NAME,
+            'CFBundleDisplayName': '{} {}'.format(PICARD_ORG_NAME,
+                                                  PICARD_APP_NAME),
+            'CFBundleIdentifier': PICARD_APP_ID,
+            'CFBundleVersion': macos_picard_version,
+            'CFBundleShortVersionString': macos_picard_short_version,
+            'LSMinimumSystemVersion': '10.12',
+        }
+        app = BUNDLE(coll,
+                     name='{} {}.app'.format(PICARD_ORG_NAME, PICARD_APP_NAME),
+                     icon='picard.icns',
+                     bundle_identifier=None,
+                     info_plist=info_plist
+                     )

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -33,6 +33,9 @@ _appconfiglocation = QStandardPaths.writableLocation(QStandardPaths.AppConfigLoc
 USER_DIR = os.path.join(_appconfiglocation, "MusicBrainz", PICARD_APP_NAME)
 USER_PLUGIN_DIR = os.path.join(USER_DIR, "plugins")
 
+# Cache directory
+CACHE_DIR = QStandardPaths.writableLocation(QStandardPaths.CacheLocation)
+
 # AcoustID client API key
 ACOUSTID_KEY = 'v8pQ6oyB'
 ACOUSTID_HOST = 'api.acoustid.org'

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -39,7 +39,6 @@ from PyQt5 import (
     QtNetwork,
 )
 from PyQt5.QtCore import (
-    QStandardPaths,
     QUrl,
     QUrlQuery,
 )
@@ -52,6 +51,7 @@ from picard import (
     config,
     log,
 )
+from picard.const import CACHE_DIR
 from picard.oauth import OAuthManager
 from picard.util import (
     build_qurl,
@@ -288,8 +288,7 @@ class WebService(QtCore.QObject):
 
     def set_cache(self, cache_size_in_mb=100):
         cache = QtNetwork.QNetworkDiskCache()
-        location = QStandardPaths.writableLocation(QStandardPaths.CacheLocation)
-        cache.setCacheDirectory(os.path.join(location, 'picard'))
+        cache.setCacheDirectory(os.path.join(CACHE_DIR, 'network'))
         cache.setMaximumCacheSize(cache_size_in_mb * 1024 * 1024)
         self.manager.setCache(cache)
         log.debug("NetworkDiskCache dir: %r size: %s / %s",

--- a/scripts/picard-portable-hook.py
+++ b/scripts/picard-portable-hook.py
@@ -1,0 +1,24 @@
+import os
+import os.path
+import sys
+
+from picard import (
+    PICARD_APP_NAME,
+    PICARD_ORG_NAME,
+)
+import picard.const
+
+
+# The portable version stores all data in a folder beside the executable
+configdir = '{}-{}'.format(PICARD_ORG_NAME, PICARD_APP_NAME)
+basedir = os.path.join(os.path.dirname(sys.executable), configdir)
+if not os.path.exists(basedir):
+    os.makedirs(basedir)
+
+# Setup config file if not specified as command line argument
+if '--config-file' not in sys.argv and '-c' not in sys.argv:
+    sys.argv.append('--config-file')
+    sys.argv.append(os.path.join(basedir, 'Config.ini'))
+
+# Setup plugin folder
+picard.const.USER_PLUGIN_DIR = os.path.join(basedir, 'Plugins')

--- a/scripts/picard-portable-hook.py
+++ b/scripts/picard-portable-hook.py
@@ -12,8 +12,7 @@ import picard.const
 # The portable version stores all data in a folder beside the executable
 configdir = '{}-{}'.format(PICARD_ORG_NAME, PICARD_APP_NAME)
 basedir = os.path.join(os.path.dirname(sys.executable), configdir)
-if not os.path.exists(basedir):
-    os.makedirs(basedir)
+os.makedirs(basedir, exist_ok=True)
 
 # Setup config file if not specified as command line argument
 if '--config-file' not in sys.argv and '-c' not in sys.argv:
@@ -22,3 +21,8 @@ if '--config-file' not in sys.argv and '-c' not in sys.argv:
 
 # Setup plugin folder
 picard.const.USER_PLUGIN_DIR = os.path.join(basedir, 'Plugins')
+
+# Set standard cache location
+cachedir = os.path.join(basedir, 'Cache')
+os.makedirs(cachedir, exist_ok=True)
+picard.const.CACHE_DIR = cachedir


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This provides Picard in a self contained exe file, which can directly be started from anywhere. Configuration and plugin data is placed in a folder “MusicBrainz-Picard” next to the exe.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Some users have requested a "portable" version of Picard for Windows. Portable in this context means, the application can be run without installation and the application data is self contained (e.g. does not save config on the system).

For the user the value is that they can run Picard without installation and e.g. place it on a USB stick together with all of its configuration. It also is an easy way to try different versions of Picard independently from one another.

That last part is interesting for us, as we can easily allow users to test new builds without the builds messing with the user configuration.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-118](https://tickets.metabrainz.org/browse/PICARD-118)
* Discussion: https://community.metabrainz.org/t/picard-as-portable-windows-app/446980
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use a PyInstaller onefile bundle to create a single, self contained exe file. Setup a special PyInstaller runtime hook to configure config, cache and plugin locations inside a `MusicBrainz-Picard` directory placed next to the exe.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

