### PR TITLE
Log more information when a plugin failed to load

### DIFF
--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -220,8 +220,8 @@ class PluginManager(QtCore.QObject):
         for name in sorted(names):
             try:
                 self._load_plugin_from_directory(name, plugindir)
-            except Exception as e:
-                log.error("Unable to load plugin '%s': %s", name, e)
+            except Exception:
+                self.plugin_error(name, _("Unable to load plugin '%s'"), name, log_func=log.exception)
 
     def _get_plugin_index_by_name(self, name):
         for index, plugin in enumerate(self.plugins):

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -169,9 +169,16 @@ class PluginManager(QtCore.QObject):
     def available_plugins(self):
         return self._available_plugins
 
-    def plugin_error(self, name, error, log_func=None):
-        if log_func is None:
-            log_func = log.error
+    def plugin_error(self, name, error, *args, **kwargs):
+        """Log a plugin loading error for the plugin `name` and signal the
+        error via the `plugin_errored` signal.
+
+        A string consisting of all `args` interpolated into `error` will be
+        passed to the function given via the `log_func` keyword argument
+        (default: log.error) and as the error message to the `plugin_errored`
+        signal."""
+        error = error % args
+        log_func = kwargs.get('log_func', log.error)
         log_func(error)
         self.plugin_errored.emit(name, error, False)
 
@@ -224,12 +231,13 @@ class PluginManager(QtCore.QObject):
 
     def _load_plugin_from_directory(self, name, plugindir):
         module_file = None
-        (zip_importer, module_name, manifest_data) = zip_import(os.path.join(plugindir, name + '.zip'))
+        zipfilename = os.path.join(plugindir, name + '.zip')
+        (zip_importer, module_name, manifest_data) = zip_import(zipfilename)
         if zip_importer:
             name = module_name
             if not zip_importer.find_module(name):
-                error = _("Failed loading zipped plugin %r") % name
-                self.plugin_error(name, error)
+                error = _("Failed loading zipped plugin %r from %r")
+                self.plugin_error(name, error, name, zipfilename)
                 return None
             module_pathname = zip_importer.get_filename(name)
         else:
@@ -238,8 +246,8 @@ class PluginManager(QtCore.QObject):
                 module_file = info[0]
                 module_pathname = info[1]
             except ImportError:
-                error = _("Failed loading plugin %r") % name
-                self.plugin_error(name, error)
+                error = _("Failed loading plugin %r in %r")
+                self.plugin_error(name, error, name, [plugindir])
                 return None
 
         plugin = None
@@ -278,11 +286,11 @@ class PluginManager(QtCore.QObject):
                           "version of Picard.") % (plugin.name, plugin.file)
                 self.plugin_error(plugin.name, error, log_func=log.warning)
         except VersionError as e:
-            error = _("Plugin %r has an invalid API version string : %s") % (name, e)
-            self.plugin_error(name, error)
+            error = _("Plugin %r has an invalid API version string : %s")
+            self.plugin_error(name, error, name, e)
         except BaseException:
-            error = _("Plugin %r : %s") % (name, traceback.format_exc())
-            self.plugin_error(name, error)
+            error = _("Plugin %r : %s")
+            self.plugin_error(name, error, name, traceback.format_exc())
         if module_file is not None:
             module_file.close()
         return plugin

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -26,7 +26,6 @@ import json
 import os.path
 import shutil
 import tempfile
-import traceback
 import zipfile
 import zipimport
 
@@ -289,8 +288,8 @@ class PluginManager(QtCore.QObject):
             error = _("Plugin %r has an invalid API version string : %s")
             self.plugin_error(name, error, name, e)
         except BaseException:
-            error = _("Plugin %r : %s")
-            self.plugin_error(name, error, name, traceback.format_exc())
+            error = _("Plugin %r")
+            self.plugin_error(name, error, name, log_func=log.exception)
         if module_file is not None:
             module_file.close()
         return plugin


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [X] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Plugin loading errors included nearly no information about which plugin from where was loaded at the point of failure and/or swallowed stack traces. Fix that.

# Solution

Log all the things! The individual commits have more details, including log entries before & after the change.

This also makes `plugin_error` behave more like the functions in `picard.log` in that it just takes an unformatted string with placeholders for formatting and a bunch of strings and does the formatting, instead of leaving that up to its callers.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

No.