### PR TITLE
test_regexfilter: Fix the test

### DIFF
--- a/test/test_taggenrefilter.py
+++ b/test/test_taggenrefilter.py
@@ -73,7 +73,6 @@ class TagGenreFilterTest(PicardTestCase):
             -/r[io]ck$/
             -/disco+/
             +/discoooo/
-            +/*/
         """
         tag_filter = TagGenreFilter(filters)
 
@@ -90,6 +89,31 @@ class TagGenreFilterTest(PicardTestCase):
         self.assertTrue(tag_filter.skip('disco'))
         self.assertTrue(tag_filter.skip('xdiscox'))
         self.assertTrue(tag_filter.skip('xdiscooox'))
+        self.assertFalse(tag_filter.skip('xdiscoooox'))
+
+    def test_regex_filter_keep_all(self):
+        filters = """
+            -/^j.zz/
+            -/r[io]ck$/
+            -/disco+/
+            +/discoooo/
+            +/.*/
+        """
+        tag_filter = TagGenreFilter(filters)
+
+        self.assertFalse(tag_filter.skip('jazz'))
+        self.assertFalse(tag_filter.skip('jizz'))
+        self.assertFalse(tag_filter.skip('jazz blues'))
+        self.assertFalse(tag_filter.skip('blues jazz'))
+
+        self.assertFalse(tag_filter.skip('rock'))
+        self.assertFalse(tag_filter.skip('blues rock'))
+        self.assertFalse(tag_filter.skip('blues rick'))
+        self.assertFalse(tag_filter.skip('rock blues'))
+
+        self.assertFalse(tag_filter.skip('disco'))
+        self.assertFalse(tag_filter.skip('xdiscox'))
+        self.assertFalse(tag_filter.skip('xdiscooox'))
         self.assertFalse(tag_filter.skip('xdiscoooox'))
 
     def test_uppercased_filter(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

`*` only repeats the preceding regular expression, but in the old test, there was
nothing preceding it. This showed up when tests were executed via `python
setup.py test`:

> .........................................E: 20:54:38,617 /home/wieland/dev/picard/picard/track.__init__:88: Failed to compile regex /*/: nothing to repeat at position 0
> Traceback (most recent call last):
>   File "/home/wieland/dev/picard/picard/track.py", line 86, in __init__
>     regex_search = re.compile(remain, re.IGNORECASE)
>   File "/usr/lib/python3.7/re.py", line 234, in compile
>     return _compile(pattern, flags)
>   File "/usr/lib/python3.7/re.py", line 286, in _compile
>     p = sre_compile.compile(pattern, flags)
>   File "/usr/lib/python3.7/sre_compile.py", line 764, in compile
>     p = sre_parse.parse(p, flags)
>   File "/usr/lib/python3.7/sre_parse.py", line 930, in parse
>     p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
>   File "/usr/lib/python3.7/sre_parse.py", line 426, in _parse_sub
>     not nested and not items))
>   File "/usr/lib/python3.7/sre_parse.py", line 651, in _parse
>     source.tell() - here + len(this))
> re.error: nothing to repeat at position 0

This was swallowed by py.test's behaviour to swallow stdout & stderr if no tests
fail.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Remove `*` from test_regexfilter and add an additional test with `/.*/` to
ensure this works.

The genre filter UI handled this correctly by showing the re.error in the UI.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

None.