### PR TITLE
PICARD-1632: Genre ui improvements

### DIFF
--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -63,8 +63,8 @@ TOOLTIP_TEST_GENRES_FILTER = N_("""<html><head/><body>
 This playground will not be preserved on Options exit.
 </p>
 <p>
-Red background means the tag will be skipped<br/>
-Green background means the tag will be kept
+Red background means the tag will be skipped.<br/>
+Green background means the tag will be kept.
 </p>
 </body></html>""")
 

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -94,11 +94,9 @@ class GenresOptionsPage(OptionsPage):
         self.ui.setupUi(self)
 
         self.ui.genres_filter.setToolTip(_(TOOLTIP_GENRES_FILTER))
-        self.ui.genres_filter.setToolTipDuration(5000)
         self.ui.genres_filter.textChanged.connect(self.update_test_genres_filter)
 
         self.ui.test_genres_filter.setToolTip(_(TOOLTIP_TEST_GENRES_FILTER))
-        self.ui.test_genres_filter.setToolTipDuration(5000)
         self.ui.test_genres_filter.textChanged.connect(self.update_test_genres_filter)
 
         #FIXME: colors aren't great from accessibility POV

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -50,7 +50,7 @@ comment
 <p><u>Wildcard filtering:</u></p>
 <p>
 <b>-*word</b>: exclude all genres ending with <i>word</i><br/>
-<b>+word*</b>: exclude all genres starting with <i>word</i><br/>
+<b>+word*</b>: include all genres starting with <i>word</i><br/>
 <b>-w*rd</b>: exclude all genres starting with <i>w</i> and ending with <i>rd</i>
 </p>
 <p><u>Regular expressions filtering (Python re syntax):</u></p>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

1. The tooltips on the genre options are quite long and not trivial to understand for people not
already familiar with them. Hiding them after just 5 seconds is way too soon

2. One of the examples claimed `+word*` means `word*` is excluded. This is wrong.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. To not get into bikeshedding over how long the tooltip should be shown, just don't hide it.

2. Fix the description of the example.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

None