### PR TITLE
PICARD-1633: fix system locale detection on macOS

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -63,6 +63,7 @@ def setup_gettext(localedir, ui_language=None, logger=None):
                 import Foundation
                 defaults = Foundation.NSUserDefaults.standardUserDefaults()
                 current_locale = defaults.objectForKey_('AppleLanguages')[0]
+                current_locale = current_locale.replace('-', '_')
                 locale.setlocale(locale.LC_ALL, current_locale)
             except Exception as e:
                 logger(e)

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -1,3 +1,5 @@
 discid==1.2.0
 mutagen==1.42.0
+pyobjc-core==5.2
+pyobjc-framework-Cocoa==5.2
 PyQt5==5.13.1


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
On macOS the system locale was not detected, thus setting language to "System default" did not work.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1633](https://tickets.metabrainz.org/browse/PICARD-1633)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This failed due to:
- macOS returning language / country separated by "-" instead of "_" (en-UK instead of en_UK)
- required pyobjc modules not being packaged

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

