### PR TITLE
PICARD-1634: fix filebrowser horizontal scroll position on macOS

### DIFF
--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -108,7 +108,8 @@ class FileBrowser(QtWidgets.QTreeView):
         level = -1
         super().scrollTo(index, scrolltype)
         parent = self.currentIndex().parent()
-        while parent.isValid():
+        root = self.rootIndex()
+        while parent.isValid() and parent != root:
             parent = parent.parent()
             level += 1
         pos_x = max(self.indentation() * level, 0)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixes the horizontal scroll position of the file browser on macOS to properly show the selected items and its parent.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The automatic setting of the horizontal scroll position in the filebrowser as implemented in https://github.com/metabrainz/picard/pull/1274 does not work properly on macOS, there the position is always shifted one index to the right.

The problem is that for macOS we set `self.setRootIndex(self.model.index("/Volumes"))`, and the code that determines the indentation level does not take this different root into account.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1634](https://tickets.metabrainz.org/browse/PICARD-1634)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fix the indentation code to consider the actually used root of the view.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

