### PR TITLE
PICARD-1636: Fixed POSIX compliant default locale detection

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -68,7 +68,8 @@ def setup_gettext(localedir, ui_language=None, logger=None):
                 logger(e)
         else:
             try:
-                current_locale = locale.setlocale(locale.LC_ALL, '')
+                locale.setlocale(locale.LC_ALL, '')
+                current_locale = '.'.join(locale.getlocale(locale.LC_MESSAGES))
             except Exception as e:
                 logger(e)
     os.environ['LANGUAGE'] = os.environ['LANG'] = current_locale


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
On a POSIX system if the environment is configured to have different locales (e.g. setting display language to German, but number formatting to English) Picard fails to detect the system configured language.

The reason is that Picard assumes that `locale.setlocale(locale.LC_ALL, '')` always returns the default locale name, but this is only true if all locale categories have the same locale. If one or more locale categories define different locales the returned value is instead a string like:

```python
"LC_CTYPE=de_DE.UTF-8;LC_NUMERIC=en_GB.UTF-8;LC_TIME=en_GB.UTF-8;LC_COLLATE=de_DE.UTF-8;LC_MONETARY=en_GB.UTF-8;LC_MESSAGES=de_DE.UTF-8;LC_PAPER=en_GB.UTF-8;LC_NAME=de_DE.UTF-8;LC_ADDRESS=de_DE.UTF-8;LC_TELEPHONE=de_DE.UTF-8;LC_MEASUREMENT=en_GB.UTF-8;LC_IDENTIFICATION=de_DE.UTF-8"
```

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1636](https://tickets.metabrainz.org/browse/PICARD-1636)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
On system with different locales per category (e.g. German language, but English number formats) setlocale(LC_ALL) does not return a single locale name. Query the actual set locale for LC_MESSAGES.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

