### PR TITLE
PICARD-1635: Fixed crashes on UI update for deleted files

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -17,6 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import defaultdict
 from functools import partial
 from heapq import (
     heappop,
@@ -141,18 +142,18 @@ class MainPanel(QtWidgets.QSplitter):
         TreeItem.text_color = self.palette().text().color()
         TreeItem.text_color_secondary = self.palette() \
             .brush(QtGui.QPalette.Disabled, QtGui.QPalette.Text).color()
-        TrackItem.track_colors = {
+        TrackItem.track_colors = defaultdict(lambda: TreeItem.text_color, {
             File.NORMAL: interface_colors.get_qcolor('entity_saved'),
             File.CHANGED: TreeItem.text_color,
             File.PENDING: interface_colors.get_qcolor('entity_pending'),
             File.ERROR: interface_colors.get_qcolor('entity_error'),
-        }
-        FileItem.file_colors = {
+        })
+        FileItem.file_colors = defaultdict(lambda: TreeItem.text_color, {
             File.NORMAL: TreeItem.text_color,
             File.CHANGED: TreeItem.text_color,
             File.PENDING: interface_colors.get_qcolor('entity_pending'),
             File.ERROR: interface_colors.get_qcolor('entity_error'),
-        }
+        })
 
     def save_state(self):
         config.persist["splitter_state"] = self.saveState()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
When files are already have state = REMOVED but the itemviews UI updates Picard could crash since there are no colors defined for this state.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1635](https://tickets.metabrainz.org/browse/PICARD-1635)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Define the color dicts as defaultdict.

Questions to all reviewers: Do you think we should remove the definitions that are now same as default from the dict? I left it in for now so the code is more explicit, but technically it is not needed.

So just:

```
FileItem.file_colors = defaultdict(lambda: TreeItem.text_color, {
    File.PENDING: interface_colors.get_qcolor('entity_pending'),
    File.ERROR: interface_colors.get_qcolor('entity_error'),
})
```

instead of 

```
FileItem.file_colors = defaultdict(lambda: TreeItem.text_color, {
    File.NORMAL: TreeItem.text_color,
    File.CHANGED: TreeItem.text_color,
    File.PENDING: interface_colors.get_qcolor('entity_pending'),
    File.ERROR: interface_colors.get_qcolor('entity_error'),
})
```
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

