### PR TITLE
travis: Condense IRC notification to one message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,13 @@ after_success:
   fi
 
 notifications:
-  irc: chat.freenode.net#metabrainz
+  irc:
+    channels:
+      - "ircs://chat.freenode.net:6697/#metabrainz"
+    template:
+      - "[%{repository_name}:%{branch}@%{commit} - build #%{build_number}] CI %{result}! (%{build_url})"
+    on_success: change
+    on_failure: always
 
 branches:
   only:


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Condense IRC notification alerts from three messages to one.

# Problem

The Travis CI bots are very verbose in `#metabrainz`. Currently, it comes across as three lines:

```
<travis-ci> metabrainz/picard#5094 (master - 3bd4c03 : Philipp Wolfer): The build passed.
<travis-ci> Change view : https://github.com/metabrainz/picard/compare/e44eafc03758...3bd4c031af96
<travis-ci> Build details : https://travis-ci.org/metabrainz/picard/builds/595956271
```


# Solution

This commit changes how Travis sends an alert to the `#metabrainz` IRC channel. This makes it easier for someone like me to filter human noise from bot noise in reading my client scrollback.

This commit condenses them into one:

```
<travis-ci> [infrastructure:upgrade/teleirc-1.3.2@9f909cb - build #59] CI passed! (https://travis-ci.org/FOSSRIT/infrastructure/builds/581454707)
```

The important info is included. Repo name, branch, commit hash, Travis CI build number, CI result, and a URL to get more info.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

