### PR TITLE
PICARD-1643: Fixed saving performer tags to Vorbis and APEv2

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -250,8 +250,11 @@ class APEv2File(File):
 
     @classmethod
     def supports_tag(cls, name):
-        return (bool(name) and is_valid_key(name)
-                and name not in UNSUPPORTED_TAGS)
+        return (bool(name) and name not in UNSUPPORTED_TAGS
+                and (is_valid_key(name)
+                    or name.startswith('comment:')
+                    or name.startswith('lyrics:')
+                    or name.startswith('performer:')))
 
 
 class MusepackFile(APEv2File):

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -334,7 +334,10 @@ class VCommentFile(File):
     def supports_tag(cls, name):
         unsupported_tags = ['r128_album_gain', 'r128_track_gain']
         return (bool(name) and name not in unsupported_tags
-                and is_valid_key(name))
+                and (is_valid_key(name)
+                    or name.startswith('comment:')
+                    or name.startswith('lyrics:')
+                    or name.startswith('performer:')))
 
 
 class FLACFile(VCommentFile):

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -354,6 +354,18 @@ class CommonTests:
                 self.assertNotIn('performer:piano', new_metadata)
 
         @skipUnlessTestfile
+        def test_save_performer(self):
+            if not self.format.supports_tag('performer:'):
+                return
+            instrument = "accordéon clavier « boutons »"
+            artist = "桑山哲也"
+            tag = "performer:" + instrument
+            metadata = Metadata({ tag: artist })
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertIn(tag, loaded_metadata)
+            self.assertEqual(artist, loaded_metadata[tag])
+
+        @skipUnlessTestfile
         def test_ratings(self):
             if not self.supports_ratings:
                 raise unittest.SkipTest("Ratings not supported")
@@ -409,7 +421,16 @@ class CommonTests:
             self.assertNotIn('artist', loaded_metadata)
             self.assertEqual(new_metadata['title'], loaded_metadata['title'])
 
-        def test_lyrcis_with_description(self):
-            metadata = Metadata({'lyrics:foo': 'bar'})
+        @skipUnlessTestfile
+        def test_lyrics_with_description(self):
+            metadata = Metadata({'lyrics:foó': 'bar'})
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
-            self.assertEqual(metadata['lyrics:foo'], loaded_metadata['lyrics'])
+            self.assertEqual(metadata['lyrics:foó'], loaded_metadata['lyrics'])
+
+        @skipUnlessTestfile
+        def test_comments_with_description(self):
+            if not self.format.supports_tag('comment:foó'):
+                return
+            metadata = Metadata({'comment:foó': 'bar'})
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertEqual(metadata['comment:foó'], loaded_metadata['comment:foó'])

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -71,6 +71,12 @@ class CommonApeTests:
             loaded_metadata = load_metadata(self.filename)
             self.assertEqual(0, len(loaded_metadata.images))
 
+        def test_supports_extended_tags(self):
+            performer_tag = "performer:accordéon clavier « boutons »"
+            self.assertTrue(self.format.supports_tag(performer_tag))
+            self.assertTrue(self.format.supports_tag('lyrics:foó'))
+            self.assertTrue(self.format.supports_tag('comment:foó'))
+
 
 class MonkeysAudioTest(CommonApeTests.ApeTestCase):
     testfile = 'test.ape'

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -229,7 +229,7 @@ class CommonId3Tests:
             self.assertEqual(1, len(raw_metadata['TXXX:Replaygain_Album_Peak'].text))
             self.assertNotIn('TXXX:REPLAYGAIN_ALBUM_PEAK', raw_metadata)
 
-        def test_lyrcis_with_description(self):
+        def test_lyrics_with_description(self):
             metadata = Metadata({'lyrics:foo': 'bar'})
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
             self.assertEqual(metadata['lyrics:foo'], loaded_metadata['lyrics:foo'])

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -126,6 +126,12 @@ class CommonVorbisTests:
             loaded_metadata = load_metadata(self.filename)
             self.assertEqual(0, len(loaded_metadata.images))
 
+        def test_supports_extended_tags(self):
+            performer_tag = "performer:accordéon clavier « boutons »"
+            self.assertTrue(self.format.supports_tag(performer_tag))
+            self.assertTrue(self.format.supports_tag('lyrics:foó'))
+            self.assertTrue(self.format.supports_tag('comment:foó'))
+
 
 class FLACTest(CommonVorbisTests.VorbisTestCase):
     testfile = 'test.flac'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Tags in the format of performer:instrument were not saved to Vorbis and APEv2 tags if instrument contained non-ASCII characters.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1643](https://tickets.metabrainz.org/browse/PICARD-1643)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fixed support for `performer:*`, `lyrics:*` and `comment:*` tags for Vorbis and APEv2. Added tests.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

