### PR TITLE
PICARD-1647: Fix plugin status icon not getting repainted

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -114,6 +114,9 @@ class PluginTreeWidgetItem(HashableTreeWidgetItem):
     @staticmethod
     def set_icon(button, stdicon):
         button.setIcon(button.style().standardIcon(getattr(QtWidgets.QStyle, stdicon)))
+        # Workaround for Qt sometimes not updating the icon.
+        # See https://tickets.metabrainz.org/browse/PICARD-1647
+        button.repaint()
 
     def show_install(self, button, mode):
         if mode == 'hide':


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
On macOS the plugin status button does not update the icon on click. This seems to be a repainting issue of Qt. Calling repaint() on the button works around this.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-1647](https://tickets.metabrainz.org/browse/PICARD-1647)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

