### PR TITLE
PICARD-1629: Better length calculation for AAC with APEv2

### DIFF
--- a/test/formats/test_aac.py
+++ b/test/formats/test_aac.py
@@ -27,7 +27,7 @@ class AACWithAPETest(CommonApeTests.ApeTestCase):
     testfile = 'test-apev2.aac'
     supports_ratings = False
     expected_info = {
-        'length': 125,
+        'length': 119,
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '123.824',


### PR DESCRIPTION
For AAC files with APEv2 tags the length calculation was off, since the size of the APEv2 block was used in the estimate. Now the length of the APEv2 block gets taken out of the length estimate.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Improve the length calculation of AAC files.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
For AAC files the length is an estimate calculated based on the file length. If AAC files get tagged with APEv2 tags the length of the APEv2 block is included in the length calculation, thus in some cases making the file appear significantly longer.

This, btw, is an issue most playback software has unless it specifically supports AAC files tagged with APEv2.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1629
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Try to remove the APEv2 tag size from the length calculation.

It is worth noting that this is still only an estimate, but the lengths are much closer to the actual playback time now. Also the AAC length in general is just an estimate and with some files quite inaccurate, also with other software.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
