### PR TITLE
PICARD-1654: macOS workaround for logout button not repainting

### DIFF
--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -103,6 +103,9 @@ class GeneralOptionsPage(OptionsPage):
             self.ui.logged_in.hide()
             self.ui.login.show()
             self.ui.logout.hide()
+        # Workaround for Qt not repainting the view on macOS after the changes.
+        # See https://tickets.metabrainz.org/browse/PICARD-1654
+        self.ui.vboxlayout.parentWidget().repaint()
 
     def login(self):
         self.tagger.mb_login(self.on_login_finished, self)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Another case of a view not getting repainted properly on macOS after hiding / showing widgets:

![Screenshot 2019-10-31 at 08 18 45](https://user-images.githubusercontent.com/29852/67927593-46642300-fbb9-11e9-8f4f-af4cbe3bf752.png)

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1654
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Similar to PICARD-1647


# Solution
Force repainting the view
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
As this seems to be a more general issue with views not repainting after hiding / showing widgets (see PICARD-1647) I checked the source for other places where widgets get hidden: cover art box, file browser, search dialogs progress indicator.

I could not reproduce any painting issues in these cases.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
