### PR TITLE
PICARD-1656: Allow changing coverart of clusters

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -73,6 +73,7 @@ class Cluster(QtCore.QObject, Item):
         self.related_album = related_album
         self.files = []
         self.lookup_task = None
+        self.update_metadata_images_enabled = True
 
     def __repr__(self):
         if self.related_album:
@@ -296,8 +297,11 @@ class Cluster(QtCore.QObject, Item):
 
             yield album_name, artist_name, (files[i] for i in album)
 
+    def enable_update_metadata_images(self, enabled):
+        self.update_metadata_images_enabled = enabled
+
     def update_metadata_images(self):
-        if self.can_show_coverart:
+        if self.update_metadata_images_enabled and self.can_show_coverart:
             update_metadata_images(self)
 
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -33,6 +33,7 @@ from picard import (
     log,
 )
 from picard.album import Album
+from picard.cluster import Cluster
 from picard.const import MAX_COVERS_TO_STACK
 from picard.coverart.image import (
     CoverArtImage,
@@ -479,6 +480,17 @@ class CoverArtBox(QtWidgets.QGroupBox):
             album.enable_update_metadata_images(True)
             album.update_metadata_images()
             album.update(False)
+        elif isinstance(self.item, Cluster):
+            cluster = self.item
+            cluster.enable_update_metadata_images(False)
+            set_image(cluster, coverartimage)
+            for file in cluster.iterfiles():
+                set_image(file, coverartimage)
+                file.metadata_images_changed.emit()
+                file.update()
+            cluster.enable_update_metadata_images(True)
+            cluster.update_metadata_images()
+            cluster.update()
         elif isinstance(self.item, Track):
             track = self.item
             track.album.enable_update_metadata_images(False)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Allow dropping cover art on a cluster's cover art box.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1656
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Implement handling cover art dropped on a clusters `CoverArtBox`.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
The replacement code really cries for refactoring. The code for updating cover art for `Album`, `Track` and now `Cluster` (https://github.com/phw/picard/blob/9491a6a80053bf9c69a9f1c21274c66acf61cd10/picard/ui/coverartbox.py#L469) duplicates a lot.

But there are always these slight differences that make it difficult to reduce the redundancy here: 

- `Album` has tracks, `Cluster` not
- `Track` needs special handling of the album instance
- `Album.update` takes a parameter, `Cluster.update` not

I am not really sure how to handle this. I thought about subclassing `Item` and providing a special class `CoverArtItem` that can handle the common code for updating cover art, but also allows child classes to override specific methods to handle their specific code.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
