### PR TITLE
PICARD-1592: Preserve case for APEv2 tags

### DIFF
--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -87,6 +87,25 @@ class CommonApeTests:
             self._read_case_insensitive_tag('tracknumber', 'Track')
             self._read_case_insensitive_tag('discnumber', 'Disc')
 
+        @skipUnlessTestfile
+        def test_ci_tags_preserve_case(self):
+            # Ensure values are not duplicated on repeated save and are saved
+            # case preserving.
+            for name in ('CUStom', 'ARtist'):
+                tags = {}
+                tags[name] = 'foo'
+                save_raw(self.filename, tags)
+                loaded_metadata = load_metadata(self.filename)
+                loaded_metadata[name.lower()] = 'bar'
+                save_metadata(self.filename, loaded_metadata)
+                raw_metadata = dict(load_raw(self.filename))
+                self.assertIn(name, raw_metadata)
+                self.assertEqual(
+                    raw_metadata[name],
+                    loaded_metadata[name.lower()])
+                self.assertEqual(1, len(raw_metadata[name]))
+                self.assertNotIn(name.upper(), raw_metadata)
+
         def _read_case_insensitive_tag(self, name, ape_name):
             upper_ape_name = ape_name.upper()
             metadata = {
@@ -97,7 +116,7 @@ class CommonApeTests:
             self.assertEqual(metadata[upper_ape_name], loaded_metadata[name])
             save_metadata(self.filename, loaded_metadata)
             raw_metadata = load_raw(self.filename)
-            self.assertIn(ape_name, raw_metadata.keys())
+            self.assertIn(upper_ape_name, raw_metadata.keys())
             self.assertEqual(metadata[upper_ape_name], raw_metadata[ape_name])
 
 


### PR DESCRIPTION
When reading APEv2 tags case insensitive, preserve existing casing.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
In #1334 case insensitive reading of APE tags was introduced. But saving tags always used the casing set by Picard.

This changes the behavior to keep existing casing.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1592
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
