### PR TITLE
PICARD-1406: Make setting data in Metadata consistently use strings

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -198,7 +198,7 @@ class File(QtCore.QObject, Item):
             for tag in deleted_tags:
                 del self.metadata[tag]
         for tag, values in saved_metadata.items():
-            self.metadata.set(tag, values)
+            self.metadata[tag] = values
 
         if acoustid and "acoustid_id" not in metadata.deleted_tags:
             self.metadata["acoustid_id"] = acoustid

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -249,19 +249,19 @@ class ID3File(File):
                 if frameid.startswith('T') or frameid in ["GRP1", "MVNM"]:
                     for text in frame.text:
                         if text:
-                            metadata.add(name, str(text))
+                            metadata.add(name, text)
                 elif frameid == 'COMM':
                     for text in frame.text:
                         if text:
-                            metadata.add('%s:%s' % (name, frame.desc), str(text))
+                            metadata.add('%s:%s' % (name, frame.desc), text)
                 else:
-                    metadata.add(name, str(frame))
+                    metadata.add(name, frame)
             elif frameid == 'TIT1':
                 itunes_compatible = config.setting['itunes_compatible_grouping']
                 name = 'work' if itunes_compatible else 'grouping'
                 for text in frame.text:
                     if text:
-                        metadata.add(name, str(text))
+                        metadata.add(name, text)
             elif frameid == "TMCL":
                 for role, name in frame.people:
                     if role or name:
@@ -296,12 +296,12 @@ class ID3File(File):
                     # ways.) Currently, the only tag in both is license.
                     name = '~id3:TXXX:' + name
                 for text in frame.text:
-                    metadata.add(name, str(text))
+                    metadata.add(name, text)
             elif frameid == 'USLT':
                 name = 'lyrics'
                 if frame.desc:
                     name += ':%s' % frame.desc
-                metadata.add(name, str(frame.text))
+                metadata.add(name, frame.text)
             elif frameid == 'UFID' and frame.owner == 'http://musicbrainz.org':
                 metadata['musicbrainz_recordingid'] = frame.data.decode('ascii', 'ignore')
             elif frameid in self.__tag_re_parse.keys():
@@ -329,7 +329,7 @@ class ID3File(File):
             elif frameid == 'POPM':
                 # Rating in ID3 ranges from 0 to 255, normalize this to the range 0 to 5
                 if frame.email == config.setting['rating_user_email']:
-                    rating = str(int(round(frame.rating / 255.0 * (config.setting['rating_steps'] - 1))))
+                    rating = int(round(frame.rating / 255.0 * (config.setting['rating_steps'] - 1)))
                     metadata.add('~rating', rating)
 
         if 'date' in metadata:

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -177,7 +177,7 @@ class MP4File(File):
                 metadata.add(self.__bool_tags[name], values and '1' or '0')
             elif name in self.__int_tags:
                 for value in values:
-                    metadata.add(self.__int_tags[name], str(value))
+                    metadata.add(self.__int_tags[name], value)
             elif name in self.__freeform_tags:
                 tag_name = self.__freeform_tags[name]
                 _add_text_values_to_metadata(metadata, tag_name, values)
@@ -191,11 +191,11 @@ class MP4File(File):
                     if value.startswith("MusicMagic Fingerprint"):
                         metadata.add("musicip_fingerprint", value[22:])
             elif name == "trkn":
-                metadata["tracknumber"] = str(values[0][0])
-                metadata["totaltracks"] = str(values[0][1])
+                metadata["tracknumber"] = values[0][0]
+                metadata["totaltracks"] = values[0][1]
             elif name == "disk":
-                metadata["discnumber"] = str(values[0][0])
-                metadata["totaldiscs"] = str(values[0][1])
+                metadata["discnumber"] = values[0][0]
+                metadata["totaldiscs"] = values[0][1]
             elif name == "covr":
                 for value in values:
                     if value.imageformat not in (value.FORMAT_JPEG,

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -306,24 +306,24 @@ class Metadata(MutableMapping):
         else:
             return default
 
-    def __contains__(self, name):
-        return self._store.__contains__(name)
-
     def __getitem__(self, name):
         return self.get(name, '')
 
     def set(self, name, values):
-        self._store[name] = values
-        self.deleted_tags.discard(name)
-
-    def __setitem__(self, name, values):
         if isinstance(values, str) or not isinstance(values, Iterable):
             values = [values]
         values = [str(value) for value in values if value or value == 0]
         if values:
-            self.set(name, values)
+            self._store[name] = values
+            self.deleted_tags.discard(name)
         elif name in self._store:
             del self[name]
+
+    def __setitem__(self, name, values):
+        self.set(name, values)
+
+    def __contains__(self, name):
+        return self._store.__contains__(name)
 
     def __delitem__(self, name):
         try:
@@ -335,7 +335,7 @@ class Metadata(MutableMapping):
 
     def add(self, name, value):
         if value or value == 0:
-            self._store.setdefault(name, []).append(value)
+            self._store.setdefault(name, []).append(str(value))
             self.deleted_tags.discard(name)
 
     def add_unique(self, name, value):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -53,6 +53,20 @@ class MetadataTest(PicardTestCase):
         self.assertEqual(self.multi3, self.metadata.getraw("multi3"))
         self.assertEqual(["hidden-value"], self.metadata.getraw("~hidden"))
 
+    def test_metadata_set_all_values_as_string(self):
+        for val in (0, 2, True):
+            str_val = str(val)
+            self.metadata.set('val1', val)
+            self.assertEqual([str_val], self.metadata.getraw("val1"))
+            self.metadata['val2'] = val
+            self.assertEqual([str_val], self.metadata.getraw("val2"))
+            del self.metadata['val3']
+            self.metadata.add('val3', val)
+            self.assertEqual([str_val], self.metadata.getraw("val3"))
+            del self.metadata['val4']
+            self.metadata.add_unique('val4', val)
+            self.assertEqual([str_val], self.metadata.getraw("val4"))
+
     def test_metadata_get(self):
         self.assertEqual("single1-value", self.metadata["single1"])
         self.assertEqual("single1-value", self.metadata.get("single1"))
@@ -86,13 +100,6 @@ class MetadataTest(PicardTestCase):
         self.metadata["unknown"] = ""
         self.assertNotIn("unknown", self.metadata)
         self.assertNotIn("unknown", self.metadata.deleted_tags)
-
-    def test_metadata_set_explicit_empty(self):
-        self.metadata.delete("single1")
-        self.metadata.set("single1", [])
-        self.assertIn("single1", self.metadata)
-        self.assertNotIn("single1", self.metadata.deleted_tags)
-        self.assertEqual([], self.metadata.getall("single1"))
 
     def test_metadata_undelete(self):
         self.metadata.delete("single1")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The methods of `Metadata` which set data are inconsistent. `__setitem__` and `set` behave differently and only `__setitem__` did conversion to string. This is a confusing API. Also because tag values are treated as strings everywhere this lead to a lot of explicit `str()` conversions when using `add` or `add_unique`.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1406
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- All Metadata methods setting data (`__setitem__`, `set`, `add`, `add_unique`) will convert values to strings
- `__setitem__` and `set` are equivalent
- get rid of explicit `str()` conversions when calling `add` / `add_unique`

I searched both the Picard and picard-plugins code for uses of `set`, `add` and `add_unique`. In all cases code was either passing already an string or did str conversion. So while this is a potentially breaking change I don't think it should break anything official. And if some plugin really stores some non-string value in Metadata this is already very hackish and easily breaks when combined with scripting.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
