### PR TITLE
PICARD-1667: Functions for boolean checks must return "" on False

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -726,7 +726,7 @@ def func_is_complete(parser):
     if (file and file.parent and hasattr(file.parent, 'album')
             and file.parent.album.is_complete()):
         return "1"
-    return "0"
+    return ""
 
 
 def func_firstalphachar(parser, text="", nonalpha="#"):
@@ -759,13 +759,13 @@ def func_firstwords(parser, text, length):
 def func_startswith(parser, text, prefix):
     if text.startswith(prefix):
         return "1"
-    return "0"
+    return ""
 
 
 def func_endswith(parser, text, suffix):
     if text.endswith(suffix):
         return "1"
-    return "0"
+    return ""
 
 
 def func_truncate(parser, text, length):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -292,15 +292,15 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$startswith(abc,a)", "1")
         self.assertScriptResultEquals("$startswith(abc,abc)", "1")
         self.assertScriptResultEquals("$startswith(abc,)", "1")
-        self.assertScriptResultEquals("$startswith(abc,b)", "0")
-        self.assertScriptResultEquals("$startswith(abc,Ab)", "0")
+        self.assertScriptResultEquals("$startswith(abc,b)", "")
+        self.assertScriptResultEquals("$startswith(abc,Ab)", "")
 
     def test_cmd_endswith(self):
         self.assertScriptResultEquals("$endswith(abc,c)", "1")
         self.assertScriptResultEquals("$endswith(abc,abc)", "1")
         self.assertScriptResultEquals("$endswith(abc,)", "1")
-        self.assertScriptResultEquals("$endswith(abc,b)", "0")
-        self.assertScriptResultEquals("$endswith(abc,bC)", "0")
+        self.assertScriptResultEquals("$endswith(abc,b)", "")
+        self.assertScriptResultEquals("$endswith(abc,bC)", "")
 
     def test_cmd_truncate(self):
         self.assertScriptResultEquals("$truncate(abcdefg,0)", "")
@@ -582,15 +582,15 @@ class ScriptParserTest(PicardTestCase):
         file.parent.album.is_complete.return_value = True
         self.assertScriptResultEquals("$is_complete()", "1", file=file)
         file.parent.album.is_complete.return_value = False
-        self.assertScriptResultEquals("$is_complete()", "0", file=file)
-        self.assertScriptResultEquals("$is_complete()", "0")
+        self.assertScriptResultEquals("$is_complete()", "", file=file)
+        self.assertScriptResultEquals("$is_complete()", "")
 
     def test_cmd_is_complete_with_cluster(self):
         file = MagicMock()
         cluster = Cluster(name="Test")
         cluster.files.append(file)
         file.parent = cluster
-        self.assertScriptResultEquals("$is_complete()", "0", file=file)
+        self.assertScriptResultEquals("$is_complete()", "", file=file)
 
     def test_cmd_is_video(self):
         context = Metadata({'~video': '1'})


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Some scripting functions, that look like they should be used as a boolean condition in an $if, will always evaluate to true. Affected are $is_complete, $startswith and $endswith.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1667
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fixed the affected functions.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
