### PR TITLE
PICARD-1668: Added checks for actual value presence in "trkn" and "disk" mp4 tags

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -191,15 +191,17 @@ class MP4File(File):
                     if value.startswith("MusicMagic Fingerprint"):
                         metadata.add("musicip_fingerprint", value[22:])
             elif name == "trkn":
-                if (len(values) >= 1 and len(values[0] >= 1)):
+                try:
                     metadata["tracknumber"] = values[0][0]
-                    if (len(values[0])>=2):
-                        metadata["totaltracks"] = values[0][1]
+                    metadata["totaltracks"] = values[0][1]
+                except:
+                    pass
             elif name == "disk":
-                if (len(values) >= 1 and len(values[0] >= 1)):
+                try:
                     metadata["discnumber"] = values[0][0]
-                    if (len(values[0])>=2):
-                        metadata["totaldiscs"] = values[0][1]
+                    metadata["totaldiscs"] = values[0][1]
+                except:
+                    pass
             elif name == "covr":
                 for value in values:
                     if value.imageformat not in (value.FORMAT_JPEG,

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -194,14 +194,14 @@ class MP4File(File):
                 try:
                     metadata["tracknumber"] = values[0][0]
                     metadata["totaltracks"] = values[0][1]
-                except:
-                    pass
+                except IndexError:
+                    log.debug('trkn is invalid, ignoring')
             elif name == "disk":
                 try:
                     metadata["discnumber"] = values[0][0]
                     metadata["totaldiscs"] = values[0][1]
-                except:
-                    pass
+                except IndexError:
+                    log.debug('disk is invalid, ignoring')
             elif name == "covr":
                 for value in values:
                     if value.imageformat not in (value.FORMAT_JPEG,

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -191,11 +191,15 @@ class MP4File(File):
                     if value.startswith("MusicMagic Fingerprint"):
                         metadata.add("musicip_fingerprint", value[22:])
             elif name == "trkn":
-                metadata["tracknumber"] = values[0][0]
-                metadata["totaltracks"] = values[0][1]
+                if (len(values) >= 1 and len(values[0] >= 1)):
+                    metadata["tracknumber"] = values[0][0]
+                    if (len(values[0])>=2):
+                        metadata["totaltracks"] = values[0][1]
             elif name == "disk":
-                metadata["discnumber"] = values[0][0]
-                metadata["totaldiscs"] = values[0][1]
+                if (len(values) >= 1 and len(values[0] >= 1)):
+                    metadata["discnumber"] = values[0][0]
+                    if (len(values[0])>=2):
+                        metadata["totaldiscs"] = values[0][1]
             elif name == "covr":
                 for value in values:
                     if value.imageformat not in (value.FORMAT_JPEG,


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Added checks to the actual presence of values in mp4 tags "trkn" and "disk". If not present, just ignore and don't set it into parsed metadata

# Problem

When importing a file with these tags set but with empty values picard breaks with an exception and marks as errored.

Steps to reproduce:

1. Make a m4a/mp4/acc file with these tags present but with empty values
2. Try to import them in picard

* JIRA ticket : PICARD-1668

# Solution

Add checks of actual value presence in them

# Action

~~I will add tests as I just found them for formats/mp4.~~
Ready to merge
