### PR TITLE
PICARD-1666: Consider video / audio when comparing files to tracks

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -88,6 +88,7 @@ class File(QtCore.QObject, Item):
         "releasetype": 20,
         "releasecountry": 2,
         "format": 2,
+        "isvideo": 2,
     }
 
     class PreserveTimesStatError(Exception):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -241,6 +241,12 @@ class Metadata(MutableMapping):
                 sim *= track['score'] / 100
             return SimMatchTrack(similarity=sim, releasegroup=None, release=None, track=track)
 
+        if 'isvideo' in weights:
+            metadata_is_video = self['~video'] == '1'
+            track_is_video = track.get('video', False)
+            score = 1 if metadata_is_video == track_is_video else 0
+            parts.append((score, weights['isvideo']))
+
         result = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
         for release in releases:
             release_parts = self.compare_to_release_parts(release, weights)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard does happily match audio only recordings to video files and video recordings to audio files.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1666
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a weight that triggers if the video flag of both the file and the recording match.

I tested with a couple of video files, which then really preferred the video recordings on MB if they existed.

Some considerations:

- The weight is there to trigger Picard preferring an equivalent video file. But it is intentionally not set too high to not get a match with otherwise wrong metadata just because it is a video
- Video recordings do often not exist on MB, hence it is important to still allow matching video files to recordings not flagged as video.
- Likewise we don't reliable detect if a file is a video in all cases. That's also why it is important to still match files and recordings with differences in the flags.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
