### PR TITLE
PICARD-1672: Flag MP4 files with the hdvd tag as video

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -312,5 +312,5 @@ class MP4File(File):
         filename = file.filename
         if isinstance(filename, bytes):
             filename = filename.decode()
-        if filename.lower().endswith(".m4v"):
+        if filename.lower().endswith(".m4v") or 'hdvd' in file.tags:
             metadata['~video'] = '1'

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -1,4 +1,5 @@
 import mutagen
+import unittest
 
 from picard.formats import ext_to_format
 
@@ -78,6 +79,14 @@ class M4ATest(CommonMP4Tests.MP4TestCase):
         '~bits_per_sample': '16',
     }
     unexpected_info = ['~video']
+
+    @unittest.skipUnless(mutagen.version >= (1, 43, 0), "mutagen >= 1.43.0 required")
+    def test_hdvd_tag_considered_video(self):
+        tags = mutagen.mp4.MP4Tags()
+        tags['hdvd'] = [1]
+        save_raw(self.filename, tags)
+        metadata = load_metadata(self.filename)
+        self.assertEqual('1', metadata["~video"])
 
 
 class M4VTest(CommonMP4Tests.MP4TestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Apple supports a `hdvd` atom in MP4, which is a 8 bit integer where:

0 - SD
1 - 720p
2 - 1080p

We can use the presence of this atom to identify a file as video.

This requires mutagen 1.43, see https://github.com/quodlibet/mutagen/pull/386

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1672
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Set the `~video` variable for all MP4 files containing the `hdvd` atom.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
