### PR TITLE
PICARD-1673: Show load and save progress in Windows taskbar

### DIFF
--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -66,16 +66,22 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self.val4.setToolTip(t4)
         self.label4.setToolTip(t4)
 
-    def setFiles(self, num):
+    def update(self, files=0, albums=0, pending_files=0, pending_requests=0):
+        self.set_files(files)
+        self.set_albums(albums)
+        self.set_pending_files(pending_files)
+        self.set_pending_requests(pending_requests)
+
+    def set_files(self, num):
         self.val1.setText(str(num))
 
-    def setAlbums(self, num):
+    def set_albums(self, num):
         self.val2.setText(str(num))
 
-    def setPendingFiles(self, num):
+    def set_pending_files(self, num):
         self.val3.setText(str(num))
 
-    def setPendingRequests(self, num):
+    def set_pending_requests(self, num):
         if num <= 0:
             enabled = QtGui.QIcon.Disabled
         else:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -77,6 +77,7 @@ from picard.ui.passworddialog import (
 from picard.ui.playertoolbar import Player
 from picard.ui.searchdialog.album import AlbumSearchDialog
 from picard.ui.searchdialog.track import TrackSearchDialog
+from picard.ui.statusindicator import DesktopStatusIndicator
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.util import (
     MultiDirsSelectDialog,
@@ -203,6 +204,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if self.tagger.autoupdate_enabled:
             self.auto_update_check()
         self.metadata_box.restore_state()
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if DesktopStatusIndicator:
+            self.register_status_indicator(DesktopStatusIndicator(self.windowHandle()))
 
     def closeEvent(self, event):
         if config.setting["quit_confirmation"] and not self.show_quit_confirmation():

--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.const.sys import IS_WIN
+
+
+DesktopStatusIndicator = None
+
+if IS_WIN:
+    from PyQt5.QtWinExtras import QWinTaskbarButton
+
+    class WindowsTaskbarStatusIndicator:
+        def __init__(self, window):
+            self.max_pending = 0
+            taskbar_button = QWinTaskbarButton(window)
+            taskbar_button.setWindow(window)
+            self.progress = taskbar_button.progress()
+
+        def update(self, files=0, albums=0, pending_files=0, pending_requests=0):
+            if not self.progress:
+                return
+
+            total_pending = pending_files + pending_requests
+
+            if total_pending > self.max_pending:
+                self.max_pending = total_pending
+
+            if total_pending == 0 or self.max_pending <= 1:  # No need to show progress for single item
+                self.max_pending = 0
+                self.progress.hide()
+                return
+
+            completion = 1 - (total_pending / self.max_pending)
+            self.progress.setValue(int(completion * 100))
+            self.progress.show()
+
+    DesktopStatusIndicator = WindowsTaskbarStatusIndicator


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The taskbar on Windows 7 and later can show a progress indicator. If Picard is busy with long running operations, e.g. web requests for a large collection or saving a lot of files, it would be useful to make use of this to indicate progress.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1673
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use `QWinTaskbarButton` to update the progress display in the Windows taskbar (see animation below). The progress is based on both pending files and pending requests.

![Peek 2019-11-19 18-08](https://user-images.githubusercontent.com/29852/69169013-f1e8ff00-0af7-11ea-9fe9-cc8b654e9e3e.gif)

FOr implementation I abstracted the existing update of the counts in the status bar to support alternative implementations of showing pending actions.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
The implementation was done to allow additional implementations. The clear candidate for this on Linux is implementing the `com.canonical.Unity.LauncherEntry` D-Bus interface, which was done originally for Unity but is supported by multiple implementations (e.g. KDE and the GNOME Dash-to-Dock extension both support it).

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
