### PR TITLE
PICARD-1674: Linux desktop progress indicator using Unity.LauncherEntry DBus interface

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -35,8 +35,10 @@ from PyQt5 import (
     QtGui,
     QtWidgets,
 )
+from PyQt5.QtDBus import QDBusConnection
 
 from picard import (
+    PICARD_APP_ID,
     PICARD_APP_NAME,
     PICARD_DESKTOP_NAME,
     PICARD_FANCY_VERSION_STR,
@@ -909,6 +911,10 @@ def main(localedir=None, autoupdate=True):
         return version()
     if picard_args.long_version:
         return longversion()
+
+    if not (IS_WIN or IS_MACOS or IS_HAIKU):
+        dbus = QDBusConnection.sessionBus()
+        dbus.registerService(PICARD_APP_ID)
 
     tagger = Tagger(picard_args, unparsed_args, localedir, autoupdate)
 

--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -41,9 +41,9 @@ class AbstractProgressStatusIndicator:
         if total_pending == self._last_pending:
             return  # No changes, avoid update
 
+        previous_done = self._max_pending - self._last_pending
+        self._max_pending = max(self._max_pending, previous_done + total_pending)
         self._last_pending = total_pending
-        if total_pending > self._max_pending:
-            self._max_pending = total_pending
 
         if total_pending == 0 or self._max_pending <= 1:  # No need to show progress for single item
             self._max_pending = 0

--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -17,37 +17,165 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from picard.const.sys import IS_WIN
+from picard.const.sys import (
+    IS_HAIKU,
+    IS_MACOS,
+    IS_WIN,
+)
 
 
 DesktopStatusIndicator = None
 
+
+class AbstractProgressStatusIndicator:
+    def __init__(self):
+        self._max_pending = 0
+        self._last_pending = 0
+
+    def update(self, files=0, albums=0, pending_files=0, pending_requests=0):
+        if not self.is_available:
+            return
+
+        total_pending = pending_files + pending_requests
+
+        if total_pending == self._last_pending:
+            return  # No changes, avoid update
+
+        self._last_pending = total_pending
+        if total_pending > self._max_pending:
+            self._max_pending = total_pending
+
+        if total_pending == 0 or self._max_pending <= 1:  # No need to show progress for single item
+            self._max_pending = 0
+            self.hide_progress()
+            return
+
+        progress = 1 - (total_pending / self._max_pending)
+        self.set_progress(progress)
+
+    @property
+    def is_available(self):
+        return True
+
+    def hide_progress(self):
+        raise NotImplementedError
+
+    def set_progress(self, progress):
+        raise NotImplementedError
+
+
 if IS_WIN:
     from PyQt5.QtWinExtras import QWinTaskbarButton
 
-    class WindowsTaskbarStatusIndicator:
+    class WindowsTaskbarStatusIndicator(AbstractProgressStatusIndicator):
         def __init__(self, window):
-            self.max_pending = 0
+            self.super().__init__()
             taskbar_button = QWinTaskbarButton(window)
             taskbar_button.setWindow(window)
-            self.progress = taskbar_button.progress()
+            self._progress = taskbar_button.progress()
 
-        def update(self, files=0, albums=0, pending_files=0, pending_requests=0):
-            if not self.progress:
-                return
+        @property
+        def is_available(self):
+            return bool(self._progress)
 
-            total_pending = pending_files + pending_requests
+        def hide_progress(self):
+            self._progress.hide()
 
-            if total_pending > self.max_pending:
-                self.max_pending = total_pending
-
-            if total_pending == 0 or self.max_pending <= 1:  # No need to show progress for single item
-                self.max_pending = 0
-                self.progress.hide()
-                return
-
-            completion = 1 - (total_pending / self.max_pending)
-            self.progress.setValue(int(completion * 100))
-            self.progress.show()
+        def set_progress(self, progress):
+            self._progress.setValue(int(progress * 100))
+            self._progress.show()
 
     DesktopStatusIndicator = WindowsTaskbarStatusIndicator
+
+elif not (IS_MACOS or IS_HAIKU):
+    from PyQt5.QtCore import (
+        Q_CLASSINFO,
+        QObject,
+        pyqtSlot,
+    )
+    from PyQt5.QtDBus import (
+        QDBusAbstractAdaptor,
+        QDBusConnection,
+        QDBusMessage,
+    )
+
+    from picard import PICARD_DESKTOP_NAME
+
+    DBUS_INTERFACE = 'com.canonical.Unity.LauncherEntry'
+
+    class UnityLauncherEntryService(QObject):
+
+        def __init__(self, bus, app_id):
+            QObject.__init__(self)
+            self._bus = bus
+            self._app_id = app_id
+            self._path = '/'
+            self._progress = 0
+            self._visible = False
+            self._dbus_adaptor = UnityLauncherEntryAdaptor(self)
+            self._available = bus.registerObject(self._path, self)
+
+        @property
+        def current_progress(self):
+            return {
+                "progress": self._progress,
+                "progress-visible": self._visible,
+            }
+
+        @property
+        def is_available(self):
+            return self._available
+
+        def update(self, progress, visible=True):
+            self._progress = progress
+            self._visible = visible
+            # Automatic forwarding of Qt signals does not work in this case
+            # since Qt cannot handle the complex "a{sv}" type.
+            # Create the signal message manually.
+            message = QDBusMessage.createSignal(self._path, DBUS_INTERFACE, 'Update')
+            message.setArguments([self._app_id, self.current_progress])
+            self._bus.send(message)
+
+        def query(self):
+            return [self._app_id, self.current_progress]
+
+    class UnityLauncherEntryAdaptor(QDBusAbstractAdaptor):
+        """ This provides the DBus adaptor to the outside world"""
+
+        Q_CLASSINFO("D-Bus Interface", DBUS_INTERFACE)
+        Q_CLASSINFO("D-Bus Introspection",
+            '<interface name="%s">\n'
+            '  <signal name="Update">\n'
+            '    <arg direction="out" type="s" name="app_uri"/>\n'
+            '    <arg direction="out" type="a{sv}" name="properties"/>\n'
+            '  </signal>\n'
+            '  <method name="Query">\n'
+            '    <arg direction="out" type="s" name="app_uri"/>\n'
+            '    <arg direction="out" type="a{sv}" name="properties"/>\n'
+            '  </method>\n'
+            '</interface>' % DBUS_INTERFACE)
+
+        def __init__(self, parent):
+            super().__init__(parent)
+
+        @pyqtSlot(name="Query", result=list)
+        def query(self):
+            return self.parent().query()
+
+    class UnityLauncherEntryStatusIndicator(AbstractProgressStatusIndicator):
+        def __init__(self, window):
+            super().__init__()
+            bus = QDBusConnection.sessionBus()
+            self._service = UnityLauncherEntryService(bus, PICARD_DESKTOP_NAME)
+
+        @property
+        def is_available(self):
+            return self._service.is_available
+
+        def hide_progress(self):
+            self._service.update(0, False)
+
+        def set_progress(self, progress):
+            self._service.update(progress)
+
+    DesktopStatusIndicator = UnityLauncherEntryStatusIndicator


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Same functionality as implented on Windows in #1368, but for Linux desktops supporting the DBus based [Unity Launcher API](https://wiki.ubuntu.com/Unity/LauncherAPI).
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1674
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Expose the [`com.canonical.Unity.LauncherEntry` DBus interface](https://wiki.ubuntu.com/Unity/LauncherAPI#Low_level_DBus_API:_com.canonical.Unity.LauncherEntry). The DBus interface is initiated always except for platforms where it does not make sense. If DBus is not available this is handled by QDBus, the `bus.registerObject` returns False in this case and the `UnityLauncherEntryStatusIndicator` skips any updates.

This was tested on:
- Ubuntu with default Ubuntu GNOME desktop (which is using Dash to Dock)
- KDE Plasma
- Arch Linux with GNOME and Dash to Dock installed
- Plank dock (also installed on GNOME)

For screenshots see https://community.metabrainz.org/t/wishlist-progress-shown-in-windows-taskbar/447056/6



<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
