### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -1,0 +1,32 @@
+name: Package for macOS
+
+on: [push]
+
+jobs:
+  package:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Setup macOS build environment
+      run: |
+        ./scripts/package/macos-setup.sh
+      env:
+        DISCID_VERSION: 0.6.2
+        FPCALC_VERSION: 1.4.3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        source bin/activate
+        pip install -r requirements-macos.txt
+    - name: Build macOS app
+      run: |
+        source bin/activate
+        ./scripts/package/macos-package-app.sh
+      env:
+        UPLOAD_OSX: 1

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -36,3 +36,10 @@ jobs:
       with:
         name: macos-builds
         path: artifacts/
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: artifacts/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -34,6 +34,12 @@ jobs:
         source bin/activate
         ./scripts/package/macos-package-app.sh
         mv dist/*.dmg artifacts/
+      env:
+        APPLE_ID_USER: ${{ secrets. APPLE_ID_USER }}
+        APPLE_ID_PASSWORD: ${{ secrets. APPLE_ID_PASSWORD }}
+        encrypted_be5fb2212036_key: ${{ secrets.CODESIGN_MACOS_ENCRYPTED_KEY }}
+        encrypted_be5fb2212036_iv: ${{ secrets.CODESIGN_MACOS_ENCRYPTED_IV }}
+        appledev_p12_password: ${{ secrets.CODESIGN_MACOS_P12_PASSWORD }}
     - name: Archive production artifacts
       uses: actions/upload-artifact@v1
       if: always()

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -13,6 +13,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Patch build version
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        python setup.py patch_version --platform=$(git rev-list --count HEAD).$(git rev-parse --short HEAD)
     - name: Setup macOS build environment
       run: |
         ./scripts/package/macos-setup.sh

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Setup macOS build environment
       run: |
         ./scripts/package/macos-setup.sh
+        mkdir artifacts
       env:
         DISCID_VERSION: 0.6.2
         FPCALC_VERSION: 1.4.3
@@ -28,5 +29,10 @@ jobs:
       run: |
         source bin/activate
         ./scripts/package/macos-package-app.sh
-      env:
-        UPLOAD_OSX: 1
+        mv dist/*.dmg artifacts/
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: macos-builds
+        path: artifacts/

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -20,6 +20,18 @@ jobs:
       env:
         DISCID_VERSION: 0.6.2
         FPCALC_VERSION: 1.4.3
+    - name: Prepare code signing certificate
+      run: |
+        pip install awscli
+        aws s3 cp "$Env:CODESIGN_PFX_URL" .\codesign.pfx
+        $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_PFX_PASSWORD -Force -AsPlainText
+        Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath .\codesign.pfx -Password $CertPassword
+      env:
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        CODESIGN_PFX_URL: ${{ secrets.CODESIGN_PFX_URL }}
+        CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -1,0 +1,43 @@
+name: Package for Windows
+
+on: [push]
+
+jobs:
+  package:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Setup Windows build environment
+      run: |
+        & .\scripts\package\win-setup.ps1 -DiscidVersion $Env:DISCID_VERSION -FpcalVersion $Env:FPCALC_VERSION
+      env:
+        DISCID_VERSION: 0.6.2
+        FPCALC_VERSION: 1.4.3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-build.txt
+        pip install -r requirements-win.txt
+    - name: Build Windows 10 app package
+      run: |
+        $Env:PATH += ";C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64"
+        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
+        & .\scripts\package\win-package-appx.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+    - name: Build Windows installer
+      if: always()
+      run: |
+        choco install nsis
+        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
+        & .\scripts\package\win-package-installer.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+        dist\picard\fpcalc -version
+    - name: Build Windows portable app
+      if: always()
+      run: |
+        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
+        & .\scripts\package\win-package-portable.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -51,3 +51,10 @@ jobs:
       with:
         name: windows-builds
         path: artifacts/
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: artifacts/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -13,6 +13,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Patch build version
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        python setup.py patch_version --platform=$(git rev-list --count HEAD).$(git rev-parse --short HEAD)
     - name: Setup Windows build environment
       run: |
         & .\scripts\package\win-setup.ps1 -DiscidVersion $Env:DISCID_VERSION -FpcalVersion $Env:FPCALC_VERSION

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -24,14 +24,11 @@ jobs:
       run: |
         pip install awscli
         aws s3 cp "$Env:CODESIGN_PFX_URL" .\codesign.pfx
-        $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_PFX_PASSWORD -Force -AsPlainText
-        Import-PfxCertificate -CertStoreLocation Cert:\CurrentUser\My -FilePath .\codesign.pfx -Password $CertPassword
       env:
         AWS_DEFAULT_REGION: eu-central-1
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         CODESIGN_PFX_URL: ${{ secrets.CODESIGN_PFX_URL }}
-        CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -40,23 +37,30 @@ jobs:
     - name: Build Windows 10 app package
       run: |
         $Env:PATH += ";C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64"
-        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
-        & .\scripts\package\win-package-appx.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+        & .\scripts\package\win-package-appx.ps1 -BuildNumber $(git rev-list --count HEAD) -CertificateFile .\codesign.pfx -CertificatePassword $Env:CODESIGN_PFX_PASSWORD
         Move-Item .\dist\*.msix .\artifacts
+      env:
+        CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
     - name: Build Windows installer
       if: always()
       run: |
-        choco install nsis
-        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
+        # choco install nsis
+        $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_PFX_PASSWORD -Force -AsPlainText
+        $Certificate = Get-PfxCertificate -FilePath .\codesign.pfx -Password $CertPassword
         & .\scripts\package\win-package-installer.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
         Move-Item .\installer\*.exe .\artifacts
         dist\picard\fpcalc -version
+      env:
+        CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
     - name: Build Windows portable app
       if: always()
       run: |
-        $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
+        $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_PFX_PASSWORD -Force -AsPlainText
+        $Certificate = Get-PfxCertificate -FilePath .\codesign.pfx -Password $CertPassword
         & .\scripts\package\win-package-portable.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
         Move-Item .\dist\*.exe .\artifacts
+      env:
+        CODESIGN_PFX_PASSWORD: ${{ secrets.CODESIGN_PFX_PASSWORD }}
     - name: Archive production artifacts
       uses: actions/upload-artifact@v1
       if: always()

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Setup Windows build environment
       run: |
         & .\scripts\package\win-setup.ps1 -DiscidVersion $Env:DISCID_VERSION -FpcalVersion $Env:FPCALC_VERSION
+        New-Item -Name .\artifacts -ItemType Directory
       env:
         DISCID_VERSION: 0.6.2
         FPCALC_VERSION: 1.4.3
@@ -29,15 +30,24 @@ jobs:
         $Env:PATH += ";C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64"
         $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
         & .\scripts\package\win-package-appx.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+        Move-Item .\dist\*.msix .\artifacts
     - name: Build Windows installer
       if: always()
       run: |
         choco install nsis
         $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
         & .\scripts\package\win-package-installer.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+        Move-Item .\installer\*.exe .\artifacts
         dist\picard\fpcalc -version
     - name: Build Windows portable app
       if: always()
       run: |
         $Certificate = @(Get-ChildItem cert:\CurrentUser\My -codesign)[0]
         & .\scripts\package\win-package-portable.ps1 -BuildNumber $(git rev-list --count HEAD) -Certificate $Certificate
+        Move-Item .\dist\*.exe .\artifacts
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: windows-builds
+        path: artifacts/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,37 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Check coding style
+      run: |
+        pip install flake8 isort
+        flake8 picard --count --show-source --statistics
+        isort --check-only --diff --recursive picard test
+    - name: Test with pytest
+      run: |
+        pip install pytest pytest-randomly pytest-cov
+        pytest --verbose --cov=picard --cov-report xml:coverage.xml test
+    # - name: Submit code coverage to codacy
+    #   if: secrets.CODACY_PROJECT_TOKEN
+    #   run: |
+    #     pip install codacy-coverage
+    #     python-codacy-coverage -r coverage.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
     steps:
     - uses: actions/checkout@v1
@@ -30,8 +32,8 @@ jobs:
       run: |
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose --cov=picard --cov-report xml:coverage.xml test
-    # - name: Submit code coverage to codacy
-    #   if: secrets.CODACY_PROJECT_TOKEN
-    #   run: |
-    #     pip install codacy-coverage
-    #     python-codacy-coverage -r coverage.xml
+    - name: Submit code coverage to Codacy
+      if: env.CODACY_PROJECT_TOKEN
+      run: |
+        pip install codacy-coverage
+        python-codacy-coverage -r coverage.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,3 +36,29 @@ jobs:
       run: |
         pip install codacy-coverage
         python-codacy-coverage -r coverage.xml
+
+  pip-install: # Test whether a clean pip install from source works
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install gettext (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get install gettext
+    - name: Install gettext (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install gettext
+        brew link gettext --force
+    - name: Run pip install .
+      run: |
+        python -m pip install --upgrade pip
+        pip install .

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -77,7 +77,11 @@ LIBDISCID_REGEX="libdiscid [0-9]+\.[0-9]+\.[0-9]+"
 "MusicBrainz Picard.app/Contents/MacOS/fpcalc" -version
 
 # Package app bundle into DMG image
-DMG="MusicBrainz Picard $VERSION macOS $MACOS_VERSION_MAJOR.$MACOS_VERSION_MINOR.dmg"
+if [ -n "$TRAVIS_OSX_IMAGE" ]; then
+  DMG="MusicBrainz-Picard-${VERSION}_macOS-$MACOS_VERSION_MAJOR.$MACOS_VERSION_MINOR.dmg"
+else
+  DMG="MusicBrainz-Picard-$VERSION.dmg"
+fi
 hdiutil create -volname "MusicBrainz Picard $VERSION" \
   -srcfolder 'MusicBrainz Picard.app' -ov -format UDBZ "$DMG"
 [ "$CODESIGN" = '1' ] && codesign --verify --verbose \

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -z "$TRAVIS_TAG" ]
-then
+if [ -z "$TRAVIS_TAG" ] && [ -n "$TRAVIS_OSX_IMAGE" ]; then
     python3 setup.py patch_version --platform=osx.$TRAVIS_OSX_IMAGE
 fi
 VERSION=$(python3 -c 'import picard; print(picard.__version__)')

--- a/scripts/package/macos-setup.sh
+++ b/scripts/package/macos-setup.sh
@@ -7,9 +7,11 @@ brew install gettext
 brew link gettext --force
 
 # Install requested Python version
-wget "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macosx10.9.pkg"
-sudo installer -pkg python-${PYTHON_VERSION}-macosx10.9.pkg -target /
-sudo python3 -m ensurepip
+if [ ! -z "$PYTHON_VERSION" ]; then
+  wget "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macosx10.9.pkg"
+  sudo installer -pkg python-${PYTHON_VERSION}-macosx10.9.pkg -target /
+  sudo python3 -m ensurepip
+fi
 
 # Install libdiscid
 wget "ftp://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/libdiscid-$DISCID_VERSION.tar.gz"

--- a/scripts/package/win-package-appx.ps1
+++ b/scripts/package/win-package-appx.ps1
@@ -7,6 +7,10 @@ Param(
   $BuildNumber
 )
 
+# Errors are handled explicitly. Otherwise any output to stderr when
+# calling classic Windows exes causes a script error.
+$ErrorActionPreference = 'Continue'
+
 If (-Not $BuildNumber) {
   $BuildNumber = 0
 }

--- a/scripts/package/win-package-appx.ps1
+++ b/scripts/package/win-package-appx.ps1
@@ -57,7 +57,7 @@ Pop-Location
 
 # Generate msix package
 $PicardVersion = (python -c "import picard; print(picard.__version__)")
-$PackageFile = "dist\MusicBrainz Picard $PicardVersion.msix"
+$PackageFile = "dist\MusicBrainz-Picard-$PicardVersion.msix"
 MakeAppx pack /o /h SHA256 /d $PackageDir /p $PackageFile
 ThrowOnExeError "MakeAppx failed"
 

--- a/scripts/package/win-package-installer.ps1
+++ b/scripts/package/win-package-installer.ps1
@@ -7,6 +7,10 @@ Param(
   $BuildNumber
 )
 
+# Errors are handled explicitly. Otherwise any output to stderr when
+# calling classic Windows exes causes a script error.
+$ErrorActionPreference = 'Continue'
+
 If (-Not $BuildNumber) {
   $BuildNumber = 0
 }

--- a/scripts/package/win-package-portable.ps1
+++ b/scripts/package/win-package-portable.ps1
@@ -7,6 +7,10 @@ Param(
   $BuildNumber
 )
 
+# Errors are handled explicitly. Otherwise any output to stderr when
+# calling classic Windows exes causes a script error.
+$ErrorActionPreference = 'Continue'
+
 If (-Not $BuildNumber) {
   $BuildNumber = 0
 }

--- a/scripts/package/win-setup.ps1
+++ b/scripts/package/win-setup.ps1
@@ -1,0 +1,39 @@
+Param(
+  [Parameter(Mandatory=$true)]
+  [String]
+  $DiscidVersion,
+  [Parameter(Mandatory=$true)]
+  [String]
+  $FpcalVersion
+)
+
+$ErrorActionPreference = "Stop"
+
+Function DownloadFile {
+  Param(
+    [Parameter(Mandatory=$true)]
+    [String]
+    $FileName,
+    [Parameter(Mandatory=$true)]
+    [String]
+    $Url
+  )
+  $OutputPath = (Join-Path (Resolve-Path .) $FileName)
+  (New-Object System.Net.WebClient).DownloadFile($Url, "$OutputPath")
+}
+
+New-Item -Name .\build -ItemType Directory -ErrorAction Ignore
+
+$ArchiveFile = ".\build\libdiscid.zip"
+Write-Output "Downloading libdiscid to $ArchiveFile..."
+DownloadFile -Url "https://github.com/metabrainz/libdiscid/releases/download/v$DiscidVersion/libdiscid-$DiscidVersion-win64.zip" `
+  -FileName $ArchiveFile
+Expand-Archive -Path $ArchiveFile -DestinationPath .\build\libdiscid -Force
+Copy-Item .\build\libdiscid\discid.dll .
+
+$ArchiveFile = ".\build\fpcalc.zip"
+Write-Output "Downloading chromaprint-fpcalc to $ArchiveFile..."
+DownloadFile -Url "https://github.com/acoustid/chromaprint/releases/download/v$FpcalVersion/chromaprint-fpcalc-$FpcalVersion-windows-x86_64.zip" `
+    -FileName $ArchiveFile
+Expand-Archive -Path $ArchiveFile -DestinationPath .\build\fpcalc -Force
+Copy-Item .\build\fpcalc\chromaprint-fpcalc-$FpcalVersion-windows-x86_64\fpcalc.exe .


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Run tests and packaging / deployment with Github Actions
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This performs all our test, build and deployment tasks we have running on travis / appveyor into Github actions.

Advantages:
- All tasks in one place
- Unified and simpler configuration. E.g. the majority of code in `run-tests.yml` is shared between operating systems (there is only a minor difference for installing gettext on Linux and macOS)
- Packaging of the macOS and Windows apps is pretty similar
- We get artifacts storage for all builds (previously only for appveyor)
- It is more flexible, since Github Actions is more than just for CI. E.g. we can react to changes on releases
- It runs faster (full run with all builds and tests is finished in under 10 minutes)

Disadvantages:
- Only newer versions of OS images are available. E.g. there is only a brand new Catalina 10.15. As far as I have tested we should be fine with current builds (macOS builds should run on our current target of macOS >= 10.12, Windows builds work on Windows 7 still). But currently it is not quite clear how Github will deal with updates in the future (e.g. how long they will keep existing versions of images).



<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Once we merge this I would like to disable the triggers for the appveyor and travisci builds. If needed we could keep the configs around for a while. But reactivating the old builds would be no big deal either way.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
