### PR TITLE
PICARD-1678: Fix Picard crashing on non-integer search scores

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -519,3 +519,15 @@ def add_user_genres(node, obj):
 def add_isrcs_to_metadata(node, metadata):
     for isrc in node:
         metadata.add('isrc', isrc)
+
+
+def get_score(node):
+    """Returns the score attribute for a node.
+    The score is expected to be an integer between 0 and 100, it is returned as
+    a value between 0.0 and 1.0. If there is no score attribute or it has an
+    invalid value 1.0 will be returned.
+    """
+    try:
+        return int(node.get('score', 100)) / 100
+    except (TypeError, ValueError):
+        return 1.0

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+import os
 import struct
 import unittest
 
@@ -8,6 +10,7 @@ from picard import (
     config,
     log,
 )
+from picard.releasegroup import ReleaseGroup
 
 
 class FakeTagger(QtCore.QObject):
@@ -33,6 +36,9 @@ class FakeTagger(QtCore.QObject):
     def emit(self, *args):
         pass
 
+    def get_release_group_by_id(self, rg_id):  # pylint: disable=no-self-use
+        return ReleaseGroup(rg_id)
+
 
 class PicardTestCase(unittest.TestCase):
     def setUp(self):
@@ -45,3 +51,8 @@ class PicardTestCase(unittest.TestCase):
 def create_fake_png(extra):
     """Creates fake PNG data that satisfies Picard's internal image type detection"""
     return b'\x89PNG\x0D\x0A\x1A\x0A' + (b'a' * 4) + b'IHDR' + struct.pack('>LL', 100, 100) + extra
+
+
+def load_test_json(filename):
+    with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
+        return json.load(f)

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -1,10 +1,12 @@
-import json
 import os.path
 import shutil
 import sys
 import tempfile
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    load_test_json,
+)
 
 from picard import config
 from picard.i18n import setup_gettext
@@ -21,11 +23,6 @@ settings = {
 
 class ReleaseTest(PicardTestCase):
 
-    @staticmethod
-    def load_data(filename):
-        with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
-            return json.load(f)
-
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
@@ -41,7 +38,7 @@ class ReleaseTest(PicardTestCase):
 
     def test_1(self):
         config.setting = settings.copy()
-        rlist = self.load_data('release_group_2.json')
+        rlist = load_test_json('release_group_2.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],
@@ -53,7 +50,7 @@ class ReleaseTest(PicardTestCase):
 
     def test_2(self):
         config.setting = settings.copy()
-        rlist = self.load_data('release_group_3.json')
+        rlist = load_test_json('release_group_3.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],
@@ -63,7 +60,7 @@ class ReleaseTest(PicardTestCase):
 
     def test_3(self):
         config.setting = settings.copy()
-        rlist = self.load_data('release_group_4.json')
+        rlist = load_test_json('release_group_4.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If the search scores returned by the server are not integer values Picard crashed during metadata comparisson.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1678
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Try to convert score to integer, handle conversion errors.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
