### PR TITLE
PICARD-1664: Use preferred release type for cluster lookup

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -57,6 +57,7 @@ class Cluster(QtCore.QObject, Item):
         'album': 17,
         'albumartist': 6,
         'totaltracks': 5,
+        'releasetype': 16,
         'releasecountry': 2,
         'format': 2,
     }

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -57,7 +57,7 @@ class Cluster(QtCore.QObject, Item):
         'album': 17,
         'albumartist': 6,
         'totaltracks': 5,
-        'releasetype': 16,
+        'releasetype': 10,
         'releasecountry': 2,
         'format': 2,
     }

--- a/picard/file.py
+++ b/picard/file.py
@@ -85,7 +85,7 @@ class File(QtCore.QObject, Item):
         "album": 5,
         "length": 10,
         "totaltracks": 4,
-        "releasetype": 20,
+        "releasetype": 14,
         "releasecountry": 2,
         "format": 2,
         "isvideo": 2,

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -36,7 +36,7 @@ class MatchingOptionsPage(OptionsPage):
 
     options = [
         config.FloatOption("setting", "file_lookup_threshold", 0.7),
-        config.FloatOption("setting", "cluster_lookup_threshold", 0.8),
+        config.FloatOption("setting", "cluster_lookup_threshold", 0.7),
         config.FloatOption("setting", "track_matching_threshold", 0.4),
     ]
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -29,6 +29,9 @@ settings = {
     'standardize_artists': False,
     'standardize_instruments': False,
     'translate_artist_names': False,
+    'release_type_scores': [
+        ('Album', 1.0)
+    ],
 }
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Cluster lookup was not using preferred release type.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1664
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This adds `releasetype` to the weights for cluster lookup.

The score was set so that it is the same as in the file weights relative to the total score.

File weights are currently:
```
comparison_weights = {
        "title": 13,
        "artist": 4,
        "album": 5,
        "length": 10,
        "totaltracks": 4,
        "releasetype": 20,
        "releasecountry": 2,
        "format": 2,
        "isvideo": 2,
    }
```

This is 62 maximum, with releasetype being 32%. Applying this to cluster gives:

```
comparison_weights = {
        'album': 17,
        'albumartist': 6,
        'totaltracks': 5,
        'releasetype': 16,
        'releasecountry': 2,
        'format': 2,
    }
```

I am not entirely sure about this, we could probably lower this but it is hard to tell.

The rationale why the weight is set so high is that this weight must be seen relative to other releases and gets modified by the sliders. So usually the sliders are at 0.5 for all release types, which means all matches get a score of 10 assigned here. With this setting no release is preferred over any other because of the release type. The score was intentionally made quite high so changes to release type slider can have a significant impact, e.g. setting a slider to 0 will cause this release type to be practically never be picked, while setting it to 1.0 will give this release types a significant boost over other release types even if they otherwise match better.

However, one side effect of this is that the matching score in general will be lower. Even a perfect match with default settings of 0.5 match per releastype will miss ~17% of the total score (10 points of 56 total for file lookups, 8 of 48 total for cluster lookups). This means in the thresholds for matches will easier be missed. Hence I also lowered the default threshold for cluster lookups to the same value as file lookups.

In my tests so far this behaved quite well, but I still wonder whether we should decrease the releasetype score a bit.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
