### PR TITLE
PICARD-170: Customizable main panel columns

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -204,10 +204,6 @@ class Album(DataObject, Item):
             m.apply_func(asciipunct)
 
         m['totaldiscs'] = len(release_node['media'])
-        m['totaltracks'] = sum([m['track-count'] for m in release_node['media']])
-        # Generate a list of unique media, but keep order of first appearance
-        all_media = [media['format'] for media in release_node['media']]
-        m['media'] = " / ".join(list(OrderedDict.fromkeys(all_media)))
 
         # Add album to collections
         add_release_to_user_collections(release_node)
@@ -278,8 +274,9 @@ class Album(DataObject, Item):
 
         if not self._tracks_loaded:
             artists = set()
-            totalalbumtracks = 0
+            all_media = []
             absolutetracknumber = 0
+
             va = self._new_metadata['musicbrainz_albumartistid'] == VARIOUS_ARTISTS_ID
 
             djmix_ars = {}
@@ -291,6 +288,9 @@ class Album(DataObject, Item):
                 mm.copy(self._new_metadata)
                 medium_to_metadata(medium_node, mm)
                 discpregap = False
+                format = medium_node.get('format')
+                if format:
+                    all_media.append(format)
 
                 for dj in djmix_ars.get(mm["discnumber"], []):
                     mm.add("djmixer", dj)
@@ -319,7 +319,10 @@ class Album(DataObject, Item):
                         track = self._finalize_loading_track(track_node, mm, artists, va, absolutetracknumber, discpregap)
                         track.metadata['~datatrack'] = "1"
 
-            totalalbumtracks = str(absolutetracknumber)
+            totalalbumtracks = absolutetracknumber
+            self._new_metadata['~totalalbumtracks'] = totalalbumtracks
+            # Generate a list of unique media, but keep order of first appearance
+            self._new_metadata['media'] = " / ".join(list(OrderedDict.fromkeys(all_media)))
 
             for track in self._new_tracks:
                 track.metadata["~totalalbumtracks"] = totalalbumtracks
@@ -645,7 +648,7 @@ class Album(DataObject, Item):
         elif column == 'artist':
             return self.metadata['albumartist']
         elif column == 'tracknumber':
-            return self.metadata['totaltracks']
+            return self.metadata['~totalalbumtracks']
         elif column == 'discnumber':
             return self.metadata['totaldiscs']
         else:

--- a/picard/album.py
+++ b/picard/album.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import (
+    OrderedDict,
     defaultdict,
     namedtuple,
 )
@@ -203,6 +204,10 @@ class Album(DataObject, Item):
             m.apply_func(asciipunct)
 
         m['totaldiscs'] = len(release_node['media'])
+        m['totaltracks'] = sum([m['track-count'] for m in release_node['media']])
+        # Generate a list of unique media, but keep order of first appearance
+        all_media = [media['format'] for media in release_node['media']]
+        m['media'] = " / ".join(list(OrderedDict.fromkeys(all_media)))
 
         # Add album to collections
         add_release_to_user_collections(release_node)
@@ -639,8 +644,12 @@ class Album(DataObject, Item):
                 return ''
         elif column == 'artist':
             return self.metadata['albumartist']
+        elif column == 'tracknumber':
+            return self.metadata['totaltracks']
+        elif column == 'discnumber':
+            return self.metadata['totaldiscs']
         else:
-            return ''
+            return self.metadata[column]
 
     def switch_release_version(self, mbid):
         if mbid == self.id:

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -181,6 +181,10 @@ class Cluster(QtCore.QObject, Item):
             return format_time(self.metadata.length)
         elif column == 'artist':
             return self.metadata['albumartist']
+        elif column == 'tracknumber':
+            return self.metadata['totaltracks']
+        elif column == 'discnumber':
+            return self.metadata['totaldiscs']
         return self.metadata[column]
 
     def _lookup_finished(self, document, http, error):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -518,22 +518,19 @@ class BaseTreeView(QtWidgets.QTreeWidget):
     @restore_method
     def restore_state(self):
         header = self.header()
-        header.update_visible_columns([int(i) for i in config.persist[self.view_columns.name]])
-        sizes = config.persist[self.view_sizes.name]
-        sizes = sizes.split(" ")
-        for i in range(self.columnCount() - 1):
-            try:
-                size = int(sizes[i])
-            except IndexError:
-                size = header.defaultSectionSize()
-            header.resizeSection(i, size)
+        header.update_visible_columns([int(i) for i in config.persist[self.visible_columns.name]])
+        state = config.persist[self.header_state.name]
+        if state:
+            header.restoreState(state)
+        else:
+            header.update_visible_columns([0, 1, 2])
+            for i, size in enumerate([250, 50, 100]):
+                header.resizeSection(i, size)
 
     def save_state(self):
         header = self.header()
-        config.persist[self.view_columns.name] = list(header.visible_columns)
-        cols = range(self.columnCount() - 1)
-        sizes = " ".join(str(header.sectionSize(i)) for i in cols)
-        config.persist[self.view_sizes.name] = sizes
+        config.persist[self.visible_columns.name] = list(header.visible_columns)
+        config.persist[self.header_state.name] = header.saveState()
 
     def supportedDropActions(self):
         return QtCore.Qt.CopyAction | QtCore.Qt.MoveAction
@@ -673,8 +670,8 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
 class FileTreeView(BaseTreeView):
 
-    view_columns = config.ListOption("persist", "file_view_columns", [0, 1, 2])
-    view_sizes = config.TextOption("persist", "file_view_sizes", "250 50 100")
+    visible_columns = config.ListOption("persist", "album_visible_columns", [0, 1, 2])
+    header_state = config.Option("persist", "file_view_header_state", QtCore.QByteArray())
 
     def __init__(self, window, parent=None):
         super().__init__(window, parent)
@@ -704,8 +701,8 @@ class FileTreeView(BaseTreeView):
 
 class AlbumTreeView(BaseTreeView):
 
-    view_columns = config.ListOption("persist", "album_view_columns", [0, 1, 2])
-    view_sizes = config.TextOption("persist", "album_view_sizes", "250 50 100")
+    visible_columns = config.ListOption("persist", "album_visible_columns", [0, 1, 2])
+    header_state = config.Option("persist", "album_view_header_state", QtCore.QByteArray())
 
     def __init__(self, window, parent=None):
         super().__init__(window, parent)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Makes the list of columns displayed in the two main panes user configurable.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-170
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a context menu to the view headers which allows the user to select the columns to be displayed (see screenshot below). A "Restore default columns" action is also available.

Saving the state was simplified by using `QHeaderView.saveState()` and `QHeaderView.restoreState()`. This makes sure the visible columns, their sizes and their position are all saved. As a side effect this now also persists the order of columns, which previously could already be changed but the change was not saved.

For the columns I chose columns that were commonly requested in discussions (see below) and which can easily be used and are obviously useful. There are related requests for sortable status columns of some kind, see PICARD-893 and PICARD-903. This functionality can now easily be implemented on top of this, but should be done separately.

Also I made sure to preserve the way plugins like the [add_album_column](https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/add_album_column/__init__.py) plugin currently append columns with e.g. `MainPanel.columns.append((N_('Column'), 'tagname'))`. This will still work, but now will just add the column to the list of available columns. That way users can still extend the columns for e.g. custom tags.

![grafik](https://user-images.githubusercontent.com/29852/70000175-c126b200-155a-11ea-9367-3a497ec38cfd.png)

Some related discussions:

- https://community.metabrainz.org/t/add-album-column-plugin-modification-new-columns/430922/4
- https://community.metabrainz.org/t/help-with-script-adding-columns-to-main-panel/379458
- https://community.metabrainz.org/t/picard-additonal-visible-data-in-the-main-window-was-ui-modifications-attainable-via-plug-in-or-code-level/447294

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
