### PR TITLE
PICARD-1349: Allow resetting a column to unsorted state

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -62,6 +62,7 @@ from picard.ui.collectionmenu import CollectionMenu
 from picard.ui.colors import interface_colors
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
+from picard.ui.widgets.tristatesortheaderview import TristateSortHeaderView
 
 
 class BaseAction(QtWidgets.QAction):
@@ -255,7 +256,7 @@ class MainPanel(QtWidgets.QSplitter):
             self.update_current_view()
 
 
-class ConfigurableColumnsHeader(QtWidgets.QHeaderView):
+class ConfigurableColumnsHeader(TristateSortHeaderView):
 
     def __init__(self, parent=None):
         super().__init__(QtCore.Qt.Horizontal, parent)
@@ -543,6 +544,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             header.update_visible_columns([0, 1, 2])
             for i, size in enumerate([250, 50, 100]):
                 header.resizeSection(i, size)
+            self.sortByColumn(-1, QtCore.Qt.AscendingOrder)
 
     def supportedDropActions(self):
         return QtCore.Qt.CopyAction | QtCore.Qt.MoveAction

--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+
+
+class TristateSortHeaderView(QtWidgets.QHeaderView):
+    """A QHeaderView implementation supporting tristate sorting.
+
+    A column can either be sorted ascending, descending or not sorted. The view
+    toggles through these states by clicking on a section header.
+    """
+
+    STATE_NONE = 0
+    STATE_SECTION_MOVED_OR_RESIZED = 1
+
+    def __init__(self, orientation, parent=None):
+        super().__init__(orientation, parent)
+
+        # Remember if resize / move event just happened
+        self._section_moved_or_resized = False
+
+        def update_state(i, o, n):
+            self._section_moved_or_resized = True
+
+        self.sectionResized.connect(update_state)
+        self.sectionMoved.connect(update_state)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == QtCore.Qt.LeftButton:
+            index = self.logicalIndexAt(event.pos())
+            if (index != -1 and index == self.sortIndicatorSection()
+                and self.sortIndicatorOrder() == QtCore.Qt.DescendingOrder):
+                # After a column was sorted descending we want to reset it
+                # to no sorting state. But we need to call the parent
+                # implementation of mouseReleaseEvent in order to handle
+                # other events, such as column move and resize.
+                # Disable clickable sections temporarily so the parent
+                # implementation  will not do the normal click behavior.
+                self.setSectionsClickable(False)
+                self._section_moved_or_resized = False
+                super().mouseReleaseEvent(event)
+                self.setSectionsClickable(True)
+                # Only treat this as an actual click if no move
+                # or resize event occurred.
+                if not self._section_moved_or_resized:
+                    self.setSortIndicator(-1, self.sortIndicatorOrder())
+                return
+        # Normal handling of events
+        super().mouseReleaseEvent(event)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Currently once a column is selected for sorting the treeview stay sorted. One can toggle between ascending and descending order or sort a different column, but the treeview cannot be set to an unsorted state.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1349
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Implement a custom `TristateSortHeaderView`, which toggles between the three states "ascending", "descending" and unsorted.

The implementation has to work around that a `mouseReleaseEvent` occurs both when a click happened and when a move or resize option ended. Only when it was not a move or resize it was an actual click that changes sort order. Unfortunately the default implementation does not indicate a indication of this. To avoid reimplementing all of `mousePressEvent`, `mouseMoveEvent` and `mouseReleaseEvent` and duplicating the original code this implementation instead tries to detect if a move or resize event happened.

Two things to note:
1. Resetting to unsorted does not change the current order of items. We don't remember any "unsorted" order separately. It just means that newly added items won't automatically get sorted into the list but always end up at the end.
2. There is one minor case not covered: If a column is sorted descending and one drags and drops a separate column on top of it without actually causing a column move then this will be counted as a click on the target column and the sort order is reset. I don't see a way to detect this, but it is a minor edge case and probably the user does probably not even notice when it happens.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
