### PR TITLE
PICARD-1312: Enable mnemonics for buttons and other UI elements on macOS

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -904,6 +904,9 @@ def main(localedir=None, autoupdate=True):
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
+    # Enable mnemonics on all platforms, even macOS
+    QtGui.qt_set_sequence_auto_mnemonic(True)
+
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     picard_args, unparsed_args = process_picard_args()


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
On macOS mnemonics are disabled by default. But this also means that many UI elements (e.g. triggering buttons in dialogs) cannot be used with keyboard only as it is possible on other platforms. Enabling this on macOS allows better keyboard navigation for all users consistent across platforms.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1312
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Call `qt_set_sequence_auto_mnemonic` to enable mnemonics.

This is somewhat against macOS UI guidelines, but the alternative would be to add separate shortcuts for all kind of actions across the entire app just for macOS.

For background see

- https://doc.qt.io/qt-5/qshortcut.html#mnemonic
- https://community.metabrainz.org/t/ui-keyboard-input-code-question-arrow-key-input-tkinter-gtk/453139/13

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
