### PR TITLE
PICARD-1686: Always keep [non-album tracks] at first position

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -724,7 +724,11 @@ class AlbumTreeView(BaseTreeView):
         self.tagger.album_removed.connect(self.remove_album)
 
     def add_album(self, album):
-        item = AlbumItem(album, True, self)
+        if isinstance(album, NatAlbum):
+            item = NatAlbumItem(album, True)
+            self.insertTopLevelItem(0, item)
+        else:
+            item = AlbumItem(album, True, self)
         item.setIcon(0, AlbumItem.icon_cd)
         for i, column in enumerate(MainPanel.columns):
             font = item.font(i)
@@ -855,6 +859,19 @@ class AlbumItem(TreeItem):
         # Workaround for PICARD-1446: Expand/collapse indicator for the release
         # is briefly missing on Windows
         self.emitDataChanged()
+
+    def __lt__(self, other):
+        # Always show NAT entry on top, see also NatAlbumItem.__lt__
+        if isinstance(other, NatAlbumItem):
+            return not other.__lt__(self)
+        return super().__lt__(other)
+
+
+class NatAlbumItem(AlbumItem):
+    def __lt__(self, other):
+        # Always show NAT entry on top
+        order = self.treeWidget().header().sortIndicatorOrder()
+        return order == QtCore.Qt.AscendingOrder
 
 
 class TrackItem(TreeItem):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The [non-album tracks] is a special type of AlbumItem entry that holds all the loaded non-album tracks. Currently this is sorted into the list like every other album, which can non-album tracks hard to find.

I propose to keep this special entry always on the first position of the right pane to make it easier to handle non-album tracks.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1686
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Always insert the NAT album entry at first position and implement `__lt__` comparison so this item always sorts at first position.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
