### PR TITLE
PICARD-1693: Save geometry of log view dialogs

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -162,8 +162,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if not self.show_cover_art_action.isChecked():
             self.cover_art_box.hide()
 
-        self.logDialog = LogView(self)
-        self.historyDialog = HistoryView(self)
+        self.log_dialog = LogView(self)
+        self.history_dialog = HistoryView(self)
         self.optionsDialog = None
 
         bottomLayout = QtWidgets.QHBoxLayout()
@@ -252,6 +252,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         config.persist["window_state"] = self.saveState()
         isMaximized = int(self.windowState()) & QtCore.Qt.WindowMaximized != 0
         self.save_geometry()
+        self.log_dialog.save_geometry()
+        self.history_dialog.save_geometry()
         config.persist["window_maximized"] = isMaximized
         config.persist["view_cover_art"] = self.show_cover_art_action.isChecked()
         config.persist["view_toolbar"] = self.show_toolbar_action.isChecked()
@@ -919,14 +921,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         webbrowser2.goto('documentation')
 
     def show_log(self):
-        self.logDialog.show()
-        self.logDialog.raise_()
-        self.logDialog.activateWindow()
+        self.log_dialog.show()
+        self.log_dialog.raise_()
+        self.log_dialog.activateWindow()
 
     def show_history(self):
-        self.historyDialog.show()
-        self.historyDialog.raise_()
-        self.historyDialog.activateWindow()
+        self.history_dialog.show()
+        self.history_dialog.raise_()
+        self.history_dialog.activateWindow()
 
     def open_bug_report(self):
         webbrowser2.goto('troubleshooting')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Even though both the log view and the activity history dialog implement PicardDialog, their geometry is not persisted. This is because those dialogs are permanent and never actually closed.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1693
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Save geometry of logview dialogs on exit
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
