### PR TITLE
Added generic SingletonDialog class for managing a single dialog instance

### DIFF
--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -57,6 +57,28 @@ class PreserveGeometry:
         config.persist[self.opt_name()] = self.saveGeometry()
 
 
+class SingletonDialog:
+    _instance = None
+
+    @classmethod
+    def get_instance(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = cls(*args, **kwargs)
+            cls._instance.finished.connect(cls._on_dialog_finished)
+        return cls._instance
+
+    @classmethod
+    def show_instance(cls, *args, **kwargs):
+        instance = cls.get_instance(*args, **kwargs)
+        instance.show()
+        instance.raise_()
+        instance.activateWindow()
+
+    @classmethod
+    def _on_dialog_finished(cls):
+        cls._instance = None
+
+
 class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     flags = QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowCloseButtonHint

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -164,7 +164,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.log_dialog = LogView(self)
         self.history_dialog = HistoryView(self)
-        self.optionsDialog = None
 
         bottomLayout = QtWidgets.QHBoxLayout()
         bottomLayout.setContentsMargins(0, 0, 0, 0)
@@ -907,15 +906,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.show_options("about")
 
     def show_options(self, page=None):
-        if not self.optionsDialog:
-            self.optionsDialog = OptionsDialog(page, self)
-            self.optionsDialog.finished.connect(self.on_options_closed)
-        self.optionsDialog.show()
-        self.optionsDialog.raise_()
-        self.optionsDialog.activateWindow()
-
-    def on_options_closed(self):
-        self.optionsDialog = None
+        OptionsDialog.show_instance(page, self)
 
     def show_help(self):
         webbrowser2.goto('documentation')

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -35,6 +35,7 @@ from picard.util import (
 from picard.ui import (
     HashableTreeWidgetItem,
     PicardDialog,
+    SingletonDialog,
 )
 from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     OptionsCheckError,
@@ -63,7 +64,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
 from picard.ui.util import StandardButton
 
 
-class OptionsDialog(PicardDialog):
+class OptionsDialog(PicardDialog, SingletonDialog):
 
     autorestore = False
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Replace the specific implementation in MainWindow to manage a single instance of OptionsDialog by a generic implementation.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a `SingletonDialog` class that can be subclassed by dialogs to enable management of a single instance open at a time. This single instance can still be closed and destroyed, but as long as the `SingletonDialog` functions are used to create the dialog no more than one instance exist.

This is currently only used by OptionsDialog but could now be easily reused by dialogs with similar requirements.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
