### PR TITLE
PICARD-321: Support backslash in filenames on non-Windows OS

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -163,9 +163,13 @@ def strip_non_alnum(string):  # noqa: E302
     return _re_non_alphanum.sub(" ", string).strip()
 
 
-_re_slashes = re.compile(r'[\\/]', re.UNICODE)
-def sanitize_filename(string, repl="_"):  # noqa: E302
-    return _re_slashes.sub(repl, string)
+def sanitize_filename(string, repl="_", win_compat=False):
+    string = string.replace(os.sep, repl)
+    if os.altsep:
+        string = string.replace(os.altsep, repl)
+    if win_compat and os.altsep != '\\':
+        string = string.replace('\\', repl)
+    return string
 
 
 def _reverse_sortname(sortname):

--- a/picard/util/scripttofilename.py
+++ b/picard/util/scripttofilename.py
@@ -34,15 +34,17 @@ def script_to_filename(naming_format, metadata, file=None, settings=None):
     if settings is None:
         settings = config.setting
     # make sure every metadata can safely be used in a path name
+    win_compat = IS_WIN or settings["windows_compatibility"]
     meta = Metadata()
     for name in metadata:
-        meta[name] = [sanitize_filename(str(v)) for v in metadata.getall(name)]
+        meta[name] = [sanitize_filename(str(v), win_compat=win_compat)
+                      for v in metadata.getall(name)]
     naming_format = naming_format.replace("\t", "").replace("\n", "")
     filename = ScriptParser().eval(naming_format, meta, file)
     if settings["ascii_filenames"]:
-        filename = replace_non_ascii(filename, pathsave=True)
+        filename = replace_non_ascii(filename, pathsave=True, win_compat=win_compat)
     # replace incompatible characters
-    if settings["windows_compatibility"] or IS_WIN:
+    if win_compat:
         filename = replace_win32_incompat(filename)
     # remove null characters
     filename = filename.replace("\x00", "")

--- a/picard/util/textencoding.py
+++ b/picard/util/textencoding.py
@@ -179,12 +179,16 @@ _simplify_punctuation = {
     "\u200B": "",  # Zero Width Space
 }
 _re_simplify_punctuation = _re_any(_simplify_punctuation.keys())
-_pathsave_simplify_punctuation = {k: sanitize_filename(v) for k, v in _simplify_punctuation.items()}
 
 
-def unicode_simplify_punctuation(string, pathsave=False):
-    punctuation = _pathsave_simplify_punctuation if pathsave else _simplify_punctuation
-    return _re_simplify_punctuation.sub(lambda m: punctuation[m.group(0)], string)
+def unicode_simplify_punctuation(string, pathsave=False, win_compat=False):
+    def repl(m):
+        if pathsave:
+            return sanitize_filename(_simplify_punctuation[m.group(0)], win_compat=win_compat)
+        else:
+            return _simplify_punctuation[m.group(0)]
+
+    return _re_simplify_punctuation.sub(repl, string)
 
 
 _simplify_combinations = {
@@ -413,12 +417,16 @@ _simplify_combinations = {
     "\u01BE": "ts",  # LATIN LETTER TS LIGATION (see http://unicode.org/notes/tn27/)
 }
 _re_simplify_combinations = _re_any(_simplify_combinations)
-_pathsave_simplify_combinations = {k: sanitize_filename(v) for k, v in _simplify_combinations.items()}
 
 
-def unicode_simplify_combinations(string, pathsave=False):
-    combinations = _pathsave_simplify_combinations if pathsave else _simplify_combinations
-    return _re_simplify_combinations.sub(lambda m: combinations[m.group(0)], string)
+def unicode_simplify_combinations(string, pathsave=False, win_compat=False):
+    def repl(m):
+        if pathsave:
+            return sanitize_filename(_simplify_combinations[m.group(0)], win_compat=win_compat)
+        else:
+            return _simplify_combinations[m.group(0)]
+
+    return _re_simplify_combinations.sub(repl, string)
 
 
 def unicode_simplify_accents(string):
@@ -436,11 +444,11 @@ def unaccent(string):
     return unicode_simplify_accents(string)
 
 
-def replace_non_ascii(string, repl="_", pathsave=False):
+def replace_non_ascii(string, repl="_", pathsave=False, win_compat=False):
     """Replace non-ASCII characters from ``string`` by ``repl``."""
-    interim = unicode_simplify_combinations(string, pathsave)
+    interim = unicode_simplify_combinations(string, pathsave, win_compat)
     interim = unicode_simplify_accents(interim)
-    interim = unicode_simplify_punctuation(interim, pathsave)
+    interim = unicode_simplify_punctuation(interim, pathsave, win_compat)
     interim = unicode_simplify_compatibility(interim)
 
     def error_repl(e, repl="_"):

--- a/test/test_textencoding.py
+++ b/test/test_textencoding.py
@@ -2,9 +2,8 @@
 from test.picardtestcase import PicardTestCase
 
 from picard import util
+from picard.const.sys import IS_WIN
 
-
-#from picard.util import textencoding
 
 # Set the value to true below to show the coverage of Latin characters
 show_latin2ascii_coverage = False
@@ -129,8 +128,12 @@ class PunctuationTest(PicardTestCase):
         self.assertEqual(util.textencoding.unicode_simplify_punctuation(ascii_chars), ascii_chars)
 
     def test_pathsave(self):
-        self.assertEqual(util.textencoding.unicode_simplify_punctuation('\u2215', True), '_')
-        self.assertEqual(util.textencoding.unicode_simplify_punctuation('/\\\u2215', True), '/\\_')
+        self.assertEqual(util.textencoding.unicode_simplify_punctuation('\u2215\u2216', True), '__' if IS_WIN else '_\\')
+        self.assertEqual(util.textencoding.unicode_simplify_punctuation('/\\\u2215\u2216', True), '/\\__' if IS_WIN else '/\\_\\')
+
+    def test_pathsave_win_compat(self):
+        self.assertEqual(util.textencoding.unicode_simplify_punctuation('\u2215\u2216', True, True), '__')
+        self.assertEqual(util.textencoding.unicode_simplify_punctuation('/\\\u2215\u2216', True, True), '/\\__')
 
     def test_incorrect(self):
         pass
@@ -200,7 +203,11 @@ class ReplaceNonAsciiTest(PicardTestCase):
         self.assertEqual(util.textencoding.replace_non_ascii(u"１２３"), u"123") # Fullwidth digits
 
     def test_pathsave(self):
-        self.assertEqual(util.textencoding.replace_non_ascii('\u2044/8½\\', pathsave=True), '_/8 1_2\\')
+        expected = '__/8 1_2\\' if IS_WIN else '\\_/8 1_2\\'
+        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044/8½\\', pathsave=True), expected)
+
+    def test_win_compat(self):
+        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044/8½\\', pathsave=True, win_compat=True), '__/8 1_2\\')
 
     def test_incorrect(self):
         self.assertNotEqual(util.textencoding.replace_non_ascii(u"Lukáš"), u"Lukáš")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -63,6 +63,26 @@ class SanitizeDateTest(PicardTestCase):
         self.assertNotEqual(util.sanitize_date("2006.03.02"), "2006-03-02")
 
 
+class SanitizeFilenameTest(PicardTestCase):
+
+    def test_replace_slashes(self):
+        self.assertEqual(util.sanitize_filename("AC/DC"), "AC_DC")
+
+    def test_custom_replacement(self):
+        self.assertEqual(util.sanitize_filename("AC/DC", "|"), "AC|DC")
+
+    def test_win_compat(self):
+        self.assertEqual(util.sanitize_filename("AC\\/DC", win_compat=True), "AC__DC")
+
+    @unittest.skipUnless(IS_WIN, "windows test")
+    def test_replace_backslashes(self):
+        self.assertEqual(util.sanitize_filename("AC\\DC"), "AC_DC")
+
+    @unittest.skipIf(IS_WIN, "non-windows test")
+    def test_keep_backslashes(self):
+        self.assertEqual(util.sanitize_filename("AC\\DC"), "AC\\DC")
+
+
 class TranslateArtistTest(PicardTestCase):
 
     def test_latin(self):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Allow backslashes to be used in filenames on systems other than Windows. Only if Windows compatibility is activated backslashes will be replaced as before.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-321
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
The core change is in `util.sanitize_filename`, where there is now no longer a hardcoded replacement of `\` and `/` but instead `os.sep` and `os.altsep` are used an a `win_compat` parameter is accepted in addition. Ensure functions in `textencoding`  and `script_to_filename` set the `win_compat` parameter accordingly.

Tested on Linux and Windows 10
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
