### PR TITLE
PICARD-1596: Use Github Actions to publish to PyPI

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  pypi-sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade -r requirements.txt
+    - name: Run tests
+      run: |
+        python setup.py test
+    - name: Build Python source distribution
+      run: |
+        python setup.py clean sdist
+    - name: Publish Python distribution to PyPI
+      run: |
+        pip install --upgrade twine
+        twine upload --non-interactive dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
Publish release tags to PyPI using Github Actions.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1596
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Added Github Actions workflow to publish to PyPI using Twine.

I have tested the commands in this order locally minus the actual twine upload, but I could not fully test this workflow. I think it is fine, but please look at it carefully. Once this is merged we probably should do a dev release soon to check our deployment process in entirety.

There are some [Github Actions](https://github.com/marketplace?utf8=%E2%9C%93&type=actions&query=pypi) specifically for this, but I think the process using twine directly is so straight forward that adding basically another dependency and passing the credentials around to another external dependency is just adding an unnecessary complexity.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
We should consider also building bdist packages, at least for Windows and maybe macOS.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
