### PR TITLE
Allow pre-release version numbers (alpha, beta, rc)

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -41,8 +41,8 @@ class VersionError(Exception):
 def version_to_string(version, short=False):
     if len(version) != 5:
         raise VersionError("Length != 5")
-    if version[3] not in ('final', 'dev'):
-        raise VersionError("Should be either 'final' or 'dev'")
+    if version[3] not in ('final', 'dev', 'alpha', 'beta', 'rc'):
+        raise VersionError("Should be either 'final', 'dev', 'alpha', 'beta' or 'rc'")
     _version = []
     for p in version:
         try:
@@ -50,6 +50,8 @@ def version_to_string(version, short=False):
         except ValueError:
             n = p
         _version.append(n)
+    if short and _version[3] in ('alpha', 'beta'):
+        _version[3] = _version[3][:1]
     version = tuple(_version)
     if short and version[3] == 'final':
         if version[2] == 0:
@@ -61,7 +63,7 @@ def version_to_string(version, short=False):
     return version_str
 
 
-_version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|final)[._]?(\d+))?)?$")
+_version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?$")
 
 
 def version_from_string(version_str):
@@ -72,7 +74,8 @@ def version_from_string(version_str):
             return (int(g[0]), int(g[1]), 0, 'final', 0)
         if g[3] is None:
             return (int(g[0]), int(g[1]), int(g[2]), 'final', 0)
-        return (int(g[0]), int(g[1]), int(g[2]), g[3], int(g[4]))
+        identifier = {'a': 'alpha', 'b': 'beta'}.get(g[3], g[3])
+        return (int(g[0]), int(g[1]), int(g[2]), identifier, int(g[4]))
     raise VersionError("String '%s' does not match regex '%s'" % (version_str,
                                                                   _version_re.pattern))
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from picard import (
     PICARD_DESKTOP_NAME,
     PICARD_DISPLAY_NAME,
     PICARD_VERSION,
-    __version__,
+    PICARD_VERSION_STR_SHORT,
 )
 
 
@@ -704,7 +704,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 args = {
     'name': PACKAGE_NAME,
-    'version': __version__,
+    'version': PICARD_VERSION_STR_SHORT,
     'description': 'The next generation MusicBrainz tagger',
     'keywords': 'MusicBrainz metadata tagger picard',
     'long_description': long_description,

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -14,94 +14,60 @@ from picard import (
 
 class VersionsTest(PicardTestCase):
 
-    def test_version_conv_1(self):
-        l, s = (0, 0, 1, 'dev', 1), '0.0.1.dev1'
-        r = '0.0.1.dev1'
-        self.assertEqual(version_to_string(l), s)
-        self.assertEqual(l, version_from_string(s))
-        self.assertEqual(l, version_from_string(r))
+    def test_version_conversion(self):
+        versions =  (
+            ((1, 1, 0, 'final', 0), '1.1.0.final0'),
+            ((0, 0, 1, 'dev', 1), '0.0.1.dev1'),
+            ((1, 1, 0, 'dev', 0), '1.1.0.dev0'),
+            ((999, 999, 999, 'dev', 999), '999.999.999.dev999'),
+            ((1, 1, 2, 'alpha', 2), '1.1.2.alpha2'),
+            ((1, 1, 2, 'beta', 2), '1.1.2.beta2'),
+            ((1, 1, 2, 'rc', 2), '1.1.2.rc2'),
+        )
+        for l, s in versions:
+            self.assertEqual(version_to_string(l), s)
+            self.assertEqual(l, version_from_string(s))
 
-    def test_version_conv_2(self):
-        l, s = (1, 1, 0, 'final', 0), '1.1.0.final0'
-        r = '1.1.0.final0'
-        self.assertEqual(version_to_string(l), s)
-        self.assertEqual(l, version_from_string(s))
-        self.assertEqual(l, version_from_string(r))
+    def test_version_conversion_short(self):
+        versions =  (
+            ((1, 1, 0, 'final', 0), '1.1'),
+            ((1, 1, 1, 'final', 0), '1.1.1'),
+            ((0, 0, 1, 'dev', 1), '0.0.1.dev1'),
+            ((1, 1, 0, 'dev', 0), '1.1.0.dev0'),
+            ((1, 1, 2, 'alpha', 2), '1.1.2.a2'),
+            ((1, 1, 2, 'beta', 2), '1.1.2.b2'),
+            ((1, 1, 2, 'rc', 2), '1.1.2.rc2'),
+        )
+        for l, s in versions:
+            self.assertEqual(version_to_string(l, short=True), s)
+            self.assertEqual(l, version_from_string(s))
 
-    def test_version_conv_3(self):
-        l, s = (1, 1, 0, 'dev', 0), '1.1.0.dev0'
-        r = '1.1.0.dev0'
-        self.assertEqual(version_to_string(l), s)
-        self.assertEqual(l, version_from_string(s))
-        self.assertEqual(l, version_from_string(r))
-
-    def test_version_conv_4(self):
-        l, s = (1, 0, 2, 'final', 0), '1.0.2'
-        self.assertEqual(version_to_string(l, short=True), s)
-        self.assertEqual(l, version_from_string(s))
-
-    def test_version_conv_5(self):
-        l, s = (999, 999, 999, 'dev', 999), '999.999.999.dev999'
-        r = '999.999.999dev999'
-        self.assertEqual(version_to_string(l), s)
-        self.assertEqual(l, version_from_string(s))
-        self.assertEqual(l, version_from_string(r))
-
-    def test_version_conv_6(self):
+    def test_version_to_string_invalid_identifier(self):
         l = (1, 0, 2, 'xx', 0)
         self.assertRaises(VersionError, version_to_string, (l))
 
-    def test_version_conv_7(self):
-        l, s = (1, 1, 0, 'final', 0), '1.1'
-        self.assertEqual(version_to_string(l, short=True), s)
-
-    def test_version_conv_8(self):
-        l, s = (1, 1, 1, 'final', 0), '1.1.1'
-        self.assertEqual(version_to_string(l, short=True), s)
-
-    def test_version_conv_9(self):
-        l, s = (1, 1, 0, 'final', 1), '1.1'
-        self.assertEqual(version_to_string(l, short=True), s)
-
-    def test_version_conv_10(self):
-        l, s = (1, 1, 0, 'dev', 0), '1.1.0.dev0'
-        self.assertEqual(version_to_string(l, short=True), s)
-
-    def test_version_conv_11(self):
-        l, s = ('1', '1', '0', 'dev', '0'), '1.1.0.dev0'
-        self.assertEqual(version_to_string(l), s)
-
-    def test_version_conv_12(self):
+    def test_version_from_string_underscores(self):
         l, s = (1, 1, 0, 'dev', 0), '1_1_0_dev_0'
         self.assertEqual(l, version_from_string(s))
 
-    def test_version_conv_13(self):
+    def test_version_from_string_prefixed(self):
         l, s = (1, 1, 0, 'dev', 0), 'anything_28_1_1_0_dev_0'
         self.assertEqual(l, version_from_string(s))
 
-    def test_version_conv_14(self):
+    def test_version_from_string_invalid(self):
         l = 'anything_28x_1_0_dev_0'
         self.assertRaises(VersionError, version_to_string, (l))
 
-    def test_version_conv_15(self):
+    def test_version_from_string_prefixed_final(self):
         l, s = (1, 1, 0, 'final', 0), 'anything_28_1_1_0'
         self.assertEqual(l, version_from_string(s))
 
-    def test_version_conv_16(self):
+    def test_from_string_invalid_identifier(self):
         self.assertRaises(VersionError, version_from_string, '1.1.0dev')
-
-    def test_version_conv_17(self):
         self.assertRaises(VersionError, version_from_string, '1.1.0devx')
 
-    def test_version_conv_18(self):
-        l, s = (1, 1, 0, 'final', 0), '1.1'
-        self.assertEqual(version_to_string(l, short=True), s)
-        self.assertEqual(l, version_from_string(s))
-
-    def test_version_conv_19(self):
+    def test_version_from_string_invalid_partial(self):
         self.assertRaises(VersionError, version_from_string, '123')
-
-    def test_version_conv_20(self):
         self.assertRaises(VersionError, version_from_string, '123.')
 
     @unittest.skipUnless(len(api_versions) > 1, "api_versions do not have enough elements")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Re-add ability to mark alpha, beta and rc pre-release versions

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
For Picard versions support the version identifiers 'alpha', 'beta' and 'rc' again (in addition to 'final' and 'dev'). This used to be supported, but got lost at some point
    
Long version strings will be e.g. 2.3.0beta2. If the shortened string is generated the idenfitiers for alpha and beta will be shortened to 'a' and 'b' (e.g. 2.3.0b2). This confirms to pre-release versioning is defined in PEP 440.

The background for this is that I really want to do a proper beta release for Picard 2.3 this time, as there are some changes where I would like to see a release that clearly indicates it is a pre-release meant to gather user feedback. Also before this I would like to tag an alpha release of current development status primarily to test our deployment process with new CI and automation.

Both of this requires proper tagging of pre-releases and ideally a version that is compatible with [PEP 440 pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases).
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
I am not entirely sure why we lost the ability to tag `alpha`, `beta` and `rc` versions. Was it intentional to limit this to `final` and `dev`?
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
