### PR TITLE
GHA: Run tests with older dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Run tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  test-latest:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,6 +37,38 @@ jobs:
       run: |
         pip install codacy-coverage
         python-codacy-coverage -r coverage.xml
+
+  test-requirements:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7]
+        dependencies: [
+          "PyQt5==5.12.3",
+          "PyQt5==5.11.3",
+          "PyQt5==5.10.1 sip==4.19.8",
+          "PyQt5==5.9.2 sip==4.19.8",
+          "PyQt5==5.8.2 sip==4.19.8 mutagen==1.37"
+        ]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install $DEPENDENCIES
+        pip install -r requirements.txt
+      env:
+        DEPENDENCIES: ${{ matrix.dependencies }}
+    - name: Test with pytest
+      run: |
+        pip install pytest pytest-randomly pytest-cov
+        pytest --verbose test
 
   pip-install: # Test whether a clean pip install from source works
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Run tests on Github Actions with older sip dependencies (mainly older PyQt5 versions).
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Run tests with older sip dependencies. To not escalate this too much I limited this to run on Linux only. For macOS and Windows I would prefer to only officially support the versions we have defined in the `requirements-{mac|win}.txt` files, as used by the packaging, and the actual latest versions.

I also consider to run these extended tests only on the master branch and not for all PRs, opinions?

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
I had an alternative implementation where I ran tests with different dependencies inside the current jobs, see https://github.com/phw/picard/commit/5291de1f56cc610cbee2dff44c62f14ac57ff9cb

But I dislike how this increases the build time to multiple minutes per job.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
