### PR TITLE
PICARD-1665: Normalize plugin and const paths for better comparison

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -30,11 +30,11 @@ builtins.__dict__['N_'] = lambda a: a
 
 # Config directory
 _appconfiglocation = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)
-USER_DIR = os.path.join(_appconfiglocation, "MusicBrainz", PICARD_APP_NAME)
-USER_PLUGIN_DIR = os.path.join(USER_DIR, "plugins")
+USER_DIR = os.path.normpath(os.path.join(_appconfiglocation, "MusicBrainz", PICARD_APP_NAME))
+USER_PLUGIN_DIR = os.path.normpath(os.path.join(USER_DIR, "plugins"))
 
 # Cache directory
-CACHE_DIR = QStandardPaths.writableLocation(QStandardPaths.CacheLocation)
+CACHE_DIR = os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.CacheLocation))
 
 # AcoustID client API key
 ACOUSTID_KEY = 'v8pQ6oyB'

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import defaultdict
+import os.path
 
 from picard import (
     config,
@@ -92,7 +93,7 @@ class PluginWrapper(PluginShared):
         super().__init__()
         self.module = module
         self.compatible = False
-        self.dir = plugindir
+        self.dir = os.path.normpath(plugindir)
         self._file = file
         self.data = manifest_data or self.module.__dict__
 

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -26,6 +26,7 @@ from picard import (
     config,
     log,
 )
+from picard.const import USER_PLUGIN_DIR
 
 
 _PLUGIN_MODULE_PREFIX = "picard.plugins."
@@ -163,6 +164,10 @@ class PluginWrapper(PluginShared):
     @property
     def files_list(self):
         return self.file[len(self.dir)+1:]
+
+    @property
+    def is_user_installed(self):
+        return self.dir == USER_PLUGIN_DIR
 
 
 class PluginData(PluginShared):

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -528,7 +528,7 @@ class PluginsOptionsPage(OptionsPage):
         if item.is_installed:
             item.buttons['install'].mode('hide')
             item.buttons['uninstall'].mode(
-                'show' if plugin.dir == USER_PLUGIN_DIR else 'hide')
+                'show' if plugin.is_user_installed else 'hide')
             item.enable(enabled, greyout=False)
 
             def uninstall_processor():

--- a/scripts/pyinstaller/portable-hook.py
+++ b/scripts/pyinstaller/portable-hook.py
@@ -20,9 +20,9 @@ if '--config-file' not in sys.argv and '-c' not in sys.argv:
     sys.argv.append(os.path.join(basedir, 'Config.ini'))
 
 # Setup plugin folder
-picard.const.USER_PLUGIN_DIR = os.path.join(basedir, 'Plugins')
+picard.const.USER_PLUGIN_DIR = os.path.normpath(os.path.join(basedir, 'Plugins'))
 
 # Set standard cache location
-cachedir = os.path.join(basedir, 'Cache')
+cachedir = os.path.normpath(os.path.join(basedir, 'Cache'))
 os.makedirs(cachedir, exist_ok=True)
 picard.const.CACHE_DIR = cachedir

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -31,8 +31,10 @@ from picard import (
     VersionError,
     version_from_string,
 )
+from picard.const import USER_PLUGIN_DIR
 from picard.plugin import (
     _PLUGIN_MODULE_PREFIX,
+    PluginWrapper,
     _unregister_module_extensions,
 )
 from picard.pluginmanager import (
@@ -160,7 +162,7 @@ class TestPicardPluginsInstall(TestPicardPluginsCommonTmpDir):
         self.assertEqual(pm.plugins[0].name, 'Dummy plugin', msg)
 
         # if module is properly loaded, this should work
-        from picard.plugins.dummyplugin import DummyPlugin
+        from picard.plugins.dummyplugin import DummyPlugin  # noqa: F811
         DummyPlugin()
 
     def _test_plugin_install_data(self, name):
@@ -180,7 +182,7 @@ class TestPicardPluginsInstall(TestPicardPluginsCommonTmpDir):
         self.assertEqual(pm.plugins[0].name, 'Dummy plugin', msg)
 
         # if module is properly loaded, this should work
-        from picard.plugins.dummyplugin import DummyPlugin
+        from picard.plugins.dummyplugin import DummyPlugin  # noqa: F811
         DummyPlugin()
 
     # module
@@ -236,7 +238,7 @@ class TestPicardPluginsLoad(TestPicardPluginsCommonTmpDir):
         self.assertEqual(pm.plugins[0].name, 'Dummy plugin', msg)
 
         # if module is properly loaded, this should work
-        from picard.plugins.dummyplugin import DummyPlugin
+        from picard.plugins.dummyplugin import DummyPlugin  # noqa: F811
         DummyPlugin()
 
     # singlefile
@@ -254,3 +256,15 @@ class TestPicardPluginsLoad(TestPicardPluginsCommonTmpDir):
     # module
     def test_plugin_load_from_directory_module(self):
         self._test_plugin_load_from_directory('module')
+
+
+class TestPluginWrapper(PicardTestCase):
+
+    def test_is_user_installed(self):
+        manifest = {
+            'PLUGIN_NAME': 'foo'
+        }
+        user_plugin = PluginWrapper({}, USER_PLUGIN_DIR, manifest_data=manifest)
+        self.assertTrue(user_plugin.is_user_installed)
+        system_plugin = PluginWrapper({}, '/other/path/plugins', manifest_data=manifest)
+        self.assertFalse(system_plugin.is_user_installed)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This is a bugfix for https://github.com/metabrainz/picard/pull/1400 on Windows.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Without this path comparisson to check wheter a plugin is installed in the user plugin dir fails on Windows. The issue is that the compared paths can look like this:

```
plugin.dir == "C:\Users\Developer\AppData\Local\MusicBrainz\Picard\plugins"
USER_PLUGIN_DIR == "C:/Users/Developer/AppData/Local\MusicBrainz\Picard\plugins"
```

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1665
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
