### PR TITLE
Implement proper version comparison for dev, alpha, beta and rc releases

### DIFF
--- a/picard.spec
+++ b/picard.spec
@@ -17,12 +17,6 @@ from picard import (
     __version__,
 )
 
-pv = [str(x) for x in PICARD_VERSION]
-macos_picard_version = '.'.join(pv[:3])
-macos_picard_short_version = macos_picard_version
-if pv[3] != 'final':
-    macos_picard_version += pv[3][0] + ''.join(pv[4:])
-
 
 def _picard_get_locale_files():
     locales = []
@@ -140,7 +134,6 @@ else:
                    upx=False,
                    name='picard')
 
-
     if os_name == 'Darwin':
         info_plist = {
             'NSHighResolutionCapable': 'True',
@@ -148,8 +141,8 @@ else:
             'CFBundleName': PICARD_APP_NAME,
             'CFBundleDisplayName': PICARD_DISPLAY_NAME,
             'CFBundleIdentifier': PICARD_APP_ID,
-            'CFBundleVersion': macos_picard_version,
-            'CFBundleShortVersionString': macos_picard_short_version,
+            'CFBundleVersion': '%d.%d.%d' % PICARD_VERSION[:3],
+            'CFBundleShortVersionString': PICARD_VERSION.to_string(short=True),
             'LSMinimumSystemVersion': '10.12',
         }
         app = BUNDLE(coll,

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -17,7 +17,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import re
+from picard.version import (
+    Version,
+    VersionError,
+)
 
 
 PICARD_ORG_NAME = "MusicBrainz"
@@ -25,7 +28,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = (2, 3, 0, 'alpha', 1)
+PICARD_VERSION = Version(2, 3, 0, 'alpha', 1)
 
 
 # optional build version
@@ -34,56 +37,21 @@ PICARD_VERSION = (2, 3, 0, 'alpha', 1)
 PICARD_BUILD_VERSION_STR = ""
 
 
-class VersionError(Exception):
-    pass
-
-
 def version_to_string(version, short=False):
     if len(version) != 5:
         raise VersionError("Length != 5")
-    if version[3] not in ('final', 'dev', 'alpha', 'beta', 'rc'):
-        raise VersionError("Should be either 'final', 'dev', 'alpha', 'beta' or 'rc'")
-    _version = []
-    for p in version:
-        try:
-            n = int(p)
-        except ValueError:
-            n = p
-        _version.append(n)
-    if short and _version[3] in ('alpha', 'beta'):
-        _version[3] = _version[3][:1]
-    version = tuple(_version)
-    if short and version[3] == 'final':
-        if version[2] == 0:
-            version_str = '%d.%d' % version[:2]
-        else:
-            version_str = '%d.%d.%d' % version[:3]
-    elif short and version[3] in ('a', 'b', 'rc'):
-        version_str = '%d.%d.%d%s%d' % version
-    else:
-        version_str = '%d.%d.%d.%s%d' % version
-    return version_str
-
-
-_version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?$")
+    if not isinstance(version, Version):
+        version = Version(*version)
+    return version.to_string(short=short)
 
 
 def version_from_string(version_str):
-    m = _version_re.search(version_str)
-    if m:
-        g = m.groups()
-        if g[2] is None:
-            return (int(g[0]), int(g[1]), 0, 'final', 0)
-        if g[3] is None:
-            return (int(g[0]), int(g[1]), int(g[2]), 'final', 0)
-        identifier = {'a': 'alpha', 'b': 'beta'}.get(g[3], g[3])
-        return (int(g[0]), int(g[1]), int(g[2]), identifier, int(g[4]))
-    raise VersionError("String '%s' does not match regex '%s'" % (version_str,
-                                                                  _version_re.pattern))
+    """Deprecated: Use picard.version.Version.from_string instead"""
+    return Version.from_string(version_str)
 
 
-PICARD_VERSION_STR = version_to_string(PICARD_VERSION)
-PICARD_VERSION_STR_SHORT = version_to_string(PICARD_VERSION, short=True)
+PICARD_VERSION_STR = PICARD_VERSION.to_string()
+PICARD_VERSION_STR_SHORT = PICARD_VERSION.to_string(short=True)
 if PICARD_BUILD_VERSION_STR:
     __version__ = "%s+%s" % (PICARD_VERSION_STR, PICARD_BUILD_VERSION_STR)
     PICARD_FANCY_VERSION_STR = "%s (%s)" % (PICARD_VERSION_STR_SHORT,
@@ -99,4 +67,4 @@ api_versions = [
     "2.2",
 ]
 
-api_versions_tuple = [version_from_string(v) for v in api_versions]
+api_versions_tuple = [Version.from_string(v) for v in api_versions]

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -34,7 +34,6 @@ from PyQt5 import QtCore
 from picard import (
     VersionError,
     log,
-    version_from_string,
     version_to_string,
 )
 from picard.const import (
@@ -48,6 +47,7 @@ from picard.plugin import (
     _unregister_module_extensions,
 )
 import picard.plugins
+from picard.version import Version
 
 
 _SUFFIXES = tuple(importlib.machinery.all_suffixes())
@@ -145,7 +145,7 @@ def zip_import(path):
 
 
 def _compatible_api_versions(api_versions):
-    versions = [version_from_string(v) for v in list(api_versions)]
+    versions = [Version.from_string(v) for v in list(api_versions)]
     return set(versions) & set(picard.api_versions_tuple)
 
 

--- a/picard/version.py
+++ b/picard/version.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import re
+
+
+class VersionError(Exception):
+    pass
+
+
+class Version(tuple):
+    _version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?$")
+
+    _identifiers = {
+        'dev': 0,
+        'alpha': 1,
+        'a': 1,
+        'beta': 2,
+        'b': 2,
+        'rc': 3,
+        'final': 4
+    }
+
+    def __new__(cls, major, minor, patch, identifier='final', revision=0):
+        if identifier not in cls.valid_identifiers():
+            raise VersionError("Should be either 'final', 'dev', 'alpha', 'beta' or 'rc'")
+        identifier = {'a': 'alpha', 'b': 'beta'}.get(identifier, identifier)
+        return super(Version, cls).__new__(cls, (major, minor, patch, identifier, revision))
+
+    @classmethod
+    def from_string(cls, version_str):
+        m = cls._version_re.search(version_str)
+        if m:
+            g = m.groups()
+            if g[2] is None:
+                return Version(int(g[0]), int(g[1]), 0, 'final', 0)
+            if g[3] is None:
+                return Version(int(g[0]), int(g[1]), int(g[2]), 'final', 0)
+            return Version(int(g[0]), int(g[1]), int(g[2]), g[3], int(g[4]))
+        raise VersionError("String '%s' does not match regex '%s'" % (version_str,
+                                                                      cls._version_re.pattern))
+
+    @classmethod
+    def valid_identifiers(cls):
+        return cls._identifiers.keys()
+
+    def to_string(self, short=False):
+        _version = []
+        for p in self:
+            try:
+                n = int(p)
+            except ValueError:
+                n = p
+            _version.append(n)
+        if short and _version[3] in ('alpha', 'beta'):
+            _version[3] = _version[3][:1]
+        version = tuple(_version)
+        if short and version[3] == 'final':
+            if version[2] == 0:
+                version_str = '%d.%d' % version[:2]
+            else:
+                version_str = '%d.%d.%d' % version[:3]
+        elif short and version[3] in ('a', 'b', 'rc'):
+            version_str = '%d.%d.%d%s%d' % version
+        else:
+            version_str = '%d.%d.%d.%s%d' % version
+        return version_str
+
+    @property
+    def sortkey(self):
+        return self[:3] + (self._identifiers.get(self[3], 0), self[4])
+
+    def __str__(self):
+        return self.to_string()
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey < other.sortkey
+
+    def __le__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey <= other.sortkey
+
+    def __gt__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey > other.sortkey
+
+    def __ge__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey >= other.sortkey
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey == other.sortkey
+
+    def __ne__(self, other):
+        if not isinstance(other, Version):
+            other = Version(*other)
+        return self.sortkey != other.sortkey
+
+    def __hash__(self):
+        return super().__hash__()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -27,10 +27,6 @@ import unittest
 from test.picardtestcase import PicardTestCase
 
 import picard
-from picard import (
-    VersionError,
-    version_from_string,
-)
 from picard.const import USER_PLUGIN_DIR
 from picard.plugin import (
     _PLUGIN_MODULE_PREFIX,
@@ -41,6 +37,10 @@ from picard.pluginmanager import (
     PluginManager,
     _compatible_api_versions,
     _plugin_name_from_path,
+)
+from picard.version import (
+    Version,
+    VersionError,
 )
 
 
@@ -123,7 +123,7 @@ class TestPicardPluginManager(TestPicardPluginsCommon):
 
         # use first element from picard.api_versions, it should be compatible
         api_versions = picard.api_versions[:1]
-        expected = set([version_from_string(v) for v in api_versions])
+        expected = set([Version.from_string(v) for v in api_versions])
         result = _compatible_api_versions(api_versions)
         self.assertEqual(result, expected)
 

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -99,6 +99,12 @@ class VersionsTest(PicardTestCase):
             b = api_versions_tuple[i+1]
             self.assertLess(a, b)
 
+    def test_version_invalid_new(self):
+        self.assertRaises(VersionError, Version, '1', 'a')
+        self.assertRaises(VersionError, Version, None, 0)
+        self.assertRaises(VersionError, Version, 1, 0, 0, 'final', None)
+        self.assertRaises(VersionError, Version, 1, 0, 0, 'invalid', 0)
+
     def test_sortkey(self):
         self.assertEqual((2, 1, 3, 4, 2), Version(2, 1, 3, 'final', 2).sortkey)
         self.assertEqual((2, 0, 0, 1, 0), Version(2, 0, 0, 'a', 0).sortkey)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
The version identifier was previously compared alphabetically, which fails for e.g. "dev" < "alpha".

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
With the recent addition of (again) supporting alpha, beta and rc releases the comparison of the version identifier broke. This would lead to warnings such as "Warning: config file 2.3.0.dev1 was created by a more recent version of Picard (current is 2.3.0.alpha1)".
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Implement proper version comparison by introducing a Version class (inherited from tuple), which implements proper comparison operators. Also moved the logic fro to and from string conversion there.

`picard.version_from_string` is now considered obsolete, but I did not yet remove it as it might be used by plugin code. `version_to_string` is still useful when one has only a version tuple.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
