### PR TITLE
PICARD-1700: Fix crash on PyQt >= 5.14 on cover art context menu

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -538,7 +538,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         if not menu.isEmpty():
             menu.addSeparator()
 
-        load_image_behavior_group = QtWidgets.QActionGroup(self.parent, exclusive=True)
+        load_image_behavior_group = QtWidgets.QActionGroup(self.parent)
         action = load_image_behavior_group.addAction(QtWidgets.QAction(_('Replace front cover art on drop'), self.parent, checkable=True))
         action.triggered.connect(partial(self.set_load_image_behavior, behavior='replace'))
         if config.setting["load_image_behavior"] == 'replace':

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -539,13 +539,18 @@ class CoverArtBox(QtWidgets.QGroupBox):
             menu.addSeparator()
 
         load_image_behavior_group = QtWidgets.QActionGroup(self.parent)
-        action = load_image_behavior_group.addAction(QtWidgets.QAction(_('Replace front cover art on drop'), self.parent, checkable=True))
+        action = QtWidgets.QAction(_('Replace front cover art on drop'), self.parent)
+        action.setCheckable(True)
         action.triggered.connect(partial(self.set_load_image_behavior, behavior='replace'))
+        load_image_behavior_group.addAction(action)
         if config.setting["load_image_behavior"] == 'replace':
             action.setChecked(True)
         menu.addAction(action)
-        action = load_image_behavior_group.addAction(QtWidgets.QAction(_('Append front cover art on drop'), self.parent, checkable=True))
+
+        action = QtWidgets.QAction(_('Append front cover art on drop'), self.parent)
+        action.setCheckable(True)
         action.triggered.connect(partial(self.set_load_image_behavior, behavior='append'))
+        load_image_behavior_group.addAction(action)
         if config.setting["load_image_behavior"] == 'append':
             action.setChecked(True)
         menu.addAction(action)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -131,11 +131,12 @@ class VerbosityMenu(QtWidgets.QMenu):
         self.action_group = QtWidgets.QActionGroup(self)
         self.actions = {}
         for level, feat in log.levels_features.items():
-            act = QtWidgets.QAction(_(feat.name), self, checkable=True)
-            act.triggered.connect(partial(self.verbosity_changed.emit, level))
-            self.action_group.addAction(act)
-            self.addAction(act)
-            self.actions[level] = act
+            action = QtWidgets.QAction(_(feat.name), self)
+            action.setCheckable(True)
+            action.triggered.connect(partial(self.verbosity_changed.emit, level))
+            self.action_group.addAction(action)
+            self.addAction(action)
+            self.actions[level] = action
 
     def set_verbosity(self, level):
         self.actions[level].setChecked(True)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -129,7 +129,6 @@ class VerbosityMenu(QtWidgets.QMenu):
         super().__init__(parent=parent)
 
         self.action_group = QtWidgets.QActionGroup(self)
-        self.action_group .setExclusive(True)
         self.actions = {}
         for level, feat in log.levels_features.items():
             act = QtWidgets.QAction(_(feat.name), self, checkable=True)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
In PyQt 5.14 the exclusive parameter for QActionGroup is no longer available. Also QActionGroup is exclusive by default in Qt5 (it even was in Qt4), so there is no need to set this (see https://doc.qt.io/qt-5/qactiongroup.html#QActionGroup).
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1700
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
