### PR TITLE
PICARD-1054: Allow Qt to handle default Qt and X command line arguments 

### DIFF
--- a/org.musicbrainz.Picard.desktop
+++ b/org.musicbrainz.Picard.desktop
@@ -5,7 +5,6 @@ Exec=picard %F
 Terminal=false
 Type=Application
 StartupNotify=true
-StartupWMClass=MusicBrainz-Picard
 Icon=org.musicbrainz.Picard
 Categories=AudioVideo;Audio;AudioVideoEditing;
 MimeType=application/ogg;application/x-flac;audio/aac;audio/ac3;audio/aiff;audio/ape;audio/dsf;audio/flac;audio/midi;audio/mp4;audio/mpeg;audio/mpeg4;audio/mpg;audio/ogg;audio/vorbis;audio/x-aac;audio/x-aiff;audio/x-ape;audio/x-flac;audio/x-flac+ogg;audio/x-m4a;audio/x-midi;audio/x-mp3;audio/x-mpc;audio/x-mpeg;audio/x-ms-wma;audio/x-ms-wmv;audio/x-musepack;audio/x-oggflac;audio/x-speex;audio/x-speex+ogg;audio/x-tak;audio/x-tta;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-wma;video/x-ms-asf;video/x-theora;video/x-wmv;

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -888,6 +888,14 @@ def process_picard_args():
     parser = argparse.ArgumentParser(
         epilog="If one of the filenames begins with a hyphen, use -- to separate the options from the filenames."
     )
+    # Qt default arguments. Parse them so Picard does not interpret the
+    # arguments as file names to load.
+    parser.add_argument("-style", nargs=1, help=argparse.SUPPRESS)
+    parser.add_argument("-stylesheet", nargs=1, help=argparse.SUPPRESS)
+    # Same for default X arguments
+    parser.add_argument("-display", nargs=1, help=argparse.SUPPRESS)
+
+    # Picard specific arguments
     parser.add_argument("-c", "--config-file", action='store',
                         default=None,
                         help="location of the configuration file")

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -143,9 +143,7 @@ class Tagger(QtWidgets.QApplication):
         if not IS_MACOS and not IS_HAIKU:
             self.setStyle('Fusion')
 
-        # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
-        # can use it to look up the app
-        super().__init__(['MusicBrainz-Picard'] + unparsed_args)
+        super().__init__(sys.argv)
         self.__class__.__instance = self
         config._setup(self, picard_args.config_file)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixes Picard's handling of argv and allows passing the default Qt command line arguments (e.g. `-style [Stylename]`)
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The current handling of argv caused some issues. The QApplication classes expect a full argv to be passed to them, but we only passed on the remaining args, which caused a few issues.

- argv[0] is supposed to be the path to the executed binary, but it wasn't for us. This breaks e.g. `QCoreApplication.applicationFilePath` and also was what caused us to need to include this `StartupWMClass` workaround
- Command line arguments for Qt and/or X which require an additional keyword (e.g. `-style` or `-desktop`) where broken. E.g. if passing `-style Windows` then "Windows" would be interpreted as a filename, and Qt would only receive `-style` without parameter.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1054
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- Properly pass complete argv to `QApplication`
- Add specific support for parameterized default Qt/X command line arguments, so they are handled correctly and not interpreted as filenames. These parameters are hidden from help for now, but are available for users knowing about standard parameters.
- Remove StartupWMClass workaround
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
