### PR TITLE
PICARD-1625: Keep UI responsive when clustering, moving or matching large amount of files

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -521,6 +521,7 @@ class Album(DataObject, Item):
                         similarity=track.metadata.compare(file.orig_metadata),
                         track=track
                     )
+                    QtCore.QCoreApplication.processEvents()
 
             no_match = SimMatchAlbum(similarity=-1, track=self.unmatched_files)
             best_match = find_best_match(candidates, no_match)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -447,9 +447,11 @@ class Tagger(QtWidgets.QApplication):
         if isinstance(target, (Track, Cluster)):
             for file in files:
                 file.move(target)
+                QtCore.QCoreApplication.processEvents()
         elif isinstance(target, File):
             for file in files:
                 file.move(target.parent)
+                QtCore.QCoreApplication.processEvents()
         elif isinstance(target, Album):
             self.move_files_to_album(files, album=target)
         elif isinstance(target, ClusterList):
@@ -829,6 +831,7 @@ class Tagger(QtWidgets.QApplication):
             cluster = self.load_cluster(name, artist)
             for file in sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')):
                 file.move(cluster)
+                QtCore.QCoreApplication.processEvents()
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -712,13 +712,16 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         # text/uri-list
         urls = data.urls()
         if urls:
-            self.drop_urls(urls, target)
+            # Use QTimer.singleShot to run expensive processing outside of the drop handler.
+            QtCore.QTimer.singleShot(0, partial(self.drop_urls, urls, target))
             handled = True
         # application/picard.album-list
         albums = data.data("application/picard.album-list")
         if albums:
             albums = [self.tagger.load_album(id) for id in bytes(albums).decode().split("\n")]
-            self.tagger.move_files(self.tagger.get_files_from_objects(albums), target)
+            # Use QTimer.singleShot to run expensive processing outside of the drop handler.
+            QtCore.QTimer.singleShot(0, partial(self.tagger.move_files,
+                self.tagger.get_files_from_objects(albums), target))
             handled = True
         return handled
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Make sure the UI stays responsive while clustering, moving large amount of files in the tree view or while matching files to releases.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
While matching files to releases Picard becomes unresponsive. This is especially noticeable on releases with a huge number of tracks like e.g. https://musicbrainz.org/release/44f53f7b-7a0c-4796-b06c-1077327b13ff

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1625
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Keep the UI responsive by frequently calling `QCoreApplication.processEvents()` while processing a list of files.

Also ensure the drop handlers finish fast and the actual processing is done afterwards by using `QtCore.QTimer.singleShot()`. If this is not done drag and drop will not work until the operation has fully completed.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

I also had tried to instead run the file moving in a separate thread, see https://github.com/phw/picard/commit/e445812423b23e6dd8781db5967efc8d19d03cc8 . But this did not work very well. For one it had caused some bugs where randomly I got stray file items duplicated in the tree view, where the duplicate could neither be removed nor moved again. Also the perceived performance was even worse.

I think this is because a large amount of the work done here is actually in the UI and needs to run on the main thread. Because of this in the threaded code I force many of the functions in itemviews which got called during the update to run on the main thread. Running on the main thread involves sending an event which then gets handled on main. Overall this was a solution that is tricky to get right and with unsatisfying performance.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
