### PR TITLE
PICARD-1589: Support language for ID3 comments.

### DIFF
--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -17,6 +17,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import re
+
+
 TAG_NAMES = {
     'acoustid_fingerprint': N_('AcoustID Fingerprint'),
     'acoustid_id': N_('AcoustID'),
@@ -32,7 +35,7 @@ TAG_NAMES = {
     'barcode': N_('Barcode'),
     'bpm': N_('BPM'),
     'catalognumber': N_('Catalog Number'),
-    'comment:': N_('Comment'),
+    'comment': N_('Comment'),
     'compilation': N_('Compilation (iTunes)'),
     'composer': N_('Composer'),
     'composersort': N_('Composer Sort Order'),
@@ -127,3 +130,19 @@ def display_tag_name(name):
         if desc:
             return '%s [%s]' % (_(TAG_NAMES.get(name, name)), desc)
     return _(TAG_NAMES.get(name, name))
+
+
+RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
+def parse_comment_tag(name):  # noqa: E302
+    """
+    Parses a tag name like "comment:XXX:desc", where XXX is the language.
+    If language is not set ("comment:desc") "eng" is assumed as default.
+    Returns a (lang, desc) tuple.
+    """
+    desc = name.split(':', 1)[1]
+    lang = 'eng'
+    match = RE_COMMENT_LANG.match(desc)
+    if match:
+        lang = match.group(1)
+        desc = desc[4:]
+    return (lang, desc)

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -87,6 +87,7 @@ TAGS = {
     'catalognumber': 'Foo',
     'comment:': 'Foo',
     'comment:foo': 'Foo',
+    'comment:deu:foo': 'Foo',
     'compilation': '1',
     'composer': 'Foo',
     'composersort': 'Foo',

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -101,14 +101,18 @@ class CommonId3Tests:
         def test_comment_delete(self):
             metadata = Metadata(self.tags)
             metadata['comment:bar'] = 'Foo'
+            metadata['comment:XXX:withlang'] = 'Foo'
             original_metadata = save_and_load_metadata(self.filename, metadata)
             del metadata['comment:bar']
+            del metadata['comment:XXX:withlang']
             new_metadata = save_and_load_metadata(self.filename, metadata)
 
             self.assertIn('comment:foo', original_metadata)
             self.assertIn('comment:bar', original_metadata)
+            self.assertIn('comment:XXX:withlang', original_metadata)
             self.assertIn('comment:foo', new_metadata)
             self.assertNotIn('comment:bar', new_metadata)
+            self.assertNotIn('comment:XXX:withlang', new_metadata)
 
         @skipUnlessTestfile
         def test_id3v23_simple_tags(self):

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from test.picardtestcase import PicardTestCase
+
+from picard.util.tags import (
+    display_tag_name,
+    parse_comment_tag,
+)
+
+
+class UtilTagsTest(PicardTestCase):
+    def test_display_tag_name(self):
+        self.assertEqual('Artist', display_tag_name('artist'))
+        self.assertEqual('Lyrics', display_tag_name('lyrics:'))
+        self.assertEqual('Comment [Foo]', display_tag_name('comment:Foo'))
+
+    def test_parse_comment_tag(self):
+        self.assertEqual(('XXX', 'foo'), parse_comment_tag('comment:XXX:foo'))
+        self.assertEqual(('eng', 'foo'), parse_comment_tag('comment:foo'))


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Adds syntax `comment:{language}:{description}` in addition to existing `comment:{language}:{description}` for comment tag names.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
ID3 allows saving a language for comment tags. Currently Picard is hard coded to always write "eng", and most of the files seen in the wild seem to default to "eng".

An exception is MediaMonkey, which allows the user to write "custom" tags. Those custom tags get stored to COMM frames with a description on "Songs-DB_Custom1", "Songs-DB_Custom2" etc. and language set to "XXX".

Picard not supporting this currently has two affects:
- Trying to create such a tag with Picard fails. $set(comment:Songs-DB_Custom1,test) will write a COMM tag with proper description, but language set to "eng".
- Loading such a file will basically duplicate the tag. The existing tag with lang=XXX stays and a new tag with lang=eng gets written.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1589
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
This adds proper support for the syntax `comment:{language}:{description}` for ID3. The language will be set accordingly, but still default to `eng`.

For Vorbis and Ape tags this works transparently, as the additional language part will just be treated as an extended description part. So e.g. the tag `comment:deu:foo` will be saved as:

```
COMMENT=The comment (deu:foo)
```

Loading this back is fine.

For ASF and MP4 this does currently also not change anything in behavior, as these do neither support the `comment:desc` syntax currently nor do they properly save more than one comment. This needs to be fixed separately, see PICARD-587.




<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
