### PR TITLE
PICARD-1712: use QtGui.QKeySequence.Delete for remove albums/files shortcut

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -560,7 +560,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.view_log_action = QtWidgets.QAction(_("View &Error/Debug Log"), self)
         self.view_log_action.triggered.connect(self.show_log)
         # TR: Keyboard shortcut for "View Error/Debug Log"
-        self.view_log_action.setShortcut(QtGui.QKeySequence(_("Ctrl+E")))
+        self.view_log_action.setShortcut(QtGui.QKeySequence(_("Ctrl+G")))
 
         self.view_history_action = QtWidgets.QAction(_("View Activity &History"), self)
         self.view_history_action.triggered.connect(self.show_history)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -407,10 +407,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.add_files_action.setShortcut(QtGui.QKeySequence.Open)
         self.add_files_action.triggered.connect(self.add_files)
 
-        self.add_directory_action = QtWidgets.QAction(icontheme.lookup('folder'), _("A&dd Folder..."), self)
+        self.add_directory_action = QtWidgets.QAction(icontheme.lookup('folder'), _("Add Fold&er..."), self)
         self.add_directory_action.setStatusTip(_("Add a folder to the tagger"))
         # TR: Keyboard shortcut for "Add Directory..."
-        self.add_directory_action.setShortcut(QtGui.QKeySequence(_("Ctrl+D")))
+        self.add_directory_action.setShortcut(QtGui.QKeySequence(_("Ctrl+E")))
         self.add_directory_action.triggered.connect(self.add_directory)
 
         if self.show_close_window:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -438,6 +438,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.remove_action = QtWidgets.QAction(icontheme.lookup('list-remove'), _("&Remove"), self)
         self.remove_action.setStatusTip(_("Remove selected files/albums"))
+        self.remove_action.setShortcut(QtGui.QKeySequence.Delete)
         self.remove_action.setEnabled(False)
         self.remove_action.triggered.connect(self.remove)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

There is no keyboard shortcut for Remove albums/files action, and Ctrl+D is already used for Add Folder.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1712
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Use Ctrl+E as shortcut, and `e` as accelerator for Add Folder
Use Del/Ctrl+D for Remove action

See https://doc.qt.io/qt-5/qkeysequence.html
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
