### PR TITLE
PICARD-239: Handle tags like "comment" and "comment:" the same

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -161,11 +161,10 @@ class APEv2File(File):
                             metadata["totaldiscs"] = disc[1]
                             value = disc[0]
                     elif name == 'performer' or name == 'comment':
-                        name = name + ':'
                         if value.endswith(')'):
                             start = value.rfind(' (')
                             if start > 0:
-                                name += value[start + 2:-1]
+                                name += ':' + value[start + 2:-1]
                                 value = value[:start]
                     elif name in self.__rtranslate:
                         name = self.__rtranslate[name]

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -131,7 +131,7 @@ class ASFFile(File):
         'discsubtitle': 'WM/SetSubTitle',
         'tracknumber': 'WM/TrackNumber',
         'discnumber': 'WM/PartOfSet',
-        'comment:': 'Description',
+        'comment': 'Description',
         'genre': 'WM/Genre',
         'bpm': 'WM/BeatsPerMinute',
         'key': 'WM/InitialKey',

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -415,7 +415,7 @@ class ID3File(File):
                         tipl.people.append([role, value])
                     else:
                         tmcl.people.append([role, value])
-            elif name.startswith('comment:'):
+            elif name == 'comment' or name.startswith('comment:'):
                 (lang, desc) = parse_comment_tag(name)
                 if desc.lower()[:4] == 'itun':
                     tags.delall('COMM:' + desc)

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -139,7 +139,10 @@ def parse_comment_tag(name):  # noqa: E302
     If language is not set ("comment:desc") "eng" is assumed as default.
     Returns a (lang, desc) tuple.
     """
-    desc = name.split(':', 1)[1]
+    try:
+        desc = name.split(':', 1)[1]
+    except IndexError:
+        desc = ''
     lang = 'eng'
     match = RE_COMMENT_LANG.match(desc)
     if match:

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -85,7 +85,7 @@ TAGS = {
     'barcode': 'Foo',
     'bpm': '80',
     'catalognumber': 'Foo',
-    'comment:': 'Foo',
+    'comment': 'Foo',
     'comment:foo': 'Foo',
     'comment:deu:foo': 'Foo',
     'compilation': '1',

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -131,6 +131,22 @@ class MetadataTest(PicardTestCase):
         self.assertIn("single1", self.metadata)
         self.assertNotIn("single1", self.metadata.deleted_tags)
 
+    def test_normalize_tag(self):
+        self.assertEqual('sometag', Metadata.normalize_tag('sometag'))
+        self.assertEqual('sometag', Metadata.normalize_tag('sometag:'))
+        self.assertEqual('sometag', Metadata.normalize_tag('sometag::'))
+        self.assertEqual('sometag:desc', Metadata.normalize_tag('sometag:desc'))
+
+    def test_metadata_tag_trailing_colon(self):
+        self.metadata['tag:'] = 'Foo'
+        self.assertIn('tag', self.metadata)
+        self.assertIn('tag:', self.metadata)
+        self.assertEqual('Foo', self.metadata['tag'])
+        self.assertEqual('Foo', self.metadata['tag:'])
+        del self.metadata['tag']
+        self.assertNotIn('tag', self.metadata)
+        self.assertNotIn('tag:', self.metadata)
+
     def test_metadata_copy(self):
         m = Metadata()
         m["old"] = "old-value"

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -16,3 +16,4 @@ class UtilTagsTest(PicardTestCase):
     def test_parse_comment_tag(self):
         self.assertEqual(('XXX', 'foo'), parse_comment_tag('comment:XXX:foo'))
         self.assertEqual(('eng', 'foo'), parse_comment_tag('comment:foo'))
+        self.assertEqual(('eng', ''), parse_comment_tag('comment'))


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Some of Picard's tag names allow an additional description separated by a colon, e.g. "comment:desc". In case the description part is empty and the tag ends on a colon this is now treated the same as without any colon. So "lyrics" and "lyrics:" are the same tag.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-239
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Change `Metadata` to treat tags ending on a colon behave the same as the same without the colon.

Handling this in Metadata makes this change immediately available in scripting and to all formats. Script using both forms will still work. Only minor changes where necessary to the formats themselves.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
