### PR TITLE
PICARD-1646: Consider release types for AcoustId results

### DIFF
--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -26,6 +26,10 @@ def _make_releases_node(recording):
             release_mb['id'] = release['id']
             release_mb['release-group'] = {}
             release_mb['release-group']['id'] = release_group['id']
+            if 'type' in release_group:
+                release_mb['release-group']['primary-type'] = release_group['type']
+            if 'secondarytypes' in release_group:
+                release_mb['release-group']['secondary-types'] = release_group['secondarytypes']
             if 'title' in release:
                 release_mb['title'] = release['title']
             else:

--- a/test/data/ws_data/acoustid.json
+++ b/test/data/ws_data/acoustid.json
@@ -8,8 +8,11 @@
     "duration": 225,
     "releasegroups": [
         {
-            "type": "Album",
             "id": "c24e5416-cd2e-4cff-851b-5faa78db98a2",
+            "type": "Album",
+            "secondarytypes": [
+                "Compilation"
+            ],
             "releases": [
                 {
                     "track_count": 12,

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -44,7 +44,11 @@ class RecordingTest(AcoustIDTest):
         self.assertEqual(release['media'], [{'format': 'CD', 'track-count': 12}])
         self.assertEqual(release['title'], 'x')
         self.assertEqual(release['id'], 'a2b25883-306f-4a53-809a-a234737c209d')
-        self.assertEqual(release['release-group'], {'id': 'c24e5416-cd2e-4cff-851b-5faa78db98a2'})
+        self.assertEqual(release['release-group'], {
+            'id': 'c24e5416-cd2e-4cff-851b-5faa78db98a2',
+            'primary-type': 'Album',
+            'secondary-types': ['Compilation']
+        })
         self.assertEqual(release['country'], 'XE')
         self.assertEqual(artist_credit['artist'], {'sort-name': 'Ed Sheeran',
                                                    'name': 'Ed Sheeran',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Make the release primary and secondary type as provided by AcoustId available to the matching.

This actually makes the preferred release types work for AcoustId lookups.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1646
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Convert release types returned from AcoustID into proper MB structure.

I tested this with https://www.youtube.com/watch?v=Nw_rbZ5kJU8 (which is the track also used in the ticket) and some local files. With the change it is possible switching between EP, Album and Compilation result for this recording by changing the weighting for preferred release types.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
