### PR TITLE
PICARD-1716: Add script functions for strings, multi-value variables, and loops

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -1054,7 +1054,6 @@ def func_map_multi(parser,
 
     Returns the updated multi-value variable.
     """
-    loop_count = 0
     multi_value = _get_multi_values(parser, multi, separator)
     for loop_count, value in enumerate(multi_value, 1):
         func_set(parser, '_loop_count', str(loop_count))

--- a/picard/script.py
+++ b/picard/script.py
@@ -1004,8 +1004,8 @@ def func_foreach_multi(parser,
     """
     loop_count = 0
     multi_value = _get_multi_values(parser, multi, separator)
-    for value in multi_value:
-        loop_count += 1
+    for index, value in enumerate(multi_value):
+        loop_count = index + 1
         func_set(parser, '_loop_count', str(loop_count))
         func_set(parser, '_loop_value', str(value))
         loop_code.eval(parser)
@@ -1021,9 +1021,9 @@ def func_while_loop(parser, condition, loop_code):
         condition: Script code to check before each iteration through the loop.
         loop_code: Script code to be processed on each iteration.
     """
-    runaway_check = 1000
-    loop_count = 0
     if condition and loop_code:
+        runaway_check = 1000
+        loop_count = 0
         while condition.eval(parser) and loop_count < runaway_check:
             loop_count += 1
             func_set(parser, '_loop_count', str(loop_count))
@@ -1051,11 +1051,11 @@ def func_map_multi(parser,
     """
     loop_count = 0
     multi_value = _get_multi_values(parser, multi, separator)
-    for value in multi_value:
-        loop_count += 1
+    for index, value in enumerate(multi_value):
+        loop_count = index + 1
         func_set(parser, '_loop_count', str(loop_count))
         func_set(parser, '_loop_value', str(value))
-        multi_value[loop_count - 1] = str(loop_code.eval(parser))
+        multi_value[index] = str(loop_code.eval(parser))
     func_unset(parser, '_loop_count')
     func_unset(parser, '_loop_value')
     if not isinstance(separator, str):

--- a/picard/script.py
+++ b/picard/script.py
@@ -1058,7 +1058,7 @@ def func_map_multi(parser,
         multi_value[loop_count - 1] = str(loop_code.eval(parser))
     func_unset(parser, '_loop_count')
     func_unset(parser, '_loop_value')
-    if type(separator) is not str:
+    if not isinstance(separator, str):
         separator = separator.eval(parser)
     return separator.join(multi_value)
 

--- a/picard/script.py
+++ b/picard/script.py
@@ -910,6 +910,143 @@ def func_is_video(parser):
         return ""
 
 
+def func_find_str(parser, haystack, needle):
+    """Find the location of the first occurrence of one string within another.
+
+    Arguments:
+        haystack {str} -- The string to search
+        needle {str} -- The substring to find
+
+    Returns:
+        str -- Returns the zero-based index of the first occurrance of needle in haystack, or -1 if needle was not found.
+    """
+    return str(haystack.find(needle))
+
+
+def func_reverse_str(parser, text):
+    """Returns 'text' in reverse order.
+
+    Arguments:
+        text {str} -- Text to be processed
+
+    Returns:
+        str -- Text in reverse order.
+    """
+    return text[::-1]
+
+
+def func_substr(parser, text, start_index, end_index):
+    """Extract a specified portion of a string.
+
+    Arguments:
+        text {str} -- The string from which the extract will be made.
+        start_index {int} -- Index of the first character to extract.
+        end_index {int} -- Index of the first character that will not be extracted.
+
+    Returns:
+        str -- Returns the substring beginning with the character at the start index,
+               up to (but not including) the character at the end index.  The first
+               character is at index number 0.  If the start index is left blank, it
+               defaults to the first character in the string.  If the end index is
+               left blank, it defaults to the number of characters in the string.
+               If either index is negative, it is subtracted from the total number of
+               characters in the string to provide the index used.
+    """
+    _start = int(start_index) if start_index else None
+    _end = int(end_index) if end_index else None
+    return text[_start:_end]
+
+
+def func_get_multi_item(parser, multi, item_index, separator=MULTI_VALUED_JOINER):
+    """Returns value of the item at the specified index in the multi-value variable.  Index values are zero-based.
+
+    Arguments:
+        multi {multi-value} -- The multi-value from which the item is to be retrieved.
+        item_index {int} -- The zero-based index of the item to be retrieved.
+
+    Returns:
+        str -- Returns value of the item at the specified index in the multi-value variable.  Index values are zero-based.
+    """
+    if item_index:
+        _index = int(item_index.eval(parser))
+    else:
+        return ''
+    _multi = _get_multi_values(parser, multi, separator)
+    try:
+        return str(_multi[_index])
+    except IndexError:
+        return ''
+
+
+def func_foreach_multi_item(parser, multi, loop_code, _loop_value="_loop_value", _loop_count="_loop_count", separator=MULTI_VALUED_JOINER):
+    """Iterates over each element found in the specified multi-value variable, executing the specified code.
+    For each loop, the element value is first stored in the tag specified by _loop_value and the count is
+    stored in the tag specified by _loop_count.  This allows the element or count value to be accessed within
+    the code script.
+
+    Arguments:
+        multi {multi-value} -- The multi-value to be iterated.
+        loop_code {str} -- Script code to be processed on each iteration.
+
+    Keyword Arguments:
+        _loop_value {str} -- Tag name to use for the element for the current loop (default: {"_loop_value"})
+        _loop_count {str} -- Tag name to use for the count of the current loop (default: {"_loop_count"})
+    """
+    loop_count = 0
+    _multi = _get_multi_values(parser, multi, separator)
+    for value in _multi:
+        loop_count += 1
+        func_set(parser, _loop_count, str(loop_count))
+        func_set(parser, _loop_value, str(value))
+        loop_code.eval(parser)
+    func_unset(parser, _loop_count)
+    func_unset(parser, _loop_value)
+    return ''
+
+
+def func_for_loop(parser, name, start, end, increment, loop_code):
+    """Standard Python 'for' loop.
+
+    Sets the value of name to the start value (integer) and loops through the specified code until the value
+    of name is greater than or equal to the end value (integer).  At the end of each loop, the value of name is
+    incremented by the specified increment value (integer).
+
+    Arguments:
+        name {str} -- Tag name to use for the loop count.  This can be accessed within the code block.
+        start {int} -- The initial value for the loop counter.
+        end {int} -- The value at which the loop exits.
+        increment {int} -- The value by which the loop count variable is incremented for each loop.
+        loop_code {str} -- Script code to be processed on each iteration.
+    """
+    if name and start and end and increment and loop_code:
+        _count = int(start.eval(parser))
+        _end = int(end.eval(parser))
+        _inc = int(increment.eval(parser))
+        _name = str(name.eval(parser))
+        if _inc > 0:
+            while _count < _end:
+                func_set(parser, _name, str(_count))
+                loop_code.eval(parser)
+                _count += _inc
+            func_unset(parser, _name)
+    return ''
+
+
+def func_while_loop(parser, condition, loop_code):
+    """Standard Python 'while' loop.  Also includes a runaway check to limit the maximum number of iterations.
+
+    Arguments:
+        condition {str} -- Script code to check before each iteration through the loop.
+        loop_code {str} -- Script code to be processed on each iteration.
+    """
+    runaway_check = 1000
+    if condition and loop_code:
+        while condition.eval(parser) and runaway_check:
+            loop_code.eval(parser)
+            runaway_check -= 1
+    return ''
+
+
 register_script_function(func_if, "if", eval_args=False)
 register_script_function(func_if2, "if2", eval_args=False)
 register_script_function(func_noop, "noop", eval_args=False)
@@ -967,3 +1104,10 @@ register_script_function(func_ne_any, "ne_any", check_argcount=False)
 register_script_function(func_title, "title")
 register_script_function(func_is_audio, "is_audio")
 register_script_function(func_is_video, "is_video")
+register_script_function(func_find_str, "find")
+register_script_function(func_reverse_str, "reverse")
+register_script_function(func_substr, "substr")
+register_script_function(func_get_multi_item, "get_multi_item", eval_args=False)
+register_script_function(func_foreach_multi_item, "foreach", eval_args=False)
+register_script_function(func_for_loop, "for", eval_args=False)
+register_script_function(func_while_loop, "while", eval_args=False)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -756,6 +756,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,)", "", context)
         self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,10+1)", "", context)
         self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,a)", "", context)
+        # Tests with missing inputs
+        self.assertScriptResultEquals("$get_multi(,0)", "", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,)", "", context)
         # Tests with invalid number of arguments
         areg = r"^Wrong number of arguments for \$get_multi: Expected between 2 and 3, "
         with self.assertRaisesRegex(ScriptError, areg):
@@ -780,6 +783,11 @@ class ScriptParserTest(PicardTestCase):
         # Tests with static inputs
         context["output"] = "Output:"
         self.assertScriptResultEquals("$foreach(First:A; Second:B; Third:C,$set(output,%output% %_loop_count%=%_loop_value%))%output%", loop_output, context)
+        # Tests with missing inputs
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(,$set(output,%output% %_loop_count%=%_loop_value%))%output%", "Output: 1=", context)
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(First:A; Second:B; Third:C,)%output%", "Output:", context)
         # Tests with separator override
         context["output"] = "Output:"
         self.assertScriptResultEquals("$foreach(First:A; Second:B; Third:C,$set(output,%output% %_loop_count%=%_loop_value%),:)%output%", alternate_output, context)
@@ -836,6 +844,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$map(%bar%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
         # Tests with static inputs
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
+        # Tests with missing inputs
+        self.assertScriptResultEquals("$map(,$upper(%_loop_count%=%_loop_value%))", "1=", context)
+        self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,)", "; ; ", context)
         # Tests with separator override
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%),:)", alternate_output, context)
         # Tests with invalid number of arguments

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -633,3 +633,216 @@ class ScriptParserTest(PicardTestCase):
         self.assertRaises(ScriptSyntaxError, self.parser.eval, '%var()%')
         self.assertRaises(ScriptSyntaxError, self.parser.eval, '$noop(()')
         self.assertRaises(ScriptSyntaxError, self.parser.eval, '\\x')
+
+    def test_cmd_find(self):
+        context = Metadata()
+        context["foo"] = "First:A; Second:B; Third:C"
+        context["bar"] = ["First:A", "Second:B", "Third:C"]
+        context["baz"] = "Second"
+        context["err"] = "Forth"
+        # Tests with context
+        self.assertScriptResultEquals("$find(%foo%,%baz%)", "9", context)
+        self.assertScriptResultEquals("$find(%bar%,%baz%)", "9", context)
+        self.assertScriptResultEquals("$find(%foo%,%bar%)", "0", context)
+        self.assertScriptResultEquals("$find(%bar%,%foo%)", "0", context)
+        self.assertScriptResultEquals("$find(%foo%,%err%)", "-1", context)
+        # Tests with static input
+        self.assertScriptResultEquals("$find(abcdef,c)", "2", context)
+        self.assertScriptResultEquals("$find(abcdef,cd)", "2", context)
+        self.assertScriptResultEquals("$find(abcdef,g)", "-1", context)
+        # Tests ends of string
+        self.assertScriptResultEquals("$find(abcdef,a)", "0", context)
+        self.assertScriptResultEquals("$find(abcdef,ab)", "0", context)
+        self.assertScriptResultEquals("$find(abcdef,f)", "5", context)
+        self.assertScriptResultEquals("$find(abcdef,ef)", "4", context)
+        # Tests case sensitivity
+        self.assertScriptResultEquals("$find(abcdef,C)", "-1", context)
+        # Tests no characters processed as wildcards
+        self.assertScriptResultEquals("$find(abcdef,.f)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,?f)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,*f)", "-1", context)
+        self.assertScriptResultEquals("$find(abc.ef,cde)", "-1", context)
+        self.assertScriptResultEquals("$find(abc?ef,cde)", "-1", context)
+        self.assertScriptResultEquals("$find(abc*ef,cde)", "-1", context)
+        # Tests missing inputs
+        self.assertScriptResultEquals("$find(,c)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,)", "0", context)
+        # Tests wrong number of arguments
+        areg = r"^Wrong number of arguments for \$find: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$find(abcdef)")
+
+    def test_cmd_reverse(self):
+        context = Metadata()
+        context["foo"] = "One; Two; Three"
+        context["bar"] = ["One", "Two", "Three"]
+        # Tests with context
+        self.assertScriptResultEquals("$reverse(%foo%)", "eerhT ;owT ;enO", context)
+        self.assertScriptResultEquals("$reverse(%bar%)", "eerhT ;owT ;enO", context)
+        # Tests with static input
+        self.assertScriptResultEquals("$reverse(One; Two; Three)", "eerhT ;owT ;enO", context)
+        # Tests with missing input
+        areg = r"^Wrong number of arguments for \$reverse: Expected exactly 1, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$reverse()")
+
+    def test_cmd_substr(self):
+        context = Metadata()
+        context["foo"] = "One; Two; Three"
+        context["bar"] = ["One", "Two", "Three"]
+        context["start"] = '5'
+        context["end"] = '9'
+        # Tests with context
+        self.assertScriptResultEquals("$substr(%foo%,%start%,%end%)", "Two;", context)
+        self.assertScriptResultEquals("$substr(%bar%,%start%,%end%)", "Two;", context)
+        # Tests with static input
+        self.assertScriptResultEquals("$substr(One; Two; Three,5,9)", "Two;", context)
+        # Tests ends of string
+        self.assertScriptResultEquals("$substr(One; Two; Three,0,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,15)", "Three", context)
+        # Tests negative index inputs
+        self.assertScriptResultEquals("$substr(One; Two; Three,-15,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,-5,15)", "Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,-10,8)", "Two", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,5,-7)", "Two", context)
+        # Tests overrun ends of string
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,25)", "Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,-25,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,-5,25)", "Three", context)
+        # Tests invalid ranges (end < start, end = start)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,9)", "", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,10)", "", context)
+        # Tests invalid index inputs
+        self.assertScriptResultEquals("$substr(One; Two; Three,10-1,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,4+2)", "Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10-1,4+2)", "One; Two; Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,a,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,0,b)", "One; Two; Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,a,b)", "One; Two; Three", context)
+        # # Tests with missing input
+        self.assertScriptResultEquals("$substr(One; Two; Three,,4)", "One;", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,10,)", "Three", context)
+        self.assertScriptResultEquals("$substr(One; Two; Three,,)", "One; Two; Three", context)
+        # Tests with missing input
+        areg = r"^Wrong number of arguments for \$substr: Expected exactly 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$substr()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$substr(abc)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$substr(abc,0)")
+
+    def test_cmd_get_multi(self):
+        context = Metadata()
+        context["foo"] = ["First:A", "Second:B", "Third:C"]
+        context["index"] = "1"
+        # Tests with context
+        self.assertScriptResultEquals("$get_multi(%foo%,%index%)", "Second:B", context)
+        # Tests with static inputs
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,0)", "First:A", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,1)", "Second:B", context)
+        # Tests separator override
+        self.assertScriptResultEquals("$get_multi(%foo%,1,:)", "A; Second", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,1,:)", "A; Second", context)
+        # Tests negative index values
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,-1)", "Third:C", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,-2)", "Second:B", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,-3)", "First:A", context)
+        # Tests out of range index values
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,10)", "", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,-4)", "", context)
+        # Tests invalid index values
+        self.assertScriptResultEquals("$get_multi(,0)", "", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,)", "", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,10+1)", "", context)
+        self.assertScriptResultEquals("$get_multi(First:A; Second:B; Third:C,a)", "", context)
+        # Tests with invalid number of arguments
+        areg = r"^Wrong number of arguments for \$get_multi: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$get_multi()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$get_multi(abc)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$get_multi(abc,0,; ,extra)")
+
+    def test_cmd_foreach(self):
+        context = Metadata()
+        context["foo"] = "First:A; Second:B; Third:C"
+        context["bar"] = ["First:A", "Second:B", "Third:C"]
+        foo_output = "Output: 1=First:A; Second:B; Third:C"
+        loop_output = "Output: 1=First:A 2=Second:B 3=Third:C"
+        alternate_output = "Output: 1=First 2=A; Second 3=B; Third 4=C"
+        # Tests with context
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(%foo%,$set(output,%output% %_loop_count%=%_loop_value%))%output%", foo_output, context)
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(%bar%,$set(output,%output% %_loop_count%=%_loop_value%))%output%", loop_output, context)
+        # Tests with static inputs
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(First:A; Second:B; Third:C,$set(output,%output% %_loop_count%=%_loop_value%))%output%", loop_output, context)
+        # Tests with separator override
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$foreach(First:A; Second:B; Third:C,$set(output,%output% %_loop_count%=%_loop_value%),:)%output%", alternate_output, context)
+        # Tests with invalid number of arguments
+        areg = r"^Wrong number of arguments for \$foreach: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$foreach()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$foreach(abc;def)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$foreach(abc:def,$noop(),:,extra)")
+
+    def test_cmd_while(self):
+        context = Metadata()
+        context["max_value"] = '5'
+        loop_output = "Output: 1 2 3 4 5"
+        # Tests with context
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,%max_value%),$set(output,%output% %_loop_count%))%output%", loop_output, context)
+        # Tests with static inputs
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,5),$set(output,%output% %_loop_count%))%output%", loop_output, context)
+        # Tests with invalid conditional input
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$while($lt(%_loop_count%,5),$set(output,%output% %_loop_count%))%output%", "Output:", context)
+        # Tests with forced conditional (runaway condition)
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$while(1,$set(output,%output% %_loop_count%))$right(%output%,4)", "1000", context)
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$while(0,$set(output,%output% %_loop_count%))$right(%output%,4)", "1000", context)
+        # Tests with missing inputs
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$while($lt(%_loop_count%,5),)%output%", "Output:", context)
+        context["output"] = "Output:"
+        self.assertScriptResultEquals("$while(,$set(output,%output% %_loop_count%))%output%", "Output:", context)
+        # Tests with invalid number of arguments
+        areg = r"^Wrong number of arguments for \$while: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$while()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$while(a)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$while(a,$noop(),extra)")
+
+    def test_cmd_map(self):
+        context = Metadata()
+        context["foo"] = "First:A; Second:B; Third:C"
+        context["bar"] = ["First:A", "Second:B", "Third:C"]
+        foo_output = "1=FIRST:A; SECOND:B; THIRD:C"
+        loop_output = "1=FIRST:A; 2=SECOND:B; 3=THIRD:C"
+        alternate_output = "1=FIRST:2=A; SECOND:3=B; THIRD:4=C"
+        # Tests with context
+        self.assertScriptResultEquals("$map(%foo%,$upper(%_loop_count%=%_loop_value%))", foo_output, context)
+        self.assertScriptResultEquals("$map(%bar%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
+        # Tests with static inputs
+        self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
+        # Tests with separator override
+        self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%),:)", alternate_output, context)
+        # Tests with invalid number of arguments
+        areg = r"^Wrong number of arguments for \$map: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$map()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$map(abc; def)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$map(abc:def,$noop(),:,extra)")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Add new functions to the scripting library.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Add new functions as:**
    * 'find' substring within string
    * string 'reverse'
    * 'substr' to extract a substring from a string
    * 'get_multi_item' to get an element from a multi-value variable
    * 'foreach' to loop through each item in a multi-value variable
    * 'for' loop
    * 'while' loop

# Problem

This additional functionality will allow users to easily access individual elements of multi-value variables, and perform repetitive code within loops that can be dynamically constructed.  Additional string functions allow searching for and extracting substrings.  Reverse can be used to find the last occurrence of a substring rather than just the first.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1716
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Suggested changes to the Scripting page of the Picard Website include:



**$find(haystack,needle)**

Find the location of the first occurrence of one string within another. Returns the zero-based index of the first occurrance of needle in haystack, or -1 if needle was not found.  Examples:

```
$findstr(abcdef,cde) returns 2
$findstr(abcdef,) returns 0
$findstr(abcdef,cdf) returns -1
```

**$reverse(text)**

Returns text in reverse order.  Example:

```
$reverse(abcde) returns 'edcba'
```

**$substr(text,start_index,end_index)**

Extract a specified portion of a string.  Returns the substring beginning with the character at the start index, up to (but not including) the character at the end index.  The first character is at index number 0.  If the start index is left blank, it defaults to the first character in the string.  If the end index is left blank, it defaults to the number of characters in the string.  If either index is negative, it is subtracted from the total number of characters in the string to provide the index used.  Examples:

```
$substr(abcde,1,2) returns 'b'
$substr(abcde,,2) returns 'ab'
$substr(abcde,1,) returns 'bcde'
$substr(abcde,,) returns 'abcde'
$substr(abcde,-2,) returns 'de'
$substr(abcde,-4,-2) returns 'bc'
```

**$get_multi_item(multi,item_index)**

Returns the value of the item at the specified index in the multi-value variable.  Index values are zero-based.  Example:

```
$get_multi_item(a; b; c; d; e,2) returns 'c'
```

**$foreach(multi,loop_code,_loop_value="_loop_value",_loop_count="_loop_count")**

Iterates over each element found in the specified multi-value variable, executing the specified code. For each loop, the element value is first stored in the tag specified by _loop_value and the count is stored in the tag specified by _loop_count.  This allows the element or count value to be accessed within the code script.  Example:

```
$foreach(isrc; year; comment; artists,$unset(%_loop_value%))
```

**$for(name,start,end,increment,loop_code)**

Standard 'for' loop.  Sets the value of name to the start value (integer) and loops through the specified code until the value of name is greater than or equal to the end value (integer).  At the end of each loop, the value of name is incremented by the specified increment value (integer).  Example:

```
$set(testing,Testing)
$for(_count,1,4,1,$set(testing,%testing% %_count%...))
```

**$while_loop(condition,loop_code)**

Standard 'while' loop.  Loops through the loop_code until the condition is no longer True.  Example:

```
$set(testing,Echo)
$while($lt($len(%testing%,20)),$set(testing,%testing% echo...))
```


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
