### PR TITLE
PICARD-1717: Backup config on upgrade

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -139,6 +139,11 @@ class Config(QtCore.QSettings):
                                   QtCore.QSettings.UserScope, PICARD_ORG_NAME,
                                   PICARD_APP_NAME, parent)
 
+        # Check if there is a config file specifically for this version
+        versioned_config_file = this._versioned_config_filename(PICARD_VERSION)
+        if os.path.isfile(versioned_config_file):
+            return cls.from_file(parent, versioned_config_file)
+
         # If there are no settings, copy existing settings from old format
         # (registry on windows systems)
         if not this.allKeys():
@@ -250,9 +255,11 @@ class Config(QtCore.QSettings):
         self.application["version"] = self._version.to_string()
         self.sync()
 
-    def _versioned_config_filename(self):
+    def _versioned_config_filename(self, version=None):
+        if not version:
+            version = self._version
         return os.path.join(os.path.dirname(self.fileName()), '%s-%s.ini' % (
-            self.applicationName(), self._version.to_string(short=True)))
+            self.applicationName(), version.to_string(short=True)))
 
 
 class Option(QtCore.QObject):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Make an update of existing config file on upgrade.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard's configuration will get updated if necessary on updates, but there is no support for downgrade. That means older versions of Picard might not be able to run with config files created by newer versions and an update might make the config unusable by older versions.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1717
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
1. When running a version that is newer then the loaded config file, make a copy of the current config with a name of `Picard-x.y.z.ini`, where `x.y.z` is the old version. This ensures old config gets saved before it is altered, giving the user the opportunity to restore the old config if needed.
2. When starting Picard and there is an existing `Picard-x.y.z.ini` file matching the current `PICARD_VERSION`, use this instead of the default `Picard.ini`. This ensures the user can easily roll back to an older Picard version or use an old and new Picard side by side.

Both of the above only is applied when using the default app config. One can still launch with the `-c` parameter to load a specific file.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
