### PR TITLE
PICARD-1719: Fix $unset must not mark tags for deletion.

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -381,6 +381,18 @@ class Metadata(MutableMapping):
         """Deprecated: use del directly"""
         del self[self.normalize_tag(name)]
 
+    def unset(self, name):
+        """Removes a tag from the metadata, but does not mark it for deletion.
+
+        Args:
+            name: name of the tag to unset
+
+        Raises:
+            KeyError: name not set
+        """
+        name = self.normalize_tag(name)
+        del self._store[name]
+
     def __iter__(self):
         return iter(self._store)
 

--- a/picard/script.py
+++ b/picard/script.py
@@ -489,10 +489,10 @@ def func_unset(parser, name):
         name = name[:-1]
         for key in list(parser.context.keys()):
             if key.startswith(name):
-                del parser.context[key]
+                parser.context.unset(key)
         return ""
     try:
-        del parser.context[name]
+        parser.context.unset(name)
     except KeyError:
         pass
     return ""

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -108,7 +108,18 @@ class MetadataTest(PicardTestCase):
         metadata_items = [(x, z) for (x, y) in self.metadata.rawitems() for z in y]
         self.assertEqual(metadata_items, list(self.metadata.items()))
 
+    def test_metadata_unset(self):
+        self.metadata.unset("single1")
+        self.assertNotIn("single1", self.metadata)
+        self.assertNotIn("single1", self.metadata.deleted_tags)
+        self.assertRaises(KeyError, self.metadata.unset, 'unknown_tag')
+
     def test_metadata_delete(self):
+        del self.metadata["single1"]
+        self.assertNotIn("single1", self.metadata)
+        self.assertIn("single1", self.metadata.deleted_tags)
+
+    def test_metadata_legacy_delete(self):
         self.metadata.delete("single1")
         self.assertNotIn("single1", self.metadata)
         self.assertIn("single1", self.metadata.deleted_tags)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -69,7 +69,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$right(abcd,x)", "")
 
     def test_cmd_set(self):
-        self.assertScriptResultEquals("$set(test,aaa)%test%", "aaa")
+        context = Metadata()
+        self.assertScriptResultEquals("$set(test,aaa)%test%", "aaa", context)
+        self.assertEqual(context['test'], 'aaa')
 
     def test_cmd_set_empty(self):
         self.assertScriptResultEquals("$set(test,)%test%", "")
@@ -463,6 +465,13 @@ class ScriptParserTest(PicardTestCase):
         self.parser.eval("$unset(performer:*)", context)
         self.assertNotIn('performer:bar', context)
         self.assertNotIn('performer:foo', context)
+
+    def test_cmd_unset(self):
+        context = Metadata()
+        context['title'] = 'Foo'
+        self.parser.eval("$unset(title)", context)
+        self.assertNotIn('title', context)
+        self.assertNotIn('title', context.deleted_tags)
 
     def test_cmd_delete(self):
         context = Metadata()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Since Picard 2.2 with commit 503b520 both $unset and $delete behave basically the same, both marking a tag for deletion.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1719
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Added an explicit `Metadata.unset` method to clear a tag without adding it to the deleted_tags array. use this for $unset.

Also added tests for $unset to avoid future regressions.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
