### PR TITLE
PICARD-1720: Add scripting $slice() with associated tests.

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -1166,3 +1166,38 @@ def func_join(parser, multi, join_phrase, separator=MULTI_VALUED_JOINER):
     join_phrase = str(join_phrase.eval(parser))
     multi_value = _get_multi_values(parser, multi, separator)
     return join_phrase.join(multi_value)
+
+
+@script_function(eval_args=False)
+def func_slice(parser, multi, start_index, end_index, separator=MULTI_VALUED_JOINER):
+    """Returns a multi-value containing a slice of the supplied multi-value.  Index values are zero-based.
+
+    Arguments:
+        parser: The ScriptParser object used to parse the script.
+        multi: The ScriptVariable/Function that evaluates to a multi-value from
+            which the slice is to be retrieved.
+        start_index: The ScriptVariable/Function that evaluates to a zero-based integer
+            index of the first item included in the slice.
+        end_index: The ScriptVariable/Function that evaluates to a zero-based integer
+            index of the first item not included in the slice.
+        separator: A string or the ScriptVariable/Function that evaluates to the
+            string used to separate the elements in the multi-value.
+
+    Returns:
+        Returns a multi-value variable containing the specified slice.
+    """
+    try:
+        start = int(start_index.eval(parser)) if start_index else None
+    except ValueError:
+        start = None
+    try:
+        end = int(end_index.eval(parser)) if end_index else None
+    except ValueError:
+        end = None
+    try:
+        multi_var = _get_multi_values(parser, multi, separator)
+        if not isinstance(separator, str):
+            separator = separator.eval(parser)
+        return separator.join(multi_var[start:end])
+    except IndexError:
+        return ''


### PR DESCRIPTION
Add a scripting function to extract (slice) a portion of a multi-value variable. An example would be to use `$setmulti(supporting_artists,$slice(%artists%,1))` to get a multi-value variable with all artists except the first.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Add new `$slice_multi()` scripting function with associated tests.**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-1720
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Added new `$slice()` scripting function with associated tests.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
