### PR TITLE
PICARD-1721: Add $join() script function and associated tests

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -1146,3 +1146,23 @@ def func_map(parser, multi, loop_code, separator=MULTI_VALUED_JOINER):
     if not isinstance(separator, str):
         separator = separator.eval(parser)
     return separator.join(multi_value)
+
+
+@script_function(eval_args=False)
+def func_join(parser, multi, join_phrase, separator=MULTI_VALUED_JOINER):
+    """Joins all elements in the specified multi-value variable, placing the join_phrase between each element.
+
+    Arguments:
+        parser: The ScriptParser object used to parse the script.
+        multi: The ScriptVariable/Function that evaluates to a multi-value whose
+            elements are to be joined.
+        join_phrase: The ScriptVariable/Function that evaluates to a string which
+            will be placed between each of the elements.
+        separator: A string or the ScriptVariable/Function that evaluates to the
+            string used to separate the elements in the multi-value.
+
+    Returns a string with the elements joined.
+    """
+    join_phrase = str(join_phrase.eval(parser))
+    multi_value = _get_multi_values(parser, multi, separator)
+    return join_phrase.join(multi_value)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Add a scripting function to join the elements of a multi-value variable into a string using a supplied join phrase. An example might be `$set(artist_string,$join(%artists%,\, ))`

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Added a `join_multi()` scripting function to join the elements of a multi-value variable into a string using a supplied join phrase.  Also added associated tests.

# Problem
 Provide a way to quickly and easily join the elements of a multi-value variable into a string, using a custom join phrase between the elements.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket : PICARD-1721
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Added a `join()` scripting function to join the elements of a multi-value variable into a string using a supplied join phrase.  Also added associated tests.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
