### PR TITLE
PICARD-1726: Fix crash when closing options while loading plugins

### DIFF
--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -44,6 +44,16 @@ class OptionsPage(QtWidgets.QWidget):
         super().__init__(*args, **kwargs)
         self.setStyleSheet(self.STYLESHEET)
 
+        # Keep track whether the options page has been destroyed to avoid
+        # trying to update deleted UI widgets after plugin list refresh.
+        self.deleted = False
+
+        # The on destroyed cannot be created as a method on this class or it will never get called.
+        # See https://stackoverflow.com/questions/16842955/widgets-destroyed-signal-is-not-fired-pyqt
+        def on_destroyed(obj=None):
+            self.deleted = True
+        self.destroyed.connect(on_destroyed)
+
     def check(self):
         pass
 

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -235,16 +235,6 @@ class PluginsOptionsPage(OptionsPage):
         self.ui.folder_open.clicked.connect(self.open_plugin_dir)
         self.ui.reload_list_of_plugins.clicked.connect(self.reload_list_of_plugins)
 
-        # Keep track whether the object has been destroyed to avoid trying to update
-        # deleted UI widgets after plugin list refresh.
-        self._deleted = False
-
-        # The on destroyed cannot be created as a method on this class or it will never get called.
-        # See https://stackoverflow.com/questions/16842955/widgets-destroyed-signal-is-not-fired-pyqt
-        def on_destroyed(obj=None):
-            self._deleted = True
-        self.destroyed.connect(on_destroyed)
-
         self.manager = self.tagger.pluginmanager
         self.manager.plugin_installed.connect(self.plugin_installed)
         self.manager.plugin_updated.connect(self.plugin_updated)
@@ -383,7 +373,7 @@ class PluginsOptionsPage(OptionsPage):
                     self.set_current_item(item, scroll=True)
 
     def _reload(self):
-        if self._deleted:
+        if self.deleted:
             return
         self._remove_all()
         self._populate()


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fix crash when closing options while loading plugins
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Closing options while the web request for plugins is running causes Picard to crash with

    RuntimeError: wrapped C/C++ object of type QTreeWidget has been deleted

That's because the C++ object has already been deleted while the callback still has a reference to the Python wrapper objects.

See also http://enki-editor.org/2014/08/23/Pyqt_mem_mgmt.html
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1726
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Work around Qt C++ objects getting deleted before request callback gets called by connecting to the destroyed signal and setting a deleted state.

This feels kind of hacky, but I could not find a clean way to otherwise detect if an object is deleted. This fixes the issue and I think is an acceptable workaround. But I would welcome any more elegant solution :)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
