### PR TITLE
PICARD-1724: Do not mark fingerprints in left pane for submission

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -530,8 +530,8 @@ class File(QtCore.QObject, Item):
         recording_id = None
         if self.parent and hasattr(self.parent, 'orig_metadata'):
             recording_id = self.parent.orig_metadata['musicbrainz_recordingid']
-        if not recording_id:
-            recording_id = self.metadata['musicbrainz_recordingid']
+            if not recording_id:
+                recording_id = self.metadata['musicbrainz_recordingid']
         self.tagger.acoustidmanager.update(self, recording_id)
         self.update_item()
 


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Since the addition of the generate AcoustID fingerprints feature it was possible that files on the left pane were marked for fingerprint submission (red fingerprint indicator icon, "Submit AcoustIDs" lighted up).

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The issue happens if a file on the left has the fingerprint generated and also has the `musicbrainz_recordingid` tag set.

But submitting fingerprints should only be done if files are properly matched to tracks on the right. They should not be marked as submittable if they are on the left, even if they have `musicbrainz_recordingid` set. This behavior is confusing, as the left is supposed to contain unmatched files with probably wrong metadata.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Only update the acoustidmanager with a recording ID if the file is matched to a proper parent
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
