### PR TITLE
Tests: ensure temporary directories and files are removed after tests

### DIFF
--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import os.path
-import shutil
-from tempfile import mkstemp
 import unittest
 
 import mutagen
@@ -189,18 +187,6 @@ class CommonTests:
 
         def copy_of_original_testfile(self):
             return self.copy_file_tmp(self.testfile_path, self.testfile_ext)
-
-        def copy_file_tmp(self, filename, ext):
-            fd, copy = mkstemp(suffix=ext)
-            self.addCleanup(self.remove_file_tmp, copy)
-            os.close(fd)
-            shutil.copy(filename, copy)
-            return copy
-
-        @staticmethod
-        def remove_file_tmp(tmpfile):
-            if os.path.isfile(tmpfile):
-                os.unlink(tmpfile)
 
     class SimpleFormatsTestCase(BaseFileTestCase):
 

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -1,8 +1,6 @@
 import base64
 import logging
 import os
-import shutil
-from tempfile import mkstemp
 
 from mutagen.flac import (
     Padding,
@@ -330,11 +328,8 @@ class OggAudioVideoFileTest(PicardTestCase):
         self.assertIsInstance(f, expected_type)
 
     def _copy_file_tmp(self, filename, ext):
-        fd, copy = mkstemp(suffix=ext)
-        self.addCleanup(os.unlink, copy)
-        os.close(fd)
-        shutil.copy(os.path.join('test', 'data', filename), copy)
-        return copy
+        path = os.path.join('test', 'data', filename)
+        return self.copy_file_tmp(path, ext)
 
 
 class OggCoverArtTest(CommonCoverArtTests.CoverArtTestCase):

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -3,7 +3,10 @@ import json
 import os
 import shutil
 import struct
-from tempfile import mkdtemp
+from tempfile import (
+    mkdtemp,
+    mkstemp,
+)
 import unittest
 
 from PyQt5 import QtCore
@@ -53,6 +56,19 @@ class PicardTestCase(unittest.TestCase):
         tmpdir = mkdtemp(suffix=self.__class__.__name__)
         self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=ignore_errors)
         return tmpdir
+
+    def copy_file_tmp(self, filepath, ext):
+        fd, copy = mkstemp(suffix=ext)
+        os.close(fd)
+        self.addCleanup(self.remove_file_tmp, copy)
+        shutil.copy(filepath, copy)
+        return copy
+
+    @staticmethod
+    def remove_file_tmp(filepath):
+        if os.path.isfile(filepath):
+            os.unlink(filepath)
+
 
 def create_fake_png(extra):
     """Creates fake PNG data that satisfies Picard's internal image type detection"""

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+import shutil
 import struct
+from tempfile import mkdtemp
 import unittest
 
 from PyQt5 import QtCore
@@ -47,6 +49,10 @@ class PicardTestCase(unittest.TestCase):
         self.addCleanup(self.tagger.run_cleanup)
         config.setting = {}
 
+    def mktmpdir(self, ignore_errors=False):
+        tmpdir = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=ignore_errors)
+        return tmpdir
 
 def create_fake_png(extra):
     """Creates fake PNG data that satisfies Picard's internal image type detection"""

--- a/test/test_bytes2human.py
+++ b/test/test_bytes2human.py
@@ -1,6 +1,4 @@
 import os.path
-import shutil
-import tempfile
 
 from test.picardtestcase import PicardTestCase
 
@@ -12,8 +10,7 @@ class Testbytes2human(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.tmp_path = self.mktmpdir()
         self.localedir = os.path.join(self.tmp_path, 'locale')
 
     def test_00(self):

--- a/test/test_bytes2human.py
+++ b/test/test_bytes2human.py
@@ -1,6 +1,5 @@
 import os.path
 import shutil
-import sys
 import tempfile
 
 from test.picardtestcase import PicardTestCase
@@ -13,14 +12,9 @@ class Testbytes2human(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp()
-        if sys.hexversion >= 0x020700F0:
-            self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.tmp_path)
         self.localedir = os.path.join(self.tmp_path, 'locale')
-
-    def tearDown(self):
-        if sys.hexversion < 0x020700F0:
-            shutil.rmtree(self.tmp_path)
 
     def test_00(self):
         # testing with default C locale, english

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -20,7 +20,6 @@
 import logging
 import os
 import shutil
-from tempfile import mkdtemp
 
 from test.picardtestcase import PicardTestCase
 
@@ -40,8 +39,7 @@ class TestPicardConfigCommon(PicardTestCase):
     def setUp(self):
         super().setUp()
 
-        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_directory)
+        self.tmp_directory = self.mktmpdir()
 
         self.configpath = os.path.join(self.tmp_directory, 'test.ini')
         shutil.copy(os.path.join('test', 'data', 'test.ini'), self.configpath)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -39,16 +39,26 @@ class TestPicardConfigCommon(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        self.tmp_directory = mkdtemp()
+
+        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.tmp_directory)
+
         self.configpath = os.path.join(self.tmp_directory, 'test.ini')
         shutil.copy(os.path.join('test', 'data', 'test.ini'), self.configpath)
+        self.addCleanup(os.remove, self.configpath)
+
         self.config = Config.from_file(None, self.configpath)
+        self.addCleanup(self.cleanup_config_obj)
+
         self.config.application["version"] = "testing"
         logging.disable(logging.ERROR)
         Option.registry = {}
 
-    def tearDown(self):
-        shutil.rmtree(self.tmp_directory)
+    def cleanup_config_obj(self):
+        # Ensure QSettings do not recreate the file on exit
+        self.config.sync()
+        del self.config
+        self.config = None
 
 
 class TestPicardConfig(TestPicardConfigCommon):

--- a/test/test_coverart_utils.py
+++ b/test/test_coverart_utils.py
@@ -14,9 +14,9 @@ class CaaTypeTranslationTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp()
-        self.localedir = os.path.join(self.tmp_path, 'locale')
+        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
         self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.localedir = os.path.join(self.tmp_path, 'locale')
         setup_gettext(self.localedir, "C")
 
     def test_translating_unknown_types_returns_input(self):

--- a/test/test_coverart_utils.py
+++ b/test/test_coverart_utils.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 import os.path
-import shutil
-import tempfile
 
 from test.picardtestcase import PicardTestCase
 
@@ -14,8 +12,7 @@ class CaaTypeTranslationTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.tmp_path = self.mktmpdir()
         self.localedir = os.path.join(self.tmp_path, 'locale')
         setup_gettext(self.localedir, "C")
 

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
-from tempfile import mkstemp
+from tempfile import NamedTemporaryFile
 
 from test.picardtestcase import PicardTestCase
 
@@ -47,10 +47,8 @@ class EmptyDirTest(EmptyDirTestCommon):
         self.assertFalse(emptydir.is_empty_dir(tempdir))
 
     def test_is_empty_dir_on_file(self):
-        fd, file_ = mkstemp()
-        self.addCleanup(os.remove, file_)
-        self.assertRaises(NotADirectoryError, emptydir.is_empty_dir, file_)
-        os.close(fd)
+        with NamedTemporaryFile() as f:
+            self.assertRaises(NotADirectoryError, emptydir.is_empty_dir, f.name)
 
 
 class RmEmptyDirTest(EmptyDirTestCommon):
@@ -80,10 +78,5 @@ class RmEmptyDirTest(EmptyDirTestCommon):
         emptydir.PROTECTED_DIRECTORIES = orig_portected_dirs
 
     def test_is_empty_dir_on_file(self):
-        fd, file_ = mkstemp()
-        self.addCleanup(os.remove, file_)
-        self.assertRaises(NotADirectoryError, emptydir.rm_empty_dir, file_)
-        os.close(fd)
-
-
-
+        with NamedTemporaryFile() as f:
+            self.assertRaises(NotADirectoryError, emptydir.rm_empty_dir, f.name)

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -1,21 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import os.path
-import shutil
-from tempfile import (
-    mkdtemp,
-    mkstemp,
-)
-import unittest
+from tempfile import mkstemp
+
+from test.picardtestcase import PicardTestCase
 
 from picard.util import emptydir
 
 
-class EmptyDirTestCommon(unittest.TestCase):
+class EmptyDirTestCommon(PicardTestCase):
 
     def create_temp_dir(self, extra_files=(), extra_dirs=(), ignore_errors=False):
-        tempdir = mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, tempdir, ignore_errors=ignore_errors)
+        tempdir = self.mktmpdir(ignore_errors=ignore_errors)
         for f in extra_files:
             open(os.path.join(tempdir, f), 'a').close()
         for f in extra_dirs:

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+import shutil
 from tempfile import (
     mkdtemp,
     mkstemp,
@@ -10,73 +11,83 @@ import unittest
 from picard.util import emptydir
 
 
-class EmptyDirTest(unittest.TestCase):
+class EmptyDirTestCommon(unittest.TestCase):
+
+    def create_temp_dir(self, extra_files=(), extra_dirs=(), ignore_errors=False):
+        tempdir = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, tempdir, ignore_errors=ignore_errors)
+        for f in extra_files:
+            open(os.path.join(tempdir, f), 'a').close()
+        for f in extra_dirs:
+            os.mkdir(os.path.join(tempdir, f))
+        return tempdir
+
+
+class EmptyDirTest(EmptyDirTestCommon):
 
     def test_is_empty_dir_really_empty(self):
-        dir = _create_temp_dir()
-        self.assertTrue(emptydir.is_empty_dir(dir))
+        tempdir = self.create_temp_dir()
+        self.assertTrue(emptydir.is_empty_dir(tempdir))
 
     def test_is_empty_dir_only_junk_files(self):
-        dir = _create_temp_dir(extra_files=emptydir.JUNK_FILES)
-        self.assertTrue(len(os.listdir(dir)) > 0)
-        self.assertTrue(emptydir.is_empty_dir(dir))
+        tempdir = self.create_temp_dir(extra_files=emptydir.JUNK_FILES)
+        self.assertTrue(len(os.listdir(tempdir)) > 0)
+        self.assertTrue(emptydir.is_empty_dir(tempdir))
 
     def test_is_empty_dir_not_empty(self):
-        dir = _create_temp_dir(extra_files=['.notempty'])
-        self.assertEqual(1, len(os.listdir(dir)))
-        self.assertFalse(emptydir.is_empty_dir(dir))
+        tempdir = self.create_temp_dir(extra_files=['.notempty'])
+        self.assertEqual(1, len(os.listdir(tempdir)))
+        self.assertFalse(emptydir.is_empty_dir(tempdir))
 
     def test_is_empty_dir_custom_ignore_files(self):
         ignored_files = ['.empty']
-        dir = _create_temp_dir(extra_files=ignored_files)
-        self.assertEqual(1, len(os.listdir(dir)))
-        self.assertTrue(emptydir.is_empty_dir(dir, ignored_files=ignored_files))
+        tempdir = self.create_temp_dir(extra_files=ignored_files)
+        self.assertEqual(1, len(os.listdir(tempdir)))
+        self.assertTrue(emptydir.is_empty_dir(tempdir, ignored_files=ignored_files))
 
     def test_is_empty_dir_not_empty_child_dir(self):
-        dir = _create_temp_dir(extra_dirs=['childdir'])
-        self.assertEqual(1, len(os.listdir(dir)))
-        self.assertFalse(emptydir.is_empty_dir(dir))
+        tempdir = self.create_temp_dir(extra_dirs=['childdir'])
+        self.assertEqual(1, len(os.listdir(tempdir)))
+        self.assertFalse(emptydir.is_empty_dir(tempdir))
 
     def test_is_empty_dir_on_file(self):
         fd, file_ = mkstemp()
+        self.addCleanup(os.remove, file_)
         self.assertRaises(NotADirectoryError, emptydir.is_empty_dir, file_)
+        os.close(fd)
 
 
-class RmEmptyDirTest(unittest.TestCase):
+class RmEmptyDirTest(EmptyDirTestCommon):
 
     def test_rm_empty_dir_really_empty(self):
-        dir = _create_temp_dir()
-        self.assertTrue(os.path.isdir(dir))
-        emptydir.rm_empty_dir(dir)
-        self.assertFalse(os.path.exists(dir))
+        tempdir = self.create_temp_dir(ignore_errors=True)
+        self.assertTrue(os.path.isdir(tempdir))
+        emptydir.rm_empty_dir(tempdir)
+        self.assertFalse(os.path.exists(tempdir))
 
     def test_rm_empty_dir_only_junk_files(self):
-        dir = _create_temp_dir(extra_files=emptydir.JUNK_FILES)
-        self.assertTrue(os.path.isdir(dir))
-        emptydir.rm_empty_dir(dir)
-        self.assertFalse(os.path.exists(dir))
+        tempdir = self.create_temp_dir(extra_files=emptydir.JUNK_FILES, ignore_errors=True)
+        self.assertTrue(os.path.isdir(tempdir))
+        emptydir.rm_empty_dir(tempdir)
+        self.assertFalse(os.path.exists(tempdir))
 
     def test_rm_empty_dir_not_empty(self):
-        dir = _create_temp_dir(['.notempty'])
-        self.assertEqual(1, len(os.listdir(dir)))
-        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, dir)
+        tempdir = self.create_temp_dir(['.notempty'])
+        self.assertEqual(1, len(os.listdir(tempdir)))
+        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, tempdir)
 
     def test_rm_empty_dir_is_special(self):
-        dir = _create_temp_dir()
+        tempdir = self.create_temp_dir()
         orig_portected_dirs = emptydir.PROTECTED_DIRECTORIES
-        emptydir.PROTECTED_DIRECTORIES.add(os.path.realpath(dir))
-        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, dir)
+        emptydir.PROTECTED_DIRECTORIES.add(os.path.realpath(tempdir))
+        self.assertRaises(emptydir.SkipRemoveDir, emptydir.rm_empty_dir, tempdir)
         emptydir.PROTECTED_DIRECTORIES = orig_portected_dirs
 
     def test_is_empty_dir_on_file(self):
         fd, file_ = mkstemp()
+        self.addCleanup(os.remove, file_)
         self.assertRaises(NotADirectoryError, emptydir.rm_empty_dir, file_)
+        os.close(fd)
 
 
-def _create_temp_dir(extra_files=(), extra_dirs=()):
-    dir = mkdtemp()
-    for f in extra_files:
-        open(os.path.join(dir, f), 'a').close()
-    for f in extra_dirs:
-        os.mkdir(os.path.join(dir, f))
-    return dir
+

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-from tempfile import mkdtemp
 import unittest
 
 from test.picardtestcase import PicardTestCase
@@ -43,8 +41,7 @@ class TestPreserveTimes(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_directory)
+        self.tmp_directory = self.mktmpdir()
         filepath = os.path.join(self.tmp_directory, 'a.mp3')
         self.file = File(filepath)
 

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -43,12 +43,10 @@ class TestPreserveTimes(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        self.tmp_directory = mkdtemp()
+        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.tmp_directory)
         filepath = os.path.join(self.tmp_directory, 'a.mp3')
         self.file = File(filepath)
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp_directory)
 
     def _create_testfile(self):
         # create a dummy file

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -2,7 +2,6 @@
 from contextlib import suppress
 import os.path
 import shutil
-from tempfile import mkdtemp
 
 from test.picardtestcase import PicardTestCase
 
@@ -22,10 +21,8 @@ class TestFileSystem(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        self.src_directory = mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.src_directory)
-        self.tgt_directory = mkdtemp()
-        self.addCleanup(shutil.rmtree, self.tgt_directory)
+        self.src_directory = self.mktmpdir()
+        self.tgt_directory = self.mktmpdir()
         config.setting = settings.copy()
 
     def _prepare_files(self, src_rel_path='', tgt_rel_path=''):

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -22,13 +22,11 @@ class TestFileSystem(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        self.src_directory = mkdtemp()
+        self.src_directory = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.src_directory)
         self.tgt_directory = mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tgt_directory)
         config.setting = settings.copy()
-
-    def tearDown(self):
-        shutil.rmtree(self.src_directory)
-        shutil.rmtree(self.tgt_directory)
 
     def _prepare_files(self, src_rel_path='', tgt_rel_path=''):
         """Prepare src files and tgt filenames for a test."""

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -110,11 +110,8 @@ class TestPicardPluginsCommonTmpDir(TestPicardPluginsCommon):
 
     def setUp(self):
         super().setUp()
-        self.tmp_directory = mkdtemp()
-
-    def tearDown(self):
-        super().tearDown()
-        shutil.rmtree(self.tmp_directory)
+        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.tmp_directory)
 
 
 class TestPicardPluginManager(TestPicardPluginsCommon):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -19,9 +19,7 @@
 
 import logging
 import os
-import shutil
 import sys
-from tempfile import mkdtemp
 import unittest
 
 from test.picardtestcase import PicardTestCase
@@ -110,8 +108,7 @@ class TestPicardPluginsCommonTmpDir(TestPicardPluginsCommon):
 
     def setUp(self):
         super().setUp()
-        self.tmp_directory = mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_directory)
+        self.tmp_directory = self.mktmpdir()
 
 
 class TestPicardPluginManager(TestPicardPluginsCommon):

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -1,6 +1,4 @@
 import os.path
-import shutil
-import tempfile
 
 from test.picardtestcase import (
     PicardTestCase,
@@ -25,8 +23,7 @@ class ReleaseTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
-        self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.tmp_path = self.mktmpdir()
         self.localedir = os.path.join(self.tmp_path, 'locale')
         setup_gettext(self.localedir, 'C')
 

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -1,6 +1,5 @@
 import os.path
 import shutil
-import sys
 import tempfile
 
 from test.picardtestcase import (
@@ -26,15 +25,10 @@ class ReleaseTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         # we are using temporary locales for tests
-        self.tmp_path = tempfile.mkdtemp()
-        if sys.hexversion >= 0x020700F0:
-            self.addCleanup(shutil.rmtree, self.tmp_path)
+        self.tmp_path = tempfile.mkdtemp(suffix=self.__class__.__name__)
+        self.addCleanup(shutil.rmtree, self.tmp_path)
         self.localedir = os.path.join(self.tmp_path, 'locale')
         setup_gettext(self.localedir, 'C')
-
-    def tearDown(self):
-        if sys.hexversion < 0x020700F0:
-            shutil.rmtree(self.tmp_path)
 
     def test_1(self):
         config.setting = settings.copy()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -259,7 +259,7 @@ class ImageInfoTest(PicardTestCase):
                           imageinfo.identify, data)
 
 
-class CompareBarcodesTest(unittest.TestCase):
+class CompareBarcodesTest(PicardTestCase):
 
     def test_same(self):
         self.assertTrue(util.compare_barcodes('0727361379704', '0727361379704'))
@@ -278,7 +278,7 @@ class CompareBarcodesTest(unittest.TestCase):
         self.assertFalse(util.compare_barcodes(None, '0727361379704'))
 
 
-class MbidValidateTest(unittest.TestCase):
+class MbidValidateTest(PicardTestCase):
 
     def test_ok(self):
         self.assertTrue(util.mbid_validate('2944824d-4c26-476f-a981-be849081942f'))
@@ -297,7 +297,7 @@ class MbidValidateTest(unittest.TestCase):
 SimMatchTest = namedtuple('SimMatchTest', 'similarity name')
 
 
-class SortBySimilarity(unittest.TestCase):
+class SortBySimilarity(PicardTestCase):
 
     def setUp(self):
         self.test_values = [
@@ -334,7 +334,7 @@ class SortBySimilarity(unittest.TestCase):
         self.assertEqual(best_match.num_results, 0)
 
 
-class GetQtEnum(unittest.TestCase):
+class GetQtEnum(PicardTestCase):
 
     def test_get_qt_enum(self):
         from PyQt5.QtCore import QStandardPaths


### PR DESCRIPTION
- QSettings object needs special care, as file was re-created on exit
- Append a cleanup function as soon as possible to ensure temporary dirs & files are removed in any case
- prefer addCleanup() over tearDown(), keeping creation and cleanup together

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Many stuff is left over in temporary directory (/tmp on linux) after running tests.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
