### PR TITLE
PICARD-1718: Try to log and show exception details on crash

### DIFF
--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -1,3 +1,30 @@
 #!/usr/bin/env python3
-from picard.tagger import main
-main('%(localedir)s', %(autoupdate)s)
+
+try:
+    from picard.tagger import main
+    main('%(localedir)s', %(autoupdate)s)
+except SystemExit:
+    raise  # Just continue with a normal application exit
+except:  # noqa: F722
+    # First try to get traceback information and write it to a log file
+    # with minimum chance to fail.
+    import os
+    import sys
+    import tempfile
+    import traceback
+    trace = traceback.format_exc()
+    logfile = None
+    try:
+        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
+        os.write(fd, trace.encode(errors="replace"))
+        os.close(fd)
+    except:  # noqa: F722
+        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+
+    # Display the crash information to the user as a dialog. This requires
+    # importing Qt5 and has some potential to fail if things are broken.
+    from PyQt5 import QtWidgets
+    app = QtWidgets.QApplication(sys.argv)
+    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    raise

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -10,13 +10,13 @@ except:  # noqa: F722
     # with minimum chance to fail.
     import os
     import sys
-    import tempfile
+    from tempfile import NamedTemporaryFile
     import traceback
     trace = traceback.format_exc()
     try:
-        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
-        os.write(fd, trace.encode(errors="replace"))
-        os.close(fd)
+        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
+            f.write(trace.encode(errors="replace"))
+            logfile = f.name
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
         logfile = None

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -23,11 +23,23 @@ except:  # noqa: F722
 
     # Display the crash information to the user as a dialog. This requires
     # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5 import QtWidgets
-    app = QtWidgets.QApplication(sys.argv)
-    msg = []
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    _unused = QApplication(sys.argv)
+    msgbox = QMessageBox()
+    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setWindowTitle("Picard terminated unexpectedly")
+    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setText(
+        'An unexpected error has caused Picard to crash. '
+        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
     if logfile:
-        msg.append("A logfile has been written to {0}".format(logfile))
-    msg.append("Error details: \n{0}".format(trace))
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
+        logfile_url = QUrl.fromLocalFile(logfile)
+        msgbox.setInformativeText(
+            'A logfile has been written to <a href="{0}">{1}</a>.'
+            .format(logfile_url.url(), logfile))
+    msgbox.setDetailedText(trace)
+    msgbox.setStandardButtons(QMessageBox.Close)
+    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.exec_()
     raise

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -13,18 +13,21 @@ except:  # noqa: F722
     import tempfile
     import traceback
     trace = traceback.format_exc()
-    logfile = None
     try:
         (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
         os.write(fd, trace.encode(errors="replace"))
         os.close(fd)
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+        logfile = None
 
     # Display the crash information to the user as a dialog. This requires
     # importing Qt5 and has some potential to fail if things are broken.
     from PyQt5 import QtWidgets
     app = QtWidgets.QApplication(sys.argv)
-    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    msg = []
+    if logfile:
+        msg.append("A logfile has been written to {0}".format(logfile))
+    msg.append("Error details: \n{0}".format(trace))
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -36,11 +36,23 @@ except:  # noqa: F722
 
     # Display the crash information to the user as a dialog. This requires#
     # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5 import QtWidgets
-    app = QtWidgets.QApplication(sys.argv)
-    msg = []
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    _unused = QApplication(sys.argv)
+    msgbox = QMessageBox()
+    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setWindowTitle("Picard terminated unexpectedly")
+    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setText(
+        'An unexpected error has caused Picard to crash. '
+        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
     if logfile:
-        msg.append("A logfile has been written to {0}".format(logfile))
-    msg.append("Error details: \n{0}".format(trace))
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
+        logfile_url = QUrl.fromLocalFile(logfile)
+        msgbox.setInformativeText(
+            'A logfile has been written to <a href="{0}">{1}</a>.'
+                .format(logfile_url.url(), logfile))
+    msgbox.setDetailedText(trace)
+    msgbox.setStandardButtons(QMessageBox.Close)
+    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.exec_()
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -26,18 +26,21 @@ except:  # noqa: F722
     import tempfile
     import traceback
     trace = traceback.format_exc()
-    logfile = None
     try:
         (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
         os.write(fd, trace.encode(errors="replace"))
         os.close(fd)
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+        logfile = None
 
     # Display the crash information to the user as a dialog. This requires#
     # importing Qt5 and has some potential to fail if things are broken.
     from PyQt5 import QtWidgets
     app = QtWidgets.QApplication(sys.argv)
-    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    msg = []
+    if logfile:
+        msg.append("A logfile has been written to {0}".format(logfile))
+    msg.append("Error details: \n{0}".format(trace))
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -15,5 +15,29 @@ else:
 if sys.platform == 'win32':
     os.environ['PATH'] = basedir + ';' + os.environ['PATH']
 
-from picard.tagger import main
-main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+try:
+    from picard.tagger import main
+    main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+except SystemExit:
+    raise  # Just continue with a normal application exit
+except:  # noqa: F722
+    # First try to get traceback information and write it to a log file
+    # with minimum chance to fail.
+    import tempfile
+    import traceback
+    trace = traceback.format_exc()
+    logfile = None
+    try:
+        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
+        os.write(fd, trace.encode(errors="replace"))
+        os.close(fd)
+    except:  # noqa: F722
+        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+
+    # Display the crash information to the user as a dialog. This requires#
+    # importing Qt5 and has some potential to fail if things are broken.
+    from PyQt5 import QtWidgets
+    app = QtWidgets.QApplication(sys.argv)
+    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -23,13 +23,13 @@ except SystemExit:
 except:  # noqa: F722
     # First try to get traceback information and write it to a log file
     # with minimum chance to fail.
-    import tempfile
+    from tempfile import NamedTemporaryFile
     import traceback
     trace = traceback.format_exc()
     try:
-        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
-        os.write(fd, trace.encode(errors="replace"))
-        os.close(fd)
+        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
+            f.write(trace.encode(errors="replace"))
+            logfile = f.name
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
         logfile = None


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If Picard crashes try to log the traceback to a file and show a dialog to the user before exiting.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
If Picard crashes due to some bug error output is written to stdout. But most GUI users won't see those messages unless they explicitly start Picard from command line. This has some issues:

1. The crash that just happened may not be easily reproducible. So even if the user starts from command line they will probably not trigger this issue.

2. For users of macOS and especially Windows this is more difficult. Especially for Windows users this is often unknown territory and the default terminal of Windows has pretty bad usability

3. On Windows the portable install and the Windows store version don't write to stdout. There is no convenient way to start the store version from command line at all.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1718
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Catch all exceptions and display a dialog box with traceback defaults. This works fine on typical Python issues, including syntax errors or crashes caused by plugins.

To discuss:

1. This won't fetch crashes caused by native code like memory access validations. I had some experiments with enabling the faulthandler module available since Python 3.3, see https://github.com/phw/picard/commit/0fa2aaac091108ebfaeb20f635b31626d63de083 . While I was able to fetch coredumps on Linux with this it did have no effect on Windows, which I kind of see the primary target for this.

2. I am annoyed by the code duplication for both `tagger.py` and `picard`. But I really want to keep this code inline. I think the actual goal should be to get rid of the duplicate entry points and use only a single one, but I did not want to start this change here.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
