### PR TITLE
PICARD-1751, PICARD-1752: multi release country tagging

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -462,6 +462,7 @@ def release_to_metadata(node, m, album=None):
                 m['~releaselanguage'] = value['language']
             if 'script' in value:
                 m['script'] = value['script']
+    m['~releasecountries'] = countries_from_node(node)
     add_genres_from_node(node, album)
 
 

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -462,7 +462,14 @@ def release_to_metadata(node, m, album=None):
                 m['~releaselanguage'] = value['language']
             if 'script' in value:
                 m['script'] = value['script']
-    m['~releasecountries'] = countries_from_node(node)
+    m['~releasecountries'] = release_countries = countries_from_node(node)
+    # The MB web service returns the first release country in the country tag.
+    # If the user has configured preferred release countries, use the first one
+    # if it is one in the complete list of release countries.
+    for country in config.setting["preferred_release_countries"]:
+        if country in release_countries:
+            m['releasecountry'] = country
+            break
     add_genres_from_node(node, album)
 
 

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -164,6 +164,18 @@
                 "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
                 "name": "United Kingdom"
             }
+        },
+        {
+            "area": {
+                "sort-name": "New Zealand",
+                "name": "New Zealand",
+                "iso-3166-1-codes": [
+                    "NZ"
+                ],
+                "disambiguation": "",
+                "id": "8524c7d9-f472-3890-a458-f28d5081d9c4"
+            },
+            "date": "1973"
         }
     ],
     "quality": "normal",

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -66,6 +66,7 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~albumartists'], 'Pink Floyd')
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
         self.assertEqual(m['~releaselanguage'], 'eng')
+        self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
         self.assertEqual(a.genres, {
             'genre1': 6, 'genre2': 3,
             'tag1': 6, 'tag2': 3})

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -28,6 +28,7 @@ settings = {
     "standardize_releases": False,
     "translate_artist_names": True,
     "standardize_instruments": True,
+    "preferred_release_countries": [],
     "artist_locale": 'en'
 }
 
@@ -74,6 +75,18 @@ class ReleaseTest(MBJSONTest):
             self.assertEqual(artist.genres, {
                 'british': 2,
                 'progressive rock': 10})
+
+    def test_preferred_release_country(self):
+        m = Metadata()
+        a = Album("1")
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'GB')
+        config.setting['preferred_release_countries'] = ['NZ', 'GB']
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'NZ')
+        config.setting['preferred_release_countries'] = ['GB', 'NZ']
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'GB')
 
     def test_media_formats_from_node(self):
         formats = media_formats_from_node(self.json_doc['media'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Better tagging capabilities for multi-release country releases by providing a `%_releasecountries%` variable and improved selection of the value for `%releasecountry%`.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The existing "releasecountry" tag contains a single release country as returned in the country field for a release as returned by the MB web service. If there are multiple release countries only the first is used (in alphabetical order it seems).

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* PICARD-1751
* PICARD-1752
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- Add a `%_releasecountries%` variable
- Consider preferred releases to select the value for `%releasecountry%`
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
