### PR TITLE
PICARD-1750: Set AcoustID fingerprint to AcoustIDManager

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -462,6 +462,7 @@ def release_to_metadata(node, m, album=None):
                 m['~releaselanguage'] = value['language']
             if 'script' in value:
                 m['script'] = value['script']
+    m['~releasecountries'] = countries_from_node(node)
     add_genres_from_node(node, album)
 
 

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -462,7 +462,14 @@ def release_to_metadata(node, m, album=None):
                 m['~releaselanguage'] = value['language']
             if 'script' in value:
                 m['script'] = value['script']
-    m['~releasecountries'] = countries_from_node(node)
+    m['~releasecountries'] = release_countries = countries_from_node(node)
+    # The MB web service returns the first release country in the country tag.
+    # If the user has configured preferred release countries, use the first one
+    # if it is one in the complete list of release countries.
+    for country in config.setting["preferred_release_countries"]:
+        if country in release_countries:
+            m['releasecountry'] = country
+            break
     add_genres_from_node(node, album)
 
 

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -2,6 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 # Copyright (C) 2012 Michael Wiencek
+# Copyright (C) 2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -30,7 +31,10 @@ from picard.mbjson import (
     media_formats_from_node,
 )
 from picard.metadata import Metadata
-from picard.util import uniqify
+from picard.util import (
+    limited_join,
+    uniqify,
+)
 
 
 class ReleaseGroup(DataObject):
@@ -86,8 +90,8 @@ class ReleaseGroup(DataObject):
             release = {
                 "id":      node['id'],
                 "year":    node['date'][:4] if "date" in node else "????",
-                "country": "+".join(countries) if countries
-                           else node.get('country', '') or "??",
+                "country": limited_join(countries, 10, '+', '…') if countries
+                else node.get('country', '') or "??",
                 "format":  media_formats_from_node(node['media']),
                 "label":  ", ".join([' '.join(x.split(' ')[:2]) for x in set(labels)]),
                 "catnum": ", ".join(set(catnums)),

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -3,6 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 # Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -593,3 +594,39 @@ def get_qt_enum(cls, enum):
         if isinstance(value, enum):
             values.append(key)
     return values
+
+
+def limited_join(a_list, limit, join_string='+', middle_string='…'):
+    """Join elements of a list with `join_string`
+    If list is longer than `limit`, middle elements will be dropped,
+    and replaced by `middle_string`.
+
+    Args:
+        a_list: list of strings to join
+        limit: maximum number of elements to join before limiting
+        join_string: string used to join elements
+        middle_string: string to insert in the middle if limited
+
+    Returns:
+        A string
+
+    Example:
+        >>> limited_join(['a', 'b', 'c', 'd', 'e', 'f'], 2)
+        'a+…+f'
+        >>> limited_join(['a', 'b', 'c', 'd', 'e', 'f'], 3)
+        'a+…+f'
+        >>> limited_join(['a', 'b', 'c', 'd', 'e', 'f'], 4)
+        'a+b+…+e+f'
+        >>> limited_join(['a', 'b', 'c', 'd', 'e', 'f'], 6)
+        'a+b+c+d+e+f'
+        >>> limited_join(['a', 'b', 'c', 'd', 'e', 'f'], 2, ',', '?')
+        'a,?,f'
+    """
+    length = len(a_list)
+    if limit <= 1 or limit >= length:
+        return join_string.join(a_list)
+
+    half = limit // 2
+    start = a_list[:half]
+    end = a_list[-half:]
+    return join_string.join(start + [middle_string] + end)

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -164,6 +164,18 @@
                 "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
                 "name": "United Kingdom"
             }
+        },
+        {
+            "area": {
+                "sort-name": "New Zealand",
+                "name": "New Zealand",
+                "iso-3166-1-codes": [
+                    "NZ"
+                ],
+                "disambiguation": "",
+                "id": "8524c7d9-f472-3890-a458-f28d5081d9c4"
+            },
+            "date": "1973"
         }
     ],
     "quality": "normal",

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -66,6 +66,7 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~albumartists'], 'Pink Floyd')
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
         self.assertEqual(m['~releaselanguage'], 'eng')
+        self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
         self.assertEqual(a.genres, {
             'genre1': 6, 'genre2': 3,
             'tag1': 6, 'tag2': 3})

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -28,6 +28,7 @@ settings = {
     "standardize_releases": False,
     "translate_artist_names": True,
     "standardize_instruments": True,
+    "preferred_release_countries": [],
     "artist_locale": 'en'
 }
 
@@ -74,6 +75,18 @@ class ReleaseTest(MBJSONTest):
             self.assertEqual(artist.genres, {
                 'british': 2,
                 'progressive rock': 10})
+
+    def test_preferred_release_country(self):
+        m = Metadata()
+        a = Album("1")
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'GB')
+        config.setting['preferred_release_countries'] = ['NZ', 'GB']
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'NZ')
+        config.setting['preferred_release_countries'] = ['GB', 'NZ']
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['releasecountry'], 'GB')
 
     def test_media_formats_from_node(self):
         formats = media_formats_from_node(self.json_doc['media'])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,6 +12,7 @@ from picard.const.sys import IS_WIN
 from picard.util import (
     find_best_match,
     imageinfo,
+    limited_join,
     sort_by_similarity,
 )
 
@@ -342,3 +343,28 @@ class GetQtEnum(PicardTestCase):
         self.assertIn('LocateFile', values)
         self.assertIn('LocateDirectory', values)
         self.assertNotIn('DesktopLocation', values)
+
+
+class LimitedJoin(PicardTestCase):
+
+    def setUp(self):
+        self.list = [str(x) for x in range(0, 10)]
+
+    def test_1(self):
+        expected = '0+1+...+8+9'
+        result = limited_join(self.list, 5, '+', '...')
+        self.assertEqual(result, expected)
+
+    def test_2(self):
+        expected = '0+1+2+3+4+5+6+7+8+9'
+        result = limited_join(self.list, -1)
+        self.assertEqual(result, expected)
+        result = limited_join(self.list, len(self.list))
+        self.assertEqual(result, expected)
+        result = limited_join(self.list, len(self.list) + 1)
+        self.assertEqual(result, expected)
+
+    def test_3(self):
+        expected = '0,1,2,3,…,6,7,8,9'
+        result = limited_join(self.list, len(self.list) - 1, ',')
+        self.assertEqual(result, expected)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


If a file already contains an acoustid_fingerprint tag and "Ignore existing AcoustID fingerprints" is turned off and if scan is used on this file, then:

    fpcalc does not get called (expected)
    the fingerprint does not get added to AcoustId manager (fail)

The result is that even after matching the file to a proper recording it is not possible to submit the AcoustID.

Also ideall Picard would already indicate the presence of the fingerprint after loading the file.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1750
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- Refactor the code so that `File` actually manages the acoustid_* attributes. This makes these always available and centralizes the calls to update AcoustIDManager.
- Already set `File.acoustid_*` attributes on file load, if the file contains the `acoustid_fingerprint` tag **and** `ignore_existing_acoustid_fingerprints` is not set. This ensures the fingerprint is available from the start and can be used for submissions.
- When using the fingerprint from metadata on `AcoustIDClient.analyze` also  set `File.acoustid_*` attributes. This covers the case where the user had the `ignore_existing_acoustid_fingerprints` on load but later analyzes with this option disabled.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
