### PR TITLE
PICARD-1750: Set AcoustID fingerprint to AcoustIDManager

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -187,9 +187,7 @@ class AcoustIDClient(QtCore.QObject):
         finally:
             if result and result[0] == 'fingerprint':
                 fp_type, fingerprint, length = result
-                file.acoustid_fingerprint = fingerprint
-                file.acoustid_length = length
-                self.tagger.acoustidmanager.add(file, None)
+                file.set_acoustid_fingerprint(fingerprint, length)
             next_func(result)
 
     def _on_fpcalc_error(self, next_func, filename, error):
@@ -222,7 +220,7 @@ class AcoustIDClient(QtCore.QObject):
     def analyze(self, file, next_func):
         fpcalc_next = partial(self._lookup_fingerprint, next_func, file.filename)
 
-        fingerprint = getattr(file, 'acoustid_fingerprint', None)
+        fingerprint = file.acoustid_fingerprint
         if not fingerprint and not config.setting["ignore_existing_acoustid_fingerprints"]:
             # use cached fingerprint from file metadata
             fingerprints = file.metadata.getall('acoustid_fingerprint')
@@ -231,7 +229,7 @@ class AcoustIDClient(QtCore.QObject):
 
         # If the fingerprint already exists skip calling fpcalc
         if fingerprint:
-            length = int(file.metadata.length / 1000)
+            length = file.acoustid_length
             fpcalc_next(result=('fingerprint', fingerprint, length))
             return
 

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -226,6 +226,7 @@ class AcoustIDClient(QtCore.QObject):
             fingerprints = file.metadata.getall('acoustid_fingerprint')
             if fingerprints:
                 fingerprint = fingerprints[0]
+                file.set_acoustid_fingerprint(fingerprint)
 
         # If the fingerprint already exists skip calling fpcalc
         if fingerprint:

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -48,9 +48,7 @@ class AcoustIDManager(QtCore.QObject):
         self._acoustid_api = acoustid_api
 
     def add(self, file, recordingid):
-        if not hasattr(file, 'acoustid_fingerprint'):
-            return
-        if not hasattr(file, 'acoustid_length'):
+        if not file.acoustid_fingerprint or not file.acoustid_length:
             return
         puid = file.metadata['musicip_puid']
         self._fingerprints[file] = Submission(file.acoustid_fingerprint, file.acoustid_length, recordingid, recordingid, puid)

--- a/picard/file.py
+++ b/picard/file.py
@@ -166,6 +166,11 @@ class File(QtCore.QObject, Item):
             self.error = None
             self.state = self.NORMAL
             self._copy_loaded_metadata(result)
+        # use cached fingerprint from file metadata
+        if not config.setting["ignore_existing_acoustid_fingerprints"]:
+            fingerprints = self.metadata.getall('acoustid_fingerprint')
+            if fingerprints:
+                self.set_acoustid_fingerprint(fingerprints[0])
         run_file_post_load_processors(self)
         self.update()
         callback(self)

--- a/picard/file.py
+++ b/picard/file.py
@@ -119,6 +119,9 @@ class File(QtCore.QObject, Item):
         self.lookup_task = None
         self.item = None
 
+        self.acoustid_fingerprint = None
+        self.acoustid_length = 0
+
     def __repr__(self):
         return '<%s %r>' % (type(self).__name__, self.base_filename)
 
@@ -524,6 +527,17 @@ class File(QtCore.QObject, Item):
             if self.parent:
                 self.parent.remove_file(self)
             self.parent = parent
+            self.acoustid_update()
+
+    def set_acoustid_fingerprint(self, fingerprint, length=None):
+        if not fingerprint:
+            self.acoustid_fingerprint = None
+            self.acoustid_length = 0
+            self.tagger.acoustidmanager.remove(self)
+        elif fingerprint != self.acoustid_fingerprint:
+            self.acoustid_fingerprint = fingerprint
+            self.acoustid_length = length or self.metadata.length // 1000
+            self.tagger.acoustidmanager.add(self, None)
             self.acoustid_update()
 
     def acoustid_update(self):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -802,7 +802,6 @@ class Tagger(QtWidgets.QApplication):
         files = self.get_files_from_objects(objs)
 
         def finished(file, result):
-            file.acoustid_update()
             file.clear_pending()
 
         for file in files:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1068,7 +1068,7 @@ class FileItem(TreeItem):
 
     @staticmethod
     def decide_fingerprint_icon_info(file):
-        if getattr(file, 'acoustid_fingerprint', None):
+        if file.acoustid_fingerprint:
             if QtCore.QObject.tagger.acoustidmanager.is_submitted(file):
                 return _('Fingerprint has already been submitted')
             else:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


If a file already contains an acoustid_fingerprint tag and "Ignore existing AcoustID fingerprints" is turned off and if scan is used on this file, then:

    fpcalc does not get called (expected)
    the fingerprint does not get added to AcoustId manager (fail)

The result is that even after matching the file to a proper recording it is not possible to submit the AcoustID.

Also ideally Picard would already indicate the presence of the fingerprint after loading the file.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1750
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
- Refactor the code so that `File` actually manages the acoustid_* attributes. This makes these always available and centralizes the calls to update AcoustIDManager.
- Already set `File.acoustid_*` attributes on file load, if the file contains the `acoustid_fingerprint` tag **and** `ignore_existing_acoustid_fingerprints` is not set. This ensures the fingerprint is available from the start and can be used for submissions.
- When using the fingerprint from metadata on `AcoustIDClient.analyze` also  set `File.acoustid_*` attributes. This covers the case where the user had the `ignore_existing_acoustid_fingerprints` on load but later analyzes with this option disabled.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
