### PR TITLE
PICARD-1771: Scoring change to ignore undesired release types

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -60,6 +60,7 @@ class Cluster(QtCore.QObject, Item):
         'releasetype': 10,
         'releasecountry': 2,
         'format': 2,
+        'date': 3,
     }
 
     def __init__(self, name, artist="", special=False, related_album=None, hide_if_empty=False):

--- a/picard/file.py
+++ b/picard/file.py
@@ -90,6 +90,7 @@ class File(QtCore.QObject, Item):
         "releasecountry": 2,
         "format": 2,
         "isvideo": 2,
+        "date": 3,
     }
 
     class PreserveTimesStatError(Exception):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -81,7 +81,7 @@ def weights_from_release_type_scores(parts, release, release_type_scores,
             type_score = type_scores.get(release_type, other_score)
             if type_score == 0:
                 skip_it = True
-            score += type_scores.get(release_type, other_score)
+            score += type_score
         score /= len(types_found)
 
     if skip_it:

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -67,6 +67,9 @@ def weights_from_release_type_scores(parts, release, release_type_scores,
     # If no types are found, it is set to the score of the 'Other' type or 0.5 if 'Other' doesnt exist
     # It appends (score, weight_release_type) to passed parts list
 
+    # if our preference is zero for the release_type, force to never return this recording. By using large zero weight. This means it only gets picked if there are no others at all
+    skip_it = False
+
     type_scores = dict(release_type_scores)
     score = 0.0
     if 'release-group' in release and 'primary-type' in release['release-group']:
@@ -75,9 +78,16 @@ def weights_from_release_type_scores(parts, release, release_type_scores,
             types_found += release['release-group']['secondary-types']
         other_score = type_scores.get('Other', 0.5)
         for release_type in types_found:
+            type_score = type_scores.get(release_type, other_score)
+            if type_score == 0:
+                skip_it = True
             score += type_scores.get(release_type, other_score)
         score /= len(types_found)
-    parts.append((score, weight_release_type))
+
+    if skip_it:
+        parts.append((0, 9999))
+    else:
+        parts.append((score, weight_release_type))
 
 
 def weights_from_preferred_countries(parts, release,
@@ -217,6 +227,9 @@ class Metadata(MutableMapping):
             parts.append((score, weights["totaltracks"]))
         except (ValueError, KeyError):
             pass
+
+        if "date" in release:
+            parts.append((1.0, weights['date']))
 
         weights_from_preferred_countries(parts, release,
                                          config.setting["preferred_release_countries"],


### PR DESCRIPTION
# Summary
Scoring change to ignore undesired release types, and add some weight for tracks with non-null release date.

* This is a…
    * [] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

1. Some results have no release date, which are less desirable to match to.

2. While user can leverage the sliders in the preferences screen, to lower the priority of certain "release types," they have no way to completely exclude it. since final result is based on several factors, these undesirable types still get chosen by picard. I found this particularly troublesome with compilations. I want to tag my mp3 with the original album, not a recent compilation.

PICARD-1771

# Solution

1. Higher priority should be given to results that have a non-null release date.

2. If the slider in preferences screen is set to zero (far left) for a given Release Type, then Picard should never have its final pick be of that release type. If user just wants to de-prioritize it, they can move slider slightly right of the far left.