### PR TITLE
Parse additional fields from the AcoustId response

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -15,7 +15,7 @@
 # Copyright (C) 2017-2018 Antonio Larrosa
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018 Xincognito10
-# Copyright (C) 2020 Ray
+# Copyright (C) 2020 Ray Bouchard
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2020 Ray Bouchard
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -64,7 +65,7 @@ class RecordingTest(AcoustIDTest):
         self.assertEqual(parsed_recording['id'], '017830c1-d1cf-46f3-8801-aaaa0a930223')
         self.assertEqual(parsed_recording['length'], 225000)
         self.assertEqual(parsed_recording['title'], 'Nina')
-        self.assertEqual(release['media'], [{'format': 'CD', 'track-count': 12}])
+        self.assertEqual(release['media'], [{'format': 'CD', 'track-count': 12, 'position': 1, 'track': [{'position': 5, 'id': '16affcc3-9f34-48e5-88dc-68378c4cc208', 'number': 5}]}])
         self.assertEqual(release['title'], 'x')
         self.assertEqual(release['id'], 'a2b25883-306f-4a53-809a-a234737c209d')
         self.assertEqual(release['release-group'], {
@@ -73,6 +74,9 @@ class RecordingTest(AcoustIDTest):
             'secondary-types': ['Compilation']
         })
         self.assertEqual(release['country'], 'XE')
+        self.assertEqual(release['date'], {'month': 6, 'day': 23, 'year': 2014})
+        self.assertEqual(release['medium-count'], 1)
+        self.assertEqual(release['track-count'], 12)
         self.assertEqual(artist_credit['artist'], {'sort-name': 'Ed Sheeran',
                                                    'name': 'Ed Sheeran',
                                                    'id': 'b8a7c51f-362c-4dcb-a259-bc6e0095f0a6'})


### PR DESCRIPTION
#Summary
Parse additional fields from the AcoustId response

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem
AcoustId returns many data elements, but not all are parsed out and made available within Picard.


# Solution
Changed acoustid/json_helpers.py to parse out additional data elements.