### PR TITLE
Run fix header script on all Python source files

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -1,7 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011-2014 Lukáš Lalinský
+# Copyright (C) 2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013-2019 Laurent Monin
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2015 Sophist-UK
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2017 Wieland Hoffmann
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2018 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +28,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard.version import (
     Version,

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2011 Lukáš Lalinský
+# Copyright (C) 2017-2018 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018-2019 Laurent Monin
+# Copyright (C) 2018-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import deque
 from functools import partial

--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2011 Lukáš Lalinský
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/album.py
+++ b/picard/album.py
@@ -1,8 +1,25 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2006-2009, 2011-2012, 2014 Lukáš Lalinský
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2008 Hendrik van Antwerpen
+# Copyright (C) 2008 ojnkpjg
+# Copyright (C) 2008-2011, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2011-2012 Chad Wilson
+# Copyright (C) 2011-2013, 2019 Michael Wiencek
+# Copyright (C) 2012-2013, 2016-2017 Wieland Hoffmann
+# Copyright (C) 2013, 2018 Calvin Walton
+# Copyright (C) 2013-2015, 2017 Sophist-UK
+# Copyright (C) 2013-2015, 2017-2019 Laurent Monin
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019 Joel Lintunen
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +34,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import (
     OrderedDict,

--- a/picard/browser/__init__.py
+++ b/picard/browser/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006 Lukáš Lalinský
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2011 Lukáš Lalinský
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012-2013, 2018 Philipp Wolfer
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from urllib.parse import (
     parse_qs,

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -1,8 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (c) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2004 Robert Kaye
+# Copyright (C) 2006-2008, 2011-2012 Lukáš Lalinský
+# Copyright (C) 2011 Pavan Chander
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2014-2015 Sophist-UK
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2015-2016 Wieland Hoffmann
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os.path
 import re

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -1,8 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2008 Hendrik van Antwerpen
+# Copyright (C) 2008 Will
+# Copyright (C) 2010-2011, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012 Wieland Hoffmann
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +30,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 from heapq import (

--- a/picard/collection.py
+++ b/picard/collection.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2014 Lukáš Lalinský
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2014, 2017-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/config.py
+++ b/picard/config.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2014, 2017 Lukáš Lalinský
+# Copyright (C) 2008, 2014, 2019-2020 Philipp Wolfer
+# Copyright (C) 2012, 2017 Wieland Hoffmann
+# Copyright (C) 2012-2014 Michael Wiencek
+# Copyright (C) 2013-2016, 2018-2019 Laurent Monin
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from operator import itemgetter
 import os

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2013-2014 Laurent Monin
+#
+# Copyright (C) 2013-2014 Michael Wiencek
+# Copyright (C) 2013-2016, 2018-2019 Laurent Monin
+# Copyright (C) 2014, 2017 Lukáš Lalinský
+# Copyright (C) 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2007, 2014, 2016 Lukáš Lalinský
+# Copyright (C) 2014, 2019-2020 Philipp Wolfer
+# Copyright (C) 2014-2016, 2018-2020 Laurent Monin
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Wieland Hoffmann
+# Copyright (C) 2016-2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import OrderedDict
 import os

--- a/picard/const/languages.py
+++ b/picard/const/languages.py
@@ -3,6 +3,10 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2014, 2018, 2020 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Shen-Ta Hsieh
+# Copyright (C) 2018-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/const/locales.py
+++ b/picard/const/locales.py
@@ -3,6 +3,9 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2014, 2020 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/const/sys.py
+++ b/picard/const/sys.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import sys
 

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Oliver Charles
-# Copyright (C) 2007-2011 Philipp Wolfer
-# Copyright (C) 2007, 2010, 2011 Lukáš Lalinský
+# Copyright (C) 2007, 2010-2011 Lukáš Lalinský
+# Copyright (C) 2007-2011, 2019 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2014 Laurent Monin
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Oliver Charles
-# Copyright (C) 2007-2011 Philipp Wolfer
-# Copyright (C) 2007, 2010, 2011 Lukáš Lalinský
+# Copyright (C) 2007, 2010-2011 Lukáš Lalinský
+# Copyright (C) 2007-2011, 2014, 2018-2019 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
-# Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2014 Laurent Monin
+# Copyright (C) 2011-2012, 2015 Wieland Hoffmann
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016 Ville Skyttä
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,6 +26,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from hashlib import md5
 import os
 import shutil

--- a/picard/coverart/providers/__init__.py
+++ b/picard/coverart/providers/__init__.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2014 Laurent Monin
+#
+# Copyright (C) 2014-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2015 Rahul Raturi
+# Copyright (C) 2016 Ville Skyttä
+# Copyright (C) 2016 Wieland Hoffmann
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from collections import defaultdict, namedtuple
 import traceback
 

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Oliver Charles
-# Copyright (C) 2007-2011 Philipp Wolfer
-# Copyright (C) 2007, 2010, 2011 Lukáš Lalinský
+# Copyright (C) 2007, 2010-2011 Lukáš Lalinský
+# Copyright (C) 2007-2011, 2015, 2018-2019 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2014 Laurent Monin
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2015-2016 Rahul Raturi
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import (
     OrderedDict,

--- a/picard/coverart/providers/caa_release_group.py
+++ b/picard/coverart/providers/caa_release_group.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2014 Laurent Monin
+#
+# Copyright (C) 2014-2016, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2015 Laurent Monin
+#
+# Copyright (C) 2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 import re

--- a/picard/coverart/providers/whitelist.py
+++ b/picard/coverart/providers/whitelist.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Oliver Charles
+# Copyright (C) 2007, 2010-2011 Lukáš Lalinský
 # Copyright (C) 2007-2011 Philipp Wolfer
-# Copyright (C) 2007, 2010, 2011 Lukáš Lalinský
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2014 Laurent Monin
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/coverart/utils.py
+++ b/picard/coverart/utils.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2013 Laurent Monin
+#
+# Copyright (C) 2013-2015 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard.const import MB_ATTRIBUTES
 from picard.i18n import gettext_attr

--- a/picard/dataobj.py
+++ b/picard/dataobj.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
+# Copyright (C) 2006-2008 Lukáš Lalinský
+# Copyright (C) 2011-2012 Michael Wiencek
+# Copyright (C) 2013 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 from picard.util import LockableObject

--- a/picard/disc.py
+++ b/picard/disc.py
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
 # Copyright (C) 2006 Matthias Friedrich
-# Copyright (C) 2013 Laurent Monin
-# Copyright (C) 2018, 2019 Philipp Wolfer
+# Copyright (C) 2007-2008 Lukáš Lalinský
+# Copyright (C) 2008 Robert Kaye
+# Copyright (C) 2009, 2013, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013 Johannes Dewender
+# Copyright (C) 2013 Sebastian Ramacher
+# Copyright (C) 2013 Wieland Hoffmann
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import traceback
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -1,8 +1,28 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2006-2009, 2011-2013, 2017 Lukáš Lalinský
+# Copyright (C) 2007-2011, 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2008-2009 Nikolai Prokoschenko
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009 David Hilton
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012 Erik Wasser
+# Copyright (C) 2012 Johannes Weißl
+# Copyright (C) 2012 noobie
+# Copyright (C) 2012-2014 Wieland Hoffmann
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2014 Ionuț Ciocîrlan
+# Copyright (C) 2013-2014, 2017 Sophist-UK
+# Copyright (C) 2013-2014, 2017-2019 Laurent Monin
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Ville Skyttä
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017-2018 Antonio Larrosa
+# Copyright (C) 2019 Joel Lintunen
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +37,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 import fnmatch

--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2012 Lukáš Lalinský
+# Copyright (C) 2008 Will
+# Copyright (C) 2010, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2013, 2017-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2017 Ville Skyttä
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import log
 from picard.plugin import ExtensionPoint

--- a/picard/formats/ac3.py
+++ b/picard/formats/ac3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import mutagen
 

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2009, 2011 Lukáš Lalinský
+# Copyright (C) 2009-2011, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011-2014 Wieland Hoffmann
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from __future__ import absolute_import
 

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2011 Lukáš Lalinský
+# Copyright (C) 2009-2011, 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011-2014 Wieland Hoffmann
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2014-2015, 2017 Sophist-UK
+# Copyright (C) 2016-2018 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import struct
 

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -1,7 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2009, 2011-2012 Lukáš Lalinský
+# Copyright (C) 2008-2011, 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2011-2012 Johannes Weißl
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2011-2014 Wieland Hoffmann
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2014, 2017-2019 Laurent Monin
+# Copyright (C) 2013-2015, 2017 Sophist-UK
+# Copyright (C) 2015 Frederik “Freso” S. Olesen
+# Copyright (C) 2016 Christoph Reiter
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 tungol
+# Copyright (C) 2019 Zenara Daley
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +30,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 import re

--- a/picard/formats/midi.py
+++ b/picard/formats/midi.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2018 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from mutagen.smf import SMF
 

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2009-2011, 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011 Johannes Weißl
+# Copyright (C) 2011-2014 Wieland Hoffmann
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013 Frederik “Freso” S. Olesen
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2014-2015 Sophist-UK
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2019 Reinaldo Antonio Camargo Rauch
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/formats/mutagenext/__init__.py
+++ b/picard/formats/mutagenext/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006 Lukáš Lalinský
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or

--- a/picard/formats/mutagenext/aac.py
+++ b/picard/formats/mutagenext/aac.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2018 Philipp Wolfer
+#
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from mutagen._util import loadfile
 from mutagen.aac import AAC

--- a/picard/formats/mutagenext/ac3.py
+++ b/picard/formats/mutagenext/ac3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from mutagen._file import FileType
 from mutagen._util import (

--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
 # Copyright (C) 2005 Michael Urman
+# Copyright (C) 2006-2008, 2011-2012 Lukáš Lalinský
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2016 Christoph Reiter
+# Copyright (C) 2016 Ville Skyttä
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from mutagen.id3 import (
     ID3,

--- a/picard/formats/mutagenext/tak.py
+++ b/picard/formats/mutagenext/tak.py
@@ -1,12 +1,26 @@
-# Tom's lossless Audio Kompressor (TAK) reader/tagger
+# -*- coding: utf-8 -*-
 #
-# Copyright 2008 Lukas Lalinsky <lalinsky@gmail.com>
+# Picard, the next-generation MusicBrainz tagger
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# Copyright (C) 2008 Lukáš Lalinský
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
-# $$
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 """Tom's lossless Audio Kompressor streams with APEv2 tags.
 

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2012 Lukáš Lalinský
+# Copyright (C) 2008 Hendrik van Antwerpen
+# Copyright (C) 2008-2010, 2014-2015, 2018-2019 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2012-2014 Wieland Hoffmann
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2014, 2017-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import base64
 import re

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2012-2013, 2017 Wieland Hoffmann
+# Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import wave
 

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2013 Laurent Monin
+#
+# Copyright (C) 2012 Frederik “Freso” S. Olesen
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import builtins
 import gettext

--- a/picard/log.py
+++ b/picard/log.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2007, 2011 Lukáš Lalinský
+# Copyright (C) 2008-2010, 2019 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013, 2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Wieland Hoffmann
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import (
     OrderedDict,

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2017 Sambhav Kothari
+#
+# Copyright (C) 2017 David Mandelberg
+# Copyright (C) 2017-2018 Sambhav Kothari
+# Copyright (C) 2017-2019 Laurent Monin
+# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2019 Michael Wiencek
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -1,7 +1,20 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2009, 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012 Johannes Weißl
+# Copyright (C) 2012-2014, 2018 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2016, 2018-2020 Laurent Monin
+# Copyright (C) 2013-2014, 2017 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017-2018 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018 Xincognito10
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,8 +28,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
-# USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from collections import namedtuple
 from collections.abc import (
     Iterable,

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2014 Lukáš Lalinský
+# Copyright (C) 2015 Sophist-UK
+# Copyright (C) 2015 Wieland Hoffmann
+# Copyright (C) 2015, 2018 Philipp Wolfer
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018-2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 import time

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -1,9 +1,22 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2007-2008 Lukáš Lalinský
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009, 2014, 2017-2020 Philipp Wolfer
+# Copyright (C) 2011 johnny64
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013 Sebastian Ramacher
+# Copyright (C) 2013 Wieland Hoffmann
+# Copyright (C) 2013 brainz34
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2014 Johannes Dewender
 # Copyright (C) 2014 Shadab Zafar
-# Copyright (C) 2015 Laurent Monin
+# Copyright (C) 2014-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +31,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 import os.path

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2014 Shadab Zafar
 # Copyright (C) 2015-2019 Laurent Monin
+# Copyright (C) 2019 Wieland Hoffmann
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 import imp

--- a/picard/plugins/__init__.py
+++ b/picard/plugins/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2012 Michael Wiencek
-# Copyright (C) 2020 Laurent Monin
+#
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013, 2018-2020 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2017 Wieland Hoffmann
+# Copyright (C) 2017-2018 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 from functools import partial

--- a/picard/script.py
+++ b/picard/script.py
@@ -1,10 +1,24 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2007 Javier Kohen
-# Copyright (C) 2008 Philipp Wolfer
 #
+# Copyright (C) 2006-2009, 2012 Lukáš Lalinský
+# Copyright (C) 2007 Javier Kohen
+# Copyright (C) 2008-2011, 2014-2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2011-2012 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012 stephen
+# Copyright (C) 2012, 2014, 2017 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2017-2020 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2016-2017 Ville Skyttä
+# Copyright (C) 2017-2018 Antonio Larrosa
+# Copyright (C) 2018 Calvin Walton
+# Copyright (C) 2018 virusMac
+# Copyright (C) 2020 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,6 +33,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import namedtuple
 from collections.abc import MutableSequence

--- a/picard/similarity.py
+++ b/picard/similarity.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2008 Will
+# Copyright (C) 2011-2012 Michael Wiencek
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1,8 +1,30 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2006-2009, 2011-2014, 2017 Lukáš Lalinský
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2008 amckinle
+# Copyright (C) 2008-2010, 2014-2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2010 Andrew Barnert
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2011-2014, 2017-2019 Wieland Hoffmann
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013 Ionuț Ciocîrlan
+# Copyright (C) 2013 brainz34
+# Copyright (C) 2013-2014, 2017 Sophist-UK
+# Copyright (C) 2013-2015, 2017-2019 Laurent Monin
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Simon Legner
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017-2018 Vishal Choudhary
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 virusMac
+# Copyright (C) 2019 Joel Lintunen
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +39,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import argparse
 from functools import partial

--- a/picard/track.py
+++ b/picard/track.py
@@ -1,8 +1,25 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2006-2007, 2011 Lukáš Lalinský
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2010, 2014-2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011 Chad Wilson
+# Copyright (C) 2011 Wieland Hoffmann
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2014-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016 Mark Trolley
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2017-2018 Sambhav Kothari
+# Copyright (C) 2018 Calvin Walton
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019 Joel Lintunen
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +34,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 from functools import partial

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008 Lukáš Lalinský
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2014, 2018 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2009, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/checkbox_list_item.py
+++ b/picard/ui/checkbox_list_item.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2018 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QListWidgetItem

--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2014-2015, 2018 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import locale
 

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import QtGui
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -1,7 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006,2011 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2011 Lukáš Lalinský
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2012-2014 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2017-2019 Laurent Monin
+# Copyright (C) 2014 Francois Ferrand
+# Copyright (C) 2015 Sophist-UK
+# Copyright (C) 2016 Ville Skyttä
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Paul Roub
+# Copyright (C) 2017-2019 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +30,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 import os

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2011 Michael Wiencek
-# Copyright (C) 2019 Philipp Wolfer
+#
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Wieland Hoffmann
+# Copyright (C) 2017-2018 Laurent Monin
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008 Lukáš Lalinský
+# Copyright (C) 2008 Hendrik van Antwerpen
+# Copyright (C) 2008-2009, 2019 Philipp Wolfer
+# Copyright (C) 2011 Andrew Barnert
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013 Wieland Hoffmann
+# Copyright (C) 2013, 2017 Sophist-UK
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2015 Jeroen Kromwijk
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -15,8 +26,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012-2014, 2017, 2019 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017-2019 Antonio Larrosa
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +26,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import namedtuple
 import os.path

--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -2,6 +2,10 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2019 Philipp Wolfer
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -15,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2010, 2018 Philipp Wolfer
+# Copyright (C) 2011-2012 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2013 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1,7 +1,26 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011-2012 Lukáš Lalinský
+# Copyright (C) 2007 Robert Kaye
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2008 Hendrik van Antwerpen
+# Copyright (C) 2008-2011, 2014-2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2011 Tim Blechmann
+# Copyright (C) 2011-2012 Chad Wilson
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Your Name
+# Copyright (C) 2012-2013 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2016, 2018-2019 Laurent Monin
+# Copyright (C) 2013-2014, 2017 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Simon Legner
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +35,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 from functools import partial

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2008-2009, 2019-2020 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016, 2018 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1,7 +1,32 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011-2012, 2014 Lukáš Lalinský
+# Copyright (C) 2007 Nikolai Prokoschenko
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2008 Robert Kaye
+# Copyright (C) 2008 Will
+# Copyright (C) 2008-2010, 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009 David Hilton
+# Copyright (C) 2011-2012 Chad Wilson
+# Copyright (C) 2011-2013, 2015-2017 Wieland Hoffmann
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2013-2014, 2017 Sophist-UK
+# Copyright (C) 2013-2020 Laurent Monin
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2015 samithaj
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 Simon Legner
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 Kartik Ohri
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018 virusMac
+# Copyright (C) 2019 Timur Enikeev
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +41,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import OrderedDict
 import datetime

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -1,8 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2006-2007, 2012 Lukáš Lalinský
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012 Nikolai Prokoschenko
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2013-2014, 2017-2019 Laurent Monin
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2015 Wieland Hoffmann
+# Copyright (C) 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 from functools import partial

--- a/picard/ui/moveable_list_view.py
+++ b/picard/ui/moveable_list_view.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2018 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2009, 2019-2020 Philipp Wolfer
+# Copyright (C) 2013, 2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/ui/options/about.py
+++ b/picard/ui/options/about.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006-2014 Lukáš Lalinský
+# Copyright (C) 2008, 2013, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011 Pavan Chander
+# Copyright (C) 2011, 2013 Wieland Hoffmann
+# Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2013-2015, 2018 Laurent Monin
+# Copyright (C) 2014 Ismael Olea
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard.const import PICARD_URLS
 from picard.formats import supported_extensions

--- a/picard/ui/options/advanced.py
+++ b/picard/ui/options/advanced.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2013-2015, 2018 Laurent Monin
+# Copyright (C) 2014, 2019 Philipp Wolfer
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/ui/options/cdlookup.py
+++ b/picard/ui/options/cdlookup.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (c) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2004 Robert Kaye
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2008, 2019 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 from picard.util.cdrom import (

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2010, 2018-2019 Philipp Wolfer
+# Copyright (C) 2012, 2014 Wieland Hoffmann
+# Copyright (C) 2012-2014 Michael Wiencek
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Suhas
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 from picard.coverart.providers import cover_art_providers

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2007 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2008-2009 Nikolai Prokoschenko
+# Copyright (C) 2008-2009, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011 Pavan Chander
+# Copyright (C) 2011-2012, 2019 Wieland Hoffmann
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013, 2017-2019 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Suhas
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2011 Lukáš Lalinský
+#
+# Copyright (C) 2011-2012 Lukáš Lalinský
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2015 Philipp Wolfer
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2014 Lukáš Lalinský
+# Copyright (C) 2008, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011, 2013 Michael Wiencek
+# Copyright (C) 2011, 2019 Wieland Hoffmann
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 virusMac
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +26,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import QtCore
 

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2008 Lukáš Lalinský
+# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Wieland Hoffmann
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import (

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2007-2008 Lukáš Lalinský
+# Copyright (C) 2008 Will
+# Copyright (C) 2009, 2019-2020 Philipp Wolfer
+# Copyright (C) 2011, 2013 Michael Wiencek
+# Copyright (C) 2013, 2019 Wieland Hoffmann
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2018 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +26,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 import locale

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/options/interface_top_tags.py
+++ b/picard/ui/options/interface_top_tags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2009, 2011, 2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2018 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2008-2009, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011 Johannes Weißl
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2014 Wieland Hoffmann
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 from picard.const import ALIAS_LOCALES

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2013 Philipp Wolfer
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013, 2015, 2018-2019 Laurent Monin
+# Copyright (C) 2013, 2017 Sophist-UK
 # Copyright (C) 2014 Shadab Zafar
-# Copyright (C) 2015 Laurent Monin
+# Copyright (C) 2015, 2017 Wieland Hoffmann
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Suhas
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018 yagyanshbhatia
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,6 +28,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 from operator import attrgetter

--- a/picard/ui/options/ratings.py
+++ b/picard/ui/options/ratings.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2008 Philipp Wolfer
+#
+# Copyright (C) 2008-2009 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2018 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012 Frederik “Freso” S. Olesen
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Suhas
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from locale import strxfrm
 from operator import itemgetter

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006-2008 Lukáš Lalinský
-# Copyright (C) 2009 Nikolai Prokoschenko
+#
+# Copyright (C) 2006-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2008-2009 Nikolai Prokoschenko
+# Copyright (C) 2009-2010, 2014-2015, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2011-2013 Wieland Hoffmann
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013 Ionuț Ciocîrlan
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2015 Alex Berman
+# Copyright (C) 2015 Ohm Patel
+# Copyright (C) 2016 Suhas
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +29,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 import os.path

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2009 Lukáš Lalinský
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2009-2010, 2019 Philipp Wolfer
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013-2015, 2017-2019 Laurent Monin
+# Copyright (C) 2014 m42i
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2016-2017 Suhas
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007, 2011 Lukáš Lalinský
+# Copyright (C) 2009 Nikolai Prokoschenko
+# Copyright (C) 2009-2010, 2018-2019 Philipp Wolfer
+# Copyright (C) 2012 Erik Wasser
+# Copyright (C) 2012 Johannes Weißl
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013, 2017 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017-2018 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/ui/options/tags_compatibility.py
+++ b/picard/ui/options/tags_compatibility.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/passworddialog.py
+++ b/picard/ui/passworddialog.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2008 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2012, 2014 Lukáš Lalinský
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2019 Philipp Wolfer
+#
 # Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 # Copyright (C) 2019 Timur Enikeev
 #
 # This program is free software; you can redistribute it and/or
@@ -18,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 

--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2008 Philipp Wolfer
+#
+# Copyright (C) 2008, 2018-2019 Philipp Wolfer
+# Copyright (C) 2011, 2013 Michael Wiencek
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018 Yvan Rivière
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2016 Rahul Raturi
-# Copyright (C) 2018 Laurent Monin
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2018-2019 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import (
     OrderedDict,

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2016 Rahul Raturi
-# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018-2019 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/searchdialog/artist.py
+++ b/picard/ui/searchdialog/artist.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2016 Rahul Raturi
 # Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import QtCore
 

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2016 Rahul Raturi
-# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018 Antonio Larrosa
+# Copyright (C) 2018-2019 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import QtCore
 

--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard.const.sys import (
     IS_HAIKU,

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2009, 2014, 2019 Philipp Wolfer
+# Copyright (C) 2012-2013 Michael Wiencek
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +24,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os.path
 import re

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/widgets/editablelistview.py
+++ b/picard/ui/widgets/editablelistview.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/ui/widgets/scriptlistwidget.py
+++ b/picard/ui/widgets/scriptlistwidget.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/ui/widgets/taglisteditor.py
+++ b/picard/ui/widgets/taglisteditor.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import QtWidgets
 

--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5 import (
     QtCore,

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1,9 +1,25 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
-# Copyright (C) 2006 Lukáš Lalinský
-# Copyright (C) 2020 Laurent Monin
+# Copyright (C) 2006-2009, 2011-2012, 2014 Lukáš Lalinský
+# Copyright (C) 2008-2011, 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009 david
+# Copyright (C) 2010 fatih
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012, 2014-2015 Wieland Hoffmann
+# Copyright (C) 2013 Ionuț Ciocîrlan
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2013-2014, 2018-2020 Laurent Monin
+# Copyright (C) 2014 Johannes Dewender
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016 barami
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +34,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import builtins
 from collections import namedtuple
 import html

--- a/picard/util/astrcmp.py
+++ b/picard/util/astrcmp.py
@@ -1,3 +1,5 @@
+# fix-header: skip
+
 # http://hetland.org/coding/python/levenshtein.py
 
 # This is a straightforward implementation of a well-known algorithm, and thus

--- a/picard/util/bytes2human.py
+++ b/picard/util/bytes2human.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2013 Laurent Monin
+#
+# Copyright (C) 2013, 2019-2020 Laurent Monin
+# Copyright (C) 2018 Wieland Hoffmann
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 """Helper class to convert bytes to human-readable form
 

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -1,8 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (c) 2004 Robert Kaye
+#
+# Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2008 Will
+# Copyright (C) 2008, 2018-2019 Philipp Wolfer
+# Copyright (C) 2009 david
+# Copyright (C) 2013 Johannes Dewender
+# Copyright (C) 2013 Sebastian Ramacher
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2013-2014 Michael Wiencek
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +27,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from PyQt5.QtCore import (
     QFile,

--- a/picard/util/checkupdate.py
+++ b/picard/util/checkupdate.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018, 2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from functools import partial
 

--- a/picard/util/emptydir.py
+++ b/picard/util/emptydir.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2019 Philipp Wolfer
+#
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 import os.path

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -2,6 +2,14 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
+# Copyright (C) 2013-2014 Ionuț Ciocîrlan
+# Copyright (C) 2013-2014, 2018-2019 Laurent Monin
+# Copyright (C) 2014 Michael Wiencek
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2018 Antonio Larrosa
+# Copyright (C) 2019 Philipp Wolfer
+#
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
@@ -15,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import math
 import os

--- a/picard/util/icontheme.py
+++ b/picard/util/icontheme.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2008 Lukáš Lalinský
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os.path
 

--- a/picard/util/imageinfo.py
+++ b/picard/util/imageinfo.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2014 Laurent Monin
+#
+# Copyright (C) 2014, 2018, 2020 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from io import BytesIO
 import struct

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2017 Antonio Larrosa <alarrosa@suse.com>
-# Copyright (C) 2018 Philipp Wolfer <ph.wolfer@gmail.com>
+#
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections.abc import MutableSequence
 

--- a/picard/util/lrucache.py
+++ b/picard/util/lrucache.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2017 Antonio Larrosa <alarrosa@suse.com>
+#
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2018-2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections.abc import MutableMapping
 

--- a/picard/util/natsort.py
+++ b/picard/util/natsort.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 """Functions for natural sorting of strings containing numbers.
 """

--- a/picard/util/preservedtags.py
+++ b/picard/util/preservedtags.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2019-2020 Philipp Wolfer
 #
@@ -17,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 

--- a/picard/util/scripttofilename.py
+++ b/picard/util/scripttofilename.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2006 Lukáš Lalinský
-# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from picard import config
 from picard.const.sys import IS_WIN

--- a/picard/util/settingsoverride.py
+++ b/picard/util/settingsoverride.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections.abc import MutableMapping
 

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2007 Lukáš Lalinský
+#
+# Copyright (C) 2007-2008, 2011 Lukáš Lalinský
+# Copyright (C) 2008-2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2011 Johannes Weißl
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2013 Calvin Walton
+# Copyright (C) 2013-2014, 2019 Laurent Monin
+# Copyright (C) 2013-2015, 2017 Sophist-UK
+# Copyright (C) 2019 Zenara Daley
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/util/textencoding.py
+++ b/picard/util/textencoding.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2014, 2018 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 # This modules provides functionality for simplifying unicode strings.
 

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2008 Gary van der Merwe
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import sys
 import traceback

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006-2014 Lukáš Lalinský
-# Copyright (C) 2014 Laurent Monin
+# Copyright (C) 2014-2015, 2017-2018 Laurent Monin
+# Copyright (C) 2016 Sambhav Kothari
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import OrderedDict
 from platform import python_version

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2006 Lukáš Lalinský
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2011 Calvin Walton
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 """A webbrowser extension for Picard.
 

--- a/picard/util/xml.py
+++ b/picard/util/xml.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -18,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/version.py
+++ b/picard/version.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2019 Philipp Wolfer
+#
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import namedtuple
 import re

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 

--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from collections import defaultdict
 import math

--- a/resources/__init__.py
+++ b/resources/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/resources/compile.py
+++ b/resources/compile.py
@@ -1,4 +1,27 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2014 Shadab Zafar
+# Copyright (C) 2016 Sambhav Kothari
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from distutils import log
 from distutils.dep_util import newer

--- a/resources/makeqrc.py
+++ b/resources/makeqrc.py
@@ -1,4 +1,28 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013-2014, 2018 Laurent Monin
+# Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Ville Skyttä
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from distutils import log
 from distutils.dep_util import newer

--- a/scripts/pyinstaller/macos-library-path-hook.py
+++ b/scripts/pyinstaller/macos-library-path-hook.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 import sys
 

--- a/scripts/pyinstaller/portable-hook.py
+++ b/scripts/pyinstaller/portable-hook.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 import os.path
 import sys

--- a/scripts/pyinstaller/win-console-hook.py
+++ b/scripts/pyinstaller/win-console-hook.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import sys
 
 

--- a/scripts/tools/changelog-for-version.py
+++ b/scripts/tools/changelog-for-version.py
@@ -1,4 +1,24 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import re
 import sys

--- a/scripts/tools/fix-header.py
+++ b/scripts/tools/fix-header.py
@@ -118,7 +118,7 @@ def parse_file(path):
     with open(path) as f:
         lines = f.readlines()
         found = defaultdict(lambda: None)
-        if lines[0].startswith('#!'):
+        if lines and lines[0].startswith('#!'):
             found["shebang"] = lines[0].rstrip()
             del lines[0]
         for num, line in enumerate(lines):

--- a/scripts/tools/fix-header.py
+++ b/scripts/tools/fix-header.py
@@ -282,10 +282,12 @@ def main():
             print("Skipping %s (%s)" % (path, info), file=sys.stderr)
             continue
         if args.in_place:
+            print("Parsing and fixing %s (in place)" % path, file=sys.stderr)
             with open(path, 'w') as f:
                 print(new_content, file=f)
         else:
             # by default, we just output to stdout
+            print("Parsing and fixing %s (stdout)" % path, file=sys.stderr)
             print(new_content)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,41 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006-2008, 2011-2014, 2017 Lukáš Lalinský
+# Copyright (C) 2007 Santiago M. Mola
+# Copyright (C) 2008 Robert Kaye
+# Copyright (C) 2008-2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2011-2012, 2014, 2016-2018 Wieland Hoffmann
+# Copyright (C) 2011-2014 Michael Wiencek
+# Copyright (C) 2012, 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2013-2014 Johannes Dewender
+# Copyright (C) 2013-2015, 2017-2019 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2016-2017 Ville Skyttä
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2018 Kartik Ohri
+# Copyright (C) 2018 abhi-ohri
+# Copyright (C) 2018 virusMac
+# Copyright (C) 2019 Kurt Mosiejczuk
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import datetime
 from distutils import log

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import glob
 import os.path
 

--- a/test/data/testplugins/module/dummyplugin/__init__.py
+++ b/test/data/testplugins/module/dummyplugin/__init__.py
@@ -1,6 +1,25 @@
 # -*- coding: utf-8 -*-
-"""Dummy plugin for tests"""
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+
+"""Dummy plugin for tests"""
 PLUGIN_NAME = "Dummy plugin"
 PLUGIN_AUTHOR = "Zas"
 PLUGIN_DESCRIPTION = "Dummy plugin description"

--- a/test/data/testplugins/singlefile/dummyplugin.py
+++ b/test/data/testplugins/singlefile/dummyplugin.py
@@ -1,6 +1,25 @@
 # -*- coding: utf-8 -*-
-"""Dummy plugin for tests"""
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+
+"""Dummy plugin for tests"""
 PLUGIN_NAME = "Dummy plugin"
 PLUGIN_AUTHOR = "Zas"
 PLUGIN_DESCRIPTION = "Dummy plugin description"

--- a/test/formats/__init__.py
+++ b/test/formats/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -1,4 +1,26 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Zenara Daley
+# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 import unittest
 

--- a/test/formats/coverart.py
+++ b/test/formats/coverart.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 
 from picard import config

--- a/test/formats/test_aac.py
+++ b/test/formats/test_aac.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 
 from picard import config

--- a/test/formats/test_ac3.py
+++ b/test/formats/test_ac3.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 import unittest
 

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 
 from mutagen.apev2 import (

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import (
     PicardTestCase,
     create_fake_png,

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019 Zenara Daley
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 
 import mutagen

--- a/test/formats/test_midi.py
+++ b/test/formats/test_midi.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from .common import CommonTests
 
 

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import unittest
 
 import mutagen

--- a/test/formats/test_mutagenext.py
+++ b/test/formats/test_mutagenext.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard.formats import mutagenext

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import base64
 import logging
 import os

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from .common import (
     REPLAYGAIN_TAGS,
     TAGS,

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -1,4 +1,26 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import json
 import os
 import shutil

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019-2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import json
 import os
 

--- a/test/test_acoustidmanager.py
+++ b/test/test_acoustidmanager.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Laurent Monin
+# Copyright (C) 2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from unittest.mock import (
     MagicMock,
     Mock,

--- a/test/test_amazon_urls.py
+++ b/test/test_amazon_urls.py
@@ -1,4 +1,25 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016 barami
+# Copyright (C) 2018 Wieland Hoffmann
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.picardtestcase import PicardTestCase
 

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from unittest.mock import MagicMock
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from unittest.mock import patch
 from urllib.parse import (
     parse_qs,

--- a/test/test_bytes2human.py
+++ b/test/test_bytes2human.py
@@ -1,3 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013, 2019-2020 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_compatid3.py
+++ b/test/test_compatid3.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2016 Christoph Reiter
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from mutagen import id3
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2019 Laurent Monin
+#
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import logging
 import os

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.test_config import TestPicardConfigCommon
 

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -1,4 +1,25 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 import unittest
 

--- a/test/test_coverart_utils.py
+++ b/test/test_coverart_utils.py
@@ -1,4 +1,26 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_dataobj.py
+++ b/test/test_dataobj.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard import config

--- a/test/test_emptydir.py
+++ b/test/test_emptydir.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os.path
 from tempfile import NamedTemporaryFile

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2019-2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os
 import unittest
 from unittest.mock import MagicMock

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018 Antonio Larrosa
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from contextlib import suppress
 import os.path
 import shutil

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -1,4 +1,25 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2019 Wieland Hoffmann
+# Copyright (C) 2018-2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.picardtestcase import (
     PicardTestCase,

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -1,3 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017, 2019 Laurent Monin
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import (
     PicardTestCase,
     load_test_json,

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2020 Laurent Monin
+# Copyright (C) 2018-2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import (
     PicardTestCase,
     load_test_json,

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
-# Copyright (C) 2019 Laurent Monin
+#
+# Copyright (C) 2019-2020 Laurent Monin
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import logging
 import os

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -1,3 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013, 2018, 2020 Laurent Monin
+# Copyright (C) 2014 Michael Wiencek
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import os.path
 
 from test.picardtestcase import (

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1,3 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2007 Lukáš Lalinský
+# Copyright (C) 2010, 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2012 Chad Wilson
+# Copyright (C) 2013 Michael Wiencek
+# Copyright (C) 2013, 2017-2020 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016-2017 Sambhav Kothari
+# Copyright (C) 2017 Antonio Larrosa
+# Copyright (C) 2017-2018 Wieland Hoffmann
+# Copyright (C) 2018 virusMac
+# Copyright (C) 2020 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import copy
 import datetime
 from unittest.mock import MagicMock

--- a/test/test_scripttofilename.py
+++ b/test/test_scripttofilename.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2019 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import unittest
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_settingsoverride.py
+++ b/test/test_settingsoverride.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard import config

--- a/test/test_similarity.py
+++ b/test/test_similarity.py
@@ -1,4 +1,25 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006 Lukáš Lalinský
+# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2018 Wieland Hoffmann
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.picardtestcase import PicardTestCase
 

--- a/test/test_taggenrefilter.py
+++ b/test/test_taggenrefilter.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019 Wieland Hoffmann
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.picardtestcase import PicardTestCase
 

--- a/test/test_textencoding.py
+++ b/test/test_textencoding.py
@@ -1,4 +1,28 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2015, 2018, 2020 Laurent Monin
+# Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard import util

--- a/test/test_tracknum.py
+++ b/test/test_tracknum.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard.util import tracknum_from_filename

--- a/test/test_union_sorted_lists.py
+++ b/test/test_union_sorted_lists.py
@@ -1,4 +1,26 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2016 Rahul Raturi
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018, 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard.util import union_sorted_lists

--- a/test/test_util_astrcmp.py
+++ b/test/test_util_astrcmp.py
@@ -1,4 +1,28 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Lukáš Lalinský
+# Copyright (C) 2017 Sophist-UK
+# Copyright (C) 2017-2018 Wieland Hoffmann
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2018-2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import unittest
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013-2014 Ionuț Ciocîrlan
+# Copyright (C) 2016 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2019 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import os
 import os.path

--- a/test/test_util_lrucache.py
+++ b/test/test_util_lrucache.py
@@ -1,4 +1,23 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019-2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 from test.picardtestcase import PicardTestCase
 

--- a/test/test_util_natsort.py
+++ b/test/test_util_natsort.py
@@ -1,4 +1,25 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2020 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard.util import natsort

--- a/test/test_util_preservedtags.py
+++ b/test/test_util_preservedtags.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard import config
@@ -52,4 +72,3 @@ class PreservedTagsTest(PicardTestCase):
         preserved.add('tag1')
         preserved.discard('tag2')
         self.assertEqual(config.setting[PreservedTags.opt_name], 'tag1, tag3')
-

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019-2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from test.picardtestcase import PicardTestCase
 
 from picard.util.tags import (

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,32 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2006-2007 Lukáš Lalinský
+# Copyright (C) 2010 fatih
+# Copyright (C) 2010-2011, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2012, 2014, 2018 Wieland Hoffmann
+# Copyright (C) 2013 Ionuț Ciocîrlan
+# Copyright (C) 2013-2014, 2018-2020 Laurent Monin
+# Copyright (C) 2014, 2017 Sophist-UK
+# Copyright (C) 2016 Frederik “Freso” S. Olesen
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017 Shen-Ta Hsieh
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
 
 import builtins
 from collections import namedtuple

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2013-2014, 2018-2020 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2018 Wieland Hoffmann
+# Copyright (C) 2018-2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 import unittest
 
 from test.picardtestcase import PicardTestCase

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -1,4 +1,27 @@
 # -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017-2018 Wieland Hoffmann
+# Copyright (C) 2018 Laurent Monin
+# Copyright (C) 2019 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
 from unittest.mock import (
     MagicMock,
     patch,


### PR DESCRIPTION
In many source files we have a license header, but this wasn't well maintained over the time, with following consequences:
- some files have no header
- some files have badly formatted header
- some files have only partial copyright information

This is why we wrote an helper script to extract authors from git log and merge it with existing headers.
It helps to have consistent license headers in all files.