### PR TITLE
PICARD-1772: Fix negative length handling in $num

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -549,7 +549,7 @@ def func_rsearch(parser, text, pattern):
 @script_function()
 def func_num(parser, text, length):
     try:
-        format_ = "%%0%dd" % min(int(length), 20)
+        format_ = "%%0%dd" % max(0, min(int(length), 20))
     except ValueError:
         return ""
     try:

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -290,6 +290,8 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$num(123,2)", "123")
         self.assertScriptResultEquals("$num(123,a)", "")
         self.assertScriptResultEquals("$num(a,2)", "00")
+        self.assertScriptResultEquals("$num(123,-1)", "123")
+        self.assertScriptResultEquals("$num(123,35)", "00000000000000000123")
 
     def test_cmd_or(self):
         self.assertScriptResultEquals("$or(,)", "")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Added negative length checking to `$num` function.  Also added tests for negative length and length greater than 20.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-1772
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When a negative length is provided as an input to `$num`, the number will be right-padded with spaces.  The number of spaces added is the absolute value of the negative length provided.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add negative length checking to `$num` function.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
