### PR TITLE
PICARD-1774: Return "0" for $lenmulti if 'name' is not entered or is blank

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -805,6 +805,8 @@ def func_len(parser, text=""):
 
 @script_function(eval_args=False)
 def func_lenmulti(parser, multi, separator=MULTI_VALUED_JOINER):
+    if not multi:
+        return "0"
     return str(len(MultiValue(parser, multi, separator)))
 
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -732,6 +732,17 @@ class ScriptParserTest(PicardTestCase):
         # Test no separator
         self.assertScriptResultEquals("$lenmulti(%foo%,)", "1", context)
         self.assertScriptResultEquals("$lenmulti(%bar%,)", "1", context)
+        # Test blank name
+        context["baz"] = ""
+        self.assertScriptResultEquals("$lenmulti(%baz%)", "0", context)
+        self.assertScriptResultEquals("$lenmulti(%baz%,:)", "1", context)   # Bug in multi-value evaluation?
+        # Test empty multi-value
+        context["baz"] = []
+        self.assertScriptResultEquals("$lenmulti(%baz%)", "0", context)
+        self.assertScriptResultEquals("$lenmulti(%baz%,:)", "1", context)   # Bug in multi-value evaluation?
+        # Test missing name
+        self.assertScriptResultEquals("$lenmulti(,)", "0", context)
+        self.assertScriptResultEquals("$lenmulti(,:)", "0", context)
 
     def test_cmd_performer(self):
         context = Metadata()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Return "0" for `$lenmulti` if `name` is not entered or is blank.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-1774
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
When calling the `$lenmulti` function with no name specified (e.g. `$lenmulti(,)` or `$lenmulti(,; )`) the function returns a count of "1".  This should probably return "0".


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Return "0" for `$lenmulti` if `name` is not entered or is blank.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
When updating the tests, I noticed an unexpected return value if the function was passed a variable that evaluated to an empty string and a separator override was set.  The function returned "1" when I would expect it to return "0".  Possibly a bug in the multi-var parser?  I noted this on the specific tests.