### PR TITLE
PICARD-1776: Trap ValueError exception in $datetime function

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -73,6 +73,10 @@ class ScriptUnknownFunction(ScriptError):
     pass
 
 
+class ScriptRuntimeError(ScriptError):
+    pass
+
+
 class ScriptText(str):
 
     def eval(self, state):
@@ -1267,7 +1271,10 @@ def func_datetime(parser, format=None):
     try:
         return datetime.datetime.now(tz=local_tz).strftime(format)
     except ValueError:
-        return ''
+        raise ScriptRuntimeError(
+            "Unsupported format code in $%s at position %i, line %i"
+            % ('datetime', parser._x, parser._y)
+        )
 
 
 @script_function(eval_args=False)

--- a/picard/script.py
+++ b/picard/script.py
@@ -1264,8 +1264,10 @@ def func_datetime(parser, format=None):
     # Handle case where format evaluates to ''
     if not format:
         format = '%Y-%m-%d %H:%M:%S'
-
-    return datetime.datetime.now(tz=local_tz).strftime(format)
+    try:
+        return datetime.datetime.now(tz=local_tz).strftime(format)
+    except ValueError:
+        return ''
 
 
 @script_function(eval_args=False)

--- a/picard/script.py
+++ b/picard/script.py
@@ -1283,8 +1283,8 @@ def func_datetime(parser, format=None):
         raise ScriptRuntimeError(
             "Unsupported format code",
             parser._function_stack.get(),
-            parser._x,
-            parser._y
+            parser._y,
+            parser._x
         )
 
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1202,7 +1202,7 @@ class ScriptParserTest(PicardTestCase):
 
         try:
             context = Metadata()
-            areg = r"^\$datetime:\d+:\d+: Unsupported format code"
+            areg = r"^\$datetime:1:\d+: Unsupported format code"
             # Tests with invalid format code (platform dependent tests)
             for test_case in tests_to_run:
                 with self.assertRaisesRegex(ScriptRuntimeError, areg):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1171,8 +1171,6 @@ class ScriptParserTest(PicardTestCase):
             areg = r"^Wrong number of arguments for \$datetime: Expected between 0 and 1, "
             with self.assertRaisesRegex(ScriptError, areg):
                 self.parser.eval("$datetime(abc,def)")
-        except (AssertionError, ValueError, IndexError) as err:
-            raise err
         finally:
             # Restore original datetime object
             datetime.datetime = original_datetime
@@ -1207,8 +1205,6 @@ class ScriptParserTest(PicardTestCase):
             for test_case in tests_to_run:
                 with self.assertRaisesRegex(ScriptRuntimeError, areg):
                     self.parser.eval(r'$datetime(\{0})'.format(test_case))
-        except (AssertionError, ValueError, IndexError) as err:
-            raise err
         finally:
             # Restore original datetime object
             datetime.datetime = original_datetime


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:  Trap the `ValueError` in `$datetime`.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-1776
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
When specifying a platform-specific format code (e.g. "%-d" on Windows 7), `$datetime` crashes with a ValueError.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Trap the `ValueError` in `$datetime` and ~~return "Invalid Format" message~~ raise a `ScriptRuntimeError` exception.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
