### PR TITLE
PICARD-1796: Date scoring logic

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -16,6 +16,7 @@
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2020 Ray Bouchard
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -74,6 +75,7 @@ class Cluster(QtCore.QObject, Item):
         'releasetype': 10,
         'releasecountry': 2,
         'format': 2,
+        'date': 4,
     }
 
     def __init__(self, name, artist="", special=False, related_album=None, hide_if_empty=False):

--- a/picard/file.py
+++ b/picard/file.py
@@ -260,7 +260,7 @@ class File(QtCore.QObject, Item):
             # https://docs.python.org/3/library/os.html#os.utime
             # Since Python 3.3, ns parameter is available
             # The best way to preserve exact times is to use the st_atime_ns and st_mtime_ns
-            #  fields from the os.stat() result object with the ns parameter to utime.
+            # fields from the os.stat() result object with the ns parameter to utime.
             st = os.stat(filename)
         except OSError as why:
             errmsg = "Couldn't read timestamps from %r: %s" % (filename, why)
@@ -489,7 +489,7 @@ class File(QtCore.QObject, Item):
         new_path = os.path.dirname(new_filename)
         old_path = os.path.dirname(old_filename)
         if new_path == old_path:
-            #  skip, same directory, nothing to move
+            # skip, same directory, nothing to move
             return
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()

--- a/picard/file.py
+++ b/picard/file.py
@@ -23,6 +23,7 @@
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017-2018 Antonio Larrosa
 # Copyright (C) 2019 Joel Lintunen
+# Copyright (C) 2020 Ray Bouchard
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -111,6 +112,7 @@ class File(QtCore.QObject, Item):
         "releasecountry": 2,
         "format": 2,
         "isvideo": 2,
+        "date": 4,
     }
 
     class PreserveTimesStatError(Exception):
@@ -258,7 +260,7 @@ class File(QtCore.QObject, Item):
             # https://docs.python.org/3/library/os.html#os.utime
             # Since Python 3.3, ns parameter is available
             # The best way to preserve exact times is to use the st_atime_ns and st_mtime_ns
-            # fields from the os.stat() result object with the ns parameter to utime.
+            #  fields from the os.stat() result object with the ns parameter to utime.
             st = os.stat(filename)
         except OSError as why:
             errmsg = "Couldn't read timestamps from %r: %s" % (filename, why)
@@ -487,7 +489,7 @@ class File(QtCore.QObject, Item):
         new_path = os.path.dirname(new_filename)
         old_path = os.path.dirname(old_filename)
         if new_path == old_path:
-            # skip, same directory, nothing to move
+            #  skip, same directory, nothing to move
             return
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -38,8 +38,6 @@ from collections.abc import (
     MutableMapping,
 )
 
-from dateutil.parser import parse
-
 from PyQt5.QtCore import QObject
 
 from picard import config
@@ -52,7 +50,10 @@ from picard.plugin import (
     PluginPriority,
 )
 from picard.similarity import similarity2
-from picard.util import linear_combination_of_weights
+from picard.util import (
+    extract_year_from_date,
+    linear_combination_of_weights,
+)
 from picard.util.imagelist import ImageList
 from picard.util.tags import PRESERVED_TAGS
 
@@ -227,18 +228,6 @@ class Metadata(MutableMapping):
         sim = linear_combination_of_weights(parts) * get_score(release)
         return SimMatchRelease(similarity=sim, release=release)
 
-    @staticmethod
-    def extract_year_from_date(dt):
-        """ Extracts year from  passed in date either dict or string """
-
-        if isinstance(dt, Mapping):
-            year = int(dt.get('year'))
-        else:
-            parsed_dt = parse(dt)
-            year = parsed_dt.year
-
-        return year
-
     def compare_to_release_parts(self, release, weights):
         parts = []
         if "album" in self:
@@ -268,13 +257,13 @@ class Metadata(MutableMapping):
         factor = 0.0
         if "date" in release:
             release_date = release['date']
-            release_year = Metadata.extract_year_from_date(release_date)
+            release_year = extract_year_from_date(release_date)
             if "date" in self:
                 metadata_date = self['date']
                 if release_date == metadata_date:
                     factor = 1.00
                 else:
-                    metadata_year = Metadata.extract_year_from_date(metadata_date)
+                    metadata_year = extract_year_from_date(metadata_date)
                     if release_year == metadata_year:
                         factor = 0.95
                     elif abs(release_year - metadata_year) <= 2:

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -255,7 +255,7 @@ class Metadata(MutableMapping):
         # release has a no date (all else equal, we don't prefer this release since its date is missing)
         # release has a date but it does not match ours(all else equal, its better to have an unknown date than a wrong date. since the unknown could actually be correct)
         factor = 0.0
-        if "date" in release:
+        if "date" in release and release['date'] != '':
             release_date = release['date']
             release_year = extract_year_from_date(release_date)
             if "date" in self:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -20,6 +20,7 @@
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
 # Copyright (C) 2018 Bob Swift
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2020 Ray Bouchard
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -38,6 +39,7 @@
 
 import builtins
 from collections import namedtuple
+from collections.abc import Mapping
 import html
 import json
 import ntpath
@@ -47,6 +49,8 @@ import re
 import sys
 from time import time
 import unicodedata
+
+from dateutil.parser import parse
 
 from PyQt5 import QtCore
 
@@ -645,3 +649,15 @@ def limited_join(a_list, limit, join_string='+', middle_string='…'):
     start = a_list[:half]
     end = a_list[-half:]
     return join_string.join(start + [middle_string] + end)
+
+
+def extract_year_from_date(dt):
+    """ Extracts year from  passed in date either dict or string """
+
+    if isinstance(dt, Mapping):
+        year = int(dt.get('year'))
+    else:
+        parsed_dt = parse(dt)
+        year = parsed_dt.year
+
+    return year

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -1,3 +1,4 @@
+python-dateutil==2.8.1
 discid==1.2.0
 mutagen==1.44.0
 pyobjc-core==5.2

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,3 +1,4 @@
+python-dateutil==2.8.1
 discid==1.2.0
 mutagen==1.44.0
 PyQt5==5.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+python-dateutil>=2.8.1
 discid
 mutagen>=1.37
 PyQt5>=5.7.1
-dateutils==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discid
 mutagen>=1.37
 PyQt5>=5.7.1
+dateutils==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -769,7 +769,7 @@ args = {
         'patch_version': picard_patch_version,
     },
     'scripts': ['scripts/' + PACKAGE_NAME],
-    'install_requires': ['PyQt5', 'mutagen'],
+    'install_requires': ['PyQt5', 'mutagen', 'python-dateutil'],
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
#  Summary
New logic to include the release date in scoring process.

(Separated out from PR 1771 as you requested)

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem
Seems some of the results from AcoustId don't have a release date, and we need a way to de-prioritize those records with lower quality data from the match process.

PICARD-1796

# Solution

Enhanced the scoring process to consider the release date.  It will give highest Part Score to results that have a date that match our own tag, next to records that have a date where year is +/-2 years, next to records that have a non-blank date, next a minimal score if the date is missing, and the lowest Part Score if the date is there but does not match.

# Action
Sorry need little guidance on creating the JIRA you asked to have associated with this.

Please ignore the _config.yml for theme.  Very bizzare that showed up when I first forked, and I definitely did not commit it???