### PR TITLE
PICARD-1781: Have $find return '' rather than '-1' on not found

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -1045,7 +1045,7 @@ def func_find(parser, haystack, needle):
         needle: The substring to find.
 
     Returns:
-        The zero-based index of the first occurrance of needle in haystack, or -1 if needle was not found.
+        The zero-based index of the first occurrence of needle in haystack, or "" if needle was not found.
     """
     index = haystack.find(needle)
     if index < 0:

--- a/picard/script.py
+++ b/picard/script.py
@@ -1047,7 +1047,10 @@ def func_find(parser, haystack, needle):
     Returns:
         The zero-based index of the first occurrance of needle in haystack, or -1 if needle was not found.
     """
-    return str(haystack.find(needle))
+    index = haystack.find(needle)
+    if index < 0:
+        return ''
+    return str(index)
 
 
 @script_function()

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -852,27 +852,27 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$find(%bar%,%baz%)", "9", context)
         self.assertScriptResultEquals("$find(%foo%,%bar%)", "0", context)
         self.assertScriptResultEquals("$find(%bar%,%foo%)", "0", context)
-        self.assertScriptResultEquals("$find(%foo%,%err%)", "-1", context)
+        self.assertScriptResultEquals("$find(%foo%,%err%)", "", context)
         # Tests with static input
         self.assertScriptResultEquals("$find(abcdef,c)", "2", context)
         self.assertScriptResultEquals("$find(abcdef,cd)", "2", context)
-        self.assertScriptResultEquals("$find(abcdef,g)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,g)", "", context)
         # Tests ends of string
         self.assertScriptResultEquals("$find(abcdef,a)", "0", context)
         self.assertScriptResultEquals("$find(abcdef,ab)", "0", context)
         self.assertScriptResultEquals("$find(abcdef,f)", "5", context)
         self.assertScriptResultEquals("$find(abcdef,ef)", "4", context)
         # Tests case sensitivity
-        self.assertScriptResultEquals("$find(abcdef,C)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,C)", "", context)
         # Tests no characters processed as wildcards
-        self.assertScriptResultEquals("$find(abcdef,.f)", "-1", context)
-        self.assertScriptResultEquals("$find(abcdef,?f)", "-1", context)
-        self.assertScriptResultEquals("$find(abcdef,*f)", "-1", context)
-        self.assertScriptResultEquals("$find(abc.ef,cde)", "-1", context)
-        self.assertScriptResultEquals("$find(abc?ef,cde)", "-1", context)
-        self.assertScriptResultEquals("$find(abc*ef,cde)", "-1", context)
+        self.assertScriptResultEquals("$find(abcdef,.f)", "", context)
+        self.assertScriptResultEquals("$find(abcdef,?f)", "", context)
+        self.assertScriptResultEquals("$find(abcdef,*f)", "", context)
+        self.assertScriptResultEquals("$find(abc.ef,cde)", "", context)
+        self.assertScriptResultEquals("$find(abc?ef,cde)", "", context)
+        self.assertScriptResultEquals("$find(abc*ef,cde)", "", context)
         # Tests missing inputs
-        self.assertScriptResultEquals("$find(,c)", "-1", context)
+        self.assertScriptResultEquals("$find(,c)", "", context)
         self.assertScriptResultEquals("$find(abcdef,)", "0", context)
         # Tests wrong number of arguments
         areg = r"^Wrong number of arguments for \$find: Expected exactly 2, "


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**: Have `$find` return "" rather than "-1" on not found

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-1781
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The `$find` scripting function currently returns "-1" if `needle` is not found in `haystack`.  This was based on the return value of the Python `find` method.  This is not consistent with other Picard scripting functions, which return "" for a `False` (not found?) condition.  For consistency, consider changing the `$find` function to return "" on a "not found" condition.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Have $find return "" rather than "-1" on not found.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
