### PR TITLE
PICARD-1777: Properly support fractional scaling on Windows 10

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -955,6 +955,11 @@ def main(localedir=None, autoupdate=True):
     # Allow High DPI Support
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    # HighDpiScaleFactorRoundingPolicy is available since Qt 5.14. This is
+    # required to support fractional scaling properly.
+    if hasattr(QtGui.QGuiApplication, 'setHighDpiScaleFactorRoundingPolicy'):
+        QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+            QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
 
     # Enable mnemonics on all platforms, even macOS
     QtGui.qt_set_sequence_auto_mnemonic(True)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
With Qt 5.14 setting HighDpiScaleFactorRoundingPolicy allows proper scaling to e.g. 150% on Windows 10. Otherwise Qt5 would just scale to the next full factor, e.g. 200%.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1777
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Since Qt 5.14 is is possible to set `HighDpiScaleFactorRoundingPolicy.PassThrough`. This will configure Qt to use the scaling factor as provided by the operating system, e.g. 1.5 on Windows if the scaling is set to 150%. By default it is set to `Round`, which results in 1.5 getting rounded up to 2.

I tested this on Windows and Linux:

- Windows with Qt 5.14 will now correctly consider the scaling factor. With Qt 5.13 this is not supported and a system setting of 150% will effectively scale to 200%.
- Linux GNOME 3.34 (Wayland) Qt 5.14 fractional scaling is experimental and a mess, looks awful and blurry.
- ~~Linux GNOME 3.34 in general using just the default settings the scaling is only respected for the font sizes, not the graphics. You can manually tweak this for Qt by setting appropriate environment variables. But the proposed change makes no difference here.~~ That's no true, I had `QT_AUTO_SCREEN_SCALE_FACTOR=0` set on my environment due to issues I had with this in the past. But by default it works well.
- Linux KDE Plasma 5.18 and Qt 5.14 scaling of Qt applications works as expected, including using fractional scaling. This is true with and without the proposed change here.
- On macOS I can't test as I don't have a retina display. I suppose it is fine as this platform had the best support for scaling.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
