### PR TITLE
PICARD-1784: fix a typo leading to Coverart error: Host not found

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -638,7 +638,7 @@ class CoverArtProviderCaa(CoverArtProvider):
                             # thumbnail will be used to "display" PDF in info
                             # dialog
                             thumbnail = self.coverartimage_thumbnail_class(
-                                url=url[0],
+                                url=urls[0],
                                 types=image["types"],
                                 is_front=image['front'],
                                 comment=image["comment"],


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

When downloading PDF cover art images, thumbnail URL is only the first letter of the actual URL.
This leads to various problems.

```
D: 18:12:01,232 coverart.next_in_queue:204: Downloading CaaThumbnailCoverArtImage(url='h', types=['booklet'], support_types=True, support_multi_types=True, is_front=False)
D: 18:12:01,232 webservice.ratecontrol._out_of_backoff:229: ('ia800305.us.archive.org', 80): oobackoff; delay: 1000ms -> 1000ms; slow start; window size 1.000 -> 2.000
D: 18:12:01,233 webservice.ratecontrol.get_delay_to_next_request:113: ('', 80): First request
D: 18:12:01,234 webservice.ratecontrol.increment_requests:138: ('', 80): Incrementing requests to: 1
D: 18:12:01,235 webservice.ratecontrol.decrement_requests:146: ('', 80): Decrementing requests to: 0
E: 18:12:01,236 webservice._handle_reply:396: Network request error for : Host not found (QT code 3, HTTP code 0)
E: 18:12:01,236 album.error_append:278: Coverart error: Host not found
```

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1784
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

It happens only with releases having PDF cover art images from CAA, and when those images are actually downloaded by Picard (depending on selected options), but it was there since years

This issue was introduced in 30635246f6e13d6b46b61dd38c4aaa82ad4c9c88

That's a typo: `url[0]` -> `urls[0]` (hence the 'h')

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
