### PR TITLE
PICARD-1803: Fixed decamelcasing relationship attributes

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -100,7 +100,7 @@ _RELEASE_GROUP_TO_METADATA = {
 
 
 def _decamelcase(text):
-    return re.sub(r'([A-Z])', r' \1', text).strip()
+    return re.sub(r'(?<![A-Z\s])([A-Z])', r' \1', text).strip()
 
 
 _REPLACE_MAP = {}

--- a/test/data/ws_data/recording_credits.json
+++ b/test/data/ws_data/recording_credits.json
@@ -164,6 +164,30 @@
     "attributes": ["solo"],
     "type": "vocal",
     "type-id": "0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa"
+  }, {
+    "attribute-credits": {},
+    "attributes": [
+      "EWI"
+    ],
+    "end": null,
+    "artist": {
+      "sort-name": "Brecker, Michael",
+      "id": "795058e7-927e-4fcd-a5a0-f57c2fe9d3d1",
+      "name": "Michael Brecker",
+      "disambiguation": ""
+    },
+    "source-credit": "",
+    "type-id": "59054b12-01ac-43ee-a618-285fd397e461",
+    "attribute-values": {},
+    "begin": null,
+    "type": "instrument",
+    "target-credit": "",
+    "attribute-ids": {
+      "EWI": "7061c07c-e87a-4f5f-b45f-fb1138733e32"
+    },
+    "ended": false,
+    "direction": "backward",
+    "target-type": "artist"
   }],
   "length": 242640,
   "id": "2d40c8b2-7524-49e3-af44-ebb924c5b023",

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -30,6 +30,7 @@ from test.picardtestcase import (
 from picard import config
 from picard.album import Album
 from picard.mbjson import (
+    _decamelcase,
     artist_to_metadata,
     countries_from_node,
     get_score,
@@ -205,6 +206,12 @@ class RecordingCreditsTest(MBJSONTest):
         self.assertNotIn('performer:solo', m)
         self.assertEqual(m['performer:solo vocals'], 'Anni-Frid Lyngstad')
 
+    def test_recording_instrument_decamelcase(self):
+        m = Metadata()
+        t = Track("1")
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['performer:ewi'], 'Michael Brecker')
+
 
 class TrackTest(MBJSONTest):
 
@@ -371,3 +378,12 @@ class GetScoreTest(PicardTestCase):
 
     def test_get_score_no_score(self):
         self.assertEqual(1.0, get_score({}))
+
+
+class DecamelcaseTest(PicardTestCase):
+    def test_decamelcase(self):
+        self.assertEqual('foo bar', _decamelcase('foo bar'))
+        self.assertEqual('Foo Bar', _decamelcase('Foo Bar'))
+        self.assertEqual('Foo Bar', _decamelcase('FooBar'))
+        self.assertEqual('Foo BAr', _decamelcase('FooBAr'))
+        self.assertEqual('EWI', _decamelcase('EWI'))


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
EWI must not become E W I

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The _decamelcase function in mbjson turns "EWI" into "E W I".
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1803
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fix the decamelcase function, to not enter spaces before a upper case character if it is preceded by another upper case or whitespace character.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
@zas This fixes the issue of added whitespaces in EWI, but I am not sure about two things:

1. Do we need the decamelcase at all? For which attributes is it needed? I have a faint memory of this, but it probably is for some legacy reason. If it is only for some specific attributes we maybe could at least call decamelcase only when needed.

2. With this patch "EWI" still gets turned to lowercase "ewi". Is this expected? Should we change it?
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
