### PR TITLE
PICARD-1809: Load based on extensions, fallback to guessing if it fails

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -165,7 +165,16 @@ class File(QtCore.QObject, Item):
         if self.tagger.stopping:
             log.debug("File not loaded because %s is stopping: %r", PICARD_APP_NAME, self.filename)
             return None
-        return self._load(filename)
+        try:
+            # Try loading based on extension first
+            return self._load(filename)
+        except Exception:
+            from picard.formats import guess_format
+            # If it fails, force format guessing and try loading again
+            file_format = guess_format(filename)
+            if not file_format and type(file_format) == type(self):
+                raise
+            return file_format._load(filename)
 
     def _load(self, filename):
         """Load metadata from the file."""

--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -79,15 +79,16 @@ def guess_format(filename, options=_formats):
 def open_(filename):
     """Open the specified file and return a File instance with the appropriate format handler, or None."""
     try:
-        # First try to guess the format on the basis of file headers
-        audio_file = guess_format(filename)
-        if not audio_file:
-            i = filename.rfind(".")
-            if i < 0:
-                return None
+        # Use extension based opening as default
+        i = filename.rfind(".")
+        if i >= 0:
             ext = filename[i+1:].lower()
-            # Switch to extension based opening if guess_format fails
             audio_file = _extensions[ext](filename)
+        else:
+            # If there is no extension, try to guess the format based on file headers
+            audio_file = guess_format(filename)
+        if not audio_file:
+            return None
         return audio_file
     except KeyError:
         # None is returned if both the methods fail


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary


<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Prioritize loading based on file extension and fallback to format guessing if it fails.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The current logic opens one file at a time, reads the file header, try to guess the file format based on the header and then proceeds to the loading phase. This results in a huge overhead of opening every single file twice, which in case of large libraries can be even worse as the file doesn't stay in memory cache.

* JIRA ticket (_optional_): PICARD-1809
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Assume that a file extension is correct if one exists. Try to load the file based on the file extension and fallback to format guessing based on the header if it fails. Finally, retry loading with guessed format. There are 3 file opening operations in case of failures, but the file stays cached in memory.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
