### PR TITLE
Mitigate thread competition by scanning directories before loading files

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -539,7 +539,6 @@ class Album(DataObject, Item):
                         similarity=track.metadata.compare(file.orig_metadata),
                         track=track
                     )
-                    QtCore.QCoreApplication.processEvents()
 
             no_match = SimMatchAlbum(similarity=-1, track=self.unmatched_files)
             best_match = find_best_match(candidates, no_match)

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -494,7 +494,6 @@ class ClusterEngine(object):
                     c = similarity(token_x, token_y)
                     if c >= threshold:
                         heappush(heap, ((1.0 - c), [x, y]))
-            QtCore.QCoreApplication.processEvents()
 
         for i in range(self.cluster_dict.get_size()):
             word, count = self.cluster_dict.get_word_and_count(i)

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -68,7 +68,8 @@ class DataHash:
             self._hash = m.hexdigest()
             if self._hash not in _datafiles:
                 (fd, self._filename) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
-                QObject.tagger.register_cleanup(self.delete_file)
+                if hasattr(QObject, 'tagger'):
+                    QObject.tagger.register_cleanup(self.delete_file)
                 with os.fdopen(fd, "wb") as imagefile:
                     imagefile.write(data)
                 _datafiles[self._hash] = self._filename

--- a/picard/file.py
+++ b/picard/file.py
@@ -180,12 +180,12 @@ class File(QtCore.QObject, Item):
     @staticmethod
     def _load_check_metadata(stopping, process_queue, result_queue):
         from picard.formats import open_ as open_file
+        result_queue.cancel_join_thread()
         while True:
             filename = process_queue.get()
             if stopping.value:
                 break
             result_queue.put((filename, File._load_check_metadata_thread(open_file, filename)))
-        result_queue.cancel_join_thread()
 
     @staticmethod
     def _load_check_metadata_thread(open_file, filename):

--- a/picard/file.py
+++ b/picard/file.py
@@ -180,10 +180,9 @@ class File(QtCore.QObject, Item):
     @staticmethod
     def _load_check_metadata(stopping, process_queue, result_queue):
         from picard.formats import open_ as open_file
-        result_queue.cancel_join_thread()
         while True:
             filename = process_queue.get()
-            if stopping.value:
+            if stopping:
                 break
             result_queue.put((filename, File._load_check_metadata_thread(open_file, filename)))
 

--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -10,6 +10,7 @@
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2017 Ville Skyttä
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -10,7 +10,6 @@
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2017 Ville Skyttä
-# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -25,6 +25,7 @@
 # Copyright (C) 2018 Bob Swift
 # Copyright (C) 2018 virusMac
 # Copyright (C) 2019 Joel Lintunen
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -52,6 +53,7 @@ import re
 import shutil
 import signal
 import sys
+from threading import Thread
 
 from PyQt5 import (
     QtCore,
@@ -517,76 +519,53 @@ class Tagger(QtWidgets.QApplication):
             for file in new_files:
                 file.load(partial(self._file_loaded, target=target))
 
-    def add_directory(self, path):
-        if config.setting['recursively_add_files']:
-            self._add_directory_recursive(path)
-        else:
-            self._add_directory_non_recursive(path)
-
-    def _add_directory_recursive(self, path):
-        ignore_hidden = config.setting["ignore_hidden_files"]
-        walk = os.walk(path)
-
-        def get_files():
-            try:
-                root, dirs, files = next(walk)
-                if ignore_hidden:
-                    dirs[:] = [d for d in dirs if not is_hidden(os.path.join(root, d))]
-            except StopIteration:
-                return None
-            else:
-                number_of_files = len(files)
-                if number_of_files:
-                    mparms = {
-                        'count': number_of_files,
-                        'directory': root,
-                    }
-                    log.debug("Adding %(count)d files from '%(directory)r'" %
-                              mparms)
-                    self.window.set_statusbar_message(
-                        ngettext(
-                            "Adding %(count)d file from '%(directory)s' ...",
-                            "Adding %(count)d files from '%(directory)s' ...",
-                            number_of_files),
-                        mparms,
-                        translate=None,
-                        echo=None
-                    )
-                return (os.path.join(root, f) for f in files)
-
-        def process(result=None, error=None):
-            if result:
-                if error is None:
-                    self.add_files(result)
-                thread.run_task(get_files, process)
-
-        process(True, False)
-
-    def _add_directory_non_recursive(self, path):
+    def _scan_dir(self, ignore_hidden, folders, recursive):
         files = []
-        for f in os.listdir(path):
-            listing = os.path.join(path, f)
-            if os.path.isfile(listing):
-                files.append(listing)
-        number_of_files = len(files)
-        if number_of_files:
-            mparms = {
-                'count': number_of_files,
-                'directory': path,
-            }
-            log.debug("Adding %(count)d files from '%(directory)r'" %
-                      mparms)
-            self.window.set_statusbar_message(
-                ngettext(
-                    "Adding %(count)d file from '%(directory)s' ...",
-                    "Adding %(count)d files from '%(directory)s' ...",
-                    number_of_files),
-                mparms,
-                translate=None,
-                echo=None
-            )
-            # Function call only if files exist
-            self.add_files(files)
+        local_folders = list(folders)
+        while len(local_folders) > 0:
+            current_folder = local_folders.pop(0)
+            current_folder_files = []
+            for entry in os.scandir(current_folder):
+                if ignore_hidden and is_hidden(entry.path):
+                    continue
+                if recursive and entry.is_dir():
+                    local_folders.extend([entry.path])
+                else:
+                    current_folder_files.extend([entry.path])
+
+            number_of_files = len(current_folder_files)
+            if number_of_files:
+                mparms = {
+                    'count': number_of_files,
+                    'directory': current_folder,
+                }
+                log.debug("Adding %(count)d files from '%(directory)r'" %
+                          mparms)
+                self.window.set_statusbar_message(
+                    ngettext(
+                        "Adding %(count)d file from '%(directory)s' ...",
+                        "Adding %(count)d files from '%(directory)s' ...",
+                        number_of_files),
+                    mparms,
+                    translate=None,
+                    echo=None
+                )
+                files.extend(current_folder_files)
+        return files
+
+    def add_directory(self, path):
+        Thread(target=self._add_directory, args=[path, config.setting['recursively_add_files']]).start()
+
+    def _add_directory(self, path, recursive=False):
+        if not os.path.exists(path) or not os.path.isdir(path):
+            return
+
+        ignore_hidden = config.setting["ignore_hidden_files"]
+        files = self._scan_dir(ignore_hidden, [path], recursive)
+
+        # Add files at once
+        if files:
+            thread.to_main(self.add_files, files)
 
     def get_file_lookup(self):
         """Return a FileLookup object."""

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -26,8 +26,8 @@
 
 
 import sys
-import traceback
 from threading import Event
+import traceback
 
 from PyQt5.QtCore import (
     QCoreApplication,
@@ -38,12 +38,12 @@ from PyQt5.QtCore import (
 
 class ProxyToMainEvent(QEvent):
 
-    def __init__(self, func, *args, **kwargs):
+    def __init__(self, func, event=None, *args, **kwargs):
         super().__init__(QEvent.User)
         self.func = func
         self.args = args
         self.kwargs = kwargs
-        self.event = kwargs.pop('event') if 'event' in kwargs else None
+        self.event = event
 
     def run(self):
         self.func(*self.args, **self.kwargs)
@@ -79,7 +79,6 @@ def run_task(func, next_func, priority=0, thread_pool=None, traceback=True):
 
 def to_main(func, *args, **kwargs):
     event = Event()
-    kwargs['event'] = event
     QCoreApplication.postEvent(QCoreApplication.instance(),
-                               ProxyToMainEvent(func, *args, **kwargs))
+                               ProxyToMainEvent(func, event, *args, **kwargs))
     return event

--- a/scripts/pyinstaller/portable-hook.py
+++ b/scripts/pyinstaller/portable-hook.py
@@ -22,6 +22,8 @@
 import os
 import os.path
 import sys
+import multiprocessing
+
 
 from picard import (
     PICARD_APP_NAME,
@@ -29,6 +31,7 @@ from picard import (
 )
 import picard.const
 
+multiprocessing.freeze_support()
 
 # The portable version stores all data in a folder beside the executable
 configdir = '{}-{}'.format(PICARD_ORG_NAME, PICARD_APP_NAME)

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import multiprocessing
 import os
 import sys
 

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -15,5 +15,7 @@ else:
 if sys.platform == 'win32':
     os.environ['PATH'] = basedir + ';' + os.environ['PATH']
 
-from picard.tagger import main
-main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+if __name__ == '__main__':
+    multiprocessing.freeze_support()
+    from picard.tagger import main
+    main(os.path.join(basedir, 'locale'), %(autoupdate)s)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Change directory scanning (add_directory) logic to scan everything before adding files (add_files).

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
The thread pool threads have to deal with a whole bunch of different tasks and compete for both IO and CPU. The current code launches concurrent tasks for directory scanning and file processing, which leads to harmful competition and slows down the file processing. 

* JIRA ticket (_optional_): PICARD-840
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Instead of running the directory scanning interleaved with the file processing, a single Python thread is used to scan first and then forwards the files list to the Tagger.add_files at once. The thread runs the unified recursive/non-recursive file scanning code. 

Tested on a 17k file library cleaning file cache before and between tests (SysInternals RamMap->Empty Standby list). Completely loading the library took: 
- Latest master clone: 32 minutes, with HDD reading speeds fluctuating between 1-5 MB/s for for most of the time (was running reasonably fine until the 7-8k song mark, then slowed down. Seemingly due to the lack of files to process as the directory/file scanning is frequently interrupted);
- Latest branch clone: 13 minutes, with HDD reading speeds fluctuating between 8-10MB/s for most of the time.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
