### PR TITLE
PICARD-1818: Make PyQt5.QtDBus optional

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -58,7 +58,6 @@ from PyQt5 import (
     QtGui,
     QtWidgets,
 )
-from PyQt5.QtDBus import QDBusConnection
 
 from picard import (
     PICARD_APP_ID,
@@ -972,9 +971,12 @@ def main(localedir=None, autoupdate=True):
     if picard_args.long_version:
         return longversion()
 
-    if not (IS_WIN or IS_MACOS or IS_HAIKU):
+    try:
+        from PyQt5.QtDBus import QDBusConnection
         dbus = QDBusConnection.sessionBus()
         dbus.registerService(PICARD_APP_ID)
+    except ImportError:
+        pass
 
     tagger = Tagger(picard_args, unparsed_args, localedir, autoupdate)
 

--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -90,94 +90,102 @@ if IS_WIN:
     DesktopStatusIndicator = WindowsTaskbarStatusIndicator
 
 elif not (IS_MACOS or IS_HAIKU):
-    from PyQt5.QtCore import (
-        Q_CLASSINFO,
-        QObject,
-        pyqtSlot,
-    )
-    from PyQt5.QtDBus import (
-        QDBusAbstractAdaptor,
-        QDBusConnection,
-        QDBusMessage,
-    )
+    QDBusConnection = None
 
-    from picard import PICARD_DESKTOP_NAME
+    try:
+        from PyQt5.QtCore import (
+            Q_CLASSINFO,
+            QObject,
+            pyqtSlot,
+        )
+        from PyQt5.QtDBus import (
+            QDBusAbstractAdaptor,
+            QDBusConnection,
+            QDBusMessage,
+        )
 
-    DBUS_INTERFACE = 'com.canonical.Unity.LauncherEntry'
+    except ImportError:
+        pass
 
-    class UnityLauncherEntryService(QObject):
+    else:
 
-        def __init__(self, bus, app_id):
-            QObject.__init__(self)
-            self._bus = bus
-            self._app_id = app_id
-            self._path = '/'
-            self._progress = 0
-            self._visible = False
-            self._dbus_adaptor = UnityLauncherEntryAdaptor(self)
-            self._available = bus.registerObject(self._path, self)
+        from picard import PICARD_DESKTOP_NAME
 
-        @property
-        def current_progress(self):
-            return {
-                "progress": self._progress,
-                "progress-visible": self._visible,
-            }
+        DBUS_INTERFACE = 'com.canonical.Unity.LauncherEntry'
 
-        @property
-        def is_available(self):
-            return self._available
+        class UnityLauncherEntryService(QObject):
 
-        def update(self, progress, visible=True):
-            self._progress = progress
-            self._visible = visible
-            # Automatic forwarding of Qt signals does not work in this case
-            # since Qt cannot handle the complex "a{sv}" type.
-            # Create the signal message manually.
-            message = QDBusMessage.createSignal(self._path, DBUS_INTERFACE, 'Update')
-            message.setArguments([self._app_id, self.current_progress])
-            self._bus.send(message)
+            def __init__(self, bus, app_id):
+                QObject.__init__(self)
+                self._bus = bus
+                self._app_id = app_id
+                self._path = '/'
+                self._progress = 0
+                self._visible = False
+                self._dbus_adaptor = UnityLauncherEntryAdaptor(self)
+                self._available = bus.registerObject(self._path, self)
 
-        def query(self):
-            return [self._app_id, self.current_progress]
+            @property
+            def current_progress(self):
+                return {
+                    "progress": self._progress,
+                    "progress-visible": self._visible,
+                }
 
-    class UnityLauncherEntryAdaptor(QDBusAbstractAdaptor):
-        """ This provides the DBus adaptor to the outside world"""
+            @property
+            def is_available(self):
+                return self._available
 
-        Q_CLASSINFO("D-Bus Interface", DBUS_INTERFACE)
-        Q_CLASSINFO("D-Bus Introspection",
-            '<interface name="%s">\n'
-            '  <signal name="Update">\n'
-            '    <arg direction="out" type="s" name="app_uri"/>\n'
-            '    <arg direction="out" type="a{sv}" name="properties"/>\n'
-            '  </signal>\n'
-            '  <method name="Query">\n'
-            '    <arg direction="out" type="s" name="app_uri"/>\n'
-            '    <arg direction="out" type="a{sv}" name="properties"/>\n'
-            '  </method>\n'
-            '</interface>' % DBUS_INTERFACE)
+            def update(self, progress, visible=True):
+                self._progress = progress
+                self._visible = visible
+                # Automatic forwarding of Qt signals does not work in this case
+                # since Qt cannot handle the complex "a{sv}" type.
+                # Create the signal message manually.
+                message = QDBusMessage.createSignal(self._path, DBUS_INTERFACE, 'Update')
+                message.setArguments([self._app_id, self.current_progress])
+                self._bus.send(message)
 
-        def __init__(self, parent):
-            super().__init__(parent)
+            def query(self):
+                return [self._app_id, self.current_progress]
 
-        @pyqtSlot(name="Query", result=list)
-        def query(self):
-            return self.parent().query()
+        class UnityLauncherEntryAdaptor(QDBusAbstractAdaptor):
+            """ This provides the DBus adaptor to the outside world"""
 
-    class UnityLauncherEntryStatusIndicator(AbstractProgressStatusIndicator):
-        def __init__(self, window):
-            super().__init__()
-            bus = QDBusConnection.sessionBus()
-            self._service = UnityLauncherEntryService(bus, PICARD_DESKTOP_NAME)
+            Q_CLASSINFO("D-Bus Interface", DBUS_INTERFACE)
+            Q_CLASSINFO("D-Bus Introspection",
+                '<interface name="%s">\n'
+                '  <signal name="Update">\n'
+                '    <arg direction="out" type="s" name="app_uri"/>\n'
+                '    <arg direction="out" type="a{sv}" name="properties"/>\n'
+                '  </signal>\n'
+                '  <method name="Query">\n'
+                '    <arg direction="out" type="s" name="app_uri"/>\n'
+                '    <arg direction="out" type="a{sv}" name="properties"/>\n'
+                '  </method>\n'
+                '</interface>' % DBUS_INTERFACE)
 
-        @property
-        def is_available(self):
-            return self._service.is_available
+            def __init__(self, parent):
+                super().__init__(parent)
 
-        def hide_progress(self):
-            self._service.update(0, False)
+            @pyqtSlot(name="Query", result=list)
+            def query(self):
+                return self.parent().query()
 
-        def set_progress(self, progress):
-            self._service.update(progress)
+        class UnityLauncherEntryStatusIndicator(AbstractProgressStatusIndicator):
+            def __init__(self, window):
+                super().__init__()
+                bus = QDBusConnection.sessionBus()
+                self._service = UnityLauncherEntryService(bus, PICARD_DESKTOP_NAME)
 
-    DesktopStatusIndicator = UnityLauncherEntryStatusIndicator
+            @property
+            def is_available(self):
+                return self._service.is_available
+
+            def hide_progress(self):
+                self._service.update(0, False)
+
+            def set_progress(self, progress):
+                self._service.update(progress)
+
+        DesktopStatusIndicator = UnityLauncherEntryStatusIndicator


### PR DESCRIPTION
# Summary
* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other: Minor enhancement?
* Make PyQt5.QtDBus optional / do not fail if QtDBus cannot be imported

# Problem

It is possible to install PyQt5 without support for dbus ([e.g. under gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/PyQt5/PyQt5-5.14.2.ebuild?id=52d0279f1ae255004dbf5b3e5b8525d6ff1e4912#n125)) resulting in Picard failing to start up with a message like
```
Traceback (most recent call last):
  File "/usr/bin/picard", line 2, in <module>
    from picard.tagger import main
  File "/usr/lib/python3.7/site-packages/picard/tagger.py", line 61, in <module>
    from PyQt5.QtDBus import QDBusConnection
ModuleNotFoundError: No module named 'PyQt5.QtDBus'
```

PICARD-1818

# Solution

Wrap imports of `PyQt5.QtDBus` with `try`.