### PR TITLE
PICARD-1823: Sort genre tags lexicographically

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -315,6 +315,7 @@ class Track(DataObject, Item):
                 break
             name = _TRANSLATE_TAGS.get(name, name.title())
             genre.append(name)
+        genre.sort()
         join_genres = config.setting['join_genres']
         if join_genres:
             genre = [join_genres.join(genre)]


### PR DESCRIPTION
This commit sorts genres lexicographically so that the order is
deterministic, preventing tag updates due to changes in hash functions
etc.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

[PICARD-1823](https://tickets.metabrainz.org/browse/PICARD-1823)

When opening releases on different platforms I've noticed that the order of genre tags is non-deterministic (probably due to differences in the Python hash function), which causes the genre tag to be needlessly rewritten. 

# Solution

This trivial commit calls sort() on the genre array, ensuring that the order of genres is deterministic.