### PR TITLE
PICARD-1843: Improves load and clustering performance

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -187,7 +187,7 @@ class Tagger(QtWidgets.QApplication):
         # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
         # It's a valid reference, but its start() method doesn't work.
         self.thread_pool = QtCore.QThreadPool(self)
-        self.thread_pool.setMaxThreadCount(4)
+        self.thread_pool.setMaxThreadCount(6)
 
         # Provide a separate thread pool for operations that should not be
         # delayed by longer background processing tasks, e.g. because the user

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -842,12 +842,15 @@ class Tagger(QtWidgets.QApplication):
             files = list(self.unclustered_files.files)
         else:
             files = self.get_files_from_objects(objs)
+
+        self.window.panel.set_sorting(False)
         for name, artist, files in Cluster.cluster(files, 1.0):
             QtCore.QCoreApplication.processEvents()
             cluster = self.load_cluster(name, artist)
             for file in sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')):
                 file.move(cluster)
                 QtCore.QCoreApplication.processEvents()
+        self.window.panel.set_sorting(True)
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -431,7 +431,7 @@ class Tagger(QtWidgets.QApplication):
     def _file_loaded(self, file, target=None):
         self._pending_files_count -= 1
         if self._pending_files_count == 0:
-            self.window.panel.set_sorting(True)
+            self.window.set_sorting(True)
 
         if file is None:
             return
@@ -526,7 +526,7 @@ class Tagger(QtWidgets.QApplication):
         if new_files:
             log.debug("Adding files %r", new_files)
             new_files.sort(key=lambda x: x.filename)
-            self.window.panel.set_sorting(False)
+            self.window.set_sorting(False)
             if target is None or target is self.unclustered_files:
                 target = None
             for file in new_files:
@@ -843,14 +843,14 @@ class Tagger(QtWidgets.QApplication):
         else:
             files = self.get_files_from_objects(objs)
 
-        self.window.panel.set_sorting(False)
+        self.window.set_sorting(False)
         for name, artist, files in Cluster.cluster(files, 1.0):
             QtCore.QCoreApplication.processEvents()
             cluster = self.load_cluster(name, artist)
             for file in sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')):
                 file.move(cluster)
                 QtCore.QCoreApplication.processEvents()
-        self.window.panel.set_sorting(True)
+        self.window.set_sorting(True)
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -361,7 +361,7 @@ class Tagger(QtWidgets.QApplication):
         """Move `file` to recording `recordingid` on album `albumid`."""
         self.window.setUpdatesEnabled(False)
         album = self.load_album(albumid)
-        file.move(album.unmatched_files)
+        album.run_when_loaded(partial(file.move, album.unmatched_files))
         album.run_when_loaded(partial(album.match_files, [file],
                                       recordingid=recordingid))
         self.window.setUpdatesEnabled(True)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -343,6 +343,7 @@ class Tagger(QtWidgets.QApplication):
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""
+        self.window.setUpdatesEnabled(False)
         if album is None:
             album = self.load_album(albumid)
         if album.loaded:
@@ -350,6 +351,7 @@ class Tagger(QtWidgets.QApplication):
         else:
             for file in list(files):
                 file.move(album.unmatched_files)
+        self.window.setUpdatesEnabled(True)
 
     def move_file_to_album(self, file, albumid):
         """Move `file` to a track on album `albumid`."""
@@ -357,10 +359,12 @@ class Tagger(QtWidgets.QApplication):
 
     def move_file_to_track(self, file, albumid, recordingid):
         """Move `file` to recording `recordingid` on album `albumid`."""
+        self.window.setUpdatesEnabled(False)
         album = self.load_album(albumid)
         file.move(album.unmatched_files)
         album.run_when_loaded(partial(album.match_files, [file],
                                       recordingid=recordingid))
+        self.window.setUpdatesEnabled(True)
 
     def create_nats(self):
         if self.nats is None:
@@ -371,12 +375,14 @@ class Tagger(QtWidgets.QApplication):
         return self.nats
 
     def move_file_to_nat(self, file, recordingid, node=None):
+        self.window.setUpdatesEnabled(False)
         self.create_nats()
         file.move(self.nats.unmatched_files)
         nat = self.load_nat(recordingid, node=node)
         nat.run_when_loaded(partial(file.move, nat))
         if nat.loaded:
             self.nats.update()
+        self.window.setUpdatesEnabled(True)
 
     def exit(self):
         if self.stopping:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -502,7 +502,7 @@ class Tagger(QtWidgets.QApplication):
     def add_files(self, filenames, target=None, result=None):
         """Add files to the tagger."""
         if result:
-            filenames = result
+            filenames = result   # Handles add_directory task results coming from a worker thread
         ignoreregex = None
         pattern = config.setting['ignore_regex']
         if pattern:
@@ -533,11 +533,9 @@ class Tagger(QtWidgets.QApplication):
             log.debug("Adding files %r", new_files)
             new_files.sort(key=lambda x: x.filename)
             self.window.set_sorting(False)
-            if target is None or target is self.unclustered_files:
-                target = None
+            self._pending_files_count += len(new_files)
             for file in new_files:
                 file.load(partial(self._file_loaded, target=target))
-            self._pending_files_count += len(new_files)
 
     def _scan_dir(self, folders, recursive, ignore_hidden):
         files = []

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -25,6 +25,7 @@
 # Copyright (C) 2018 Bob Swift
 # Copyright (C) 2018 virusMac
 # Copyright (C) 2019 Joel Lintunen
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -425,7 +426,11 @@ class Tagger(QtWidgets.QApplication):
         return super().event(event)
 
     def _file_loaded(self, file, target=None):
-        if file is None or file.has_error():
+        if file is None:
+            return
+        
+        if file.has_error():
+            self.unclustered_files.add_file(file)
             return
 
         if target is not None:
@@ -456,6 +461,8 @@ class Tagger(QtWidgets.QApplication):
                           file, recordingid)
                 self.move_file_to_nat(file, recordingid)
                 return
+
+        self.unclustered_files.add_file(file)
 
         # fallback on analyze if nothing else worked
         if config.setting['analyze_new_files'] and file.can_analyze():
@@ -511,7 +518,6 @@ class Tagger(QtWidgets.QApplication):
             log.debug("Adding files %r", new_files)
             new_files.sort(key=lambda x: x.filename)
             if target is None or target is self.unclustered_files:
-                self.unclustered_files.add_files(new_files)
                 target = None
             for file in new_files:
                 file.load(partial(self._file_loaded, target=target))

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -435,7 +435,7 @@ class Tagger(QtWidgets.QApplication):
 
         if file is None:
             return
-        
+
         if file.has_error():
             self.unclustered_files.add_file(file)
             return
@@ -572,12 +572,11 @@ class Tagger(QtWidgets.QApplication):
         return files
 
     def add_directory(self, path):
-            thread.run_task(
-                partial(self._scan_dir, [path],
-                        config.setting['recursively_add_files'],
-                        config.setting["ignore_hidden_files"]),
-                partial(self.add_files, None),
-                traceback=self._debug)
+        thread.run_task(partial(self._scan_dir, [path],
+                            config.setting['recursively_add_files'],
+                            config.setting["ignore_hidden_files"]),
+                        partial(self.add_files, None),
+                        traceback=self._debug)
 
     def get_file_lookup(self):
         """Return a FileLookup object."""

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -171,8 +171,8 @@ class MainPanel(QtWidgets.QSplitter):
         super().__init__(parent)
         self.window = window
         self.create_icons()
-        self.views = [FileTreeView(window, self), AlbumTreeView(window, self)]
-        self._selected_view = self.views[0]
+        self._views = [FileTreeView(window, self), AlbumTreeView(window, self)]
+        self._selected_view = self._views[0]
         self._ignore_selection_changes = False
 
         def _view_update_selection(view):
@@ -181,7 +181,7 @@ class MainPanel(QtWidgets.QSplitter):
                 self._update_selection(view)
                 self._ignore_selection_changes = False
 
-        for view in self.views:
+        for view in self._views:
             view.itemSelectionChanged.connect(partial(_view_update_selection, view))
 
         TreeItem.window = window
@@ -207,14 +207,14 @@ class MainPanel(QtWidgets.QSplitter):
 
     def tab_order(self, tab_order, before, after):
         prev = before
-        for view in self.views:
+        for view in self._views:
             tab_order(prev, view)
             prev = view
         tab_order(prev, after)
 
     def save_state(self):
         config.persist["splitter_state"] = self.saveState()
-        for view in self.views:
+        for view in self._views:
             view.save_state()
 
     @restore_method
@@ -269,7 +269,7 @@ class MainPanel(QtWidgets.QSplitter):
         self.icon_plugins = icontheme.lookup('applications-system', icontheme.ICON_SIZE_MENU)
 
     def _update_selection(self, selected_view):
-        for view in self.views:
+        for view in self._views:
             if view != selected_view:
                 view.clearSelection()
             else:
@@ -293,7 +293,7 @@ class MainPanel(QtWidgets.QSplitter):
             self.update_current_view()
 
     def set_sorting(self, sort=True):
-        for view in self.views:
+        for view in self._views:
             view.setSortingEnabled(sort)
 
 

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -302,6 +302,7 @@ class MainPanel(QtWidgets.QSplitter):
         else:
             self._views[0].expandAll()
 
+
 def paint_fingerprint_icon(painter, rect, icon):
     if not icon:
         return

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -39,6 +39,7 @@
 
 
 from collections import defaultdict
+from enum import Enum
 from functools import partial
 from heapq import (
     heappop,
@@ -141,6 +142,11 @@ def get_match_color(similarity, basecolor):
         c2[2] + (c1[2] - c2[2]) * similarity)
 
 
+class Panels(Enum):
+    CLUSTERS = 0
+    ALBUMS = 1
+
+
 class MainPanel(QtWidgets.QSplitter):
 
     options = [
@@ -172,8 +178,8 @@ class MainPanel(QtWidgets.QSplitter):
         self.window = window
         self.create_icons()
         self.views = [FileTreeView(window, self), AlbumTreeView(window, self)]
-        self.views[0].itemSelectionChanged.connect(self.update_selection_0)
-        self.views[1].itemSelectionChanged.connect(self.update_selection_1)
+        self.views[Panels.CLUSTERS.value].itemSelectionChanged.connect(self.update_selection_clusters)
+        self.views[Panels.ALBUMS.value].itemSelectionChanged.connect(self.update_selection_albums)
         self._selected_view = 0
         self._ignore_selection_changes = False
 
@@ -260,16 +266,16 @@ class MainPanel(QtWidgets.QSplitter):
         self.window.update_selection(
             [item.obj for item in self.views[i].selectedItems()])
 
-    def update_selection_0(self):
+    def update_selection_clusters(self):
         if not self._ignore_selection_changes:
             self._ignore_selection_changes = True
-            self.update_selection(0, 1)
+            self.update_selection(Panels.CLUSTERS.value, Panels.ALBUMS.value)
             self._ignore_selection_changes = False
 
-    def update_selection_1(self):
+    def update_selection_albums(self):
         if not self._ignore_selection_changes:
             self._ignore_selection_changes = True
-            self.update_selection(1, 0)
+            self.update_selection(Panels.ALBUMS.value, Panels.CLUSTERS.value)
             self._ignore_selection_changes = False
 
     def update_current_view(self):
@@ -287,6 +293,10 @@ class MainPanel(QtWidgets.QSplitter):
             view.setCurrentIndex(index)
         else:
             self.update_current_view()
+
+    def set_sorting(self, sort=True):
+        self.views[Panels.CLUSTERS.value].setSortingEnabled(sort)
+        self.views[Panels.ALBUMS.value].setSortingEnabled(sort)
 
 
 def paint_fingerprint_icon(painter, rect, icon):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -296,6 +296,11 @@ class MainPanel(QtWidgets.QSplitter):
         for view in self._views:
             view.setSortingEnabled(sort)
 
+    def collapse_clusters(self, collapse=True):
+        if collapse:
+            self._views[0].collapseAll()
+        else:
+            self._views[0].expandAll()
 
 def paint_fingerprint_icon(painter, rect, icon):
     if not icon:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -213,6 +213,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def set_processing(self, processing=True):
         self.panel.set_processing(processing)
 
+    def set_sorting(self, sorting=True):
+        self.panel.set_sorting(sorting)
+        self.panel.collapse_clusters(not sorting)
+
     def keyPressEvent(self, event):
         # On macOS Command+Backspace triggers the so called "Forward Delete".
         # It should be treated the same as the Delete button.

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -215,7 +215,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def set_sorting(self, sorting=True):
         self.panel.set_sorting(sorting)
-        self.panel.collapse_clusters(not sorting)
+        # self.panel.collapse_clusters(not sorting)
 
     def keyPressEvent(self, event):
         # On macOS Command+Backspace triggers the so called "Forward Delete".

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -857,9 +857,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         tab_order(self.search_edit, self.search_button)
         # Panels
         tab_order(self.search_button, self.file_browser)
-        tab_order(self.file_browser, self.panel.views[0])
-        tab_order(self.panel.views[0], self.panel.views[1])
-        tab_order(self.panel.views[1], self.metadata_box)
+        self.panel.tab_order(tab_order, self.file_browser, self.metadata_box)
 
     def enable_submit(self, enabled):
         """Enable/disable the 'Submit fingerprints' action."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Speeds up loading by scanning the entire directory before feeding threads instead of concurrently, preventing starvation of worker threads.
Speeds up clustering and file moving by disabling panel sorting during operations. 

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Load and clustering are slow, especially with a large library. More details can be found [here](https://github.com/metabrainz/picard/pull/1531).

Partially addresses PICARD-840, PICARD-905, PICARD-1432 and PICARD-1780, but none of them in particular.

* JIRA ticket (_optional_): PICARD-1843
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1 - Scan entire directory before feeding worker threads, to prevent starvation (around 3x/8x speedup without/with the following changes).
2 - Postpone inclusion of loaded files to the unclustered_files cluster to the tagger.file_loaded section, where it can be included directly to the correct album cluster instead of being moved later, saving up a bunch of time for partially processed libraries.
3 - During movements between cluster/panels, temporarily disable treeview sorting, to speed up inclusion of new entries (100x speedup for 19k files clustering).
Testing with a 19k file library:
Loading 50m->6m (avg. 6 songs/sec -> 53 songs/sec)
Clustering 5h17m->3m (avg. 1 songs/sec -> 106 songs/sec)
Total(loading+clustering) 6h7m->9m

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->