### PR TITLE
PICARD-1826: Consider .ogg files as generic Ogg container files

### DIFF
--- a/picard/formats/__init__.py
+++ b/picard/formats/__init__.py
@@ -56,6 +56,7 @@ from picard.formats.util import (  # noqa: F401 # pylint: disable=unused-import
 from picard.formats.vorbis import (
     FLACFile,
     OggAudioFile,
+    OggContainerFile,
     OggFLACFile,
     OggOpusFile,
     OggSpeexFile,
@@ -78,6 +79,7 @@ register_format(MP3File)
 register_format(MP4File)
 register_format(MusepackFile)
 register_format(OggAudioFile)
+register_format(OggContainerFile)
 register_format(OggFLACFile)
 register_format(OggOpusFile)
 register_format(OggSpeexFile)

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -404,7 +404,7 @@ class OggTheoraFile(VCommentFile):
 class OggVorbisFile(VCommentFile):
 
     """Ogg Vorbis file."""
-    EXTENSIONS = [".ogg"]
+    EXTENSIONS = []
     NAME = "Ogg Vorbis"
     _File = mutagen.oggvorbis.OggVorbis
 
@@ -425,7 +425,7 @@ class OggOpusFile(VCommentFile):
 
 def OggAudioFile(filename):
     """Generic Ogg audio file."""
-    options = [OggFLACFile, OggSpeexFile, OggVorbisFile]
+    options = [OggFLACFile, OggOpusFile, OggSpeexFile, OggVorbisFile]
     return guess_format(filename, options)
 
 
@@ -443,3 +443,20 @@ def OggVideoFile(filename):
 OggVideoFile.EXTENSIONS = [".ogv"]
 OggVideoFile.NAME = "Ogg Video"
 OggVideoFile.supports_tag = VCommentFile.supports_tag
+
+
+def OggContainerFile(filename):
+    """Generic Ogg file."""
+    options = [
+        OggFLACFile,
+        OggOpusFile,
+        OggSpeexFile,
+        OggTheoraFile,
+        OggVorbisFile
+    ]
+    return guess_format(filename, options)
+
+
+OggContainerFile.EXTENSIONS = [".ogg"]
+OggContainerFile.NAME = "Ogg"
+OggContainerFile.supports_tag = VCommentFile.supports_tag

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -462,9 +462,10 @@ class CommonTests:
         def test_split_ext(self):
             f = picard.formats.open_(self.filename)
             self.assertEqual(f._fixed_splitext(f.filename), os.path.splitext(f.filename))
-            self.assertEqual(f._fixed_splitext(f.EXTENSIONS[0]), ('', f.EXTENSIONS[0]))
             self.assertEqual(f._fixed_splitext('.test'), os.path.splitext('.test'))
-            self.assertNotEqual(f._fixed_splitext(f.EXTENSIONS[0]), os.path.splitext(f.EXTENSIONS[0]))
+            if f.EXTENSIONS:
+                self.assertEqual(f._fixed_splitext(f.EXTENSIONS[0]), ('', f.EXTENSIONS[0]))
+                self.assertNotEqual(f._fixed_splitext(f.EXTENSIONS[0]), os.path.splitext(f.EXTENSIONS[0]))
 
         @skipUnlessTestfile
         def test_clear_existing_tags_off(self):

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -41,6 +41,7 @@ from picard import (
 )
 from picard.coverart.image import CoverArtImage
 from picard.formats import vorbis
+from picard.formats.util import open_ as open_format
 from picard.metadata import Metadata
 
 from .common import (
@@ -327,21 +328,31 @@ class FlacCoverArtTest(CommonCoverArtTests.CoverArtTestCase):
 class OggAudioVideoFileTest(PicardTestCase):
     def test_ogg_audio(self):
         self._test_file_is_type(
-            vorbis.OggAudioFile,
+            open_format,
             self._copy_file_tmp('test-oggflac.oga', '.oga'),
             vorbis.OggFLACFile)
         self._test_file_is_type(
-            vorbis.OggAudioFile,
+            open_format,
             self._copy_file_tmp('test.spx', '.oga'),
             vorbis.OggSpeexFile)
         self._test_file_is_type(
-            vorbis.OggAudioFile,
+            open_format,
             self._copy_file_tmp('test.ogg', '.oga'),
             vorbis.OggVorbisFile)
 
+    def test_ogg_opus(self):
+        self._test_file_is_type(
+            open_format,
+            self._copy_file_tmp('test.opus', '.oga'),
+            vorbis.OggOpusFile)
+        self._test_file_is_type(
+            open_format,
+            self._copy_file_tmp('test.opus', '.ogg'),
+            vorbis.OggOpusFile)
+
     def test_ogg_video(self):
         self._test_file_is_type(
-            vorbis.OggVideoFile,
+            open_format,
             self._copy_file_tmp('test.ogv', '.ogv'),
             vorbis.OggTheoraFile)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixes e.g. loading Ogg Opus files with .ogg extension, instead of assuming .ogg is always Ogg Vorbis.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
This broke in PICARD-1809 when we started preferring the file extension again. Now every .ogg file iso considered a generic file in a Ogg container. This means of course for these files we basically do content based detection again.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1826
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
