### PR TITLE
PICARD-1831: Mitigate performance impacts of file selection and UI updates during processing

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -17,6 +17,7 @@
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2020 Ray Bouchard
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -129,6 +130,7 @@ class Cluster(QtCore.QObject, Item):
         self.add_files([file])
 
     def remove_file(self, file):
+        self.tagger.window.set_processing(True)
         self.metadata.length -= file.metadata.length
         self.files.remove(file)
         self.metadata['totaltracks'] = len(self.files)
@@ -139,6 +141,7 @@ class Cluster(QtCore.QObject, Item):
             file.metadata_images_changed.disconnect(self.update_metadata_images)
             remove_metadata_images(self, [file])
         self._update_related_album(removed_files=[file])
+        self.tagger.window.set_processing(False)
 
     def update(self):
         if self.item:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -21,6 +21,7 @@
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -193,6 +194,9 @@ class MainPanel(QtWidgets.QSplitter):
             File.PENDING: interface_colors.get_qcolor('entity_pending'),
             File.ERROR: interface_colors.get_qcolor('entity_error'),
         })
+
+    def set_processing(self, processing=True):
+        self._ignore_selection_changes = processing
 
     def save_state(self):
         config.persist["splitter_state"] = self.saveState()
@@ -866,8 +870,6 @@ class ClusterItem(TreeItem):
         album = self.obj.related_album
         if self.obj.special and album and album.loaded:
             album.item.update(update_tracks=False)
-        if self.isSelected():
-            TreeItem.window.update_selection()
 
     def add_file(self, file):
         self.add_files([file])
@@ -942,8 +944,6 @@ class AlbumItem(TreeItem):
                 self.setToolTip(MainPanel.TITLE_COLUMN, _("Album unchanged"))
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, album.column(column[1]))
-        if selection_changed:
-            TreeItem.window.panel.update_current_view()
         # Workaround for PICARD-1446: Expand/collapse indicator for the release
         # is briefly missing on Windows
         self.emitDataChanged()
@@ -1027,8 +1027,6 @@ class TrackItem(TreeItem):
             self.setText(i, track.column(column[1]))
             self.setForeground(i, color)
             self.setBackground(i, bgcolor)
-        if self.isSelected():
-            TreeItem.window.update_selection()
         if update_album:
             self.parent().update(update_tracks=False)
 
@@ -1050,8 +1048,6 @@ class FileItem(TreeItem):
             if not tree_widget.itemWidget(self, MainPanel.FINGERPRINT_COLUMN):
                 tree_widget.setItemWidget(self, MainPanel.FINGERPRINT_COLUMN,
                     FingerprintColumnWidget(file=file))
-        if self.isSelected():
-            TreeItem.window.update_selection()
 
         parent = self.parent()
         if isinstance(parent, TrackItem) and update_track:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -27,6 +27,7 @@
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018 virusMac
 # Copyright (C) 2019 Timur Enikeev
+# Copyright (C) 2020 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -208,6 +209,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         for function in ui_init:
             function(self)
+
+    def set_processing(self, processing=True):
+        self.panel.set_processing(processing)
 
     def keyPressEvent(self, event):
         # On macOS Command+Backspace triggers the so called "Forward Delete".


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Mitigate code that forces unnecessary draws during item updates, letting Qt handle the changes. Prevent exponential checks caused by `MainPanel._view_update_selection`, as detailed in https://github.com/metabrainz/picard/pull/1543#issuecomment-633148605 during the removal of an item of the selected list (all moves cause this). 

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1831
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The solution implemented in this PR bypasses the the selection checks by disabling them during processing (e.g. moving things around either manually or during clustering). As soon as the move finishes, the selection can be changed. 

The other change to reduce draws works by removing `if self.isSelected(): [...]`, which updated the screen on the spot if changes were detected and the file is selected. Removing the calls delay the screen update, but drastically reduces draws. This results in speed up of operations such as saving.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
