### PR TITLE
Remove frames from compatid3 supported by mutagen >= 1.37

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -65,9 +65,6 @@ from picard.util.tags import parse_comment_tag
 
 
 id3.GRP1 = compatid3.GRP1
-id3.TCMP = compatid3.TCMP
-id3.TSO2 = compatid3.TSO2
-id3.TSOC = compatid3.TSOC
 
 __IMAGE_TYPES = [
     ("obi", 0),

--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -41,10 +41,6 @@ except ImportError:
         pass
 
 
-class XDOR(TextFrame):
-    pass
-
-
 class XSOP(TextFrame):
     pass
 
@@ -52,7 +48,6 @@ class XSOP(TextFrame):
 known_frames = dict(Frames)
 known_frames.update(dict(Frames_2_2))
 known_frames["GRP1"] = GRP1  # Available since mutagen >= 1.38
-known_frames["XDOR"] = XDOR
 known_frames["XSOP"] = XSOP
 
 

--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2008, 2011-2012 Lukáš Lalinský
 # Copyright (C) 2013-2014 Sophist-UK
 # Copyright (C) 2013-2014, 2018 Laurent Monin
-# Copyright (C) 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2014, 2018-2020 Philipp Wolfer
 # Copyright (C) 2016 Christoph Reiter
 # Copyright (C) 2016 Ville Skyttä
 # Copyright (C) 2017 Sambhav Kothari
@@ -41,18 +41,6 @@ except ImportError:
         pass
 
 
-class TCMP(TextFrame):
-    pass
-
-
-class TSO2(TextFrame):
-    pass
-
-
-class TSOC(TextFrame):
-    pass
-
-
 class XDOR(TextFrame):
     pass
 
@@ -63,10 +51,7 @@ class XSOP(TextFrame):
 
 known_frames = dict(Frames)
 known_frames.update(dict(Frames_2_2))
-known_frames["GRP1"] = GRP1
-known_frames["TCMP"] = TCMP
-known_frames["TSO2"] = TSO2
-known_frames["TSOC"] = TSOC
+known_frames["GRP1"] = GRP1  # Available since mutagen >= 1.38
 known_frames["XDOR"] = XDOR
 known_frames["XSOP"] = XSOP
 
@@ -75,7 +60,6 @@ class CompatID3(ID3):
 
     """
     Additional features over mutagen.id3.ID3:
-     * iTunes' TCMP frame
      * Allow some v2.4 frames also in v2.3
     """
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

This cleans up compatid3 by removing frames that are natively supported by mutagen >= 1.37 (which is our current minimum supported version). In 1.38 even `GRP1` would be supported, but I think it is ok to stick with 1.37 for now.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
