### PR TITLE
PICARD-1842: Full ID3 tag support for AIFF, DSF and WAVE

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -700,12 +700,8 @@ class TrueAudioFile(ID3File):
         return self._File(filename, ID3=compatid3.CompatID3)
 
 
-class DSFFile(ID3File):
-
-    """DSF file."""
-    EXTENSIONS = [".dsf"]
-    NAME = "DSF"
-    _File = mutagen.dsf.DSF
+class NonCompatID3File(ID3File):
+    """Base class for ID3 files which do not support setting `compatid3.CompatID3`."""
 
     def _get_file(self, filename):
         return self._File(filename, known_frames=compatid3.known_frames)
@@ -718,23 +714,23 @@ class DSFFile(ID3File):
 
     def _save_tags(self, tags, filename):
         if config.setting['write_id3v23']:
-            tags.update_to_v23()
+            compatid3.update_to_v23(tags)
             separator = config.setting['id3v23_join_with']
             tags.save(filename, v2_version=3, v23_sep=separator)
         else:
             tags.update_to_v24()
             tags.save(filename, v2_version=4)
 
-    @classmethod
-    def supports_tag(cls, name):
-        return (super().supports_tag(name)
-                and name not in {'albumsort',
-                                 'artistsort',
-                                 'discsubtitle',
-                                 'titlesort'})
+
+class DSFFile(NonCompatID3File):
+
+    """DSF file."""
+    EXTENSIONS = [".dsf"]
+    NAME = "DSF"
+    _File = mutagen.dsf.DSF
 
 
-class AiffFile(DSFFile):
+class AiffFile(NonCompatID3File):
 
     """AIFF file."""
     EXTENSIONS = [".aiff", ".aif", ".aifc"]

--- a/picard/formats/mutagenext/compatid3.py
+++ b/picard/formats/mutagenext/compatid3.py
@@ -66,11 +66,15 @@ class CompatID3(ID3):
         super().__init__(*args, **kwargs)
 
     def update_to_v23(self):
-        # leave TSOP, TSOA and TSOT even though they are officially defined
-        # only in ID3v2.4, because most applications use them also in ID3v2.3
-        frames = []
-        for key in ["TSOP", "TSOA", "TSOT", "TSST"]:
-            frames.extend(self.getall(key))
-        super().update_to_v23()
-        for frame in frames:
-            self.add(frame)
+        update_to_v23(self)
+
+
+def update_to_v23(tags):
+    # leave TSOP, TSOA and TSOT even though they are officially defined
+    # only in ID3v2.4, because most applications use them also in ID3v2.3
+    frames = []
+    for key in ["TSOP", "TSOA", "TSOT", "TSST"]:
+        frames.extend(tags.getall(key))
+    ID3.update_to_v23(tags)
+    for frame in frames:
+        tags.add(frame)

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -32,8 +32,7 @@ from picard import (
     log,
 )
 from picard.file import File
-from picard.formats.id3 import ID3File
-from picard.formats.mutagenext import compatid3
+from picard.formats.id3 import NonCompatID3File
 from picard.metadata import Metadata
 
 
@@ -182,13 +181,10 @@ try:
         def __str__(self):
             return str(self.__tags)
 
-    class WAVFile(ID3File):
+    class WAVFile(NonCompatID3File):
         EXTENSIONS = [".wav"]
         NAME = "Microsoft WAVE"
         _File = mutagen.wave.WAVE
-
-        def _get_file(self, filename):
-            return self._File(filename, known_frames=compatid3.known_frames)
 
         def _info(self, metadata, file):
             super()._info(metadata, file)
@@ -223,29 +219,6 @@ try:
             elif config.setting['remove_wave_riff_info']:
                 info = RiffListInfo(encoding=config.setting['wave_riff_info_encoding'])
                 info.delete(filename)
-
-        def _get_tags(self, filename):
-            file = self._get_file(filename)
-            if file.tags is None:
-                file.add_tags()
-            return file.tags
-
-        def _save_tags(self, tags, filename):
-            if config.setting['write_id3v23']:
-                tags.update_to_v23()
-                separator = config.setting['id3v23_join_with']
-                tags.save(filename, v2_version=3, v23_sep=separator)
-            else:
-                tags.update_to_v24()
-                tags.save(filename, v2_version=4)
-
-        @classmethod
-        def supports_tag(cls, name):
-            return (super().supports_tag(name)
-                    and name not in {'albumsort',
-                                     'artistsort',
-                                     'discsubtitle',
-                                     'titlesort'})
 
 except ImportError:
     import wave


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
AIFF and DSF lacked support for the tags albumsort, artistsort, titlesort and discsubtitle due to limitations in using CompatID3.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1842
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a `compatid3.update_to_v23` that can be used on existing `mutagen.id3.ID3` instances.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
