### PR TITLE
PICARD-1820: Allow single digit versions like "2" to be parsed

### DIFF
--- a/picard/version.py
+++ b/picard/version.py
@@ -28,7 +28,7 @@ class VersionError(Exception):
 
 
 class Version(namedtuple('VersionBase', 'major minor patch identifier revision')):
-    _version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?$")
+    _version_re = re.compile(r"(\d+)(?:[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?)?$")
 
     _identifiers = {
         'dev': 0,
@@ -40,7 +40,7 @@ class Version(namedtuple('VersionBase', 'major minor patch identifier revision')
         'final': 4
     }
 
-    def __new__(cls, major, minor, patch=0, identifier='final', revision=0):
+    def __new__(cls, major, minor=0, patch=0, identifier='final', revision=0):
         if identifier not in cls.valid_identifiers():
             raise VersionError("Should be either 'final', 'dev', 'alpha', 'beta' or 'rc'")
         identifier = {'a': 'alpha', 'b': 'beta'}.get(identifier, identifier)
@@ -59,6 +59,8 @@ class Version(namedtuple('VersionBase', 'major minor patch identifier revision')
         if match:
             (major, minor, patch, identifier, revision) = match.groups()
             major = int(major)
+            if minor is None:
+                return Version(major)
             minor = int(minor)
             if patch is None:
                 return Version(major, minor)

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -88,6 +88,11 @@ class VersionsTest(PicardTestCase):
         l, s = (1, 1, 0, 'dev', 0), 'anything_28_1_1_0_dev_0'
         self.assertEqual(l, version_from_string(s))
 
+    def test_version_single_digit(self):
+        l, s = (2, 0, 0, 'final', 0), '2'
+        self.assertEqual(l, version_from_string(s))
+        self.assertEqual(l, Version(2))
+
     def test_version_from_string_invalid(self):
         invalid = 'anything_28x_1_0_dev_0'
         self.assertRaises(VersionError, version_to_string, (invalid))
@@ -101,7 +106,8 @@ class VersionsTest(PicardTestCase):
         self.assertRaises(VersionError, version_from_string, '1.1.0devx')
 
     def test_version_from_string_invalid_partial(self):
-        self.assertRaises(VersionError, version_from_string, '123')
+        self.assertRaises(VersionError, version_from_string, '1dev')
+        self.assertRaises(VersionError, version_from_string, '1.0dev')
         self.assertRaises(VersionError, version_from_string, '123.')
 
     @unittest.skipUnless(len(api_versions) > 1, "api_versions do not have enough elements")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
A version "2" should be treated equivalent to "2.0" or "2.0.0". Allows setting a single digit plugin version and have it displayed correctly.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1820
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

