### PR TITLE
PICARD-1844: Further improve loading and clustering performance

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -412,7 +412,7 @@ class Metadata(MutableMapping):
             return default
 
     def __getitem__(self, name):
-        return self.get(self.normalize_tag(name), '')
+        return self.get(name, '')
 
     def set(self, name, values):
         name = self.normalize_tag(name)
@@ -426,7 +426,7 @@ class Metadata(MutableMapping):
             del self[name]
 
     def __setitem__(self, name, values):
-        self.set(self.normalize_tag(name), values)
+        self.set(name, values)
 
     def __contains__(self, name):
         return self._store.__contains__(self.normalize_tag(name))

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -43,6 +43,7 @@
 
 
 import argparse
+from collections import defaultdict
 from functools import partial
 from itertools import chain
 import logging
@@ -842,12 +843,13 @@ class Tagger(QtWidgets.QApplication):
             files = self.get_files_from_objects(objs)
 
         self.window.set_sorting(False)
+        cluster_files = defaultdict(list)
         for name, artist, files in Cluster.cluster(files, 1.0, self):
-            QtCore.QCoreApplication.processEvents()
             cluster = self.load_cluster(name, artist)
-            for file in sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')):
-                file.move(cluster)
-                QtCore.QCoreApplication.processEvents()
+            cluster_files[cluster].extend(sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')))
+        for cluster, files in cluster_files.items():
+            cluster.add_files(files)
+            QtCore.QCoreApplication.processEvents()
         self.window.set_sorting(True)
 
     def load_cluster(self, name, artist):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -342,7 +342,6 @@ class Tagger(QtWidgets.QApplication):
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""
-        self.window.setUpdatesEnabled(False)
         if album is None:
             album = self.load_album(albumid)
         if album.loaded:
@@ -350,7 +349,6 @@ class Tagger(QtWidgets.QApplication):
         else:
             for file in list(files):
                 file.move(album.unmatched_files)
-        self.window.setUpdatesEnabled(True)
 
     def move_file_to_album(self, file, albumid):
         """Move `file` to a track on album `albumid`."""
@@ -358,12 +356,10 @@ class Tagger(QtWidgets.QApplication):
 
     def move_file_to_track(self, file, albumid, recordingid):
         """Move `file` to recording `recordingid` on album `albumid`."""
-        self.window.setUpdatesEnabled(False)
         album = self.load_album(albumid)
         album.run_when_loaded(partial(file.move, album.unmatched_files))
         album.run_when_loaded(partial(album.match_files, [file],
                                       recordingid=recordingid))
-        self.window.setUpdatesEnabled(True)
 
     def create_nats(self):
         if self.nats is None:
@@ -374,14 +370,12 @@ class Tagger(QtWidgets.QApplication):
         return self.nats
 
     def move_file_to_nat(self, file, recordingid, node=None):
-        self.window.setUpdatesEnabled(False)
         self.create_nats()
         file.move(self.nats.unmatched_files)
         nat = self.load_nat(recordingid, node=node)
         nat.run_when_loaded(partial(file.move, nat))
         if nat.loaded:
             self.nats.update()
-        self.window.setUpdatesEnabled(True)
 
     def exit(self):
         if self.stopping:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -849,7 +849,7 @@ class Tagger(QtWidgets.QApplication):
             files = self.get_files_from_objects(objs)
 
         self.window.set_sorting(False)
-        for name, artist, files in Cluster.cluster(files, 1.0):
+        for name, artist, files in Cluster.cluster(files, 1.0, self):
             QtCore.QCoreApplication.processEvents()
             cluster = self.load_cluster(name, artist)
             for file in sorted(files, key=attrgetter('discnumber', 'tracknumber', 'base_filename')):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -482,6 +482,7 @@ class Tagger(QtWidgets.QApplication):
         if target is None:
             log.debug("Aborting move since target is invalid")
             return
+        self.window.set_sorting(False)
         if isinstance(target, (Track, Cluster)):
             for file in files:
                 file.move(target)
@@ -494,6 +495,7 @@ class Tagger(QtWidgets.QApplication):
             self.move_files_to_album(files, album=target)
         elif isinstance(target, ClusterList):
             self.cluster(files)
+        self.window.set_sorting(True)
 
     def add_files(self, filenames, target=None, result=None):
         """Add files to the tagger."""

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -187,7 +187,6 @@ class Tagger(QtWidgets.QApplication):
         # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
         # It's a valid reference, but its start() method doesn't work.
         self.thread_pool = QtCore.QThreadPool(self)
-        self.thread_pool.setMaxThreadCount(6)
 
         # Provide a separate thread pool for operations that should not be
         # delayed by longer background processing tasks, e.g. because the user

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -527,6 +527,7 @@ class Tagger(QtWidgets.QApplication):
                 if file:
                     self.files[filename] = file
                     new_files.append(file)
+                QtCore.QCoreApplication.processEvents()
         if new_files:
             log.debug("Adding files %r", new_files)
             new_files.sort(key=lambda x: x.filename)
@@ -534,6 +535,7 @@ class Tagger(QtWidgets.QApplication):
             self._pending_files_count += len(new_files)
             for file in new_files:
                 file.load(partial(self._file_loaded, target=target))
+                QtCore.QCoreApplication.processEvents()
 
     def _scan_dir(self, folders, recursive, ignore_hidden):
         files = []
@@ -571,14 +573,14 @@ class Tagger(QtWidgets.QApplication):
                     echo=None
                 )
                 files.extend(current_folder_files)
+                QtCore.QCoreApplication.processEvents()
         return files
 
     def add_directory(self, path):
-        thread.run_task(partial(self._scan_dir, [path],
+        files = self._scan_dir([path],
                             config.setting['recursively_add_files'],
-                            config.setting["ignore_hidden_files"]),
-                        partial(self.add_files, None),
-                        traceback=self._debug)
+                            config.setting["ignore_hidden_files"])
+        self.add_files(files)
 
     def get_file_lookup(self):
         """Return a FileLookup object."""

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -443,6 +443,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         self.select_all_action.triggered.connect(self.selectAll)
         self.select_all_action.setShortcut(QtGui.QKeySequence(_("Ctrl+A")))
         self.doubleClicked.connect(self.activate_item)
+        self.setUniformRowHeights(True)
 
     def contextMenuEvent(self, event):
         item = self.itemAt(event.pos())

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -87,6 +87,9 @@ from picard.ui.widgets.tristatesortheaderview import TristateSortHeaderView
 
 
 COLUMN_ICON_SIZE = 16
+COLUMN_ICON_BORDER = 2
+ICON_SIZE = QtCore.QSize(COLUMN_ICON_SIZE+COLUMN_ICON_BORDER,
+                         COLUMN_ICON_SIZE+COLUMN_ICON_BORDER)
 
 
 class BaseAction(QtWidgets.QAction):
@@ -859,6 +862,7 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         self.setTextAlignment(1, QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         self.setTextAlignment(7, QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         self.setTextAlignment(8, QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+        self.setSizeHint(MainPanel.TITLE_COLUMN, ICON_SIZE)
 
     def __lt__(self, other):
         if not self.sortable:

--- a/picard/util/progresscheckpoints.py
+++ b/picard/util/progresscheckpoints.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Laurent Monin
+# Copyright (C) 2020 Gabriel Ferreira
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+class ProgressCheckpoints:
+
+    def __init__(self, num_jobs, num_checkpoints=10):
+        """Create a set of unique and evenly spaced indexes of jobs, used as checkpoints for progress"""
+        self.num_jobs = num_jobs
+        self._checkpoints = {}
+
+        if num_checkpoints > 0:
+            self._offset = num_jobs/num_checkpoints
+            for i in range(1, num_checkpoints):
+                self._checkpoints[int(i*self._offset)] = 100*i//num_checkpoints
+            if num_jobs > 0:
+                self._checkpoints[num_jobs-1] = 100
+
+    def is_checkpoint(self, index):
+        if index in self._checkpoints:
+            return True
+        return False
+
+    def progress(self, index):
+        try:
+            return self._checkpoints[index]
+        except KeyError:
+            return None

--- a/picard/util/textencoding.py
+++ b/picard/util/textencoding.py
@@ -181,19 +181,17 @@ _simplify_punctuation = {
 }
 
 
-def _replace_unicode_simplify_punctuation(char, pathsave, win_compat):
-    result = _simplify_punctuation.get(char)
-    if result is None:
-        return char
-    elif not pathsave:
-        return result
-    else:
-        return sanitize_filename(result, win_compat=win_compat)
-
-
 def unicode_simplify_punctuation(string, pathsave=False, win_compat=False):
-    return ''.join(
-        _replace_unicode_simplify_punctuation(c, pathsave, win_compat) for c in string)
+    temp = []
+    for c in string:
+        try:
+            result = _simplify_punctuation[c]
+            if c != result and pathsave:
+                result = sanitize_filename(result, win_compat=win_compat)
+        except KeyError:
+            result = c
+        temp.append(result)
+    return ''.join(temp)
 
 
 _simplify_combinations = {

--- a/po/picard.pot
+++ b/po/picard.pot
@@ -69,7 +69,17 @@ msgstr ""
 msgid "Looking up the metadata for cluster %(album)s..."
 msgstr ""
 
-#: picard/cluster.py:337
+#: picard/cluster.py:478
+#, python-format
+msgid "Metadata Extraction"
+msgstr ""
+
+#: picard/cluster.py:294 picard/cluster.py:541
+#, python-format
+msgid "Clustering - step %(step)d/3: %(cluster_type)s (%(update)d%%)"
+msgstr ""
+
+#: picard/cluster.py:350
 msgid "Unclustered Files"
 msgstr ""
 
@@ -2933,14 +2943,16 @@ msgstr ""
 msgid "Whitelist"
 msgstr ""
 
-#: picard/ui/cdlookup.py:72 picard/ui/itemviews.py:156
-#: picard/ui/mainwindow.py:800 picard/util/tags.py:38
+#: picard/ui/cdlookup.py:72 picard/ui/itemviews.py:155
+#: picard/ui/mainwindow.py:792 picard/util/tags.py:38
+#: picard/cluster.py:479
 msgid "Album"
 msgstr ""
 
 #: picard/ui/cdlookup.py:72 picard/ui/itemviews.py:153
 #: picard/ui/mainwindow.py:801 picard/ui/searchdialog/album.py:153
 #: picard/ui/searchdialog/track.py:65 picard/util/tags.py:41
+#: picard/cluster.py:478
 msgid "Artist"
 msgstr ""
 

--- a/test/test_util_progresscheckpoints.py
+++ b/test/test_util_progresscheckpoints.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Gabriel Ferreira
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from test.picardtestcase import PicardTestCase
+
+from picard.util.progresscheckpoints import ProgressCheckpoints
+
+
+class ProgressCheckpointsTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_empty_jobs(self):
+        checkpoints = ProgressCheckpoints(0, 1)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [])
+
+        checkpoints = ProgressCheckpoints(0, 0)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [])
+
+        checkpoints = ProgressCheckpoints(1, 0)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [])
+
+    def test_uniformly_spaced_integer_distance(self):
+        checkpoints = ProgressCheckpoints(100, 10)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [10, 20, 30, 40, 50, 60, 70, 80, 90, 99])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+
+    def test_uniformly_spaced_fractional_distance(self):
+        checkpoints = ProgressCheckpoints(100, 7)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [14, 28, 42, 57, 71, 85, 99])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [14, 28, 42, 57, 71, 85, 100])
+
+        checkpoints = ProgressCheckpoints(10, 20)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [5, 15, 25, 35, 45, 55, 65, 75, 85, 100])
+
+        checkpoints = ProgressCheckpoints(5, 10)
+        self.assertEqual(list(sorted(checkpoints._checkpoints.keys())), [0, 1, 2, 3, 4])
+        self.assertEqual(list(sorted(checkpoints._checkpoints.values())), [10, 30, 50, 70, 100])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Clustering is slow due to a multitude of factors, but especially due to screen updates and things blocking the main thread, which handles these updates. Offloading clustering to a worker thread mitigates this problem.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
Some of the changes meant to https://github.com/metabrainz/picard/pull/1543 ended up being lost while I was reworking the code to remove the Python threads code. This PR contains those changes.

* JIRA ticket (_optional_): PICARD-1844
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
This PR contains the following changes to address the slow clustering issue:

Updating statusbar with the clustering progress, as it takes some time to complete
~Return a Python event when sending callbacks for the main thread, allowing worker threads to wait for the main thread, giving it time to work on the UI~
~Allow for worker thread tasks without callbacks for the main thread~
~Run clustering on a worker thread and slowly send move commands (that update the UI) to the main thread~
Moving files to clusters in batches
Size hints for icon updates and panel height (with uniform row height)

For comparison, the clustering of my 19k file library that originally took ~5h (expanded clusters), was reduced to 10m on the previous PR (collapsed clusters). This PR further reduces the clustering time of the same library to ~3m (collapsed clusters) and ~5m (expanded clusters, 60x speedup over the original). 

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
