### PR TITLE
PICARD-1845: Add "Lookup in Browser" context menu for musicbrainz_discid

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -96,6 +96,9 @@ class FileLookup(object):
     def release_group_lookup(self, release_group_id):
         return self._lookup('release-group', release_group_id)
 
+    def discid_lookup(self, discid):
+        return self._lookup('cdtoc', discid)
+
     def acoust_lookup(self, acoust_id):
         return self.launch(PICARD_URLS['acoustid_track'] + acoust_id)
 

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -249,6 +249,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             "musicbrainz_artistid": lookup.artist_lookup,
             "musicbrainz_albumartistid": lookup.artist_lookup,
             "musicbrainz_releasegroupid": lookup.release_group_lookup,
+            "musicbrainz_discid": lookup.discid_lookup,
             "acoustid_id": lookup.acoust_lookup
         }
         return LOOKUP_TAGS


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Add "Lookup in Browser" context menu for musicbrainz_discid
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


For other MusicBrainz identifies, such as MB release or artist ID, Picard offers a "Lookup in Browser" context menu of the metadata box.

Add this option also for musicbrainz_discid

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1845
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

