### PR TITLE
Adjust weights for pending files and requests in progress indicators

### DIFF
--- a/picard/ui/statusindicator.py
+++ b/picard/ui/statusindicator.py
@@ -38,7 +38,8 @@ class AbstractProgressStatusIndicator:
         if not self.is_available:
             return
 
-        total_pending = pending_files + pending_requests
+        # Weight pending network requests higher as they are slower then file loads
+        total_pending = pending_files + 10 * pending_requests
 
         if total_pending == self._last_pending:
             return  # No changes, avoid update


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

With recent improvements on the performance the processing difference between loading a file and a network request became more obvious, making the progress bars look odd. Weight pending requests higher to better reflect actual progress.

The part of loading the files is still faster, but I think now it "feels good" for the user looking at the progress bar, which is kind of what counts.

On a side note I also tested if there is any performance impact on having the status indicators active or not. But there was no measurable difference in overall loading time of my 4k test files. The status update (which handles both updating the status bar at the bottom and the desktop progress bars) is already throttled, and this seems to be sufficient.