### PR TITLE
PICARD-1840: Fix possible crash when unsetting lyricist

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -390,7 +390,10 @@ def recording_to_metadata(node, m, track=None):
     if m.length:
         m['~length'] = format_time(m.length)
     if 'instrumental' in m.getall('~performance_attributes'):
-        m.unset('lyricist')
+        try:
+            m.unset('lyricist')
+        except KeyError:
+            pass
         m['language'] = 'zxx'
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This is a bugfix for https://github.com/metabrainz/picard/pull/1556, which would crash if there is no lyricist set for a work marked as instrumental.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1840
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

