### PR TITLE
PICARD-1846: Do not raise KeyError in Metadata.unset

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -460,12 +460,12 @@ class Metadata(MutableMapping):
 
         Args:
             name: name of the tag to unset
-
-        Raises:
-            KeyError: name not set
         """
         name = self.normalize_tag(name)
-        del self._store[name]
+        try:
+            del self._store[name]
+        except KeyError:
+            pass
 
     def __iter__(self):
         return iter(self._store)

--- a/picard/script.py
+++ b/picard/script.py
@@ -783,10 +783,7 @@ def func_unset(parser, name):
             if key.startswith(name):
                 parser.context.unset(key)
         return ""
-    try:
-        parser.context.unset(name)
-    except KeyError:
-        pass
+    parser.context.unset(name)
     return ""
 
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -135,7 +135,7 @@ class MetadataTest(PicardTestCase):
         self.metadata.unset("single1")
         self.assertNotIn("single1", self.metadata)
         self.assertNotIn("single1", self.metadata.deleted_tags)
-        self.assertRaises(KeyError, self.metadata.unset, 'unknown_tag')
+        self.metadata.unset('unknown_tag')
 
     def test_metadata_delete(self):
         del self.metadata["single1"]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Having Metadata.unset raise an KeyError is kind of unexpected, especially as other operations like Metadata.get or Metadata.delete don't do this.

This also fixes a possible crash introduced in https://github.com/metabrainz/picard/pull/1556

See discussion in https://github.com/metabrainz/picard/pull/1559

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1846
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Update Metadata.unset to always succeed, even for unknown values.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
