### PR TITLE
PICARD-1753: Fixed script font not scaling on Windows

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -227,8 +227,6 @@ class Tagger(QtWidgets.QApplication):
         if IS_MACOS:
             # On macOS it is not common that the global menu shows icons
             self.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus)
-            # Ensure monospace font works on macOS
-            QtGui.QFont.insertSubstitution('Monospace', 'Menlo')
 
         # Setup logging
         log.debug("Starting Picard from %r", os.path.abspath(__file__))

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -42,7 +42,7 @@ from picard.util import restore_method
 
 if IS_MACOS:
     FONT_FAMILY_MONOSPACE = 'Menlo'
-if IS_WIN:
+elif IS_WIN:
     FONT_FAMILY_MONOSPACE = 'Courier'
 else:
     FONT_FAMILY_MONOSPACE = 'Monospace'

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -33,7 +33,19 @@ from PyQt5 import (
 )
 
 from picard import config
+from picard.const.sys import (
+    IS_MACOS,
+    IS_WIN,
+)
 from picard.util import restore_method
+
+
+if IS_MACOS:
+    FONT_FAMILY_MONOSPACE = 'Menlo'
+if IS_WIN:
+    FONT_FAMILY_MONOSPACE = 'Courier'
+else:
+    FONT_FAMILY_MONOSPACE = 'Monospace'
 
 
 class PreserveGeometry:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -40,7 +40,10 @@ from picard import (
 )
 from picard.util import reconnect
 
-from picard.ui import PicardDialog
+from picard.ui import (
+    FONT_FAMILY_MONOSPACE,
+    PicardDialog,
+)
 from picard.ui.colors import interface_colors
 
 
@@ -232,11 +235,9 @@ class LogView(LogViewCommon):
     def _setup_formats(self):
         interface_colors.load_from_config()
         self.formats = {}
-        font = QtGui.QFont()
-        font.setFamily("Monospace")
         for level, feat in log.levels_features.items():
             text_fmt = QtGui.QTextCharFormat()
-            text_fmt.setFont(font)
+            text_fmt.setFontFamily(FONT_FAMILY_MONOSPACE)
             text_fmt.setForeground(interface_colors.get_qcolor(feat.color_key))
             self.formats[level] = text_fmt
 

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -36,10 +36,7 @@ import os.path
 
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QStandardPaths
-from PyQt5.QtGui import (
-    QFont,
-    QPalette,
-)
+from PyQt5.QtGui import QPalette
 
 from picard import config
 from picard.const import (
@@ -119,9 +116,6 @@ class RenamingOptionsPage(OptionsPage):
         self.ui.move_files_to_browse.clicked.connect(self.move_files_to_browse)
 
         script_edit = self.ui.file_naming_format
-        font = QFont('Monospace')
-        font.setStyleHint(QFont.TypeWriter)
-        script_edit.setFont(font)
         self.script_palette_normal = script_edit.palette()
         self.script_palette_readonly = QPalette(self.script_palette_normal)
         disabled_color = self.script_palette_normal.color(QPalette.Inactive, QPalette.Window)

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -26,10 +26,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt5 import (
-    QtCore,
-    QtGui,
-)
+from PyQt5 import QtCore
 
 from picard import config
 from picard.const import PICARD_URLS
@@ -159,9 +156,6 @@ class ScriptingOptionsPage(OptionsPage):
         self.ui.tagger_script.setEnabled(False)
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 2)
-        font = QtGui.QFont('Monospace')
-        font.setStyleHint(QtGui.QFont.TypeWriter)
-        self.ui.tagger_script.setFont(font)
         self.move_view = MoveableListView(self.ui.script_list, self.ui.move_up_button,
                                           self.ui.move_down_button)
         self.ui.scripting_documentation_button.clicked.connect(self.show_scripting_documentation)

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -32,12 +32,10 @@ from PyQt5.QtWidgets import (
     QTextEdit,
 )
 
-from picard.const.sys import (
-    IS_MACOS,
-    IS_WIN,
-)
 from picard.script import script_function_names
 from picard.util.tags import TAG_NAMES
+
+from picard.ui import FONT_FAMILY_MONOSPACE
 
 
 class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
@@ -130,12 +128,7 @@ class ScriptTextEdit(QTextEdit):
         super().__init__(parent)
         self.highlighter = TaggerScriptSyntaxHighlighter(self.document())
         self.enable_completer()
-        if IS_MACOS:
-            self.setFontFamily('Menlo')
-        if IS_WIN:
-            self.setFontFamily('Courier')
-        else:
-            self.setFontFamily('Monospace')
+        self.setFontFamily(FONT_FAMILY_MONOSPACE)
 
     def enable_completer(self):
         self.completer = ScriptCompleter()

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -32,6 +32,10 @@ from PyQt5.QtWidgets import (
     QTextEdit,
 )
 
+from picard.const.sys import (
+    IS_MACOS,
+    IS_WIN,
+)
 from picard.script import script_function_names
 from picard.util.tags import TAG_NAMES
 
@@ -126,6 +130,12 @@ class ScriptTextEdit(QTextEdit):
         super().__init__(parent)
         self.highlighter = TaggerScriptSyntaxHighlighter(self.document())
         self.enable_completer()
+        if IS_MACOS:
+            self.setFontFamily('Menlo')
+        if IS_WIN:
+            self.setFontFamily('Courier')
+        else:
+            self.setFontFamily('Monospace')
 
     def enable_completer(self):
         self.completer = ScriptCompleter()


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fix using the proper monospaced font on Windows in correct size.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The script editor font on Windows is rendered smaller then elsewhere. Also sometimes it picks a font which renders pixelated. Same was true for the log view.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1753
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Explicitly define a font based on operating system. The generic approach did not work well on Windows and chose a less optimal font. Also explicitly setting the font overwrote the font size on Windows to be way too small.

![picard-editor-font-fixed](https://user-images.githubusercontent.com/29852/85202607-db15bf80-b307-11ea-8018-7d154e26f157.png)

I also tried other ways getting a decent default font, but it did not work reliable. E.g. ` const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont)`   gave a very bad result on Linux, and about the same mess as before on Windows.

On macOS the situation is unchanged and ok.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
