### PR TITLE
PICARD-920: Remember last opened options page

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -84,6 +84,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
     autorestore = False
 
     options = [
+        config.TextOption("persist", "options_last_active_page", ""),
         config.ListOption("persist", "options_pages_tree_state", []),
         config.Option("persist", "options_splitter", QtCore.QByteArray()),
     ]
@@ -145,6 +146,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.item_to_page = {}
         self.page_to_item = {}
         self.default_item = None
+        if not default_page:
+            default_page = config.persist["options_last_active_page"]
         self.add_pages(None, default_page, self.ui.pages_tree)
 
         # work-around to set optimal option pane width
@@ -172,6 +175,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         items = self.ui.pages_tree.selectedItems()
         if items:
             page = self.item_to_page[items[0]]
+            if page.NAME != 'about':
+                config.persist["options_last_active_page"] = page.NAME
             self.ui.pages_stack.setCurrentWidget(page)
 
     def disable_page(self, name):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Remember the option page the user had opened the last time and show this again as default when opening the options dialog.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-920
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Remember the last active page in a config option. Ignore the about name, as I think this is not useful and opening Help > About should not reset the last active real options page.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
