### PR TITLE
PICARD-1853: Fix natsort crashing on strings with '\0'

### DIFF
--- a/picard/util/natsort.py
+++ b/picard/util/natsort.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -34,7 +34,7 @@ def natkey(text):
     Return a sort key for a string for natural sort order.
     """
     return [int(s) if s.isdigit() else strxfrm(s)
-            for s in RE_NUMBER.split(str(text))]
+            for s in RE_NUMBER.split(str(text).replace('\0', ''))]
 
 
 def natsorted(values):

--- a/test/test_util_natsort.py
+++ b/test/test_util_natsort.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 # Copyright (C) 2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -36,3 +36,6 @@ class NatsortTest(PicardTestCase):
         expected = ['foo0', 'foo1', 'foo02', 'foo9', 'foo10', 'foo11', 'foo0012']
         sorted_list = natsort.natsorted(unsorted_list)
         self.assertEqual(expected, sorted_list)
+
+    def test_natkey_handles_null_char(self):
+        self.assertEqual(natsort.natkey('foo\0'), natsort.natkey('foo'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fix crash when loading files where tag values contain null characters, if those tags are used for column sorting.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
`natsort.natkey` will crash on strings which contain `\0` chars.

```
(env) ~\devel\musicbrainz\picard [PICARD-1852-about-dialog]> python .\tagger.py
W: 16:20:30,547 ui.mainwindow.create_actions:529: CDROM: discid library not found - Lookup CD functionality disabled
Traceback (most recent call last):
  File ".\picard\ui\itemviews.py", line 872, in __lt__
    return self.sortkey(column) < other.sortkey(column)
  File ".\picard\ui\itemviews.py", line 877, in sortkey
    return natsort.natkey(self.text(column).lower())
  File ".\picard\util\natsort.py", line 36, in natkey
    return [int(s) if s.isdigit() else strxfrm(s)
  File ".\picard\util\natsort.py", line 36, in <listcomp>
    return [int(s) if s.isdigit() else strxfrm(s)
ValueError: embedded null character
```
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1853
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Remove null chars from strings in natkey
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
