### PR TITLE
PICARD-1856: Use gettext.pgettext in Python 3.8

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -283,7 +283,8 @@ min-similarity-lines=4
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid defining new builtins when possible.
-additional-builtins=_, N_, ngettext, gettext_countries, gettext_attributes
+additional-builtins=_, N_, ngettext, gettext_countries,
+                    gettext_attributes, pgettext_attributes
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes

--- a/picard/coverart/utils.py
+++ b/picard/coverart/utils.py
@@ -23,7 +23,6 @@
 
 
 from picard.const import MB_ATTRIBUTES
-from picard.i18n import gettext_attr
 
 
 # list of types from http://musicbrainz.org/doc/Cover_Art/Types
@@ -46,4 +45,4 @@ def translate_caa_type(name):
         return _(CAA_TYPES_TR[name])
     else:
         title = CAA_TYPES_TR.get(name, name)
-        return gettext_attr(title, "cover_art_type")
+        return pgettext_attributes("cover_art_type", title)

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -98,14 +98,22 @@ def setup_gettext(localedir, ui_language=None, logger=None):
     builtins.__dict__['gettext_countries'] = trans_countries.gettext
     builtins.__dict__['gettext_attributes'] = trans_attributes.gettext
 
+    if hasattr(trans_attributes, 'pgettext'):
+        builtins.__dict__['pgettext_attributes'] = trans_attributes.pgettext
+    else:
+        def pgettext(context, message):
+            return gettext_ctxt(trans_attributes.gettext, message, context)
+        builtins.__dict__['pgettext_attributes'] = pgettext
+
     logger("_ = %r", _)
     logger("N_ = %r", N_)
     logger("ngettext = %r", ngettext)
     logger("gettext_countries = %r", gettext_countries)
     logger("gettext_attributes = %r", gettext_attributes)
+    logger("pgettext_attributes = %r", pgettext_attributes)
 
 
-# Workaround for po files with msgctxt which isn't supported by current python
+# Workaround for po files with msgctxt which isn't supported by Python < 3.8
 # gettext
 # msgctxt are used within attributes.po, and gettext is failing to translate
 # strings due to that
@@ -123,8 +131,3 @@ def gettext_ctxt(gettext_, message, context=None):
         # no translation found, return original message
         return message
     return translated
-
-
-def gettext_attr(message, context=None):
-    """Translate MB attributes, depending on context"""
-    return gettext_ctxt(gettext_attributes, message, context)

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -41,7 +41,6 @@ from picard.const import (
     RELEASE_SECONDARY_GROUPS,
 )
 from picard.const.sys import IS_WIN
-from picard.i18n import gettext_attr
 
 from picard.ui.options import (
     OptionsPage,
@@ -171,7 +170,7 @@ class ReleasesOptionsPage(OptionsPage):
         self._release_type_sliders = {}
 
         def add_slider(name, griditer, context):
-            label = gettext_attr(name, context)
+            label = pgettext_attributes(context, name)
             self._release_type_sliders[name] = \
                 ReleaseTypeScore(self.ui.type_group,
                                  self.ui.gridLayout,
@@ -184,7 +183,7 @@ class ReleasesOptionsPage(OptionsPage):
         for name in RELEASE_PRIMARY_GROUPS:
             add_slider(name, griditer, context='release_group_primary_type')
         for name in sorted(RELEASE_SECONDARY_GROUPS,
-                           key=lambda v: gettext_attr(v, 'release_group_secondary_type')):
+                           key=lambda v: pgettext_attributes('release_group_secondary_type', v)):
             add_slider(name, griditer, context='release_group_secondary_type')
 
         self.reset_preferred_types_btn = QtWidgets.QPushButton(self.ui.type_group)
@@ -264,7 +263,7 @@ class ReleasesOptionsPage(OptionsPage):
             source_list = [(c[0], gettext_countries(c[1])) for c in
                            source.items()]
         elif setting == "preferred_release_formats":
-            source_list = [(c[0], gettext_attr(c[1], "medium_format")) for c
+            source_list = [(c[0], pgettext_attributes("medium_format", c[1])) for c
                            in source.items()]
         else:
             source_list = [(c[0], _(c[1])) for c in source.items()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 # E501: line too long (xx > 79 characters)
 # W503: line break occurred before a binary operator
 ignore = E127,E128,E129,E226,E241,E501,W503
-builtins = _,N_,ngettext,gettext_attributes,gettext_countries,string_
+builtins = _,N_,ngettext,gettext_attributes,pgettext_attributes,gettext_countries,string_
 exclude = ui_*.py,picard/resources.py
 
 [coverage:run]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If available, use gettext.pgettext (available since Python 3.8). Fall back to custom implementation for older Python versions.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


For the attributes we need to access gettext strings with context. Normally this is provided by gettext with the pgettext(context, message) function, but this was not available in Python until version 3.8

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1856
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add support for pgettext in Python 3.8, but keep the old code for older versions.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

