### PR TITLE
PICARD-1853: Fix crash in natsort on superscript numeric chars

### DIFF
--- a/picard/util/natsort.py
+++ b/picard/util/natsort.py
@@ -33,7 +33,7 @@ def natkey(text):
     """
     Return a sort key for a string for natural sort order.
     """
-    return [int(s) if s.isdigit() else strxfrm(s)
+    return [int(s) if s.isdecimal() else strxfrm(s)
             for s in RE_NUMBER.split(str(text).replace('\0', ''))]
 
 

--- a/test/test_util_natsort.py
+++ b/test/test_util_natsort.py
@@ -19,6 +19,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from locale import strxfrm
 
 from test.picardtestcase import PicardTestCase
 
@@ -39,3 +40,9 @@ class NatsortTest(PicardTestCase):
 
     def test_natkey_handles_null_char(self):
         self.assertEqual(natsort.natkey('foo\0'), natsort.natkey('foo'))
+
+    def test_natkey_handles_numeric_chars(self):
+        self.assertEqual(
+            natsort.natkey('foo0123456789|²³|٠١٢٣٤٥٦٧٨٩|๐๑๒๓๔๕๖๗๘๙|𝟜𝟚bar'),
+            [strxfrm('foo'), 123456789, strxfrm('|²³|'), 123456789,
+             strxfrm('|'), 123456789, strxfrm('|'), 42, strxfrm('bar')])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Picard crashes in natsort when encountering characters that are considered numeric, but not decimal, such as e.g. `²`.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1853
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use `str.isdecimal` to check for valid characters. Add tests to ensure there is no crash, but decimal numbers also from other writing systems still work. That means natsort will still naturally sort e.g. numbers in Arabic script (٠١٢٣٤٥٦٧٨٩), but not crash on superscript or subscript characters.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
The code now would not properly sort `'⁸'` < `'⁰⁹'`. We could implement also this by converting the input string to e.g. `'^8'` and `'^09'`. But this ads additional overhead, it makes natkey more than twice as slow. I don't think it is worth it, but I have an implementation of this at https://github.com/phw/picard/commit/cd7cf2e3f2fb586e2f8bae6e88d7324daaafced2 
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
