### PR TITLE
PICARD-1855: Ensure all recording details get loaded for NATs

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -728,16 +728,16 @@ class File(QtCore.QObject, Item):
                 statusbar(N_("No matching tracks above the threshold for file '%(filename)s'"))
             else:
                 statusbar(N_("File '%(filename)s' identified!"))
-                (track_id, release_group_id, release_id, acoustid, node) = trackmatch
+                (recording_id, release_group_id, release_id, acoustid, node) = trackmatch
                 if lookuptype == File.LOOKUP_ACOUSTID:
                     self.metadata['acoustid_id'] = acoustid
-                    self.tagger.acoustidmanager.add(self, track_id)
+                    self.tagger.acoustidmanager.add(self, recording_id)
                 if release_group_id is not None:
                     releasegroup = self.tagger.get_release_group_by_id(release_group_id)
                     releasegroup.loaded_albums.add(release_id)
-                    self.tagger.move_file_to_track(self, release_id, track_id)
+                    self.tagger.move_file_to_track(self, release_id, recording_id)
                 else:
-                    self.tagger.move_file_to_nat(self, track_id, node=node)
+                    self.tagger.move_file_to_nat(self, recording_id)
         else:
             statusbar(N_("No matching tracks for file '%(filename)s'"))
 


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If a file is matched against a NAT during lookup, ensure the full metadata is loaded for this recording instead of relying on the search result.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When a file got matched against a standalone recording (aka non-album track) the metadata from the search result was used, which lacked extended metadata.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1855
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Ensure a separate request for the recording is made, including all the metadata.
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
