### PR TITLE
PICARD-1864: Reorder move to target

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -433,10 +433,6 @@ class Tagger(QtWidgets.QApplication):
             self.unclustered_files.add_file(file)
             return
 
-        if target is not None:
-            self.move_files([file], target)
-            return
-
         if not config.setting["ignore_file_mbids"]:
             recordingid = file.metadata['musicbrainz_recordingid']
             is_valid_recordingid = mbid_validate(recordingid)
@@ -462,7 +458,10 @@ class Tagger(QtWidgets.QApplication):
                 self.move_file_to_nat(file, recordingid)
                 return
 
-        self.unclustered_files.add_file(file)
+        if target:
+            self.move_files([file], target)
+        else:
+            self.unclustered_files.add_file(file)
 
         # fallback on analyze if nothing else worked
         if config.setting['analyze_new_files'] and file.can_analyze():


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Postpone move to target to make sure MBIDs can be checked first.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1864
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

During refactoring to reduce moves between clusters, I didn't pay enough attention to target!=none case of file_loaded (which doesn't happen unless you're moving things around from file browser), skipping necessary checks.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Reorder the move to target and remove return to make sure all files are tested for 'analyze_new_files' and 'ignore_file_mbids'.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
