### PR TITLE
PICARD-1867: Fix guess_format fallback on file load error

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -183,7 +183,12 @@ class File(QtCore.QObject, Item):
 
             # If loading failed, force format guessing and try loading again
             from picard.formats.util import guess_format
-            alternative_file = guess_format(self.base_filename)
+            try:
+                alternative_file = guess_format(self.filename)
+            except (FileNotFoundError, OSError):
+                log.error("Guessing format of %s failed", self.filename, exc_info=True)
+                alternative_file = None
+
             if alternative_file:
                 # Do not retry reloading exactly the same file format
                 if type(alternative_file) != type(self):  # pylint: disable=unidiomatic-typecheck

--- a/picard/file.py
+++ b/picard/file.py
@@ -201,8 +201,8 @@ class File(QtCore.QObject, Item):
             from picard.formats import supported_extensions
             file_name, file_extension = os.path.splitext(self.base_filename)
             if file_extension not in supported_extensions():
-                self.remove()
                 log.error('Unsupported media file %r wrongly loaded. Removing ...', self)
+                callback(self, remove_file=True)
                 return
         else:
             self.error = None

--- a/picard/file.py
+++ b/picard/file.py
@@ -194,7 +194,7 @@ class File(QtCore.QObject, Item):
                 if type(alternative_file) != type(self):  # pylint: disable=unidiomatic-typecheck
                     log.debug('Loading %r failed, retrying as %r' % (self, alternative_file))
                     self.remove()
-                    self.tagger.add_file(alternative_file, callback)
+                    alternative_file.load(callback)
                     return
                 else:
                     alternative_file.remove()  # cleanup unused File object

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -421,10 +421,14 @@ class Tagger(QtWidgets.QApplication):
             return 1
         return super().event(event)
 
-    def _file_loaded(self, file, target=None):
+    def _file_loaded(self, file, target=None, remove_file=False):
         self._pending_files_count -= 1
         if self._pending_files_count == 0:
             self.window.set_sorting(True)
+
+        if remove_file:
+            file.remove()
+            return
 
         if file is None:
             return

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -527,6 +527,10 @@ class Tagger(QtWidgets.QApplication):
                 file.load(partial(self._file_loaded, target=target))
                 QtCore.QCoreApplication.processEvents()
 
+    def add_file(self, file_, callback):
+        self._pending_files_count += 1
+        file_.load(callback)
+
     def _scan_dir(self, folders, recursive, ignore_hidden):
         files = []
         local_folders = list(folders)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -527,10 +527,6 @@ class Tagger(QtWidgets.QApplication):
                 file.load(partial(self._file_loaded, target=target))
                 QtCore.QCoreApplication.processEvents()
 
-    def add_file(self, file_, callback):
-        self._pending_files_count += 1
-        file_.load(callback)
-
     def _scan_dir(self, folders, recursive, ignore_hidden):
         files = []
         local_folders = list(folders)


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Properly handle trying an alternative file format on file load errors by injecting the guessed file format into the file load queue. Avoids issues with the loaded file object being the wrong type and having two file objects causing the pending files to be displayed wrongly.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The implementation of trying alternatve file format in File._load_check has some flaws.

For one, it just returns the result of a different format, but the original `File` object stays the same. So you e.g. get a MP3 file called "mp3.wav" properly loaded because `WAVFile._load_check()`  will return the result of `MP3File._load()`, but the original file object will still be of type `WAVFile`.

Also the creation of the additional file object will increase the pending files count, but this never gets released.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1867
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Handle retrying to load later. Instead of trying to resolve this in place, remove the currently loaded file object and inject the alternative format as a separate file into the load queue.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
