### PR TITLE
PICARD-1866: Restore cheaper update_selection for itemview updates

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -920,6 +920,8 @@ class ClusterItem(TreeItem):
         album = self.obj.related_album
         if self.obj.special and album and album.loaded:
             album.item.update(update_tracks=False)
+        if self.isSelected():
+            TreeItem.window.update_selection(new_selection=False)
 
     def add_file(self, file):
         self.add_files([file])
@@ -994,6 +996,8 @@ class AlbumItem(TreeItem):
                 self.setToolTip(MainPanel.TITLE_COLUMN, _("Album unchanged"))
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, album.column(column[1]))
+        if selection_changed:
+            TreeItem.window.update_selection(new_selection=False)
         # Workaround for PICARD-1446: Expand/collapse indicator for the release
         # is briefly missing on Windows
         self.emitDataChanged()
@@ -1077,6 +1081,8 @@ class TrackItem(TreeItem):
             self.setText(i, track.column(column[1]))
             self.setForeground(i, color)
             self.setBackground(i, bgcolor)
+        if self.isSelected():
+            TreeItem.window.update_selection(new_selection=False)
         if update_album:
             self.parent().update(update_tracks=False)
 
@@ -1098,7 +1104,8 @@ class FileItem(TreeItem):
             if not tree_widget.itemWidget(self, MainPanel.FINGERPRINT_COLUMN):
                 tree_widget.setItemWidget(self, MainPanel.FINGERPRINT_COLUMN,
                     FingerprintColumnWidget(file=file))
-
+        if self.isSelected():
+            TreeItem.window.update_selection(new_selection=False)
         parent = self.parent()
         if isinstance(parent, TrackItem) and update_track:
             parent.update(update_files=False)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1112,7 +1112,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.tags_from_filenames_action.setEnabled(bool(files))
         self.track_search_action.setEnabled(have_objects)
 
-    def update_selection(self, objects=None):
+    def update_selection(self, objects=None, new_selection=True):
         if self.ignore_selection_changes:
             return
 
@@ -1176,8 +1176,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             elif obj.can_show_coverart:
                 metadata = obj.metadata
 
-        self.metadata_box.selection_dirty = True
-        self.metadata_box.update()
+        if new_selection:
+            self.metadata_box.selection_dirty = True
+            self.metadata_box.update()
         self.cover_art_box.set_metadata(metadata, orig_metadata, obj)
         self.selection_updated.emit(objects)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Restore itemview calls to MainWindow.update_selection, fixing coverart updates on the metadatabox. 

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
While trying to improve performance with large libraries, I ended up removing MainWindow.update_selection calls, which are exponential. Further analysis shown that the expensive part of the call is the comparison of tag values of selected files and respective updates of the metadatabox.

* JIRA ticket (_optional_): PICARD-1866
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Calls to MainWindow.update_selection are restored in itemview updates, but using a flag to indicate the selection remains the same to skip tag comparison during updates. This solves part of the reported issues, while still requiring the user to manually change the file selection to trigger the expensive updates.

This deviates from the previous behavior but ensures that performance is kept basically constant throughout processing even when a ton of files are selected.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
