### PR TITLE
PICARD-1866: Update metadatabox if a single file/cluster/track/album metadata changes.

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1178,7 +1178,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         if new_selection:
             self.metadata_box.selection_dirty = True
-            self.metadata_box.update()
+        self.metadata_box.update()
         self.cover_art_box.set_metadata(metadata, orig_metadata, obj)
         self.selection_updated.emit(objects)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Update metadatabox more frequently to reflect user changes after editing a single file/cluster/track/album.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1866
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
In PR https://github.com/metabrainz/picard/pull/1579 part of the issue in PICARD-1866 was solved, but it still required users to click on other items and then click again on the edited item to update its tags. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

This PR lets Picard continue updating the metadata box in case a single file/cluster/track/album is selected, which should solve the issue for what is assumed to be the common use case. If more than a cluster/album are selected, the metadatabox keeps its original value during updates to prevent reprocessing the tags. If the file/track selection changes, the metadatabox is updated.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
