### PR TITLE
Increase contrast between focused and unfocused highlighted items while using accent colors on Windows

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -81,16 +81,25 @@ class BaseTheme:
     def update_palette(self, palette, dark_theme, accent_color):
         if accent_color:
             accent_text_color = QtCore.Qt.white if accent_color.lightness() < 160 else QtCore.Qt.black
+            palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color)
             palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.HighlightedText, accent_text_color)
-            palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.HighlightedText, accent_text_color)
-            if dark_theme:
-                palette.setColor(QtGui.QPalette.Link, accent_color.lighter())
-                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color.lighter())
-                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color)
-            else:
-                palette.setColor(QtGui.QPalette.Link, accent_color)
-                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color)
-                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color.lighter())
+
+            link_color = accent_color
+            while True:
+                if dark_theme:
+                    if link_color.lightness() < 160:
+                        link_color = link_color.lighter()
+                        continue
+                else:
+                    if link_color.lightness() > 160:
+                        link_color = link_color.darker()
+                        continue
+                break
+            palette.setColor(QtGui.QPalette.Link, link_color)
+
+        if dark_theme:
+            palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, QtGui.QColor(51, 51, 51))
+            palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.HighlightedText, QtCore.Qt.white)
 
 
 if IS_WIN:

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -81,12 +81,16 @@ class BaseTheme:
     def update_palette(self, palette, dark_theme, accent_color):
         if accent_color:
             accent_text_color = QtCore.Qt.white if accent_color.lightness() < 160 else QtCore.Qt.black
-            palette.setColor(QtGui.QPalette.Highlight, accent_color)
-            palette.setColor(QtGui.QPalette.HighlightedText, accent_text_color)
+            palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.HighlightedText, accent_text_color)
+            palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.HighlightedText, accent_text_color)
             if dark_theme:
                 palette.setColor(QtGui.QPalette.Link, accent_color.lighter())
+                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color.lighter())
+                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color)
             else:
                 palette.setColor(QtGui.QPalette.Link, accent_color)
+                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color)
+                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color.lighter())
 
 
 if IS_WIN:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Change color of inactive highlighted items to differentiate them from active highlighted items.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
Active and inactive highlighted items currently use the same color, confusing users as reported in [link](https://community.metabrainz.org/t/picard-2-4-beta-2-selection-focus-issue/484898).

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Differentiate active and inactive color for highlighted items, deriving the color from the selected accent.
```
            if dark_theme:
                palette.setColor(QtGui.QPalette.Link, accent_color.lighter())
                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color.lighter())
                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color)
            else:
                palette.setColor(QtGui.QPalette.Link, accent_color)
                palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color)
                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, accent_color.lighter())
```

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
