### PR TITLE
PICARD-1881: Use scripting syntax function color for script docs

### DIFF
--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -43,7 +43,6 @@ _DEFAULT_COLORS = {
     'tagstatus_added': DefaultColor('green', N_("Tag added")),
     'tagstatus_changed': DefaultColor('darkgoldenrod', N_("Tag changed")),
     'tagstatus_removed': DefaultColor('red', N_("Tag removed")),
-    'script_function_fg': DefaultColor('#220', N_("Script Function")),
 }
 
 

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -40,13 +40,13 @@ from picard.ui import (
     FONT_FAMILY_MONOSPACE,
     PicardDialog,
 )
-from picard.ui.colors import interface_colors
 from picard.ui.moveable_list_view import MoveableListView
 from picard.ui.options import (
     OptionsCheckError,
     OptionsPage,
     register_options_page,
 )
+from picard.ui.theme import theme
 from picard.ui.ui_options_script import Ui_ScriptingOptionsPage
 from picard.ui.ui_scripting_documentation_dialog import (
     Ui_ScriptingDocumentationDialog,
@@ -120,10 +120,10 @@ class ScriptingDocumentationDialog(PicardDialog):
             postprocessor=process_html,
         )
 
-        color_fg = interface_colors.get_color('script_function_fg')
+        syntax_theme = theme.get_syntax_theme()
         html = DOCUMENTATION_HTML_TEMPLATE % {
             'html': "<dl>%s</dl>" % funcdoc,
-            'script_function_fg': color_fg,
+            'script_function_fg': syntax_theme.func.name(),
             'monospace_font': FONT_FAMILY_MONOSPACE,
         }
         self.ui.textBrowser.setHtml(html)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -35,11 +35,11 @@ from picard.const.sys import (
 SyntaxTheme = namedtuple('SyntaxTheme', 'func var escape special noop')
 
 light_syntax_theme = SyntaxTheme(
-    func=QtCore.Qt.blue,
-    var=QtCore.Qt.darkCyan,
-    escape=QtCore.Qt.darkRed,
-    special=QtCore.Qt.blue,
-    noop=QtCore.Qt.darkGray,
+    func=QtGui.QColor(QtCore.Qt.blue),
+    var=QtGui.QColor(QtCore.Qt.darkCyan),
+    escape=QtGui.QColor(QtCore.Qt.darkRed),
+    special=QtGui.QColor(QtCore.Qt.blue),
+    noop=QtGui.QColor(QtCore.Qt.darkGray),
 )
 
 dark_syntax_theme = SyntaxTheme(


### PR DESCRIPTION
Instead of having a separate configurable color use the color from the syntax theme.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When a dark background is used for the scripting documentation window the functions are not readable. Change the code to use the function color for the syntax theme, which can  be made aware of the color.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1881
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Take the function color from the syntax theme.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Right now this fixes the issue for Windows, not macOS and KDE. For macOS our release builds do currently not support dark theme anyway. For KDE we need to detect usage of dark UI.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
