### PR TITLE
PICARD-1889: Don't use release relationships if "Use release relationships" is disabled

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -462,7 +462,7 @@ def release_to_metadata(node, m, album=None):
                     artist = credit['artist']
                     artist_obj = album.append_album_artist(artist['id'])
                     add_genres_from_node(artist, artist_obj)
-        elif key == 'relations':
+        elif key == 'relations' and config.setting['release_ars']:
             _relations_to_metadata(value, m)
         elif key == 'label-info':
             m['label'], m['catalognumber'] = label_info_from_node(value)

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -285,6 +285,32 @@
             "end": null,
             "direction": "backward",
             "type-id": "0b58dc9b-9c49-4b19-bb58-9c06d41c8fbf"
+        },
+        {
+            "attribute-values": {
+
+            },
+            "begin": null,
+            "type": "producer",
+            "target-type": "artist",
+            "target-credit": "",
+            "source-credit": "",
+            "attributes": [
+
+            ],
+            "ended": false,
+            "artist": {
+                "id": "fd1a4572-59ca-40f2-8f55-b82be28bb0ff",
+                "sort-name": "Hipgnosis",
+                "aliases": [
+
+                ],
+                "disambiguation": "UK art design group",
+                "name": "Hipgnosis"
+            },
+            "end": null,
+            "direction": "backward",
+            "type-id": "8bf377ba-8d71-4ecc-97f2-7bb2d8a2a75f"
         }
     ],
     "id": "b84ee12a-09ef-421b-82de-0441a926375b",

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -87,6 +87,38 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['label'], 'Harvest')
         self.assertEqual(m['musicbrainz_albumartistid'], '83d91898-7763-47d7-b03b-b92132375c47')
         self.assertEqual(m['musicbrainz_albumid'], 'b84ee12a-09ef-421b-82de-0441a926375b')
+        self.assertEqual(m['producer'], 'Hipgnosis')
+        self.assertEqual(m['releasecountry'], 'GB')
+        self.assertEqual(m['releasestatus'], 'official')
+        self.assertEqual(m['script'], 'Latn')
+        self.assertEqual(m['~albumartists'], 'Pink Floyd')
+        self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
+        self.assertEqual(m['~releaselanguage'], 'eng')
+        self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
+        self.assertEqual(a.genres, {
+            'genre1': 6, 'genre2': 3,
+            'tag1': 6, 'tag2': 3})
+        for artist in a._album_artists:
+            self.assertEqual(artist.genres, {
+                'british': 2,
+                'progressive rock': 10})
+
+    def test_release_without_release_relationships(self):
+        config.setting['release_ars'] = False
+        m = Metadata()
+        a = Album("1")
+        release_to_metadata(self.json_doc, m, a)
+        self.assertEqual(m['album'], 'The Dark Side of the Moon')
+        self.assertEqual(m['albumartist'], 'Pink Floyd')
+        self.assertEqual(m['albumartistsort'], 'Pink Floyd')
+        self.assertEqual(m['asin'], 'b123')
+        self.assertEqual(m['barcode'], '123')
+        self.assertEqual(m['catalognumber'], 'SHVL 804')
+        self.assertEqual(m['date'], '1973-03-24')
+        self.assertEqual(m['label'], 'Harvest')
+        self.assertEqual(m['musicbrainz_albumartistid'], '83d91898-7763-47d7-b03b-b92132375c47')
+        self.assertEqual(m['musicbrainz_albumid'], 'b84ee12a-09ef-421b-82de-0441a926375b')
+        self.assertEqual(m['producer'], '')
         self.assertEqual(m['releasecountry'], 'GB')
         self.assertEqual(m['releasestatus'], 'official')
         self.assertEqual(m['script'], 'Latn')

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -53,6 +53,7 @@ settings = {
     "standardize_releases": False,
     "translate_artist_names": True,
     "standardize_instruments": True,
+    "release_ars": True,
     "preferred_release_countries": [],
     "artist_locale": 'en'
 }

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -55,6 +55,7 @@ settings = {
     'standardize_artists': False,
     'standardize_instruments': False,
     'translate_artist_names': False,
+    'release_ars': True,
     'release_type_scores': [
         ('Album', 1.0)
     ],


### PR DESCRIPTION
# PICARD-1889: Don't use release relationships if "Use release relationships" is disabled

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Don't use release relationships in tags when "Use release relationships" is disabled.

# Problem

When "Use track relationships" is enabled in Metadata Options but "Use release relationships" is disabled, Picard would write release relationships to tags anyway. There is no way at the webservice request level to exclude Release-Artist relationships if you also want Recording-Artist and Work-Artist relationships, so the release-level relationships must be filtered out client-side.

* JIRA ticket (_optional_): PICARD-1889

# Solution

Filter out release-level relationships if "Use release relationships" is disabled.


# Action


