### PR TITLE
PICARD 2.3.2 / 2.4.0b2 "is damaged and cannot be opened. Move to trash"

### DIFF
--- a/scripts/pyinstaller/macos-library-path-hook.py
+++ b/scripts/pyinstaller/macos-library-path-hook.py
@@ -23,6 +23,9 @@ import os
 import sys
 
 
+# The macOS app crashes on launch if the working directory happens to be sys._MEIPASS
+os.chdir(os.path.abspath(os.path.join(sys._MEIPASS, '..', '..')))
+
 # On macOS ensure libraries such as libdiscid.dylib get loaded from app bundle
 os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = '%s:%s' % (
     os.path.dirname(sys.executable), os.environ.get('DYLD_FALLBACK_LIBRARY_PATH', ''))


### PR DESCRIPTION
Hello,

i downloaded MusicBrainz 2.3.2 and 2.4.0b2 on macOS 10.13.6 (latest for my mac)

- Starting "MusicBrainz Picard" from DMG ist works
- Starting "MusicBrainz Picard" from a copy everywhere on hard drive the system tells me "is damaged and cannot be opened"
- Calling "...//MusicBrainz\ Picard.app/Contents/MacOS/picard-run" from terminal it works, too!

What fucking apple guardian makes "MusicBrainz Picard" unable to start on macOS 10.13.6?
