### PR TITLE
PICARD-1892: Fixed deleting totaldiscs / totaltracks from Vorbis tags

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -327,7 +327,7 @@ class VCommentFile(File):
                             existing_tags.remove(item)
                     tags[real_name] = existing_tags
                 else:
-                    if tag in ('totaldiscs', 'totaltracks'):
+                    if tag in ('totaldiscs', 'totaltracks') and tag in tags:
                         # both tag and real_name are to be deleted in this case
                         del tags[tag]
                     del tags[real_name]

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 # Copyright (C) 2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -155,6 +155,24 @@ class CommonVorbisTests:
             self.assertTrue(self.format.supports_tag(performer_tag))
             self.assertTrue(self.format.supports_tag('lyrics:foó'))
             self.assertTrue(self.format.supports_tag('comment:foó'))
+
+        @skipUnlessTestfile
+        def test_delete_totaldiscs_totaltracks(self):
+            # Create a test file that contains only disctotal / tracktotal,
+            # but not totaldiscs and totaltracks
+            save_raw(self.filename, {
+                'disctotal': '3',
+                'tracktotal': '2',
+            })
+            metadata = Metadata()
+            del metadata['totaldiscs']
+            del metadata['totaltracks']
+            save_metadata(self.filename, metadata)
+            loaded_metadata = load_raw(self.filename)
+            self.assertNotIn('disctotal', loaded_metadata)
+            self.assertNotIn('totaldiscs', loaded_metadata)
+            self.assertNotIn('tracktotal', loaded_metadata)
+            self.assertNotIn('totaltracks', loaded_metadata)
 
 
 class FLACTest(CommonVorbisTests.VorbisTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Deleting of totaldiscs or totaltracks failed if the file only contained disctotal or tracktotal tags, but not also totaldiscs or totaltracks.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1892
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Check existence of tags before trying to delete them. Added a test.