### PR TITLE
PICARD-1891: handle incorrect date parsing exceptions

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -260,25 +260,27 @@ class Metadata(MutableMapping):
         date_match_factor = 0.0
         if "date" in release and release['date'] != '':
             release_date = release['date']
-            release_year = extract_year_from_date(release_date)
             if "date" in self:
                 metadata_date = self['date']
                 if release_date == metadata_date:
                     # release has a date and it matches what our metadata had exactly.
                     date_match_factor = self.__date_match_factors['exact']
                 else:
-                    metadata_year = extract_year_from_date(metadata_date)
-                    if release_year == metadata_year:
-                        # release has a date and it matches what our metadata had for year exactly.
-                        date_match_factor = self.__date_match_factors['year']
-                    elif abs(release_year - metadata_year) <= 2:
-                        # release has a date and it matches what our metadata had closely (year +/- 2).
-                        date_match_factor = self.__date_match_factors['close_year']
-                    else:
-                        # release has a date but it does not match ours (all else equal,
-                        # its better to have an unknown date than a wrong date, since
-                        # the unknown could actually be correct)
-                        date_match_factor = self.__date_match_factors['differed']
+                    release_year = extract_year_from_date(release_date)
+                    if release_year is not None:
+                        metadata_year = extract_year_from_date(metadata_date)
+                        if metadata_year is not None:
+                            if release_year == metadata_year:
+                                # release has a date and it matches what our metadata had for year exactly.
+                                date_match_factor = self.__date_match_factors['year']
+                            elif abs(release_year - metadata_year) <= 2:
+                                # release has a date and it matches what our metadata had closely (year +/- 2).
+                                date_match_factor = self.__date_match_factors['close_year']
+                            else:
+                                # release has a date but it does not match ours (all else equal,
+                                # its better to have an unknown date than a wrong date, since
+                                # the unknown could actually be correct)
+                                date_match_factor = self.__date_match_factors['differed']
             else:
                 # release has a date but we don't have one (all else equal, we prefer
                 # tracks that have non-blank date values)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -655,15 +655,10 @@ def limited_join(a_list, limit, join_string='+', middle_string='…'):
 def extract_year_from_date(dt):
     """ Extracts year from  passed in date either dict or string """
 
-    if isinstance(dt, Mapping):
-        try:
+    try:
+        if isinstance(dt, Mapping):
             return int(dt.get('year'))
-        except (TypeError, ValueError) as e:
-            log.debug(e)
-    else:
-        try:
+        else:
             return parse(dt).year
-        except (ParserError, TypeError) as e:
-            log.debug(e)
-
-    return None
+    except (ParserError, TypeError, ValueError):
+        return None

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -50,11 +50,14 @@ import sys
 from time import time
 import unicodedata
 
-from dateutil.parser import parse
+from dateutil.parser import (
+    ParserError,
+    parse,
+)
 
 from PyQt5 import QtCore
 
-# Required for compatibility with lastfmplus which imports this from here rather than loading it direct.
+from picard import log
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.const.sys import (
     FROZEN_TEMP_PATH,
@@ -97,7 +100,6 @@ _io_encoding = sys.getfilesystemencoding()
 # intentionally
 def check_io_encoding():
     if _io_encoding == "ANSI_X3.4-1968":
-        from picard import log
         log.warning("""
 System locale charset is ANSI_X3.4-1968
 Your system's locale charset (i.e. the charset used to encode filenames)
@@ -505,7 +507,6 @@ def __convert_to_string(obj):
 
 
 def convert_to_string(obj):
-    from picard import log
     log.warning("string_() and convert_to_string() are deprecated, do not use")
     return __convert_to_string(obj)
 
@@ -655,9 +656,14 @@ def extract_year_from_date(dt):
     """ Extracts year from  passed in date either dict or string """
 
     if isinstance(dt, Mapping):
-        year = int(dt.get('year'))
+        try:
+            return int(dt.get('year'))
+        except (TypeError, ValueError) as e:
+            log.debug(e)
     else:
-        parsed_dt = parse(dt)
-        year = parsed_dt.year
+        try:
+            return parse(dt).year
+        except (ParserError, TypeError) as e:
+            log.debug(e)
 
-    return year
+    return None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -86,6 +86,8 @@ class ExtractYearTest(PicardTestCase):
         self.assertEqual(extract_year_from_date('2020-02-28'), 2020)
         self.assertEqual(extract_year_from_date('2015.02'), 2015)
         self.assertEqual(extract_year_from_date('2015; 2015'), None)
+        # test for the format as supported by ID3 (https://id3.org/id3v2.4.0-structure): yyyy-MM-ddTHH:mm:ss
+        self.assertEqual(extract_year_from_date('2020-07-21T13:00:00'), 2020)
 
     def test_mapping(self):
         self.assertEqual(extract_year_from_date({}), None)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -38,6 +38,7 @@ from test.picardtestcase import PicardTestCase
 from picard import util
 from picard.const.sys import IS_WIN
 from picard.util import (
+    extract_year_from_date,
     find_best_match,
     imageinfo,
     limited_join,
@@ -75,6 +76,23 @@ class ReplaceWin32IncompatTest(PicardTestCase):
     def test_incorrect(self):
         self.assertNotEqual(util.replace_win32_incompat("c:\\test\\te\"st2"),
                              "c:\\test\\te\"st2")
+
+
+class ExtractYearTest(PicardTestCase):
+    def test_string(self):
+        self.assertEqual(extract_year_from_date(""), None)
+        self.assertEqual(extract_year_from_date(2020), None)
+        self.assertEqual(extract_year_from_date("2020"), 2020)
+        self.assertEqual(extract_year_from_date('2020-02-28'), 2020)
+        self.assertEqual(extract_year_from_date('2015.02'), 2015)
+        self.assertEqual(extract_year_from_date('2015; 2015'), None)
+
+    def test_mapping(self):
+        self.assertEqual(extract_year_from_date({}), None)
+        self.assertEqual(extract_year_from_date({'year': 'abc'}), None)
+        self.assertEqual(extract_year_from_date({'year': '2020'}), 2020)
+        self.assertEqual(extract_year_from_date({'year': 2020}), 2020)
+        self.assertEqual(extract_year_from_date({'year': '2020-02-28'}), None)
 
 
 class SanitizeDateTest(PicardTestCase):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1891

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Incorrect year data could cause unhandled exceptions.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- catch exceptions in extract_year_from_date() and log them to debug
- return None if year cannot be extracted
- check for None in metadata.compare_to_release_parts() before trying to compare years

This isn't perfect, the function is called a lot of time and it spams debug log (if enabled)

Note: I removed a very old comment in imports that doesn't make any sense (it was introduced 6 years ago in 323d12892c7f975b1e7286f57d72b60274a096e7) and it was making isort unhappy.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
