### PR TITLE
PICARD-1894: Fix tracknumber detection from filename

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -222,7 +222,7 @@ class File(QtCore.QObject, Item):
         metadata['~length'] = format_time(metadata.length)
         if 'tracknumber' not in metadata:
             tracknumber = tracknum_from_filename(self.base_filename)
-            if tracknumber != -1:
+            if tracknumber is not None:
                 tracknumber = str(tracknumber)
                 metadata['tracknumber'] = tracknumber
                 if 'title' not in metadata:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -324,15 +324,15 @@ _tracknum_regexps = (
     # search for explicit track number (prefix "track")
     r"track[\s_-]*(?:no|nr)?[\s_-]*(\d+)",
     # search for 2-digit number at start of string
-    r"^(\d{2})\D?",
+    r"^(\d{2})\D",
     # search for 2-digit number at end of string
-    r"\D?(\d{2})$",
+    r"\D(\d{2})$",
 )
 
 
 def tracknum_from_filename(base_filename):
     """Guess and extract track number from filename
-    Returns -1 if none found, the number as integer else
+    Returns `None` if none found, the number as integer else
     """
     filename, _ = os.path.splitext(base_filename)
     for r in _tracknum_regexps:
@@ -348,7 +348,7 @@ def tracknum_from_filename(base_filename):
                       0 < int(n) <= 99])
     if numbers:
         return numbers[0]
-    return -1
+    return None
 
 
 # Provide os.path.samefile equivalent which is missing in Python under Windows

--- a/test/test_tracknum.py
+++ b/test/test_tracknum.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2013, 2018 Laurent Monin
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -27,87 +27,80 @@ from test.picardtestcase import PicardTestCase
 from picard.util import tracknum_from_filename
 
 
-def parse(filename):
-    return tracknum_from_filename(filename)
-
-
 class TracknumTest(PicardTestCase):
 
     def test_matched_tracknum_01(self):
-        self.assertEqual(parse('1.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('1.mp3'), 1)
 
     def test_matched_tracknum_02(self):
-        self.assertEqual(parse('01.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01.mp3'), 1)
 
     def test_matched_tracknum_03(self):
-        self.assertEqual(parse('001.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('001.mp3'), 1)
 
     def test_matched_tracknum_04(self):
-        self.assertEqual(parse('01 song.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01 song.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('1 song.mp3'), 1)
 
     def test_matched_tracknum_05(self):
-        self.assertEqual(parse('song 01.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('song 01.mp3'), 1)
 
     def test_matched_tracknum_06(self):
-        self.assertEqual(parse('artist - song (01).mp3'), 1)
+        self.assertEqual(tracknum_from_filename('artist - song (01).mp3'), 1)
 
     def test_matched_tracknum_07(self):
-        self.assertEqual(parse('artist - s 02 ong (01).mp3'), 1)
+        self.assertEqual(tracknum_from_filename('artist - s 02 ong (01).mp3'), 1)
 
     def test_matched_tracknum_08(self):
-        self.assertEqual(parse('artist song 2004 track01 xxxx.ogg'), 1)
+        self.assertEqual(tracknum_from_filename('artist song 2004 track01 xxxx.ogg'), 1)
 
     def test_matched_tracknum_09(self):
-        self.assertEqual(parse('artist song 2004 track-no-01 xxxx.ogg'), 1)
+        self.assertEqual(tracknum_from_filename('artist song 2004 track-no-01 xxxx.ogg'), 1)
 
     def test_matched_tracknum_10(self):
-        self.assertEqual(parse('artist song 2004 track-no_01 xxxx.ogg'), 1)
+        self.assertEqual(tracknum_from_filename('artist song 2004 track-no_01 xxxx.ogg'), 1)
 
     def test_matched_tracknum_11(self):
-        self.assertEqual(parse('artist song-(666) (01) xxx.ogg'), 1)
+        self.assertEqual(tracknum_from_filename('artist song-(666) (01) xxx.ogg'), 1)
 
     def test_matched_tracknum_12(self):
-        self.assertEqual(parse('artist song [2004] [01].mp3'), 1)
+        self.assertEqual(tracknum_from_filename('artist song [2004] [01].mp3'), 1)
 
     def test_matched_tracknum_13(self):
-        self.assertEqual(parse('artist song [2004] (01).mp3'), 1)
+        self.assertEqual(tracknum_from_filename('artist song [2004] (01).mp3'), 1)
 
     def test_matched_tracknum_14(self):
-        self.assertEqual(parse('01 artist song [2004] (02).mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01 artist song [2004] (02).mp3'), 1)
 
     def test_matched_tracknum_15(self):
-        self.assertEqual(parse('01 artist song [04].mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01 artist song [04].mp3'), 1)
 
     def test_matched_tracknum_16(self):
-        self.assertEqual(parse('xx 01 artist song [04].mp3'), 1)
+        self.assertEqual(tracknum_from_filename('xx 01 artist song [04].mp3'), 1)
 
     def test_matched_tracknum_17(self):
-        self.assertEqual(parse('song [2004] [1].mp3'), 1)
+        self.assertEqual(tracknum_from_filename('song [2004] [1].mp3'), 1)
 
     def test_matched_tracknum_18(self):
-        self.assertEqual(parse('song-70s 69 comment.mp3'), 69)
+        self.assertEqual(tracknum_from_filename('song-70s 69 comment.mp3'), 69)
 
     def test_matched_tracknum_19(self):
-        self.assertEqual(parse('01_foo.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01_foo.mp3'), 1)
 
     def test_matched_tracknum_20(self):
-        self.assertEqual(parse('01ābc.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01ābc.mp3'), 1)
 
     def test_matched_tracknum_21(self):
-        self.assertEqual(parse('01abc.mp3'), 1)
+        self.assertEqual(tracknum_from_filename('01abc.mp3'), 1)
 
     def test_matched_tracknum_22(self):
         t = u"11 Linda Jones - Things I've Been Through 08.flac"
-        self.assertEqual(parse(t), 11)
+        self.assertEqual(tracknum_from_filename(t), 11)
 
-    def test_unmatched_tracknum_01(self):
-        self.assertEqual(parse('0.mp3'), -1)
-
-    def test_unmatched_tracknum_02(self):
-        self.assertEqual(parse('track00.mp3'), -1)
-
-    def test_unmatched_tracknum_03(self):
-        self.assertEqual(parse('song.mp3'), -1)
-
-    def test_unmatched_tracknum_04(self):
-        self.assertEqual(parse('song [2004] [1000].mp3'), -1)
+    def test_unmatched_tracknum(self):
+        self.assertEqual(tracknum_from_filename('0.mp3'), None)
+        self.assertEqual(tracknum_from_filename('track00.mp3'), None)
+        self.assertEqual(tracknum_from_filename('song.mp3'), None)
+        self.assertEqual(tracknum_from_filename('song [2004] [1000].mp3'), None)
+        self.assertEqual(tracknum_from_filename('song 2015.mp3'), None)
+        self.assertEqual(tracknum_from_filename('2015 song.mp3'), None)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Do not detect parts of longer numbers as track no., e.g. "Song 2015" must not be detected as track no. 15.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1894
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

