### PR TITLE
PICARD-1902: Fixed script syntax highlighter crash

### DIFF
--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -83,33 +83,34 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         # Ignore everything if we're already in a noop function
         index = self.noop_re.indexIn(text) if self.previousBlockState() <= 0 else 0
         open_brackets = self.previousBlockState() if self.previousBlockState() > 0 else 0
+        text_length = len(text)
         while index >= 0:
             next_index = self.bracket_re.indexIn(text, index)
 
             # Skip escaped brackets
-            if (next_index > 0) and text[next_index - 1] == '\\':
+            if next_index > 0 and text[next_index - 1] == '\\':
                 next_index += 1
 
             # Reached end of text?
-            if next_index >= len(text):
-                self.setFormat(index, next_index - index, self.noop_fmt)
+            if next_index >= text_length:
+                self.setFormat(index, text_length - index, self.noop_fmt)
                 break
 
-            if (next_index > -1) and text[next_index] == '(':
+            if next_index > -1 and text[next_index] == '(':
                 open_brackets += 1
-            elif (next_index > -1) and text[next_index] == ')':
+            elif next_index > -1 and text[next_index] == ')':
                 open_brackets -= 1
 
             if next_index > -1:
                 self.setFormat(index, next_index - index + 1, self.noop_fmt)
-            elif (next_index == -1) and (open_brackets > 0):
-                self.setFormat(index, len(text) - index, self.noop_fmt)
+            elif next_index == -1 and open_brackets > 0:
+                self.setFormat(index, text_length - index, self.noop_fmt)
 
             # Check for next noop operation, necessary for multiple noops in one line
             if open_brackets == 0:
                 next_index = self.noop_re.indexIn(text, next_index)
 
-            index = next_index + 1 if (next_index > -1) and (next_index < len(text)) else -1
+            index = next_index + 1 if next_index > -1 and next_index < text_length else -1
 
         self.setCurrentBlockState(open_brackets)
 

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -90,6 +90,11 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             if (next_index > 0) and text[next_index - 1] == '\\':
                 next_index += 1
 
+            # Reached end of text?
+            if next_index >= len(text):
+                self.setFormat(index, next_index - index, self.noop_fmt)
+                break
+
             if (next_index > -1) and text[next_index] == '(':
                 open_brackets += 1
             elif (next_index > -1) and text[next_index] == ')':


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Fixed Picard crashing when entering `$noop(\)` as a script.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1902
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fixed syntax highlighting to check for end of script.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

