### PR TITLE
PICARD-1921: Set base color for inactive elements with dark Windows theme

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -134,6 +134,7 @@ if IS_WIN:
                 palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Text, QtCore.Qt.darkGray)
                 palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor(0, 0, 0, 0))
                 palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, QtCore.Qt.darkGray)
+                palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Base, QtGui.QColor(60, 60, 60))
 
     theme = WindowsTheme()
 


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
There is no separate look for inactive / active checkboxes on Windows 10 with dark theme
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1921
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Status quo:
![grafik](https://user-images.githubusercontent.com/29852/90515140-7c7f8d00-e162-11ea-992b-f17943885447.png)


Fixed:
![grafik](https://user-images.githubusercontent.com/29852/90515057-5d80fb00-e162-11ea-9a8d-8656db8c97fe.png)


# Solution
Set inactive base color.

I could not find a proper color used commonly for this on Windows, but this way it looks good to me. Lighter or darker make it look out of place.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

