### PR TITLE
PICARD-1918: Fix issue saving cover art without front image

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -497,7 +497,9 @@ class File(QtCore.QObject, Item):
         counters = defaultdict(lambda: 0)
         images = []
         if config.setting["caa_save_single_front_image"]:
-            images = [metadata.images.get_front_image()]
+            front = metadata.images.get_front_image()
+            if front:
+                images.append(front)
         if not images:
             images = metadata.images
         for image in images:


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Trying to save cover art as separate files would fail, if there is no image with type "front" and caa_save_single_front_image is enabled.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1918
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Check if a front image was found before updating the list of images to save. This way we don't end up with `images == [None]` 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
This fixed the exception, but we have a more general problem with this.

The caa_save_single_front_image option is really odd, and I am not fully sure what it is supposed to do. First off it is presented as a CAA option, but it applies to all cover art.

Also the code as it was and is now suggests that if there is no front image all images will be saved anyway. That looks wrong to me. Either it should save nothing or maybe fall back to the first image found.

I think we should move this option to the general Options > Cover Art page, rename it to save_only_one_front_image and implement it exactly like embed_only_one_front_image. @zas ?

