### PR TITLE
PICARD-1928: Ensure fingerprint status icon is rendered correctly after clustering

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -935,8 +935,8 @@ class ClusterItem(TreeItem):
         # Benchmarked performance was not noticeably different.
         for file in files:
             item = FileItem(file, True)
-            item.update()
             self.addChild(item)
+            item.update()
 
     def remove_file(self, file):
         file.item.setSelected(False)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
When files have the fingerprint generated the fingerprint column gets emptied after clustering the files. This is a pure display issue, as the fingerprint is still kept with the file.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1928
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
The issue got introduced with the refactoring in 155da500f43e7661808ab4cce911466e75ddb759, but is not directly caused by it but rather makes the problem visible.


# Solution
Update file item after being added to cluster item
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
