### PR TITLE
PICARD-1935: Include tests in sdist (again)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -113,3 +113,8 @@ jobs:
     - name: Test running installed package
       if: runner.os != 'Windows'
       run: picard --long-version
+    - name: Verify sdist package
+      if: runner.os != 'Windows'
+      run: |
+        pip install pytest
+        scripts/package/run-sdist-test.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 graft po
-prune test
 
 recursive-include scripts *.in
 recursive-exclude scripts picard
@@ -9,4 +8,8 @@ include *.in
 include *.md
 include *.txt
 
+recursive-include test *.py
+recursive-include test/data *
+
 exclude org.musicbrainz.Picard.appdata.xml
+exclude win-version-info.txt

--- a/scripts/package/run-sdist-test.sh
+++ b/scripts/package/run-sdist-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Build the sdist archive, extract it and run the tests.
+
+set -e
+
+rm -rf dist
+python3 setup.py sdist
+cd dist
+SDIST_ARCHIVE=$(echo picard-*.tar.gz)
+tar xvf "$SDIST_ARCHIVE"
+cd "${SDIST_ARCHIVE%.tar.gz}"
+pytest --verbose


### PR DESCRIPTION
Verify in CI the sdist package is complete and passes tests.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This makes sure the sdist tarball includes all files needed to run the tests.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Users and distributions wanting to install or package from the sdist and wanting to verify the tests pass need to have the tests available.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1935
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
I know we had this discussion before (see #1282 and #1288), but I have to agree with David who reported on PICARD-1935. The tests should really be part of the source, it should not be difficult to run the tests from it.

If I look at the default behavior of setuptools (including test) and the documentation at https://docs.python.org/3/distutils/sourcedist.html#specifying-the-files-to-distribute I really think it is the intention to include those installs.

It also has no horrible effect on the package size. The current .tar.gz is 3.4 MiB, with the tests included it is 3.6 MiB.

If we want to provide packages more optimized for user installs we should provide wheels in addition to the sdist. With the current CI we could easily set this up at least for the major target platforms.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
