### PR TITLE
PICARD-1939: Ensure selection update after cluster removal

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -137,13 +137,13 @@ class Cluster(QtCore.QObject, Item):
         self.files.remove(file)
         self.metadata['totaltracks'] = len(self.files)
         self.item.remove_file(file)
-        if not self.special and self.get_num_files() == 0:
-            self.tagger.remove_cluster(self)
         if self.can_show_coverart:
             file.metadata_images_changed.disconnect(self.update_metadata_images)
             remove_metadata_images(self, [file])
         self._update_related_album(removed_files=[file])
         self.tagger.window.set_processing(False)
+        if not self.special and self.get_num_files() == 0:
+            self.tagger.remove_cluster(self)
 
     def update(self):
         if self.item:


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
If clusters where removed because of file removal scan or lookup selection updates where disabled. Ensure selection gets updated.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Selection was not updated after automatic cluster removal, e.g. during lookup or scan. This meant the action buttons stayed enabled, and e.g. the remove file action would still be available but crash on use.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1939
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Have selection update enabled for cluster removal. The actual selection changed event will still only trigger, if the cluster was actually selected before. In itemviews.py `cluster.item.setSelected(False)` gets called, which does not trigger any even if the status does not actually change.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
