### PR TITLE
Add tagger.add_paths to load both files and directories

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -482,10 +482,8 @@ class Tagger(QtWidgets.QApplication):
             self.cluster(files)
         self.window.set_sorting(True)
 
-    def add_files(self, filenames, target=None, result=None):
+    def add_files(self, filenames, target=None):
         """Add files to the tagger."""
-        if result:
-            filenames = result   # Handles add_directory task results coming from a worker thread
         ignoreregex = None
         pattern = config.setting['ignore_regex']
         if pattern:

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -185,12 +185,8 @@ class FileBrowser(QtWidgets.QTreeView):
         if not indexes:
             return
         paths = set(self.model.filePath(index) for index in indexes)
-        dirs = set(p for p in paths if os.path.isdir(p))
-        files = paths - dirs
         tagger = QtCore.QObject.tagger
-        for d in dirs:
-            tagger.add_directory(d)
-        tagger.add_files(files)
+        tagger.add_paths(paths)
 
     def move_files_here(self):
         indexes = self.selectedIndexes()

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -940,8 +940,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                     {'directory': dir_list[0]}
                 )
 
-            for directory in dir_list:
-                self.tagger.add_directory(directory)
+            self.tagger.add_paths(dir_list)
 
     def close_active_window(self):
         self.tagger.activeWindow().close()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This replaces tagger.add_directory and simplifies the code to load files at different places. As suggested at https://github.com/metabrainz/picard/pull/1623#pullrequestreview-483911047
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


