### PR TITLE
PICARD-1946: Map "vocal arranger" relationship to arranger tag

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -56,6 +56,7 @@ _artist_rel_types = {
     # "recording": "engineer",
     "remixer": "remixer",
     "sound": "engineer",
+    "vocal arranger": "arranger",
     "writer": "writer",
 }
 


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem

* JIRA ticket (_optional_): PICARD-1946

# Solution

Map _vocal arranger_ relationship to the `arranger` tag (in addition to unspecific _arranger_, _instrument arranger_ and _orchestrator_).
This change has been tested with a manipulated [release from the test server](https://test.musicbrainz.org/release/542ef258-7bfd-48a6-83f3-443291a0ea29) as I have not found a suitable release that has all the other arranger relationship types besides a _vocal arranger_ relationship.