### PR TITLE
PICARD-1879: Sequential matching of files on drop

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -170,6 +170,13 @@ class Album(DataObject, Item):
                     file.metadata['musicbrainz_discid'] = track_discids
                     file.update()
 
+    def get_next_track(self, track):
+        try:
+            index = self.tracks.index(track)
+            return self.tracks[index + 1]
+        except (IndexError, ValueError):
+            return None
+
     def get_album_artists(self):
         """Returns the list of album artists (as AlbumArtist objects)"""
         return self._album_artists

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -468,9 +468,15 @@ class Tagger(QtWidgets.QApplication):
             log.debug("Aborting move since target is invalid")
             return
         self.window.set_sorting(False)
-        if isinstance(target, (Track, Cluster)):
+        if isinstance(target, Cluster):
             for file in files:
                 file.move(target)
+                QtCore.QCoreApplication.processEvents()
+        elif isinstance(target, Track):
+            album = target.album
+            for file in files:
+                file.move(target)
+                target = album.get_next_track(target) or album.unmatched_files
                 QtCore.QCoreApplication.processEvents()
         elif isinstance(target, File):
             for file in files:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -463,7 +463,7 @@ class Tagger(QtWidgets.QApplication):
             log.debug("Trying to analyze %r ...", file)
             self.analyze([file])
 
-    def move_files(self, files, target):
+    def move_files(self, files, target, move_to_multi_tracks=True):
         if target is None:
             log.debug("Aborting move since target is invalid")
             return
@@ -476,7 +476,8 @@ class Tagger(QtWidgets.QApplication):
             album = target.album
             for file in files:
                 file.move(target)
-                target = album.get_next_track(target) or album.unmatched_files
+                if move_to_multi_tracks:  # Assign next file to following track
+                    target = album.get_next_track(target) or album.unmatched_files
                 QtCore.QCoreApplication.processEvents()
         elif isinstance(target, File):
             for file in files:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

When dragging and dropping multiple files onto a track, assign the first file to this track and the following files to the following tracks in order.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1879
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Currently when dragging and dropping multiple files onto a track all the dropped files get assigned to this track. This is probably seldom what you want unless you explicitly have multiple files of the same track.

This patch changes the default behavior so multiple files get matched in sequence to multiple tracks, starting with the first file getting matched to the track being dropped on and the following files to the next tracks.

For the rare circumstances someone really wants to add multiple files to a single track the patch allows dragging with the Alt modifier pressed. I consider this an advanced feature we could document and advanced users could use. But in practice often this is not really necessary, as usually even if you have multiple files for the same track you probably have only 2 or so (e.g. lossy and lossless format, as I usually tag).


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
