### PR TITLE
PICARD-259: Execute tagger script when file gets moved to track

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -368,6 +368,7 @@ class Album(DataObject, Item):
                     except ScriptError:
                         log.exception("Failed to run tagger script %s on track", s_name)
                     track.metadata.strip_whitespace()
+                    track.scripted_metadata.update(track.metadata)
                 # Run tagger script for the album itself
                 try:
                     parser.eval(s_text, self._new_metadata)

--- a/picard/album.py
+++ b/picard/album.py
@@ -422,7 +422,6 @@ class Album(DataObject, Item):
         tm.copy(metadata)
         track_to_metadata(track_node, track)
         tm["~absolutetracknumber"] = absolutetracknumber
-        track.orig_metadata.copy(tm)
         track._customize_metadata()
 
         self._new_metadata.length += tm.length
@@ -440,6 +439,7 @@ class Album(DataObject, Item):
         except BaseException:
             self.error_append(traceback.format_exc())
 
+        track.orig_metadata.copy(tm)
         return track
 
     def load(self, priority=False, refresh=False):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -375,6 +375,16 @@ class Metadata(MutableMapping):
             # no argument, raise TypeError to mimic dict.update()
             raise TypeError("descriptor 'update' of '%s' object needs an argument" % self.__class__.__name__)
 
+    def diff(self, other):
+        """Returns a new Metadata object with only the tags that changed in self compared to other"""
+        m = Metadata()
+        for tag, values in self.rawitems():
+            other_values = other.getall(tag)
+            if other_values != values:
+                m[tag] = values
+        m.deleted_tags = self.deleted_tags - other.deleted_tags
+        return m
+
     def _update_from_metadata(self, other, copy_images=True):
         for k, v in other.rawitems():
             self.set(k, v[:])

--- a/picard/track.py
+++ b/picard/track.py
@@ -415,9 +415,9 @@ class NonAlbumTrack(Track):
     def _parse_recording(self, recording):
         m = self.metadata
         recording_to_metadata(recording, m, self)
-        self.orig_metadata.copy(m)
         self._customize_metadata()
         run_track_metadata_processors(self.album, m, recording)
+        self.orig_metadata.copy(m)
         self.run_scripts(m)
         self.loaded = True
         self.status = None

--- a/picard/track.py
+++ b/picard/track.py
@@ -147,6 +147,7 @@ class Track(DataObject, Item):
         self.num_linked_files = 0
         self.metadata = Metadata()
         self.orig_metadata = Metadata()
+        self.scripted_metadata = Metadata()
         self.error = None
         self._track_artists = []
 
@@ -175,8 +176,10 @@ class Track(DataObject, Item):
         metadata = Metadata(file.metadata)
         metadata.update(self.orig_metadata)
         self.run_scripts(metadata)
+        # Apply changes to the track's metadata done manually after the scripts ran
+        meta_diff = self.metadata.diff(self.scripted_metadata)
+        metadata.update(meta_diff)
         file.copy_metadata(metadata)
-        file.metadata['~extension'] = file.orig_metadata['~extension']
         file.update(signal=False)
         self.update()
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -215,6 +215,19 @@ class MetadataTest(PicardTestCase):
         self.metadata["old"] = "old-value"
         self.assertEqual(self.metadata._store, m._store)
 
+    def test_metadata_diff(self):
+        m1 = Metadata({
+            "foo1": "bar1",
+            "foo2": "bar2",
+            "foo3": "bar3",
+        })
+        m2 = Metadata(m1)
+        m1["foo1"] = "baz"
+        del m1["foo2"]
+        diff = m1.diff(m2)
+        self.assertEqual({"foo1": "baz"}, diff)
+        self.assertEqual(set(["foo2"]), diff.deleted_tags)
+
     def test_metadata_clear(self):
         self.metadata.clear()
         self.assertEqual(0, len(self.metadata))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This allows using existing file metadata and and specific file variables (such as e.g. %_bitrate%) to be used in tagger script.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-259, PICARD-23
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
When a file gets moved to a track run the scripts on a combined metadata object consisting of the file's metadata + the track's metadata.

A similar patch had been proposed earlier in #170, but it got reverted. This patch is conceptually the same, but a bit simpler due to:

- we now have `track.orig_metadata` already available
- the script is not run against the track's metadata again, which also means we do not need to handle the file removal as restoring file's original metadata is already done. I don't think we need to re-run the script on the track, as the file's data is used for saving and even display is already using the file metadata in case a single file is matched. In the multi-file case it does not make sense to apply any file's metadata to the track anyway
- The previous patch caused issues with the preserved metadata (PICARD-1247). This is avoided here, since `file.copy_metadata` (which takes care of preserved tags) is run after running the scripts.

I did some measurements on the overall runtime effect of loading ~4k files in ~340 releases. Loading took ~350 seconds on my system, without a measurable difference even with a heavy script (https://gist.github.com/phw/2345486ff89538c3ee1ca621ce23959e). The reason seems to be that we have the one second delay in network requests, which is much longer than script execution takes in between.

I would appreciate if you give this some proper testing, we must avoid this having any unwanted side effect. But in my tests this worked well.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
