### PR TITLE
PICARD-1858: Fix running on macOS Big Sur

### DIFF
--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -4,4 +4,4 @@ markdown
 mutagen==1.45.1
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2
-PyQt5==5.13.2
+PyQt5==5.13.1

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -2,6 +2,6 @@ python-dateutil==2.8.1
 discid==1.2.0
 markdown
 mutagen==1.45.1
-pyobjc-core==5.2
-pyobjc-framework-Cocoa==5.2
+pyobjc-core==6.2.2
+pyobjc-framework-Cocoa==6.2.2
 PyQt5==5.13.2


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This PR downgrades PyQt from 5.13.2 to 5.13.1, which resolves startup issues on the new macOS 11 Big Sur.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1858
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On macOS Big Sur the application stops responding after start without showing the UI. Actually even a very minimalistic Qt5 app with only an empty window will stop responding as soon as the app's mainloop gets executed. The exact reason is unknown, but it happens with PyQt >= 5.13.2 (tested up to 5.15.1).

This actually only happens when running from the packaged app. Running from Picard from source works fine. For now I can't say whether the core problem lies within PyQt5 or PyInstaller.

# Solution
For now downgrade PyQt. As we are using PyQt 5.13 series anyway for backward compatibility with macOS 10.12 this does not matter much.

For the future we should be able to upgrade to make use of improvements and bugfixes in Qt5. I expect that there will be some macOS 11 specific improvements, e.g. there are open issues about theming improvements [QTBUG-86513](https://bugreports.qt.io/browse/QTBUG-86513) and support for arm64 [QTBUG-85279](https://bugreports.qt.io/browse/QTBUG-85279).

I will try to look into this and see whether I can find the root cause.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
