### PR TITLE
PICARD-1951: Prevent complete hiding of metadata box or file panes

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -41,7 +41,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 5, 0, 'dev', 1)
+PICARD_VERSION = Version(2, 5, 0, 'dev', 2)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -312,6 +312,12 @@ def upgrade_to_v2_5_0_dev_1(config):
     ]
 
 
+def upgrade_to_v2_5_0_dev_2(config):
+    """Reset main view splitter states"""
+    config.persist["splitter_state"] = b''
+    config.persist["bottom_splitter_state"] = b''
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -337,4 +343,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_2_0_dev_3)
     cfg.register_upgrade_hook(upgrade_to_v2_4_0_beta_3)
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_1)
+    cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_2)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -185,6 +185,7 @@ class MainPanel(QtWidgets.QSplitter):
 
     def __init__(self, window, parent=None):
         super().__init__(parent)
+        self.setChildrenCollapsible(False)
         self.window = window
         self.create_icons()
         self._views = [FileTreeView(window, self), AlbumTreeView(window, self)]

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -175,8 +175,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.search_toolbar.setMovable(False)
 
         mainLayout = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        mainLayout.setChildrenCollapsible(False)
         mainLayout.setContentsMargins(0, 0, 0, 0)
-        mainLayout.setHandleWidth(1)
 
         self.panel = MainPanel(self, mainLayout)
         self.file_browser = FileBrowser(self.panel)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2019 Laurent Monin
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,6 +19,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from PyQt5.QtCore import QByteArray
 
 from test.test_config import TestPicardConfigCommon
 
@@ -26,6 +27,7 @@ from picard.config import (
     BoolOption,
     IntOption,
     ListOption,
+    Option,
     TextOption,
 )
 from picard.config_upgrade import (
@@ -47,6 +49,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_2_0_dev_4,
     upgrade_to_v2_4_0_beta_3,
     upgrade_to_v2_5_0_dev_1,
+    upgrade_to_v2_5_0_dev_2,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -272,3 +275,12 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         ]
         upgrade_to_v2_5_0_dev_1(self.config)
         self.assertEqual(expected, self.config.setting['ca_providers'])
+
+    def test_upgrade_to_v2_5_0_dev_2(self):
+        Option("persist", "splitter_state", QByteArray())
+        Option("persist", "bottom_splitter_state", QByteArray())
+        self.config.persist["splitter_state"] = b'foo'
+        self.config.persist["bottom_splitter_state"] = b'bar'
+        upgrade_to_v2_5_0_dev_2(self.config)
+        self.assertEqual(b'', self.config.persist['splitter_state'])
+        self.assertEqual(b'', self.config.persist['bottom_splitter_state'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Prevent complete hiding of metadata box or file panes
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other


# Problem
By completely dragging the splitter between the file panes and the metadata box up or down the user can completely hide any of those parts. This results in a UI that appears broken, and without any hint to the user that there is a missing part and that they can make it visible again.

See the screenshots in PICARD-1951
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1951
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Set the parts of the splitter to be not-collapsible.

Note: According to Qt5 documentation one should be able to do this with a single call to `splitter.setChildrenCollapsible(False)`, see https://doc.qt.io/qt-5/qsplitter.html#childrenCollapsible-prop

But when I tried this (with PyQt 5.15.1 on Windows 10) it had no effect. Only setting `setCollapsible` per element worked.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
