### PR TITLE
PICARD-1952: Use native theme in Linux

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -27,6 +27,7 @@ from PyQt5 import (
 from picard import log
 from picard.const.sys import (
     IS_HAIKU,
+    IS_LINUX,
     IS_MACOS,
     IS_WIN,
 )
@@ -55,7 +56,7 @@ class BaseTheme:
     def setup(self, app):
         # Use the new fusion style from PyQt5 for a modern and consistent look
         # across all OSes.
-        if not IS_MACOS and not IS_HAIKU:
+        if not IS_MACOS and not IS_HAIKU and not IS_LINUX:
             app.setStyle('Fusion')
 
         app.setStyleSheet(


### PR DESCRIPTION
# Summary

Most Linux distributions have good Qt themes. Using native themes on Linux gives users best experience.

# Problem

Picard has a different appearance than other apps in Linux.

PICARD-1952

# Solution

Make Picard use native styles in Linux.


# Action

No
