### PR TITLE
PICARD-1952: Add option to use system theme on systems other than macOS and Windows

### DIFF
--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -220,6 +220,11 @@ class InterfaceOptionsPage(OptionsPage):
         if new_theme_setting != config.setting["use_system_theme"]:
             restart_warning_title = _('Theme changed')
             restart_warning = _('You have changed the application theme. You have to restart Picard in order for the change to take effect.')
+            if new_theme_setting:
+                restart_warning += '\n\n' + _(
+                    'Please note that using the system theme might cause the user interface to be not shown correctly. '
+                    'If this is the case disable the "Use system theme" option to use Picard\'s default theme again.'
+                )
         elif new_language != config.setting["ui_language"]:
             restart_warning_title = _('Language changed')
             restart_warning = _('You have changed the interface language. You have to restart Picard in order for the change to take effect.')

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -24,7 +24,10 @@ from PyQt5 import (
     QtGui,
 )
 
-from picard import log
+from picard import (
+    config,
+    log,
+)
 from picard.const.sys import (
     IS_HAIKU,
     IS_MACOS,
@@ -58,7 +61,7 @@ class BaseTheme:
     def setup(self, app):
         # Use the new fusion style from PyQt5 for a modern and consistent look
         # across all OSes.
-        if not IS_MACOS and not IS_HAIKU:
+        if not IS_MACOS and not IS_HAIKU and not config.setting['use_system_theme']:
             app.setStyle('Fusion')
 
         app.setStyleSheet(
@@ -99,6 +102,10 @@ if IS_WIN:
     import winreg
 
     class WindowsTheme(BaseTheme):
+        def setup(self, app):
+            app.setStyle('Fusion')
+            super().setup(app)
+
         @property
         def is_dark_theme(self):
             dark_theme = False

--- a/picard/ui/ui_options_interface.py
+++ b/picard/ui/ui_options_interface.py
@@ -20,6 +20,9 @@ class Ui_InterfaceOptionsPage(object):
         self.toolbar_show_labels = QtWidgets.QCheckBox(self.groupBox_2)
         self.toolbar_show_labels.setObjectName("toolbar_show_labels")
         self.vboxlayout1.addWidget(self.toolbar_show_labels)
+        self.use_system_theme = QtWidgets.QCheckBox(self.groupBox_2)
+        self.use_system_theme.setObjectName("use_system_theme")
+        self.vboxlayout1.addWidget(self.use_system_theme)
         self.toolbar_multiselect = QtWidgets.QCheckBox(self.groupBox_2)
         self.toolbar_multiselect.setObjectName("toolbar_multiselect")
         self.vboxlayout1.addWidget(self.toolbar_multiselect)
@@ -126,6 +129,7 @@ class Ui_InterfaceOptionsPage(object):
         _translate = QtCore.QCoreApplication.translate
         self.groupBox_2.setTitle(_("Miscellaneous"))
         self.toolbar_show_labels.setText(_("Show text labels under icons"))
+        self.use_system_theme.setText(_("Use system theme"))
         self.toolbar_multiselect.setText(_("Allow selection of multiple directories"))
         self.builtin_search.setText(_("Use builtin search rather than looking in browser"))
         self.use_adv_search_syntax.setText(_("Use advanced query syntax"))

--- a/ui/options_interface.ui
+++ b/ui/options_interface.ui
@@ -25,6 +25,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="use_system_theme">
+        <property name="text">
+         <string>Use system theme</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="toolbar_multiselect">
         <property name="text">
          <string>Allow selection of multiple directories</string>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

In #1635 it is proposed to use the system Qt theme on Linux. This is an alternative proposal to still default to the Fusion theme but add an option to opt-in using the system theme.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1952
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard uses the Fusion themes on most platforms, with the notable exception of macOS where Qt's "macintosh" theme is used.

On Linux it is common to configure different Qt themes, so some users want Picard to obey this. On the other hand we as the devlopers can't guarantee that the UI remains pretty and usable when an arbitrary theme is being used.


# Solution

Still default to the Fusion theme, but add an option "Use system theme" in Options > User interface . When selected, Picard will use the system's default theme. When this is being activated a warning is shown to the user:

> Please note that using the system theme might cause the user interface to be not shown correctly. If this is the case disable the "Use system theme" option to use Picard's default theme again.

**Note:** There are already ways for the user on Linux to affect the look of Picard.

- On KDE Qt5 respects the color palette settings. So if  the user has configured KDE to use the dark variant of the Breeze theme, Picard will still use the Fusion theme but it will be dark colored.
- One can override the theme by setting `QT_STYLE_OVERRIDE`, e.g. one could start Picard with:

      QT_STYLE_OVERRIDE=Breeze picard
- One can override the theme by using the `-style` command line parameter, e.g. one could start Picard with:

      picard -style=Breeze

We could also rely on those mechanisms only.

**Update:** I just noticed that the override methods above stopped working with the 2.4 release. It works in 2.3.2 and earlier. In this case we probably should restore support for this.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Make a decision!
