### PR TITLE
PICARD-1955: Use built-in search by default

### DIFF
--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -122,7 +122,7 @@ class InterfaceOptionsPage(OptionsPage):
     options = [
         config.BoolOption("setting", "toolbar_show_labels", True),
         config.BoolOption("setting", "toolbar_multiselect", False),
-        config.BoolOption("setting", "builtin_search", False),
+        config.BoolOption("setting", "builtin_search", True),
         config.BoolOption("setting", "use_adv_search_syntax", False),
         config.BoolOption("setting", "quit_confirmation", True),
         config.TextOption("setting", "ui_language", ""),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Make the built-in search enabled by default.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1955
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The built-in search is easier to use for new users and does not rely on the browser integration (which causes frequent trouble for new users and needs quite some technical explaining if it does not work as expected). Also the "Lookup in browser" functionality is still available separately, even from within the search dialogs.

We keep the option. The browser based search can offer more flexibility, as it allows using all the search functionality the MB website has to offer. Hence advanced users might want to turn off the built-in search.

Existing users are not affected, their config remains untouched.
