### PR TITLE
PICARD-1957: Load files in file browser on double click

### DIFF
--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -71,6 +71,7 @@ class FileBrowser(QtWidgets.QTreeView):
         self.set_as_starting_directory_action = QtWidgets.QAction(_("&Set as starting directory"), self)
         self.set_as_starting_directory_action.triggered.connect(self.set_as_starting_directory)
         self.addAction(self.set_as_starting_directory_action)
+        self.doubleClicked.connect(self.load_file_for_item)
         self.focused = False
         self._set_model()
 
@@ -180,13 +181,17 @@ class FileBrowser(QtWidgets.QTreeView):
             destination = os.path.dirname(destination)
         return destination
 
+    def load_file_for_item(self, index):
+        QtCore.QObject.tagger.add_paths([
+            self.model.filePath(index)
+        ])
+
     def load_selected_files(self):
         indexes = self.selectedIndexes()
         if not indexes:
             return
         paths = set(self.model.filePath(index) for index in indexes)
-        tagger = QtCore.QObject.tagger
-        tagger.add_paths(paths)
+        QtCore.QObject.tagger.add_paths(paths)
 
     def move_files_here(self):
         indexes = self.selectedIndexes()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Allow the user to load files into Picard by double clicking files or folders in the file browser. Double clicking to open a file is a common behaviour and offers another alternative to drag and drop (which sometimes is difficult to do) or the new context menu entry.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1957
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

