### PR TITLE
PICARD-1782: Allow locking itemview table headers

### DIFF
--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -40,6 +40,7 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
 
         # Remember if resize / move event just happened
         self._section_moved_or_resized = False
+        self.lock(False)
 
         def update_state(i, o, n):
             self._section_moved_or_resized = True
@@ -48,6 +49,9 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
         self.sectionMoved.connect(update_state)
 
     def mouseReleaseEvent(self, event):
+        if self.is_locked:
+            return
+
         if event.button() == QtCore.Qt.LeftButton:
             index = self.logicalIndexAt(event.pos())
             if (index != -1 and index == self.sortIndicatorSection()
@@ -69,3 +73,13 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
                 return
         # Normal handling of events
         super().mouseReleaseEvent(event)
+
+    def lock(self, is_locked):
+        self.is_locked = is_locked
+        self.setSectionsClickable(not is_locked)
+        self.setSectionsMovable(not is_locked)
+        if is_locked:
+            resize_mode = QtWidgets.QHeaderView.Fixed
+        else:
+            resize_mode = QtWidgets.QHeaderView.Interactive
+        self.setSectionResizeMode(resize_mode)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Allow locking the table headers in the main view.

Locked headers cannot be changed. This prevents accidental resorting and changes to the list views. The lock state of each table header is persisted.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1782
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Implement locking in `TristateSortHeaderView` and add an action to the header's context menu to toggle this.

![grafik](https://user-images.githubusercontent.com/29852/94550582-3edb4d00-0254-11eb-81c6-42e068e50bc8.png)

