### PR TITLE
PICARD-1782: Show a tooltip when user clicks on locked table header

### DIFF
--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -50,6 +50,10 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
 
     def mouseReleaseEvent(self, event):
         if self.is_locked:
+            tooltip = _(
+                "The table is locked. To enable sorting and column resizing\n"
+                "unlock the table in the table header's context menu.")
+            QtWidgets.QToolTip.showText(event.globalPos(), tooltip, self)
             return
 
         if event.button() == QtCore.Qt.LeftButton:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

As suggested in #1643 show a tooltip explaining how to unlock a locked table header. The tooltip is shown when the user clicks on a locked table header.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1782
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

