### PR TITLE
PICARD-1958: macOS: Add a link to /Applications to DMG

### DIFF
--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -84,8 +84,12 @@ if [ -n "$TRAVIS_OSX_IMAGE" ]; then
 else
   DMG="MusicBrainz-Picard-$VERSION.dmg"
 fi
+mkdir staging
+mv "MusicBrainz Picard.app" staging/
+# Offer a link to /Applications for easy installation
+ln -s /Applications staging/Applications
 hdiutil create -volname "MusicBrainz Picard $VERSION" \
-  -srcfolder 'MusicBrainz Picard.app' -ov -format UDBZ "$DMG"
+  -srcfolder staging -ov -format UDBZ "$DMG"
 [ "$CODESIGN" = '1' ] && codesign --verify --verbose \
   --keychain "$KEYCHAIN_PATH" --sign "$CERTIFICATE_NAME" "$DMG"
 md5 -r "$DMG"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Add a symlink to `/Applications` in the macOS DMG image. This is quite common when distributing macOS applications to offer the user a simple way to install the app on the system.

![Screenshot 2020-10-02 at 09 31 58](https://user-images.githubusercontent.com/29852/94898685-3f612700-0492-11eb-9083-91beb7147c0b.png)

`/Applications` is the usual place for putting the app bundle and having the symlink makes it easy for the user to copy the app bundle over without the need to open a second Finder window.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1958
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add a symlink to the DMG