### PR TITLE
macOS: Handle OS version 11.0 in package script

### DIFF
--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -44,7 +44,7 @@ if [ -f scripts/package/appledev.p12 ] && [ -n "$appledev_p12_password" ]; then
 fi
 
 # Submit app for notarization on macOS >= 10.14
-if ([ "$MACOS_VERSION_MAJOR" -eq 10 ] && [ "$MACOS_VERSION_MINOR" -ge 14 ]) || [ "$MACOS_VERSION_MAJOR" -ge 11 ]; then
+if { [ "$MACOS_VERSION_MAJOR" -eq 10 ] && [ "$MACOS_VERSION_MINOR" -ge 14 ]; } || [ "$MACOS_VERSION_MAJOR" -ge 11 ]; then
     NOTARIZE=1
 fi
 

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -7,7 +7,8 @@ fi
 VERSION=$(python3 -c 'import picard; print(picard.__version__)')
 
 MACOS_VERSION=$(sw_vers -productVersion)
-MACOS_VERSION_MAJOR=${MACOS_VERSION%.*.*}
+MACOS_VERSION_MAJOR=${MACOS_VERSION%.*}
+MACOS_VERSION_MAJOR=${MACOS_VERSION_MAJOR%.*}
 MACOS_VERSION_MINOR=${MACOS_VERSION#*.}
 MACOS_VERSION_MINOR=${MACOS_VERSION_MINOR%.*}
 
@@ -43,7 +44,7 @@ if [ -f scripts/package/appledev.p12 ] && [ -n "$appledev_p12_password" ]; then
 fi
 
 # Submit app for notarization on macOS >= 10.14
-if [ "$MACOS_VERSION_MAJOR" -eq 10 ] && [ "$MACOS_VERSION_MINOR" -ge 14 ]; then
+if ([ "$MACOS_VERSION_MAJOR" -eq 10 ] && [ "$MACOS_VERSION_MINOR" -ge 14 ]) || [ "$MACOS_VERSION_MAJOR" -ge 11 ]; then
     NOTARIZE=1
 fi
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other

In macOS packaging script support detection of version 11.0 for notarization support.

# Problem

There are actual two issues with the version detection for macOS 11 Big Sur:

1. Have notarization enabled for version 11. This was discussed in https://github.com/metabrainz/picard/pull/1351, but not added since we did not know anything about major version 11 at that point.
2. Support versions with only two segments. The versioning code assumed the version always had 3 segments (0.0.0), but Big Sur reports itself as being 11.0 only. This caused the MACOS_VERSION_MAJOR variable to be 11.0. The changed script will both properly detect the major version for 11.0.0 and 11.0.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
