### PR TITLE
PICARD-1882: Generic detection of dark color scheme in use

### DIFF
--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -120,10 +120,9 @@ class ScriptingDocumentationDialog(PicardDialog):
             postprocessor=process_html,
         )
 
-        syntax_theme = theme.get_syntax_theme()
         html = DOCUMENTATION_HTML_TEMPLATE % {
             'html': "<dl>%s</dl>" % funcdoc,
-            'script_function_fg': syntax_theme.func.name(),
+            'script_function_fg': theme.syntax_theme.func.name(),
             'monospace_font': FONT_FAMILY_MONOSPACE,
         }
         self.ui.textBrowser.setHtml(html)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -52,6 +52,9 @@ dark_syntax_theme = SyntaxTheme(
 
 
 class BaseTheme:
+    def __init__(self):
+        self._dark_theme = False
+
     def setup(self, app):
         # Use the new fusion style from PyQt5 for a modern and consistent look
         # across all OSes.
@@ -63,12 +66,14 @@ class BaseTheme:
         )
 
         palette = QtGui.QPalette(app.palette())
+        base_color = palette.color(QtGui.QPalette.Active, QtGui.QPalette.Base)
+        self._dark_theme = base_color.lightness() < 128
         self.update_palette(palette, self.is_dark_theme(), self.get_accent_color())
         app.setPalette(palette)
 
     # pylint: disable=no-self-use
     def is_dark_theme(self):
-        return False
+        return self._dark_theme
 
     # pylint: disable=no-self-use
     def get_accent_color(self):

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -68,19 +68,20 @@ class BaseTheme:
         palette = QtGui.QPalette(app.palette())
         base_color = palette.color(QtGui.QPalette.Active, QtGui.QPalette.Base)
         self._dark_theme = base_color.lightness() < 128
-        self.update_palette(palette, self.is_dark_theme(), self.get_accent_color())
+        self.update_palette(palette, self.is_dark_theme, self.accent_color)
         app.setPalette(palette)
 
-    # pylint: disable=no-self-use
+    @property
     def is_dark_theme(self):
         return self._dark_theme
 
-    # pylint: disable=no-self-use
-    def get_accent_color(self):
+    @property
+    def accent_color(self):  # pylint: disable=no-self-use
         return None
 
-    def get_syntax_theme(self):
-        return dark_syntax_theme if self.is_dark_theme() else light_syntax_theme
+    @property
+    def syntax_theme(self):
+        return dark_syntax_theme if self.is_dark_theme else light_syntax_theme
 
     # pylint: disable=no-self-use
     def update_palette(self, palette, dark_theme, accent_color):
@@ -98,6 +99,7 @@ if IS_WIN:
     import winreg
 
     class WindowsTheme(BaseTheme):
+        @property
         def is_dark_theme(self):
             dark_theme = False
             try:
@@ -107,7 +109,8 @@ if IS_WIN:
                 log.warning('Failed reading AppsUseLightTheme from registry')
             return dark_theme
 
-        def get_accent_color(self):
+        @property
+        def accent_color(self):
             accent_color = None
             try:
                 with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\DWM") as key:
@@ -148,6 +151,7 @@ elif IS_MACOS:
         AppKit = None
 
     class MacTheme(BaseTheme):
+        @property
         def is_dark_theme(self):
             if not AppKit:
                 return False

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -43,7 +43,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
     def __init__(self, document):
         super().__init__(document)
-        syntax_theme = theme.get_syntax_theme()
+        syntax_theme = theme.syntax_theme
         self.func_re = QtCore.QRegExp(r"\$(?!noop)[a-zA-Z][_a-zA-Z0-9]*\(")
         self.func_fmt = QtGui.QTextCharFormat()
         self.func_fmt.setFontWeight(QtGui.QFont.Bold)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Try to automatically switch the syntax highighting color on a dark color scheme.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1882
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard might use a dark color palette. This can happen e.g. on KDE (which sets a color palette based on the selected theme), or  by the user actually switching the Qt style once we have #1638 merged. Dark background colors makes reading the default syntax highlighting theme difficult. We have an optimized version for dark colors and should use this.




# Solution
This PR tries to dynamically detect dark background colors being used by actually looking at the lightness of the base color set in the palette.

Note: If the color is somewhere in between both themes might actually look bad. But this would be more an issue with the theme itself, the issue is not limited to our use case. Actual themes avoid this as it provides bad contrast with both light and dark fonts.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
