### PR TITLE
PICARD-1959: Rename disc ID "Lookup in Browser" to "Submit disc ID"

### DIFF
--- a/picard/ui/ui_cdlookup.py
+++ b/picard/ui/ui_cdlookup.py
@@ -87,5 +87,5 @@ class Ui_Dialog(object):
         self.no_results_label.setText(_("No matching releases found for this disc."))
         self.submit_button.setText(_("Submit disc ID"))
         self.ok_button.setText(_("&Load into Picard"))
-        self.lookup_button.setText(_("Lookup in &Browser"))
+        self.lookup_button.setText(_("&Submit disc ID"))
         self.cancel_button.setText(_("&Cancel"))

--- a/ui/cdlookup.ui
+++ b/ui/cdlookup.ui
@@ -173,7 +173,7 @@
      <item>
       <widget class="QPushButton" name="lookup_button">
        <property name="text">
-        <string>Lookup in &amp;Browser</string>
+        <string>&amp;Submit disc ID</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

If there are matches for a disc ID but it does not match the release the users are looking for, many users struggle with how to actually submit the disc ID.

The dialog offers a "Lookup in Browser" button, but it is not obvious that this provides a way to submit the disc ID to MB. I suggest renaming the button to "Submit disc ID".


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1959
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
![grafik](https://user-images.githubusercontent.com/29852/94917883-b8bc4200-04b1-11eb-9fe6-61c3e08dd6fa.png)
