### PR TITLE
PICARD-1877: Support language for lyrics tags

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -61,7 +61,11 @@ from picard.util import (
     encode_filename,
     sanitize_date,
 )
-from picard.util.tags import parse_comment_tag
+from picard.util.tags import (
+    create_lang_desc_tag,
+    parse_comment_tag,
+    parse_lang_desc_tag,
+)
 
 
 id3.GRP1 = compatid3.GRP1
@@ -324,9 +328,7 @@ class ID3File(File):
                 for text in frame.text:
                     metadata.add(name, text)
             elif frameid == 'USLT':
-                name = 'lyrics'
-                if frame.desc:
-                    name += ':%s' % frame.desc
+                name = create_lang_desc_tag('lyrics', frame.lang, frame.desc)
                 metadata.add(name, frame.text)
             elif frameid == 'UFID' and frame.owner == 'http://musicbrainz.org':
                 metadata['musicbrainz_recordingid'] = frame.data.decode('ascii', 'ignore')
@@ -444,12 +446,9 @@ class ID3File(File):
                 else:
                     tags.add(id3.COMM(encoding=encoding, desc=desc, lang=lang, text=values))
             elif name.startswith('lyrics:') or name == 'lyrics':
-                if ':' in name:
-                    desc = name.split(':', 1)[1]
-                else:
-                    desc = ''
+                (lang, desc) = parse_lang_desc_tag(name)
                 for value in values:
-                    tags.add(id3.USLT(encoding=encoding, desc=desc, text=value))
+                    tags.add(id3.USLT(encoding=encoding, desc=desc, lang=lang, text=value))
             elif name in self._rtipl_roles:
                 for value in values:
                     tipl.people.append([self._rtipl_roles[name], value])
@@ -556,12 +555,10 @@ class ID3File(File):
                             and frame.lang == lang):
                             del tags[key]
                 elif name.startswith('lyrics:') or name == 'lyrics':
-                    if ':' in name:
-                        desc = name.split(':', 1)[1]
-                    else:
-                        desc = ''
+                    (lang, desc) = parse_lang_desc_tag(name)
                     for key, frame in list(tags.items()):
-                        if frame.FrameID == 'USLT' and frame.desc == desc:
+                        if (frame.FrameID == 'USLT' and frame.desc == desc
+                            and frame.lang == lang):
                             del tags[key]
                 elif name in self._rtipl_roles:
                     role = self._rtipl_roles[name]

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -146,7 +146,7 @@ RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
 def parse_comment_tag(name):  # noqa: E302
     """
     Parses a tag name like "comment:XXX:desc", where XXX is the language.
-    If language is not set ("comment:desc") "eng" is assumed as default.
+    If language is not set ("comment:desc") default_language is used.
     Returns a (lang, desc) tuple.
     """
     try:
@@ -159,3 +159,36 @@ def parse_comment_tag(name):  # noqa: E302
         lang = match.group(1)
         desc = desc[4:]
     return (lang, desc)
+
+
+RE_LYRICS_TAG = re.compile('^(?P<name>[^:]+)(?::(?P<lang>[a-zA-Z]{3})?)?(?::(?P<desc>.*))?$')
+def parse_lang_desc_tag(name, default_language='xxx'):  # noqa: E302
+    """
+    Parses a tag name like with a language and description such as "lyrics:XXX:desc".
+
+    Language must be a 3 letter language code as defined in ISO639-2, with the special
+    value 'xxx' being used if the language is not specified. If language is not set ("lyrics"
+    or "lyrics::desc") default_language is used.
+    Language and description are optional.
+
+    Returns a (lang, desc) tuple.
+    """
+    match = RE_LYRICS_TAG.match(name)
+    lang = default_language
+    desc = ''
+    if match:
+        lang = match.group('lang') or default_language
+        desc = match.group('desc') or ''
+    return (lang, desc)
+
+
+def create_lang_desc_tag(name, language='xxx', description='', default_language='xxx'):
+    name_parts = [name, ]
+    if language and language.lower() != default_language:
+        name_parts.append(language)
+    elif description:
+        # Add empty language part if description is also set
+        name_parts.append('')
+    if description:
+        name_parts.append(description)
+    return ':'.join(name_parts)

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -356,7 +356,7 @@ class CommonTests:
         @skipUnlessTestfile
         def test_delete_tags_with_description(self):
             for key in (
-                'comment:foo', 'comment:de:foo', 'performer:foo', 'lyrics:foo',
+                'comment:foo', 'comment:deu:foo', 'performer:foo', 'lyrics::foo', 'lyrics:jpn:foo'
                 'comment:a*', 'comment:a[', 'performer:(x)', 'performer: Ä é '
             ):
                 if not self.format.supports_tag(key):

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -334,10 +334,25 @@ class CommonId3Tests:
             self.assertNotIn('TXXX:REPLAYGAIN_ALBUM_PEAK', raw_metadata)
 
         @skipUnlessTestfile
-        def test_lyrics_with_description(self):
-            metadata = Metadata({'lyrics:foo': 'bar'})
+        def test_lyrics_with_language(self):
+            metadata = Metadata({'lyrics:jpn': 'bar'})
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
-            self.assertEqual(metadata['lyrics:foo'], loaded_metadata['lyrics:foo'])
+            self.assertIn('lyrics:jpn', loaded_metadata)
+            self.assertEqual(metadata['lyrics:jpn'], loaded_metadata['lyrics:jpn'])
+
+        @skipUnlessTestfile
+        def test_lyrics_with_description(self):
+            metadata = Metadata({'lyrics::foo': 'bar'})
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertIn('lyrics::foo', loaded_metadata)
+            self.assertEqual(metadata['lyrics::foo'], loaded_metadata['lyrics::foo'])
+
+        @skipUnlessTestfile
+        def test_lyrics_with_language_and_description(self):
+            metadata = Metadata({'lyrics:fra:foo': 'bar'})
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertIn('lyrics:fra:foo', loaded_metadata)
+            self.assertEqual(metadata['lyrics:fra:foo'], loaded_metadata['lyrics:fra:foo'])
 
         @skipUnlessTestfile
         def test_invalid_track_and_discnumber(self):

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -22,8 +22,10 @@
 from test.picardtestcase import PicardTestCase
 
 from picard.util.tags import (
+    create_lang_desc_tag,
     display_tag_name,
     parse_comment_tag,
+    parse_lang_desc_tag,
 )
 
 
@@ -37,3 +39,19 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(('XXX', 'foo'), parse_comment_tag('comment:XXX:foo'))
         self.assertEqual(('eng', 'foo'), parse_comment_tag('comment:foo'))
         self.assertEqual(('eng', ''), parse_comment_tag('comment'))
+
+    def test_parse_lang_desc_tag(self):
+        self.assertEqual(('jpn', ''), parse_lang_desc_tag('lyrics:jpn'))
+        self.assertEqual(('jpn', ''), parse_lang_desc_tag('lyrics:jpn:'))
+        self.assertEqual(('jpn', 'foo'), parse_lang_desc_tag('lyrics:jpn:foo'))
+        self.assertEqual(('xxx', 'foo'), parse_lang_desc_tag('lyrics::foo'))
+        self.assertEqual(('xxx', 'notalanguage:foo'), parse_lang_desc_tag('lyrics:notalanguage:foo'))
+
+    def test_create_lang_desc_tag(self):
+        self.assertEqual('comment', create_lang_desc_tag('comment'))
+        self.assertEqual('comment:eng', create_lang_desc_tag('comment', language='eng'))
+        self.assertEqual('comment::foo', create_lang_desc_tag('comment', description='foo'))
+        self.assertEqual('lyrics:jpn:foo', create_lang_desc_tag(
+            'lyrics', language='jpn', description='foo'))
+        self.assertEqual('lyrics::foo', create_lang_desc_tag(
+            'lyrics', language='jpn', description='foo', default_language='jpn'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Support loading the language for ID3 lyrics tags. This avoids Picard overwriting the lyrics on existing USLT tags with "xxx" (which is mutagen's default if no language is given).
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Picard overwrites existing language information on USLT tags.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1877
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Lyrics tags will be set as lyrcis[:lang[:desc]], where lang can also be empty to default to 'xxx'.

Note: This is very similar to how comments behave, but different. I tried to completely unify it, but it is difficult if we want to keep backward compatibility and compatibility with other formats.

The differences are, how partial and empty values will be treated.

For lyrics only ID3 supports descriptions and languages, for all other tag formats it gets converted to just a plain lyrics tag. In ID3 the following are valid:

- `lyrics` (default language xxx and no description)
- `lyrics:lng:desc` (language and description)
- `lyrics:lng` (only language)
- `lyrics::description` (only description)
- `lyrics:something  that is not a 3 char language code` (only description, because the only value is never a valid language code; this is mainly to provide some backward compatibility should someone use this format ins scripts)

For comments it is different, as we supported description before:

- `comment` (default language eng and no description
- `comment:des` (default language eng and short description)
- `comment:lng:des` (language + description)

This is because we introduced the language support later and support plain "comment:description" also for e.g. APEv2. We probably should unify this, but it requires a bit of refactoring to existing formats and tests and is a small backward incompatible change.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

