### PR TITLE
PICARD-1961: Keep instrument and other attributes spelling as is

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import re
-
 from picard import config
 from picard.const import RELEASE_FORMATS
 from picard.util import (
@@ -100,10 +98,6 @@ _RELEASE_GROUP_TO_METADATA = {
 }
 
 
-def _decamelcase(text):
-    return re.sub(r'(?<![A-Z\s])([A-Z])', r' \1', text).strip()
-
-
 _REPLACE_MAP = {}
 _PREFIX_ATTRS = ['guest', 'additional', 'minor', 'solo']
 _BLANK_SPECIAL_RELTYPES = {'vocal': 'vocals'}
@@ -113,7 +107,7 @@ def _transform_attribute(attr, attr_credits):
     if attr in attr_credits:
         return attr_credits[attr]
     else:
-        return _decamelcase(_REPLACE_MAP.get(attr, attr))
+        return _REPLACE_MAP.get(attr, attr)
 
 
 def _parse_attributes(attrs, reltype, attr_credits):
@@ -132,7 +126,7 @@ def _parse_attributes(attrs, reltype, attr_credits):
         result = nouns[0]
     else:
         result = _BLANK_SPECIAL_RELTYPES.get(reltype, '')
-    return ' '.join([prefix, result]).strip().lower()
+    return ' '.join([prefix, result]).strip()
 
 
 def _relations_to_metadata(relations, m):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -30,7 +30,6 @@ from test.picardtestcase import (
 from picard import config
 from picard.album import Album
 from picard.mbjson import (
-    _decamelcase,
     artist_to_metadata,
     countries_from_node,
     get_score,
@@ -252,11 +251,11 @@ class RecordingCreditsTest(MBJSONTest):
         self.assertNotIn('performer:solo', m)
         self.assertEqual(m['performer:solo vocals'], 'Anni-Frid Lyngstad')
 
-    def test_recording_instrument_decamelcase(self):
+    def test_recording_instrument_keep_case(self):
         m = Metadata()
         t = Track("1")
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['performer:ewi'], 'Michael Brecker')
+        self.assertEqual(m['performer:EWI'], 'Michael Brecker')
 
 
 class TrackTest(MBJSONTest):
@@ -436,12 +435,3 @@ class GetScoreTest(PicardTestCase):
 
     def test_get_score_no_score(self):
         self.assertEqual(1.0, get_score({}))
-
-
-class DecamelcaseTest(PicardTestCase):
-    def test_decamelcase(self):
-        self.assertEqual('foo bar', _decamelcase('foo bar'))
-        self.assertEqual('Foo Bar', _decamelcase('Foo Bar'))
-        self.assertEqual('Foo Bar', _decamelcase('FooBar'))
-        self.assertEqual('Foo BAr', _decamelcase('FooBAr'))
-        self.assertEqual('EWI', _decamelcase('EWI'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Do not lower case or de-camelcase attribute names. Fixes issues with instrument names getting case messed up.

# Problem
This was introduced very eraly in d923c9a. Originally MB provided a more fixed list of instruments, with instrument names as attributes actually being camel cased.

This is no longer the case and instruments should now be used as given in the API response.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1961, PICARD-1804
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Remove the obsolete code.