### PR TITLE
PICARD-1963: Avoid stack overflow when loading large amount of files

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -453,7 +453,7 @@ class Tagger(QtWidgets.QApplication):
                 return
 
         if target:
-            self.move_files([file], target)
+            self.move_file(file, target)
         else:
             self.unclustered_files.add_file(file)
 
@@ -461,6 +461,19 @@ class Tagger(QtWidgets.QApplication):
         if config.setting['analyze_new_files'] and file.can_analyze():
             log.debug("Trying to analyze %r ...", file)
             self.analyze([file])
+
+    def move_file(self, file, target):
+        if target is None:
+            log.debug("Aborting move since target is invalid")
+            return
+        if isinstance(target, Album):
+            self.move_files_to_album([file], album=target)
+        elif isinstance(target, ClusterList):
+            if isinstance(file.parent, Track):
+                file.parent.remove_file(file)
+            self.cluster([file])
+        elif hasattr(target, 'move'):
+            file.move(target)
 
     def move_files(self, files, target, move_to_multi_tracks=True):
         if target is None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Avoid a possible crash due to a stack overflow when loading files.

# Problem
When loading a large list of files this could result in a stack overflow,
since tagger.move_files calls QCoreApplication.processEvents, which in
return might process an event to call tagger.move_files again, resulting
in a deep recursion. See PICARD-1963 for a more detailed explanation.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1963

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Refactor the special case of moving a single file into a separate method.

Note that instead removing the processEvents calls from tagger.move_files is not really an option. This method is basically a large UI update task, so needs to run in the main thread. And not processing events in between makes Picard unresponsive in other cases.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
