### PR TITLE
PICARD-1965: Allow opening AcoustID options from missing API key dialog

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -400,9 +400,19 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _on_submit_acoustid(self):
         if self.tagger.use_acoustid:
             if not config.setting["acoustid_apikey"]:
-                QtWidgets.QMessageBox.warning(self,
-                    _("Submission Error"),
-                    _("You need to configure your AcoustID API key before you can submit fingerprints."))
+                msg = QtWidgets.QMessageBox(self)
+                msg.setIcon(QtWidgets.QMessageBox.Information)
+                msg.setWindowModality(QtCore.Qt.WindowModal)
+                msg.setWindowTitle(_("AcoustID submission not configured"))
+                msg.setText(_(
+                    "You need to configure your AcoustID API key before you can submit fingerprints."))
+                open_options = QtWidgets.QPushButton(
+                    icontheme.lookup('preferences-desktop'), _("Open AcoustID options"))
+                msg.addButton(QtWidgets.QMessageBox.Cancel)
+                msg.addButton(open_options, QtWidgets.QMessageBox.YesRole)
+                msg.exec_()
+                if msg.clickedButton() == open_options:
+                    self.show_options("fingerprinting")
             else:
                 self.tagger.acoustidmanager.submit()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

When the user tries to submit fingerprints but has no AcoustID API key configured a warning dialog is shown. Add a button to directly open the fingerprinting options from within this dialog.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1965
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

![grafik](https://user-images.githubusercontent.com/29852/95476786-e872ba80-0987-11eb-8e63-adafb021100d.png)
