### PR TITLE
PICARD-1964: Support right-to-left text flow in scripting docs

### DIFF
--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -67,7 +67,8 @@ dt {
     color: %(script_function_fg)s
 }
 dd {
-    padding: 50px;
+    /* Qt does not support margin-inline-start, use margin-left/margin-right instead */
+    margin-%(inline_start)s: 50px;
     margin-bottom: 50px;
 }
 code {
@@ -75,7 +76,7 @@ code {
 }
 </style>
 </head>
-<body>
+<body dir="%(dir)s">
     %(html)s
 </body>
 </html>
@@ -122,11 +123,21 @@ class ScriptingDocumentationDialog(PicardDialog):
             postprocessor=process_html,
         )
 
+        if self.ui.textBrowser.layoutDirection() == QtCore.Qt.RightToLeft:
+            text_direction = 'rtl'
+        else:
+            text_direction = 'ltr'
+
         html = DOCUMENTATION_HTML_TEMPLATE % {
             'html': "<dl>%s</dl>" % funcdoc,
             'script_function_fg': theme.syntax_theme.func.name(),
             'monospace_font': FONT_FAMILY_MONOSPACE,
+            'dir': text_direction,
+            'inline_start': 'right' if text_direction == 'rtl' else 'left'
         }
+        # Scripting code is always left-to-right. Qt does not support the dir
+        # attribute on inline tags, insert explicit left-right-marks instead.
+        html = html.replace('<code>', '<code>&#8206;')
         self.ui.textBrowser.setHtml(html)
         self.ui.buttonBox.rejected.connect(self.close)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Fixed rendering of scripting documentation for scripts running from right to left.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1964
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Set the general text direction to right-to-left. Also insert a left order mark into code blocks, to fix rendering of code snippets.

The latter is necessary, because in a code block like "$set(...)" the leading $ would still be rendered in RTL mode, that means it would visually turn into "get(a)$". Take e.g. the following without the left-order-mark:

<span dir="rtl">עִבְרִית $get(a) עִבְרִית</span>

And with left-order-mark:

<span dir="rtl">עִבְרִית &lrm;$get(a) עִבְרִית</span>


Example of how it looks like:

![grafik](https://user-images.githubusercontent.com/29852/95578531-4f4dad80-0a34-11eb-9897-b39e32aea2bd.png)



# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
