### PR TITLE
PICARD-1972: When matching files to tracks preserve track length

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -175,9 +175,8 @@ class Metadata(MutableMapping):
         self.images = ImageList()
         self.has_common_images = True
 
-        d = dict(*args, **kwargs)
-        for k, v in d.items():
-            self[k] = v
+        if args or kwargs:
+            self.update(*args, **kwargs)
         if images is not None:
             for image in images:
                 self.images.append(image)

--- a/picard/track.py
+++ b/picard/track.py
@@ -175,11 +175,13 @@ class Track(DataObject, Item):
         # Run the scripts for the file to allow usage of
         # file specific metadata and variables
         if config.setting["clear_existing_tags"]:
-            metadata = Metadata(self.orig_metadata)
+            metadata = Metadata()
+            metadata.update(self.orig_metadata)
             metadata_proxy = MultiMetadataProxy(metadata, file.metadata)
             self.run_scripts(metadata_proxy)
         else:
-            metadata = Metadata(file.metadata)
+            metadata = Metadata()
+            metadata.update(file.metadata)
             metadata.update(self.orig_metadata)
             self.run_scripts(metadata)
         # Apply changes to the track's metadata done manually after the scripts ran

--- a/picard/track.py
+++ b/picard/track.py
@@ -175,13 +175,11 @@ class Track(DataObject, Item):
         # Run the scripts for the file to allow usage of
         # file specific metadata and variables
         if config.setting["clear_existing_tags"]:
-            metadata = Metadata()
-            metadata.update(self.orig_metadata)
+            metadata = Metadata(self.orig_metadata)
             metadata_proxy = MultiMetadataProxy(metadata, file.metadata)
             self.run_scripts(metadata_proxy)
         else:
-            metadata = Metadata()
-            metadata.update(file.metadata)
+            metadata = Metadata(file.metadata)
             metadata.update(self.orig_metadata)
             self.run_scripts(metadata)
         # Apply changes to the track's metadata done manually after the scripts ran


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Fixes track times getting reset to 0 if files get matched to tracks and clear_existing_tags is active.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1972
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use the full track metadata object to copy all data and don't treat it as a dict.

This just copies the metadata tags as a dict:

```
m = Metadata(old_metadata)
```

This does a full copy:

```
m = Metadata()
m.update(old_metadata)
```

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

