### PR TITLE
PICARD-1974: Fix Tags From Filenames handling same tag multiple times

### DIFF
--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -26,6 +26,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections import OrderedDict
 import os.path
 import re
 
@@ -37,6 +38,56 @@ from picard.util.tags import display_tag_name
 from picard.ui import PicardDialog
 from picard.ui.ui_tagsfromfilenames import Ui_TagsFromFileNamesDialog
 from picard.ui.util import StandardButton
+
+
+class TagMatchExpression:
+    _numeric_tags = ('tracknumber', 'totaltracks', 'discnumber', 'totaldiscs')
+
+    def __init__(self, expression, replace_underscores=False):
+        self.replace_underscores = replace_underscores
+        self._tag_re = re.compile(r"(%\w+%)")
+        self._parse(expression)
+
+    def _parse(self, expression):
+        self._group_map = {}
+        format_re = ['(?:^|/)']
+        for i, part in enumerate(self._tag_re.split(expression)):
+            if part.startswith('%') and part.endswith('%'):
+                tag = part[1:-1]
+                group = '%s_%i' % (tag, i)
+                self._group_map[group] = tag
+                if tag in self._numeric_tags:
+                    format_re.append(r'(?P<' + group + r'>\d+)')
+                elif tag == 'date':
+                    format_re.append(r'(?P<' + group + r'>\d+(?:-\d+(?:-\d+)?)?)')
+                else:
+                    format_re.append(r'(?P<' + group + r'>[^/]*?)')
+            else:
+                format_re.append(re.escape(part))
+        # Optional extension
+        format_re.append(r'(?:\.\w+)?$')
+        self._format_re = re.compile("".join(format_re))
+
+    @property
+    def matched_tags(self):
+        # Return unique values, but preserve order
+        return list(OrderedDict.fromkeys(self._group_map.values()))
+
+    def match_file(self, filename):
+        match = self._format_re.search(filename.replace('\\', '/'))
+        if match:
+            result = {}
+            for group, value in match.groupdict().items():
+                value = value.strip()
+                tag = self._group_map[group]
+                if tag in self._numeric_tags:
+                    value = value.lstrip("0")
+                if self.replace_underscores:
+                    value = value.replace('_', ' ')
+                result[tag] = value
+            return result
+        else:
+            return {}
 
 
 class TagsFromFileNamesDialog(PicardDialog):
@@ -82,58 +133,24 @@ class TagsFromFileNamesDialog(PicardDialog):
             item = QtWidgets.QTreeWidgetItem(self.ui.files)
             item.setText(0, os.path.basename(file.filename))
             self.items.append(item)
-        self._tag_re = re.compile(r"(%\w+%)")
-        self.numeric_tags = ('tracknumber', 'totaltracks', 'discnumber', 'totaldiscs')
-
-    def parse_response(self):
-        tff_format = self.ui.format.currentText()
-        columns = []
-        format_re = ['(?:^|/)']
-        for part in self._tag_re.split(tff_format):
-            if part.startswith('%') and part.endswith('%'):
-                name = part[1:-1]
-                columns.append(name)
-                if name in self.numeric_tags:
-                    format_re.append('(?P<' + name + r'>\d+)')
-                elif name == 'date':
-                    format_re.append('(?P<' + name + r'>\d+(?:-\d+(?:-\d+)?)?)')
-                else:
-                    format_re.append('(?P<' + name + '>[^/]*?)')
-            else:
-                format_re.append(re.escape(part))
-        format_re.append(r'\.(\w+)$')
-        format_re = re.compile("".join(format_re))
-        return format_re, columns
-
-    def match_file(self, file, tff_format):
-        match = tff_format.search(file.filename.replace('\\', '/'))
-        if match:
-            result = {}
-            for name, value in match.groupdict().items():
-                value = value.strip()
-                if name in self.numeric_tags:
-                    value = value.lstrip("0")
-                if self.ui.replace_underscores.isChecked():
-                    value = value.replace('_', ' ')
-                result[name] = value
-            return result
-        else:
-            return {}
 
     def preview(self):
-        tff_format, columns = self.parse_response()
-        self.ui.files.setHeaderLabels([_("File Name")] + list(map(display_tag_name, columns)))
+        expression = TagMatchExpression(self.ui.format.currentText(), self.ui.replace_underscores.isChecked())
+        columns = expression.matched_tags
+        headers = [_("File Name")] + list(map(display_tag_name, columns))
+        self.ui.files.setColumnCount(len(headers))
+        self.ui.files.setHeaderLabels(headers)
         for item, file in zip(self.items, self.files):
-            matches = self.match_file(file, tff_format)
+            matches = expression.match_file(file.filename)
             for i, column in enumerate(columns):
                 item.setText(i + 1, matches.get(column, ''))
         self.ui.files.header().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
         self.ui.files.header().setStretchLastSection(True)
 
     def accept(self):
-        tff_format, columns = self.parse_response()
+        expression = TagMatchExpression(self.ui.format.currentText(), self.ui.replace_underscores.isChecked())
         for file in self.files:
-            metadata = self.match_file(file, tff_format)
+            metadata = expression.match_file(file.filename)
             for name, value in metadata.items():
                 file.metadata[name] = value
             file.update()

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -50,7 +50,7 @@ class TagMatchExpression:
         self._parse(expression)
 
     def _parse(self, expression):
-        self._group_map = {}
+        self._group_map = OrderedDict()
         format_re = ['(?:^|/)']
         for i, part in enumerate(self._tag_re.split(expression)):
             if part.startswith('%') and part.endswith('%'):
@@ -79,9 +79,8 @@ class TagMatchExpression:
         match = self._format_re.search(filename.replace('\\', '/'))
         if match:
             result = {}
-            for group, value in match.groupdict().items():
-                value = value.strip()
-                tag = self._group_map[group]
+            for group, tag in self._group_map.items():
+                value = match.group(group).strip()
                 if tag in self._numeric_tags:
                     value = value.lstrip("0")
                 if self.replace_underscores:

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -33,6 +33,7 @@ import re
 from PyQt5 import QtWidgets
 
 from picard import config
+from picard.script.parser import normalize_tagname
 from picard.util.tags import display_tag_name
 
 from picard.ui import PicardDialog
@@ -53,8 +54,9 @@ class TagMatchExpression:
         format_re = ['(?:^|/)']
         for i, part in enumerate(self._tag_re.split(expression)):
             if part.startswith('%') and part.endswith('%'):
-                tag = part[1:-1]
-                group = '%s_%i' % (tag, i)
+                name = part[1:-1]
+                group = '%s_%i' % (name, i)
+                tag = normalize_tagname(name)
                 self._group_map[group] = tag
                 if tag in self._numeric_tags:
                     format_re.append(r'(?P<' + group + r'>\d+)')

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -85,7 +85,9 @@ class TagMatchExpression:
                     value = value.lstrip("0")
                 if self.replace_underscores:
                     value = value.replace('_', ' ')
-                result[tag] = value
+                all_values = result.get(tag, [])
+                all_values.append(value)
+                result[tag] = all_values
             return result
         else:
             return {}
@@ -144,7 +146,8 @@ class TagsFromFileNamesDialog(PicardDialog):
         for item, file in zip(self.items, self.files):
             matches = expression.match_file(file.filename)
             for i, column in enumerate(columns):
-                item.setText(i + 1, matches.get(column, ''))
+                values = matches.get(column, [])
+                item.setText(i + 1, '; '.join(values))
         self.ui.files.header().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
         self.ui.files.header().setStretchLastSection(True)
 
@@ -152,8 +155,8 @@ class TagsFromFileNamesDialog(PicardDialog):
         expression = TagMatchExpression(self.ui.format.currentText(), self.ui.replace_underscores.isChecked())
         for file in self.files:
             metadata = expression.match_file(file.filename)
-            for name, value in metadata.items():
-                file.metadata[name] = value
+            for name, values in metadata.items():
+                file.metadata[name] = values
             file.update()
         config.persist["tags_from_filenames_format"] = self.ui.format.currentText()
         super().accept()

--- a/test/test_tagsfromfilenames.py
+++ b/test/test_tagsfromfilenames.py
@@ -74,6 +74,14 @@ class TagMatchExpressionTest(PicardTestCase):
         self.assertEqual('title', matches['title'])
         self.assertEqual('bar', matches['dummy'])
 
+    def test_parse_tags_hidden(self):
+        expression = TagMatchExpression(r'%_dummy% %title% %_dummy%')
+        expected_tags = ['~dummy', 'title']
+        self.assertEqual(expected_tags, expression.matched_tags)
+        matches = expression.match_file('foo title bar')
+        self.assertEqual('title', matches['title'])
+        self.assertEqual('bar', matches['~dummy'])
+
     def test_parse_empty(self):
         expression = TagMatchExpression(r'')
         expected_tags = []

--- a/test/test_tagsfromfilenames.py
+++ b/test/test_tagsfromfilenames.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.tagsfromfilenames import TagMatchExpression
+
+
+class TagMatchExpressionTest(PicardTestCase):
+
+    def test_parse_tags(self):
+        expression = TagMatchExpression(r'%tracknumber% - %title%')
+        expected_tags = ['tracknumber', 'title']
+        self.assertEqual(expected_tags, expression.matched_tags)
+        files = [
+            '042 - The Title',
+            '042 - The Title.mp3',
+            '/foo/042 - The Title'
+            '/foo/042 - The Title.mp3'
+            '/042 - The Title'
+            '/042 - The Title.mp3'
+            'C:\\foo\\042 - The Title.mp3'
+        ]
+        for filename in files:
+            matches = expression.match_file(filename)
+            self.assertEqual('42', matches['tracknumber'])
+            self.assertEqual('The Title', matches['title'])
+
+    def test_parse_tags_with_path(self):
+        expression = TagMatchExpression(r'%artist%/%album%/%tracknumber% - %title%')
+        expected_tags = ['artist', 'album', 'tracknumber', 'title']
+        self.assertEqual(expected_tags, expression.matched_tags)
+        files = [
+            'The Artist/The Album/01 - The Title',
+            'The Artist/The Album/01 - The Title.wv',
+            'C:\\foo\\The Artist\\The Album\\01 - The Title.wv',
+        ]
+        for filename in files:
+            matches = expression.match_file(filename)
+            self.assertEqual('The Artist', matches['artist'])
+            self.assertEqual('The Album', matches['album'])
+            self.assertEqual('1', matches['tracknumber'])
+            self.assertEqual('The Title', matches['title'])
+
+    def test_parse_replace_underscores(self):
+        expression = TagMatchExpression(r'%artist%-%title%', replace_underscores=True)
+        matches = expression.match_file('Some_Artist-Some_Title.ogg')
+        self.assertEqual('Some Artist', matches['artist'])
+        self.assertEqual('Some Title', matches['title'])
+
+    def test_parse_tags_duplicates(self):
+        expression = TagMatchExpression(r'%dummy% %title% %dummy%')
+        expected_tags = ['dummy', 'title']
+        self.assertEqual(expected_tags, expression.matched_tags)
+        matches = expression.match_file('foo title bar')
+        self.assertEqual('title', matches['title'])
+        self.assertEqual('bar', matches['dummy'])
+
+    def test_parse_empty(self):
+        expression = TagMatchExpression(r'')
+        expected_tags = []
+        self.assertEqual(expected_tags, expression.matched_tags)

--- a/test/test_tagsfromfilenames.py
+++ b/test/test_tagsfromfilenames.py
@@ -41,8 +41,8 @@ class TagMatchExpressionTest(PicardTestCase):
         ]
         for filename in files:
             matches = expression.match_file(filename)
-            self.assertEqual('42', matches['tracknumber'])
-            self.assertEqual('The Title', matches['title'])
+            self.assertEqual(['42'], matches['tracknumber'])
+            self.assertEqual(['The Title'], matches['title'])
 
     def test_parse_tags_with_path(self):
         expression = TagMatchExpression(r'%artist%/%album%/%tracknumber% - %title%')
@@ -55,32 +55,32 @@ class TagMatchExpressionTest(PicardTestCase):
         ]
         for filename in files:
             matches = expression.match_file(filename)
-            self.assertEqual('The Artist', matches['artist'])
-            self.assertEqual('The Album', matches['album'])
-            self.assertEqual('1', matches['tracknumber'])
-            self.assertEqual('The Title', matches['title'])
+            self.assertEqual(['The Artist'], matches['artist'])
+            self.assertEqual(['The Album'], matches['album'])
+            self.assertEqual(['1'], matches['tracknumber'])
+            self.assertEqual(['The Title'], matches['title'])
 
     def test_parse_replace_underscores(self):
         expression = TagMatchExpression(r'%artist%-%title%', replace_underscores=True)
         matches = expression.match_file('Some_Artist-Some_Title.ogg')
-        self.assertEqual('Some Artist', matches['artist'])
-        self.assertEqual('Some Title', matches['title'])
+        self.assertEqual(['Some Artist'], matches['artist'])
+        self.assertEqual(['Some Title'], matches['title'])
 
     def test_parse_tags_duplicates(self):
         expression = TagMatchExpression(r'%dummy% %title% %dummy%')
         expected_tags = ['dummy', 'title']
         self.assertEqual(expected_tags, expression.matched_tags)
         matches = expression.match_file('foo title bar')
-        self.assertEqual('title', matches['title'])
-        self.assertEqual('bar', matches['dummy'])
+        self.assertEqual(['title'], matches['title'])
+        self.assertEqual(['foo', 'bar'], matches['dummy'])
 
     def test_parse_tags_hidden(self):
         expression = TagMatchExpression(r'%_dummy% %title% %_dummy%')
         expected_tags = ['~dummy', 'title']
         self.assertEqual(expected_tags, expression.matched_tags)
         matches = expression.match_file('foo title bar')
-        self.assertEqual('title', matches['title'])
-        self.assertEqual('bar', matches['~dummy'])
+        self.assertEqual(['title'], matches['title'])
+        self.assertEqual(['foo', 'bar'], matches['~dummy'])
 
     def test_parse_empty(self):
         expression = TagMatchExpression(r'')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

Fix tags from filenames crashing if same tag is used more than once in match expression.#

Also allow parsing hidden tags.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1974, PICARD-1975
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

# Solution

Refactor tags from filenames to have a `TagMatchExpression` class to handle parsing the expression and matching files. This allows testing.

Fix the issue with multiple groups of same name by separating tag names from group names and ensure group names are unique. Also fix setting hidden tags with an underscore expression like `%_foo%` (PICARD-1975).