### PR TITLE
PICARD-1976: Fixed handling query args in CoverArtImage URLs

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2007 Oliver Charles
 # Copyright (C) 2007, 2010-2011 Lukáš Lalinský
-# Copyright (C) 2007-2011, 2019 Philipp Wolfer
+# Copyright (C) 2007-2011, 2019-2020 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
 # Copyright (C) 2013-2015, 2018-2019 Laurent Monin
@@ -207,6 +207,7 @@ class CoverArt:
             coverartimage.port,
             coverartimage.path,
             partial(self._coverart_downloaded, coverartimage),
+            queryargs=coverartimage.queryargs,
             priority=True,
             important=False
         )

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2007 Oliver Charles
 # Copyright (C) 2007, 2010-2011 Lukáš Lalinský
-# Copyright (C) 2007-2011, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2007-2011, 2014, 2018-2020 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012, 2015 Wieland Hoffmann
 # Copyright (C) 2013-2015, 2018-2019 Laurent Monin
@@ -37,6 +37,7 @@ from PyQt5.QtCore import (
     QMutex,
     QObject,
     QUrl,
+    QUrlQuery,
 )
 
 from picard import (
@@ -165,7 +166,10 @@ class CoverArtImage:
         self.port = self.url.port(443 if self.url.scheme() == 'https' else 80)
         self.path = self.url.path(QUrl.FullyEncoded)
         if self.url.hasQuery():
-            self.path += '?' + self.url.query(QUrl.FullyEncoded)
+            query = QUrlQuery(self.url.query())
+            self.queryargs = dict(query.queryItems())
+        else:
+            self.queryargs = None
 
     @property
     def source(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Loading cover art images from URLs with query arguments (such as e.g. `https://api.deezer.com/album/393516/image?size=big`) fails because the query arguments do not get passed properly to the webservice module.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1976
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Properly handle parse the query arguments and use them in the ws request.