### PR TITLE
PICARD-1979: Fix saving comment tag to MP4 files

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -80,7 +80,7 @@ class MP4File(File):
         "\xa9day": "date",
         "\xa9gen": "genre",
         "\xa9lyr": "lyrics",
-        "\xa9cmt": "comment:",
+        "\xa9cmt": "comment",
         "\xa9too": "encodedby",
         "cprt": "copyright",
         "soal": "albumsort",
@@ -258,6 +258,8 @@ class MP4File(File):
         for name, values in metadata.rawitems():
             if name.startswith('lyrics:'):
                 name = 'lyrics'
+            if name == 'comment:':
+                name = 'comment'
             if name in self.__r_text_tags:
                 tags[self.__r_text_tags[name]] = values
             elif name in self.__r_bool_tags:


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

For MP4 both "comment" and "comment:" must be treated the same and must be saved to @cmt.

# Problem
When loading tags Picard loaded `@cmt` as `comment:`, but this is treated as just `comment` internally. On saving the mapping expected `comment:` again, and if receiving just `comment` it would consider it an unmapped tag and save to ` ----:com.apple.iTunes` instead.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1979
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Fix the mapping to be `comment`
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

