### PR TITLE
PICARD-1982: When matching file to track copy images

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -185,6 +185,8 @@ class Track(DataObject, Item):
         # Apply changes to the track's metadata done manually after the scripts ran
         meta_diff = self.metadata.diff(self.scripted_metadata)
         metadata.update(meta_diff)
+        # Images are not affected by scripting, always use the tracks current images
+        metadata.images = self.metadata.images
         file.copy_metadata(metadata)
         file.update(signal=False)
         self.update()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix images not getting saved for files matched to a track.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1982
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Fix setting track images to the file when it gets matched to the file. This broke in #1631


# Solution
Files matched to a track always get the track's images copied over.