### PR TITLE
 PICARD-214: Fix Picard adding numbers on file rename on case insensitive file systems

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -75,6 +75,7 @@ from picard.util import (
     emptydir,
     find_best_match,
     format_time,
+    samefile,
     thread,
     tracknum_from_filename,
 )
@@ -485,7 +486,7 @@ class File(QtCore.QObject, Item):
         tmp_filename = new_filename
         i = 1
         while (os.path.exists(new_filename + ext)
-               and not os.path.samefile(old_filename, new_filename + ext)):
+               and not samefile(old_filename, new_filename + ext)):
             new_filename = "%s (%d)" % (tmp_filename, i)
             i += 1
         new_filename = new_filename + ext

--- a/picard/file.py
+++ b/picard/file.py
@@ -75,7 +75,6 @@ from picard.util import (
     emptydir,
     find_best_match,
     format_time,
-    pathcmp,
     thread,
     tracknum_from_filename,
 )
@@ -485,8 +484,8 @@ class File(QtCore.QObject, Item):
             os.makedirs(new_dirname)
         tmp_filename = new_filename
         i = 1
-        while (not pathcmp(old_filename, new_filename + ext)
-               and os.path.exists(new_filename + ext)):
+        while (os.path.exists(new_filename + ext)
+               and not os.path.samefile(old_filename, new_filename + ext)):
             new_filename = "%s (%d)" % (tmp_filename, i)
             i += 1
         new_filename = new_filename + ext

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -154,10 +154,6 @@ def decode_filename(filename):
         return filename.decode(_io_encoding)
 
 
-def pathcmp(a, b):
-    return os.path.normcase(a) == os.path.normcase(b)
-
-
 def format_time(ms, display_zero=False):
     """Formats time in milliseconds to a string representation."""
     ms = float(ms)
@@ -372,16 +368,6 @@ def tracknum_from_filename(base_filename):
     if numbers:
         return numbers[0]
     return None
-
-
-# Provide os.path.samefile equivalent which is missing in Python under Windows
-if IS_WIN:
-    def os_path_samefile(p1, p2):
-        ap1 = os.path.abspath(p1)
-        ap2 = os.path.abspath(p2)
-        return ap1 == ap2
-else:
-    os_path_samefile = os.path.samefile
 
 
 def is_hidden(filepath):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -154,6 +154,21 @@ def decode_filename(filename):
         return filename.decode(_io_encoding)
 
 
+def samepath(path1, path2):
+    return os.path.normcase(os.path.normpath(path1)) == os.path.normcase(os.path.normpath(path2))
+
+
+def samefile(path1, path2):
+    """Returns True, if both `path1` and `path2` refer to the same file.
+
+    Behaves similar to os.path.samefile, but first checks identical paths including
+    case insensitive comparison on Windows using os.path.normcase. This fixes issues on
+    some network drives (e.g. VirtualBox mounts) where two paths different only in case
+    are considered separate files by os.path.samefile.
+    """
+    return samepath(path1, path2) or os.path.samefile(path1, path2)
+
+
 def format_time(ms, display_zero=False):
     """Formats time in milliseconds to a string representation."""
     ms = float(ms)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
If a file got renamed and the only change was in casing Picard would append a number on case insensitive file systems (except on Windows).

On Windows this worked because `os.path.normcase`, which was used by `picard.util.pathcmp`, would do the proper thing and normalize the casing. But on other OS it would leave the paths as is, even if the underlying filesystem is case insensitive.


<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-214
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use `os.path.samefile` to properly check if the old and new path refer to the same file. This is fully supported even on Windows since Python 3.2.

Note that `os.path.samefile` requires a stat on both paths in order to compare inodes. But I don't see a easy way around that.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Needs more testing.

So far I tested this on:

- Windows: As expected behavior is unchanged. Case-only changes do not result in numbers being added to files and the casing is changed.
- On Linux with ext4 and case insensitive directory: In this setup I could reproduce the original issue. The change to `os.path.samefile` fixes it (1) 

But this needs additional testing on:

- macOS with case insensitive file system (both AFPS and HFS)
- Mounted FAT32 or NTFS drives on platforms other than Windows
- Network file systems. Not sure whether `os.path.samefile` can handle those.

(1) One thing to note with ext4 case-insensitive is that the file's casing will not be changed on saving. But actually this seems to be an issue with the ext4 case-insensitive implementation in general. In my tests I could also not rename such a file. I think POSIX does not even allow for such a thing.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
