### PR TITLE
PICARD-1990: Fix file renaming not performed on case-only changes

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -461,17 +461,18 @@ class File(QtCore.QObject, Item):
                 new_dirname = os.path.normpath(os.path.join(os.path.dirname(filename), new_dirname))
         else:
             new_dirname = os.path.dirname(filename)
+        try:
+            new_dirname = os.path.realpath(new_dirname)
+        except FileNotFoundError:
+            # os.path.realpath can fail if cwd does not exist and path is relative
+            pass
         new_filename = os.path.basename(filename)
 
         if settings["rename_files"] or settings["move_files"]:
             new_filename = self._format_filename(new_dirname, new_filename, metadata, settings)
 
         new_path = os.path.join(new_dirname, new_filename)
-        try:
-            return os.path.realpath(new_path)
-        except FileNotFoundError:
-            # os.path.realpath can fail if cwd doesn't exist
-            return new_path
+        return new_path
 
     def _rename(self, old_filename, metadata):
         new_filename, ext = os.path.splitext(


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix renaming files on Windows if only casing is changed and Python >= 3.8 is in use.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1990
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This affects only Windows with Python >= 3.8, as `os.path.realpath` will
return the path as it is on disk.

# Solution
Do not make `File.make_filename` return `os.path.realpath`. This should be fine, as it already use `os.path.realpath` on the directory. Still use `os.path.realpath` on the result of `File._rename` to ensure we use a canonical name for the reloaded file.

See https://github.com/metabrainz/picard/pull/1665#issuecomment-715899992 for in-depth explanation.

Also https://gist.github.com/phw/d30ffb94171c5ea3248691f951310d54 for an overview of case-insensitive behavior and issues.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
