### PR TITLE
PICARD-1985: Use "performer:chorus master" instead of performer:conductor

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -36,7 +36,7 @@ from picard.util import (
 _artist_rel_types = {
     "arranger": "arranger",
     "audio": "engineer",
-    "chorus master": "conductor",
+    "chorus master": "performer:chorus master",
     "composer": "composer",
     "concertmaster": "performer:concertmaster",
     "conductor": "conductor",


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Use "performer:chorus master" instead of performer:conductor for chorus master

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1985
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

"performer:conductor" is not really fitting. This changes makes this consistent with how we handle concertmaster.
