### PR TITLE
PICARD-1997: Reduce performance impact of fingerprint column

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -897,7 +897,6 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
             MainPanel.DISCNUMBER_COLUMN,
         ]:
             self.setTextAlignment(column, QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
-        self.setSizeHint(MainPanel.TITLE_COLUMN, ICON_SIZE)
 
     def setText(self, column, text):
         self._sortkeys[column] = None


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1997, PICARD-1989
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
The fingerprint column has a huge impact on rendering performance. The column content gets repainted a lot and can reduce loading performance significantly.


# Solution
Use the default icon implementation of `QTreeWidget` instead of custom implementation.

In my tests this improved performance a lot. If the fingerprint column is visible this reduced loading time for 4k files by 80%. Even if the column is hidden loading time is still reduced by 32%. See the following results for loading 4k files (with ignore MBIDs):

|                        |  master | this patch | reduction |
|--------------------|------------|---------------|------------|
| column visible | 78s       | 16s           |  79%     |
| column hidden | 22s       | 15s           |  32%     |

As an alternative I also tried setting the `sizeHint` on the custom `FingerprintColumnWidget` and even caching the painted column, but this had no big impact. In the end I could reduce the loading time of the 4k files to 72s this way, which is not really a gain compared to the 16s with this patch.

This is visually not the same. Instead of being neatly centered the icon is now left aligned, and I can't get the column smaller. This is how it is in current releases:

![grafik](https://user-images.githubusercontent.com/29852/97410895-e86b3800-18ff-11eb-8d3f-994e8d65bac3.png)

This is the patched version:

![grafik](https://user-images.githubusercontent.com/29852/97410777-c671b580-18ff-11eb-977d-82f9502b12c9.png)

The first one is clearly nicer and the reason why I did the implementation as it is on master. But this is for sure not worth the huge performance hit.

In https://github.com/metabrainz/picard/commit/ab8b8effe5abc5cac31a9d0c556af1d05d4dc2e3 I also removed the size hint for the title column, which fixed PICARD-1989. In my tests this had no really measurable impact on loading time, maybe it shoved of 0.5 to 1.0 seconds. But this is definitely balanced out by the fingerprint column gains.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
