### PR TITLE
PICARD-1828: Allow setting cover art for multiple selected files

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -262,7 +262,7 @@ class File(QtCore.QObject, Item):
 
     def keep_original_images(self):
         self.metadata.images = self.orig_metadata.images.copy()
-        self.update()
+        self.update(signal=False)
         self.metadata_images_changed.emit()
 
     def has_error(self):

--- a/picard/track.py
+++ b/picard/track.py
@@ -360,7 +360,6 @@ class Track(DataObject, Item):
             self.metadata.images = self.orig_metadata.images.copy()
         else:
             self.metadata.images = ImageList()
-        self.update()
 
 
 class NonAlbumTrack(Track):

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -472,7 +472,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             for file in album.iterfiles():
                 set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
-                file.update()
+                file.update(signal=False)
             album.enable_update_metadata_images(True)
             album.update_metadata_images()
             album.update(False)
@@ -483,7 +483,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             for file in cluster.iterfiles():
                 set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
-                file.update()
+                file.update(signal=False)
             cluster.enable_update_metadata_images(True)
             cluster.update_metadata_images()
             cluster.update()
@@ -495,10 +495,11 @@ class CoverArtBox(QtWidgets.QGroupBox):
             for file in track.iterfiles():
                 set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
-                file.update()
+                file.update(signal=False)
             track.album.enable_update_metadata_images(True)
             track.album.update_metadata_images()
             track.album.update(False)
+            track.update()
         elif isinstance(self.item, File):
             file = self.item
             set_image(file, coverartimage)
@@ -528,6 +529,11 @@ class CoverArtBox(QtWidgets.QGroupBox):
     def set_load_image_behavior(self, behavior):
         config.setting["load_image_behavior"] = behavior
 
+    def keep_original_images(self):
+        self.item.keep_original_images()
+        self.cover_art.set_metadata(self.item.metadata)
+        self.show()
+
     def contextMenuEvent(self, event):
         menu = QtWidgets.QMenu(self)
         if self.show_details_button.isVisible():
@@ -539,7 +545,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         if self.orig_cover_art.isVisible():
             name = _('Keep original cover art')
             use_orig_value_action = QtWidgets.QAction(name, self.parent)
-            use_orig_value_action.triggered.connect(self.item.keep_original_images)
+            use_orig_value_action.triggered.connect(self.keep_original_images)
             menu.addAction(use_orig_value_action)
 
         if self.item and self.item.can_show_coverart:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -48,7 +48,7 @@ from picard import (
     log,
 )
 from picard.album import Album
-from picard.cluster import Cluster
+from picard.cluster import FileList
 from picard.const import MAX_COVERS_TO_STACK
 from picard.coverart.image import (
     CoverArtImage,
@@ -476,7 +476,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             album.enable_update_metadata_images(True)
             album.update_metadata_images()
             album.update(False)
-        elif isinstance(self.item, Cluster):
+        elif isinstance(self.item, FileList):
             cluster = self.item
             cluster.enable_update_metadata_images(False)
             set_image(cluster, coverartimage)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -61,7 +61,10 @@ from picard import (
     log,
 )
 from picard.album import Album
-from picard.cluster import Cluster
+from picard.cluster import (
+    Cluster,
+    FileList,
+)
 from picard.const import PROGRAM_UPDATE_LEVELS
 from picard.const.sys import IS_MACOS
 from picard.file import File
@@ -1188,6 +1191,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 orig_metadata = obj.orig_metadata
             elif obj.can_show_coverart:
                 metadata = obj.metadata
+        else:
+            # Create a temporary file list which allows changing cover art for all selected files
+            files = self.tagger.get_files_from_objects(objects)
+            obj = FileList(files)
+            metadata = obj.metadata
+            orig_metadata = obj.orig_metadata
 
         if new_selection:
             self.metadata_box.selection_dirty = True

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2017 Sambhav Kothari
-# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018, 2020 Philipp Wolfer
 # Copyright (C) 2019 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -139,7 +139,7 @@ def _update_state(obj, state):
 # TODO: use functools.singledispatch when py3 is supported
 def _get_state(obj):
     from picard.album import Album
-    from picard.cluster import Cluster
+    from picard.cluster import (Cluster, FileList)
     from picard.track import Track
 
     state = ImageListState()
@@ -157,6 +157,10 @@ def _get_state(obj):
     elif isinstance(obj, Cluster):
         state.sources = obj.files
         state.update_new_metadata = True
+    elif isinstance(obj, FileList):
+        state.sources = obj.files
+        state.update_new_metadata = True
+        state.update_orig_metadata = True
 
     return state
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1828
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a new class `FileList`, which acts kind of like a temporary ad-hoc cluster. In fact I have made it the parent of the `Cluster` class, as it shares some basic code.

The cover art box only can handle a single object. When multiple files are selected create a `FileList` object and use this for the cover art box.

This PR also optimized the event handling and avoids unnecessary signalling. Previously the coverart box caused many selection changes. For "use original coverart" it even relied on a roundtrip to update cover art on items -> items signal updates -> main window updates selection -> cover art box updates view. This is not needed, the cover art box can update right away. Indeed with > 100 files selected this made updating nearly impossible. With the changed signalling I had no issue updating the cover art of all 4k loaded files.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
I think the approach to let cover art box only handle a single item and have an item that can handle multi-selection is the right approach. We probably should extend this to the metadatabox, I can imagine this would simplify the handling there. Currently much of the complexity comes from the need to update the selection and gather data on many files. If we instead pass a new `FileList` item to metadatabox we could avoid much of the threading complexity involved in updating the file list.