### PR TITLE
PICARD-1992: Fix case only changes when renaming files

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -80,8 +80,8 @@ from picard.util import (
     tracknum_from_filename,
 )
 from picard.util.filenaming import (
-    fix_filename_casing,
     make_short_filename,
+    move_ensure_casing,
 )
 from picard.util.preservedtags import PreservedTags
 from picard.util.scripttofilename import script_to_filename_with_metadata
@@ -495,8 +495,7 @@ class File(QtCore.QObject, Item):
             i += 1
         new_filename = new_filename + ext
         log.debug("Moving file %r => %r", old_filename, new_filename)
-        shutil.move(old_filename, new_filename)
-        fix_filename_casing(new_filename)
+        move_ensure_casing(old_filename, new_filename)
         return new_filename
 
     def _save_images(self, dirname, metadata):

--- a/picard/file.py
+++ b/picard/file.py
@@ -79,7 +79,10 @@ from picard.util import (
     thread,
     tracknum_from_filename,
 )
-from picard.util.filenaming import make_short_filename
+from picard.util.filenaming import (
+    fix_filename_casing,
+    make_short_filename,
+)
 from picard.util.preservedtags import PreservedTags
 from picard.util.scripttofilename import script_to_filename_with_metadata
 from picard.util.tags import PRESERVED_TAGS
@@ -493,6 +496,7 @@ class File(QtCore.QObject, Item):
         new_filename = new_filename + ext
         log.debug("Moving file %r => %r", old_filename, new_filename)
         shutil.move(old_filename, new_filename)
+        fix_filename_casing(new_filename)
         return new_filename
 
     def _save_images(self, dirname, metadata):

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -3,3 +3,4 @@ discid==1.2.0
 markdown==3.2.2
 mutagen==1.45.1
 PyQt5==5.15.1
+pywin32==228

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mutagen>=1.37
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-Cocoa; sys_platform == 'darwin'
 PyQt5>=5.7.1
+pywin32; sys_platform == 'win32'

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -168,13 +168,15 @@ class FixFilenameCasingTest(PicardTestCase):
 
     @unittest.skipUnless(IS_WIN, "windows test")
     def test_fix_filename_casing(self):
+        import win32api
+
         with NamedTemporaryFile(prefix='foo') as f:
             created_name = f.name
             wanted_name = created_name.title()
             self.assertTrue(fix_filename_casing(wanted_name))
             self.assertEqual(
                 os.path.basename(wanted_name),
-                os.path.basename(os.path.realpath(created_name)))
+                os.path.basename(win32api.GetLongPathNameW(win32api.GetShortPathName(created_name))))
             self.assertFalse(fix_filename_casing(wanted_name))
 
     def test_fix_filename_casing_non_existant_file(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1991, PICARD-1992
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If a rename results only in the casing of file names changing this is not applied by a simple `shutil.move` or `os.rename` in some situations on case insensitive file systems. Specifically this never works for Linux when using case insensitive file systems (e.g. FAT32, ext4 with case-insensitivity enabled, CIFS share) and on Windows 10 for FAT32 and extFAT file systems.

See also the comparison on https://gist.github.com/phw/d30ffb94171c5ea3248691f951310d54

# Solution
IF a case-only change happens (file stays in same directory, file name changes only in casing) on a case insensitive file system (case sensitive file systems are not affected by design) and the OS is affected by this (macOS handles this correctly already on OS level)

THEN apply a workaround by renaming the file twice, first to a temporary name then to the final name.

The workaround for Windows and Linux is basically the same. For Windows I tried to optimize this, because it already works there for NTFS and nework shares. To avoid double renames especially on network shares the renaming is first attempted normally. Then the actual case of the file is checked and only if the renaming was unsuccessful (i.e. on FAT32 or extFAT) another double rename is performed.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

