### PR TITLE
PICARD-2005: Fix tags being shown as unchanged if multiple tracks are selected

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -519,9 +519,6 @@ class MetadataBox(QtWidgets.QTableWidget):
         tag_diff = TagDiff(max_length_diff=config.setting["ignore_track_duration_difference_under"])
         orig_tags = tag_diff.orig
         new_tags = tag_diff.new
-        # existing_tags are orig_tags that would not be overwritten by
-        # any new_tags, assuming clear_existing_tags is disabled.
-        existing_tags = set()
         tag_diff.objects = len(files)
 
         clear_existing_tags = config.setting["clear_existing_tags"]
@@ -535,9 +532,8 @@ class MetadataBox(QtWidgets.QTableWidget):
                 new_values = new_metadata.getall(name)
                 orig_values = orig_metadata.getall(name)
 
-                if not ((new_values and name not in existing_tags) or clear_existing_tags):
+                if not clear_existing_tags and not new_values:
                     new_values = list(orig_values or [""])
-                    existing_tags.add(name)
 
                 removed = name in new_metadata.deleted_tags
                 tag_diff.add(name, orig_values, new_values, True, removed)


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2005
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

IF multiple tracks have been selected where some have changes in existing tags but the first track being looked at has no changes because incoming metadata is empty,  
THEN the tag is being shown as unchanged.

If you take the example from PICARD-2005 and look at the code at https://github.com/metabrainz/picard/blob/master/picard/ui/metadatabox.py#L538 the following happens:

If the first file being considered is the one of track 2, the tag "lyrics_language" will have:

orig values `['Japanese']`  
new values `[]`

It then gets new values set to orig values, and the tag is added to `existing_tags`. This results in no change (both ori values and new values are the same).

The next track being looked at is track 1, then it will have

orig values `['Japanese']`  
new values `[jpn]`

This tag is clearly changed. But because the tag name is in `existing_tags` the if clause also triggers and it also gets new values set to orig values. Now there is no difference anymore and this counts as unchanged.

# Solution

Get rid of the `existing_tags` set.

@zas I suppose this was added for a reason, but looking at that I cannot imagine any use case this tried to solve. The condition seems clearly wrong. But we might miss something and introduce a different regression. Any ideas what this was for?

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
