### PR TITLE
PICARD-2007: Disable fingerprinting for MIDI files

### DIFF
--- a/picard/formats/midi.py
+++ b/picard/formats/midi.py
@@ -54,3 +54,6 @@ class MIDIFile(File):
     @classmethod
     def supports_tag(cls, name):
         return False
+
+    def can_analyze(self):
+        return False

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -798,9 +798,9 @@ class Tagger(QtWidgets.QApplication):
             return
         files = self.get_files_from_objects(objs)
         for file in files:
-            file.set_pending()
-            self._acoustid.analyze(file, partial(file._lookup_finished,
-                                                 File.LOOKUP_ACOUSTID))
+            if file.can_analyze():
+                file.set_pending()
+                self._acoustid.analyze(file, partial(file._lookup_finished, File.LOOKUP_ACOUSTID))
 
     def generate_fingerprints(self, objs):
         """Generate the fingerprints without matching the files."""


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Audio fingerprinting can by design not work on MIDI files. Disable the fingerprinting action for those files and avoid spawning fingerprinting processes if those files are part of a selection that can be fingerprinted.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2007
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Implement `MIDIFile.can_analyze`

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
