### PR TITLE
PICARD-2006: Optimize moving files to albums on load

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -151,6 +151,7 @@ class File(QtCore.QObject, Item):
 
         self.acoustid_fingerprint = None
         self.acoustid_length = 0
+        self.match_recordingid = None
 
     def __repr__(self):
         return '<%s %r>' % (type(self).__name__, self.base_filename)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -349,9 +349,8 @@ class Tagger(QtWidgets.QApplication):
     def move_file_to_track(self, file, albumid, recordingid):
         """Move `file` to recording `recordingid` on album `albumid`."""
         album = self.load_album(albumid)
-        album.run_when_loaded(partial(file.move, album.unmatched_files), always=True)
-        album.run_when_loaded(partial(album.match_files, [file],
-                                      recordingid=recordingid))
+        file.match_recordingid = recordingid
+        album.match_files([file])
 
     def create_nats(self):
         if self.nats is None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2006, PICARD-2012
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When files gets loaded that are already matched to a release, the files are not added to the release until after the album is fully loaded. This was changed in https://github.com/metabrainz/picard/commit/fac2b37d8cf8dad8e821de541b9c40ee2ae0a0b8 .

This causes various issues:

- The files are not available to plugins or cover art providers that run during the loading of the release. See PICARD-2006
- In case of a MBID redirect, where the redirect target is already loaded, Picard attempts to move unmatched files to the already loaded release. This broke with the above commit, causing the files to being still loaded without being visible in the UI. PICARD-2012
- The files are not visible in the UI until after loading has finished.


# Solution
Basically revert https://github.com/metabrainz/picard/commit/fac2b37d8cf8dad8e821de541b9c40ee2ae0a0b8 and add files to albums right away. This ensures files of an album are available to plugins and cover art
providers during loading.

But refactor `Album.match_files` to optimize this a bit. If the album is already loaded `Album.match_files`  will match directly as before. If the album is still loading it will add the files to `unmatched_files` instead. After loading has finished album already calls `self.match_files(self.unmatched_files.files)`, so this works.

This optimizes two cases:
- If a file gets moved to an already loaded release the unnecessary move to unmatched_files before matching is skipped
- If a file gets moved to a release during loading, `Album.match_files` is only called once after loading has finished. In the old implementation it would be called once in `Album._finalize_loading`  and then again once per pre-matched file as a after_load_callback.

During testing I did not observe any performance issues. https://github.com/metabrainz/picard/commit/fac2b37d8cf8dad8e821de541b9c40ee2ae0a0b8  was originally done as a performance improvement, but probably other optimizations have a bigger impact. My test of loading 4k files took the same amount of time (both just loading files and overall loading times) with this branch and master.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
`Album.run_when_loaded`  is with this change currently unused in Picard. But I kept it, I think it is a useful API for plugins.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
