### PR TITLE
Build with PyInstaller 4.1 and use latest Python 3.8.x for Windows builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -104,10 +104,10 @@ jobs:
       with:
         fetch-depth: 0  # Fetch entire history, needed for setting the build number
     - run: git fetch --depth=1 origin +refs/tags/release-*:refs/tags/release-*
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Setup Windows build environment
       run: |
         & .\scripts\package\win-setup.ps1 -DiscidVersion $Env:DISCID_VERSION -FpcalVersion $Env:FPCALC_VERSION

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,3 +1,3 @@
 Babel==2.6
-PyInstaller==4.0
+PyInstaller==4.1
 setuptools<45.0.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

PyInstaller 4.1 was released, allowing us to build with Python 3.8 or 3.9

# Solution

Build with PyInstaller 4.1 and use latest Python 3.8.x for Windows builds

**Why not use Python 3.9 for Windows?**

Python 3.9 dropped support for Windows 7. I actually tested building with Python 3.9 and the builds will indeed fail to start on Win 7. While I think we will at some point no longer support Windows 7 and I already would not be willing to make bigger compromises just to keep it alive, there is also no need to break compatibility without need.

**Why not use newer Python for macOS?**

For some reason not quite clear to me using any Python version later then 3.7.6 results in code signing errors and a resulting rejection of the notarization. At some point we need to solve this.