### PR TITLE
PICARD-2017: Fix crash when removing NATs

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -718,6 +718,8 @@ class Tagger(QtWidgets.QApplication):
         """Remove the specified non-album track."""
         log.debug("Removing %r", track)
         self.remove_files(self.get_files_from_objects([track]))
+        if not self.nats:
+            return
         self.nats.tracks.remove(track)
         if not self.nats.tracks:
             self.remove_album(self.nats)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2017
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When the non-album track "album" entry got removed just before a non-album track was also removed Picard would crash.

I actually could not intentionally reproduce this, but in theory it can happen. tagger.remove just goes over all selected objects to remove and calls the appropriate functions. If it would have both the non-album tracks "album" entry and the NATs themselves queued for deletion and deletes the album first, it would still call the remove_nat per file.

# Solution
Check for existence of self.nats
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
