### PR TITLE
Generate appdata for non-Linux platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -292,7 +292,7 @@ class picard_build(build):
                 'publisher': os.environ.get('PICARD_APPX_PUBLISHER', default_publisher),
                 'version': '.'.join([str(v) for v in store_version]),
             })
-        elif sys.platform == 'linux':
+        elif sys.platform not in ['darwin', 'haiku1', 'win32']:
             self.run_command('build_appdata')
         build.run(self)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
Generate appdata for non-Linux platforms.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Setup attempts to install the appdata for all platforms not darwin, haiku1, or win32, yet it is only generated for linux. This was introduced in [edfa273](https://github.com/metabrainz/picard/commit/edfa2733535b328ab7deeff6c7cf619642fd1319) and causes installation errors on platforms such as FreeBSD since the appdata was not previously generated. 
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Generate the appdata for the platforms that setup tries to install it on.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
