### PR TITLE
PICARD-2020: Handle multi-value musicbrainz_albumid/musicbrainz_recordingid on load

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -428,10 +428,12 @@ class Tagger(QtWidgets.QApplication):
             return
 
         if not config.setting["ignore_file_mbids"]:
-            recordingid = file.metadata['musicbrainz_recordingid']
+            recordingid = file.metadata.getall('musicbrainz_recordingid')
+            recordingid = recordingid[0] if recordingid else ''
             is_valid_recordingid = mbid_validate(recordingid)
 
-            albumid = file.metadata['musicbrainz_albumid']
+            albumid = file.metadata.getall('musicbrainz_albumid')
+            albumid = albumid[0] if albumid else ''
             is_valid_albumid = mbid_validate(albumid)
 
             if is_valid_albumid and is_valid_recordingid:


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2020
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If already tagged files are loaded into Picard, but the existing album or recording IDs are stored as multi-value (can be the same ID stored multiple times), then Picard will fail to detect the IDs and hence not load the album or NAT.

# Solution
if musicbrainz_albumid or musicbrainz_recordingid contain multiple values, use the first one to load the proper album / recording for already tagged files.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
