### PR TITLE
PICARD-2021: Ignore SameFileError when moving files

### DIFF
--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -465,4 +465,8 @@ def move_ensure_casing(source_path, target_path):
                 pass
             return
     # Just perform a normal move
-    shutil.move(source_path, target_path)
+    try:
+        shutil.move(source_path, target_path)
+    except shutil.SameFileError:
+        # Sometimes different paths refer to the same file (e.g. network path / local path on Windows)
+        pass


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Fixes errors when moving files from a network path to local path (or vice versa) on Windows, if both paths refer to the same file.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2021
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
See the detailed description in PICARD-2021


# Solution
Ignore SameFileError when moving files
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
