### PR TITLE
PICARD-2019: Fix os.path.isabs not detecting Windows share correctly

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -50,6 +50,7 @@ from picard.util import (
     decode_filename,
     encode_filename,
     imageinfo,
+    is_absolute_path,
 )
 from picard.util.scripttofilename import script_to_filename
 
@@ -291,7 +292,7 @@ class CoverArtImage:
         filename = script_to_filename(filename, metadata)
         if not filename:
             filename = "cover"
-        if not os.path.isabs(filename):
+        if not is_absolute_path(filename):
             filename = os.path.join(dirname, filename)
         return encode_filename(filename)
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -75,6 +75,7 @@ from picard.util import (
     emptydir,
     find_best_match,
     format_time,
+    is_absolute_path,
     samefile,
     thread,
     tracknum_from_filename,
@@ -461,7 +462,7 @@ class File(QtCore.QObject, Item):
             settings = config.setting
         if settings["move_files"]:
             new_dirname = settings["move_files_to"]
-            if not os.path.isabs(new_dirname):
+            if not is_absolute_path(new_dirname):
                 new_dirname = os.path.normpath(os.path.join(os.path.dirname(filename), new_dirname))
         else:
             new_dirname = os.path.dirname(filename)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -163,6 +163,13 @@ def normpath(path):
     return os.path.normpath(path)
 
 
+def is_absolute_path(path):
+    """Similar to os.path.isabs, but properly detects Windows shares as absolute paths
+    See https://bugs.python.org/issue22302
+    """
+    return os.path.isabs(path) or (IS_WIN and os.path.normpath(path).startswith("\\\\"))
+
+
 def samepath(path1, path2):
     return os.path.normcase(os.path.normpath(path1)) == os.path.normcase(os.path.normpath(path2))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,6 +41,7 @@ from picard.util import (
     extract_year_from_date,
     find_best_match,
     imageinfo,
+    is_absolute_path,
     limited_join,
     sort_by_similarity,
 )
@@ -263,6 +264,25 @@ class AlbumArtistFromPathTest(PicardTestCase):
         self.assertEqual(aafp(r'/artistx/albumy/the DVD 23 B/file.flac', '', ''), ('albumy', 'artistx'))
         self.assertEqual(aafp(r'/artistx/albumy/disc23/file.flac', '', ''), ('albumy', 'artistx'))
         self.assertNotEqual(aafp(r'/artistx/albumy/disc/file.flac', '', ''), ('albumy', 'artistx'))
+
+
+class IsAbsolutePathTest(PicardTestCase):
+
+    def test_is_absolute(self):
+        self.assertTrue(is_absolute_path('/foo/bar'))
+        self.assertFalse(is_absolute_path('foo/bar'))
+        self.assertFalse(is_absolute_path('./foo/bar'))
+        self.assertFalse(is_absolute_path('../foo/bar'))
+
+    @unittest.skipUnless(IS_WIN, "windows test")
+    def test_is_absolute_windows(self):
+        self.assertTrue(is_absolute_path('D:/foo/bar'))
+        self.assertTrue(is_absolute_path('D:\\foo\\bar'))
+        self.assertTrue(is_absolute_path('\\foo\\bar'))
+        # Paths to Windows shares
+        self.assertTrue(is_absolute_path('\\\\foo\\bar'))
+        self.assertTrue(is_absolute_path('\\\\foo\\bar\\'))
+        self.assertTrue(is_absolute_path('\\\\foo\\bar\\baz'))
 
 
 class ImageInfoTest(PicardTestCase):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Works around the issue that os.path.isabs detects a path like \\server\share not as absolute.
This can break file naming on Windows shares and result in recursive sub folders.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2019
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

One Windows a network share can be addressed like `\\server\share`. There can be additional sub directories under this share, e.g.  `\\server\share\foo`. Likewise there can be `\\server\share\` which uses the top level dir of this share. This is semantically the same as `\\server\share`. But Python's os.path.isabs detects `\\server\share` (without any dir) as a relative path.

This caused creation of recursive directory structures on repetitive saves of files, if the target dir was set to `\\server\share`.

See also https://bugs.python.org/issue22302

# Solution

Implement `picard.util.is_absolute_path`, which calls `os.path.isabs` but has special handling for the above bug.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

