### PR TITLE
PICARD-2028: Ignore selection changes when clustering or removing files

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -743,6 +743,7 @@ class Tagger(QtWidgets.QApplication):
     def remove(self, objects):
         """Remove the specified objects."""
         files = []
+        self.window.ignore_selection_changes = True
         for obj in objects:
             if isinstance(obj, File):
                 files.append(obj)
@@ -766,6 +767,8 @@ class Tagger(QtWidgets.QApplication):
                 self.remove_cluster(obj)
         if files:
             self.remove_files(files)
+        self.window.ignore_selection_changes = False
+        self.window.update_selection()
 
     def _lookup_disc(self, disc, result=None, error=None):
         self.restore_cursor()
@@ -840,6 +843,7 @@ class Tagger(QtWidgets.QApplication):
         else:
             files = self.get_files_from_objects(objs)
 
+        self.window.ignore_selection_changes = True
         self.window.set_sorting(False)
         cluster_files = defaultdict(list)
         for name, artist, files in Cluster.cluster(files, 1.0, self):
@@ -848,6 +852,8 @@ class Tagger(QtWidgets.QApplication):
         for cluster, files in process_events_iter(cluster_files.items()):
             cluster.add_files(files)
         self.window.set_sorting(True)
+        self.window.ignore_selection_changes = False
+        self.window.update_selection()
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -743,32 +743,30 @@ class Tagger(QtWidgets.QApplication):
     def remove(self, objects):
         """Remove the specified objects."""
         files = []
-        self.window.ignore_selection_changes = True
-        for obj in objects:
-            if isinstance(obj, File):
-                files.append(obj)
-            elif isinstance(obj, NonAlbumTrack):
-                self.remove_nat(obj)
-            elif isinstance(obj, Track):
-                files.extend(obj.linked_files)
-            elif isinstance(obj, Album):
-                self.window.set_statusbar_message(
-                    N_("Removing album %(id)s: %(artist)s - %(album)s"),
-                    {
-                        'id': obj.id,
-                        'artist': obj.metadata['albumartist'],
-                        'album': obj.metadata['album']
-                    }
-                )
-                self.remove_album(obj)
-            elif isinstance(obj, UnclusteredFiles):
-                files.extend(list(obj.files))
-            elif isinstance(obj, Cluster):
-                self.remove_cluster(obj)
-        if files:
-            self.remove_files(files)
-        self.window.ignore_selection_changes = False
-        self.window.update_selection()
+        with self.window.ignore_selection_changes:
+            for obj in objects:
+                if isinstance(obj, File):
+                    files.append(obj)
+                elif isinstance(obj, NonAlbumTrack):
+                    self.remove_nat(obj)
+                elif isinstance(obj, Track):
+                    files.extend(obj.linked_files)
+                elif isinstance(obj, Album):
+                    self.window.set_statusbar_message(
+                        N_("Removing album %(id)s: %(artist)s - %(album)s"),
+                        {
+                            'id': obj.id,
+                            'artist': obj.metadata['albumartist'],
+                            'album': obj.metadata['album']
+                        }
+                    )
+                    self.remove_album(obj)
+                elif isinstance(obj, UnclusteredFiles):
+                    files.extend(list(obj.files))
+                elif isinstance(obj, Cluster):
+                    self.remove_cluster(obj)
+            if files:
+                self.remove_files(files)
 
     def _lookup_disc(self, disc, result=None, error=None):
         self.restore_cursor()
@@ -843,17 +841,15 @@ class Tagger(QtWidgets.QApplication):
         else:
             files = self.get_files_from_objects(objs)
 
-        self.window.ignore_selection_changes = True
-        self.window.set_sorting(False)
-        cluster_files = defaultdict(list)
-        for name, artist, files in Cluster.cluster(files, 1.0, self):
-            cluster = self.load_cluster(name, artist)
-            cluster_files[cluster].extend(files)
-        for cluster, files in process_events_iter(cluster_files.items()):
-            cluster.add_files(files)
-        self.window.set_sorting(True)
-        self.window.ignore_selection_changes = False
-        self.window.update_selection()
+        with self.window.ignore_selection_changes:
+            self.window.set_sorting(False)
+            cluster_files = defaultdict(list)
+            for name, artist, files in Cluster.cluster(files, 1.0, self):
+                cluster = self.load_cluster(name, artist)
+                cluster_files[cluster].extend(files)
+            for cluster, files in process_events_iter(cluster_files.items()):
+                cluster.add_files(files)
+            self.window.set_sorting(True)
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -286,14 +286,12 @@ class EditTagDialog(PicardDialog):
                                              list(self.metadata_box.tag_diff.new[self.tag]) or [""])
 
     def accept(self):
-        self.window.ignore_selection_changes = True
-        for tag, values in self.modified_tags.items():
-            self.modified_tags[tag] = [v for v in values if v]
-        modified_tags = self.modified_tags.items()
-        for obj in self.metadata_box.objects:
-            for tag, values in modified_tags:
-                obj.metadata[tag] = list(values)
-            obj.update()
-        self.window.ignore_selection_changes = False
-        self.window.update_selection()
+        with self.window.ignore_selection_changes:
+            for tag, values in self.modified_tags.items():
+                self.modified_tags[tag] = [v for v in values if v]
+            modified_tags = self.modified_tags.items()
+            for obj in self.metadata_box.objects:
+                for tag, values in modified_tags:
+                    obj.metadata[tag] = list(values)
+                obj.update()
         super().accept()

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -122,6 +122,24 @@ def register_ui_init(function):
     ui_init.register(function.__module__, function)
 
 
+class IgnoreSelectionContext:
+
+    def __init__(self, onexit=None):
+        self._ignore = False
+        self._onexit = onexit
+
+    def __enter__(self):
+        self._ignore = True
+
+    def __exit__(self, type, value, tb):
+        self._ignore = False
+        if self._onexit:
+            self._onexit()
+
+    def __bool__(self):
+        return self._ignore
+
+
 class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     defaultsize = QtCore.QSize(780, 560)
@@ -143,7 +161,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def __init__(self, parent=None, disable_player=False):
         super().__init__(parent)
         self.selected_objects = []
-        self.ignore_selection_changes = False
+        self.ignore_selection_changes = IgnoreSelectionContext(self.update_selection)
         self.toolbar = None
         self.player = None
         self.status_indicators = []

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -123,21 +123,32 @@ def register_ui_init(function):
 
 
 class IgnoreSelectionContext:
+    """Context manager for holding a boolean value, indicating whether selection changes are performed or not.
+    By default the context resolves to False. If entered it is True. This allows
+    to temporarily set a state on a block of code like:
+
+        ignore_changes = IgnoreSelectionContext()
+        # Initially ignore_changes is True
+        with ignore_changes:
+            # Perform some tasks with ignore_changes now being True
+            ...
+        # ignore_changes is False again
+    """
 
     def __init__(self, onexit=None):
-        self._ignore = False
+        self._entered = 0
         self._onexit = onexit
 
     def __enter__(self):
-        self._ignore = True
+        self._entered += 1
 
     def __exit__(self, type, value, tb):
-        self._ignore = False
+        self._entered -= 1
         if self._onexit:
             self._onexit()
 
     def __bool__(self):
-        return self._ignore
+        return self._entered > 0
 
 
 class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -435,18 +435,17 @@ class MetadataBox(QtWidgets.QTableWidget):
     def set_tag_values(self, tag, values, objects=None):
         if objects is None:
             objects = self.objects
-        self.parent.ignore_selection_changes = True
-        if values == [""]:
-            values = []
-        if not values and self.tag_is_removable(tag):
-            for obj in objects:
-                del obj.metadata[tag]
-                obj.update()
-        elif values:
-            for obj in objects:
-                obj.metadata[tag] = values
-                obj.update()
-        self.parent.ignore_selection_changes = False
+        with self.window.ignore_selection_changes:
+            if values == [""]:
+                values = []
+            if not values and self.tag_is_removable(tag):
+                for obj in objects:
+                    del obj.metadata[tag]
+                    obj.update()
+            elif values:
+                for obj in objects:
+                    obj.metadata[tag] = values
+                    obj.update()
 
     def remove_tag(self, tag):
         self.set_tag_values(tag, [])

--- a/test/test_ui_mainwindow.py
+++ b/test/test_ui_mainwindow.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from unittest.mock import Mock
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.mainwindow import IgnoreSelectionContext
+
+
+class IgnoreSelectionContextTest(PicardTestCase):
+
+    def test_enter_exit(self):
+        context = IgnoreSelectionContext()
+        self.assertFalse(context)
+        with context:
+            self.assertTrue(context)
+        self.assertFalse(context)
+
+    def test_run_onexit(self):
+        onexit = Mock()
+        context = IgnoreSelectionContext(onexit=onexit)
+        with context:
+            onexit.assert_not_called()
+        onexit.assert_called_once()
+
+    def test_nested_with(self):
+        context = IgnoreSelectionContext()
+        with context:
+            with context:
+                self.assertTrue(context)
+            self.assertTrue(context)
+        self.assertFalse(context)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2028
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Removing or clustering files calls MainWindow.update_selection a lot. This can cause a significant slow down if many files are selected.


# Solution
Call MainWindow.update_selection only once after the deletion / clustering is completed.

Also refactored MainWindow.ignore_selection_changes to use a context manager, so one can do:

```python
with window.ignore_selection_changes:
   # perform some action
   # window.update_selection will automatically be called when the context manager exits
```
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
The main cause why the many calls to update_selection caused such a significant slowdown in PICARD-2028 is actually the cover art for multiple selected files feature. While this performs well for the case that the user selects a huge amount of files it is still significantly slow that repated update_selection calls will greatly harm the performance.

I am in parallel working on optimizations for this part only, as there might be other places in code where this has a negative effect. But the fixes here already have the effect that the performance of removing all selected files is basically equivalent to how it was in Picard 2.5.1