### PR TITLE
PICARD-2035: Improve the tooltip on Album errors

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -976,7 +976,7 @@ class AlbumItem(TreeItem):
                     item.update(update_album=False)
         if album.errors:
             self.setIcon(MainPanel.TITLE_COLUMN, AlbumItem.icon_error)
-            self.setToolTip(MainPanel.TITLE_COLUMN, _("Error"))
+            self.setToolTip(MainPanel.TITLE_COLUMN, _("Processing error(s): See the Errors tab in the Album Info popup"))
         elif album.is_complete():
             if album.is_modified():
                 self.setIcon(MainPanel.TITLE_COLUMN, AlbumItem.icon_cd_saved_modified)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -976,7 +976,7 @@ class AlbumItem(TreeItem):
                     item.update(update_album=False)
         if album.errors:
             self.setIcon(MainPanel.TITLE_COLUMN, AlbumItem.icon_error)
-            self.setToolTip(MainPanel.TITLE_COLUMN, _("Processing error(s): See the Errors tab in the Album Info popup"))
+            self.setToolTip(MainPanel.TITLE_COLUMN, _("Processing error(s): See the Errors tab in the Album Info dialog"))
         elif album.is_complete():
             if album.is_modified():
                 self.setIcon(MainPanel.TITLE_COLUMN, AlbumItem.icon_cd_saved_modified)


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other

Improves the tooltip when a processing error (like a CAA retrieval failure) causes the Album icon to indicate an error.

# Problem

I was getting albums with an error icon. I tracked this down to a failure to retrieve CAA covers.
 
* JIRA ticket (_optional_): PICARD-2033, PICARD-2035

# Solution

Provide a better tooltip.