### PR TITLE
PICARD-2037: Make Info/Errors tab more readable

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -357,7 +357,7 @@ class AlbumInfoDialog(InfoDialog):
         tab_index = tabWidget.indexOf(tab)
         if album.errors:
             tabWidget.setTabText(tab_index, _("&Errors"))
-            text = '<br />'.join(map(lambda s: '<font color="darkred">%s</font>' %
+            text = '<br />'.join(map(lambda s: '<font color="red">%s</font>' %
                                      '<br />'.join(htmlescape(str(s))
                                                    .replace('\t', ' ')
                                                    .replace(' ', '&nbsp;')

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -364,7 +364,7 @@ class AlbumInfoDialog(InfoDialog):
                                                    .replace('\t', ' ')
                                                    .replace(' ', '&nbsp;')
                                                    .splitlines()
-                                                   )), 
+                                                   )),
                                      album.errors)
                                  )
             self.ui.info.setText(text + '<hr />')

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -58,7 +58,7 @@ from picard.util import (
 from picard.ui import PicardDialog
 from picard.ui.ui_infodialog import Ui_InfoDialog
 from picard.ui.util import StandardButton
-from picard.ui.colors import get_color
+from picard.ui.colors import interface_colors
 
 
 class ArtworkCoverWidget(QtWidgets.QWidget):
@@ -358,7 +358,7 @@ class AlbumInfoDialog(InfoDialog):
         tab_index = tabWidget.indexOf(tab)
         if album.errors:
             tabWidget.setTabText(tab_index, _("&Errors"))
-            color = get_color("log_error")
+            color = interface_colors.get_color("log_error")
             text = '<br />'.join(map(lambda s: '<font color="%s">%s</font>' %
                                      (color, '<br />'.join(htmlescape(str(s))
                                                    .replace('\t', ' ')

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -364,7 +364,7 @@ class AlbumInfoDialog(InfoDialog):
                                                    .replace('\t', ' ')
                                                    .replace(' ', '&nbsp;')
                                                    .splitlines()
-                                      )),
+                                     )),
                                      album.errors)
                                  )
             self.ui.info.setText(text + '<hr />')

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -58,6 +58,7 @@ from picard.util import (
 from picard.ui import PicardDialog
 from picard.ui.ui_infodialog import Ui_InfoDialog
 from picard.ui.util import StandardButton
+from picard.ui.colors import get_color
 
 
 class ArtworkCoverWidget(QtWidgets.QWidget):
@@ -357,12 +358,14 @@ class AlbumInfoDialog(InfoDialog):
         tab_index = tabWidget.indexOf(tab)
         if album.errors:
             tabWidget.setTabText(tab_index, _("&Errors"))
-            text = '<br />'.join(map(lambda s: '<font color="red">%s</font>' %
-                                     '<br />'.join(htmlescape(str(s))
+            color = get_color("log_error")
+            text = '<br />'.join(map(lambda s: '<font color="%s">%s</font>' %
+                                     (color, '<br />'.join(htmlescape(str(s))
                                                    .replace('\t', ' ')
                                                    .replace(' ', '&nbsp;')
                                                    .splitlines()
-                                                   ), album.errors)
+                                                   )), 
+                                     album.errors)
                                  )
             self.ui.info.setText(text + '<hr />')
         else:

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -364,7 +364,7 @@ class AlbumInfoDialog(InfoDialog):
                                                    .replace('\t', ' ')
                                                    .replace(' ', '&nbsp;')
                                                    .splitlines()
-                                                   )),
+                                      )),
                                      album.errors)
                                  )
             self.ui.info.setText(text + '<hr />')


### PR DESCRIPTION
# Summary

On the Errors tab in the Info popup, text is dark red on a dark grey background which is not very readable. Switching to bright red.

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

On the Errors tab in the Info popup, text is dark red on a dark grey background which is not very readable. 

* JIRA ticket (_optional_): PICARD-2037

# Solution

Switching to log-error colour defined in Options/UI/Colours.
