### PR TITLE
PICARD-2028: Optimize and speedup coverart updates

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -403,6 +403,7 @@ class Album(DataObject, Item):
                     file.move(self.unmatched_files)
             self.metadata = self._new_metadata
             self.orig_metadata.copy(self.metadata)
+            self.orig_metadata.images.clear()
             self.tracks = self._new_tracks
             del self._new_metadata
             del self._new_tracks

--- a/picard/album.py
+++ b/picard/album.py
@@ -718,9 +718,9 @@ class Album(DataObject, Item):
         if not self.update_metadata_images_enabled:
             return
 
-        update_metadata_images(self)
-        self.update(False)
-        self.metadata_images_changed.emit()
+        if update_metadata_images(self):
+            self.update(False)
+            self.metadata_images_changed.emit()
 
     def keep_original_images(self):
         self.enable_update_metadata_images(False)

--- a/picard/album.py
+++ b/picard/album.py
@@ -168,7 +168,7 @@ class Album(DataObject, Item):
             if track_discids:
                 track.metadata['musicbrainz_discid'] = track_discids
                 track.update()
-                for file in track.linked_files:
+                for file in track.files:
                     file.metadata['musicbrainz_discid'] = track_discids
                     file.update()
 
@@ -399,7 +399,7 @@ class Album(DataObject, Item):
                 self._new_metadata.strip_whitespace()
 
             for track in self.tracks:
-                for file in list(track.linked_files):
+                for file in list(track.files):
                     file.move(self.unmatched_files)
             self.metadata = self._new_metadata
             self.orig_metadata.copy(self.metadata)
@@ -632,7 +632,7 @@ class Album(DataObject, Item):
     def is_modified(self):
         if self.tracks:
             for track in self.tracks:
-                for file in track.linked_files:
+                for file in track.files:
                     if not file.is_saved():
                         return True
         return False
@@ -640,7 +640,7 @@ class Album(DataObject, Item):
     def get_num_unsaved_files(self):
         count = 0
         for track in self.tracks:
-            for file in track.linked_files:
+            for file in track.files:
                 if not file.is_saved():
                     count += 1
         return count
@@ -746,7 +746,7 @@ class NatAlbum(Album):
         for track in self.tracks:
             if old_album_title == track.metadata["album"]:
                 track.metadata["album"] = self.metadata["album"]
-            for file in track.linked_files:
+            for file in track.files:
                 track.update_file_metadata(file)
         self.enable_update_metadata_images(True)
         super().update(update_tracks)

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -102,8 +102,8 @@ class FileList(QtCore.QObject, Item):
 
     def update_metadata_images(self):
         if self.update_metadata_images_enabled and self.can_show_coverart:
-            update_metadata_images(self)
-            self.metadata_images_changed.emit()
+            if update_metadata_images(self):
+                self.metadata_images_changed.emit()
 
     def keep_original_images(self):
         self.enable_update_metadata_images(False)
@@ -378,13 +378,6 @@ class Cluster(FileList):
                 artist_name = artist_cluster_engine.get_cluster_title(artist_id)
 
             yield album_name, artist_name, (files[i] for i in album)
-
-    def enable_update_metadata_images(self, enabled):
-        self.update_metadata_images_enabled = enabled
-
-    def update_metadata_images(self):
-        if self.update_metadata_images_enabled and self.can_show_coverart:
-            update_metadata_images(self)
 
 
 class UnclusteredFiles(Cluster):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -72,6 +72,8 @@ from picard.ui.item import Item
 
 class FileList(QtCore.QObject, Item):
 
+    metadata_images_changed = QtCore.pyqtSignal()
+
     def __init__(self, files=None):
         QtCore.QObject.__init__(self)
         self.metadata = Metadata()
@@ -81,7 +83,8 @@ class FileList(QtCore.QObject, Item):
         for file in self.files:
             if self.can_show_coverart:
                 file.metadata_images_changed.connect(self.update_metadata_images)
-        update_metadata_images(self)
+        if self.files:
+            update_metadata_images(self)
 
     def iterfiles(self, save=False):
         for file in self.files:
@@ -100,6 +103,7 @@ class FileList(QtCore.QObject, Item):
     def update_metadata_images(self):
         if self.update_metadata_images_enabled and self.can_show_coverart:
             update_metadata_images(self)
+            self.metadata_images_changed.emit()
 
     def keep_original_images(self):
         self.enable_update_metadata_images(False)

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -67,19 +67,21 @@ from picard.util.imagelist import (
 )
 from picard.util.progresscheckpoints import ProgressCheckpoints
 
-from picard.ui.item import Item
+from picard.ui.item import (
+    FileListItem,
+    Item,
+)
 
 
-class FileList(QtCore.QObject, Item):
+class FileList(QtCore.QObject, FileListItem):
 
     metadata_images_changed = QtCore.pyqtSignal()
 
     def __init__(self, files=None):
         QtCore.QObject.__init__(self)
+        FileListItem.__init__(self, files)
         self.metadata = Metadata()
         self.orig_metadata = Metadata()
-        self.files = files or []
-        self.update_metadata_images_enabled = True
         for file in self.files:
             if self.can_show_coverart:
                 file.metadata_images_changed.connect(self.update_metadata_images)
@@ -96,21 +98,6 @@ class FileList(QtCore.QObject, Item):
     @property
     def can_show_coverart(self):
         return True
-
-    def enable_update_metadata_images(self, enabled):
-        self.update_metadata_images_enabled = enabled
-
-    def update_metadata_images(self):
-        if self.update_metadata_images_enabled and self.can_show_coverart:
-            if update_metadata_images(self):
-                self.metadata_images_changed.emit()
-
-    def keep_original_images(self):
-        self.enable_update_metadata_images(False)
-        for file in list(self.files):
-            file.keep_original_images()
-        self.enable_update_metadata_images(True)
-        self.update_metadata_images()
 
 
 class Cluster(FileList):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -750,7 +750,7 @@ class Tagger(QtWidgets.QApplication):
                 elif isinstance(obj, NonAlbumTrack):
                     self.remove_nat(obj)
                 elif isinstance(obj, Track):
-                    files.extend(obj.linked_files)
+                    files.extend(obj.files)
                 elif isinstance(obj, Album):
                     self.window.set_statusbar_message(
                         N_("Removing album %(id)s: %(artist)s - %(album)s"),

--- a/picard/track.py
+++ b/picard/track.py
@@ -48,6 +48,7 @@ from picard import (
     config,
     log,
 )
+from picard.cluster import FileList
 from picard.const import (
     DATA_TRACK_TITLE,
     SILENCE_TRACK_TITLE,
@@ -73,11 +74,8 @@ from picard.util.imagelist import (
     ImageList,
     add_metadata_images,
     remove_metadata_images,
-    update_metadata_images,
 )
 from picard.util.textencoding import asciipunct
-
-from picard.ui.item import Item
 
 
 _TRANSLATE_TAGS = {
@@ -137,39 +135,42 @@ class TrackArtist(DataObject):
         super().__init__(ta_id)
 
 
-class Track(DataObject, Item):
+class Track(DataObject, FileList):
 
     metadata_images_changed = QtCore.pyqtSignal()
 
     def __init__(self, track_id, album=None):
         DataObject.__init__(self, track_id)
+        FileList.__init__(self)
         self.album = album
-        self.linked_files = []
         self.num_linked_files = 0
-        self.metadata = Metadata()
-        self.orig_metadata = Metadata()
         self.scripted_metadata = Metadata()
         self._track_artists = []
 
     def __repr__(self):
         return '<Track %s %r>' % (self.id, self.metadata["title"])
 
+    @property
+    def linked_files(self):
+        """For backward compatibility with old code in plugins"""
+        return self.files
+
     def add_file(self, file):
-        if file not in self.linked_files:
+        if file not in self.files:
             track_will_expand = self.num_linked_files == 1
-            self.linked_files.append(file)
+            self.files.append(file)
             self.num_linked_files += 1
         self.update_file_metadata(file)
         add_metadata_images(self, [file])
         self.album._add_file(self, file)
-        file.metadata_images_changed.connect(self.update_orig_metadata_images)
+        file.metadata_images_changed.connect(self.update_metadata_images)
         run_file_post_addition_to_track_processors(self, file)
         if track_will_expand:
             # Files get expanded, ensure the existing item renders correctly
-            self.linked_files[0].update_item()
+            self.files[0].update_item()
 
     def update_file_metadata(self, file):
-        if file not in self.linked_files:
+        if file not in self.files:
             return
         # Run the scripts for the file to allow usage of
         # file specific metadata and variables
@@ -191,12 +192,12 @@ class Track(DataObject, Item):
         self.update()
 
     def remove_file(self, file):
-        if file not in self.linked_files:
+        if file not in self.files:
             return
-        self.linked_files.remove(file)
+        self.files.remove(file)
         self.num_linked_files -= 1
         file.copy_metadata(file.orig_metadata, preserve_deleted=False)
-        file.metadata_images_changed.disconnect(self.update_orig_metadata_images)
+        file.metadata_images_changed.disconnect(self.update_metadata_images)
         self.album._remove_file(self, file)
         remove_metadata_images(self, [file])
         run_file_post_removal_from_track_processors(self, file)
@@ -218,23 +219,19 @@ class Track(DataObject, Item):
         if self.item:
             self.item.update()
 
-    def iterfiles(self, save=False):
-        for file in self.linked_files:
-            yield file
-
     def is_linked(self):
         return self.num_linked_files > 0
 
     def can_save(self):
         """Return if this object can be saved."""
-        for file in self.linked_files:
+        for file in self.files:
             if file.can_save():
                 return True
         return False
 
     def can_remove(self):
         """Return if this object can be removed."""
-        for file in self.linked_files:
+        for file in self.files:
             if file.can_remove():
                 return True
         return False
@@ -254,7 +251,7 @@ class Track(DataObject, Item):
         elif column in m:
             return m[column]
         elif self.num_linked_files == 1:
-            return self.linked_files[0].column(column)
+            return self.files[0].column(column)
 
     def is_video(self):
         return self.metadata['~video'] == '1'
@@ -348,15 +345,9 @@ class Track(DataObject, Item):
             genre = [join_genres.join(genre)]
         self.metadata['genre'] = genre
 
-    def update_orig_metadata_images(self):
-        update_metadata_images(self)
-        self.metadata_images_changed.emit()
-
     def keep_original_images(self):
-        for file in self.linked_files:
-            file.keep_original_images()
-        self.update_orig_metadata_images()
-        if self.linked_files:
+        super().keep_original_images()
+        if self.files:
             self.metadata.images = self.orig_metadata.images.copy()
         else:
             self.metadata.images = ImageList()
@@ -411,7 +402,7 @@ class NonAlbumTrack(Track):
             return
         try:
             self._parse_recording(recording)
-            for file in self.linked_files:
+            for file in self.files:
                 self.update_file_metadata(file)
         except Exception:
             self._set_error(traceback.format_exc())

--- a/picard/track.py
+++ b/picard/track.py
@@ -48,7 +48,6 @@ from picard import (
     config,
     log,
 )
-from picard.cluster import FileList
 from picard.const import (
     DATA_TRACK_TITLE,
     SILENCE_TRACK_TITLE,
@@ -75,6 +74,8 @@ from picard.util.imagelist import (
     remove_metadata_images,
 )
 from picard.util.textencoding import asciipunct
+
+from picard.ui.item import FileListItem
 
 
 _TRANSLATE_TAGS = {
@@ -134,13 +135,15 @@ class TrackArtist(DataObject):
         super().__init__(ta_id)
 
 
-class Track(DataObject, FileList):
+class Track(DataObject, FileListItem):
 
     metadata_images_changed = QtCore.pyqtSignal()
 
     def __init__(self, track_id, album=None):
         DataObject.__init__(self, track_id)
-        FileList.__init__(self)
+        FileListItem.__init__(self)
+        self.metadata = Metadata()
+        self.orig_metadata = Metadata()
         self.album = album
         self.num_linked_files = 0
         self.scripted_metadata = Metadata()

--- a/picard/track.py
+++ b/picard/track.py
@@ -350,6 +350,7 @@ class Track(DataObject, Item):
 
     def update_orig_metadata_images(self):
         update_metadata_images(self)
+        self.metadata_images_changed.emit()
 
     def keep_original_images(self):
         for file in self.linked_files:

--- a/picard/track.py
+++ b/picard/track.py
@@ -71,7 +71,6 @@ from picard.script import (
     enabled_tagger_scripts_texts,
 )
 from picard.util.imagelist import (
-    ImageList,
     add_metadata_images,
     remove_metadata_images,
 )
@@ -344,13 +343,6 @@ class Track(DataObject, FileList):
         if join_genres:
             genre = [join_genres.join(genre)]
         self.metadata['genre'] = genre
-
-    def keep_original_images(self):
-        super().keep_original_images()
-        if self.files:
-            self.metadata.images = self.orig_metadata.images.copy()
-        else:
-            self.metadata.images = ImageList()
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -196,8 +196,8 @@ class Track(DataObject, FileList):
             return
         self.files.remove(file)
         self.num_linked_files -= 1
-        file.copy_metadata(file.orig_metadata, preserve_deleted=False)
         file.metadata_images_changed.disconnect(self.update_metadata_images)
+        file.copy_metadata(file.orig_metadata, preserve_deleted=False)
         self.album._remove_file(self, file)
         remove_metadata_images(self, [file])
         run_file_post_removal_from_track_processors(self, file)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -55,7 +55,6 @@ from picard.coverart.image import (
     CoverArtImageError,
 )
 from picard.file import File
-from picard.track import Track
 from picard.util import imageinfo
 from picard.util.lrucache import LRUCache
 
@@ -488,29 +487,16 @@ class CoverArtBox(QtWidgets.QGroupBox):
             album.update_metadata_images()
             album.update(False)
         elif isinstance(self.item, FileList):
-            cluster = self.item
-            cluster.enable_update_metadata_images(False)
-            set_image(cluster, coverartimage)
-            for file in cluster.iterfiles():
+            filelist = self.item
+            filelist.enable_update_metadata_images(False)
+            set_image(filelist, coverartimage)
+            for file in filelist.iterfiles():
                 set_image(file, coverartimage)
                 file.metadata_images_changed.emit()
                 file.update(signal=False)
-            cluster.enable_update_metadata_images(True)
-            cluster.update_metadata_images()
-            cluster.update()
-        elif isinstance(self.item, Track):
-            track = self.item
-            track.album.enable_update_metadata_images(False)
-            set_image(track, coverartimage)
-            track.metadata_images_changed.emit()
-            for file in track.iterfiles():
-                set_image(file, coverartimage)
-                file.metadata_images_changed.emit()
-                file.update(signal=False)
-            track.album.enable_update_metadata_images(True)
-            track.album.update_metadata_images()
-            track.album.update(False)
-            track.update()
+            filelist.enable_update_metadata_images(True)
+            filelist.update_metadata_images()
+            filelist.update()
         elif isinstance(self.item, File):
             file = self.item
             set_image(file, coverartimage)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -48,10 +48,7 @@ from picard import (
     log,
 )
 from picard.album import Album
-from picard.cluster import (
-    Cluster,
-    FileList,
-)
+from picard.cluster import Cluster
 from picard.const import MAX_COVERS_TO_STACK
 from picard.coverart.image import (
     CoverArtImage,
@@ -62,6 +59,7 @@ from picard.track import Track
 from picard.util import imageinfo
 from picard.util.lrucache import LRUCache
 
+from picard.ui.item import FileListItem
 from picard.ui.widgets import ActiveLabel
 
 
@@ -502,7 +500,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 track.enable_update_metadata_images(True)
             album.enable_update_metadata_images(True)
             album.update(update_tracks=False)
-        elif isinstance(self.item, FileList):
+        elif isinstance(self.item, FileListItem):
             parents = set()
             filelist = self.item
             filelist.enable_update_metadata_images(False)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -376,7 +376,13 @@ class CoverArtBox(QtWidgets.QGroupBox):
             return
 
         metadata = self.item.metadata
-        orig_metadata = self.item.orig_metadata
+        orig_metadata = None
+        if isinstance(self.item, Track):
+            track = self.item
+            if track.num_linked_files == 1:
+                orig_metadata = track.files[0].orig_metadata
+        elif hasattr(self.item, 'orig_metadata'):
+            orig_metadata = self.item.orig_metadata
 
         if not metadata or not metadata.images:
             self.cover_art.set_metadata(orig_metadata)

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -399,7 +399,7 @@ class TrackInfoDialog(InfoDialog):
         tabWidget.setTabText(tab_index, _("&Info"))
         text = ngettext("%i file in this track", "%i files in this track",
                         track.num_linked_files) % track.num_linked_files
-        info_files = [format_file_info(file_) for file_ in track.linked_files]
+        info_files = [format_file_info(file_) for file_ in track.files]
         text += '<hr />' + '<hr />'.join(info_files)
         self.ui.info.setText(text)
 

--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -24,6 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from picard import log
+from picard.util.imagelist import update_metadata_images
 
 
 class Item(object):
@@ -97,3 +98,31 @@ class Item(object):
 
     def clear_errors(self):
         self._errors = []
+
+
+class FileListItem(Item):
+
+    def __init__(self, files=None):
+        super().__init__()
+        self.files = files or []
+        self.update_metadata_images_enabled = True
+
+    def iterfiles(self, save=False):
+        for file in self.files:
+            yield file
+
+    def enable_update_metadata_images(self, enabled):
+        self.update_metadata_images_enabled = enabled
+
+    def update_metadata_images(self):
+        if self.update_metadata_images_enabled and self.can_show_coverart:
+            if update_metadata_images(self):
+                self.metadata_images_changed.emit()
+
+    def keep_original_images(self):
+        self.enable_update_metadata_images(False)
+        for file in list(self.files):
+            if file.can_show_coverart:
+                file.keep_original_images()
+        self.enable_update_metadata_images(True)
+        self.update_metadata_images()

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1018,7 +1018,7 @@ class TrackItem(TreeItem):
     def update(self, update_album=True, update_files=True):
         track = self.obj
         if track.num_linked_files == 1:
-            file = track.linked_files[0]
+            file = track.files[0]
             file.item = self
             color = TrackItem.track_colors[file.state]
             bgcolor = get_match_color(file.similarity, TreeItem.base_color)
@@ -1053,14 +1053,14 @@ class TrackItem(TreeItem):
                     oldnum = newnum
                 for i in range(oldnum):  # update existing items
                     item = self.child(i)
-                    file = track.linked_files[i]
+                    file = track.files[i]
                     item.obj = file
                     file.item = item
                     item.update(update_track=False)
                 if newnum > oldnum:  # add new items
                     items = []
                     for i in range(newnum - 1, oldnum - 1, -1):
-                        item = FileItem(track.linked_files[i], False)
+                        item = FileItem(track.files[i], False)
                         item.update(update_track=False)
                         items.append(item)
                     self.addChildren(items)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1077,7 +1077,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def show_more_tracks(self):
         obj = self.selected_objects[0]
         if isinstance(obj, Track):
-            obj = obj.linked_files[0]
+            obj = obj.files[0]
         dialog = TrackSearchDialog(self)
         dialog.load_similar_tracks(obj)
         dialog.exec_()
@@ -1193,7 +1193,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 self.set_statusbar_message(msg, mparms, echo=None, history=None)
             elif isinstance(obj, Track):
                 if obj.num_linked_files == 1:
-                    file = obj.linked_files[0]
+                    file = obj.files[0]
                     if file.has_error():
                         msg = N_("%(filename)s (%(similarity)d%%) (error: %(error)s)")
                         mparms = {

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1168,8 +1168,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.update_actions()
 
-        metadata = None
-        orig_metadata = None
         obj = None
 
         # Clear any existing status bar messages
@@ -1181,8 +1179,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if len(objects) == 1:
             obj = list(objects)[0]
             if isinstance(obj, File):
-                metadata = obj.metadata
-                orig_metadata = obj.orig_metadata
                 if obj.state == obj.ERROR:
                     msg = N_("%(filename)s (error: %(error)s)")
                     mparms = {
@@ -1196,10 +1192,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                     }
                 self.set_statusbar_message(msg, mparms, echo=None, history=None)
             elif isinstance(obj, Track):
-                metadata = obj.metadata
                 if obj.num_linked_files == 1:
                     file = obj.linked_files[0]
-                    orig_metadata = file.orig_metadata
                     if file.has_error():
                         msg = N_("%(filename)s (%(similarity)d%%) (error: %(error)s)")
                         mparms = {
@@ -1215,22 +1209,15 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                         }
                     self.set_statusbar_message(msg, mparms, echo=None,
                                                history=None)
-            elif isinstance(obj, Album):
-                metadata = obj.metadata
-                orig_metadata = obj.orig_metadata
-            elif obj.can_show_coverart:
-                metadata = obj.metadata
-        else:
+        elif new_selection:
             # Create a temporary file list which allows changing cover art for all selected files
             files = self.tagger.get_files_from_objects(objects)
             obj = FileList(files)
-            metadata = obj.metadata
-            orig_metadata = obj.orig_metadata
 
         if new_selection:
             self.metadata_box.selection_dirty = True
+            self.cover_art_box.set_item(obj)
         self.metadata_box.update(drop_album_caches=drop_album_caches)
-        self.cover_art_box.set_metadata(metadata, orig_metadata, obj)
         self.selection_updated.emit(objects)
 
     def refresh_metadatabox(self):

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -395,7 +395,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                         track_albums = set()
                         for file in self.files:
                             objects = [file]
-                            if file.parent in self.tracks and len(self.files & set(file.parent.linked_files)) == 1:
+                            if file.parent in self.tracks and len(self.files & set(file.parent.files)) == 1:
                                 objects.append(file.parent)
                                 file_tracks.append(file.parent)
                                 track_albums.add(file.parent.album)
@@ -503,7 +503,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                 files.add(obj)
             elif isinstance(obj, Track):
                 tracks.add(obj)
-                files.update(obj.linked_files)
+                files.update(obj.files)
             elif isinstance(obj, Cluster) and obj.can_edit_tags():
                 objects.add(obj)
                 files.update(obj.files)
@@ -511,7 +511,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                 objects.add(obj)
                 tracks.update(obj.tracks)
                 for track in obj.tracks:
-                    files.update(track.linked_files)
+                    files.update(track.files)
         objects.update(files)
         objects.update(tracks)
         self.selection_dirty = False

--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -95,7 +95,7 @@ class RatingWidget(QtWidgets.QWidget):
         track = self._track
         rating = str(self._rating)
         track.metadata["~rating"] = rating
-        for file in track.linked_files:
+        for file in track.files:
             file.metadata["~rating"] = rating
         if config.setting["submit_ratings"]:
             ratings = {("recording", track.id): self._rating}

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -82,4 +82,4 @@ class ScriptsMenu(QtWidgets.QMenu):
                 yield from self._get_metadata_objects(obj.tracks)
                 yield from self._get_metadata_objects(obj.unmatched_files.iterfiles())
             if isinstance(obj, Track):
-                yield from self._get_metadata_objects(obj.linked_files)
+                yield from self._get_metadata_objects(obj.files)

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -160,7 +160,10 @@ def _get_state(obj):
         state.sources += obj.unmatched_files.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
-    elif isinstance(obj, FileList) or isinstance(obj, Track):
+    elif isinstance(obj, Track):
+        state.sources = obj.files
+        state.update_orig_metadata = True
+    elif isinstance(obj, FileList):
         state.sources = obj.files
         state.update_new_metadata = True
         state.update_orig_metadata = True

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -53,6 +53,8 @@ class ImageList(MutableSequence):
         return sorted(self, key=lambda image: image.normalized_types())
 
     def __eq__(self, other):
+        if len(self) != len(other):
+            return False
         return self._sorted() == other._sorted()
 
     def copy(self):
@@ -124,16 +126,23 @@ def _process_images(state, src_obj):
 
 
 def _update_state(obj, state):
+    changed = False
     for src_obj in state.sources:
         _process_images(state, src_obj)
 
     if state.update_new_metadata:
-        obj.metadata.images = ImageList(state.new_images)
+        updated_images = ImageList(state.new_images)
+        changed |= updated_images != obj.metadata.images
+        obj.metadata.images = updated_images
         obj.metadata.has_common_images = state.has_common_new_images
 
     if state.update_orig_metadata:
-        obj.orig_metadata.images = ImageList(state.orig_images)
+        updated_images = ImageList(state.orig_images)
+        changed |= updated_images != obj.orig_metadata.images
+        obj.orig_metadata.images = updated_images
         obj.orig_metadata.has_common_images = state.has_common_orig_images
+
+    return changed
 
 
 # TODO: use functools.singledispatch when py3 is supported
@@ -188,8 +197,10 @@ def update_metadata_images(obj):
 
     Args:
         obj: A `Cluster`, `Album` or `Track` object with `metadata` property
+    Returns:
+        bool: True, if images where changed, False otherwise
     """
-    _update_state(obj, _get_state(obj))
+    return _update_state(obj, _get_state(obj))
 
 
 def _add_images(metadata, added_images):

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -149,6 +149,7 @@ def _update_state(obj, state):
 def _get_state(obj):
     from picard.album import Album
     from picard.cluster import FileList
+    from picard.track import Track
 
     state = ImageListState()
 
@@ -159,7 +160,7 @@ def _get_state(obj):
         state.sources += obj.unmatched_files.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
-    elif isinstance(obj, FileList):
+    elif isinstance(obj, FileList) or isinstance(obj, Track):
         state.sources = obj.files
         state.update_new_metadata = True
         state.update_orig_metadata = True

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -148,8 +148,7 @@ def _update_state(obj, state):
 # TODO: use functools.singledispatch when py3 is supported
 def _get_state(obj):
     from picard.album import Album
-    from picard.cluster import (Cluster, FileList)
-    from picard.track import Track
+    from picard.cluster import FileList
 
     state = ImageListState()
 
@@ -160,12 +159,6 @@ def _get_state(obj):
         state.sources += obj.unmatched_files.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
-    elif isinstance(obj, Track):
-        state.sources = obj.files
-        state.update_orig_metadata = True
-    elif isinstance(obj, Cluster):
-        state.sources = obj.files
-        state.update_new_metadata = True
     elif isinstance(obj, FileList):
         state.sources = obj.files
         state.update_new_metadata = True

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -147,12 +147,12 @@ def _get_state(obj):
     if isinstance(obj, Album):
         for track in obj.tracks:
             state.sources.append(track)
-            state.sources += track.linked_files
+            state.sources += track.files
         state.sources += obj.unmatched_files.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
     elif isinstance(obj, Track):
-        state.sources = obj.linked_files
+        state.sources = obj.files
         state.update_orig_metadata = True
     elif isinstance(obj, Cluster):
         state.sources = obj.files

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -67,44 +67,44 @@ class UpdateMetadataImagesTest(PicardTestCase):
     def test_update_cluster_images(self):
         cluster = Cluster('Test')
         cluster.files = list(self.test_files)
-        update_metadata_images(cluster)
+        self.assertTrue(update_metadata_images(cluster))
         self.assertEqual(set(self.test_images), set(cluster.metadata.images))
         self.assertFalse(cluster.metadata.has_common_images)
 
         cluster.files.remove(self.test_files[2])
-        update_metadata_images(cluster)
+        self.assertFalse(update_metadata_images(cluster))
         self.assertEqual(set(self.test_images), set(cluster.metadata.images))
         self.assertFalse(cluster.metadata.has_common_images)
 
         cluster.files.remove(self.test_files[0])
-        update_metadata_images(cluster)
+        self.assertTrue(update_metadata_images(cluster))
         self.assertEqual(set(self.test_images[1:]), set(cluster.metadata.images))
         self.assertTrue(cluster.metadata.has_common_images)
 
         cluster.files.append(self.test_files[2])
-        update_metadata_images(cluster)
+        self.assertFalse(update_metadata_images(cluster))
         self.assertEqual(set(self.test_images[1:]), set(cluster.metadata.images))
         self.assertTrue(cluster.metadata.has_common_images)
 
     def test_update_track_images(self):
         track = Track('00000000-0000-0000-0000-000000000000')
         track.files = list(self.test_files)
-        update_metadata_images(track)
+        self.assertTrue(update_metadata_images(track))
         self.assertEqual(set(self.test_images), set(track.orig_metadata.images))
         self.assertFalse(track.orig_metadata.has_common_images)
 
         track.files.remove(self.test_files[2])
-        update_metadata_images(track)
+        self.assertFalse(update_metadata_images(track))
         self.assertEqual(set(self.test_images), set(track.orig_metadata.images))
         self.assertFalse(track.orig_metadata.has_common_images)
 
         track.files.remove(self.test_files[0])
-        update_metadata_images(track)
+        self.assertTrue(update_metadata_images(track))
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 
         track.files.append(self.test_files[2])
-        update_metadata_images(track)
+        self.assertFalse(update_metadata_images(track))
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 
@@ -116,23 +116,23 @@ class UpdateMetadataImagesTest(PicardTestCase):
         track2.files.append(self.test_files[1])
         album.tracks = [track1, track2]
         album.unmatched_files.files.append(self.test_files[2])
-        update_metadata_images(album)
+        self.assertTrue(update_metadata_images(album))
         self.assertEqual(set(self.test_images), set(album.orig_metadata.images))
         self.assertFalse(album.orig_metadata.has_common_images)
 
         album.tracks.remove(track2)
-        update_metadata_images(album)
+        self.assertFalse(update_metadata_images(album))
         self.assertEqual(set(self.test_images), set(album.orig_metadata.images))
         self.assertFalse(album.orig_metadata.has_common_images)
 
         # album.unmatched_files.files.remove(self.test_files[2])
         album.tracks.remove(track1)
-        update_metadata_images(album)
+        self.assertTrue(update_metadata_images(album))
         self.assertEqual(set(self.test_images[1:]), set(album.orig_metadata.images))
         self.assertTrue(album.orig_metadata.has_common_images)
 
         album.tracks.append(track2)
-        update_metadata_images(album)
+        self.assertFalse(update_metadata_images(album))
         self.assertEqual(set(self.test_images[1:]), set(album.orig_metadata.images))
         self.assertTrue(album.orig_metadata.has_common_images)
 

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -88,22 +88,22 @@ class UpdateMetadataImagesTest(PicardTestCase):
 
     def test_update_track_images(self):
         track = Track('00000000-0000-0000-0000-000000000000')
-        track.linked_files = list(self.test_files)
+        track.files = list(self.test_files)
         update_metadata_images(track)
         self.assertEqual(set(self.test_images), set(track.orig_metadata.images))
         self.assertFalse(track.orig_metadata.has_common_images)
 
-        track.linked_files.remove(self.test_files[2])
+        track.files.remove(self.test_files[2])
         update_metadata_images(track)
         self.assertEqual(set(self.test_images), set(track.orig_metadata.images))
         self.assertFalse(track.orig_metadata.has_common_images)
 
-        track.linked_files.remove(self.test_files[0])
+        track.files.remove(self.test_files[0])
         update_metadata_images(track)
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 
-        track.linked_files.append(self.test_files[2])
+        track.files.append(self.test_files[2])
         update_metadata_images(track)
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
@@ -111,9 +111,9 @@ class UpdateMetadataImagesTest(PicardTestCase):
     def test_update_album_images(self):
         album = Album('00000000-0000-0000-0000-000000000000')
         track1 = Track('00000000-0000-0000-0000-000000000001')
-        track1.linked_files.append(self.test_files[0])
+        track1.files.append(self.test_files[0])
         track2 = Track('00000000-0000-0000-0000-000000000002')
-        track2.linked_files.append(self.test_files[1])
+        track2.files.append(self.test_files[1])
         album.tracks = [track1, track2]
         album.unmatched_files.files.append(self.test_files[2])
         update_metadata_images(album)
@@ -171,27 +171,27 @@ class RemoveMetadataImagesTest(PicardTestCase):
 
     def test_remove_from_track(self):
         track = Track('00000000-0000-0000-0000-000000000000')
-        track.linked_files = list(self.test_files)
+        track.files = list(self.test_files)
         update_metadata_images(track)
-        track.linked_files.remove(self.test_files[0])
+        track.files.remove(self.test_files[0])
         remove_metadata_images(track, [self.test_files[0]])
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 
     def test_remove_from_track_with_common_images(self):
         track = Track('00000000-0000-0000-0000-000000000000')
-        track.linked_files = list(self.test_files[1:])
+        track.files = list(self.test_files[1:])
         update_metadata_images(track)
-        track.linked_files.remove(self.test_files[1])
+        track.files.remove(self.test_files[1])
         remove_metadata_images(track, [self.test_files[1]])
         self.assertEqual(set(self.test_images[1:]), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 
     def test_remove_from_empty_track(self):
         track = Track('00000000-0000-0000-0000-000000000000')
-        track.linked_files.append(File('test1.flac'))
+        track.files.append(File('test1.flac'))
         update_metadata_images(track)
-        remove_metadata_images(track, [track.linked_files[0]])
+        remove_metadata_images(track, [track.files[0]])
         self.assertEqual(set(), set(track.orig_metadata.images))
         self.assertTrue(track.orig_metadata.has_common_images)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2028
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Cover art updates are rather expensive. This can be even more problematic then before since support for setting cover art for multiple selected files in #1673.

This PR aims to optimize this by unifying the cover art handling across different object types and avoiding updates if they are not necessary.


# Solution

- Unify handling of cover art between the different object types `Album`, `Track`, `Cluster` and `File`. The API of those objects is now similar enough to remove special handling at many places
- Avoid calling updates to cover art box unless selection changed. The cover art box instead relies on signalling for the rare case where cover art changes for a loaded object
- Avoid signalling in cover art box when cover art is changed. This was already partly done in #1673, but is now more complete. Basically the cover art box knows it updated the album, it does not need signalling back from changed items to update its view
- In general avoid emitting `metadata_images_changed` unless necessary
- Fix how keep_existing_tags was handled. In current Picard setting keep_existing_tags on all files of an album does not properly update the track and hence also not the album

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
This is quite a list of changes. But it's all interconnected optimizations. If wanted I could split this up. The individual commits are already kind of separate changesets, with a working system after each commit. But they build upon one another.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
