### PR TITLE
PICARD-2016: Strip whitespace from AcoustID API key automatically

### DIFF
--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2011-2012 Lukáš Lalinský
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2013, 2018 Laurent Monin
-# Copyright (C) 2015 Philipp Wolfer
+# Copyright (C) 2015, 2020 Philipp Wolfer
 # Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
@@ -27,6 +27,7 @@ import os
 
 from PyQt5 import (
     QtCore,
+    QtGui,
     QtWidgets,
 )
 
@@ -43,6 +44,13 @@ from picard.ui.options import (
     register_options_page,
 )
 from picard.ui.ui_options_fingerprinting import Ui_FingerprintingOptionsPage
+
+
+class ApiKeyValidator(QtGui.QValidator):
+
+    def validate(self, input, pos):
+        # Strip whitespace to avoid typical copy and paste user errors
+        return (QtGui.QValidator.Acceptable, input.strip(), pos)
 
 
 class FingerprintingOptionsPage(OptionsPage):
@@ -72,6 +80,7 @@ class FingerprintingOptionsPage(OptionsPage):
         self.ui.acoustid_fpcalc_browse.clicked.connect(self.acoustid_fpcalc_browse)
         self.ui.acoustid_fpcalc_download.clicked.connect(self.acoustid_fpcalc_download)
         self.ui.acoustid_apikey_get.clicked.connect(self.acoustid_apikey_get)
+        self.ui.acoustid_apikey.setValidator(ApiKeyValidator())
 
     def load(self):
         if config.setting["fingerprinting_system"] == "acoustid":


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2016
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Automatically strip whitespace on entered AcoustID API keys. This avoids a typical user error when copy and pasting this key from elsewhere.

# Solution
Use a `QValidator` to fixup the input automatically
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
