### PR TITLE
Avoid update selection on save and album refresh

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -398,9 +398,7 @@ class Album(DataObject, Item):
                     log.exception("Failed to run tagger script %s on album", s_name)
                 self._new_metadata.strip_whitespace()
 
-            for track in self.tracks:
-                for file in list(track.files):
-                    file.move(self.unmatched_files)
+            unmatched_files = [file for track in self.tracks for file in track.files]
             self.metadata = self._new_metadata
             self.orig_metadata.copy(self.metadata)
             self.orig_metadata.images.clear()
@@ -409,7 +407,7 @@ class Album(DataObject, Item):
             del self._new_tracks
             self.loaded = True
             self.status = None
-            self.match_files(self.unmatched_files.files)
+            self.match_files(unmatched_files + self.unmatched_files.files)
             self.enable_update_metadata_images(True)
             self.update()
             self.tagger.window.set_statusbar_message(
@@ -474,7 +472,7 @@ class Album(DataObject, Item):
             self.release_group.genres.clear()
         self.metadata.clear()
         self.genres.clear()
-        self.update()
+        self.update(update_selection=False)
         self._new_metadata = Metadata()
         self._new_tracks = []
         self._requests = 1
@@ -508,9 +506,9 @@ class Album(DataObject, Item):
             self.tagger.webservice.remove_task(self.load_task)
             self.load_task = None
 
-    def update(self, update_tracks=True):
+    def update(self, update_tracks=True, update_selection=True):
         if self.item:
-            self.item.update(update_tracks)
+            self.item.update(update_tracks, update_selection=update_selection)
 
     def _add_file(self, track, file):
         self._files += 1

--- a/picard/file.py
+++ b/picard/file.py
@@ -577,11 +577,13 @@ class File(QtCore.QObject, Item):
             log.debug("Moving %r from %r to %r", self, self.parent, parent)
             self.clear_lookup_task()
             self.tagger._acoustid.stop_analyze(self)
+            update_album = True
             if self.parent:
+                update_album = self.parent.album != parent.album
                 self.clear_pending()
-                self.parent.remove_file(self)
+                self.parent.remove_file(self, update_album=update_album)
             self.parent = parent
-            self.parent.add_file(self)
+            self.parent.add_file(self, update_album=update_album)
             self.acoustid_update()
 
     def _move(self, parent):

--- a/picard/file.py
+++ b/picard/file.py
@@ -383,7 +383,7 @@ class File(QtCore.QObject, Item):
             for k, v in temp_info.items():
                 self.orig_metadata[k] = v
             self.clear_errors()
-            self.clear_pending()
+            self.clear_pending(signal=False)
             self._add_path_to_metadata(self.orig_metadata)
             if images_changed:
                 self.metadata_images_changed.emit()
@@ -821,16 +821,17 @@ class File(QtCore.QObject, Item):
     def set_pending(self):
         if self.state != File.REMOVED:
             self.state = File.PENDING
-            self.update_item()
+            self.update_item(update_selection=False)
 
-    def clear_pending(self):
+    def clear_pending(self, signal=True):
         if self.state == File.PENDING:
             self.state = File.NORMAL if self.similarity == 1.0 else File.CHANGED
-            self.update_item()
+            if signal:
+                self.update_item(update_selection=False)
 
-    def update_item(self):
+    def update_item(self, update_selection=True):
         if self.item:
-            self.item.update()
+            self.item.update(update_selection=update_selection)
 
     def iterfiles(self, save=False):
         yield self

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -755,7 +755,7 @@ _Since Picard 0.12_"""
 def func_matchedtracks(parser, *args):
     # only works in file naming scripts, always returns zero in tagging scripts
     file = parser.file
-    if file and file.parent and hasattr(file.parent, 'album'):
+    if file and file.parent and hasattr(file.parent, 'album') and file.parent.album:
         return str(parser.file.parent.album.get_num_matched_tracks())
     return "0"
 
@@ -769,7 +769,7 @@ Returns true if every track in the album is matched to a single file.
 def func_is_complete(parser):
     # only works in file naming scripts, always returns zero in tagging scripts
     file = parser.file
-    if (file and file.parent and hasattr(file.parent, 'album')
+    if (file and file.parent and hasattr(file.parent, 'album') and file.parent.album
             and file.parent.album.is_complete()):
         return "1"
     return ""

--- a/picard/track.py
+++ b/picard/track.py
@@ -157,14 +157,15 @@ class Track(DataObject, FileListItem):
         """For backward compatibility with old code in plugins"""
         return self.files
 
-    def add_file(self, file):
+    def add_file(self, file, update_album=True):
         if file not in self.files:
             track_will_expand = self.num_linked_files == 1
             self.files.append(file)
             self.num_linked_files += 1
         self.update_file_metadata(file)
         add_metadata_images(self, [file])
-        self.album._add_file(self, file)
+        if update_album:
+            self.album._add_file(self, file)
         file.metadata_images_changed.connect(self.update_metadata_images)
         run_file_post_addition_to_track_processors(self, file)
         if track_will_expand:
@@ -193,14 +194,15 @@ class Track(DataObject, FileListItem):
         file.update(signal=False)
         self.update()
 
-    def remove_file(self, file):
+    def remove_file(self, file, update_album=True):
         if file not in self.files:
             return
         self.files.remove(file)
         self.num_linked_files -= 1
         file.metadata_images_changed.disconnect(self.update_metadata_images)
         file.copy_metadata(file.orig_metadata, preserve_deleted=False)
-        self.album._remove_file(self, file)
+        if update_album:
+            self.album._remove_file(self, file)
         remove_metadata_images(self, [file])
         run_file_post_removal_from_track_processors(self, file)
         self.update()

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -911,13 +911,13 @@ class ClusterItem(TreeItem):
         super().__init__(*args)
         self.setIcon(MainPanel.TITLE_COLUMN, ClusterItem.icon_dir)
 
-    def update(self):
+    def update(self, update_selection=True):
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, self.obj.column(column[1]))
         album = self.obj.related_album
         if self.obj.special and album and album.loaded:
             album.item.update(update_tracks=False)
-        if self.isSelected():
+        if update_selection and self.isSelected():
             TreeItem.window.update_selection(new_selection=False)
 
     def add_file(self, file):
@@ -945,7 +945,7 @@ class ClusterItem(TreeItem):
 
 class AlbumItem(TreeItem):
 
-    def update(self, update_tracks=True):
+    def update(self, update_tracks=True, update_selection=True):
         album = self.obj
         selection_changed = self.isSelected()
         if update_tracks:
@@ -993,7 +993,7 @@ class AlbumItem(TreeItem):
                 self.setToolTip(MainPanel.TITLE_COLUMN, _("Album unchanged"))
         for i, column in enumerate(MainPanel.columns):
             self.setText(i, album.column(column[1]))
-        if selection_changed:
+        if selection_changed and update_selection:
             TreeItem.window.update_selection(new_selection=False)
         # Workaround for PICARD-1446: Expand/collapse indicator for the release
         # is briefly missing on Windows
@@ -1015,7 +1015,7 @@ class NatAlbumItem(AlbumItem):
 
 class TrackItem(TreeItem):
 
-    def update(self, update_album=True, update_files=True):
+    def update(self, update_album=True, update_files=True, update_selection=True):
         track = self.obj
         if track.num_linked_files == 1:
             file = track.files[0]
@@ -1061,7 +1061,7 @@ class TrackItem(TreeItem):
                     items = []
                     for i in range(newnum - 1, oldnum - 1, -1):
                         item = FileItem(track.files[i], False)
-                        item.update(update_track=False)
+                        item.update(update_track=False, update_selection=update_selection)
                         items.append(item)
                     self.addChildren(items)
             self.setExpanded(True)
@@ -1074,15 +1074,15 @@ class TrackItem(TreeItem):
             self.setText(i, track.column(column[1]))
             self.setForeground(i, color)
             self.setBackground(i, bgcolor)
-        if self.isSelected():
+        if update_selection and self.isSelected():
             TreeItem.window.update_selection(new_selection=False)
         if update_album:
-            self.parent().update(update_tracks=False)
+            self.parent().update(update_tracks=False, update_selection=update_selection)
 
 
 class FileItem(TreeItem):
 
-    def update(self, update_track=True):
+    def update(self, update_track=True, update_selection=True):
         file = self.obj
         self.setIcon(MainPanel.TITLE_COLUMN, FileItem.decide_file_icon(file))
         fingerprint_icon, fingerprint_tooltip = FileItem.decide_fingerprint_icon_info(file)
@@ -1096,11 +1096,11 @@ class FileItem(TreeItem):
             self.setBackground(i, bgcolor)
         if file.errors:
             self.setToolTip(MainPanel.TITLE_COLUMN, _("Processing error(s): See the Errors tab in the File Info dialog"))
-        if self.isSelected():
+        if update_selection and self.isSelected():
             TreeItem.window.update_selection(new_selection=False)
         parent = self.parent()
         if isinstance(parent, TrackItem) and update_track:
-            parent.update(update_files=False)
+            parent.update(update_files=False, update_selection=update_selection)
 
     @staticmethod
     def decide_file_icon(file):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On some operations Picard issues excessive calls to MainWindow.update_selection.

Saving a single file caused 3 calls to update_selection, even if nothing selection relevant changed. Refreshing an album with only 8 tracks and matched files for each even caused 66 calls to update_selection.

# Solution

Reduce the number of calls to update_selection by skipping unneeded ones (e.g. because .

For a file save it is now only a single update_selection per file.

Refreshing the album with 8 tracks is down to 17 calls /from 66). Still much, but way better. The calls where mostly caused by moving the files between tracks -> unmatched files -> matching to tracks again. The patch avoids moving the previously matched files to unmatched files first. Also moving a file between children of the same album now causes less updates.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
