### PR TITLE
Add a tagger.iter_files_from_objects method

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -73,6 +73,7 @@ from picard.plugin import ExtensionPoint
 from picard.track import Track
 from picard.util import (
     icontheme,
+    iter_files_from_objects,
     iter_unique,
     restore_method,
     thread,
@@ -1044,7 +1045,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return QtCore.QUrl.fromLocalFile(url)
 
     def play_file(self):
-        for file in self.tagger.iter_files_from_objects(self.selected_objects):
+        for file in iter_files_from_objects(self.selected_objects):
             QtGui.QDesktopServices.openUrl(self._openUrl(file.filename))
 
     def _on_player_error(self, error, msg):
@@ -1053,7 +1054,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def open_folder(self):
         folders = iter_unique(
             os.path.dirname(f.filename) for f
-            in self.tagger.iter_files_from_objects(self.selected_objects))
+            in iter_files_from_objects(self.selected_objects))
         for folder in folders:
             QtGui.QDesktopServices.openUrl(self._openUrl(folder))
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -73,6 +73,7 @@ from picard.plugin import ExtensionPoint
 from picard.track import Track
 from picard.util import (
     icontheme,
+    iter_unique,
     restore_method,
     thread,
     throttle,
@@ -1043,16 +1044,16 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return QtCore.QUrl.fromLocalFile(url)
 
     def play_file(self):
-        files = self.tagger.get_files_from_objects(self.selected_objects)
-        for file in files:
+        for file in self.tagger.iter_files_from_objects(self.selected_objects):
             QtGui.QDesktopServices.openUrl(self._openUrl(file.filename))
 
     def _on_player_error(self, error, msg):
         self.set_statusbar_message(msg, echo=log.warning, translate=None)
 
     def open_folder(self):
-        files = self.tagger.get_files_from_objects(self.selected_objects)
-        folders = set([os.path.dirname(f.filename) for f in files])
+        folders = iter_unique(
+            os.path.dirname(f.filename) for f
+            in self.tagger.iter_files_from_objects(self.selected_objects))
         for folder in folders:
             QtGui.QDesktopServices.openUrl(self._openUrl(folder))
 

--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -133,7 +133,7 @@ class Player(QtCore.QObject):
         playlist = QtMultimedia.QMediaPlaylist(self)
         playlist.setPlaybackMode(QtMultimedia.QMediaPlaylist.Sequential)
         playlist.addMedia([QtMultimedia.QMediaContent(QtCore.QUrl.fromLocalFile(file.filename))
-                          for file in self.tagger.get_files_from_objects(self._selected_objects)])
+                          for file in self.tagger.iter_files_from_objects(self._selected_objects)])
         self._player.setPlaylist(playlist)
         self._player.play()
 

--- a/picard/ui/playertoolbar.py
+++ b/picard/ui/playertoolbar.py
@@ -37,6 +37,7 @@ from picard.const.sys import IS_MACOS
 from picard.util import (
     format_time,
     icontheme,
+    iter_files_from_objects,
 )
 
 from picard.ui.widgets import (
@@ -133,7 +134,7 @@ class Player(QtCore.QObject):
         playlist = QtMultimedia.QMediaPlaylist(self)
         playlist.setPlaybackMode(QtMultimedia.QMediaPlaylist.Sequential)
         playlist.addMedia([QtMultimedia.QMediaContent(QtCore.QUrl.fromLocalFile(file.filename))
-                          for file in self.tagger.iter_files_from_objects(self._selected_objects)])
+                          for file in iter_files_from_objects(self._selected_objects)])
         self._player.setPlaylist(playlist)
         self._player.play()
 

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2018 Laurent Monin
-# Copyright (C) 2018 Philipp Wolfer
+# Copyright (C) 2018, 2020 Philipp Wolfer
 # Copyright (C) 2018 Yvan Rivière
 #
 # This program is free software; you can redistribute it and/or
@@ -36,7 +36,7 @@ from picard.script import (
     ScriptParser,
 )
 from picard.track import Track
-from picard.util import uniqify
+from picard.util import iter_unique
 
 
 class ScriptsMenu(QtWidgets.QMenu):
@@ -53,7 +53,7 @@ class ScriptsMenu(QtWidgets.QMenu):
         s_text = script[3]
         parser = ScriptParser()
 
-        for obj in self._get_unique_metadata_objects():
+        for obj in self._iter_unique_metadata_objects():
             try:
                 parser.eval(s_text, obj.metadata)
                 obj.update()
@@ -66,20 +66,17 @@ class ScriptsMenu(QtWidgets.QMenu):
                 }
                 self.tagger.window.set_statusbar_message(msg, mparms)
 
-    def _get_unique_metadata_objects(self):
-        objs = self._get_metadata_objects(self.tagger.window.selected_objects)
-        return uniqify(objs)
+    def _iter_unique_metadata_objects(self):
+        return iter_unique(self._iter_metadata_objects(self.tagger.window.selected_objects))
 
-    def _get_metadata_objects(self, objs):
+    def _iter_metadata_objects(self, objs):
         for obj in objs:
             if hasattr(obj, 'metadata'):
                 yield obj
-            if isinstance(obj, Cluster):
-                yield from self._get_metadata_objects(obj.files)
-            if isinstance(obj, ClusterList):
-                yield from self._get_metadata_objects(obj)
-            if isinstance(obj, Album):
-                yield from self._get_metadata_objects(obj.tracks)
-                yield from self._get_metadata_objects(obj.unmatched_files.iterfiles())
-            if isinstance(obj, Track):
-                yield from self._get_metadata_objects(obj.files)
+            if isinstance(obj, Cluster) or isinstance(obj, Track):
+                yield from self._iter_metadata_objects(obj.iterfiles())
+            elif isinstance(obj, ClusterList):
+                yield from self._iter_metadata_objects(obj)
+            elif isinstance(obj, Album):
+                yield from self._iter_metadata_objects(obj.tracks)
+                yield from self._iter_metadata_objects(obj.unmatched_files.iterfiles())

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -367,6 +367,6 @@ class AlbumSearchDialog(SearchDialog):
                 release["musicbrainz_albumid"])
         album = self.tagger.load_album(release["musicbrainz_albumid"])
         if self.cluster:
-            files = self.tagger.get_files_from_objects([self.cluster])
+            files = self.cluster.iterfiles()
             self.tagger.move_files_to_album(files, release["musicbrainz_albumid"],
                                             album)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -369,6 +369,13 @@ def uniqify(seq):
     return [x for x in seq if x not in seen and not add_seen(x)]
 
 
+def iter_unique(seq):
+    """Creates an iterator only returning unique values from seq"""
+    seen = set()
+    add_seen = seen.add
+    return (x for x in seq if x not in seen and not add_seen(x))
+
+
 # order is important
 _tracknum_regexps = (
     # search for explicit track number (prefix "track")

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -41,6 +41,7 @@ import builtins
 from collections import namedtuple
 from collections.abc import Mapping
 import html
+from itertools import chain
 import json
 import ntpath
 from operator import attrgetter
@@ -110,6 +111,11 @@ def process_events_iter(iterable, interval=0.1):
                 QtCore.QCoreApplication.processEvents()
         yield item
     QtCore.QCoreApplication.processEvents()
+
+
+def iter_files_from_objects(objects, save=False):
+    """Creates an iterator over all unique files from list of albums, clusters, tracks or files."""
+    return iter_unique(chain(*(obj.iterfiles(save) for obj in objects)))
 
 
 _io_encoding = sys.getfilesystemencoding()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -368,18 +368,13 @@ def throttle(interval):
 
 def uniqify(seq):
     """Uniqify a list, preserving order"""
-    # Courtesy of Dave Kirby
-    # See http://www.peterbe.com/plog/uniqifiers-benchmark
-    seen = set()
-    add_seen = seen.add
-    return [x for x in seq if x not in seen and not add_seen(x)]
+    return list(iter_unique(seq))
 
 
 def iter_unique(seq):
     """Creates an iterator only returning unique values from seq"""
     seen = set()
-    add_seen = seen.add
-    return (x for x in seq if x not in seen and not add_seen(x))
+    return (x for x in seq if x not in seen and not seen.add(x))
 
 
 # order is important

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
 # Copyright (C) 2010 fatih
-# Copyright (C) 2010-2011, 2014, 2018-2019 Philipp Wolfer
+# Copyright (C) 2010-2011, 2014, 2018-2020 Philipp Wolfer
 # Copyright (C) 2012, 2014, 2018 Wieland Hoffmann
 # Copyright (C) 2013 Ionuț Ciocîrlan
 # Copyright (C) 2013-2014, 2018-2020 Laurent Monin
@@ -30,6 +30,7 @@
 
 import builtins
 from collections import namedtuple
+from collections.abc import Iterator
 import os.path
 import unittest
 
@@ -42,8 +43,10 @@ from picard.util import (
     find_best_match,
     imageinfo,
     is_absolute_path,
+    iter_unique,
     limited_join,
     sort_by_similarity,
+    uniqify,
 )
 
 
@@ -450,3 +453,20 @@ class LimitedJoin(PicardTestCase):
         expected = '0,1,2,3,…,6,7,8,9'
         result = limited_join(self.list, len(self.list) - 1, ',')
         self.assertEqual(result, expected)
+
+
+class IterUniqifyTest(PicardTestCase):
+
+    def test_unique(self):
+        items = [1, 2, 3, 2, 3, 4]
+        result = uniqify(items)
+        self.assertEqual([1, 2, 3, 4], result)
+
+
+class IterUniqueTest(PicardTestCase):
+
+    def test_unique(self):
+        items = [1, 2, 3, 2, 3, 4]
+        result = iter_unique(items)
+        self.assertTrue(isinstance(result, Iterator))
+        self.assertEqual([1, 2, 3, 4], list(result))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -33,6 +33,7 @@ from collections import namedtuple
 from collections.abc import Iterator
 import os.path
 import unittest
+from unittest.mock import Mock
 
 from test.picardtestcase import PicardTestCase
 
@@ -43,6 +44,7 @@ from picard.util import (
     find_best_match,
     imageinfo,
     is_absolute_path,
+    iter_files_from_objects,
     iter_unique,
     limited_join,
     sort_by_similarity,
@@ -453,6 +455,21 @@ class LimitedJoin(PicardTestCase):
         expected = '0,1,2,3,…,6,7,8,9'
         result = limited_join(self.list, len(self.list) - 1, ',')
         self.assertEqual(result, expected)
+
+
+class IterFilesFromObjectsTest(PicardTestCase):
+
+    def test_iterate_only_unique(self):
+        f1 = Mock()
+        f2 = Mock()
+        f3 = Mock()
+        obj1 = Mock()
+        obj1.iterfiles = Mock(return_value=[f1, f2])
+        obj2 = Mock()
+        obj2.iterfiles = Mock(return_value=[f2, f3])
+        result = iter_files_from_objects([obj1, obj2])
+        self.assertTrue(isinstance(result, Iterator))
+        self.assertEqual([f1, f2, f3], list(result))
 
 
 class IterUniqifyTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

`tagger.get_files_from_objects` is used in many places, usually for iterating over the selected files. `tagger.get_files_from_objects` however first creates a list of objects, chains their `iterfiles()` methods and again converts the result into a list.


# Solution

Add a `picard.util.iter_files_from_objects` function which yields all files for the selected objects, allowing efficient iteration over all selected files. This also reduces dependency on the global tagger object.

Keep `get_files_from_objects` returning a list for cases where a list is actually wanted and for backward compatibility.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
