### PR TITLE
PICARD-2050: File browser does not handle first click to expand folder

### DIFF
--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -140,10 +140,10 @@ class FileBrowser(QtWidgets.QTreeView):
         self.horizontalScrollBar().setValue(pos_x)
 
     def mousePressEvent(self, event):
+        super().mousePressEvent(event)
         index = self.indexAt(event.pos())
         if index.isValid():
             self.selectionModel().setCurrentIndex(index, QtCore.QItemSelectionModel.NoUpdate)
-        super().mousePressEvent(event)
 
     def focusInEvent(self, event):
         self.focused = True


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2050
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When clicking on the arrow icon for a folder and the view would reposition due to selection change the expansion is not performed, as the mouse event is handled after position has been changed.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Process the click before updating selection

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
