### PR TITLE
PICARD-2047: Provide separate set of interface colors for dark themes

### DIFF
--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -151,6 +151,7 @@ class InterfaceColors:
         for key in set(conf) - set(self.default_colors):
             # old color key, remove
             del conf[key]
+        config.setting[self._config_key] = conf
         return changed
 
 

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Laurent Monin
+# Copyright (C) 2019-2020 Laurent Monin
 # Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
@@ -19,6 +19,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import defaultdict
 
 from PyQt5 import QtGui
 
@@ -31,6 +32,23 @@ class UnknownColorException(Exception):
     pass
 
 
+_COLOR_DESCRIPTIONS = {
+    'entity_error': N_("Errored entity"),
+    'entity_pending': N_("Pending entity"),
+    'entity_saved': N_("Saved entity"),
+    'log_debug': N_('Log view text (debug)'),
+    'log_error': N_('Log view text (error)'),
+    'log_info': N_('Log view text (info)'),
+    'log_warning': N_('Log view text (warning)'),
+    'tagstatus_added': N_("Tag added"),
+    'tagstatus_changed': N_("Tag changed"),
+    'tagstatus_removed': N_("Tag removed"),
+}
+
+
+_DEFAULT_COLORS = defaultdict(dict)
+
+
 class DefaultColor:
 
     def __init__(self, value, description):
@@ -39,31 +57,28 @@ class DefaultColor:
         self.description = description
 
 
-_DEFAULT_COLORS = {
-    'entity_error': DefaultColor('#C80000', N_("Errored entity")),
-    'entity_pending': DefaultColor('#808080', N_("Pending entity")),
-    'entity_saved': DefaultColor('#00AA00', N_("Saved entity")),
-    'log_debug': DefaultColor('purple', N_('Log view text (debug)')),
-    'log_error': DefaultColor('red', N_('Log view text (error)')),
-    'log_info': DefaultColor('black', N_('Log view text (info)')),
-    'log_warning': DefaultColor('darkorange', N_('Log view text (warning)')),
-    'tagstatus_added': DefaultColor('green', N_("Tag added")),
-    'tagstatus_changed': DefaultColor('darkgoldenrod', N_("Tag changed")),
-    'tagstatus_removed': DefaultColor('red', N_("Tag removed")),
-}
+def register_color(themes, name, value):
+    description = _COLOR_DESCRIPTIONS.get(name, "FIXME: color desc for %s" % name)
+    for theme_name in themes:
+        _DEFAULT_COLORS[theme_name][name] = DefaultColor(value, description)
 
-_DEFAULT_COLORS_DARK = {
-    'entity_error': DefaultColor('#C80000', N_("Errored entity")),
-    'entity_pending': DefaultColor('#808080', N_("Pending entity")),
-    'entity_saved': DefaultColor('#00AA00', N_("Saved entity")),
-    'log_debug': DefaultColor('plum', N_('Log view text (debug)')),
-    'log_error': DefaultColor('red', N_('Log view text (error)')),
-    'log_info': DefaultColor('white', N_('Log view text (info)')),
-    'log_warning': DefaultColor('darkorange', N_('Log view text (warning)')),
-    'tagstatus_added': DefaultColor('green', N_("Tag added")),
-    'tagstatus_changed': DefaultColor('darkgoldenrod', N_("Tag changed")),
-    'tagstatus_removed': DefaultColor('red', N_("Tag removed")),
-}
+
+_DARK = ('dark', )
+_LIGHT = ('light', )
+_ALL = _DARK + _LIGHT
+
+register_color(_ALL, 'entity_error', '#C80000')
+register_color(_ALL, 'entity_pending', '#808080')
+register_color(_ALL, 'entity_saved', '#00AA00')
+register_color(_LIGHT, 'log_debug', 'purple')
+register_color(_DARK, 'log_debug', 'plum')
+register_color(_ALL, 'log_error', 'red')
+register_color(_LIGHT, 'log_info', 'black')
+register_color(_DARK, 'log_info', 'white')
+register_color(_ALL, 'log_warning', 'darkorange')
+register_color(_ALL, 'tagstatus_added', 'green')
+register_color(_ALL, 'tagstatus_changed', 'darkgoldenrod')
+register_color(_ALL, 'tagstatus_removed', 'red')
 
 
 class InterfaceColors:
@@ -82,9 +97,9 @@ class InterfaceColors:
     @property
     def default_colors(self):
         if self.dark_theme:
-            return _DEFAULT_COLORS_DARK
+            return _DEFAULT_COLORS['dark']
         else:
-            return _DEFAULT_COLORS
+            return _DEFAULT_COLORS['light']
 
     @property
     def _config_key(self):

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2019 Laurent Monin
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -23,6 +23,8 @@
 from PyQt5 import QtGui
 
 from picard import config
+
+from picard.ui.theme import theme
 
 
 class UnknownColorException(Exception):
@@ -50,28 +52,63 @@ _DEFAULT_COLORS = {
     'tagstatus_removed': DefaultColor('red', N_("Tag removed")),
 }
 
+_DEFAULT_COLORS_DARK = {
+    'entity_error': DefaultColor('#C80000', N_("Errored entity")),
+    'entity_pending': DefaultColor('#808080', N_("Pending entity")),
+    'entity_saved': DefaultColor('#00AA00', N_("Saved entity")),
+    'log_debug': DefaultColor('plum', N_('Log view text (debug)')),
+    'log_error': DefaultColor('red', N_('Log view text (error)')),
+    'log_info': DefaultColor('white', N_('Log view text (info)')),
+    'log_warning': DefaultColor('darkorange', N_('Log view text (warning)')),
+    'tagstatus_added': DefaultColor('green', N_("Tag added")),
+    'tagstatus_changed': DefaultColor('darkgoldenrod', N_("Tag changed")),
+    'tagstatus_removed': DefaultColor('red', N_("Tag removed")),
+}
+
 
 class InterfaceColors:
 
-    def __init__(self):
-        self.default_colors()
+    def __init__(self, dark_theme=None):
+        self._dark_theme = dark_theme
+        self.set_default_colors()
 
+    @property
+    def dark_theme(self):
+        if self._dark_theme is None:
+            return theme.is_dark_theme
+        else:
+            return self._dark_theme
+
+    @property
     def default_colors(self):
+        if self.dark_theme:
+            return _DEFAULT_COLORS_DARK
+        else:
+            return _DEFAULT_COLORS
+
+    @property
+    def _config_key(self):
+        if self.dark_theme:
+            return 'interface_colors_dark'
+        else:
+            return 'interface_colors'
+
+    def set_default_colors(self):
         self._colors = dict()
-        for color_key in _DEFAULT_COLORS:
-            color_value = _DEFAULT_COLORS[color_key].value
+        for color_key in self.default_colors:
+            color_value = self.default_colors[color_key].value
             self.set_color(color_key, color_value)
 
     def set_colors(self, colors_dict):
-        for color_key in _DEFAULT_COLORS:
+        for color_key in self.default_colors:
             if color_key in colors_dict:
                 color_value = colors_dict[color_key]
             else:
-                color_value = _DEFAULT_COLORS[color_key].value
+                color_value = self.default_colors[color_key].value
             self.set_color(color_key, color_value)
 
     def load_from_config(self):
-        self.set_colors(config.setting['interface_colors'])
+        self.set_colors(config.setting[self._config_key])
 
     def get_colors(self):
         return self._colors
@@ -80,22 +117,21 @@ class InterfaceColors:
         try:
             return self._colors[color_key]
         except KeyError:
-            if color_key in _DEFAULT_COLORS:
-                return _DEFAULT_COLORS[color_key].value
+            if color_key in self.default_colors:
+                return self.default_colors[color_key].value
             raise UnknownColorException("Unknown color key: %s" % color_key)
 
     def get_qcolor(self, color_key):
         return QtGui.QColor(self.get_color(color_key))
 
-    @staticmethod
-    def get_color_description(color_key):
-        return _(_DEFAULT_COLORS[color_key].description)
+    def get_color_description(self, color_key):
+        return _(self.default_colors[color_key].description)
 
     def set_color(self, color_key, color_value):
-        if color_key in _DEFAULT_COLORS:
+        if color_key in self.default_colors:
             qcolor = QtGui.QColor(color_value)
             if not qcolor.isValid():
-                qcolor = QtGui.QColor(_DEFAULT_COLORS[color_key].value)
+                qcolor = QtGui.QColor(self.default_colors[color_key].value)
             self._colors[color_key] = qcolor.name()
         else:
             raise UnknownColorException("Unknown color key: %s" % color_key)
@@ -103,7 +139,7 @@ class InterfaceColors:
     def save_to_config(self):
         # returns True if user has to be warned about color changes
         changed = False
-        conf = config.setting['interface_colors']
+        conf = config.setting[self._config_key]
         for key, color in self._colors.items():
             if key not in conf:
                 # new color key, not need to warn user
@@ -112,7 +148,7 @@ class InterfaceColors:
                 # color changed
                 conf[key] = color
                 changed = True
-        for key in set(conf) - set(_DEFAULT_COLORS):
+        for key in set(conf) - set(self.default_colors):
             # old color key, remove
             del conf[key]
         return changed

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2019 Laurent Monin
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -30,7 +30,10 @@ from PyQt5 import (
 
 from picard import config
 
-from picard.ui.colors import interface_colors
+from picard.ui.colors import (
+    InterfaceColors,
+    interface_colors,
+)
 from picard.ui.options import (
     OptionsPage,
     register_options_page,
@@ -89,7 +92,8 @@ class InterfaceColorsOptionsPage(OptionsPage):
     HELP_URL = '/config/options_interface_colors.html'
 
     options = [
-        config.Option("setting", "interface_colors", interface_colors.get_colors()),
+        config.Option("setting", "interface_colors", InterfaceColors(dark_theme=False).get_colors()),
+        config.Option("setting", "interface_colors_dark", InterfaceColors(dark_theme=True).get_colors()),
     ]
 
     def __init__(self, parent=None):
@@ -142,7 +146,7 @@ class InterfaceColorsOptionsPage(OptionsPage):
             dialog.exec_()
 
     def restore_defaults(self):
-        interface_colors.default_colors()
+        interface_colors.set_default_colors()
         self.update_color_selectors()
 
 

--- a/test/test_interface_colors.py
+++ b/test/test_interface_colors.py
@@ -25,7 +25,6 @@ from test.picardtestcase import PicardTestCase
 from picard import config
 
 from picard.ui.colors import (
-    _DEFAULT_COLORS,
     UnknownColorException,
     interface_colors,
 )
@@ -47,7 +46,8 @@ class InterfaceColorsTest(PicardTestCase):
     def test_interface_colors(self):
         with self.assertRaises(UnknownColorException):
             interface_colors.get_color('testcolor')
-        self.assertEqual(interface_colors.get_color('entity_error'), _DEFAULT_COLORS['entity_error'].value)
+        default_colors = interface_colors.default_colors
+        self.assertEqual(interface_colors.get_color('entity_error'), default_colors['entity_error'].value)
         interface_colors.load_from_config()
         self.assertEqual(interface_colors.get_color('entity_error'), '#abcdef')
         self.assertEqual(interface_colors.get_colors()['entity_error'], '#abcdef')
@@ -55,5 +55,5 @@ class InterfaceColorsTest(PicardTestCase):
         interface_colors.save_to_config()
         self.assertEqual(config.setting['interface_colors']['entity_error'], '#000000')
         self.assertNotIn('unknowncolor', config.setting['interface_colors'])
-        self.assertEqual(interface_colors.get_color_description('entity_error'), _DEFAULT_COLORS['entity_error'].description)
+        self.assertEqual(interface_colors.get_color_description('entity_error'), default_colors['entity_error'].description)
         self.assertEqual(interface_colors.get_qcolor('entity_error'), QColor('#000000'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Use different interface colors for light and dark themes.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2047, PICARD-2056
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Some of the default colors don't work well in the log view if a dark theme is in use.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Store a separate set of colors for light and dark UI in options. Use the one matching the current theme. This allows both having separate defaults and for the user to configure the UI differently for light and dark. This is interesting for users switching mode (e.g. some people use dark mode only in the evening / night).

Only two colors were actually changed: The info color (white instead of black) and the debug color (a bit lighter purple):

![grafik](https://user-images.githubusercontent.com/29852/101741307-32803580-3aca-11eb-9fcf-8f87b94e8c20.png)
