### PR TITLE
PICARD-2057: Add a "All files" filter to add files dialog

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -953,7 +953,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             extensions.extend(exts)
         formats.sort()
         extensions.sort()
-        formats.insert(0, _("All Supported Formats") + " (%s)" % " ".join(extensions))
+        formats.insert(0, _("All supported formats") + " (%s)" % " ".join(extensions))
+        formats.insert(1, _("All files") + " (*)")
         files, _filter = QtWidgets.QFileDialog.getOpenFileNames(self, "", current_directory, ";;".join(formats))
         if files:
             config.persist["current_directory"] = os.path.dirname(files[0])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:



Allow showing all files, independent of file type, in the Add Files file selector dialog. This allows selection of files which might have uncommon extensions or none at all.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2057
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

