### PR TITLE
PICARD-2058: Allow selection of files with upper case extension in add file dialog on Linux

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -66,7 +66,10 @@ from picard.cluster import (
     FileList,
 )
 from picard.const import PROGRAM_UPDATE_LEVELS
-from picard.const.sys import IS_MACOS
+from picard.const.sys import (
+    IS_MACOS,
+    IS_WIN,
+)
 from picard.file import File
 from picard.formats import supported_formats
 from picard.plugin import ExtensionPoint
@@ -948,7 +951,16 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         formats = []
         extensions = []
         for exts, name in supported_formats():
-            exts = ["*" + e for e in exts]
+            exts = ["*" + e.lower() for e in exts]
+            if not exts:
+                continue
+            if not IS_MACOS and not IS_WIN:
+                # Also consider upper case extensions
+                # macOS and Windows usually support case sensitive file names. Furthermore on both systems
+                # the file dialog filters list all extensions we provide, which becomes a bit long when we give the
+                # full list twice. Hence only do this trick on other operating systems.
+                exts.extend([e.upper() for e in exts])
+            exts.sort()
             formats.append("%s (%s)" % (name, " ".join(exts)))
             extensions.extend(exts)
         formats.sort()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
On case-sensitive file systems the Add File dialog does not show files with matching extension, if it is uppercase (e.g. test.MP3).

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2058<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add both lower and upper case extensions to the filters.

Do this only on OS other than Win or macOS. macOS and Windows usually support case sensitive file names. Furthermore on both systems the file dialog filters list all extensions we provide, which becomes a bit long when we give the full list twice. 
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

