### PR TITLE
PICARD-2045: Recalculate changed state after file.clear_pending()

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -827,7 +827,9 @@ class File(QtCore.QObject, Item):
 
     def clear_pending(self, signal=True):
         if self.state == File.PENDING:
-            self.state = File.NORMAL if self.similarity == 1.0 else File.CHANGED
+            self.state = File.NORMAL
+            # Update file to recalculate changed state
+            self.update(signal=False)
             if signal:
                 self.update_item(update_selection=False)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2045
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Calling `file.clear_pending()`  does not properly reset the CHANGED or NORMAL state, as it only looks at file.similarity. This e.g. causes files with changed status to become normal after fingerprinting.


# Solution
Refresh the state on clear pending.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
