### PR TITLE
Fixed removing album or track with multiple files attached

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -142,11 +142,9 @@ class Album(DataObject, Item):
 
     def iterfiles(self, save=False):
         for track in self.tracks:
-            for file in track.iterfiles():
-                yield file
+            yield from track.iterfiles()
         if not save:
-            for file in self.unmatched_files.iterfiles():
-                yield file
+            yield from self.unmatched_files.iterfiles()
 
     def enable_update_metadata_images(self, enabled):
         self.update_metadata_images_enabled = enabled

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -420,8 +420,7 @@ class ClusterList(list, Item):
 
     def iterfiles(self, save=False):
         for cluster in self:
-            for file in cluster.iterfiles(save):
-                yield file
+            yield from cluster.iterfiles(save)
 
     def can_save(self):
         return len(self) > 0

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -704,7 +704,7 @@ class Tagger(QtWidgets.QApplication):
         if album.id not in self.albums:
             return
         album.stop_loading()
-        self.remove_files(album.iterfiles())
+        self.remove_files(list(album.iterfiles()))
         del self.albums[album.id]
         if album.release_group:
             album.release_group.remove_album(album.id)
@@ -717,7 +717,7 @@ class Tagger(QtWidgets.QApplication):
     def remove_nat(self, track):
         """Remove the specified non-album track."""
         log.debug("Removing %r", track)
-        self.remove_files(track.iterfiles())
+        self.remove_files(list(track.iterfiles()))
         if not self.nats:
             return
         self.nats.tracks.remove(track)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -336,11 +336,7 @@ class Tagger(QtWidgets.QApplication):
         """Move `files` to tracks on album `albumid`."""
         if album is None:
             album = self.load_album(albumid)
-        if album.loaded:
-            album.match_files(files)
-        else:
-            for file in list(files):
-                file.move(album.unmatched_files)
+        album.match_files(files)
 
     def move_file_to_album(self, file, albumid):
         """Move `file` to a track on album `albumid`."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Removing an album or track where multiple files had been matched to a single track could result in only half of the files being actually removed. This was introduced in bab8447.

# Solution

Get the full list of files before starting iterating. Also some minor refactoring / code simplification.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
