### PR TITLE
PICARD-2074: Avoid exception when editing metadata but no tag was selected

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -353,10 +353,10 @@ class MetadataBox(QtWidgets.QTableWidget):
         menu = QtWidgets.QMenu(self)
         if self.objects:
             tags = self.selected_tags()
-            editable = self.tag_is_editable(tags[0])
             single_tag = len(tags) == 1
             if single_tag:
                 selected_tag = tags[0]
+                editable = self.tag_is_editable(selected_tag)
                 edit_tag_action = QtWidgets.QAction(_("Edit..."), self.parent)
                 edit_tag_action.triggered.connect(partial(self.edit_tag, selected_tag))
                 edit_tag_action.setShortcut(self.edit_tag_shortcut.key())


### PR DESCRIPTION
If "self.selected_tags()" returns no tags "tags[0]" will trigger an exception.

# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

* **Describe this change in 1-2 sentences**:

With a certain mp3 file picard crashes whenever I do a right click in the lower area where tags are listed.  The traceback is pretty clear I think

# Problem

    Traceback (most recent call last):
      File "/usr/lib64/python3.9/site-packages/picard/ui/metadatabox.py", line 356, in contextMenuEvent
        editable = self.tag_is_editable(tags[0])
    IndexError: list index out of range
    …
    Local variables in innermost frame:
    tags: []

* JIRA ticket (_optional_): PICARD-2074


# Solution

The code should be pretty obvious. The only minor thing is that "editable" is also accessed later in the function in a different branch. That might be susceptible to triggering an `UnboundLocalError` but the extra branch is also guarded by the same condition (`single_tag`) so it should be fine. If this seems to brittle we could also add `editable = False` outside of the branch or even `editable = self.tag_is_editable(tag[0]) if tags else False`.

