### PR TITLE
PICARD-1926: Use for per-thread config instances

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -54,9 +54,9 @@ from PyQt5 import QtCore
 
 from picard import (
     PICARD_APP_NAME,
-    config,
     log,
 )
+from picard.config import get_config
 from picard.const import QUERY_LIMIT
 from picard.const.sys import (
     IS_MACOS,
@@ -216,6 +216,7 @@ class File(QtCore.QObject, Item):
             self.state = self.NORMAL
             self._copy_loaded_metadata(result)
         # use cached fingerprint from file metadata
+        config = get_config()
         if not config.setting["ignore_existing_acoustid_fingerprints"]:
             fingerprints = self.metadata.getall('acoustid_fingerprint')
             if fingerprints:
@@ -307,6 +308,7 @@ class File(QtCore.QObject, Item):
 
     def _save_and_rename(self, old_filename, metadata):
         """Save the metadata."""
+        config = get_config()
         # Check that file has not been removed since thread was queued
         # Also don't save if we are stopping.
         if self.state == File.REMOVED:
@@ -371,6 +373,7 @@ class File(QtCore.QObject, Item):
             images_changed = self.orig_metadata.images != self.new_metadata.images
             # Data is copied from New to Original because New may be
             # a subclass to handle id3v23
+            config = get_config()
             if config.setting["clear_existing_tags"]:
                 self.orig_metadata.copy(self.new_metadata)
             else:
@@ -407,6 +410,7 @@ class File(QtCore.QObject, Item):
 
     def _script_to_filename(self, naming_format, file_metadata, file_extension, settings=None):
         if settings is None:
+            config = get_config()
             settings = config.setting
         metadata = Metadata()
         if settings["clear_existing_tags"]:
@@ -463,6 +467,7 @@ class File(QtCore.QObject, Item):
     def make_filename(self, filename, metadata, settings=None):
         """Constructs file name based on metadata and file naming formats."""
         if settings is None:
+            config = get_config()
             settings = config.setting
         if settings["move_files"]:
             new_dirname = settings["move_files_to"]
@@ -510,6 +515,7 @@ class File(QtCore.QObject, Item):
             return
         counters = defaultdict(lambda: 0)
         images = []
+        config = get_config()
         if config.setting["caa_save_single_front_image"]:
             front = metadata.images.get_front_image()
             if front:
@@ -526,6 +532,7 @@ class File(QtCore.QObject, Item):
         if new_path == old_path:
             # skip, same directory, nothing to move
             return
+        config = get_config()
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()
         for pattern in patterns.split():
@@ -626,6 +633,7 @@ class File(QtCore.QObject, Item):
         new_metadata = self.new_metadata
         names = set(new_metadata.keys())
         names.update(self.orig_metadata.keys())
+        config = get_config()
         clear_existing_tags = config.setting["clear_existing_tags"]
         ignored_tags = config.setting["compare_ignore_tags"]
         for name in names:
@@ -748,6 +756,7 @@ class File(QtCore.QObject, Item):
             if lookuptype == File.LOOKUP_ACOUSTID:
                 threshold = 0
             else:
+                config = get_config()
                 threshold = config.setting['file_lookup_threshold']
 
             trackmatch = self._match_to_track(tracks, threshold=threshold)

--- a/picard/formats/ac3.py
+++ b/picard/formats/ac3.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,10 +21,8 @@
 
 import mutagen
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.formats.apev2 import APEv2File
 from picard.util import encode_filename
 
@@ -49,6 +47,7 @@ class AC3File(APEv2File):
             metadata['~format'] = format
 
     def _save(self, filename, metadata):
+        config = get_config()
         if config.setting['ac3_save_ape']:
             super()._save(filename, metadata)
         elif config.setting['remove_ape_from_ac3']:
@@ -59,6 +58,7 @@ class AC3File(APEv2File):
 
     @classmethod
     def supports_tag(cls, name):
+        config = get_config()
         if config.setting['ac3_save_ape']:
             return APEv2File.supports_tag(name)
         else:

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -37,10 +37,8 @@ import mutagen.musepack
 import mutagen.optimfrog
 import mutagen.wavpack
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImageError,
     TagCoverArtImage,
@@ -185,6 +183,7 @@ class APEv2File(File):
     def _save(self, filename, metadata):
         """Save metadata to the file."""
         log.debug("Saving file %r", filename)
+        config = get_config()
         try:
             tags = mutagen.apev2.APEv2(encode_filename(filename))
         except mutagen.apev2.APENoHeaderError:
@@ -305,6 +304,7 @@ class WavPackFile(APEv2File):
         """Includes an additional check for WavPack correction files"""
         wvc_filename = old_filename.replace(".wv", ".wvc")
         if isfile(wvc_filename):
+            config = get_config()
             if config.setting["rename_files"] or config.setting["move_files"]:
                 self._rename(wvc_filename, metadata)
         return File._save_and_rename(self, old_filename, metadata)
@@ -356,6 +356,7 @@ class AACFile(APEv2File):
             metadata['~format'] = "%s (APEv2)" % self.NAME
 
     def _save(self, filename, metadata):
+        config = get_config()
         if config.setting['aac_save_ape']:
             super()._save(filename, metadata)
         elif config.setting['remove_ape_from_aac']:
@@ -366,6 +367,7 @@ class AACFile(APEv2File):
 
     @classmethod
     def supports_tag(cls, name):
+        config = get_config()
         if config.setting['aac_save_ape']:
             return APEv2File.supports_tag(name)
         else:

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -33,10 +33,8 @@ from mutagen.asf import (
     ASFByteArrayAttribute,
 )
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImageError,
     TagCoverArtImage,
@@ -209,6 +207,7 @@ class ASFFile(File):
 
     def _load(self, filename):
         log.debug("Loading file %r", filename)
+        config = get_config()
         self.__casemap = {}
         file = ASF(encode_filename(filename))
         metadata = Metadata()
@@ -262,6 +261,7 @@ class ASFFile(File):
 
     def _save(self, filename, metadata):
         log.debug("Saving file %r", filename)
+        config = get_config()
         file = ASF(encode_filename(filename))
         tags = file.tags
 

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -36,10 +36,8 @@ from mutagen.mp4 import (
     MP4Cover,
 )
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImageError,
     TagCoverArtImage,
@@ -247,6 +245,7 @@ class MP4File(File):
 
     def _save(self, filename, metadata):
         log.debug("Saving file %r", filename)
+        config = get_config()
         file = MP4(encode_filename(self.filename))
         if file.tags is None:
             file.add_tags()

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -38,10 +38,8 @@ import mutagen.oggspeex
 import mutagen.oggtheora
 import mutagen.oggvorbis
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImageError,
     TagCoverArtImage,
@@ -122,6 +120,7 @@ class VCommentFile(File):
 
     def _load(self, filename):
         log.debug("Loading file %r", filename)
+        config = get_config()
         file = self._File(encode_filename(filename))
         file.tags = file.tags or {}
         metadata = Metadata()
@@ -226,6 +225,7 @@ class VCommentFile(File):
     def _save(self, filename, metadata):
         """Save metadata to the file."""
         log.debug("Saving file %r", filename)
+        config = get_config()
         is_flac = self._File == mutagen.flac.FLAC
         file = self._File(encode_filename(filename))
         if file.tags is None:
@@ -334,6 +334,7 @@ class VCommentFile(File):
 
     def _get_tag_name(self, name):
         if name == '~rating':
+            config = get_config()
             if config.setting['rating_user_email']:
                 return 'rating:%s' % config.setting['rating_user_email']
             else:

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -27,10 +27,8 @@ from collections.abc import MutableMapping
 
 import mutagen
 
-from picard import (
-    config,
-    log,
-)
+from picard import log
+from picard.config import get_config
 from picard.file import File
 from picard.formats.id3 import NonCompatID3File
 from picard.metadata import Metadata
@@ -187,7 +185,7 @@ try:
         def _info(self, metadata, file):
             super()._info(metadata, file)
             metadata['~format'] = self.NAME
-
+            config = get_config()
             info = RiffListInfo(encoding=config.setting['wave_riff_info_encoding'])
             info.load(file.filename)
             for tag, value in info.items():
@@ -200,6 +198,7 @@ try:
             super()._save(filename, metadata)
 
             # Save RIFF LIST INFO
+            config = get_config()
             if config.setting['write_wave_riff_info']:
                 info = RiffListInfo(encoding=config.setting['wave_riff_info_encoding'])
                 if config.setting['clear_existing_tags']:

--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -35,7 +35,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from picard import config
+from picard.config import get_config
 from picard.script.functions import (  # noqa: F401 # pylint: disable=unused-import
     register_script_function,
     script_function,
@@ -97,6 +97,7 @@ def script_function_documentation_all(fmt='markdown', pre='',
 def enabled_tagger_scripts_texts():
     """Returns an iterator over the enabled tagger scripts.
     For each script, you'll get a tuple consisting of the script name and text"""
+    config = get_config()
     if not config.setting["enable_tagger_scripts"]:
         return []
     return [(s_name, s_text) for _s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"] if s_enabled and s_text]

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -39,11 +39,15 @@ from PyQt5 import (
     QtWidgets,
 )
 
-from picard import config
 from picard.album import Album
 from picard.browser.browser import BrowserIntegration
 from picard.browser.filelookup import FileLookup
 from picard.cluster import Cluster
+from picard.config import (
+    BoolOption,
+    Option,
+    get_config,
+)
 from picard.file import File
 from picard.metadata import MULTI_VALUED_JOINER
 from picard.track import Track
@@ -132,12 +136,15 @@ class TagDiff(object):
         else:
             return orig != new
 
-    def add(self, tag, orig_values, new_values, removable, removed=False, readonly=False):
+    def add(self, tag, orig_values, new_values, removable, removed=False, readonly=False, top_tags=None):
         if orig_values:
             self.orig.add(tag, orig_values)
 
         if new_values:
             self.new.add(tag, new_values)
+
+        if not top_tags:
+            top_tags = []
 
         if (orig_values and not new_values) or removed:
             self.status[tag] |= TagStatus.REMOVED
@@ -146,7 +153,7 @@ class TagDiff(object):
             removable = True
         elif orig_values and new_values and self.__tag_ne(tag, orig_values, new_values):
             self.status[tag] |= TagStatus.CHANGED
-        elif not (orig_values or new_values or tag in config.setting['metadatabox_top_tags']):
+        elif not (orig_values or new_values or tag in top_tags):
             self.status[tag] |= TagStatus.EMPTY
         else:
             self.status[tag] |= TagStatus.NOCHANGE
@@ -193,8 +200,8 @@ class TableTagEditorDelegate(TagEditorDelegate):
 class MetadataBox(QtWidgets.QTableWidget):
 
     options = (
-        config.Option("persist", "metadatabox_header_state", QtCore.QByteArray()),
-        config.BoolOption("persist", "show_changes_first", False)
+        Option("persist", "metadatabox_header_state", QtCore.QByteArray()),
+        BoolOption("persist", "show_changes_first", False)
     )
 
     COLUMN_ORIG = 1
@@ -202,6 +209,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def __init__(self, parent):
         super().__init__(parent)
+        config = get_config()
         self.parent = parent
         self.setAccessibleName(_("metadata view"))
         self.setAccessibleDescription(_("Displays original and new tags for the selected files"))
@@ -247,6 +255,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def get_file_lookup(self):
         """Return a FileLookup object."""
+        config = get_config()
         return FileLookup(self, config.setting["server_host"],
                           config.setting["server_port"],
                           self.browser_integration.port)
@@ -454,6 +463,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             self.edit_tag(tags[0])
 
     def toggle_changes_first(self, checked):
+        config = get_config()
         config.persist["show_changes_first"] = checked
         self.update()
 
@@ -566,12 +576,14 @@ class MetadataBox(QtWidgets.QTableWidget):
             TagStatus.CHANGED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_changed'))
         }
 
+        config = get_config()
         tag_diff = TagDiff(max_length_diff=config.setting["ignore_track_duration_difference_under"])
         orig_tags = tag_diff.orig
         new_tags = tag_diff.new
         tag_diff.objects = len(files)
 
         clear_existing_tags = config.setting["clear_existing_tags"]
+        top_tags = config.setting['metadatabox_top_tags']
 
         for file in files:
             new_metadata = file.new_metadata
@@ -586,7 +598,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                     new_values = list(orig_values or [""])
 
                 removed = name in new_metadata.deleted_tags
-                tag_diff.add(name, orig_values, new_values, True, removed)
+                tag_diff.add(name, orig_values, new_values, True, removed, top_tags=top_tags)
 
             tag_diff.add("~length", str(orig_metadata.length), str(new_metadata.length),
                          removable=False, readonly=True)
@@ -702,12 +714,14 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     @restore_method
     def restore_state(self):
+        config = get_config()
         state = config.persist["metadatabox_header_state"]
         header = self.horizontalHeader()
         header.restoreState(state)
         header.setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
 
     def save_state(self):
+        config = get_config()
         header = self.horizontalHeader()
         state = header.saveState()
         config.persist["metadatabox_header_state"] = state

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -144,7 +144,7 @@ class TagDiff(object):
             self.new.add(tag, new_values)
 
         if not top_tags:
-            top_tags = []
+            top_tags = set()
 
         if (orig_values and not new_values) or removed:
             self.status[tag] |= TagStatus.REMOVED
@@ -584,6 +584,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
         clear_existing_tags = config.setting["clear_existing_tags"]
         top_tags = config.setting['metadatabox_top_tags']
+        top_tags_set = set(top_tags)
 
         for file in files:
             new_metadata = file.new_metadata
@@ -598,7 +599,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                     new_values = list(orig_values or [""])
 
                 removed = name in new_metadata.deleted_tags
-                tag_diff.add(name, orig_values, new_values, True, removed, top_tags=top_tags)
+                tag_diff.add(name, orig_values, new_values, True, removed, top_tags=top_tags_set)
 
             tag_diff.add("~length", str(orig_metadata.length), str(new_metadata.length),
                          removable=False, readonly=True)
@@ -619,7 +620,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                 tag_diff.objects += 1
 
         all_tags = set(list(orig_tags.keys()) + list(new_tags.keys()))
-        common_tags = [tag for tag in config.setting['metadatabox_top_tags'] if tag in all_tags]
+        common_tags = [tag for tag in top_tags if tag in all_tags]
         tag_names = common_tags + sorted(all_tags.difference(common_tags),
                                          key=lambda x: display_tag_name(x).lower())
 

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2008 Will
-# Copyright (C) 2008, 2018-2019 Philipp Wolfer
+# Copyright (C) 2008, 2018-2020 Philipp Wolfer
 # Copyright (C) 2009 david
 # Copyright (C) 2013 Johannes Dewender
 # Copyright (C) 2013 Sebastian Ramacher
@@ -34,7 +34,7 @@ from PyQt5.QtCore import (
     QIODevice,
 )
 
-from picard import config
+from picard.config import get_config
 from picard.const.sys import (
     IS_LINUX,
     IS_WIN,
@@ -118,6 +118,7 @@ def get_cdrom_drives():
                     drives.append(device)
 
     else:
+        config = get_config()
         for device in config.setting["cd_lookup_device"].split(","):
             # Need to filter out empty strings,
             # particularly if the device list is empty

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -24,7 +24,7 @@
 
 from collections.abc import MutableSequence
 
-from picard import config
+from picard.config import get_config
 
 
 class ImageList(MutableSequence):
@@ -71,6 +71,7 @@ class ImageList(MutableSequence):
            passed settings or config.setting
         """
         if settings is None:
+            config = get_config()
             settings = config.setting
         if settings['save_images_to_tags']:
             only_one_front = settings['embed_only_one_front_image']

--- a/picard/util/preservedtags.py
+++ b/picard/util/preservedtags.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from picard import config
+from picard.config import get_config
 
 
 class PreservedTags:
@@ -31,9 +31,11 @@ class PreservedTags:
         self._tags = self._from_config()
 
     def _to_config(self):
+        config = get_config()
         config.setting[self.opt_name] = sorted(self._tags)
 
     def _from_config(self):
+        config = get_config()
         tags = config.setting[self.opt_name]
         return set(filter(bool, map(self._normalize_tag, tags)))
 

--- a/picard/util/scripttofilename.py
+++ b/picard/util/scripttofilename.py
@@ -22,7 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from picard import config
+from picard.config import get_config
 from picard.const.sys import IS_WIN
 from picard.metadata import Metadata
 from picard.script import ScriptParser
@@ -48,6 +48,7 @@ def script_to_filename_with_metadata(naming_format, metadata, file=None, setting
         with changes from the script as second.
     """
     if settings is None:
+        config = get_config()
         settings = config.setting
     # make sure every metadata can safely be used in a path name
     win_compat = IS_WIN or settings["windows_compatibility"]

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -201,7 +201,7 @@ class CommonTests:
 
         def setUp(self):
             super().setUp()
-            config.setting = settings.copy()
+            self.set_config_values(settings)
             if self.testfile:
                 _name, self.testfile_ext = os.path.splitext(self.testfile)
                 self.testfile_path = os.path.join('test', 'data', self.testfile)

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -27,7 +27,6 @@ import os
 
 from test.picardtestcase import PicardTestCase
 
-from picard import config
 from picard.acoustid.json_helpers import parse_recording
 from picard.mbjson import recording_to_metadata
 from picard.metadata import Metadata
@@ -49,7 +48,7 @@ class AcoustIDTest(PicardTestCase):
         self.init_test(self.filename)
 
     def init_test(self, filename):
-        config.setting = settings.copy()
+        self.set_config_values(settings)
         self.json_doc = None
         with open(os.path.join('test', 'data', 'ws_data', filename), encoding='utf-8') as f:
             self.json_doc = json.load(f)

--- a/test/test_acoustidmanager.py
+++ b/test/test_acoustidmanager.py
@@ -27,7 +27,6 @@ from unittest.mock import (
 
 from test.picardtestcase import PicardTestCase
 
-from picard import config
 from picard.acoustid.manager import AcoustIDManager
 from picard.file import File
 
@@ -55,10 +54,10 @@ def dummy_file(i):
 class AcoustIDManagerTest(PicardTestCase):
     def setUp(self):
         super().setUp()
-        config.setting = {
+        self.set_config_values({
             "clear_existing_tags": False,
             "compare_ignore_tags": []
-        }
+        })
         self.mock_api_helper = MagicMock()
         self.mock_api_helper.submit_acoustid_fingerprints = Mock(wraps=mock_succeed_submission)
         self.acoustidmanager = AcoustIDManager(self.mock_api_helper)

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -26,7 +26,6 @@ from unittest.mock import MagicMock
 
 from test.picardtestcase import PicardTestCase
 
-from picard import config
 from picard.webservice import WebService
 from picard.webservice.api_helpers import (
     APIHelper,
@@ -72,8 +71,9 @@ class APITest(PicardTestCase):
 class MBAPITest(PicardTestCase):
 
     def setUp(self):
+        super().setUp()
         self.config = {'server_host': "mb.org", "server_port": 443}
-        config.setting = self.config.copy()
+        self.set_config_values(self.config)
         self.ws = MagicMock(auto_spec=WebService)
         self.api = MBAPIHelper(self.ws)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019-2020 Philipp Wolfer
 # Copyright (C) 2019-2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -23,9 +23,11 @@
 import logging
 import os
 import shutil
+import threading
 
 from test.picardtestcase import PicardTestCase
 
+import picard.config
 from picard.config import (
     BoolOption,
     Config,
@@ -371,3 +373,14 @@ class TestPicardConfigVarOption(TestPicardConfigCommon):
         # store invalid value in config file directly
         self.config.setValue('setting/var_option', object)
         self.assertEqual(self.config.setting["var_option"], set(["a", "b"]))
+
+
+class TestPurgeConfigInstancesTimer(TestPicardConfigCommon):
+
+    def test_purge_inactive_config_instances(self):
+        thread_id = threading.get_ident()
+        self.assertIn(thread_id, picard.config._thread_configs)
+        picard.config._thread_configs['foo'] = {}
+        picard.config.purge_config_instances()
+        self.assertIn(thread_id, picard.config._thread_configs)
+        self.assertNotIn('foo', picard.config._thread_configs)

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -171,7 +171,7 @@ class FileNamingTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         self.file = File('/somepath/somefile.mp3')
-        config.setting = {
+        self.set_config_values({
             'ascii_filenames': False,
             'clear_existing_tags': False,
             'enabled_plugins': [],
@@ -180,7 +180,7 @@ class FileNamingTest(PicardTestCase):
             'move_files': False,
             'rename_files': False,
             'windows_compatibility': True,
-        }
+        })
         self.metadata = Metadata({
             'album': 'somealbum',
             'title': 'sometitle',

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -46,7 +46,7 @@ class TestFileSystem(PicardTestCase):
         super().setUp()
         self.src_directory = self.mktmpdir()
         self.tgt_directory = self.mktmpdir()
-        config.setting = settings.copy()
+        self.set_config_values(settings)
 
     def _prepare_files(self, src_rel_path='', tgt_rel_path=''):
         """Prepare src files and tgt filenames for a test."""

--- a/test/test_interface_colors.py
+++ b/test/test_interface_colors.py
@@ -47,7 +47,7 @@ settings = {
 class InterfaceColorsTest(PicardTestCase):
     def setUp(self):
         super().setUp()
-        config.setting = settings.copy()
+        self.set_config_values(settings)
 
     def test_interface_colors(self):
         for key in ('interface_colors', 'interface_colors_dark'):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -64,7 +64,7 @@ class MBJSONTest(PicardTestCase):
         self.init_test(self.filename)
 
     def init_test(self, filename):
-        config.setting = settings.copy()
+        self.set_config_values(settings)
         self.json_doc = load_test_json(filename)
 
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -29,7 +29,6 @@ from test.picardtestcase import (
 )
 from test.test_coverart_image import create_image
 
-from picard import config
 from picard.cluster import Cluster
 from picard.coverart.image import CoverArtImage
 from picard.file import File
@@ -74,7 +73,7 @@ class CommonTests:
 
         def setUp(self):
             super().setUp()
-            config.setting = settings.copy()
+            self.set_config_values(settings)
             self.metadata = self.get_metadata_object()
             self.metadata.length = 242
             self.metadata["single1"] = "single1-value"

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -31,7 +31,6 @@ from test.picardtestcase import (
     load_test_json,
 )
 
-from picard import config
 from picard.i18n import setup_gettext
 from picard.releasegroup import ReleaseGroup
 
@@ -54,7 +53,7 @@ class ReleaseTest(PicardTestCase):
         setup_gettext(self.localedir, 'C')
 
     def test_1(self):
-        config.setting = settings.copy()
+        self.set_config_values(settings)
         rlist = load_test_json('release_group_2.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
@@ -66,7 +65,7 @@ class ReleaseTest(PicardTestCase):
                          '5 / 2009 / GB / CD / label A / cat 123 / Digipak / specialx')
 
     def test_2(self):
-        config.setting = settings.copy()
+        self.set_config_values(settings)
         rlist = load_test_json('release_group_3.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
@@ -76,7 +75,7 @@ class ReleaseTest(PicardTestCase):
                          '5 / 2011 / FR / CD / label A / cat 123')
 
     def test_3(self):
-        config.setting = settings.copy()
+        self.set_config_values(settings)
         rlist = load_test_json('release_group_4.json')
         r = ReleaseGroup(1)
         r._parse_versions(rlist)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -37,7 +37,6 @@ from unittest.mock import MagicMock
 
 from test.picardtestcase import PicardTestCase
 
-from picard import config
 from picard.cluster import Cluster
 from picard.const import DEFAULT_FILE_NAMING_FORMAT
 from picard.metadata import (
@@ -106,9 +105,9 @@ class ScriptParserTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        config.setting = {
+        self.set_config_values({
             'enabled_plugins': '',
-        }
+        })
 
         self.parser = ScriptParser()
 

--- a/test/test_scripttofilename.py
+++ b/test/test_scripttofilename.py
@@ -53,7 +53,7 @@ class ScriptToFilenameTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        config.setting = settings.copy()
+        self.set_config_values(settings)
 
     def test_plain_filename(self):
         metadata = Metadata()

--- a/test/test_settingsoverride.py
+++ b/test/test_settingsoverride.py
@@ -28,8 +28,8 @@ from picard.util.settingsoverride import SettingsOverride
 class SettingsOverrideTest(PicardTestCase):
 
     def setUp(self):
-        self.config = {'key1': 'origval1', 'key2': 'origval2'}
-        config.setting = self.config.copy()
+        super().setUp()
+        self.set_config_values({'key1': 'origval1', 'key2': 'origval2'})
         self.new_settings = {'key1': 'newval2'}
 
     def test_read_orig_settings(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -388,6 +388,7 @@ SimMatchTest = namedtuple('SimMatchTest', 'similarity name')
 class SortBySimilarity(PicardTestCase):
 
     def setUp(self):
+        super().setUp()
         self.test_values = [
             SimMatchTest(similarity=0.74, name='d'),
             SimMatchTest(similarity=0.61, name='a'),
@@ -435,6 +436,7 @@ class GetQtEnum(PicardTestCase):
 class LimitedJoin(PicardTestCase):
 
     def setUp(self):
+        super().setUp()
         self.list = [str(x) for x in range(0, 10)]
 
     def test_1(self):

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -55,16 +55,12 @@ class WebServiceTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        config.setting = {
+        self.set_config_values({
             'use_proxy': False,
             'server_host': '',
             'network_transfer_timeout_seconds': 30,
-        }
+        })
         self.ws = WebService()
-
-    def tearDown(self):
-        del self.ws
-        config.setting = {}
 
     @patch.object(WebService, 'add_task')
     def test_webservice_method_calls(self, mock_add_task):
@@ -97,19 +93,15 @@ class WebServiceTaskTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        config.setting = {
+        self.set_config_values({
             'use_proxy': False,
             'network_transfer_timeout_seconds': 30,
-        }
+        })
         self.ws = WebService()
 
         # Patching the QTimers since they can only be started in a QThread
         self.ws._timer_run_next_task = MagicMock()
         self.ws._timer_count_pending_requests = MagicMock()
-
-    def tearDown(self):
-        del self.ws
-        config.setting = {}
 
     def test_add_task(self):
 
@@ -215,10 +207,7 @@ class WebServiceProxyTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
-        config.setting = PROXY_SETTINGS.copy()
-
-    def tearDown(self):
-        config.setting = {}
+        self.set_config_values(PROXY_SETTINGS)
 
     def test_proxy_setup(self):
         proxy_types = [


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1926, PICARD-1689, PICARD-2013, ~PICARD-1590~
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

QSettings is not thread safe, but instead each thread must use its own instance of QSettings. Otherwise this leads to deadlocks when reading settings shortly after writing settings in different threads.


# Solution
Prepare per-thread config instances by adding config.get_config() and using it to fix deadlocks experienced in the metadatabox.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
