### PR TITLE
docs: fix simple typo, temporarly -> temporarily

### DIFF
--- a/picard/util/settingsoverride.py
+++ b/picard/util/settingsoverride.py
@@ -23,7 +23,7 @@ from collections.abc import MutableMapping
 
 
 class SettingsOverride(MutableMapping):
-    """ This class can be used to override config temporarly
+    """ This class can be used to override config temporarily
         Basically it returns config[key] if key isn't found in internal dict
 
         Typical usage:


### PR DESCRIPTION
There is a small typo in picard/util/settingsoverride.py.

Should read `temporarily` rather than `temporarly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md