### PR TITLE
PICARD-2084: Set the AcoustID port to 443, to use TLS

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -58,7 +58,7 @@ CACHE_SIZE_IN_BYTES = 100*1000*1000
 # AcoustID client API key
 ACOUSTID_KEY = 'v8pQ6oyB'
 ACOUSTID_HOST = 'api.acoustid.org'
-ACOUSTID_PORT = 80
+ACOUSTID_PORT = 443
 FPCALC_NAMES = ['fpcalc', 'pyfpcalc']
 
 # MB OAuth client credentials


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Set the AcoustID port to 443, to use TLS.

# Problem

Requests to `api.acoustid.org` are sent in plain, unencrypted HTTP, because the port is set to be `80`, while the server does support the port `443` with TLS.

# Solution

Set the AcoustID port to 443 so that requests are sent using HTTPS.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
