### PR TITLE
PICARD-2083: Allow empty fpcalc path, auto detect path if empty

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -41,7 +41,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 5, 6, 'dev', 1)
+PICARD_VERSION = Version(2, 5, 6, 'dev', 2)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -39,6 +39,7 @@ from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
     DEFAULT_NUMBERED_SCRIPT_NAME,
 )
+from picard.const.sys import IS_FROZEN
 
 
 # TO ADD AN UPGRADE HOOK:
@@ -318,6 +319,12 @@ def upgrade_to_v2_5_0_dev_2(config):
     config.persist["bottom_splitter_state"] = b''
 
 
+def upgrade_to_v2_5_6_dev_2(config):
+    """Unset fpcalc path in environments where auto detection is preferred."""
+    if IS_FROZEN or config.setting['acoustid_fpcalc'].startswith('/snap/picard/'):
+        config.setting['acoustid_fpcalc'] = ''
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -344,4 +351,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_4_0_beta_3)
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_1)
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v2_5_6_dev_2)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -32,11 +32,8 @@ from PyQt5 import (
 )
 
 from picard import config
-from picard.const import FPCALC_NAMES
-from picard.util import (
-    find_executable,
-    webbrowser2,
-)
+from picard.acoustid import find_fpcalc
+from picard.util import webbrowser2
 
 from picard.ui.options import (
     OptionsCheckError,
@@ -87,6 +84,7 @@ class FingerprintingOptionsPage(OptionsPage):
             self.ui.use_acoustid.setChecked(True)
         else:
             self.ui.disable_fingerprinting.setChecked(True)
+        self.ui.acoustid_fpcalc.setPlaceholderText(find_fpcalc())
         self.ui.acoustid_fpcalc.setText(config.setting["acoustid_fpcalc"])
         self.ui.acoustid_apikey.setText(config.setting["acoustid_apikey"])
         self.ui.ignore_existing_acoustid_fingerprints.setChecked(config.setting["ignore_existing_acoustid_fingerprints"])
@@ -104,10 +102,6 @@ class FingerprintingOptionsPage(OptionsPage):
     def update_groupboxes(self):
         if self.ui.use_acoustid.isChecked():
             self.ui.acoustid_settings.setEnabled(True)
-            if not self.ui.acoustid_fpcalc.text():
-                fpcalc_path = find_executable(*FPCALC_NAMES)
-                if fpcalc_path:
-                    self.ui.acoustid_fpcalc.setText(fpcalc_path)
         else:
             self.ui.acoustid_settings.setEnabled(False)
         self._acoustid_fpcalc_check()
@@ -130,9 +124,7 @@ class FingerprintingOptionsPage(OptionsPage):
             return
         fpcalc = self.ui.acoustid_fpcalc.text()
         if not fpcalc:
-            self._acoustid_fpcalc_set_success("")
-            return
-
+            fpcalc = find_fpcalc()
         self._fpcalc_valid = False
         process = QtCore.QProcess(self)
         process.finished.connect(self._on_acoustid_fpcalc_check_finished)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -30,6 +30,7 @@ from picard.config import (
     Option,
     TextOption,
 )
+import picard.config_upgrade
 from picard.config_upgrade import (
     OLD_DEFAULT_FILE_NAMING_FORMAT_v1_3,
     OLD_DEFAULT_FILE_NAMING_FORMAT_v2_1,
@@ -50,6 +51,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_4_0_beta_3,
     upgrade_to_v2_5_0_dev_1,
     upgrade_to_v2_5_0_dev_2,
+    upgrade_to_v2_5_6_dev_2,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -289,3 +291,29 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_5_0_dev_2(self.config)
         self.assertEqual(b'', self.config.persist['splitter_state'])
         self.assertEqual(b'', self.config.persist['bottom_splitter_state'])
+
+    def test_upgrade_to_v2_5_6_dev_2(self):
+        TextOption("setting", "acoustid_fpcalc", "")
+        self.config.setting["acoustid_fpcalc"] = "/usr/bin/fpcalc"
+        upgrade_to_v2_5_6_dev_2(self.config)
+        self.assertEqual("/usr/bin/fpcalc", self.config.setting["acoustid_fpcalc"])
+
+    def test_upgrade_to_v2_5_6_dev_2_empty(self):
+        TextOption("setting", "acoustid_fpcalc", "")
+        self.config.setting["acoustid_fpcalc"] = None
+        upgrade_to_v2_5_6_dev_2(self.config)
+        self.assertEqual("", self.config.setting["acoustid_fpcalc"])
+
+    def test_upgrade_to_v2_5_6_dev_2_snap(self):
+        TextOption("setting", "acoustid_fpcalc", "")
+        self.config.setting["acoustid_fpcalc"] = "/snap/picard/221/usr/bin/fpcalc"
+        upgrade_to_v2_5_6_dev_2(self.config)
+        self.assertEqual("", self.config.setting["acoustid_fpcalc"])
+
+    def test_upgrade_to_v2_5_6_dev_2_frozen(self):
+        TextOption("setting", "acoustid_fpcalc", "")
+        self.config.setting["acoustid_fpcalc"] = r"C:\Program Files\MusicBrainz Picard\fpcalc.exe"
+        picard.config_upgrade.IS_FROZEN = True
+        upgrade_to_v2_5_6_dev_2(self.config)
+        picard.config_upgrade.IS_FROZEN = False
+        self.assertEqual("", self.config.setting["acoustid_fpcalc"])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Allow having an empty path for fpcalc configured and auto detect the path in this case.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2083
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Currently Picard will use the path to fpcalc as configured in options. In some cases the path can change with each launch. E.g. when packaged with PyInstaller we usually want to use the bundled fpcalc, and the path to it can change (especially for portable Windows build, which gets extracted to a temporary folder with unique name). Same is true for snap installs on Linux, where each new version installed gets a different path under `/snap/picard/`.

As a workaround for the PyInstaller case Picard on launch always resets the fpcalc path to the autodetected value. This has the side effect that the user cannot configure an alternative path in Options > Fingerprinting (it will get reset on every launch).


# Solution

Change the paradigm a bit. The majority of users likely runs with auto detected path and never has to configure this at all. So make this the default:

- The `acoustid_fpcalc` option can now be empty, which is the default. If empty the path gets auto detected **without** explicitly overwriting the `acoustid_fpcalc` with the detected path.
- Options > Fingerprinting will show the auto detected path as a placeholder hint in the text input and also use it for validating the executable. Only if auto detection does not work the user needs to actually select something
- If the user has selected a specific path this will get used. This is now also true on PyInstaller builds. This means on all platforms can the user explicitly configure a different executable
- Add a config upgrade to reset the path on empty for PyInstaller builds and for snap installs, thus triggering to use auto detection in those cases by default


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
