### PR TITLE
PICARD-2087: Fix crash with Qt < 5.10 when adding new tag

### DIFF
--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -138,7 +138,11 @@ class EditTagDialog(PicardDialog):
 
     def edit_value(self):
         item = self.value_list.currentItem()
-        if item and not self.value_list.isPersistentEditorOpen(item):
+        if item:
+            # Do not initialize editing if editor is already active. Avoids flickering of the edit field
+            # when already in edit mode. `isPersistentEditorOpen` is only supported in Qt 5.10 and later.
+            if hasattr(self.value_list, 'isPersistentEditorOpen') and self.value_list.isPersistentEditorOpen(item):
+                return
             self.value_list.editItem(item)
 
     def add_value(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2087
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard crashes when adding a new tag.

`QListWidget.isPersistentEditorOpen` is only available in Qt 5.10 or later.

# Solution

Check for support of `QListWidget.isPersistentEditorOpen`. This missing doesn't have a huge impact on functionality. We will just start editing again, which makes the current editor close and open again. This gives some flickering when clicking on edit tag with editing already active, but no big deal really.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
