### PR TITLE
PICARD-1943: Fix macOS app signature breaking on macOS 10.12/10.13

### DIFF
--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -53,6 +53,16 @@ APP_BUNDLE="MusicBrainz Picard.app"
 ditto -rsrc --arch x86_64 "$APP_BUNDLE" "$APP_BUNDLE.tmp"
 rm -r "$APP_BUNDLE"
 mv "$APP_BUNDLE.tmp" "$APP_BUNDLE"
+
+# Fix placing text files in Resources instead of Contents to avoid signatures ending up in extended attributes.
+# This fixes the signature breaking if extended attributes get removed or modified.
+# Fixes https://tickets.metabrainz.org/browse/PICARD-1943 and related issues.
+mkdir "$APP_BUNDLE/Contents/Resources/Qt/"
+mv "$APP_BUNDLE/Contents/MacOS/PyQt5/Qt/translations" "$APP_BUNDLE/Contents/Resources/Qt/"
+pushd "$APP_BUNDLE/Contents/MacOS/PyQt5/Qt/"
+ln -s ../../../Resources/Qt/translations .
+popd
+
 if [ "$CODESIGN" = '1' ]; then
     # Enable hardened runtime if app will get notarized
     if [ "$NOTARIZE" = "1" ]; then


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1943, PICARD-1763
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

App bundle's signature gets destroyed on some macOS installs.


# Solution
Avoid signature being written to extended file system attributes by moving resource files to Contents/Resources. This only affects the Qt translations. For other such files PyInstaller already takes care of this.

This is also what PyInstaller fixed for base_library.zip in https://github.com/pyinstaller/pyinstaller/issues/3550

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
