### PR TITLE
PICARD-2091: Refactor coverartbox and fix loading remote images other then PNG or JPEG

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -544,8 +544,10 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
     def choose_local_file(self):
         file_chooser = QtWidgets.QFileDialog(self)
+        extensions = ['*' + ext for ext in imageinfo.get_supported_extensions()]
+        extensions.sort()
         file_chooser.setNameFilters([
-            _("All supported image formats") + " (*.png *.jpg *.jpeg *.tif *.tiff *.gif *.pdf *.webp)",
+            _("All supported image formats") + " (" + " ".join(extensions) + ")",
             _("All files") + " (*)",
         ])
         if file_chooser.exec_():

--- a/picard/util/imageinfo.py
+++ b/picard/util/imageinfo.py
@@ -68,6 +68,10 @@ class IdentifyImageType:
     def _read(self):
         raise NotImplementedError
 
+    @classmethod
+    def all_extensions(cls):
+        return [cls.extension]
+
 
 class IdentifyJPEG(IdentifyImageType):
     mime = 'image/jpeg'
@@ -76,6 +80,10 @@ class IdentifyJPEG(IdentifyImageType):
     def match(self):
         # http://en.wikipedia.org/wiki/JPEG
         return self.data[:2] == b'\xFF\xD8'  # Start Of Image (SOI) marker
+
+    @classmethod
+    def all_extensions(cls):
+        return [cls.extension, '.jpeg']
 
     def _read(self):
         jpeg = BytesIO(self.data)
@@ -208,6 +216,10 @@ class IdentifyTiff(IdentifyImageType):
     def match(self):
         return self.data[:4] == b'II*\x00' or self.data[:4] == b'MM\x00*'
 
+    @classmethod
+    def all_extensions(cls):
+        return [cls.extension, '.tif']
+
     def _read(self):
         # See https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFF6.pdf
         data = self.data
@@ -288,3 +300,8 @@ def supports_mime_type(mime):
         if cls.mime == mime:
             return True
     return False
+
+
+def get_supported_extensions():
+    for cls in knownimagetypes:
+        yield from cls.all_extensions()

--- a/picard/util/imageinfo.py
+++ b/picard/util/imageinfo.py
@@ -251,6 +251,16 @@ class IdentifyTiff(IdentifyImageType):
         return struct.unpack(struct_format, value)[0]
 
 
+knownimagetypes = (
+    IdentifyJPEG,
+    IdentifyPNG,
+    IdentifyPDF,
+    IdentifyGIF,
+    IdentifyWebP,
+    IdentifyTiff,
+)
+
+
 def identify(data):
     """Parse data for jpg, gif, png, webp, tiff and pdf metadata
     If successfully recognized, it returns a tuple with:
@@ -265,17 +275,16 @@ def identify(data):
         - `UnexpectedError` if unhandled cases (shouldn't happen).
         - `IdentificationError` is parent class for all preceding exceptions.
     """
-    knownimagetypes = (
-        IdentifyJPEG,
-        IdentifyPNG,
-        IdentifyPDF,
-        IdentifyGIF,
-        IdentifyWebP,
-        IdentifyTiff,
-    )
     for cls in knownimagetypes:
         obj = cls(data)
         if obj.match():
             return obj.read()
 
     raise UnrecognizedFormat('Unrecognized image data')
+
+
+def supports_mime_type(mime):
+    for cls in knownimagetypes:
+        if cls.mime == mime:
+            return True
+    return False

--- a/test/test_util_imageinfo.py
+++ b/test/test_util_imageinfo.py
@@ -138,3 +138,16 @@ class SupportsMimeTypeTest(PicardTestCase):
     def test_unsupported_mime_types(self):
         self.assertFalse(imageinfo.supports_mime_type('application/octet-stream'))
         self.assertFalse(imageinfo.supports_mime_type('text/html'))
+
+
+class GetSupportedExtensionsTest(PicardTestCase):
+
+    def test_supported_extensions(self):
+        extensions = list(imageinfo.get_supported_extensions())
+        self.assertIn('.jpeg', extensions)
+        self.assertIn('.jpg', extensions)
+        self.assertIn('.pdf', extensions)
+        self.assertIn('.png', extensions)
+        self.assertIn('.tif', extensions)
+        self.assertIn('.tiff', extensions)
+        self.assertIn('.webp', extensions)

--- a/test/test_util_imageinfo.py
+++ b/test/test_util_imageinfo.py
@@ -123,3 +123,18 @@ class IdentifyTest(PicardTestCase):
                           imageinfo.identify, data)
         self.assertRaises(imageinfo.UnrecognizedFormat,
                           imageinfo.identify, data)
+
+
+class SupportsMimeTypeTest(PicardTestCase):
+
+    def test_supported_mime_types(self):
+        self.assertTrue(imageinfo.supports_mime_type('application/pdf'))
+        self.assertTrue(imageinfo.supports_mime_type('image/gif'))
+        self.assertTrue(imageinfo.supports_mime_type('image/jpeg'))
+        self.assertTrue(imageinfo.supports_mime_type('image/png'))
+        self.assertTrue(imageinfo.supports_mime_type('image/tiff'))
+        self.assertTrue(imageinfo.supports_mime_type('image/webp'))
+
+    def test_unsupported_mime_types(self):
+        self.assertFalse(imageinfo.supports_mime_type('application/octet-stream'))
+        self.assertFalse(imageinfo.supports_mime_type('text/html'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

PICARD-2091

This started as a small refactoring, but also fixes an actual bug: Fetching remote images was limited to only PNG and JPEG; hard coded in coverartbox by mimetype


# Solution
- Drop unused `mime` parameter from `CoverArtBox.load_remote_image`
- Try initializing `CoverArtImage` directly instead of probing with `imageinfo.identify` first (`CoverArtImage` will already do this)
- Get list of possible image file extensions from `imageinfo` module
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
