### PR TITLE
PICARD-204: Support for recording-level original release date

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -41,7 +41,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 6, 0, 'dev', 1)
+PICARD_VERSION = Version(2, 6, 0, 'dev', 2)
 
 
 # optional build version

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -41,7 +41,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 6, 0, 'dev', 2)
+PICARD_VERSION = Version(2, 6, 0, 'dev', 1)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -325,11 +325,6 @@ def upgrade_to_v2_6_0_dev_1(config):
         config.setting['acoustid_fpcalc'] = ''
 
 
-def upgrade_to_v2_6_0_dev_2(config):
-    """For upgrades keep using the release group's originaldate as default."""
-    config.setting['originaldate_use_recording'] = False
-
-
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -357,5 +352,4 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_1)
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_2)
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_dev_1)
-    cfg.register_upgrade_hook(upgrade_to_v2_6_0_dev_2)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2013-2014 Michael Wiencek
 # Copyright (C) 2013-2016, 2018-2019 Laurent Monin
 # Copyright (C) 2014, 2017 Lukáš Lalinský
-# Copyright (C) 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2014, 2018-2021 Philipp Wolfer
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
@@ -325,6 +325,11 @@ def upgrade_to_v2_6_0_dev_1(config):
         config.setting['acoustid_fpcalc'] = ''
 
 
+def upgrade_to_v2_6_0_dev_2(config):
+    """For upgrades keep using the release group's originaldate as default."""
+    config.setting['originaldate_use_recording'] = False
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -352,4 +357,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_1)
     cfg.register_upgrade_hook(upgrade_to_v2_5_0_dev_2)
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_dev_1)
+    cfg.register_upgrade_hook(upgrade_to_v2_6_0_dev_2)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -384,9 +384,11 @@ def recording_to_metadata(node, m, track=None):
             add_isrcs_to_metadata(value, m)
         elif key == 'video' and value:
             m['~video'] = '1'
+    config = get_config()
     if m['title']:
         m['~recordingtitle'] = m['title']
-    if m['~recordingoriginaldate']:
+    if m['~recordingoriginaldate'] and (
+        config.setting["originaldate_use_recording"] or not m['originaldate']):
         m['originaldate'] = m['~recordingoriginaldate']
         m['originalyear'] = m['originaldate'][:4]
     if m.length:

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -387,8 +387,7 @@ def recording_to_metadata(node, m, track=None):
     config = get_config()
     if m['title']:
         m['~recordingtitle'] = m['title']
-    if m['~recordingoriginaldate'] and (
-        config.setting["originaldate_use_recording"] or not m['originaldate']):
+    if m['~recordingoriginaldate'] and config.setting["originaldate_use_recording"]:
         m['originaldate'] = m['~recordingoriginaldate']
         m['originalyear'] = m['originaldate'][:4]
     if m.length:

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 David Mandelberg
 # Copyright (C) 2017-2018 Sambhav Kothari
 # Copyright (C) 2017-2019 Laurent Monin
-# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2018-2021 Philipp Wolfer
 # Copyright (C) 2019 Michael Wiencek
 #
 # This program is free software; you can redistribute it and/or
@@ -73,6 +73,7 @@ _MEDIUM_TO_METADATA = {
 
 _RECORDING_TO_METADATA = {
     'disambiguation': '~recordingcomment',
+    'first-release-date': '~recordingoriginaldate',
     'title': 'title',
 }
 
@@ -93,7 +94,7 @@ _ARTIST_TO_METADATA = {
 
 _RELEASE_GROUP_TO_METADATA = {
     'disambiguation': '~releasegroupcomment',
-    'first-release-date': 'originaldate',
+    'first-release-date': '~releaseoriginaldate',
     'title': '~releasegroup',
 }
 
@@ -385,6 +386,9 @@ def recording_to_metadata(node, m, track=None):
             m['~video'] = '1'
     if m['title']:
         m['~recordingtitle'] = m['title']
+    if m['~recordingoriginaldate']:
+        m['originaldate'] = m['~recordingoriginaldate']
+        m['originalyear'] = m['originaldate'][:4]
     if m.length:
         m['~length'] = format_time(m.length)
     if 'instrumental' in m.getall('~performance_attributes'):
@@ -494,7 +498,8 @@ def release_group_to_metadata(node, m, release_group=None):
         elif key == 'secondary-types':
             add_secondary_release_types(value, m)
     add_genres_from_node(node, release_group)
-    if m['originaldate']:
+    if m['~releaseoriginaldate']:
+        m['originaldate'] = m['~releaseoriginaldate']
         m['originalyear'] = m['originaldate'][:4]
     m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -427,6 +427,9 @@ class NonAlbumTrack(Track):
     def _customize_metadata(self):
         super()._customize_metadata()
         self.metadata['album'] = self.album.metadata['album']
+        if self.metadata['~recordingoriginaldate']:
+            self.metadata['originaldate'] = self.metadata['~recordingoriginaldate']
+            self.metadata['originalyear'] = self.metadata['originaldate'][:4]
 
     def run_when_loaded(self, func):
         if self.loaded:

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -75,7 +75,7 @@ class MetadataOptionsPage(OptionsPage):
         BoolOption("setting", "convert_punctuation", True),
         BoolOption("setting", "standardize_artists", False),
         BoolOption("setting", "standardize_instruments", True),
-        BoolOption("setting", "originaldate_use_recording", True),
+        BoolOption("setting", "originaldate_use_recording", False),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2008, 2011 Lukáš Lalinský
-# Copyright (C) 2008-2009, 2018-2019 Philipp Wolfer
+# Copyright (C) 2008-2009, 2018-2021 Philipp Wolfer
 # Copyright (C) 2011 Johannes Weißl
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2013, 2018 Laurent Monin
@@ -75,6 +75,7 @@ class MetadataOptionsPage(OptionsPage):
         BoolOption("setting", "convert_punctuation", True),
         BoolOption("setting", "standardize_artists", False),
         BoolOption("setting", "standardize_instruments", True),
+        BoolOption("setting", "originaldate_use_recording", True),
     ]
 
     def __init__(self, parent=None):
@@ -103,6 +104,10 @@ class MetadataOptionsPage(OptionsPage):
         self.ui.nat_name.setText(config.setting["nat_name"])
         self.ui.standardize_artists.setChecked(config.setting["standardize_artists"])
         self.ui.standardize_instruments.setChecked(config.setting["standardize_instruments"])
+        if config.setting["originaldate_use_recording"]:
+            self.ui.originaldate_use_recording.setChecked(True)
+        else:
+            self.ui.originaldate_use_releasegroup.setChecked(True)
 
     def save(self):
         config = get_config()
@@ -119,6 +124,7 @@ class MetadataOptionsPage(OptionsPage):
                 self.tagger.nats.update()
         config.setting["standardize_artists"] = self.ui.standardize_artists.isChecked()
         config.setting["standardize_instruments"] = self.ui.standardize_instruments.isChecked()
+        config.setting["originaldate_use_recording"] = self.ui.originaldate_use_recording.isChecked()
 
     def set_va_name_default(self):
         self.ui.va_name.setText(self.options[0].default)

--- a/picard/ui/ui_options_metadata.py
+++ b/picard/ui/ui_options_metadata.py
@@ -3,12 +3,14 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_MetadataOptionsPage(object):
     def setupUi(self, MetadataOptionsPage):
         MetadataOptionsPage.setObjectName("MetadataOptionsPage")
-        MetadataOptionsPage.resize(423, 553)
+        MetadataOptionsPage.resize(547, 553)
         self.verticalLayout = QtWidgets.QVBoxLayout(MetadataOptionsPage)
         self.verticalLayout.setObjectName("verticalLayout")
         self.metadata_groupbox = QtWidgets.QGroupBox(MetadataOptionsPage)
@@ -43,6 +45,15 @@ class Ui_MetadataOptionsPage(object):
         self.track_ars = QtWidgets.QCheckBox(self.metadata_groupbox)
         self.track_ars.setObjectName("track_ars")
         self.verticalLayout_3.addWidget(self.track_ars)
+        self.originaldate_label = QtWidgets.QLabel(self.metadata_groupbox)
+        self.originaldate_label.setObjectName("originaldate_label")
+        self.verticalLayout_3.addWidget(self.originaldate_label)
+        self.originaldate_use_recording = QtWidgets.QRadioButton(self.metadata_groupbox)
+        self.originaldate_use_recording.setObjectName("originaldate_use_recording")
+        self.verticalLayout_3.addWidget(self.originaldate_use_recording)
+        self.originaldate_use_releasegroup = QtWidgets.QRadioButton(self.metadata_groupbox)
+        self.originaldate_use_releasegroup.setObjectName("originaldate_use_releasegroup")
+        self.verticalLayout_3.addWidget(self.originaldate_use_releasegroup)
         self.verticalLayout.addWidget(self.metadata_groupbox)
         self.custom_fields_groupbox = QtWidgets.QGroupBox(MetadataOptionsPage)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum)
@@ -100,9 +111,11 @@ class Ui_MetadataOptionsPage(object):
         self.convert_punctuation.setText(_("Convert Unicode punctuation characters to ASCII"))
         self.release_ars.setText(_("Use release relationships"))
         self.track_ars.setText(_("Use track relationships"))
+        self.originaldate_label.setText(_("Original release date:"))
+        self.originaldate_use_recording.setText(_("Use the first release date of the recording"))
+        self.originaldate_use_releasegroup.setText(_("Use the first release date of the release group"))
         self.custom_fields_groupbox.setTitle(_("Custom Fields"))
         self.label_6.setText(_("Various artists:"))
         self.label_7.setText(_("Non-album tracks:"))
         self.nat_name_default.setText(_("Default"))
         self.va_name_default.setText(_("Default"))
-

--- a/test/data/ws_data/recording.json
+++ b/test/data/ws_data/recording.json
@@ -1,6 +1,9 @@
 {
-    "disambiguation":"",
     "id":"cb2cc207-8125-445c-9ef9-6ea44eee959a",
+    "title": "Thinking Out Loud",
+    "length": 281000,
+    "first-release-date": "2014-06-20",
+    "disambiguation":"",
     "aliases":[
         {
             "type":null,
@@ -672,7 +675,5 @@
     }, {
       "count": 3,
       "name": "pop"
-    }],
-    "length":281000,
-    "title":"Thinking Out Loud"
+    }]
 }

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -59,7 +59,152 @@
             "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
             "title": "",
             "format": "12\" Vinyl",
-            "track-offset": 0
+            "track-offset": 0,
+            "tracks": [
+                {
+                    "recording": {
+                        "title": "Speak to Me",
+                        "id": "bef3fddb-5aca-49f5-b2fd-d56a23268d63",
+                        "first-release-date": "1972-02-23",
+                        "length": 68346,
+                        "video": false,
+                        "disambiguation": "original stereo mix"
+                    },
+                    "length": 68346,
+                    "number": "A1",
+                    "position": 1,
+                    "title": "Speak to Me",
+                    "id": "d4156411-b884-368f-a4cb-7c0101a557a2"
+                },
+                {
+                    "recording": {
+                        "video": false,
+                        "disambiguation": "original studio stereo mix",
+                        "title": "Breathe",
+                        "id": "ecbc7c9b-e79d-4ec8-ac77-44e4a7f7f1b8",
+                        "first-release-date": "1973-03-24",
+                        "length": 168720
+                    },
+                    "length": 168720,
+                    "number": "A2",
+                    "position": 2,
+                    "title": "Breathe",
+                    "id": "7d5f0207-489b-3c93-9837-d8b754d5a821"
+                },
+                {
+                    "number": "A3",
+                    "length": 230600,
+                    "id": "ffb7f6b2-b20d-3cb4-bc1b-5b6f4c3c4054",
+                    "title": "On the Run",
+                    "position": 3,
+                    "recording": {
+                        "length": 230000,
+                        "id": "747a79a7-644e-42d4-be86-9adaf44393d8",
+                        "title": "On the Run",
+                        "disambiguation": "original studio stereo mix",
+                        "video": false
+                    }
+                },
+                {
+                    "title": "Time",
+                    "position": 4,
+                    "id": "39478197-6ea3-33ec-af39-dc7ae75c9799",
+                    "number": "A4",
+                    "length": 409600,
+                    "recording": {
+                        "disambiguation": "original studio stereo mix",
+                        "video": false,
+                        "id": "41959321-f2bb-4580-aa19-16248fe665d3",
+                        "title": "Time",
+                        "length": 412000
+                    }
+                },
+                {
+                    "id": "47d38542-2382-3a4b-af05-a8f7e5dcaa5c",
+                    "title": "The Great Gig in the Sky",
+                    "position": 5,
+                    "length": 284133,
+                    "number": "A5",
+                    "recording": {
+                        "video": false,
+                        "disambiguation": "original studio stereo mix",
+                        "title": "The Great Gig in the Sky",
+                        "id": "73b01cea-2dad-4fc2-9e61-02a31477c1b1",
+                        "length": 284133
+                    }
+                },
+                {
+                    "id": "e04126c2-457c-36b1-a6b3-9191002607bf",
+                    "position": 6,
+                    "title": "Money",
+                    "number": "B1",
+                    "length": 382746,
+                    "recording": {
+                        "length": 382746,
+                        "title": "Money",
+                        "id": "7fef22bd-76aa-4803-b56b-93a5d6e70662",
+                        "video": false,
+                        "disambiguation": "original studio stereo mix"
+                    }
+                },
+                {
+                    "recording": {
+                        "video": false,
+                        "disambiguation": "original studio stereo mix",
+                        "length": 469853,
+                        "title": "Us and Them",
+                        "id": "2d1201cf-59bb-4ffa-9f52-f5b3afa13346",
+                        "first-release-date": "1973-03-24"
+                    },
+                    "title": "Us and Them",
+                    "position": 7,
+                    "id": "25ede3e7-6233-36fb-971b-9465454f247b",
+                    "length": 469853,
+                    "number": "B2"
+                },
+                {
+                    "position": 8,
+                    "title": "Any Colour You Like",
+                    "id": "98f679d1-87ff-33df-b815-e585349719ea",
+                    "number": "B3",
+                    "length": 206213,
+                    "recording": {
+                        "title": "Any Colour You Like",
+                        "id": "7c278a16-ae04-460c-88ea-39155cadcd09",
+                        "length": 206000,
+                        "video": false,
+                        "disambiguation": "original studio stereo mix"
+                    }
+                },
+                {
+                    "recording": {
+                        "disambiguation": "original studio stereo mix",
+                        "video": false,
+                        "id": "71c0e054-b700-4fd2-a35b-95c7afc566cb",
+                        "title": "Brain Damage",
+                        "length": 227000
+                    },
+                    "position": 9,
+                    "title": "Brain Damage",
+                    "id": "c8a75ec4-0f9a-35e7-b5b5-92ea929526db",
+                    "length": 226933,
+                    "number": "B4"
+                },
+                {
+                    "recording": {
+                        "id": "76341a6e-bac9-4ab3-9d9a-3cf1c9ceac80",
+                        "title": "Eclipse",
+                        "length": 131546,
+                        "disambiguation": "original studio stereo mix",
+                        "video": false
+                    },
+                    "position": 10,
+                    "title": "Eclipse",
+                    "id": "0c7961e2-1156-34ed-beff-58d400421635",
+                    "number": "B5",
+                    "length": 131546
+                }
+            ]
         }
     ],
     "title": "The Dark Side of the Moon",

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2019 Laurent Monin
-# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2019-2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -52,6 +52,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_5_0_dev_1,
     upgrade_to_v2_5_0_dev_2,
     upgrade_to_v2_6_0_dev_1,
+    upgrade_to_v2_6_0_dev_2,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -317,3 +318,9 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_6_0_dev_1(self.config)
         picard.config_upgrade.IS_FROZEN = False
         self.assertEqual("", self.config.setting["acoustid_fpcalc"])
+
+    def test_upgrade_to_v2_6_0_dev_2(self):
+        BoolOption("setting", "originaldate_use_recording", True)
+        self.assertTrue(self.config.setting["originaldate_use_recording"])
+        upgrade_to_v2_6_0_dev_2(self.config)
+        self.assertFalse(self.config.setting["originaldate_use_recording"])

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -52,7 +52,6 @@ from picard.config_upgrade import (
     upgrade_to_v2_5_0_dev_1,
     upgrade_to_v2_5_0_dev_2,
     upgrade_to_v2_6_0_dev_1,
-    upgrade_to_v2_6_0_dev_2,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -318,9 +317,3 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_6_0_dev_1(self.config)
         picard.config_upgrade.IS_FROZEN = False
         self.assertEqual("", self.config.setting["acoustid_fpcalc"])
-
-    def test_upgrade_to_v2_6_0_dev_2(self):
-        BoolOption("setting", "originaldate_use_recording", True)
-        self.assertTrue(self.config.setting["originaldate_use_recording"])
-        upgrade_to_v2_6_0_dev_2(self.config)
-        self.assertFalse(self.config.setting["originaldate_use_recording"])

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2017, 2019 Laurent Monin
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2018-2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -149,6 +149,30 @@ class ReleaseTest(MBJSONTest):
         formats = media_formats_from_node(self.json_doc['media'])
         self.assertEqual(formats, '12" Vinyl')
 
+    def test_originaldate(self):
+        metadata = Metadata()
+        release_group_to_metadata(self.json_doc['release-group'], metadata)
+        release_to_metadata(self.json_doc, metadata)
+        self.assertEqual('1973-03-24', metadata['originaldate'])
+        # Track 1 has a custom first release date
+        track1 = self.json_doc['media'][0]['tracks'][0]
+        recording_metadata = Metadata(metadata)
+        recording_to_metadata(track1['recording'], recording_metadata)
+        self.assertEqual('1972-02-23', recording_metadata['originaldate'])
+        self.assertEqual('1972', recording_metadata['originalyear'])
+        # Track 2 has the same first release date set as the release
+        track2 = self.json_doc['media'][0]['tracks'][1]
+        recording_metadata = Metadata(metadata)
+        recording_to_metadata(track2['recording'], recording_metadata)
+        self.assertEqual('1973-03-24', recording_metadata['originaldate'])
+        self.assertEqual('1973', recording_metadata['originalyear'])
+        # Track 3 has no first release date set
+        track2 = self.json_doc['media'][0]['tracks'][2]
+        recording_metadata = Metadata(metadata)
+        recording_to_metadata(track2['recording'], recording_metadata)
+        self.assertEqual('1973-03-24', recording_metadata['originaldate'])
+        self.assertEqual('1973', recording_metadata['originalyear'])
+
 
 class NullReleaseTest(MBJSONTest):
 
@@ -190,6 +214,9 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~artists_sort'], 'Sheeran, Ed')
         self.assertEqual(m['~length'], '4:41')
         self.assertEqual(m['~recordingtitle'], 'Thinking Out Loud')
+        self.assertEqual(m['~recordingoriginaldate'], '2014-06-20')
+        self.assertEqual(m['originaldate'], '2014-06-20')
+        self.assertEqual(m['originalyear'], '2014')
         self.assertEqual(t.genres, {
             'blue-eyed soul': 1,
             'pop': 3})

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -211,8 +211,8 @@ class ReleaseTest(MBJSONTest):
         config.setting["originaldate_use_recording"] = False
         recording_to_metadata(track1['recording'], metadata)
         self.assertEqual('1972-02-23', metadata['~recordingoriginaldate'])
-        self.assertEqual('1972-02-23', metadata['originaldate'])
-        self.assertEqual('1972', metadata['originalyear'])
+        self.assertNotIn('originaldate', metadata)
+        self.assertNotIn('originalyear', metadata)
 
 
 class NullReleaseTest(MBJSONTest):

--- a/ui/options_metadata.ui
+++ b/ui/options_metadata.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>423</width>
+    <width>547</width>
     <height>553</height>
    </rect>
   </property>
@@ -74,6 +74,27 @@
        <widget class="QCheckBox" name="track_ars">
         <property name="text">
          <string>Use track relationships</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="originaldate_label">
+        <property name="text">
+         <string>Original release date:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="originaldate_use_recording">
+        <property name="text">
+         <string>Use the first release date of the recording</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="originaldate_use_releasegroup">
+        <property name="text">
+         <string>Use the first release date of the release group</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

Use first-release-date of recordings if available.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-204
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Use the `first-release-date` field on recordings if available and fill `originaldate` and `originalyear` with this information. If the data is not set on a recording (should not happen actually once this is fully rolled out) it would still use the data from the release group.

For more flexibility this makes available two additional variables `~recordingoriginaldate` and `~releaseoriginaldate` for scripting. This e.g. allows to always use the original date for the entire release instead of using the per recording date.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
At this moment this is partially rolled out on musicbrainz.org. This patch already works for getting originaldate when querying standalone-recordings. For full support also for releases with different per-recording dates https://github.com/metabrainz/musicbrainz-server/pull/1847 needs to be merged and rolled out. 