### PR TITLE
Run upgrade hooks on config upgrade only

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007, 2014, 2017 Lukáš Lalinský
-# Copyright (C) 2008, 2014, 2019-2020 Philipp Wolfer
+# Copyright (C) 2008, 2014, 2019-2021 Philipp Wolfer
 # Copyright (C) 2012, 2017 Wieland Hoffmann
 # Copyright (C) 2012-2014 Michael Wiencek
 # Copyright (C) 2013-2016, 2018-2019 Laurent Monin
@@ -195,6 +195,11 @@ class Config(QtCore.QSettings):
 
     def run_upgrade_hooks(self, outputfunc=None):
         """Executes registered functions to upgrade config version to the latest"""
+        if self._version == Version(0, 0, 0, 'dev', 0):
+            # This is a freshly created config
+            self._version = PICARD_VERSION
+            self._write_version()
+            return
         if not self._upgrade_hooks:
             return
         if self._version >= PICARD_VERSION:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

For newly created configs there is no need to run upgrade hooks, the config defaults are already set accordingly.

This also allows having hooks that do changes that apply only on upgrade.

