### PR TITLE
PICARD-2092: non annoying script autocompletion

### DIFF
--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -77,8 +77,7 @@ def script_function_documentation(name, fmt, functions=None, postprocessor=None)
 def script_function_names(functions=None):
     if functions is None:
         functions = dict(ScriptParser._function_registry)
-    for name in sorted(functions):
-        yield name
+    yield from sorted(functions)
 
 
 def script_function_documentation_all(fmt='markdown', pre='',

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -44,7 +44,7 @@ from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.theme import theme
 
 
-EXTRA_VARIABLES = [
+EXTRA_VARIABLES = (
     '~absolutetracknumber',
     '~albumartists_sort',
     '~albumartists',
@@ -70,7 +70,7 @@ EXTRA_VARIABLES = [
     '~silence',
     '~totalalbumtracks',
     '~video',
-]
+)
 
 
 class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
@@ -151,17 +151,21 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
 class ScriptCompleter(QCompleter):
     def __init__(self, parent=None):
-        choices = ['$' + name for name in script_function_names()]
-        choices += self.all_tags
-        super().__init__(choices, parent)
+        super().__init__(self.choices, parent)
         self.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
         self.highlighted.connect(self.set_highlighted)
         self.last_selected = ''
 
     @property
+    def choices(self):
+        yield from {'$' + name for name in script_function_names()}
+        yield from {'%' + name.replace('~', '_') + '%' for name in self.all_tags}
+
+    @property
     def all_tags(self):
-        tags = list(TAG_NAMES.keys()) + list(PRESERVED_TAGS) + EXTRA_VARIABLES
-        return ['%' + name.replace('~', '_') + '%' for name in tags]
+        yield from TAG_NAMES.keys()
+        yield from PRESERVED_TAGS
+        yield from EXTRA_VARIABLES
 
     def set_highlighted(self, text):
         self.last_selected = text

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -192,16 +192,17 @@ class ScriptTextEdit(QTextEdit):
         if completion.startswith('$'):
             completion += '('
         tc.insertText(completion)
-        pos = tc.position()
         # Peek at the next character to include it in the replacement
-        tc = self.textCursor()
-        tc.setPosition(pos + 1, QTextCursor.KeepAnchor)
-        first_char = completion[0]
-        next_char = tc.selectedText()
-        if (first_char == '$' and next_char == '(') or (first_char == '%' and next_char == '%'):
-            tc.removeSelectedText()
-        else:
-            tc.setPosition(pos)  # Reset position
+        if not tc.atEnd():
+            pos = tc.position()
+            tc = self.textCursor()
+            tc.setPosition(pos + 1, QTextCursor.KeepAnchor)
+            first_char = completion[0]
+            next_char = tc.selectedText()
+            if (first_char == '$' and next_char == '(') or (first_char == '%' and next_char == '%'):
+                tc.removeSelectedText()
+            else:
+                tc.setPosition(pos)  # Reset position
         self.setTextCursor(tc)
         self.popup_hide()
 
@@ -216,7 +217,7 @@ class ScriptTextEdit(QTextEdit):
             tc.setPosition(current_position, QTextCursor.KeepAnchor)
         selected_text = tc.selectedText()
         # Check for start of function or end of variable
-        if selected_text and selected_text[0] in ('(', '%'):
+        if current_position > 0 and selected_text and selected_text[0] in ('(', '%'):
             current_position -= 1
             tc.setPosition(current_position)
             tc.select(QTextCursor.WordUnderCursor)

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -120,7 +120,7 @@ class ScriptCompleter(QCompleter):
         choices = list(['$' + name for name in script_function_names()])
         choices += ['%' + name.replace('~', '_') + '%' for name in TAG_NAMES.keys()]
         super().__init__(choices, parent)
-        self.setCompletionMode(QCompleter.PopupCompletion)
+        self.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
         self.highlighted.connect(self.set_highlighted)
         self.last_selected = ''
 

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -35,10 +35,42 @@ from PyQt5.QtWidgets import (
 )
 
 from picard.script import script_function_names
-from picard.util.tags import TAG_NAMES
+from picard.util.tags import (
+    PRESERVED_TAGS,
+    TAG_NAMES,
+)
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.theme import theme
+
+
+EXTRA_VARIABLES = [
+    '~absolutetracknumber',
+    '~albumartists_sort',
+    '~albumartists',
+    '~artists_sort',
+    '~datatrack',
+    '~discpregap',
+    '~multiartist',
+    '~musicbrainz_discids',
+    '~performance_attributes',
+    '~pregap',
+    '~primaryreleasetype',
+    '~rating',
+    '~recording_firstreleasedate',
+    '~recordingcomment',
+    '~recordingtitle',
+    '~releasecomment',
+    '~releasecountries',
+    '~releasegroup_firstreleasedate',
+    '~releasegroup',
+    '~releasegroupcomment',
+    '~releaselanguage',
+    '~secondaryreleasetype',
+    '~silence',
+    '~totalalbumtracks',
+    '~video',
+]
 
 
 class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
@@ -119,12 +151,17 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
 class ScriptCompleter(QCompleter):
     def __init__(self, parent=None):
-        choices = list(['$' + name for name in script_function_names()])
-        choices += ['%' + name.replace('~', '_') + '%' for name in TAG_NAMES.keys()]
+        choices = ['$' + name for name in script_function_names()]
+        choices += self.all_tags
         super().__init__(choices, parent)
         self.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
         self.highlighted.connect(self.set_highlighted)
         self.last_selected = ''
+
+    @property
+    def all_tags(self):
+        tags = list(TAG_NAMES.keys()) + list(PRESERVED_TAGS) + EXTRA_VARIABLES
+        return ['%' + name.replace('~', '_') + '%' for name in tags]
 
     def set_highlighted(self, text):
         self.last_selected = text

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2006-2007, 2009 Lukáš Lalinský
 # Copyright (C) 2014 m42i
 # Copyright (C) 2020 Laurent Monin
-# Copyright (C) 2020 Philipp Wolfer
+# Copyright (C) 2020-2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -173,14 +173,17 @@ class ScriptTextEdit(QTextEdit):
         return tc
 
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Tab and self.completer.popup().isVisible():
-            self.completer.activated.emit(self.completer.get_selected())
-            return
+        if self.completer.popup().isVisible():
+            if event.key() in (Qt.Key_Tab, Qt.Key_Return, Qt.Key_Enter):
+                self.completer.activated.emit(self.completer.get_selected())
+                return
 
         super().keyPressEvent(event)
+        self.handle_autocomplete(event)
 
-        # Do not trigger autocomplete on cursor keys to allow for easier navigation
-        if event.key() in (Qt.Key_Left, Qt.Key_Right, Qt.Key_Up, Qt.Key_Down):
+    def handle_autocomplete(self, event):
+        # Only trigger autocomplete on actual text input
+        if not event.text():
             return
 
         tc = self.cursor_select_word()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2092
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
The script autocompleter can sometimes be annoying:

- It triggers on all kind of key presses, e.g. simply hitting Shift shows the autocompletion
- Accepting a choice only works with Tab. I personally always try to press return to accept the choice, causing a linebreak and the suggestion to abort
- It only shows fully matching suggestions


# Solution
- Only trigger on key presses that cause actual text input or removal.
- Allow explicitly opening the completion poput with Ctrl+Space at any time.
- Allow accepting choice with enter.-
- Use UnfilteredPopupCompletion completion mode ("All possible completions are displayed in a popup window with the most likely suggestion indicated as current.").
- Improved replacement of starting `(` for functions and ending `%` for variables. The `(` for functions is now automatically inserted if the inserted function ins not already followed by a `(` and the cursor placed afterwards.
- Extended variable completion by explicitly adding other known hidden variables.
- Use only the text up to the current cursor position for the suggestion. E.g. if you have a text like `$eq_all`  and you have placed the cursor directly after `$eq` the auto completion will suggest `$eq`, `$eq_all` and `$eq_any` as next choices.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
@Sophist-UK Could you run this code and see if this makes the autocompletion not annoy you?
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
