### PR TITLE
Use yield from syntax where appropriate

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -89,8 +89,7 @@ class FileList(QtCore.QObject, FileListItem):
             update_metadata_images(self)
 
     def iterfiles(self, save=False):
-        for file in self.files:
-            yield file
+        yield from self.files
 
     def update(self):
         pass

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -95,8 +95,7 @@ class ExtensionPoint(object):
         enabled_plugins = config.setting["enabled_plugins"] if config else []
         for name in self.__dict:
             if name is None or name in enabled_plugins:
-                for item in self.__dict[name]:
-                    yield item
+                yield from self.__dict[name]
 
 
 class PluginShared(object):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -338,8 +338,7 @@ class SortBySimilarity(PicardTestCase):
         ]
 
     def candidates(self):
-        for value in self.test_values:
-            yield value
+        yield from self.test_values
 
     def test_sort_by_similarity(self):
         results = [result.name for result in sort_by_similarity(self.candidates)]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:


# Solution
Just a minor change to use the `yield from` syntax where it can be used. So replacing:

```python
for x in items:
    yield x
```

with shorter

```python
yield from items
```