### PR TITLE
PICARD-1998: Add "director" (for videos) tag

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -92,6 +92,7 @@ class APEv2File(File):
     __translate = {
         "albumartist": "Album Artist",
         "remixer": "MixArtist",
+        "director": "Director",
         "website": "Weblink",
         "discsubtitle": "DiscSubtitle",
         "bpm": "BPM",

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -184,6 +184,7 @@ class ASFFile(File):
         'djmixer': 'WM/DJMixer',
         'mixer': 'WM/Mixer',
         'artists': 'WM/ARTISTS',
+        'director': 'WM/Director',
         'work': 'WM/Work',
         'website': 'WM/AuthorURL',
     }

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -193,6 +193,7 @@ class ID3File(File):
         'ASIN': 'asin',
         'MusicMagic Fingerprint': 'musicip_fingerprint',
         'ARTISTS': 'artists',
+        'DIRECTOR': 'director',
         'WORK': 'work',
         'Writer': 'writer',
         'SHOWMOVEMENT': 'showmovement',

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -80,6 +80,7 @@ class MP4File(File):
         "\xa9lyr": "lyrics",
         "\xa9cmt": "comment",
         "\xa9too": "encodedby",
+        "\xa9dir": "director",
         "cprt": "copyright",
         "soal": "albumsort",
         "soaa": "albumartistsort",

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -54,6 +54,7 @@ _artist_rel_types = {
     # "recording": "engineer",
     "remixer": "remixer",
     "sound": "engineer",
+    "video director": "director",
     "vocal arranger": "arranger",
     "writer": "writer",
 }

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -52,6 +52,7 @@ TAG_NAMES = {
     'conductor': N_('Conductor'),
     'copyright': N_('Copyright'),
     'date': N_('Date'),
+    'director': N_('Video Director'),
     'discid': N_('Disc Id'),
     'discnumber': N_('Disc Number'),
     'discsubtitle': N_('Disc Subtitle'),

--- a/test/data/ws_data/recording_video.json
+++ b/test/data/ws_data/recording_video.json
@@ -1,0 +1,238 @@
+{
+    "video": true,
+    "id": "370889ee-7a70-4d0a-8f4d-e514e0494d7e",
+    "first-release-date": "2008-05-23",
+    "aliases": [],
+    "length": 218000,
+    "artist-credit": [
+        {
+            "artist": {
+                "disambiguation": "British metal / hard rock band",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "sort-name": "Paradise Lost",
+                "aliases": [],
+                "id": "10bf95b6-30e3-44f1-817f-45762cdc0de0",
+                "name": "Paradise Lost"
+            },
+            "joinphrase": "",
+            "name": "Paradise Lost"
+        }
+    ],
+    "disambiguation": "official music video",
+    "title": "The Enemy",
+    "relations": [
+        {
+            "source-credit": "",
+            "target-type": "artist",
+            "begin": null,
+            "direction": "backward",
+            "attribute-values": {},
+            "target-credit": "Edward 209",
+            "end": null,
+            "type-id": "5c0ceac3-feb4-41f0-868d-dc06f6e27fc0",
+            "artist": {
+                "disambiguation": "",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "type": "Person",
+                "sort-name": "Mavskegg, Edward",
+                "name": "Edward Mavskegg",
+                "id": "9e26b912-16c1-4dac-991e-87f7aa184fed"
+            },
+            "attribute-ids": {},
+            "attributes": [],
+            "type": "producer",
+            "ended": false
+        },
+        {
+            "direction": "backward",
+            "begin": null,
+            "target-type": "artist",
+            "source-credit": "",
+            "artist": {
+                "name": "Edward Mavskegg",
+                "id": "9e26b912-16c1-4dac-991e-87f7aa184fed",
+                "sort-name": "Mavskegg, Edward",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": ""
+            },
+            "type-id": "578ee04d-3227-4335-ba2c-11e8ba420e0b",
+            "end": null,
+            "target-credit": "Edward 209",
+            "attribute-values": {},
+            "attribute-ids": {},
+            "ended": false,
+            "attributes": [],
+            "type": "video director"
+        },
+        {
+            "target-type": "recording",
+            "source-credit": "",
+            "begin": null,
+            "direction": "backward",
+            "attribute-values": {},
+            "target-credit": "",
+            "end": null,
+            "recording": {
+                "title": "The Enemy",
+                "disambiguation": "",
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "type": null,
+                            "type-id": null,
+                            "disambiguation": "British metal / hard rock band",
+                            "id": "10bf95b6-30e3-44f1-817f-45762cdc0de0",
+                            "name": "Paradise Lost",
+                            "sort-name": "Paradise Lost"
+                        },
+                        "joinphrase": "",
+                        "name": "Paradise Lost"
+                    }
+                ],
+                "id": "20ac46d2-aa41-45e0-b3f4-8b660560c696",
+                "length": 219066,
+                "video": false
+            },
+            "type-id": "ce3de655-7451-44d1-9224-87eb948c205d",
+            "attribute-ids": {},
+            "type": "music video",
+            "attributes": [],
+            "ended": false
+        },
+        {
+            "direction": "forward",
+            "begin": null,
+            "target-type": "url",
+            "source-credit": "",
+            "type-id": "7e41ef12-a124-4324-afdb-fdbae687a89c",
+            "end": null,
+            "target-credit": "",
+            "attribute-values": {},
+            "attribute-ids": {
+                "video": "112054d5-e706-4dd8-99ea-09aabee36cd6"
+            },
+            "url": {
+                "id": "96ebef7d-b7e5-4c58-b9d3-163715bc44bc",
+                "resource": "https://www.youtube.com/watch?v=O_HwMrrJ4M4"
+            },
+            "ended": false,
+            "attributes": [
+                "video"
+            ],
+            "type": "free streaming"
+        },
+        {
+            "ended": false,
+            "url": {
+                "resource": "http://imvdb.com/video/paradise-lost/the-enemy",
+                "id": "6a0bcc4f-f290-4328-8ee1-c63fe45a7a46"
+            },
+            "attributes": [],
+            "type": "other databases",
+            "attribute-ids": {},
+            "type-id": "bc21877b-e993-42ed-a7ce-9187ec9b638f",
+            "end": null,
+            "target-credit": "",
+            "attribute-values": {},
+            "direction": "forward",
+            "begin": null,
+            "target-type": "url",
+            "source-credit": ""
+        },
+        {
+            "direction": "forward",
+            "source-credit": "",
+            "target-type": "work",
+            "begin": null,
+            "end": null,
+            "type-id": "a3005666-a872-32c3-ad06-98af558e99b0",
+            "attribute-values": {},
+            "target-credit": "",
+            "attribute-ids": {},
+            "work": {
+                "disambiguation": "",
+                "type": "Song",
+                "attributes": [],
+                "title": "The Enemy",
+                "relations": [
+                    {
+                        "type": "composer",
+                        "attributes": [],
+                        "ended": false,
+                        "attribute-ids": {},
+                        "attribute-values": {},
+                        "target-credit": "",
+                        "end": null,
+                        "artist": {
+                            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                            "type": "Person",
+                            "disambiguation": "",
+                            "sort-name": "Mackintosh, Gregor",
+                            "name": "Gregor Mackintosh",
+                            "id": "1d82791c-f3b0-4695-985a-35a3f6c7a014"
+                        },
+                        "type-id": "d59d99ea-23d4-4a80-b066-edca32ee158f",
+                        "target-type": "artist",
+                        "source-credit": "",
+                        "begin": null,
+                        "direction": "backward"
+                    },
+                    {
+                        "attribute-ids": {},
+                        "ended": false,
+                        "type": "lyricist",
+                        "attributes": [],
+                        "begin": null,
+                        "target-type": "artist",
+                        "source-credit": "",
+                        "direction": "backward",
+                        "target-credit": "",
+                        "attribute-values": {},
+                        "artist": {
+                            "id": "c77bf917-f24d-4e91-a140-12d1707f4428",
+                            "name": "Nick Holmes",
+                            "sort-name": "Holmes, Nick",
+                            "disambiguation": "British metal vocalist",
+                            "type": "Person",
+                            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                        },
+                        "type-id": "3e48faba-ec01-47fd-8e89-30e81161661c",
+                        "end": null
+                    },
+                    {
+                        "attribute-ids": {},
+                        "ended": false,
+                        "url": {
+                            "resource": "http://lyrics.wikia.com/Paradise_Lost:The_Enemy",
+                            "id": "ae13d5e0-075b-4d61-8102-9f66127c726f"
+                        },
+                        "attributes": [],
+                        "type": "lyrics",
+                        "direction": "backward",
+                        "begin": null,
+                        "target-type": "url",
+                        "source-credit": "",
+                        "type-id": "e38e65aa-75e0-42ba-ace0-072aeb91a538",
+                        "end": null,
+                        "target-credit": "",
+                        "attribute-values": {}
+                    }
+                ],
+                "language": "eng",
+                "id": "9a186e42-bf73-3e91-9359-cc7b6579eeb8",
+                "iswcs": [
+                    "T-900.213.450-1"
+                ],
+                "languages": [
+                    "eng"
+                ],
+                "type-id": "f061270a-2fd6-32f1-a641-f0f8676d14e6"
+            },
+            "attributes": [],
+            "type": "performance",
+            "ended": false
+        }
+    ]
+}

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -115,6 +115,7 @@ TAGS = {
     'conductor': 'Foo',
     'copyright': 'Foo',
     'date': '2004',
+    'director': 'Foo',
     'discnumber': '1',
     'discsubtitle': 'Foo',
     'djmixer': 'Foo',

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -191,6 +191,7 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~length'], '4:41')
         self.assertEqual(m['~recordingtitle'], 'Thinking Out Loud')
         self.assertEqual(m['~recording_firstreleasedate'], '2014-06-20')
+        self.assertEqual(m['~video'], '')
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
         self.assertEqual(t.genres, {
@@ -221,6 +222,19 @@ class RecordingInstrumentalTest(MBJSONTest):
         self.assertIn('instrumental', m.getall('~performance_attributes'))
         self.assertEqual(m['language'], 'zxx')
         self.assertNotIn('lyricist', m)
+
+
+class RecordingVideoTest(MBJSONTest):
+
+    filename = 'recording_video.json'
+
+    def test_recording(self):
+        m = Metadata()
+        t = Track('1')
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['director'], 'Edward 209')
+        self.assertEqual(m['producer'], 'Edward 209')
+        self.assertEqual(m['~video'], '1')
 
 
 class NullRecordingTest(MBJSONTest):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary
This adds a tag "director" which is filled with the "video director" AR from MB by default.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1998
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add the `director` tag and fill it with the `video director` AR from MB.

Map the tag as follows:

 * MP4: ©dir (from iTunes Metadata Format Specification)
 * ASF: [WM/Director](https://docs.microsoft.com/en-us/previous-versions/ms867702(v=msdn.10)?redirectedfrom=MSDN#wmdirector)
 * ID3: TXXX/DIRECTOR
 * APE: Director
 * Vorbis: DIRECTOR

For ID3, APE and Vorbis this is probably not too relevant, as few people might use this for audio files only. But the mapping follows our usual naming. For MP4 and ASF there are explicit definitions in the respective specs. For Matroska there would be as well, but we don't support that yet.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Needs doc update to add the tag and tag mapping.