### PR TITLE
PICARD-2102: After cluster action select the Clusters item

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2007 Robert Kaye
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 Hendrik van Antwerpen
-# Copyright (C) 2008-2011, 2014-2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2008-2011, 2014-2015, 2018-2021 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2009 Nikolai Prokoschenko
 # Copyright (C) 2011 Tim Blechmann
@@ -323,6 +323,14 @@ class MainPanel(QtWidgets.QSplitter):
             self._views[0].collapseAll()
         else:
             self._views[0].expandAll()
+
+    def select_object(self, obj):
+        item = obj.item
+        for view in self._views:
+            if view.indexFromItem(item).isValid():
+                view.setCurrentItem(item)
+                self._update_selection(view)
+                break
 
 
 def paint_fingerprint_icon(painter, rect, icon):

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 Robert Kaye
 # Copyright (C) 2008 Will
-# Copyright (C) 2008-2010, 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2008-2010, 2015, 2018-2021 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2009 David Hilton
 # Copyright (C) 2011-2012 Chad Wilson
@@ -1146,6 +1146,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def cluster(self):
         self.tagger.cluster(self.selected_objects)
+        self.panel.update_current_view()
+        # Select clusters if no other item or only empty unclustered files item is selected
+        if not self.selected_objects or (len(self.selected_objects) == 1
+                and self.tagger.unclustered_files in self.selected_objects
+                and not self.tagger.unclustered_files.files):
+            self.panel.select_object(self.tagger.clusters)
         self.update_actions()
 
     def refresh(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
After clustering completed, if there is no selection or only Unclustered files is selected without any files, automatically select the Clusters item. This allows for easier workflow as the user can now directly use actions like Lookup on the new clusters.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2102
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Update the selection after clustering.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

