### PR TITLE
PICARD-2114: Show disambiguation comment in cdlookup dialog

### DIFF
--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2009, 2018-2019 Philipp Wolfer
+# Copyright (C) 2009, 2018-2019, 2021 Philipp Wolfer
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2013-2014, 2018 Laurent Monin
@@ -71,7 +71,8 @@ class CDLookupDialog(PicardDialog):
         release_list.setSortingEnabled(True)
         release_list.setAlternatingRowColors(True)
         release_list.setHeaderLabels([_("Album"), _("Artist"), _("Date"), _("Country"),
-                                      _("Labels"), _("Catalog #s"), _("Barcode")])
+                                      _("Labels"), _("Catalog #s"), _("Barcode"),
+                                      _("Disambiguation")])
         self.ui.submit_button.setIcon(QtGui.QIcon(":/images/cdrom.png"))
         if self.releases:
             def myjoin(values):
@@ -82,7 +83,7 @@ class CDLookupDialog(PicardDialog):
             for release in self.releases:
                 labels, catalog_numbers = label_info_from_node(release['label-info'])
                 dates, countries = release_dates_and_countries_from_node(release)
-                barcode = release['barcode'] if "barcode" in release else ""
+                barcode = release.get('barcode', '')
                 item = QtWidgets.QTreeWidgetItem(release_list)
                 if disc.mcn and compare_barcodes(barcode, disc.mcn):
                     selected = item
@@ -93,6 +94,7 @@ class CDLookupDialog(PicardDialog):
                 item.setText(4, myjoin(labels))
                 item.setText(5, myjoin(catalog_numbers))
                 item.setText(6, barcode)
+                item.setText(7, release.get('disambiguation', ''))
                 item.setData(0, QtCore.Qt.UserRole, release['id'])
             release_list.setCurrentItem(selected or release_list.topLevelItem(0))
             self.ui.ok_button.setEnabled(True)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

When looking up CD's, the window that pops up to present the choices to "Load into Picard" or to "Submit disc ID" does not show the release disambiguation, which makes it hard to tell which one is wanted.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2114
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Add a column for the disambiguation comment to the CD lookup dialog
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
