### PR TITLE
PICARD-2125: Enable CaaReleaseGroup by default

### DIFF
--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -60,7 +60,7 @@ class CoverOptionsPage(OptionsPage):
         ListOption("setting", "ca_providers", [
             ('Cover Art Archive', True),
             ('UrlRelationships', True),
-            ('CaaReleaseGroup', False),
+            ('CaaReleaseGroup', True),
             ('Local', False),
         ]),
     ]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

As discussed in #1743 enable the CaaReleaseGroup cover art provider by default, but keep its position.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2125
* See also #1743
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The CAA Release Group cover art provider is a useful fallback in case there is no cover art for a release. It might also satisfy users which otherwise would want to add a wrong cover art to the release just to get some result.


# Solution
Change default config for new installs