### PR TITLE
PICARD-2127: Fixed passing tport parameter in metadatabox browser lookup

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -10,7 +10,7 @@
 # Copyright (C) 2013-2014, 2017-2019 Laurent Monin
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2015 Wieland Hoffmann
-# Copyright (C) 2015, 2018-2020 Philipp Wolfer
+# Copyright (C) 2015, 2018-2021 Philipp Wolfer
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2020 Gabriel Ferreira
@@ -40,7 +40,6 @@ from PyQt5 import (
 )
 
 from picard.album import Album
-from picard.browser.browser import BrowserIntegration
 from picard.browser.filelookup import FileLookup
 from picard.cluster import Cluster
 from picard.config import (
@@ -240,7 +239,6 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.changes_first_action.setCheckable(True)
         self.changes_first_action.setChecked(config.persist["show_changes_first"])
         self.changes_first_action.toggled.connect(self.toggle_changes_first)
-        self.browser_integration = BrowserIntegration()
         # TR: Keyboard shortcut for "Add New Tag..."
         self.add_tag_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(_("Alt+Shift+A")), self, partial(self.edit_tag, ""))
         self.add_tag_action.setShortcut(self.add_tag_shortcut.key())
@@ -258,7 +256,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         config = get_config()
         return FileLookup(self, config.setting["server_host"],
                           config.setting["server_port"],
-                          self.browser_integration.port)
+                          self.tagger.browser_integration.port)
 
     def lookup_tags(self):
         lookup = self.get_file_lookup()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2127
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Using "lookup in browser" in the metadata box (from the context menu of a MBID tag) does not pass on the browser tport parameter. That is because it is using a separate browser integration instance.

# Solution
Use global `BrowserIntegration` instance