### PR TITLE
PICARD-2088: Fix Windows not writing to settings file

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -157,8 +157,14 @@ class Config(QtCore.QSettings):
     def sync(self):
         # Custom file locking for save multi process syncing of the config file. This is needed
         # as we have atomicSyncRequired disabled.
-        with fasteners.InterProcessLock(self.fileName()):
+        with fasteners.InterProcessLock(self.get_lockfile_name()):
             super().sync()
+
+    def get_lockfile_name(self):
+        filename = self.fileName()
+        directory = os.path.dirname(filename)
+        filename = '.' + os.path.basename(filename) + '.synclock'
+        return os.path.join(directory, filename)
 
     @classmethod
     def from_app(cls, parent):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Fix a regression of config file not getting written to on Windows after #1747

# Problem
When locking the config file itself writing to it fails on Windows.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2088
* #1747
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Use a separate lock file.

Choose a name that is distinct from Qt's default lock file name. Also make it hidden on Unix systems.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
