### PR TITLE
PICARD-2131: Workaround for slow reaction of tagger button in Firefox

### DIFF
--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -153,6 +153,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             log.error('Browser integration failed handling request', exc_info=True)
             self._response(500, 'Unexpected request error')
 
+    def log_error(self, format, *args):
+        log.error(format, *args)
+
+    def log_message(self, format, *args):
+        log.info(format, *args)
+
     def _handle_get(self):
         parsed = urlparse(self.path)
         args = parse_qs(parsed.query)

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2012-2013, 2018, 2021 Philipp Wolfer
-# Copyright (C) 2013, 2018 Laurent Monin
+# Copyright (C) 2013, 2018, 2021 Laurent Monin
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
@@ -47,6 +47,15 @@ from picard import (
 from picard.config import get_config
 from picard.util import mbid_validate
 from picard.util.thread import to_main
+
+
+try:
+    from http.server import ThreadingHTTPServer
+except ImportError:
+    from socketserver import ThreadingMixIn
+
+    class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+        daemon_threads = True
 
 
 SERVER_VERSION = '%s-%s/%s' % (PICARD_ORG_NAME, PICARD_APP_NAME, PICARD_VERSION_STR)
@@ -99,7 +108,7 @@ class BrowserIntegration(QtCore.QObject):
 
         for port in range(config.setting["browser_integration_port"], 65535):
             try:
-                self.server = HTTPServer((host_address, port), RequestHandler)
+                self.server = ThreadingHTTPServer((host_address, port), RequestHandler)
             except OSError:
                 continue
             log.info("Starting the browser integration (%s:%d)", host_address, port)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2131
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On Firefox the tagger button request blocks for > 4 seconds before succeeding since recent refactoring of the browser listener code. Closer investigation reveals that before the actual request there is kind of a ghost request received on the socket, but which blocks on reading. The exact cause is not clear to me, it does not happen on other browsers or when invoking the Picard URL in any other way from within Firefox.


# Solution
Apply a timeout to the request socket. That makes the initial ghost request fail quickly and not block the actual processing.

An alternative approach that also worked for me:

```
def handle(self):
    self.request.setblocking(False)
    super().handle()
```