### PR TITLE
PICARD-2135: Fixed saving and deleting license and website to ID3

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -485,8 +485,10 @@ class ID3File(File):
                     if frameid == 'WCOP':
                         # Only add WCOP if there is only one license URL, otherwise use TXXX:LICENSE
                         if len(values) > 1 or not valid_urls:
+                            tags.delall('WCOP')
                             tags.add(self.build_TXXX(encoding, self.__rtranslate_freetext[name], values))
                         else:
+                            tags.delall('TXXX:' + self.__rtranslate_freetext[name])
                             tags.add(id3.WCOP(url=values[0]))
                     elif frameid == 'WOAR' and valid_urls:
                         tags.delall('WOAR')
@@ -575,6 +577,9 @@ class ID3File(File):
                     for key, frame in list(tags.items()):
                         if frame.FrameID == 'UFID' and frame.owner == 'http://musicbrainz.org':
                             del tags[key]
+                elif name == 'license':
+                    tags.delall(real_name)
+                    tags.delall('TXXX:' + self.__rtranslate_freetext[name])
                 elif real_name == 'POPM':
                     user_email = config.setting['rating_user_email']
                     for key, frame in list(tags.items()):

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -489,6 +489,7 @@ class ID3File(File):
                         else:
                             tags.add(id3.WCOP(url=values[0]))
                     elif frameid == 'WOAR' and valid_urls:
+                        tags.delall('WOAR')
                         for url in values:
                             tags.add(id3.WOAR(url=url))
                 elif frameid.startswith('T') or frameid == 'MVNM':
@@ -580,7 +581,7 @@ class ID3File(File):
                         if frame.FrameID == 'POPM' and frame.email == user_email:
                             del tags[key]
                 elif real_name in self.__translate:
-                    del tags[real_name]
+                    tags.delall(real_name)
                 elif name.lower() in self.__rtranslate_freetext_ci:
                     delall_ci(tags, 'TXXX:' + self.__rtranslate_freetext_ci[name.lower()])
                 elif real_name in self.__translate_freetext:

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -454,6 +454,28 @@ class CommonId3Tests:
             self.assertIn('http://example.com/1', loaded_licenses)
             self.assertIn('http://example.com/2', loaded_licenses)
 
+        @skipUnlessTestfile
+        def test_woar_not_duplicated(self):
+            metadata = Metadata({
+                'website': 'http://example.com/1'
+            })
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertEqual(metadata['website'], loaded_metadata['website'])
+            metadata['website'] = 'http://example.com/2'
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertEqual(metadata['website'], loaded_metadata['website'])
+
+        @skipUnlessTestfile
+        def test_woar_delete(self):
+            metadata = Metadata({
+                'website': 'http://example.com/1'
+            })
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertEqual(metadata['website'], loaded_metadata['website'])
+            del metadata['website']
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertNotIn('website', loaded_metadata)
+
 
 class MP3Test(CommonId3Tests.Id3TestCase):
     testfile = 'test.mp3'

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -455,6 +455,46 @@ class CommonId3Tests:
             self.assertIn('http://example.com/2', loaded_licenses)
 
         @skipUnlessTestfile
+        def test_license_upgrade_wcop(self):
+            tags = mutagen.id3.ID3Tags()
+            tags.add(mutagen.id3.WCOP(url='http://example.com/1'))
+            save_raw(self.filename, tags)
+            metadata = load_metadata(self.filename)
+            self.assertEqual('http://example.com/1', metadata['license'])
+            metadata.add('license', 'http://example.com/2')
+            save_metadata(self.filename, metadata)
+            raw_metadata = load_raw(self.filename)
+            self.assertNotIn('WCOP', raw_metadata)
+            loaded_licenses = [url for url in raw_metadata['TXXX:LICENSE']]
+            self.assertEqual(['http://example.com/1', 'http://example.com/2'], loaded_licenses)
+
+        @skipUnlessTestfile
+        def test_license_downgrade_wcop(self):
+            tags = mutagen.id3.ID3Tags()
+            licenses = ['http://example.com/1', 'http://example.com/2']
+            tags.add(mutagen.id3.TXXX(desc='LICENSE', text=licenses))
+            save_raw(self.filename, tags)
+            raw_metadata = load_raw(self.filename)
+            metadata = load_metadata(self.filename)
+            self.assertEqual(licenses, metadata.getall('license'))
+            metadata['license'] = 'http://example.com/1'
+            save_metadata(self.filename, metadata)
+            raw_metadata = load_raw(self.filename)
+            self.assertEqual('http://example.com/1', raw_metadata['WCOP'])
+            self.assertNotIn('TXXX:LICENSE', raw_metadata)
+
+        @skipUnlessTestfile
+        def test_license_delete(self):
+            tags = mutagen.id3.ID3Tags()
+            tags.add(mutagen.id3.WCOP(url='http://example.com/1'))
+            tags.add(mutagen.id3.TXXX(desc='LICENSE', text='http://example.com/2'))
+            save_raw(self.filename, tags)
+            metadata = load_metadata(self.filename)
+            del metadata['license']
+            loaded_metadata = save_and_load_metadata(self.filename, metadata)
+            self.assertNotIn('license', loaded_metadata)
+
+        @skipUnlessTestfile
         def test_woar_not_duplicated(self):
             metadata = Metadata({
                 'website': 'http://example.com/1'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

`license` and `website` tags can get duplicated when saving and cannot be deleted completely.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2135
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Handle deletion and updating of `license` and `website` tags in ID3, added tests.