### PR TITLE
PICARD-2156: Use ⌘+⇧+H as shortcut for history window on macOS

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -664,7 +664,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.view_history_action = QtWidgets.QAction(_("View Activity &History"), self)
         self.view_history_action.triggered.connect(self.show_history)
         # TR: Keyboard shortcut for "View Activity History"
-        self.view_history_action.setShortcut(QtGui.QKeySequence(_("Ctrl+H")))
+        # On macOS ⌘+H is a system shortcut to hide the window. Use ⌘+Shift+H instead.
+        self.view_history_action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+H") if IS_MACOS else _("Ctrl+H")))
 
         webservice_manager = self.tagger.webservice.manager
         webservice_manager.authenticationRequired.connect(self.show_password_dialog)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2156
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On macOS ⌘+H is a system shortcut to hide the window, it conflicts with the default shortcut Picard uses for showing the history Window. 

# Solution
Use Use ⌘+Shift+H on macOS instead. This is also consistent with other shortcuts that we combine with Shift, e.g. for Tags from filenames or Lookup in browser.