### PR TITLE
PICARD-2168: Use Control+Space for script edit autocompletion on macOS

### DIFF
--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -34,6 +34,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
 )
 
+from picard.const.sys import IS_MACOS
 from picard.script import script_function_names
 from picard.util.tags import (
     PRESERVED_TAGS,
@@ -257,8 +258,9 @@ class ScriptTextEdit(QTextEdit):
 
     def handle_autocomplete(self, event):
         # Only trigger autocomplete on actual text input or if the user explicitly
-        # requested auto completion with Ctrl+Space
-        force_completion_popup = event.key() == QtCore.Qt.Key_Space and event.modifiers() & QtCore.Qt.ControlModifier
+        # requested auto completion with Ctrl+Space (Control+Space on macOS)
+        modifier = QtCore.Qt.MetaModifier if IS_MACOS else QtCore.Qt.ControlModifier
+        force_completion_popup = event.key() == QtCore.Qt.Key_Space and event.modifiers() & modifier
         if not (force_completion_popup
                 or event.key() in (Qt.Key_Backspace, Qt.Key_Delete)
                 or self.autocomplete_trigger_chars.match(event.text())):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2168
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The default shortcut to toggle the auto completion in script editors is set to Command+Space on macOS, but this conflicts with the system wide shortcut to trigger Spotlight search.


# Solution
Command+Space is reserved for Spotlight search. Control+Space is also what is used by XCode for autocompletion.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
