### PR TITLE
PICARD-2170: Guessed title / tracknumber should show up as changed tags

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -228,6 +228,7 @@ class File(QtCore.QObject, Item):
     def _copy_loaded_metadata(self, metadata):
         filename, _ = os.path.splitext(self.base_filename)
         metadata['~length'] = format_time(metadata.length)
+        self.orig_metadata.copy(metadata)
         if 'tracknumber' not in metadata:
             tracknumber = tracknum_from_filename(self.base_filename)
             if tracknumber is not None:
@@ -240,7 +241,6 @@ class File(QtCore.QObject, Item):
                         metadata['title'] = stripped_filename[tnlen:].lstrip()
         if 'title' not in metadata:
             metadata['title'] = filename
-        self.orig_metadata = metadata
         self.metadata.copy(metadata)
 
     def copy_metadata(self, metadata, preserve_deleted=True):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2170
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When title / tracknumber are not present in the file's tags and are guessed from filename they should show up as changed tags.


# Solution
Store original metadata before the guessed values get set.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
