### PR TITLE
PICARD-2177: Add script function to replace entries in multi-value variables

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -286,6 +286,30 @@ def func_replace(parser, text, old, new):
     return text.replace(old, new)
 
 
+@script_function(eval_args=False, documentation=N_(
+    """`$replacemulti(name,search,replace,separator="; ")`
+
+Replaces occurrences of `search` with `replace` in the multi-value variable `name`.
+
+Example:
+
+    $replacemulti(%genre%,Idm,IDM)
+"""
+))
+def func_replacemulti(parser, multi, search, replace, separator=MULTI_VALUED_JOINER):
+    if not multi or not search or replace is None or not separator:
+        return multi
+
+    search = search.eval(parser)
+    replace = replace.eval(parser)
+    multi_value = MultiValue(parser, multi, separator)
+    for n, value in enumerate(multi_value):
+        if value == search:
+            multi_value[n] = replace
+
+    return str(multi_value)
+
+
 @script_function(documentation=N_(
     """`$in(x,y)`
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -529,6 +529,20 @@ class ScriptParserTest(PicardTestCase):
     def test_cmd_replace(self):
         self.assertScriptResultEquals("$replace(abc ab abd a,ab,test)", "testc test testd a")
 
+    def test_cmd_replacemulti(self):
+        context = Metadata()
+        context["genre"] = ["Electronic", "Idm", "Techno"]
+        self.assertScriptResultEquals("$replacemulti(%genre%,Idm,IDM)", "Electronic; IDM; Techno", context)
+
+        context["genre"] = ["Electronic", "Jungle", "Bardcore"]
+        self.assertScriptResultEquals("$replacemulti(%genre%,Bardcore,Hardcore)", "Electronic; Jungle; Hardcore", context)
+
+        context["test"] = ["One", "Two", "Three"]
+        self.assertScriptResultEquals("$replacemulti(%test%,Four,Five)", "One; Two; Three", context)
+
+        context["test"] = ["Four", "Five", "Six"]
+        self.assertScriptResultEquals("$replacemulti(%test%,Five,)", "Four; ; Six", context)
+
     def test_cmd_strip(self):
         self.assertScriptResultEquals("$strip(  \t abc  de \n f  )", "abc de f")
 


### PR DESCRIPTION
* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

This is a simple patch to add a "$replacemulti" script function. It was originally implemented as a plugin for a user who was asking in IRC if it was possible to change/replace genres:

* [Community post](https://community.metabrainz.org/t/trying-to-standardize-genres-other-tags/527069/13)
* [Plugin gist](https://gist.github.com/atj/2333e8279bfa194b9ab624c9b637df65)

Happy to create a JIRA ticket if required.
