### PR TITLE
Re-enable config memoization

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -64,11 +64,6 @@ class ConfigSection(QtCore.QObject):
     def key(self, name):
         return self.__prefix + name
 
-    def _subkeys(self):
-        for key in self.__qt_config.allKeys():
-            if key[:self.__prefix_len] == self.__prefix:
-                yield key[self.__prefix_len:]
-
     def __getitem__(self, name):
         opt = Option.get(self.__name, name)
         if opt is None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->



This adds the config caching introduced in 18c4e93cf1073e21857e4e39d311eb28d9d8f76f as part of #1555 again. This was lost in the refactoring of the config for Picard 2.6


# Solution
Apply the test again, removed some obsolete code.

See also my comment at https://github.com/metabrainz/picard/pull/1780#issuecomment-815536274 for some measurements of how this can affect performance.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
