### PR TITLE
PICARD-2181: Allow Markdown for plugin descriptions

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -83,6 +83,7 @@ api_versions = [
     "2.4",
     "2.5",
     "2.6",
+    "2.7",
 ]
 
 api_versions_tuple = [Version.from_string(v) for v in api_versions]

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -45,6 +45,15 @@ from picard.version import (
 )
 
 
+try:
+    from markdown import markdown
+except ImportError:
+    def markdown(text):
+        # Simple fallback, just make sure line breaks are applied
+        if not text:
+            return ''
+        return text.strip().replace('\n', '<br>\n')
+
 _PLUGIN_MODULE_PREFIX = "picard.plugins."
 _PLUGIN_MODULE_PREFIX_LEN = len(_PLUGIN_MODULE_PREFIX)
 
@@ -138,7 +147,7 @@ class PluginWrapper(PluginShared):
     @property
     def description(self):
         try:
-            return self.data['PLUGIN_DESCRIPTION']
+            return markdown(self.data['PLUGIN_DESCRIPTION'])
         except KeyError:
             return ""
 

--- a/requirements-macos-10.12.txt
+++ b/requirements-macos-10.12.txt
@@ -1,7 +1,7 @@
 python-dateutil==2.8.1
 discid==1.2.0
 fasteners==0.16
-markdown==3.2.2
+markdown==3.3.4
 mutagen==1.45.1
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2

--- a/requirements-macos-10.14.txt
+++ b/requirements-macos-10.14.txt
@@ -1,7 +1,7 @@
 python-dateutil==2.8.1
 discid==1.2.0
 fasteners==0.16
-markdown==3.2.2
+markdown==3.3.4
 mutagen==1.45.1
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,7 +1,7 @@
 python-dateutil==2.8.1
 discid==1.2.0
 fasteners==0.16
-markdown==3.2.2
+markdown==3.3.4
 mutagen==1.45.1
 PyQt5==5.15.4
 pywin32==300


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2181
* https://github.com/metabrainz/picard-website/pull/229
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Many plugins try to come with a more comprehensive description, including some markup. So far those plugins contained HTML tags. Allowing markdown will allow easier and better readable (in source) formatting.

# Solution

Use the already used python-markdown module to render the plugin descriptions. As this module is considered optional provide a fallback that only ensures newlines are preserved.

Rendering with Markdown:

![grafik](https://user-images.githubusercontent.com/29852/114273108-2e810780-9a19-11eb-90a3-a1b45afae336.png)

Without Markdown, using fallback:

![grafik](https://user-images.githubusercontent.com/29852/114273207-7e5fce80-9a19-11eb-9d1e-794b1a1870bf.png)

As HTML is allowed in markdown existing descriptions continue to render properly. Likewise pure markdown still remains readable without conversion to HTML.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

For the listing of downloadable plugins even older Picard versions would render the description fine as the description is served by the website after conversion to HTML. We could change that, but I would keep it that way for compatibility for a while.

We should not immediately start converting plugin descriptions to Markdown, though. Older Picard versions would not render the description of installed plugins properly. Instead we should use Markdown only for plugins compatible with Picard API version 2.7 or later. This change is here to start transitioning.
