### PR TITLE
PICARD-2176: Add column to see if cover art is present 

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -21,6 +21,7 @@
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2019 Joel Lintunen
 # Copyright (C) 2020 Gabriel Ferreira
+# Copyright (C) 2021 Petit Minion
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -666,22 +667,8 @@ class Album(DataObject, Item):
                 unsaved = self.get_num_unsaved_files()
                 if unsaved:
                     text += '; %d*' % (unsaved,)
-                # CoverArt.set_metadata uses the orig_metadata.images if metadata.images is empty
-                # in order to show existing cover art if there's no cover art for a release. So
-                # we do the same here in order to show the number of images consistently.
-                if self.metadata.images:
-                    metadata = self.metadata
-                else:
-                    metadata = self.orig_metadata
-
-                number_of_images = len(metadata.images)
-                if getattr(metadata, 'has_common_images', True):
-                    text += ngettext("; %i image", "; %i images",
-                                     number_of_images) % number_of_images
-                else:
-                    text += ngettext("; %i image not in all tracks", "; %i different images among tracks",
-                                     number_of_images) % number_of_images
-                return text + ')'
+                text += self._cover_art_description(self.metadata.images, True)
+                return text
             else:
                 return title
         elif column == '~length':
@@ -696,6 +683,8 @@ class Album(DataObject, Item):
             return self.metadata['~totalalbumtracks']
         elif column == 'discnumber':
             return self.metadata['totaldiscs']
+        elif column == 'covercount':
+            return self._cover_art_description(self.metadata.images, False)
         else:
             return self.metadata[column]
 

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -18,6 +18,7 @@
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2020 Ray Bouchard
 # Copyright (C) 2020 Gabriel Ferreira
+# Copyright (C) 2021 Petit Minion
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -240,6 +241,8 @@ class Cluster(FileList):
             return self.metadata['totaltracks']
         elif column == 'discnumber':
             return self.metadata['totaldiscs']
+        elif column == 'covercount':
+            return self._cover_art_description(self.metadata.images, False)
         return self.metadata[column]
 
     def _lookup_finished(self, document, http, error):

--- a/picard/file.py
+++ b/picard/file.py
@@ -25,6 +25,7 @@
 # Copyright (C) 2019 Joel Lintunen
 # Copyright (C) 2020 Ray Bouchard
 # Copyright (C) 2020 Gabriel Ferreira
+# Copyright (C) 2021 Petit Minion
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -730,6 +731,8 @@ class File(QtCore.QObject, Item):
         m = self.metadata
         if column == "title" and not m["title"]:
             return self.base_filename
+        if column == "covercount":
+            return self._cover_art_description(self.metadata.images, False)
         return m[column]
 
     def _lookup_finished(self, lookuptype, document, http, error):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -533,7 +533,6 @@ class MultiMetadataProxy:
     metadata to use file specific metadata, without making it actually part
     of the track.
     """
-
     WRITE_METHODS = [
         'add_unique',
         'add',

--- a/picard/track.py
+++ b/picard/track.py
@@ -248,6 +248,8 @@ class Track(DataObject, FileListItem):
         if column == 'title':
             prefix = "%s-" % m['discnumber'] if m['discnumber'] and m['totaldiscs'] != "1" else ""
             return "%s%s  %s" % (prefix, m['tracknumber'].zfill(2), m['title'])
+        if column == 'covercount':
+            return self._cover_art_description(self.metadata.images, False)
         elif column in m:
             return m[column]
         elif self.num_linked_files == 1:

--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -8,6 +8,7 @@
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2013 Laurent Monin
 # Copyright (C) 2014 Sophist-UK
+# Copyright (C) 2021 Petit Minion
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -98,6 +99,28 @@ class Item(object):
 
     def clear_errors(self):
         self._errors = []
+
+    def _cover_art_description(self, images, detailed=True):
+        """Return the number of cover art images in `images` for display in the UI
+
+        Args:
+            images: An instance of picard.util.imagelist.ImageList
+            detailed: If True, return a detailed text about the images and whether they are the same across all tracks.
+                    If False only return the number as a string.
+
+        Returns:
+            A string explaining the cover art image count.
+        """
+        number_of_images = len(images)
+        if detailed:
+            if getattr(self, 'has_common_images', True):
+                return ngettext("; %i image)", "; %i images)",
+                                number_of_images) % number_of_images
+            else:
+                return ngettext("; %i image not in all tracks)", "; %i different images among tracks)",
+                                number_of_images) % number_of_images
+        else:
+            return str(number_of_images)
 
 
 class FileListItem(Item):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -167,6 +167,7 @@ class MainPanel(QtWidgets.QSplitter):
         (N_('Fingerprint status'), '~fingerprint'),
         (N_('Date'), 'date'),
         (N_('Original Release Date'), 'originaldate'),
+        (N_('Cover'), 'covercount'),
     ]
 
     _column_indexes = {column[1]: i for i, column in enumerate(columns)}


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
This add  a cover columns in album, tracks, files and cluster to be able to order by presence or abscence of cover art.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2176
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

added a method in picard.metadata wich is use by the 4 module to retrive cover art information

# Action

Because the ouptu of this method have to be a number, or a string (when it used for the title colum of the album module), I create a argument "forcount". But not shure this is the best way to go. 

this is my first piece of programming in python, hope it not to dirty o/ 
