### PR TITLE
PICARD-2182: Fix the no-op codepath of $replacemulti

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -298,7 +298,7 @@ Example:
 ))
 def func_replacemulti(parser, multi, search, replace, separator=MULTI_VALUED_JOINER):
     if not multi or not search or replace is None or not separator:
-        return multi
+        return multi.eval(parser)
 
     search = search.eval(parser)
     replace = replace.eval(parser)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -543,6 +543,9 @@ class ScriptParserTest(PicardTestCase):
         context["test"] = ["Four", "Five", "Six"]
         self.assertScriptResultEquals("$replacemulti(%test%,Five,)", "Four; ; Six", context)
 
+        self.assertScriptResultEquals("$replacemulti(a; b,,,)", "a; b")
+        self.assertScriptResultEquals("$setmulti(foo,a; b)$replacemulti(%foo%,,,)", "a; b")
+
     def test_cmd_strip(self):
         self.assertScriptResultEquals("$strip(  \t abc  de \n f  )", "abc de f")
 


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary




* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Previously,

> $replacemulti(%foo%,A,,)

failed with

> "Expected str instance, ScriptExpression found"


<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2182
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Eval the ScriptExpression to get the real value.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
