### PR TITLE
PICARD-2185: Remove empty elements from $map() output

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -290,6 +290,7 @@ def func_replace(parser, text, old, new):
     """`$replacemulti(name,search,replace,separator="; ")`
 
 Replaces occurrences of `search` with `replace` in the multi-value variable `name`.
+Empty elements are automatically removed.
 
 Example:
 
@@ -1214,7 +1215,7 @@ def func_map(parser, multi, loop_code, separator=MULTI_VALUED_JOINER):
         multi_value[loop_count - 1] = str(loop_code.eval(parser))
     func_unset(parser, '_loop_count')
     func_unset(parser, '_loop_value')
-    return multi_value.separator.join([x for x in multi_value if x])
+    return str(multi_value)
 
 
 @script_function(eval_args=False, documentation=N_(

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1196,6 +1196,8 @@ Iterates over each element found in the multi-value tag `name` and updates the
     `_loop_value` and the count is stored in the tag `_loop_count`. This allows
     the element or count value to be accessed within the `code` script.
 
+Empty elements are automatically removed.
+
 Example:
 
     $map(First:A; Second:B,$upper(%_loop_count%=%_loop_value%))
@@ -1208,10 +1210,13 @@ def func_map(parser, multi, loop_code, separator=MULTI_VALUED_JOINER):
     for loop_count, value in enumerate(multi_value, 1):
         func_set(parser, '_loop_count', str(loop_count))
         func_set(parser, '_loop_value', str(value))
+        # Make changes in-place
         multi_value[loop_count - 1] = str(loop_code.eval(parser))
     func_unset(parser, '_loop_count')
     func_unset(parser, '_loop_value')
-    return str(multi_value)
+    # Remove empty elements from existing multi-value variable
+    multi_value._multi = [x for x in multi_value if x]
+    return multi_value.separator.join(multi_value)
 
 
 @script_function(eval_args=False, documentation=N_(

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1214,9 +1214,7 @@ def func_map(parser, multi, loop_code, separator=MULTI_VALUED_JOINER):
         multi_value[loop_count - 1] = str(loop_code.eval(parser))
     func_unset(parser, '_loop_count')
     func_unset(parser, '_loop_value')
-    # Remove empty elements from existing multi-value variable
-    multi_value._multi = [x for x in multi_value if x]
-    return multi_value.separator.join(multi_value)
+    return multi_value.separator.join([x for x in multi_value if x])
 
 
 @script_function(eval_args=False, documentation=N_(

--- a/picard/script/parser.py
+++ b/picard/script/parser.py
@@ -397,4 +397,4 @@ class MultiValue(MutableSequence):
         return '%s(%r, %r, %r)' % (self.__class__.__name__, self.parser, self._multi, self.separator)
 
     def __str__(self):
-        return self.separator.join(self)
+        return self.separator.join([x for x in self if x])

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1215,9 +1215,12 @@ class ScriptParserTest(PicardTestCase):
         # Tests with static inputs
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
         # Tests for removing empty elements
-        context["baz"] = ["First:A", "Second:B", "", "Third:C"]
-        self.assertScriptResultEquals("$map(%baz%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
-        self.assertScriptResultEquals("%baz%", loop_output, context)
+        context["baz"] = ["First:A", "Second:B", "Remove", "Third:C"]
+        test_output = "1=FIRST:A; 2=SECOND:B; 4=THIRD:C"
+        self.assertScriptResultEquals("$lenmulti(%baz%)", "4", context)
+        self.assertScriptResultEquals("$setmulti(baz,$map(%baz%,$if($eq(%_loop_count%,3),,$upper(%_loop_count%=%_loop_value%))))%baz%", test_output, context)
+        self.assertScriptResultEquals("$lenmulti(%baz%)", "3", context)
+        self.assertScriptResultEquals("%baz%", test_output, context)
         # Tests with missing inputs
         self.assertScriptResultEquals("$map(,$upper(%_loop_count%=%_loop_value%))", "", context)
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,)", "", context)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1204,19 +1204,24 @@ class ScriptParserTest(PicardTestCase):
 
     def test_cmd_map(self):
         context = Metadata()
-        context["foo"] = "First:A; Second:B; Third:C"
-        context["bar"] = ["First:A", "Second:B", "Third:C"]
         foo_output = "1=FIRST:A; SECOND:B; THIRD:C"
         loop_output = "1=FIRST:A; 2=SECOND:B; 3=THIRD:C"
         alternate_output = "1=FIRST:2=A; SECOND:3=B; THIRD:4=C"
         # Tests with context
+        context["foo"] = "First:A; Second:B; Third:C"
         self.assertScriptResultEquals("$map(%foo%,$upper(%_loop_count%=%_loop_value%))", foo_output, context)
+        context["bar"] = ["First:A", "Second:B", "Third:C"]
         self.assertScriptResultEquals("$map(%bar%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
         # Tests with static inputs
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
+        # Tests for removing empty elements
+        context["baz"] = ["First:A", "Second:B", "", "Third:C"]
+        self.assertScriptResultEquals("$map(%baz%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
+        context["baz"] = ["First:A", "Second:B", "", "Third:C"]
+        self.assertScriptResultEquals("$map(%baz%,$upper(%_loop_count%=%_loop_value%)) / %baz%", loop_output + " / " + loop_output, context)
         # Tests with missing inputs
         self.assertScriptResultEquals("$map(,$upper(%_loop_count%=%_loop_value%))", "", context)
-        self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,)", "; ; ", context)
+        self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,)", "", context)
         # Tests with separator override
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,$upper(%_loop_count%=%_loop_value%),:)", alternate_output, context)
         # Tests with invalid number of arguments

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1217,8 +1217,7 @@ class ScriptParserTest(PicardTestCase):
         # Tests for removing empty elements
         context["baz"] = ["First:A", "Second:B", "", "Third:C"]
         self.assertScriptResultEquals("$map(%baz%,$upper(%_loop_count%=%_loop_value%))", loop_output, context)
-        context["baz"] = ["First:A", "Second:B", "", "Third:C"]
-        self.assertScriptResultEquals("$map(%baz%,$upper(%_loop_count%=%_loop_value%)) / %baz%", loop_output + " / " + loop_output, context)
+        self.assertScriptResultEquals("%baz%", loop_output, context)
         # Tests with missing inputs
         self.assertScriptResultEquals("$map(,$upper(%_loop_count%=%_loop_value%))", "", context)
         self.assertScriptResultEquals("$map(First:A; Second:B; Third:C,)", "", context)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -541,7 +541,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$replacemulti(%test%,Four,Five)", "One; Two; Three", context)
 
         context["test"] = ["Four", "Five", "Six"]
-        self.assertScriptResultEquals("$replacemulti(%test%,Five,)", "Four; ; Six", context)
+        self.assertScriptResultEquals("$replacemulti(%test%,Five,)", "Four; Six", context)
 
         self.assertScriptResultEquals("$replacemulti(a; b,,,)", "a; b")
         self.assertScriptResultEquals("$setmulti(foo,a; b)$replacemulti(%foo%,,,)", "a; b")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1218,6 +1218,8 @@ class ScriptParserTest(PicardTestCase):
         context["baz"] = ["First:A", "Second:B", "Remove", "Third:C"]
         test_output = "1=FIRST:A; 2=SECOND:B; 4=THIRD:C"
         self.assertScriptResultEquals("$lenmulti(%baz%)", "4", context)
+        self.assertScriptResultEquals("$map(%baz%,$if($eq(%_loop_count%,3),,$upper(%_loop_count%=%_loop_value%)))", test_output, context)
+        context["baz"] = ["First:A", "Second:B", "Remove", "Third:C"]
         self.assertScriptResultEquals("$setmulti(baz,$map(%baz%,$if($eq(%_loop_count%,3),,$upper(%_loop_count%=%_loop_value%))))%baz%", test_output, context)
         self.assertScriptResultEquals("$lenmulti(%baz%)", "3", context)
         self.assertScriptResultEquals("%baz%", test_output, context)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
The `$map()` function does not remove empty elements.  This is inconsistent with other multi-value variable processing.

* JIRA ticket (_optional_): PICARD-2185
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Automatically remove empty elements from `$map()` output.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
