### PR TITLE
PICARD-2188: Fix plugin update fetching outdated version

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -636,7 +636,7 @@ class PluginsOptionsPage(OptionsPage):
             parse_response_type=None,
             priority=True,
             important=True,
-            queryargs={"id": plugin.module_name}
+            queryargs={"id": plugin.module_name, "version": plugin.version.to_string(short=True)}
         )
 
     def download_handler(self, update, response, reply, error, plugin):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2188
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Avoid plugin API fetch old version from network cache. Still allow caching, but make sure each versions gets cached separately.

I noticed this when installing the happidev_lyrics plugin directly before our last website update, and then trying to update afterwards. The plugin list would show the update from 2.0 -> 2.1 being available, but after updating 2.0 got installed. Likewise when uninstalling the plugin it would show the 2.1 version being available, but install would fetch the ZIP from cache, resulting in 2.0 being installed.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make the URL version aware by appending the version to the parameter. We could consider making use of this parameter server side, but for now that's not necessary.

I think that's better than disabling the caching compllely.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
