### PR TITLE
Revert "PICARD-2170: Guessed title / tracknumber should show up as changed tags"

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -228,7 +228,6 @@ class File(QtCore.QObject, Item):
     def _copy_loaded_metadata(self, metadata):
         filename, _ = os.path.splitext(self.base_filename)
         metadata['~length'] = format_time(metadata.length)
-        self.orig_metadata.copy(metadata)
         if 'tracknumber' not in metadata:
             tracknumber = tracknum_from_filename(self.base_filename)
             if tracknumber is not None:
@@ -241,6 +240,7 @@ class File(QtCore.QObject, Item):
                         metadata['title'] = stripped_filename[tnlen:].lstrip()
         if 'title' not in metadata:
             metadata['title'] = filename
+        self.orig_metadata = metadata
         self.metadata.copy(metadata)
 
     def copy_metadata(self, metadata, preserve_deleted=True):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2170
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->


With PICARD-2170 the title and tracknumber fields guessed from filename when empty are treated as modified metadata.

The reasoning was that this data is not present in the file's tags and hence should not show up as original metadata.

However, the previous behavior was more useful. One can argue that this is still data from the files. Having this available for comparison when tagging the files with actual new metadata from MusicBrainz is useful. See e.g. the issue report at https://community.metabrainz.org/t/musicbrainz-picard-2-6-is-now-available/526853/23

The proposal here is to revert this change for the 2.6 series and instead provide an option to disable the tracknumber and title guessing completely in 2.7. This should satisfy both the complaints from PICARD-2170 and keep this functionality available in a useful way.



# Solution
This reverts commit bbb98f1bfc8301776a1393684eea2dfc33e0d9af.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
