### PR TITLE
PICARD-1718: crash handler

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -87,3 +87,48 @@ api_versions = [
 ]
 
 api_versions_tuple = [Version.from_string(v) for v in api_versions]
+
+
+def crash_handler():
+    """Implements minimal handling of an exception crashing the application.
+    This function tries to log the exception to a log file and display
+    a minimal crash dialog to the user.
+    This function is supposed to be called from inside an except blog.
+    """
+    # First try to get traceback information and write it to a log file
+    # with minimum chance to fail.
+    import sys
+    from tempfile import NamedTemporaryFile
+    import traceback
+    trace = traceback.format_exc()
+    logfile = None
+    try:
+        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
+            f.write(trace.encode(errors="replace"))
+            logfile = f.name
+    except:  # noqa: E722,F722 # pylint: disable=bare-except
+        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+        logfile = None
+
+    # Display the crash information to the user as a dialog. This requires
+    # importing Qt5 and has some potential to fail if things are broken.
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    # assigning QApplication to a variable is required to keep the object alive
+    _unused = QApplication(sys.argv)  # noqa: F841
+    msgbox = QMessageBox()
+    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setWindowTitle("Picard terminated unexpectedly")
+    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setText(
+        'An unexpected error has caused Picard to crash. '
+        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
+    if logfile:
+        logfile_url = QUrl.fromLocalFile(logfile)
+        msgbox.setInformativeText(
+            'A logfile has been written to <a href="{0}">{1}</a>.'
+            .format(logfile_url.url(), logfile))
+    msgbox.setDetailedText(trace)
+    msgbox.setStandardButtons(QMessageBox.Close)
+    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.exec_()

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -112,10 +112,11 @@ def crash_handler():
 
     # Display the crash information to the user as a dialog. This requires
     # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtCore import QCoreApplication, Qt, QUrl
     from PyQt5.QtWidgets import QApplication, QMessageBox
-    # assigning QApplication to a variable is required to keep the object alive
-    app = QApplication(sys.argv)
+    app = QCoreApplication.instance()
+    if not app:
+        app = QApplication(sys.argv)
     msgbox = QMessageBox()
     msgbox.setIcon(QMessageBox.Critical)
     msgbox.setWindowTitle("Picard terminated unexpectedly")

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -115,7 +115,7 @@ def crash_handler():
     from PyQt5.QtCore import Qt, QUrl
     from PyQt5.QtWidgets import QApplication, QMessageBox
     # assigning QApplication to a variable is required to keep the object alive
-    _unused = QApplication(sys.argv)  # noqa: F841
+    app = QApplication(sys.argv)
     msgbox = QMessageBox()
     msgbox.setIcon(QMessageBox.Critical)
     msgbox.setWindowTitle("Picard terminated unexpectedly")
@@ -132,3 +132,4 @@ def crash_handler():
     msgbox.setStandardButtons(QMessageBox.Close)
     msgbox.setDefaultButton(QMessageBox.Close)
     msgbox.exec_()
+    app.quit()

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -1,3 +1,30 @@
 #!/usr/bin/env python3
-from picard.tagger import main
-main('%(localedir)s', %(autoupdate)s)
+
+try:
+    from picard.tagger import main
+    main('%(localedir)s', %(autoupdate)s)
+except SystemExit:
+    raise  # Just continue with a normal application exit
+except:  # noqa: F722
+    # First try to get traceback information and write it to a log file
+    # with minimum chance to fail.
+    import os
+    import sys
+    import tempfile
+    import traceback
+    trace = traceback.format_exc()
+    logfile = None
+    try:
+        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
+        os.write(fd, trace.encode(errors="replace"))
+        os.close(fd)
+    except:  # noqa: F722
+        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+
+    # Display the crash information to the user as a dialog. This requires
+    # importing Qt5 and has some potential to fail if things are broken.
+    from PyQt5 import QtWidgets
+    app = QtWidgets.QApplication(sys.argv)
+    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    raise

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -10,13 +10,13 @@ except:  # noqa: F722
     # with minimum chance to fail.
     import os
     import sys
-    import tempfile
+    from tempfile import NamedTemporaryFile
     import traceback
     trace = traceback.format_exc()
     try:
-        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
-        os.write(fd, trace.encode(errors="replace"))
-        os.close(fd)
+        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
+            f.write(trace.encode(errors="replace"))
+            logfile = f.name
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
         logfile = None

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -23,11 +23,23 @@ except:  # noqa: F722
 
     # Display the crash information to the user as a dialog. This requires
     # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5 import QtWidgets
-    app = QtWidgets.QApplication(sys.argv)
-    msg = []
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    _unused = QApplication(sys.argv)
+    msgbox = QMessageBox()
+    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setWindowTitle("Picard terminated unexpectedly")
+    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setText(
+        'An unexpected error has caused Picard to crash. '
+        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
     if logfile:
-        msg.append("A logfile has been written to {0}".format(logfile))
-    msg.append("Error details: \n{0}".format(trace))
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
+        logfile_url = QUrl.fromLocalFile(logfile)
+        msgbox.setInformativeText(
+            'A logfile has been written to <a href="{0}">{1}</a>.'
+            .format(logfile_url.url(), logfile))
+    msgbox.setDetailedText(trace)
+    msgbox.setStandardButtons(QMessageBox.Close)
+    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.exec_()
     raise

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -5,41 +5,7 @@ try:
     main('%(localedir)s', %(autoupdate)s)
 except SystemExit:
     raise  # Just continue with a normal application exit
-except:  # noqa: F722
-    # First try to get traceback information and write it to a log file
-    # with minimum chance to fail.
-    import os
-    import sys
-    from tempfile import NamedTemporaryFile
-    import traceback
-    trace = traceback.format_exc()
-    try:
-        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
-            f.write(trace.encode(errors="replace"))
-            logfile = f.name
-    except:  # noqa: F722
-        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
-        logfile = None
-
-    # Display the crash information to the user as a dialog. This requires
-    # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5.QtCore import Qt, QUrl
-    from PyQt5.QtWidgets import QApplication, QMessageBox
-    _unused = QApplication(sys.argv)
-    msgbox = QMessageBox()
-    msgbox.setIcon(QMessageBox.Critical)
-    msgbox.setWindowTitle("Picard terminated unexpectedly")
-    msgbox.setTextFormat(Qt.RichText)
-    msgbox.setText(
-        'An unexpected error has caused Picard to crash. '
-        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
-    if logfile:
-        logfile_url = QUrl.fromLocalFile(logfile)
-        msgbox.setInformativeText(
-            'A logfile has been written to <a href="{0}">{1}</a>.'
-            .format(logfile_url.url(), logfile))
-    msgbox.setDetailedText(trace)
-    msgbox.setStandardButtons(QMessageBox.Close)
-    msgbox.setDefaultButton(QMessageBox.Close)
-    msgbox.exec_()
+except:  # noqa: E722,F722 # pylint: disable=bare-except
+    from picard import crash_handler
+    crash_handler()
     raise

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -13,18 +13,21 @@ except:  # noqa: F722
     import tempfile
     import traceback
     trace = traceback.format_exc()
-    logfile = None
     try:
         (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
         os.write(fd, trace.encode(errors="replace"))
         os.close(fd)
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+        logfile = None
 
     # Display the crash information to the user as a dialog. This requires
     # importing Qt5 and has some potential to fail if things are broken.
     from PyQt5 import QtWidgets
     app = QtWidgets.QApplication(sys.argv)
-    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    msg = []
+    if logfile:
+        msg.append("A logfile has been written to {0}".format(logfile))
+    msg.append("Error details: \n{0}".format(trace))
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -36,11 +36,23 @@ except:  # noqa: F722
 
     # Display the crash information to the user as a dialog. This requires#
     # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5 import QtWidgets
-    app = QtWidgets.QApplication(sys.argv)
-    msg = []
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    _unused = QApplication(sys.argv)
+    msgbox = QMessageBox()
+    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setWindowTitle("Picard terminated unexpectedly")
+    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setText(
+        'An unexpected error has caused Picard to crash. '
+        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
     if logfile:
-        msg.append("A logfile has been written to {0}".format(logfile))
-    msg.append("Error details: \n{0}".format(trace))
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
+        logfile_url = QUrl.fromLocalFile(logfile)
+        msgbox.setInformativeText(
+            'A logfile has been written to <a href="{0}">{1}</a>.'
+                .format(logfile_url.url(), logfile))
+    msgbox.setDetailedText(trace)
+    msgbox.setStandardButtons(QMessageBox.Close)
+    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.exec_()
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -26,18 +26,21 @@ except:  # noqa: F722
     import tempfile
     import traceback
     trace = traceback.format_exc()
-    logfile = None
     try:
         (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
         os.write(fd, trace.encode(errors="replace"))
         os.close(fd)
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+        logfile = None
 
     # Display the crash information to the user as a dialog. This requires#
     # importing Qt5 and has some potential to fail if things are broken.
     from PyQt5 import QtWidgets
     app = QtWidgets.QApplication(sys.argv)
-    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
-    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    msg = []
+    if logfile:
+        msg.append("A logfile has been written to {0}".format(logfile))
+    msg.append("Error details: \n{0}".format(trace))
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", "\n\n".join(msg))
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -15,5 +15,29 @@ else:
 if sys.platform == 'win32':
     os.environ['PATH'] = basedir + ';' + os.environ['PATH']
 
-from picard.tagger import main
-main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+try:
+    from picard.tagger import main
+    main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+except SystemExit:
+    raise  # Just continue with a normal application exit
+except:  # noqa: F722
+    # First try to get traceback information and write it to a log file
+    # with minimum chance to fail.
+    import tempfile
+    import traceback
+    trace = traceback.format_exc()
+    logfile = None
+    try:
+        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
+        os.write(fd, trace.encode(errors="replace"))
+        os.close(fd)
+    except:  # noqa: F722
+        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
+
+    # Display the crash information to the user as a dialog. This requires#
+    # importing Qt5 and has some potential to fail if things are broken.
+    from PyQt5 import QtWidgets
+    app = QtWidgets.QApplication(sys.argv)
+    msg = "A logfile has been written to {0}\n\nError details:\n{1}".format(logfile, trace)
+    QtWidgets.QMessageBox.critical(None, "Picard terminated unexpectedly", msg)
+    raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -20,39 +20,7 @@ try:
     main(os.path.join(basedir, 'locale'), %(autoupdate)s)
 except SystemExit:
     raise  # Just continue with a normal application exit
-except:  # noqa: F722
-    # First try to get traceback information and write it to a log file
-    # with minimum chance to fail.
-    from tempfile import NamedTemporaryFile
-    import traceback
-    trace = traceback.format_exc()
-    try:
-        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
-            f.write(trace.encode(errors="replace"))
-            logfile = f.name
-    except:  # noqa: F722
-        print("Failed writing log file {0}".format(logfile), file=sys.stderr)
-        logfile = None
-
-    # Display the crash information to the user as a dialog. This requires#
-    # importing Qt5 and has some potential to fail if things are broken.
-    from PyQt5.QtCore import Qt, QUrl
-    from PyQt5.QtWidgets import QApplication, QMessageBox
-    _unused = QApplication(sys.argv)
-    msgbox = QMessageBox()
-    msgbox.setIcon(QMessageBox.Critical)
-    msgbox.setWindowTitle("Picard terminated unexpectedly")
-    msgbox.setTextFormat(Qt.RichText)
-    msgbox.setText(
-        'An unexpected error has caused Picard to crash. '
-        'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
-    if logfile:
-        logfile_url = QUrl.fromLocalFile(logfile)
-        msgbox.setInformativeText(
-            'A logfile has been written to <a href="{0}">{1}</a>.'
-                .format(logfile_url.url(), logfile))
-    msgbox.setDetailedText(trace)
-    msgbox.setStandardButtons(QMessageBox.Close)
-    msgbox.setDefaultButton(QMessageBox.Close)
-    msgbox.exec_()
+except:  # noqa: E722,F722 # pylint: disable=bare-except
+    from picard import crash_handler
+    crash_handler()
     raise

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -23,13 +23,13 @@ except SystemExit:
 except:  # noqa: F722
     # First try to get traceback information and write it to a log file
     # with minimum chance to fail.
-    import tempfile
+    from tempfile import NamedTemporaryFile
     import traceback
     trace = traceback.format_exc()
     try:
-        (fd, logfile) = tempfile.mkstemp(".log", "picard-crash-")
-        os.write(fd, trace.encode(errors="replace"))
-        os.close(fd)
+        with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
+            f.write(trace.encode(errors="replace"))
+            logfile = f.name
     except:  # noqa: F722
         print("Failed writing log file {0}".format(logfile), file=sys.stderr)
         logfile = None


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1718
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
This is another submission of https://github.com/metabrainz/picard/pull/1466

Overall I'm actually for now finally merging this. If Picard suddenly crashes we and the users are usually flying in the dark. It is difficult to get users to start Picard from command line to get a proper exception stack trace, and depending on circumstance and setup (e.g. Windows portable or store versions) even impossible.

The patch as is I had now several times applied locally to narrow down a reported crash.

As I mentioned in #1466 there are still cases that might not be caught, but given that it improves the debugging a lot for the majority of cases let's merge this.

I reduced code duplication a bit compared to #1466. This makes this slightly more likely to fail, but picard/__init__.py is luckily rather minimal. We are trying to do something useful in case of a hard crash. Worst thing happening is that we crash without logging or displaying the details, which is the status quo.