### PR TITLE
Replace QThread with Python threads using concurrent.futures

### DIFF
--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -9,6 +9,7 @@
 # Copyright (C) 2016 Sambhav Kothari
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2020 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -25,14 +26,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from functools import partial
 import sys
 import traceback
 
 from PyQt5.QtCore import (
     QCoreApplication,
     QEvent,
-    QRunnable,
 )
+
+from picard import log
 
 
 class ProxyToMainEvent(QEvent):
@@ -47,30 +50,38 @@ class ProxyToMainEvent(QEvent):
         self.func(*self.args, **self.kwargs)
 
 
-class Runnable(QRunnable):
-
-    def __init__(self, func, next_func, traceback=True):
-        super().__init__()
-        self.func = func
-        self.next_func = next_func
-        self.traceback = traceback
-
-    def run(self):
-        try:
-            result = self.func()
-        except BaseException:
-            from picard import log
-            if self.traceback:
-                log.error(traceback.format_exc())
-            to_main(self.next_func, error=sys.exc_info()[1])
-        else:
-            to_main(self.next_func, result=result)
+def future_callback(callback, future, log_traceback=True):
+    try:
+        result = future.result()
+        error = None
+    except BaseException:
+        if log_traceback:
+            log.error(traceback.format_exc())
+        result = None
+        error = sys.exc_info()[1]
+    to_main(callback, result=result, error=error)
 
 
 def run_task(func, next_func, priority=0, thread_pool=None, traceback=True):
-    if thread_pool is None:
+    """Schedules func to be run on a separate thread
+
+    Args:
+        func: Function to run on a separate thread.
+        next_func: Callback function to run after the thread has been completed.
+          The callback will be run on the main thread.
+        priority: Deprecated, for backward compatibility only
+        thread_pool: Instance of concurrent.futures.Executor to run this task.
+        traceback: If set to true the stack trace will be logged to the error log
+          if an exception was raised.
+
+    Returns:
+        An instance of concurrent.futures.Future
+    """
+    if not thread_pool:
         thread_pool = QCoreApplication.instance().thread_pool
-    thread_pool.start(Runnable(func, next_func, traceback), priority)
+    future = thread_pool.submit(func)
+    future.add_done_callback(partial(future_callback, next_func, log_traceback=traceback))
+    return future
 
 
 def to_main(func, *args, **kwargs):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This aims to replace QThread with concurrent.futures to reduce dependency on Qt for core functionality outside of actual UI.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The implementation uses concurrent.futures, but maintains the existing API interface exposed by `picard.util.threads.run_task`. For normal usage of the threading feature (as this is currently being used by Picard itself and from the plugins we host) this should be backward compatible.

Differences:

- If a caller provides its own value for the `thread_pool` parameter this now needs to be a concurrent.futures.Executor. So if a plugin makes use of this (existing plugins do not) by passing a `QThreadPool` instance it would be incompatible.
- `run_task` now returns an instance of `concurrent.futures.Future`. This can be useful for the caller to get more control, e.g. to add a done callback or cancel the task. Previously this did not return anything, so this should not be a real incompatibility, rather offer new flexibility.
- The `priority` parameter becomes obsolete, as there is no equivalent for this in concurrent.futures.

# Action
We could provide a separate new interface to replace `picard.util.threads.run_task` with something more suited. We can also consider running tasks in separate processes by using `ProcessPoolExecutor` instead of `ThreadPoolExecutor`. But this requires some thought to the code being invoked here.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
