### PR TITLE
Add common functionality to open help to PicardDialog

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2007 Oliver Charles
 # Copyright (C) 2007, 2010-2011 Lukáš Lalinský
-# Copyright (C) 2007-2011, 2015, 2018-2019 Philipp Wolfer
+# Copyright (C) 2007-2011, 2015, 2018-2021 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
 # Copyright (C) 2013-2015, 2018-2021 Laurent Monin
@@ -68,7 +68,6 @@ from picard.coverart.utils import (
     CAA_TYPES,
     translate_caa_type,
 )
-from picard.util import webbrowser2
 
 from picard.ui import PicardDialog
 from picard.ui.ui_provider_options_caa import Ui_CaaOptions
@@ -228,6 +227,8 @@ class CAATypesSelectorDialog(PicardDialog):
         types_exclude {[string]} -- List of CAA image types to exclude (default: {None})
     """
 
+    help_url = 'doc_cover_art_types'
+
     def __init__(self, parent=None, types_include=None, types_exclude=None):
         super().__init__(parent)
         if types_include is None:
@@ -333,7 +334,7 @@ class CAATypesSelectorDialog(PicardDialog):
 
         self.buttonbox.accepted.connect(self.accept)
         self.buttonbox.rejected.connect(self.reject)
-        self.buttonbox.helpRequested.connect(self.help)
+        self.buttonbox.helpRequested.connect(self.show_help)
 
         self.set_buttons_enabled_state()
 
@@ -377,9 +378,6 @@ class CAATypesSelectorDialog(PicardDialog):
                 self.list_exclude.addItem(item)
             else:
                 self.list_ignore.addItem(item)
-
-    def help(self):
-        webbrowser2.open('doc_cover_art_types')
 
     def get_selected_types_include(self):
         return list(self.list_include.all_items_data()) or ['front']

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2007-2011, 2015, 2018-2019 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2013-2015, 2018-2021 Laurent Monin
 # Copyright (C) 2015-2016 Rahul Raturi
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
@@ -379,7 +379,7 @@ class CAATypesSelectorDialog(PicardDialog):
                 self.list_ignore.addItem(item)
 
     def help(self):
-        webbrowser2.goto('doc_cover_art_types')
+        webbrowser2.open('doc_cover_art_types')
 
     def get_selected_types_include(self):
         return list(self.list_include.all_items_data()) or ['front']

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2014, 2018 Laurent Monin
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
-# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2019-2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -36,11 +36,15 @@ from picard.config import (
     Option,
     get_config,
 )
+from picard.const import DOCS_BASE_URL
 from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
-from picard.util import restore_method
+from picard.util import (
+    restore_method,
+    webbrowser2,
+)
 
 
 if IS_MACOS:
@@ -105,6 +109,7 @@ class SingletonDialog:
 
 class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
+    help_url = None
     flags = QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowCloseButtonHint
 
     def __init__(self, parent=None):
@@ -113,8 +118,20 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
     def keyPressEvent(self, event):
         if event.matches(QtGui.QKeySequence.Close):
             self.close()
+        elif event.matches(QtGui.QKeySequence.HelpContents) and self.help_url:
+            self.show_help()
         else:
             super().keyPressEvent(event)
+
+    def show_help(self):
+        if self.help_url:
+            url = self.help_url
+            if url.startswith('/'):
+                url = DOCS_BASE_URL + url
+            if url.startswith('goto://'):
+                webbrowser2.goto(url[7:])
+            else:
+                webbrowser2.open(url)
 
 
 # With py3, QObjects are no longer hashable unless they have

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008 Lukáš Lalinský
 # Copyright (C) 2014 Sophist-UK
-# Copyright (C) 2014, 2018 Laurent Monin
+# Copyright (C) 2014, 2018, 2020-2021 Laurent Monin
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2019-2021 Philipp Wolfer
@@ -128,10 +128,7 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
             url = self.help_url
             if url.startswith('/'):
                 url = DOCS_BASE_URL + url
-            if url.startswith('goto://'):
-                webbrowser2.goto(url[7:])
-            else:
-                webbrowser2.open(url)
+            webbrowser2.open(url)
 
 
 # With py3, QObjects are no longer hashable unless they have

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -14,7 +14,7 @@
 # Copyright (C) 2011-2013, 2015-2017 Wieland Hoffmann
 # Copyright (C) 2011-2014 Michael Wiencek
 # Copyright (C) 2013-2014, 2017 Sophist-UK
-# Copyright (C) 2013-2020 Laurent Monin
+# Copyright (C) 2013-2021 Laurent Monin
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2015 samithaj
 # Copyright (C) 2016 Rahul Raturi
@@ -1054,7 +1054,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return OptionsDialog.show_instance(page, self)
 
     def show_help(self):
-        webbrowser2.goto('documentation')
+        webbrowser2.open('documentation')
 
     def show_log(self):
         self.log_dialog.show()
@@ -1067,13 +1067,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.history_dialog.activateWindow()
 
     def open_bug_report(self):
-        webbrowser2.goto('troubleshooting')
+        webbrowser2.open('troubleshooting')
 
     def open_support_forum(self):
-        webbrowser2.goto('forum')
+        webbrowser2.open('forum')
 
     def open_donation_page(self):
-        webbrowser2.goto('donate')
+        webbrowser2.open('donate')
 
     def save(self):
         """Tell the tagger to save the selected objects."""

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -8,7 +8,7 @@
 # Copyright (C) 2011 Pavan Chander
 # Copyright (C) 2011-2012, 2019 Wieland Hoffmann
 # Copyright (C) 2011-2013 Michael Wiencek
-# Copyright (C) 2013, 2017-2019 Laurent Monin
+# Copyright (C) 2013, 2017-2020 Laurent Monin
 # Copyright (C) 2014 Sophist-UK
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Suhas
@@ -191,7 +191,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             current_page = self.item_to_page[self.page_to_item[current_page.PARENT]]
             url = current_page.HELP_URL
         if not url:
-            url = '/config/configuration.html'
+            url = 'doc_options'  # key in PICARD_URLS
         return url
 
     def accept(self):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008, 2011 Lukáš Lalinský
 # Copyright (C) 2008-2009 Nikolai Prokoschenko
-# Copyright (C) 2008-2009, 2018-2020 Philipp Wolfer
+# Copyright (C) 2008-2009, 2018-2021 Philipp Wolfer
 # Copyright (C) 2011 Pavan Chander
 # Copyright (C) 2011-2012, 2019 Wieland Hoffmann
 # Copyright (C) 2011-2013 Michael Wiencek
@@ -31,7 +31,6 @@
 
 from PyQt5 import (
     QtCore,
-    QtGui,
     QtWidgets,
 )
 
@@ -42,11 +41,7 @@ from picard.config import (
     TextOption,
     get_config,
 )
-from picard.const import DOCS_BASE_URL
-from picard.util import (
-    restore_method,
-    webbrowser2,
-)
+from picard.util import restore_method
 
 from picard.ui import (
     HashableTreeWidgetItem,
@@ -137,7 +132,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.ui.buttonbox.rejected.connect(self.reject)
         self.ui.reset_all_button.clicked.connect(self.confirm_reset_all)
         self.ui.reset_button.clicked.connect(self.confirm_reset)
-        self.ui.buttonbox.helpRequested.connect(self.help)
+        self.ui.buttonbox.helpRequested.connect(self.show_help)
 
         self.pages = []
         for Page in page_classes:
@@ -175,12 +170,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 self.disable_page(page.NAME)
         self.ui.pages_tree.setCurrentItem(self.default_item)
 
-    def keyPressEvent(self, event):
-        if event.matches(QtGui.QKeySequence.HelpContents):
-            self.help()
-        else:
-            super().keyPressEvent(event)
-
     def switch_page(self):
         items = self.ui.pages_tree.selectedItems()
         if items:
@@ -193,7 +182,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         item = self.page_to_item[name]
         item.setDisabled(True)
 
-    def help(self):
+    @property
+    def help_url(self):
         current_page = self.ui.pages_stack.currentWidget()
         url = current_page.HELP_URL
         # If URL is empty, use the first non empty parent help URL.
@@ -201,10 +191,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             current_page = self.item_to_page[self.page_to_item[current_page.PARENT]]
             url = current_page.HELP_URL
         if not url:
-            url = DOCS_BASE_URL
-        elif url.startswith('/'):
-            url = DOCS_BASE_URL + url
-        webbrowser2.open(url)
+            url = '/config/configuration.html'
+        return url
 
     def accept(self):
         for page in self.pages:

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -4,8 +4,8 @@
 #
 # Copyright (C) 2011-2012 Lukáš Lalinský
 # Copyright (C) 2011-2013 Michael Wiencek
-# Copyright (C) 2013, 2018 Laurent Monin
 # Copyright (C) 2015, 2020 Philipp Wolfer
+# Copyright (C) 2013, 2018, 2020-2021 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
@@ -119,10 +119,10 @@ class FingerprintingOptionsPage(OptionsPage):
             self.ui.acoustid_fpcalc.setText(path)
 
     def acoustid_fpcalc_download(self):
-        webbrowser2.goto('chromaprint')
+        webbrowser2.open('chromaprint')
 
     def acoustid_apikey_get(self):
-        webbrowser2.goto('acoustid_apikey')
+        webbrowser2.open('acoustid_apikey')
 
     def _acoustid_fpcalc_check(self):
         if not self.ui.use_acoustid.isChecked():

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -8,8 +8,8 @@
 # Copyright (C) 2014, 2017 Sophist-UK
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Ville Skyttä
-# Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018, 2020-2021 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -99,7 +99,7 @@ class TagMatchExpression:
 class TagsFromFileNamesDialog(PicardDialog):
 
     autorestore = False
-    help_url = 'goto://doc_tags_from_filenames'
+    help_url = 'doc_tags_from_filenames'
 
     options = [
         TextOption("persist", "tags_from_filenames_format", ""),

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -37,7 +37,6 @@ from picard.config import (
     get_config,
 )
 from picard.script.parser import normalize_tagname
-from picard.util import webbrowser2
 from picard.util.tags import display_tag_name
 
 from picard.ui import PicardDialog
@@ -100,6 +99,7 @@ class TagMatchExpression:
 class TagsFromFileNamesDialog(PicardDialog):
 
     autorestore = False
+    help_url = 'goto://doc_tags_from_filenames'
 
     options = [
         TextOption("persist", "tags_from_filenames_format", ""),
@@ -134,7 +134,7 @@ class TagsFromFileNamesDialog(PicardDialog):
         self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.RejectRole)
         self.ui.buttonbox.accepted.connect(self.accept)
         self.ui.buttonbox.rejected.connect(self.reject)
-        self.ui.buttonbox.helpRequested.connect(self.help)
+        self.ui.buttonbox.helpRequested.connect(self.show_help)
         self.ui.preview.clicked.connect(self.preview)
         self.ui.files.setHeaderLabels([_("File Name")])
         self.files = files
@@ -168,6 +168,3 @@ class TagsFromFileNamesDialog(PicardDialog):
         config = get_config()
         config.persist["tags_from_filenames_format"] = self.ui.format.currentText()
         super().accept()
-
-    def help(self):
-        webbrowser2.goto('doc_tags_from_filenames')

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
 # Copyright (C) 2011 Calvin Walton
-# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2013, 2018-2021 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2019 Philipp Wolfer
@@ -39,6 +39,8 @@ from picard.const import PICARD_URLS
 
 
 def open(url):
+    if url in PICARD_URLS:
+        url = PICARD_URLS[url]
     try:
         webbrowser.open(url)
     except webbrowser.Error as e:
@@ -52,7 +54,3 @@ def open(url):
             # preferred browser.
             log.info("Working around https://bugs.python.org/issue31014 - URLs might not be opened in the correct browser")
             webbrowser.open(url)
-
-
-def goto(url_id):
-    open(PICARD_URLS[url_id])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Move code common to open a help page, with keyboard shortcut handling, to PicardDialog. This will make it easier to add similar functionality to other dialogs.

