### PR TITLE
PICARD-2204: Support unicode escape sequences in tagger scripts

### DIFF
--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -51,6 +51,7 @@ from picard.script.parser import (  # noqa: F401 # pylint: disable=unused-import
     ScriptRuntimeError,
     ScriptSyntaxError,
     ScriptText,
+    ScriptUnicodeError,
     ScriptUnknownFunction,
     ScriptVariable,
 )

--- a/picard/script/parser.py
+++ b/picard/script/parser.py
@@ -249,6 +249,8 @@ Grammar:
 
     def read_multi(self, count):
         text = ch = self.read()
+        if not ch:
+            self.__raise_eof()
         count -= 1
         while ch and count:
             ch = self.read()
@@ -313,11 +315,11 @@ Grammar:
                 elif ch == 't':
                     text.append('\t')
                 elif ch == 'u':
-                    hex = self.read_multi(4)
+                    codepoint = self.read_multi(4)
                     try:
-                        text.append(chr(int(hex, 16)))
-                    except ValueError:
-                        self.__raise_unicode(hex)
+                        text.append(chr(int(codepoint, 16)))
+                    except (TypeError, ValueError):
+                        self.__raise_unicode(codepoint)
                 elif ch not in "$%(),\\":
                     self.__raise_char(ch)
                 else:

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import re
+import unicodedata
 
 from PyQt5 import (
     QtCore,
@@ -179,6 +180,19 @@ class ScriptCompleter(QCompleter):
         return self.last_selected
 
 
+def _clean_text(text):
+    return "".join(_replace_control_chars(text))
+
+
+def _replace_control_chars(text):
+    simple_ctrl_chars = {'\n', '\r', '\t'}
+    for ch in text:
+        if ch not in simple_ctrl_chars and unicodedata.category(ch)[0] == "C":
+            yield '\\u' + hex(ord(ch))[2:]
+        else:
+            yield ch
+
+
 class ScriptTextEdit(QTextEdit):
     autocomplete_trigger_chars = re.compile('[$%A-Za-z0-9_]')
 
@@ -187,6 +201,10 @@ class ScriptTextEdit(QTextEdit):
         self.highlighter = TaggerScriptSyntaxHighlighter(self.document())
         self.enable_completer()
         self.setFontFamily(FONT_FAMILY_MONOSPACE)
+
+    def insertFromMimeData(self, source):
+        source.setText(_clean_text(source.text()))
+        return super().insertFromMimeData(source)
 
     def enable_completer(self):
         self.completer = ScriptCompleter()

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -86,7 +86,10 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         self.var_re = QtCore.QRegExp(r"%[_a-zA-Z0-9:]*%")
         self.var_fmt = QtGui.QTextCharFormat()
         self.var_fmt.setForeground(syntax_theme.var)
-        self.escape_re = QtCore.QRegExp(r"\\.")
+        self.unicode_re = QtCore.QRegExp(r"\\u[a-fA-F0-9]{4}")
+        self.unicode_fmt = QtGui.QTextCharFormat()
+        self.unicode_fmt.setForeground(syntax_theme.escape)
+        self.escape_re = QtCore.QRegExp(r"\\[^u]")
         self.escape_fmt = QtGui.QTextCharFormat()
         self.escape_fmt.setForeground(syntax_theme.escape)
         self.special_re = QtCore.QRegExp(r"[^\\][(),]")
@@ -101,6 +104,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         self.rules = [
             (self.func_re, self.func_fmt, 0, -1),
             (self.var_re, self.var_fmt, 0, 0),
+            (self.unicode_re, self.unicode_fmt, 0, 0),
             (self.escape_re, self.escape_fmt, 0, 0),
             (self.special_re, self.special_fmt, 1, -1),
         ]

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -161,7 +161,9 @@ class ScriptParserTest(PicardTestCase):
     def test_script_unicode_char_eof(self):
         areg = r"^\d+:\d+: Unexpected end of script"
         with self.assertRaisesRegex(ScriptEndOfFile, areg):
-            self.parser.eval("\\uaf")
+            self.parser.eval("\\u")
+        with self.assertRaisesRegex(ScriptEndOfFile, areg):
+            self.parser.eval("\\uaff")
 
     def test_script_unicode_char_err(self):
         areg = r"^\d+:\d+: Invalid unicode character '\\ufffg'"

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -54,6 +54,7 @@ from picard.script import (
     ScriptParser,
     ScriptRuntimeError,
     ScriptSyntaxError,
+    ScriptUnicodeError,
     ScriptUnknownFunction,
     register_script_function,
     script_function,
@@ -151,6 +152,21 @@ class ScriptParserTest(PicardTestCase):
                 + r'$'
 
         self.assertRegex(repr(item), regex)
+
+    def test_script_unicode_char(self):
+        self.assertScriptResultEquals("\\u6e56", "湖")
+        self.assertScriptResultEquals("foo\\u6e56bar", "foo湖bar")
+        self.assertScriptResultEquals("\\uFFFF", "\uffff")
+
+    def test_script_unicode_char_eof(self):
+        areg = r"^\d+:\d+: Unexpected end of script"
+        with self.assertRaisesRegex(ScriptEndOfFile, areg):
+            self.parser.eval("\\uaf")
+
+    def test_script_unicode_char_err(self):
+        areg = r"^\d+:\d+: Invalid unicode character '\\ufffg'"
+        with self.assertRaisesRegex(ScriptUnicodeError, areg):
+            self.parser.eval("\\ufffg")
 
     def test_script_function_decorator_default(self):
         # test default decorator and default prefix


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2204, PICARD-2200
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This adds support for Unicode escape sequences in the form of `\uFFFF` to tagger script.

Rationale:

- This would allow explicitly inserting special characters and makes it easier to define some characters the user cannot write
- Allows making invisible control characters visible (see PICARD-2200)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Extend the tagger script parser for support of Unicode escape sequences. The Unicode escape sequences always start with `\u` followed by a four digit hexadecimal number representing the Unicode code point. E.g. to get the character 湖 one can also use `\u6e56`. To explicitly insert a thin space a user can write `\u2009`.

This also extends the script editor for proper syntax highlighting and implements automatic replacement of control characters other then  newlines and tabulators with the corresponding escape sequence. This avoids issues such as accidentally inserted invisible control characters with unwanted side effects as discussed in PICARD-2200.

E.g. if a user copy and pastes from the docs and copies the left-to-right mark we insert into the docs by accident they will get this:

![grafik](https://user-images.githubusercontent.com/29852/117060328-130bd280-ad21-11eb-8419-375b63cdaecd.png)


# Action

This is the first actual syntax extension to tagger script since it's first implementation. Old script stay completely compatible. Scripts using Unicode escape sequences will not parse in older Picard versions, as `\u` is an invalid escape. Older versions will fail cleanly with a syntax error.
