### PR TITLE
PICARD-2205: Update syntax highlighting to allow functions starting with _ or 0-9

### DIFF
--- a/picard/script/parser.py
+++ b/picard/script/parser.py
@@ -210,8 +210,8 @@ Grammar:
   text        ::= [^$%] | '\$' | '\%' | '\(' | '\)' | '\,' | unicodechar
   argtext     ::= [^$%(),] | '\$' | '\%' | '\(' | '\)' | '\,' | unicodechar
   identifier  ::= [a-zA-Z0-9_]
-  variable    ::= '%' identifier '%'
-  function    ::= '$' identifier '(' (argument (',' argument)*)? ')'
+  variable    ::= '%' (identifier | ':')+ '%'
+  function    ::= '$' (identifier)+ '(' (argument (',' argument)*)? ')'
   expression  ::= (variable | function | text)*
   argument    ::= (variable | function | argtext)*
 """

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -81,7 +81,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     def __init__(self, document):
         super().__init__(document)
         syntax_theme = theme.syntax_theme
-        self.func_re = QtCore.QRegExp(r"\$(?!noop)[a-zA-Z][_a-zA-Z0-9]*\(")
+        self.func_re = QtCore.QRegExp(r"\$(?!noop)[_a-zA-Z0-9]*\(")
         self.func_fmt = QtGui.QTextCharFormat()
         self.func_fmt.setFontWeight(QtGui.QFont.Bold)
         self.func_fmt.setForeground(syntax_theme.func)


### PR DESCRIPTION


The scripting syntax definition and parser implementation allow such functions.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2205
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

According to the tagger script grammar [1]  and the actual implementation a function name can consist of the characters [a-zA-Z0-9_], without restriction on placement.

Thus the following examples are all valid function names: `$_`, `$123`, `$_a_`, `$_1a`

But the syntax highlighting assumes function names must start with [a-zA-Z].

https://github.com/metabrainz/picard/blob/master/picard/script/parser.py#L202-L212

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Update the syntax highlighting to properly highlight those functions.
