### PR TITLE
PICARD-2200: Add unicode left-to-right marks only for RTL languages

### DIFF
--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -100,7 +100,8 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         }
         # Scripting code is always left-to-right. Qt does not support the dir
         # attribute on inline tags, insert explicit left-right-marks instead.
-        html = html.replace('<code>', '<code>&#8206;')
+        if text_direction == 'rtl':
+            html = html.replace('<code>', '<code>&#8206;')
 
         link = '<a href="' + PICARD_URLS['doc_scripting'] + '">' + N_('Open Scripting Documentation in your browser') + '</a>'
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2200
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is another mitigation for people accidentally copying the Unicode left-to-right marks that we place in the inline documentation into the scripting. The previous https://github.com/metabrainz/picard/pull/1806 is a generic improvement, making it easier for users to deal with this and similar situations, and improving handling of Unicode characters in scripts in general.

This change now limits the use of the Unicode left-to-right mark U+200E only to actual right-to-left UI language. In other cases it is not needed, so the majority of users will not encounter this at all.

# Solution
Add the Unicode left-to-right mark U+200E only when UI language is a RTL language. This mitigates the issue of users accidentally copying those marks into their scripts, causing unwanted side effects.