### PR TITLE
Script editor context menu to toggle line wrap and tooltips

### DIFF
--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -432,6 +432,7 @@ class ScriptEditorPage(PicardDialog):
         display_menu.addAction(self.examples_action)
 
         display_menu.addAction(self.ui.file_naming_format.wordwrap_action)
+        display_menu.addAction(self.ui.file_naming_format.show_tooltips_action)
 
         self.docs_action = QtWidgets.QAction(_("&Show documentation"), self)
         self.docs_action.setToolTip(_("View the scripting documentation in a sidebar"))

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -339,8 +339,6 @@ class ScriptEditorPage(PicardDialog):
 
         self.synchronize_vertical_scrollbars((self.ui.example_filename_before, self.ui.example_filename_after))
 
-        self.wordwrap = True
-        self.toggle_wordwrap()  # Force update to display
         self.sidebar = True
         self.toggle_documentation()  # Force update to display
         self.examples_current_row = -1
@@ -433,12 +431,7 @@ class ScriptEditorPage(PicardDialog):
         self.examples_action.triggered.connect(self.update_example_files)
         display_menu.addAction(self.examples_action)
 
-        self.wrap_action = QtWidgets.QAction(_("&Word wrap script"), self)
-        self.wrap_action.setToolTip(_("Word wrap long lines in the editor"))
-        self.wrap_action.triggered.connect(self.toggle_wordwrap)
-        self.wrap_action.setShortcut(QtGui.QKeySequence(_("Ctrl+W")))
-        self.wrap_action.setCheckable(True)
-        display_menu.addAction(self.wrap_action)
+        display_menu.addAction(self.ui.file_naming_format.wordwrap_action)
 
         self.docs_action = QtWidgets.QAction(_("&Show documentation"), self)
         self.docs_action.setToolTip(_("View the scripting documentation in a sidebar"))
@@ -839,15 +832,6 @@ class ScriptEditorPage(PicardDialog):
         examples = self.examples.get_examples()
         self.update_example_listboxes(self.ui.example_filename_before, self.ui.example_filename_after, examples)
         self.signal_update.emit()
-
-    def toggle_wordwrap(self):
-        """Toggles wordwrap in the script editing textbox.
-        """
-        self.wordwrap = not self.wordwrap
-        if self.wordwrap:
-            self.ui.file_naming_format.setLineWrapMode(QtWidgets.QTextEdit.WidgetWidth)
-        else:
-            self.ui.file_naming_format.setLineWrapMode(QtWidgets.QTextEdit.NoWrap)
 
     def output_error(self, title, fmt, filename, msg):
         """Log error and display error message dialog.

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -318,7 +318,7 @@ class ScriptTextEdit(QTextEdit):
         self.wordwrap_action = QAction(_("&Word wrap script"), self)
         self.wordwrap_action.setToolTip(_("Word wrap long lines in the editor"))
         self.wordwrap_action.triggered.connect(self.update_wordwrap)
-        self.wordwrap_action.setShortcut(QKeySequence(_("Ctrl+W")))
+        self.wordwrap_action.setShortcut(QKeySequence(_("Ctrl+Shift+W")))
         self.wordwrap_action.setCheckable(True)
         self.wordwrap_action.setChecked(config.persist['script_editor_wordwrap'])
         self.update_wordwrap()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2197, PICARD-2207
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This adds a context menu to the script text editor to toggle line wrapping and display of tooltips.

Overall this brings the following improvements:

- "Word wrap script" is now also available in Options > Scripting via context menu
- "Word wrap script" gets persisted
- "Word wrap script" uses <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> instead of <kbd>Ctrl</kbd>+<kbd>W</kbd>. That's because <kbd>Ctrl</kbd>+<kbd>W</kbd> is already the default for closing a dialog
- A new action "Show help tooltips" has been added, which is available both via context menu and script editor dialog "Display" menu


# Solution

Move word wrap action to `ScriptTextEdit`, implement context menu.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
