### PR TITLE
PICARD-2209: Ensure DesktopStatusIndicator is registered only once

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -168,6 +168,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     defaultsize = QtCore.QSize(780, 560)
     selection_updated = QtCore.pyqtSignal(object)
+    ready_for_display = QtCore.pyqtSignal()
 
     options = [
         Option("persist", "window_state", QtCore.QByteArray()),
@@ -184,12 +185,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def __init__(self, parent=None, disable_player=False):
         super().__init__(parent)
-        self._shown = False
+        self.__shown = False
         self.selected_objects = []
         self.ignore_selection_changes = IgnoreSelectionContext(self.update_selection)
         self.toolbar = None
         self.player = None
         self.status_indicators = []
+        if DesktopStatusIndicator:
+            self.ready_for_display.connect(self._setup_desktop_status_indicator)
         if not disable_player:
             from picard.ui.playertoolbar import Player
             player = Player(self)
@@ -286,10 +289,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.metadata_box.restore_state()
 
     def showEvent(self, event):
+        if not self.__shown:
+            self.ready_for_display.emit()
+            self.__shown = True
         super().showEvent(event)
-        if not self._shown and DesktopStatusIndicator:
-            self.register_status_indicator(DesktopStatusIndicator(self.windowHandle()))
-        self._shown = True
 
     def closeEvent(self, event):
         config = get_config()
@@ -301,6 +304,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             config.persist['mediaplayer_volume'] = self.player.volume()
         self.saveWindowState()
         event.accept()
+
+    def _setup_desktop_status_indicator(self):
+        if DesktopStatusIndicator:
+            self.register_status_indicator(DesktopStatusIndicator(self.windowHandle()))
 
     def register_status_indicator(self, indicator):
         self.status_indicators.append(indicator)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -184,6 +184,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def __init__(self, parent=None, disable_player=False):
         super().__init__(parent)
+        self._shown = False
         self.selected_objects = []
         self.ignore_selection_changes = IgnoreSelectionContext(self.update_selection)
         self.toolbar = None
@@ -286,8 +287,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def showEvent(self, event):
         super().showEvent(event)
-        if DesktopStatusIndicator:
+        if not self._shown and DesktopStatusIndicator:
             self.register_status_indicator(DesktopStatusIndicator(self.windowHandle()))
+        self._shown = True
 
     def closeEvent(self, event):
         config = get_config()


### PR DESCRIPTION
Otherwise this can lead to performance issues if the user minimizes / maximizes the main window multiple times, causing multiple DesktopStatusIndicator getting registered.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2209
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When the user toggles the main window between minimized and maximized Picard will register the DesktopStatusIndicator multiple times. Doing this repeatedly can cause slow downs due to multiple registered indicators. 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Remember whether showEvent was already called or not. We cannot move this into e.g. __init__, as for Windows the window must actually exist before you can access the taskbar button's API.



# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Would QWidget provide another place to call this, but only once the widget has been fully created?