### PR TITLE
Automatically restore geometry of PicardDialog instances

### DIFF
--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -58,12 +58,9 @@ else:
 class PreserveGeometry:
 
     defaultsize = None
-    autorestore = True
 
     def __init__(self):
         Option("persist", self.opt_name(), QtCore.QByteArray())
-        if self.autorestore:
-            self.restore_geometry()
         if getattr(self, 'finished', None):
             self.finished.connect(self.save_geometry)
 
@@ -111,9 +108,12 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     help_url = None
     flags = QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowCloseButtonHint
+    ready_for_display = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent, self.flags)
+        self.__shown = False
+        self.ready_for_display.connect(self.restore_geometry)
 
     def keyPressEvent(self, event):
         if event.matches(QtGui.QKeySequence.Close):
@@ -122,6 +122,12 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
             self.show_help()
         else:
             super().keyPressEvent(event)
+
+    def showEvent(self, event):
+        if not self.__shown:
+            self.ready_for_display.emit()
+            self.__shown = True
+        return super().showEvent(event)
 
     def show_help(self):
         if self.help_url:

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -41,8 +41,6 @@ from picard.ui.ui_aboutdialog import Ui_AboutDialog
 
 class AboutDialog(PicardDialog, SingletonDialog):
 
-    autorestore = False
-
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -53,7 +53,6 @@ from picard.ui.ui_cdlookup import Ui_Dialog
 
 class CDLookupDialog(PicardDialog):
 
-    autorestore = False
     dialog_header_state = "cdlookupdialog_header_state"
 
     options = [
@@ -107,7 +106,6 @@ class CDLookupDialog(PicardDialog):
             self.ui.results_view.setCurrentIndex(1)
         self.ui.lookup_button.clicked.connect(self.lookup)
         self.ui.submit_button.clicked.connect(self.lookup)
-        self.restore_geometry()
         self.restore_header_state()
         self.finished.connect(self.save_header_state)
 

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -91,8 +91,6 @@ class TagEditorDelegate(QtWidgets.QItemDelegate):
 
 class EditTagDialog(PicardDialog):
 
-    autorestore = False
-
     def __init__(self, window, tag):
         super().__init__(window)
         self.ui = Ui_EditTagDialog()
@@ -120,7 +118,6 @@ class EditTagDialog(PicardDialog):
         self.value_list.setItemDelegate(TagEditorDelegate(self))
         self.tag_changed(tag)
         self.value_selection_changed()
-        self.restore_geometry()
 
     def keyPressEvent(self, event):
         if event.modifiers() == QtCore.Qt.NoModifier and event.key() in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return):

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -112,8 +112,6 @@ class ArtworkTable(QtWidgets.QTableWidget):
 
 class InfoDialog(PicardDialog):
 
-    autorestore = False
-
     def __init__(self, obj, parent=None):
         super().__init__(parent)
         self.obj = obj
@@ -155,7 +153,6 @@ class InfoDialog(PicardDialog):
         self.setWindowTitle(_("Info"))
         self.artwork_table = self.ui.artwork_table
         self._display_tabs()
-        self.restore_geometry()
 
     def _display_tabs(self):
         self._display_info_tab()

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -167,7 +167,6 @@ class IgnoreSelectionContext:
 class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     defaultsize = QtCore.QSize(780, 560)
-    autorestore = False
     selection_updated = QtCore.pyqtSignal(object)
 
     options = [

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -79,8 +79,6 @@ from picard.ui.util import StandardButton
 
 class OptionsDialog(PicardDialog, SingletonDialog):
 
-    autorestore = False
-
     options = [
         TextOption("persist", "options_last_active_page", ""),
         ListOption("persist", "options_pages_tree_state", []),
@@ -244,7 +242,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                     continue
                 item.setExpanded(is_expanded)
 
-        self.restore_geometry()
         self.ui.splitter.restoreState(config.persist["options_splitter"])
 
     def restore_all_defaults(self):

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -65,7 +65,6 @@ class ScriptCheckError(OptionsCheckError):
 
 class ScriptingDocumentationDialog(PicardDialog, SingletonDialog):
     defaultsize = QtCore.QSize(570, 400)
-    autorestore = False
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -79,7 +78,6 @@ class ScriptingDocumentationDialog(PicardDialog, SingletonDialog):
         self.ui.setupUi(self)
         doc_widget = ScriptingDocumentationWidget(self)
         self.ui.documentation_layout.addWidget(doc_widget)
-        self.restore_geometry()
         self.ui.buttonBox.rejected.connect(self.close)
 
     def closeEvent(self, event):

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -276,8 +276,6 @@ class ScriptEditorDialog(PicardDialog):
     default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
     default_script_filename = "picard_naming_script.pnsp"
 
-    autorestore = False
-
     def __init__(self, parent=None, examples=None):
         """Stand-alone file naming script editor.
 
@@ -304,7 +302,6 @@ class ScriptEditorDialog(PicardDialog):
         self.ui = Ui_ScriptEditor()
         self.ui.setupUi(self)
         self.make_menu()
-        self.restore_geometry()
 
         # Button tooltips
         self.ui.file_naming_editor_close.setToolTip(self.close_action.toolTip())

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -85,13 +85,11 @@ class SortableTableWidgetItem(QtWidgets.QTableWidgetItem):
 class TableBasedDialog(PicardDialog):
 
     defaultsize = QtCore.QSize(720, 360)
-    autorestore = False
     scrolled = pyqtSignal()
 
     def __init__(self, parent):
         super().__init__(parent)
         self.setupUi()
-        self.restore_state()
         self.columns = None  # self.columns has to be an ordered dict, with column name as keys, and matching label as values
         self.sorting_enabled = True
         self.create_table()
@@ -191,10 +189,6 @@ class TableBasedDialog(PicardDialog):
                 selected_rows_user_values .append(row)
             self.accept_event(selected_rows_user_values)
         super().accept()
-
-    @restore_method
-    def restore_state(self):
-        self.restore_geometry()
 
     @restore_method
     def restore_table_header_state(self):

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -98,7 +98,6 @@ class TagMatchExpression:
 
 class TagsFromFileNamesDialog(PicardDialog):
 
-    autorestore = False
     help_url = 'doc_tags_from_filenames'
 
     options = [
@@ -109,7 +108,6 @@ class TagsFromFileNamesDialog(PicardDialog):
         super().__init__(parent)
         self.ui = Ui_TagsFromFileNamesDialog()
         self.ui.setupUi(self)
-        self.restore_geometry()
         items = [
             "%artist%/%album%/%title%",
             "%artist%/%album%/%tracknumber% %title%",


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The autorestore feature of the `PreserveGeometry`  helper class can mostly not be used, as most classes intiialize the UI later. Instead `PreserveGeometry.restore_geometry` should be called for a dialog just before it is shown for the first time.

# Solution
Handle calling `restore_geometry` in `PicardDialog`. Introduce a new signal `ready_for_display` that is also emitted exactly once, just before the dialog gets shown for the first time.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
