### PR TITLE
Allow disabling graphical crash handler with --no-crash-dialog

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,7 +110,7 @@ jobs:
         pip install .
     - name: Test running installed package
       if: runner.os != 'Windows'
-      run: picard --long-version
+      run: picard --long-version --no-crash-dialog
     - name: Verify sdist package
       if: runner.os != 'Windows'
       run: |

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -99,7 +99,7 @@ def crash_handler():
     import sys
 
     # Allow disabling the graphical crash handler for debugging and CI purposes.
-    if '--no-crash-dialog' in sys.argv:
+    if set(sys.argv) & {'--no-crash-dialog', '-v', '--version', '-V', '--long-version', '-h', '--help'}:
         return
 
     # First try to get traceback information and write it to a log file

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -96,9 +96,14 @@ def crash_handler():
     a minimal crash dialog to the user.
     This function is supposed to be called from inside an except blog.
     """
+    import sys
+
+    # Allow disabling the graphical crash handler for debugging and CI purposes.
+    if '--no-crash-dialog' in sys.argv:
+        return
+
     # First try to get traceback information and write it to a log file
     # with minimum chance to fail.
-    import sys
     from tempfile import NamedTemporaryFile
     import traceback
     trace = traceback.format_exc()

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -949,6 +949,8 @@ def process_picard_args():
                         help="do not restore positions and/or sizes")
     parser.add_argument("-P", "--no-plugins", action='store_true',
                         help="do not load any plugins")
+    parser.add_argument("--no-crash-dialog", action='store_true',
+                        help="disable the crash dialog")
     parser.add_argument('-v', '--version', action='store_true',
                         help="display version information and exit")
     parser.add_argument("-V", "--long-version", action='store_true',

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -83,7 +83,7 @@ fi
 # Only test the app if it was codesigned, otherwise execution likely fails
 if [ "$CODESIGN" = '1' ]; then
   echo "Verify Picard executable works and required dependencies are bundled..."
-  VERSIONS=$("$APP_BUNDLE/Contents/MacOS/picard-run" --long-version)
+  VERSIONS=$("$APP_BUNDLE/Contents/MacOS/picard-run" --long-version --no-crash-dialog)
   echo "$VERSIONS"
   ASTRCMP_REGEX="astrcmp C"
   [[ $VERSIONS =~ $ASTRCMP_REGEX ]] || (echo "Failed: Build does not include astrcmp C" && false)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
This is mainly for running Picard in CI environments and debugging. E.g. on CI we sometimes run `picard --version`  just to verify the build package is working. But if that fails without graphical environment this fails hard when trying to show the error dialog with an error message unrelated to the original issue. See e.g. https://github.com/phw/picard/runs/2594991408:

> qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
> This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
>
> Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.
>
> /home/runner/work/_temp/fe09af7f-24b1-48eb-8c5a-def104386bab.sh: line 1:  3488 Aborted                 (core dumped) picard --long-version
> Error: Process completed with exit code 134.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
