### PR TITLE
PICARD-2218: Allow regular expressions in $performer(pattern)

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -764,15 +764,16 @@ def func_lenmulti(parser, multi, separator=MULTI_VALUED_JOINER):
     """`$performer(pattern="",join=", ")`
 
 Returns the performers where the performance type (e.g. "vocal") matches `pattern`, joined by `join`.
-You can specify a regular expression by surrounding the pattern with `/.../`. For example
-`/^guitars?$/` matches the performance type "guitar" or "guitars", but not e.g. "bass guitar".
+You can specify a regular expression in the format `/pattern/flags`. `flags` are optional. Currently
+the only supported flag is "i" (ignore case). For example `$performer(/^guitars?$/i)` matches the
+performance type "guitar" or "Guitars", but not e.g. "bass guitar".
 
 _Since Picard 0.10_"""
 ))
 def func_performer(parser, pattern="", join=", "):
     values = []
     try:
-        regex = pattern_as_regex(pattern, allow_wildcards=False, flags=re.IGNORECASE)
+        regex = pattern_as_regex(pattern, allow_wildcards=False)
     except re.error:
         return ''
     for name, value in parser.context.items():

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -767,8 +767,10 @@ _Since Picard 0.10_"""
 def func_performer(parser, pattern="", join=", "):
     values = []
     for name, value in parser.context.items():
-        if name.startswith("performer:") and pattern in name:
-            values.append(value)
+        if name.startswith("performer:"):
+            name, performance = name.split(':', 2)
+            if pattern in performance:
+                values.append(value)
     return join.join(values)
 
 

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -761,6 +761,7 @@ def func_lenmulti(parser, multi, separator=MULTI_VALUED_JOINER):
     """`$performer(pattern="",join=", ")`
 
 Returns the performers where the performance type (e.g. "vocal") matches `pattern`, joined by `join`.
+`pattern` can be a regular expression.
 
 _Since Picard 0.10_"""
 ))
@@ -769,7 +770,12 @@ def func_performer(parser, pattern="", join=", "):
     for name, value in parser.context.items():
         if name.startswith("performer:"):
             name, performance = name.split(':', 2)
-            if pattern in performance:
+            try:
+                match = bool(re.search(pattern, performance))
+            except re.error:
+                # fall back to simple string matching if regex is invalid
+                match = pattern in performance
+            if match:
                 values.append(value)
     return join.join(values)
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -68,6 +68,7 @@ from picard.script import (
     ScriptParser,
     enabled_tagger_scripts_texts,
 )
+from picard.util import pattern_as_regex
 from picard.util.imagelist import (
     add_metadata_images,
     remove_metadata_images,
@@ -96,23 +97,12 @@ class TagGenreFilter:
                 remain = line[1:].strip()
                 if not remain:
                     continue
-                if len(remain) > 2 and remain[0] == '/' and remain[-1] == '/':
-                    remain = remain[1:-1]
-                    try:
-                        regex_search = re.compile(remain, re.IGNORECASE)
-                    except Exception as e:
-                        log.error("Failed to compile regex /%s/: %s", remain, e)
-                        self.errors[lineno] = str(e)
-                        regex_search = None
-                else:
-                    # FIXME?: only support '*' (not '?' or '[abc]')
-                    # replace multiple '*' by one
-                    star = re.escape('*')
-                    remain = re.sub(star + '+', '*', remain)
-                    regex = '.*'.join([re.escape(x) for x in remain.split('*')])
-                    regex_search = re.compile('^' + regex + '$', re.IGNORECASE)
-                if regex_search:
+                try:
+                    regex_search = pattern_as_regex(remain, allow_wildcards=True, flags=re.IGNORECASE)
                     self.match_regexes[_list].append(regex_search)
+                except re.error as e:
+                    log.error("Failed to compile regex /%s/: %s", remain, e)
+                    self.errors[lineno] = str(e)
 
     def skip(self, tag):
         if not self.match_regexes:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -729,3 +729,35 @@ def extract_year_from_date(dt):
             return parse(dt).year
     except (TypeError, ValueError):
         return None
+
+
+def pattern_as_regex(pattern, allow_wildcards=False, flags=0):
+    """Parses a string and interprets it as a matching pattern.
+
+    - If pattern starts and ends with / it is interpreted as a regular expression (e.g. `/foo.*/`)
+    - Otherwise if `allow_wildcards` is True, it is interpreted as a pattern that allows wildcard matching (see below)
+    - If `allow_wildcards` is False a regex matching the literal string is returned
+
+    Wildcard matching currently supports these characters:
+    - `*`: Matches an arbitrary number of characters or none, e.g. `foo*`
+
+    Args:
+        pattern: The pattern as a string
+        allow_wildcards: If true and if the the pattern is not interpreted as a regex wildard matching is allowed.
+        flags: Additional regex flags to set (e.g. `re.I`)
+
+    Returns: An re.Pattern instance
+
+    Raises: `re.error` if the regular expression could not be parsed
+    """
+    if len(pattern) > 2 and pattern[0] == '/' and pattern[-1] == '/':
+        pattern = pattern[1:-1]
+        return re.compile(pattern, flags)
+    elif allow_wildcards:
+        # FIXME?: only support '*' (not '?' or '[abc]')
+        # replace multiple '*' by one
+        pattern = re.sub(r'\*+', '*', pattern)
+        regex = '.*'.join([re.escape(x) for x in pattern.split('*')])
+        return re.compile('^' + regex + '$', flags)
+    else:
+        return re.compile(re.escape(pattern), flags)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -734,7 +734,9 @@ def extract_year_from_date(dt):
 def pattern_as_regex(pattern, allow_wildcards=False, flags=0):
     """Parses a string and interprets it as a matching pattern.
 
-    - If pattern starts and ends with / it is interpreted as a regular expression (e.g. `/foo.*/`)
+    - If pattern is of the form /pattern/flags it is interpreted as a regular expression (e.g. `/foo.*/`).
+      The flags are optional and in addition to the flags passed in the `flags` function parameter. Supported
+      flags in the expression are "i" (ignore case) and "m" (multiline)
     - Otherwise if `allow_wildcards` is True, it is interpreted as a pattern that allows wildcard matching (see below)
     - If `allow_wildcards` is False a regex matching the literal string is returned
 
@@ -750,9 +752,14 @@ def pattern_as_regex(pattern, allow_wildcards=False, flags=0):
 
     Raises: `re.error` if the regular expression could not be parsed
     """
-    if len(pattern) > 2 and pattern[0] == '/' and pattern[-1] == '/':
-        pattern = pattern[1:-1]
-        return re.compile(pattern, flags)
+    plain_pattern = pattern.rstrip('im')
+    if len(plain_pattern) > 2 and plain_pattern[0] == '/' and plain_pattern[-1] == '/':
+        extra_flags = pattern[len(plain_pattern):]
+        if 'i' in extra_flags:
+            flags |= re.IGNORECASE
+        if 'm' in extra_flags:
+            flags |= re.MULTILINE
+        return re.compile(plain_pattern[1:-1], flags)
     elif allow_wildcards:
         # FIXME?: only support '*' (not '?' or '[abc]')
         # replace multiple '*' by one

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -932,13 +932,15 @@ class ScriptParserTest(PicardTestCase):
     def test_cmd_performer(self):
         context = Metadata()
         context['performer:guitar'] = 'Foo1'
-        context['performer:rhythm-guitar'] = 'Foo2'
+        context['performer:rhythm-guitar'] = ['Foo2', 'Foo3']
         context['performer:drums'] = 'Drummer'
+        # Matches pattern
         result = self.parser.eval("$performer(guitar)", context=context)
-        performers = result.split(', ')
-        self.assertIn('Foo1', performers)
-        self.assertIn('Foo2', performers)
-        self.assertEqual(2, len(performers))
+        self.assertEqual({'Foo1', 'Foo2', 'Foo3'}, set(result.split(', ')))
+        # Empty pattern returns all performers
+        result = self.parser.eval("$performer()", context=context)
+        self.assertEqual({'Foo1', 'Foo2', 'Foo3', 'Drummer'}, set(result.split(', ')))
+        self.assertScriptResultEquals("$performer(perf)", "", context)
 
     def test_cmd_performer_custom_join(self):
         context = Metadata()
@@ -946,10 +948,7 @@ class ScriptParserTest(PicardTestCase):
         context['performer:rhythm-guitar'] = 'Foo2'
         context['performer:drums'] = 'Drummer'
         result = self.parser.eval("$performer(guitar, / )", context=context)
-        performers = result.split(' / ')
-        self.assertIn('Foo1', performers)
-        self.assertIn('Foo2', performers)
-        self.assertEqual(2, len(performers))
+        self.assertEqual({'Foo1', 'Foo2'}, set(result.split(' / ')))
 
     def test_cmd_matchedtracks(self):
         file = MagicMock()

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2007 Lukáš Lalinský
-# Copyright (C) 2010, 2014, 2018-2020 Philipp Wolfer
+# Copyright (C) 2010, 2014, 2018-2021 Philipp Wolfer
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2013 Michael Wiencek
 # Copyright (C) 2013, 2017-2020 Laurent Monin
@@ -941,6 +941,19 @@ class ScriptParserTest(PicardTestCase):
         result = self.parser.eval("$performer()", context=context)
         self.assertEqual({'Foo1', 'Foo2', 'Foo3', 'Drummer'}, set(result.split(', ')))
         self.assertScriptResultEquals("$performer(perf)", "", context)
+
+    def test_cmd_performer_regex(self):
+        context = Metadata()
+        context['performer:guitar'] = 'Foo1'
+        context['performer:guitars'] = 'Foo2'
+        context['performer:rhythm-guitar'] = 'Foo3'
+        context['performer:drums (drum kit)'] = 'Drummer'
+        result = self.parser.eval(r"$performer(^guitar)", context=context)
+        self.assertEqual({'Foo1', 'Foo2'}, set(result.split(', ')))
+        result = self.parser.eval(r"$performer(^guitar\$)", context=context)
+        self.assertEqual({'Foo1'}, set(result.split(', ')))
+        result = self.parser.eval(r"$performer(drums \()", context=context)
+        self.assertEqual({'Drummer'}, set(result.split(', ')))
 
     def test_cmd_performer_custom_join(self):
         context = Metadata()

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -959,6 +959,14 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals(r"$performer(/drums \(/)", "", context)
         self.assertScriptResultEquals(r"$performer(drums \()", "Drummer", context)
 
+    def test_cmd_performer_regex_ignore_case(self):
+        context = Metadata()
+        context['performer:guitar'] = 'Foo1'
+        context['performer:GUITARS'] = 'Foo2'
+        context['performer:rhythm-guitar'] = 'Foo3'
+        result = self.parser.eval(r"$performer(/^guitars?/i)", context=context)
+        self.assertEqual({'Foo1', 'Foo2'}, set(result.split(', ')))
+
     def test_cmd_performer_custom_join(self):
         context = Metadata()
         context['performer:guitar'] = 'Foo1'

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -948,12 +948,16 @@ class ScriptParserTest(PicardTestCase):
         context['performer:guitars'] = 'Foo2'
         context['performer:rhythm-guitar'] = 'Foo3'
         context['performer:drums (drum kit)'] = 'Drummer'
-        result = self.parser.eval(r"$performer(^guitar)", context=context)
+        result = self.parser.eval(r"$performer(/^guitar/)", context=context)
         self.assertEqual({'Foo1', 'Foo2'}, set(result.split(', ')))
-        result = self.parser.eval(r"$performer(^guitar\$)", context=context)
+        result = self.parser.eval(r"$performer(/^guitar\$/)", context=context)
         self.assertEqual({'Foo1'}, set(result.split(', ')))
-        result = self.parser.eval(r"$performer(drums \()", context=context)
-        self.assertEqual({'Drummer'}, set(result.split(', ')))
+
+    def test_cmd_performer_regex_invalid(self):
+        context = Metadata()
+        context['performer:drums (drum kit)'] = 'Drummer'
+        self.assertScriptResultEquals(r"$performer(/drums \(/)", "", context)
+        self.assertScriptResultEquals(r"$performer(drums \()", "Drummer", context)
 
     def test_cmd_performer_custom_join(self):
         context = Metadata()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -531,6 +531,13 @@ class PatternAsRegexTest(PicardTestCase):
         self.assertTrue(regex.flags & re.IGNORECASE)
         self.assertTrue(regex.flags & re.MULTILINE)
 
+    def test_regex_extra_flags(self):
+        regex = pattern_as_regex(r'/^foo.*/im', flags=re.VERBOSE)
+        self.assertEqual(r'^foo.*', regex.pattern)
+        self.assertTrue(regex.flags & re.VERBOSE)
+        self.assertTrue(regex.flags & re.IGNORECASE)
+        self.assertTrue(regex.flags & re.MULTILINE)
+
     def test_regex_raises(self):
         with self.assertRaises(re.error):
             pattern_as_regex(r'/^foo(.*/')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2218, PICARD-2217, PICARD-2216
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

As discussed in PICARD-2216 the `$performer(pattern)` function is not very flexible if you want to access a specific instrument. The pattern will always match anywhere in the string, e.g. `$performer(vocals)` will match both "performer:vocals" and "performer: background vocals". You have no way to match only exactly "performer:vocals". This is partly intentional (`$performer` is supposed to match a substring),  but also not very flexible. Having it support regular expressions would allow for e.g. `$performer(^vocals$)` for exact match.

While looking at that an actual bug was detected: Currently the pattern is matched against the full tag name (e.g. `performer:vocals`). That means any pattern that matches against `performer:`, such as `perf` or `:`, will always match all performance entries. This is for sure not expected behavior.

# Solution
Support regular expressions (PICARD-2218) and fix the bug of matching also the "performer:" part of the tag name (PICARD-2217)
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
