### PR TITLE
PICARD-2219: Fix empty renaming script breaking the filename

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -435,6 +435,8 @@ class File(QtCore.QObject, Item):
             metadata.update(file_metadata)
         (filename, new_metadata) = script_to_filename_with_metadata(
             naming_format, metadata, file=self, settings=settings)
+        if not filename:
+            return None
         # NOTE: the script_to_filename strips the extension away
         ext = new_metadata.get('~extension', file_extension)
         return filename + '.' + ext.lstrip('.')
@@ -458,6 +460,8 @@ class File(QtCore.QObject, Item):
         naming_format = settings['file_naming_format']
         if naming_format:
             new_filename = self._script_to_filename(naming_format, metadata, ext, settings)
+            if not new_filename:
+                new_filename = old_filename
             if not settings['rename_files']:
                 new_filename = os.path.join(os.path.dirname(new_filename), old_filename)
             if not settings['move_files']:

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -223,6 +223,12 @@ class FileNamingTest(PicardTestCase):
             os.path.realpath('/somepath/subdir/somealbum/somefile.mp3'),
             filename)
 
+    def test_make_filename_empty_script(self):
+        config.setting['rename_files'] = True
+        config.setting['file_naming_format'] = '$noop()'
+        filename = self.file.make_filename(self.file.filename, self.metadata)
+        self.assertEqual(os.path.realpath('/somepath/somefile.mp3'), filename)
+
     def test_make_filename_replace_trailing_dots(self):
         config.setting['rename_files'] = True
         config.setting['move_files'] = True


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2219
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
A renaming script evaluating to an empty name would cause files to be renamed to e.g. "_mp3", breaking the file extension. Now the original filename will be kept.



# Solution
Keep original filename if naming script evaluates to an empty name. Added tests.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
