### PR TITLE
PICARD-2226: Removed config object per thread again

### DIFF
--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -29,7 +29,6 @@ from tempfile import (
     mkdtemp,
     mkstemp,
 )
-import threading
 import unittest
 from unittest.mock import Mock
 
@@ -81,8 +80,6 @@ class PicardTestCase(unittest.TestCase):
         fake_config = Mock()
         fake_config.setting = {}
         fake_config.persist = {}
-        # Make config object available to current thread
-        config._thread_configs[threading.get_ident()] = fake_config
         # Make config object available for legacy use
         config.config = fake_config
         config.setting = fake_config.setting

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -23,11 +23,9 @@
 import logging
 import os
 import shutil
-import threading
 
 from test.picardtestcase import PicardTestCase
 
-import picard.config
 from picard.config import (
     BoolOption,
     Config,
@@ -391,14 +389,3 @@ class TestPicardConfigVarOption(TestPicardConfigCommon):
         # store invalid value in config file directly
         self.config.setValue('setting/var_option', object)
         self.assertEqual(self.config.setting["var_option"], set(["a", "b"]))
-
-
-class TestPurgeConfigInstancesTimer(TestPicardConfigCommon):
-
-    def test_purge_inactive_config_instances(self):
-        thread_id = threading.get_ident()
-        self.assertIn(thread_id, picard.config._thread_configs)
-        picard.config._thread_configs['foo'] = {}
-        picard.config.purge_config_instances()
-        self.assertIn(thread_id, picard.config._thread_configs)
-        self.assertNotIn('foo', picard.config._thread_configs)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2226
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Syncing between those instances does not work [as advertised](https://doc.qt.io/qt-5/qsettings.html#accessing-settings-from-multiple-threads-or-processes-simultaneously), which causes missing updates on config changes where a config change is not reflected in tags.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Get rid of the multiple config instances, one per thread.

We added this in the hope it would resolve our deadlock issue. But the root cause was different, and is both fixed by recent PyQt5 and as well by our locking workaround at https://github.com/metabrainz/picard/blob/master/picard/config.py#L164-L186 , which makes sure this does not happen even with older versions.

While https://doc.qt.io/qt-5/qsettings.html#accessing-settings-from-multiple-threads-or-processes-simultaneously claims that one should use one tread per instance we otherwise never had issues with this until the deadlock issue came up in 2.0.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

I consider this a hotfix, that we can quickly roll out without too much code changes. Ideally we want to refactor the config module completely and get rid of QSettings, which has been a time sink with all the troubles it was causing.
