### PR TITLE
PICARD-9: Add multiple user profiles

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 7, 0, 'dev', 2)
+PICARD_VERSION = Version(2, 7, 0, 'dev', 3)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -34,6 +34,7 @@ from picard import log
 from picard.config import (
     BoolOption,
     IntOption,
+    ListOption,
     Option,
     TextOption,
 )
@@ -386,6 +387,23 @@ def upgrade_to_v2_7_0_dev_2(config):
     )
 
 
+def upgrade_to_v2_7_0_dev_3(config):
+    from picard.profile import UserProfile
+    _s = config.setting
+    _p = config.persist
+    ListOption("setting", "file_naming_scripts", [])
+    ListOption("persist", "file_naming_scripts", [])
+    Option("persist", "user_profiles", {})
+    TextOption("persist", "selected_user_profile", "")
+    # Migrate naming scripts to new persist key
+    _p["file_naming_scripts"] = _s["file_naming_scripts"]
+    _s.remove("file_naming_scripts")
+    # Create initial user profile
+    profile = UserProfile(title=_("Initial User Profile"))
+    _p["selected_user_profile"] = profile["id"]
+    _p["user_profiles"] = {profile["id"]: profile.to_dict()}
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -416,4 +434,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_beta_2)
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_beta_3)
     cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_3)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -87,6 +87,7 @@ PICARD_URLS = {
     'doc_options':             DOCS_BASE_URL + '/config/configuration.html',
     'doc_scripting':           DOCS_BASE_URL + '/extending/scripting.html',
     'doc_tags_from_filenames': DOCS_BASE_URL + '/usage/tags_from_file_names.html',
+    'doc_user_profiles':       DOCS_BASE_URL + '/config/configuration.html#user-profiles',
     'doc_cover_art_types':     "https://musicbrainz.org/doc/Cover_Art/Types",
     'plugins':                 "https://picard.musicbrainz.org/plugins/",
     'forum':                   "https://community.metabrainz.org/c/picard",

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from copy import deepcopy
+import uuid
+
+from picard.config import get_config
+
+
+class ProfileImportError(Exception):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+class UserProfile():
+    """Base class for Picard user profile objects.
+    """
+
+    OUTPUT_FIELDS = ('title', 'description', 'id', 'settings')
+    DEFAULT_TITLE = N_("User Profile")
+
+    def __init__(
+        self,
+        title='',
+        description='',
+        id=None,
+        settings_dict=None
+    ):
+        """Base class for Picard user profile objects
+
+        Args:
+            title (str): Title of the profile.
+            description (str): Description of the profile.
+            id (str): ID code for the script. Defaults to a system generated uuid.
+            settings_dict (dict): Dictionary of settings as produced using config.setting.as_dict()
+        """
+        self.title = title if title else _(self.DEFAULT_TITLE)
+        self.description = description
+        if not id:
+            self._set_new_id()
+        else:
+            self.id = id
+        self.settings = None
+        self.load_settings(settings_dict)
+
+    def _set_new_id(self):
+        """Sets the ID of the script to a new system generated uuid.
+        """
+        self.id = str(uuid.uuid4())
+
+    def __getitem__(self, setting):
+        if hasattr(self, setting):
+            value = getattr(self, setting)
+            if isinstance(value, str):
+                value = value.strip()
+            return value
+        return None
+
+    def __setitem__(self, setting, value):
+        if hasattr(self, setting):
+            if isinstance(value, str):
+                value = value.strip()
+            setattr(self, setting, value)
+
+    def load_settings(self, settings):
+        """Load settings from a dictionary.  If the dictionary provided is None or empty, uses the current config.setting.as_dict().
+
+        Args:
+            settings (dict): Dictionary of settings as produced using config.setting.as_dict()
+        """
+        if settings and isinstance(settings, dict):
+            self.settings = settings
+        else:
+            config = get_config()
+            self.settings = config.setting.as_dict()
+
+    def settings_to_config(self):
+        """Updates the current config.setting with the profile object's stored settings.
+        """
+        config = get_config()
+        for key, value in self.settings.items():
+            if key in config.setting:
+                config.setting[key] = value
+
+    def copy(self):
+        """Create a copy of the current profile object with updated title.
+        """
+        new_object = deepcopy(self)
+        new_object.title = _("%s (Copy)") % self.title
+        new_object._set_new_id()
+        return new_object
+
+    def to_dict(self):
+        """Create a dictionary from the class instance.
+
+        Returns:
+            dict: Dictionary of the instance attributes listed in OUTPUT_FIELDS
+        """
+        return {key: getattr(self, key) for key in self.OUTPUT_FIELDS}
+
+    @classmethod
+    def create_from_dict(cls, profile_dict, create_new_id=False):
+        """Creates an instance based on the contents of the dictionary provided.
+
+        Args:
+            profile_dict (dict): Dictionary containing the property settings
+            create_new_id (bool, optional): Determines whether a new ID is assigned. Defaults to False.
+
+        Returns:
+            object: An instance of the class.
+        """
+        new_object = cls()
+        if not isinstance(profile_dict, dict):
+            raise ProfileImportError(N_('Argument is not a dictionary'))
+        if 'title' not in profile_dict or 'settings' not in profile_dict:
+            raise ProfileImportError(N_('Invalid profile dictionary'))
+        for key in set(cls.OUTPUT_FIELDS).intersection(profile_dict):
+            new_object[key] = profile_dict[key]
+        if not new_object['title']:
+            new_object['title'] = _(cls.DEFAULT_TITLE)
+        if create_new_id or not new_object['id']:
+            new_object._set_new_id()
+        return new_object

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -221,3 +221,23 @@ class HashableListWidgetItem(QtWidgets.QListWidgetItem):
 
     def __hash__(self):
         return hash(str(self.id))
+
+
+def confirmation_dialog(message, parent=None):
+    """Displays a confirmation dialog with the supplied message, allowing the user to respond with either Ok or Cancel.
+
+    Args:
+        message (str): Message to display
+        parent (object): Parent object
+
+    Returns:
+        bool: True if the user clicks Ok, otherwise False
+    """
+    dialog = QtWidgets.QMessageBox(
+        QtWidgets.QMessageBox.Warning,
+        _('Confirm'),
+        message,
+        QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel,
+        parent
+    )
+    return dialog.exec_() == QtWidgets.QMessageBox.Ok

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -208,6 +208,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 log.exception('Failed saving options page %r', page)
                 self._show_page_error(page, e)
                 return
+        config = get_config()
+        selected_user_profile = config.persist["selected_user_profile"]
+        profiles = config.persist["user_profiles"]
+        if selected_user_profile in profiles:
+            profiles[selected_user_profile]['settings'] = config.setting.as_dict()
+            config.persist["user_profiles"] = profiles
+        else:
+            log.error('Unable to update user profile "%s"', selected_user_profile)
         super().accept()
 
     def _show_page_error(self, page, error):

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -91,7 +91,7 @@ class RenamingOptionsPage(OptionsPage):
         BoolOption("setting", "move_additional_files", False),
         TextOption("setting", "move_additional_files_pattern", "*.jpg *.png"),
         BoolOption("setting", "delete_empty_dirs", True),
-        ListOption("setting", "file_naming_scripts", []),
+        ListOption("persist", "file_naming_scripts", []),
         TextOption("setting", "selected_file_naming_script_id", ""),
     ]
 
@@ -265,7 +265,7 @@ class RenamingOptionsPage(OptionsPage):
         self.ui.move_additional_files.setChecked(config.setting["move_additional_files"])
         self.ui.move_additional_files_pattern.setText(config.setting["move_additional_files_pattern"])
         self.ui.delete_empty_dirs.setChecked(config.setting["delete_empty_dirs"])
-        self.naming_scripts = config.setting["file_naming_scripts"]
+        self.naming_scripts = config.persist["file_naming_scripts"]
         self.selected_naming_script_id = config.setting["selected_file_naming_script_id"]
         if self.script_editor_dialog:
             self.script_editor_dialog.load()
@@ -300,7 +300,7 @@ class RenamingOptionsPage(OptionsPage):
         config.setting["move_additional_files_pattern"] = self.ui.move_additional_files_pattern.text()
         config.setting["delete_empty_dirs"] = self.ui.delete_empty_dirs.isChecked()
         if self.script_editor_dialog:
-            config.setting["file_naming_scripts"] = self.script_editor_dialog.naming_scripts
+            config.persist["file_naming_scripts"] = self.script_editor_dialog.naming_scripts
             config.setting["selected_file_naming_script_id"] = self.script_editor_dialog.selected_script_id
         else:
             config.setting["file_naming_scripts"] = self.get_scripts_list()

--- a/picard/ui/options/user_profile.py
+++ b/picard/ui/options/user_profile.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from functools import partial
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+
+from picard import log
+from picard.config import (
+    Option,
+    TextOption,
+    get_config,
+)
+from picard.const import PICARD_URLS
+from picard.profile import UserProfile
+from picard.util import restore_method
+
+from picard.ui import (
+    PicardDialog,
+    SingletonDialog,
+    confirmation_dialog,
+)
+from picard.ui.util import StandardButton
+
+
+class UserProfilesDialog(PicardDialog, SingletonDialog):
+    options = [
+        Option("persist", "user_profiles", {}),
+        TextOption("persist", "selected_user_profile", ""),
+    ]
+    help_url = PICARD_URLS['doc_user_profiles']
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowModality(QtCore.Qt.ApplicationModal)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+        self.loading = True
+
+        from picard.ui.ui_user_profiles import Ui_UserProfileEditor
+        self.ui = Ui_UserProfileEditor()
+        self.ui.setupUi(self)
+
+        self.ui.new_profile_button = QtWidgets.QPushButton(_("&New"))
+        self.ui.new_profile_button.setToolTip(_("Create a copy of the selected profile as a new profile"))
+
+        self.ui.delete_profile_button = QtWidgets.QPushButton(_("&Delete"))
+        self.ui.delete_profile_button.setToolTip(_("Delete the selected profile"))
+
+        self.ui.apply_changes_button = QtWidgets.QPushButton(_("&Apply"))
+        self.ui.apply_changes_button.setToolTip(_("Apply changes to the profile"))
+
+        self.ui.okay_button = QtWidgets.QPushButton(_("&Ok"))
+        self.ui.okay_button.setToolTip(_("Use the selected profile"))
+
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.RejectRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.HelpRole)
+        self.ui.buttonbox.addButton(self.ui.apply_changes_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(self.ui.new_profile_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(self.ui.delete_profile_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(self.ui.okay_button, QtWidgets.QDialogButtonBox.AcceptRole)
+
+        self.ui.buttonbox.accepted.connect(self.accept)
+        self.ui.buttonbox.rejected.connect(self.reject)
+        self.ui.new_profile_button.clicked.connect(self.new_profile)
+        self.ui.delete_profile_button.clicked.connect(self.delete_profile)
+        self.ui.apply_changes_button.clicked.connect(self.update_combo_box_item)
+        self.ui.buttonbox.helpRequested.connect(self.show_help)
+
+        self.ui.user_profiles.currentIndexChanged.connect(partial(self.select_profile, skip_check=False))
+
+        self.selected_index = -1
+        self.selected_profile = ''
+
+        self.load()
+
+        self.populate_combobox()
+
+        self.loading = False
+        self.restoreWindowState()
+        self.finished.connect(self.saveWindowState)
+
+    def has_changed(self):
+        """Check if the current profile has pending edits to the title or description that have not been saved.
+
+        Returns:
+            bool: True if there are unsaved changes, otherwise false.
+        """
+        profile_item = self.ui.user_profiles.itemData(self.selected_index)
+        return self.ui.profile_title.text().strip() != profile_item['title'] or \
+            self.ui.profile_description.toPlainText().strip() != profile_item['description']
+
+    def unsaved_changes_confirmation(self):
+        """Check if there are unsaved changes and ask the user to confirm the action resulting in their loss.
+
+        Returns:
+            bool: True if no unsaved changes or user confirms the action, otherwise False.
+        """
+        if not self.loading and self.has_changed() and not confirmation_dialog(
+            _("There are unsaved changes to the current profile.  Do you want to continue and lose these changes?"),
+            self,
+        ):
+            self._set_combobox_index(self.selected_index)
+            return False
+        return True
+
+    def _set_combobox_index(self, idx):
+        """Sets the index of the profile selector combo box.
+
+        Args:
+            idx (int): New index position
+        """
+        self.ui.user_profiles.blockSignals(True)
+        self.ui.user_profiles.setCurrentIndex(idx)
+        self.ui.user_profiles.blockSignals(False)
+        self.selected_index = idx
+
+    def set_selected_profile_index(self, idx):
+        """Select the profile at the specified combo box index.
+
+        Args:
+            idx (int): Index of the profile to select
+        """
+        self._set_combobox_index(idx)
+        self.select_profile(skip_check=True)
+
+    def get_selected_item(self, idx=None):
+        """Get the selected item from the profile selection combo box.
+
+        Returns:
+            dict: Profile dictionary.
+        """
+        if idx is None or idx < 0:
+            idx = self.ui.user_profiles.currentIndex()
+        elif idx >= self.ui.user_profiles.count():
+            idx = self.ui.user_profiles.count() - 1
+        return self.ui.user_profiles.itemData(idx)
+
+    def select_profile(self, skip_check=False):
+        """Load the current profile from the combo box into the editor.
+
+        Args:
+            skip_check (bool): Skip the check for unsaved edits.  Defaults to False.
+        """
+        if self.loading or skip_check or self.unsaved_changes_confirmation():
+            profile_item = self.get_selected_item()
+            self.ui.profile_title.setText(profile_item['title'])
+            self.ui.profile_description.setPlainText(profile_item['description'])
+            self.selected_profile = profile_item['id']
+            self.selected_index = self.ui.user_profiles.currentIndex()
+            self.ui.delete_profile_button.setEnabled(len(self.profiles) > 1)
+
+    def update_combo_box_item(self):
+        """Update the title and item data for the currently selected combo box item.
+        """
+        new_title = self.ui.profile_title.text().strip()
+        if not new_title:
+            QtWidgets.QMessageBox(
+                QtWidgets.QMessageBox.Critical,
+                _("Error"),
+                _("The profile title must not be empty."),
+                QtWidgets.QMessageBox.Ok,
+                self
+            ).exec_()
+            return
+        self.profiles[self.selected_profile]['title'] = self.ui.profile_title.text().strip()
+        self.profiles[self.selected_profile]['description'] = self.ui.profile_description.toPlainText().strip()
+        self.populate_combobox()
+
+    def delete_profile(self):
+        """Removes the currently selected profile from the selection combo box and profile list.
+        """
+        if confirmation_dialog(_('Are you sure that you want to delete the profile?'), self):
+            # Mark the next item for display after the deletion.
+            idx = self.ui.user_profiles.currentIndex() + 1
+            # If the last item is being deleted, mark the preceding item for display.
+            if idx >= self.ui.user_profiles.count():
+                idx -= 2
+            self.profiles.pop(self.selected_profile, None)
+            profile = self.get_selected_item(idx)
+            self.selected_profile = profile['id']
+            self.populate_combobox()
+            self.select_profile(skip_check=True)
+
+    def populate_combobox(self):
+        """Populate the profile selection combo box.
+        """
+        self.ui.user_profiles.blockSignals(True)
+        self.ui.user_profiles.clear()
+        idx = 0
+        for count, (key, value) in enumerate(sorted(self.profiles.items(), key=lambda item: item[1]['title'])):
+            self.ui.user_profiles.addItem(value['title'], value)
+            if key == self.selected_profile:
+                idx = count
+        self.ui.user_profiles.setCurrentIndex(idx)
+        self.ui.user_profiles.blockSignals(False)
+        return idx
+
+    def load(self):
+        """Load the information into the dialog.
+        """
+        config = get_config()
+        self.profiles = config.persist["user_profiles"]
+        self.selected_profile = config.persist["selected_user_profile"]
+        self.populate_combobox()
+        self.select_profile(skip_check=True)
+
+    def new_profile(self):
+        """Create a new profile based on the currently selected profile.
+        """
+        if self.unsaved_changes_confirmation():
+            profile = UserProfile(
+                title=_("%s (Copy)") % self.ui.profile_title.text().strip(),
+                settings_dict=self.profiles[self.selected_profile]['settings']
+            )
+            new_key = profile['id']
+            self.profiles[new_key] = profile.to_dict()
+            self.selected_profile = new_key
+            self.populate_combobox()
+            self.select_profile(skip_check=True)
+
+    def show_help(self):
+        """Displays the help url in the user's browser.
+        """
+        return super().show_help()
+
+    def accept(self):
+        """Copy all settings from the currently selected profile to config.setting, saves the updated profiles
+        dictionary and updates the selected profile in config.persist.
+        """
+        self.update_combo_box_item()
+        config = get_config()
+        config.persist["user_profiles"] = self.profiles
+        config.persist["selected_user_profile"] = self.selected_profile
+        log.debug('Updating settings to profile %s', self.selected_profile)
+        new_profile = UserProfile(
+            title=self.ui.profile_title.text().strip(),
+            id=self.selected_profile,
+            settings_dict=self.profiles[self.selected_profile]['settings'],
+        )
+        new_profile.settings_to_config()
+        self.tagger.window.enable_renaming_action.setChecked(config.setting["rename_files"])
+        self.tagger.window.enable_moving_action.setChecked(config.setting["move_files"])
+        self.tagger.window.enable_tag_saving_action.setChecked(not config.setting["dont_write_tags"])
+        super().accept()
+
+    def closeEvent(self, event):
+        """Custom close event handler to check for unsaved changes.
+        """
+        if self.unsaved_changes_confirmation():
+            if self.has_changed():
+                self.select_profile(skip_check=True)
+            super().closeEvent(event)
+        else:
+            event.ignore()
+
+    def saveWindowState(self):
+        pass
+
+    @restore_method
+    def restoreWindowState(self):
+        pass

--- a/ui/user_profiles.ui
+++ b/ui/user_profiles.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UserProfileEditor</class>
+ <widget class="QWidget" name="UserProfileEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>231</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>User Profile Editor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="content_layout">
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="topMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <property name="bottomMargin">
+      <number>9</number>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="2">
+        <widget class="QPlainTextEdit" name="profile_description"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Title:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Description:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLineEdit" name="profile_title"/>
+       </item>
+       <item row="0" column="2">
+        <widget class="QComboBox" name="user_profiles">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Select the file naming script to load into the editor</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Profile:</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonbox">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Adds the ability to have multiple user profiles and switch between them quickly.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-9
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Users have requested the ability to have multiple user profiles so that they can quickly and easily change multiple settings.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
This change adds the ability to maintain and select from multiple profiles.  Each profile holds a copy of the `config.setting.as_dict()` output, and switching profiles replaces the current `config.setting` with the stored value.  Any changes made to the configuration settings are only applied to the currently selected profile, which is updated when the settings are updated.

The changes include:

* Addition of a new `UserProfile` class.
* Moving the list of scripts from `config.setting` to `config.persist` to make them available to all profiles.
* Add logic to block deleting a file naming script if it is used in a profile other than the current profile.
* Add "user_profiles" and "selected_user_profile" items in the `options.persist` section to store the available profiles and which one is currently selected.
* Add a profile management dialog that allows adding and removing profiles, editing profile titles and descriptions (notes), and selecting which profile is currently active.  This is available from the main screen under the Options item on the menu bar.
* Refactor the confirmation dialog function into the `picard.ui` module to reduce code duplication in the script editor and profile editor modules.
* Added a placeholder url to the documentation which is still under development.

Note that any testing should be done using a backup copy of your configuration file because the changes made are not backwards compatible.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Saving a copy of the full settings in each profile may be a bit of overkill and can use a lot of storage, but it is less complicated for the users (in my opinion).  This could be changed to a fixed list of selected settings, or even to a user-selected list of specific settings if that is the preferred method.