### PR TITLE
Fix unsaved changes confirmation check when changing selected script

### DIFF
--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -757,7 +757,7 @@ class ScriptEditorDialog(PicardDialog):
             skip_check (bool): Skip the check for unsaved edits.  Defaults to False.
             send_signal (bool, optional): Determines whether the update signal should be emitted. Defaults to True.
         """
-        if not self.loading or skip_check or self.unsaved_changes_confirmation():
+        if self.loading or skip_check or self.unsaved_changes_confirmation():
             script_item = self.get_selected_item()
             self.ui.script_title.setText(script_item['title'])
             self.set_script(script_item['script'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Correct the logic for checking for unsaved changes when selecting a new script in the script editor

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

There is an error in the logic that caused the unsaved changes check from being performed when switching the selected script in the combo box.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Correct the logic so that the check is properly completed.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
