### PR TITLE
PICARD-2203: Integrate addrelease functionality into Picard

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,7 @@ Required:
 * [PyQt 5.10 or newer](http://www.riverbankcomputing.co.uk/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)
+* [PyJWT 1.7 or newer](https://pyjwt.readthedocs.io/)
 * [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
 * gettext:
   * [Windows](https://mlocati.github.io/articles/gettext-iconv-windows.html)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,6 @@ Required:
 * [PyQt 5.10 or newer](http://www.riverbankcomputing.co.uk/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)
-* [PyJWT 1.7 or newer](https://pyjwt.readthedocs.io/)
 * [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
 * gettext:
   * [Windows](https://mlocati.github.io/articles/gettext-iconv-windows.html)
@@ -30,6 +29,8 @@ Optional but recommended:
    0.3.0 - 0.4.1 is not recommended.
 * [python-markdown](https://python-markdown.github.io/install/)
   * Required for the complete scripting documentation
+* [PyJWT 1.7 or newer](https://pyjwt.readthedocs.io/)
+  * Required for the add cluster as release / add file as recording functionality
 
 We recommend you use [pip](https://pip.pypa.io/en/stable/) to install the Python
 dependencies:

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -20,9 +20,6 @@
 
 from secrets import token_bytes
 
-import jwt
-import jwt.exceptions
-
 from PyQt5.QtCore import QCoreApplication
 
 from picard import log
@@ -34,6 +31,13 @@ from picard.util import (
 )
 from picard.util.webbrowser2 import open
 
+
+try:
+    import jwt
+    import jwt.exceptions
+except ImportError:
+    log.debug('PyJWT not available, addrelease functionality disabled')
+    jwt = None
 
 __key = token_bytes()  # Generating a new secret on each startup
 __algorithm = 'HS256'
@@ -62,6 +66,10 @@ class InvalidTokenError(Exception):
 
 class NotFoundError(Exception):
     pass
+
+
+def is_available():
+    return jwt is not None
 
 
 def is_enabled():

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -64,6 +64,11 @@ class NotFoundError(Exception):
     pass
 
 
+def is_enabled():
+    tagger = QCoreApplication.instance()
+    return tagger.browser_integration.is_running
+
+
 def submit_cluster(cluster):
     _open_url_with_token({'cluster': hash(cluster)})
 

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -165,6 +165,9 @@ def _get_cluster_data(cluster):
     def mkey(disc, track, name):
         return 'mediums.%i.track.%i.%s' % (disc, track, name)
 
+    labels = set()
+    barcode = None
+
     disc_counter = 0
     track_counter = 0
     last_discnumber = None
@@ -175,10 +178,24 @@ def _get_cluster_data(cluster):
             disc_counter += 1
             track_counter = 0
         last_discnumber = discnumber
+        if m['label']:
+            labels.add((m['label'], m['catalognumber']))
+        if m['barcode']:
+            barcode = m['barcode']
         data[mkey(disc_counter, track_counter, 'name')] = m['title']
         data[mkey(disc_counter, track_counter, 'number')] = m['tracknumber'] or str(track_counter + 1)
         data[mkey(disc_counter, track_counter, 'length')] = str(m.length)
+        if m['musicbrainz_recordingid']:
+            data[mkey(disc_counter, track_counter, 'recording')] = m['musicbrainz_recordingid']
         track_counter += 1
+
+    for i, label in enumerate(labels):
+        (label, catalog_number) = label
+        data['labels.%i.name' % i] = label
+        data['labels.%i.catalog_number' % i] = catalog_number
+
+    if barcode:
+        data['barcode'] = barcode
 
     return data
 

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -94,6 +94,8 @@ def serve_form(token):
 
 def _open_url_with_token(payload):
     token = jwt.encode(payload, __key, algorithm=__algorithm)
+    if isinstance(token, bytes):  # For compatibility with PyJWT 1.x
+        token = token.decode()
     browser_integration = QCoreApplication.instance().browser_integration
     url = 'http://%s:%s/add?token=%s' % (
         browser_integration.host_address, browser_integration.port, token)

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from secrets import token_bytes
+
+import jwt
+import jwt.exceptions
+
+from PyQt5.QtCore import QCoreApplication
+
+from picard.config import get_config
+from picard.const import MUSICBRAINZ_SERVERS
+from picard.util import htmlescape
+from picard.util.webbrowser2 import open
+
+
+__key = token_bytes()  # Generating a new secret on each startup
+__algorithm = 'HS256'
+
+_form_template = '''<!doctype html>
+<meta charset="UTF-8">
+<html>
+<head>
+    <title>{title}</title>
+</head>
+<body>
+    <form action="{action}" method="post">
+        {form_data}
+        <input type="submit" value="{submit_label}">
+    </form>
+    <script>document.forms[0].submit()</script>
+</body>
+'''
+
+_form_input_template = '<input type="hidden" name="{name}" value="{value}" >'
+
+
+class InvalidTokenError(Exception):
+    pass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+def submit_cluster(cluster):
+    token = jwt.encode({'cluster': hash(cluster)}, __key, algorithm=__algorithm)
+    _open_token_url(token)
+
+
+def serve_form(token):
+    try:
+        payload = jwt.decode(token, __key, algorithms=__algorithm)
+        cluster = _find_cluster(payload['cluster'])
+        if not cluster:
+            raise NotFoundError('Cluster not found')
+
+        data = _get_form(cluster)
+        return _form_template.format(**data)
+    except jwt.exceptions.InvalidTokenError:
+        raise InvalidTokenError
+
+
+def _open_token_url(token):
+    browser_integration = QCoreApplication.instance().browser_integration
+    url = 'http://%s:%s/add?token=%s' % (
+        browser_integration.host_address, browser_integration.port, token)
+    open(url)
+
+
+def _find_cluster(cluster_hash):
+    tagger = QCoreApplication.instance()
+    for cluster in tagger.clusters:
+        if hash(cluster) == cluster_hash:
+            return cluster
+    return None
+
+
+def _mbserver_url(path):
+    config = get_config()
+    host = config.setting["server_host"]
+    if host not in MUSICBRAINZ_SERVERS:
+        host = MUSICBRAINZ_SERVERS[0]  # Submission only works to official servers
+    return "https://%s%s" % (host, path)
+
+
+def _get_form(cluster):
+    form_data = _get_form_data(cluster)
+    return {
+        'title': htmlescape(_('Add cluster as release...')),
+        'action': htmlescape(_mbserver_url('/release/add')),
+        'form_data': form_data,
+        'submit_label': htmlescape(_('Add cluster as release...')),
+    }
+
+
+def _get_form_data(cluster):
+    return ''.join((
+        _form_input_template.format(name=htmlescape(name), value=htmlescape(value))
+        for name, value in _get_cluster_metadata(cluster).items()
+    ))
+
+
+def _get_cluster_metadata(cluster):
+    # See https://musicbrainz.org/doc/Development/Release_Editor_Seeding
+    metadata = cluster.metadata
+    data = {
+        'name': metadata['album'],
+        'artist_credit.names.0.artist.name': metadata['albumartist'],
+    }
+
+    def mkey(disc, track, name):
+        return 'mediums.%i.track.%i.%s' % (disc, track, name)
+
+    for i, file in enumerate(cluster.files):
+        data[mkey(0, i, 'name')] = file.metadata['title']
+        data[mkey(0, i, 'number')] = file.metadata['tracknumber'] or str(i + 1)
+        data[mkey(0, i, 'length')] = str(file.metadata.length)
+
+    return data

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -98,6 +98,10 @@ class BrowserIntegration(QtCore.QObject):
             return 0
         return self.server.server_address[1]
 
+    @property
+    def is_running(self):
+        return self.server is not None
+
     def start(self):
         if self.server:
             self.stop()

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -176,7 +176,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._load_mbid('album', args)
         elif action == '/opennat':
             self._load_mbid('nat', args)
-        elif action == '/add':
+        elif action == '/add' and addrelease.is_available():
             self._add_release(args)
         else:
             self._response(404, 'Unknown action.')

--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -45,6 +45,7 @@ from picard import (
     PICARD_VERSION_STR,
     log,
 )
+from picard.browser import addrelease
 from picard.config import get_config
 from picard.util import mbid_validate
 from picard.util.thread import to_main
@@ -171,6 +172,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._load_mbid('album', args)
         elif action == '/opennat':
             self._load_mbid('nat', args)
+        elif action == '/add':
+            self._add_release(args)
         else:
             self._response(404, 'Unknown action.')
 
@@ -186,10 +189,22 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             self._response(400, 'Missing parameter "id".')
 
-    def _response(self, code, content=''):
+    def _add_release(self, args):
+        if 'token' in args and args['token']:
+            try:
+                content = addrelease.serve_form(args['token'][0])
+                self._response(200, content, 'text/html')
+            except addrelease.NotFoundError as err:
+                self._response(404, str(err))
+            except addrelease.InvalidTokenError:
+                self._response(400, 'Invalid token')
+        else:
+            self._response(400, 'Missing parameter "token".')
+
+    def _response(self, code, content='', content_type='text/plain'):
         self.server_version = SERVER_VERSION
         self.send_response(code)
-        self.send_header('Content-Type', 'text/plain')
+        self.send_header('Content-Type', content_type)
         self.send_header('Cache-Control', 'max-age=0')
         origin = self.headers['origin']
         if _is_valid_origin(origin):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -224,6 +224,9 @@ class Cluster(FileList):
         else:
             return False
 
+    def can_submit(self):
+        return not self.special and self.files
+
     def is_album_like(self):
         return True
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -389,14 +389,19 @@ class Tagger(QtWidgets.QApplication):
             del self._cmdline_files
 
     def run(self):
-        config = get_config()
-        if config.setting["browser_integration"]:
-            self.browser_integration.start()
+        self.update_browser_integration()
         self.window.show()
         QtCore.QTimer.singleShot(0, self._run_init)
         res = self.exec_()
         self.exit()
         return res
+
+    def update_browser_integration(self):
+        config = get_config()
+        if config.setting["browser_integration"]:
+            self.browser_integration.start()
+        else:
+            self.browser_integration.stop()
 
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):

--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2010, 2018, 2020 Philipp Wolfer
+# Copyright (C) 2010, 2018, 2020-2021 Philipp Wolfer
 # Copyright (C) 2011-2012 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2013, 2020-2021 Laurent Monin
@@ -56,6 +56,10 @@ class Item(object):
         return False
 
     def can_view_info(self):
+        return False
+
+    def can_submit(self):
+        """Return True if this object can be submitted to MusicBrainz.org."""
         return False
 
     @property

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -503,6 +503,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             menu.addAction(self.window.play_file_action)
             menu.addAction(self.window.open_folder_action)
             menu.addAction(self.window.browser_lookup_action)
+            menu.addAction(self.window.submit_file_action)
             menu.addSeparator()
             menu.addAction(self.window.autotag_action)
             menu.addAction(self.window.analyze_action)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -504,8 +504,10 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             menu.addAction(self.window.play_file_action)
             menu.addAction(self.window.open_folder_action)
             menu.addAction(self.window.browser_lookup_action)
-            if self.window.submit_file_action:
-                menu.addAction(self.window.submit_file_action)
+            if self.window.submit_file_as_recording_action:
+                menu.addAction(self.window.submit_file_as_recording_action)
+            if self.window.submit_file_as_release_action:
+                menu.addAction(self.window.submit_file_as_release_action)
             menu.addSeparator()
             menu.addAction(self.window.autotag_action)
             menu.addAction(self.window.analyze_action)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -482,7 +482,8 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             if can_view_info:
                 menu.addAction(self.window.view_info_action)
             menu.addAction(self.window.browser_lookup_action)
-            menu.addAction(self.window.submit_cluster_action)
+            if self.window.submit_cluster_action:
+                menu.addAction(self.window.submit_cluster_action)
             menu.addSeparator()
             menu.addAction(self.window.autotag_action)
             menu.addAction(self.window.analyze_action)
@@ -503,7 +504,8 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             menu.addAction(self.window.play_file_action)
             menu.addAction(self.window.open_folder_action)
             menu.addAction(self.window.browser_lookup_action)
-            menu.addAction(self.window.submit_file_action)
+            if self.window.submit_file_action:
+                menu.addAction(self.window.submit_file_action)
             menu.addSeparator()
             menu.addAction(self.window.autotag_action)
             menu.addAction(self.window.analyze_action)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -482,6 +482,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             if can_view_info:
                 menu.addAction(self.window.view_info_action)
             menu.addAction(self.window.browser_lookup_action)
+            menu.addAction(self.window.submit_cluster_action)
             menu.addSeparator()
             menu.addAction(self.window.autotag_action)
             menu.addAction(self.window.analyze_action)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -550,15 +550,19 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.browser_lookup_action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+L")))
         self.browser_lookup_action.triggered.connect(self.browser_lookup)
 
-        self.submit_cluster_action = QtWidgets.QAction(_("Submit cluster as release..."), self)
-        self.submit_cluster_action.setStatusTip(_("Submit cluster as a new release to MusicBrainz"))
-        self.submit_cluster_action.setEnabled(False)
-        self.submit_cluster_action.triggered.connect(self.submit_cluster)
+        if addrelease.is_available():
+            self.submit_cluster_action = QtWidgets.QAction(_("Submit cluster as release..."), self)
+            self.submit_cluster_action.setStatusTip(_("Submit cluster as a new release to MusicBrainz"))
+            self.submit_cluster_action.setEnabled(False)
+            self.submit_cluster_action.triggered.connect(self.submit_cluster)
 
-        self.submit_file_action = QtWidgets.QAction(_("Submit file as recording..."), self)
-        self.submit_file_action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
-        self.submit_file_action.setEnabled(False)
-        self.submit_file_action.triggered.connect(self.submit_file)
+            self.submit_file_action = QtWidgets.QAction(_("Submit file as recording..."), self)
+            self.submit_file_action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
+            self.submit_file_action.setEnabled(False)
+            self.submit_file_action.triggered.connect(self.submit_file)
+        else:
+            self.submit_cluster_action = None
+            self.submit_file_action = None
 
         self.album_search_action = QtWidgets.QAction(icontheme.lookup('system-search'), _("Search for similar albums..."), self)
         self.album_search_action.setStatusTip(_("View similar releases and optionally choose a different release"))
@@ -1286,8 +1290,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.play_file_action.setEnabled(have_files)
         self.open_folder_action.setEnabled(have_files)
         self.cut_action.setEnabled(have_objects)
-        self.submit_cluster_action.setEnabled(can_submit)
-        self.submit_file_action.setEnabled(have_files)
+        if self.submit_cluster_action:
+            self.submit_cluster_action.setEnabled(can_submit)
+        if self.submit_file_action:
+            self.submit_file_action.setEnabled(have_files)
         files = self.get_selected_or_unmatched_files()
         self.tags_from_filenames_action.setEnabled(bool(files))
         self.track_search_action.setEnabled(is_file)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -556,13 +556,19 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.submit_cluster_action.setEnabled(False)
             self.submit_cluster_action.triggered.connect(self.submit_cluster)
 
-            self.submit_file_action = QtWidgets.QAction(_("Submit file as recording..."), self)
-            self.submit_file_action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
-            self.submit_file_action.setEnabled(False)
-            self.submit_file_action.triggered.connect(self.submit_file)
+            self.submit_file_as_recording_action = QtWidgets.QAction(_("Submit file as standalone recording..."), self)
+            self.submit_file_as_recording_action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
+            self.submit_file_as_recording_action.setEnabled(False)
+            self.submit_file_as_recording_action.triggered.connect(self.submit_file)
+
+            self.submit_file_as_release_action = QtWidgets.QAction(_("Submit file as release..."), self)
+            self.submit_file_as_release_action.setStatusTip(_("Submit file as a new release to MusicBrainz"))
+            self.submit_file_as_release_action.setEnabled(False)
+            self.submit_file_as_release_action.triggered.connect(partial(self.submit_file, as_release=True))
         else:
             self.submit_cluster_action = None
-            self.submit_file_action = None
+            self.submit_file_as_recording_action = None
+            self.submit_file_as_release_action = None
 
         self.album_search_action = QtWidgets.QAction(icontheme.lookup('system-search'), _("Search for similar albums..."), self)
         self.album_search_action.setStatusTip(_("View similar releases and optionally choose a different release"))
@@ -1221,10 +1227,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 if isinstance(obj, Cluster):
                     addrelease.submit_cluster(obj)
 
-    def submit_file(self):
+    def submit_file(self, as_release=False):
         if self.selected_objects and self._check_add_release():
             for file in iter_files_from_objects(self.selected_objects):
-                addrelease.submit_file(file)
+                addrelease.submit_file(file, as_release=as_release)
 
     def _check_add_release(self):
         if addrelease.is_enabled():
@@ -1292,8 +1298,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.cut_action.setEnabled(have_objects)
         if self.submit_cluster_action:
             self.submit_cluster_action.setEnabled(can_submit)
-        if self.submit_file_action:
-            self.submit_file_action.setEnabled(have_files)
+        if self.submit_file_as_recording_action:
+            self.submit_file_as_recording_action.setEnabled(have_files)
+        if self.submit_file_as_release_action:
+            self.submit_file_as_release_action.setEnabled(have_files)
         files = self.get_selected_or_unmatched_files()
         self.tags_from_filenames_action.setEnabled(bool(files))
         self.track_search_action.setEnabled(is_file)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -551,9 +551,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.browser_lookup_action.triggered.connect(self.browser_lookup)
 
         self.submit_cluster_action = QtWidgets.QAction(_("Submit cluster as release..."), self)
-        self.submit_cluster_action.setStatusTip(_("Submit cluster as a release to MusicBrainz"))
+        self.submit_cluster_action.setStatusTip(_("Submit cluster as a new release to MusicBrainz"))
         self.submit_cluster_action.setEnabled(False)
         self.submit_cluster_action.triggered.connect(self.submit_cluster)
+
+        self.submit_file_action = QtWidgets.QAction(_("Submit file as recording..."), self)
+        self.submit_file_action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
+        self.submit_file_action.setEnabled(False)
+        self.submit_file_action.triggered.connect(self.submit_file)
 
         self.album_search_action = QtWidgets.QAction(icontheme.lookup('system-search'), _("Search for similar albums..."), self)
         self.album_search_action.setStatusTip(_("View similar releases and optionally choose a different release"))
@@ -1213,6 +1218,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             if isinstance(obj, Cluster):
                 addrelease.submit_cluster(obj)
 
+    def submit_file(self):
+        if not self.selected_objects:
+            return
+        for file in iter_files_from_objects(self.selected_objects):
+            addrelease.submit_file(file)
+
     @throttle(100)
     def update_actions(self):
         can_remove = False
@@ -1257,6 +1268,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.open_folder_action.setEnabled(have_files)
         self.cut_action.setEnabled(have_objects)
         self.submit_cluster_action.setEnabled(can_submit)
+        self.submit_file_action.setEnabled(have_files)
         files = self.get_selected_or_unmatched_files()
         self.tags_from_filenames_action.setEnabled(bool(files))
         self.track_search_action.setEnabled(is_file)

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -99,13 +99,7 @@ class NetworkOptionsPage(OptionsPage):
         config.setting["browser_integration_port"] = self.ui.browser_integration_port.value()
         config.setting["browser_integration_localhost_only"] = \
             self.ui.browser_integration_localhost_only.isChecked()
-        self.update_browser_integration()
-
-    def update_browser_integration(self):
-        if self.ui.browser_integration.isChecked():
-            self.tagger.browser_integration.start()
-        else:
-            self.tagger.browser_integration.stop()
+        self.tagger.update_browser_integration()
 
 
 register_options_page(NetworkOptionsPage)

--- a/requirements-macos-10.12.txt
+++ b/requirements-macos-10.12.txt
@@ -3,6 +3,7 @@ discid==1.2.0
 fasteners==0.16
 markdown==3.3.4
 mutagen==1.45.1
+PyJWT==2.1.0
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2
 PyQt5==5.13.1

--- a/requirements-macos-10.14.txt
+++ b/requirements-macos-10.14.txt
@@ -3,6 +3,7 @@ discid==1.2.0
 fasteners==0.16
 markdown==3.3.4
 mutagen==1.45.1
+PyJWT==2.1.0
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2
 PyQt5==5.15.4

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -3,6 +3,7 @@ discid==1.2.0
 fasteners==0.16
 markdown==3.3.4
 mutagen==1.45.1
+PyJWT==2.1.0
 PyQt5==5.15.4
 pywin32==300
 pyyaml==5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ discid~=1.0
 fasteners~=0.14
 markdown~=3.2
 mutagen~=1.37
+PyJWT~=2.0
 pyobjc-core~=6.2; sys_platform == 'darwin'
 pyobjc-framework-Cocoa~=6.2; sys_platform == 'darwin'
 PyQt5~=5.10

--- a/test/test_browser_addrelease.py
+++ b/test/test_browser_addrelease.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.browser.addrelease import extract_discnumber
+from picard.metadata import Metadata
+
+
+class BrowserAddreleaseTest(PicardTestCase):
+
+    def test_extract_discnumber(self):
+        self.assertEqual(1, extract_discnumber(Metadata()))
+        self.assertEqual(1, extract_discnumber(Metadata({'discnumber': '1'})))
+        self.assertEqual(42, extract_discnumber(Metadata({'discnumber': '42'})))
+        self.assertEqual(3, extract_discnumber(Metadata({'discnumber': '3/12'})))
+        self.assertEqual(3, extract_discnumber(Metadata({'discnumber': ' 3 / 12 '})))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2203
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This integrates the functionality to submit cluster as a release / submit a file as a recording as it is currently found in the [addrelease plugin](https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/addrelease/addrelease.py).

Rationale:
- The addrelease plugin is broken in recent versions of Firefox, see PICARD-2202. This can be best solved by serving the intermediate HTML form via an actual local web server instead of loading it as a local HTML file. This can be better done from within Picard, especially as it already provides a built-in webserver for the browser integration feature.
- Originally the addrelease plugin was quite a hack. But since the [release editor seeding](https://musicbrainz.org/doc/Development/Release_Editor_Seeding) exists now for quite a while, is well documented and also used by e.g. quite a few user scripts I think it is also viable to make use of this in Picard
- A lot of users expect such functionality in Picard and are surprised they need to install a plugin for it
- Provide more data, such as labels and barcode, if set in the tags
- Address issues of the addrelease plugin: https://github.com/metabrainz/picard-plugins/issues/59 and https://github.com/metabrainz/picard-plugins/issues/46



# Solution

Implement a `/add` endpoint in the built-in web server to serve the release editor seeding intermediate HTML form. The endpoint accepts a single JWT token, that encodes the details on wich cluster or release should be seeded.

The idea here is that these endpoints can be used to query data loaded into Picard. Thus unauthorized access should be avoided. The JWT gets encoded with a random seed that changes on each start of Picard. In addition the JWT allows us a stateless implementation, where we do not need to keep track of the exposed clusters / files.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

With PyJWT this adds yet another external dependency. While I am not totally happy about this, I think it provides the best solution to the problem at hand. I have made PyJWT optional, but if it is not available the entire addrelease functionality is disabled as well.
