### PR TITLE
Refactor to reduce duplication of file naming script text in user settings

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 7, 0, 'dev', 2)
+PICARD_VERSION = Version(2, 7, 0, 'dev', 3)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -34,6 +34,7 @@ from picard import log
 from picard.config import (
     BoolOption,
     IntOption,
+    ListOption,
     Option,
     TextOption,
 )
@@ -386,6 +387,40 @@ def upgrade_to_v2_7_0_dev_2(config):
     )
 
 
+def upgrade_to_v2_7_0_dev_3(config):
+    """Save file naming scripts to dictionary.
+    """
+    from picard.script import get_file_naming_script_presets
+    from picard.script.serializer import (
+        FileNamingScript,
+        ScriptImportError,
+    )
+    Option("setting", "file_renaming_scripts", {})
+    ListOption("setting", "file_naming_scripts", [])
+    TextOption("setting", "file_naming_format", DEFAULT_FILE_NAMING_FORMAT)
+    TextOption("setting", "selected_file_naming_script_id", "")
+    scripts = {}
+    for item in config.setting["file_naming_scripts"]:
+        try:
+            script_item = FileNamingScript().create_from_yaml(item, create_new_id=False)
+            scripts[script_item["id"]] = script_item.to_dict()
+        except ScriptImportError:
+            log.error("Error converting file naming script")
+    script_list = set(scripts.keys()) | set(map(lambda item: item["id"], get_file_naming_script_presets()))
+    if config.setting["selected_file_naming_script_id"] not in script_list:
+        script_item = FileNamingScript(
+            script=config.setting["file_naming_format"],
+            title=_("Primary file naming script"),
+            readonly=False,
+            deletable=True,
+        )
+        scripts[script_item["id"]] = script_item.to_dict()
+        config.setting["selected_file_naming_script_id"] = script_item["id"]
+    config.setting["file_renaming_scripts"] = scripts
+    config.setting.remove("file_naming_scripts")
+    config.setting.remove("file_naming_format")
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -416,4 +451,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_beta_2)
     cfg.register_upgrade_hook(upgrade_to_v2_6_0_beta_3)
     cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_3)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -87,6 +87,7 @@ PICARD_URLS = {
     'doc_options':             DOCS_BASE_URL + '/config/configuration.html',
     'doc_scripting':           DOCS_BASE_URL + '/extending/scripting.html',
     'doc_tags_from_filenames': DOCS_BASE_URL + '/usage/tags_from_file_names.html',
+    'doc_naming_script_edit':  DOCS_BASE_URL + '/config/options_filerenaming_editor.html',
     'doc_cover_art_types':     "https://musicbrainz.org/doc/Cover_Art/Types",
     'plugins':                 "https://picard.musicbrainz.org/plugins/",
     'forum':                   "https://community.metabrainz.org/c/picard",

--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -116,14 +116,15 @@ def get_file_naming_script(settings):
         str: The text of the file naming script if available, otherwise None
     """
     from picard.script import get_file_naming_script_presets
-    if settings["file_renaming_scripts"] and settings["selected_file_naming_script_id"]:
-        selected_id = settings["selected_file_naming_script_id"]
-        if selected_id in settings["file_renaming_scripts"]:
-            return settings["file_renaming_scripts"][selected_id]["script"]
+    scripts = settings["file_renaming_scripts"]
+    selected_id = settings["selected_file_naming_script_id"]
+    if scripts and selected_id:
+        if selected_id in scripts:
+            return scripts[selected_id]["script"]
         for item in get_file_naming_script_presets():
             if item["id"] == selected_id:
                 return str(item["script"])
-    log.error("Unable to retrieve the file naming script '%s'", settings["selected_file_naming_script_id"])
+    log.error("Unable to retrieve the file naming script '%s'", selected_id)
     return None
 
 

--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -35,6 +35,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from picard import log
 from picard.config import get_config
 from picard.const import DEFAULT_FILE_NAMING_FORMAT
 from picard.script.functions import (  # noqa: F401 # pylint: disable=unused-import
@@ -103,6 +104,27 @@ def enabled_tagger_scripts_texts():
     if not config.setting["enable_tagger_scripts"]:
         return []
     return [(s_name, s_text) for _s_pos, s_name, s_enabled, s_text in config.setting["list_of_scripts"] if s_enabled and s_text]
+
+
+def get_file_naming_script(settings):
+    """Retrieve the file naming script.
+
+    Args:
+        settings (ConfigSection): Object containing the user settings
+
+    Returns:
+        str: The text of the file naming script if available, otherwise None
+    """
+    from picard.script import get_file_naming_script_presets
+    if settings["file_renaming_scripts"] and settings["selected_file_naming_script_id"]:
+        selected_id = settings["selected_file_naming_script_id"]
+        if selected_id in settings["file_renaming_scripts"]:
+            return settings["file_renaming_scripts"][selected_id]["script"]
+        for item in get_file_naming_script_presets():
+            if item["id"] == selected_id:
+                return str(item["script"])
+    log.error("Unable to retrieve the file naming script '%s'", settings["selected_file_naming_script_id"])
+    return None
 
 
 def get_file_naming_script_presets():

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -166,6 +166,38 @@ class PicardScript():
         if updated and 'last_updated' not in settings:
             self.update_last_updated()
 
+    def to_dict(self):
+        """Generate a dictionary containing the object's OUTPUT_FIELDS.
+
+        Returns:
+            dict: Dictionary of the object's OUTPUT_FIELDS
+        """
+        items = {key: getattr(self, key) for key in self.OUTPUT_FIELDS}
+        items["script"] = str(items["script"])
+        return items
+
+    @classmethod
+    def create_from_dict(cls, script_dict, create_new_id=True):
+        """Creates an instance based on the contents of the dictionary provided.
+        Properties in the dictionary that are not found in the script object are ignored.
+
+        Args:
+            script_dict (dict): Dictionary containing the property settings.
+            create_new_id (bool, optional): Determines whether a new ID is generated. Defaults to True.
+
+        Returns:
+            object: An instance of the class, populated from the property settings in the dictionary provided.
+        """
+        new_object = cls()
+        if not isinstance(script_dict, dict):
+            raise ScriptImportError(N_("Argument is not a dictionary"))
+        if 'title' not in script_dict or 'script' not in script_dict:
+            raise ScriptImportError(N_('Invalid script package'))
+        new_object.update_from_dict(script_dict)
+        if create_new_id or not new_object['id']:
+            new_object._set_new_id()
+        return new_object
+
     def copy(self):
         """Create a copy of the current script object with updated title and last updated attributes.
         """
@@ -196,6 +228,7 @@ class PicardScript():
 
         Args:
             yaml_string (str): YAML string containing the property settings.
+            create_new_id (bool, optional): Determines whether a new ID is generated. Defaults to True.
 
         Returns:
             object: An instance of the class, populated from the property settings in the YAML string.

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -25,6 +25,7 @@ from enum import (
     IntEnum,
     unique,
 )
+from typing import Mapping
 import uuid
 
 import yaml
@@ -189,7 +190,7 @@ class PicardScript():
             object: An instance of the class, populated from the property settings in the dictionary provided.
         """
         new_object = cls()
-        if not isinstance(script_dict, dict):
+        if not isinstance(script_dict, Mapping):
             raise ScriptImportError(N_("Argument is not a dictionary"))
         if 'title' not in script_dict or 'script' not in script_dict:
             raise ScriptImportError(N_('Invalid script package'))

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -173,7 +173,8 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         config.setting['preserve_timestamps'] = False
         config.setting['delete_empty_dirs'] = False
         config.setting['save_images_to_files'] = False
-        config.setting['file_naming_format'] = '%title%'
+        config.setting['file_renaming_scripts'] = {'test_id': {'script': '%title%'}}
+        config.setting['selected_file_naming_script_id'] = 'test_id'
         # Create dummy WavPack correction file
         source_file_wvc = self.filename + 'c'
         open(source_file_wvc, 'a').close()

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -185,11 +185,12 @@ class FileNamingTest(PicardTestCase):
             'ascii_filenames': False,
             'clear_existing_tags': False,
             'enabled_plugins': [],
-            'file_naming_format': '%album%/%title%',
             'move_files_to': '/media/music',
             'move_files': False,
             'rename_files': False,
             'windows_compatibility': True,
+            'file_renaming_scripts': {'test_id': {'script': '%album%/%title%'}},
+            'selected_file_naming_script_id': 'test_id',
         })
         self.metadata = Metadata({
             'album': 'somealbum',
@@ -230,7 +231,7 @@ class FileNamingTest(PicardTestCase):
 
     def test_make_filename_empty_script(self):
         config.setting['rename_files'] = True
-        config.setting['file_naming_format'] = '$noop()'
+        config.setting['file_renaming_scripts'] = {'test_id': {'script': '$noop()'}}
         filename = self.file.make_filename(self.file.filename, self.metadata)
         self.assertEqual(os.path.realpath('/somepath/somefile.mp3'), filename)
 
@@ -248,7 +249,7 @@ class FileNamingTest(PicardTestCase):
 
     def test_make_filename_scripted_extension(self):
         config.setting['rename_files'] = True
-        config.setting['file_naming_format'] = '$set(_extension,.foo)%title%'
+        config.setting['file_renaming_scripts'] = {'test_id': {'script': '$set(_extension,.foo)%title%'}}
         filename = self.file.make_filename(self.file.filename, self.metadata)
         self.assertEqual(os.path.realpath('/somepath/sometitle.foo'), filename)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:  Refactor to remove the duplicate "file_naming_format" setting information, and provide a helper function to retrieve the file naming script text based on the user's "selected_file_naming_script_id" setting.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Information is (potentially) duplicated in the user configuration settings, specifically the currently selected file naming script which shows up in the "file_naming_format" settings as well as one of the elements of the "file_naming_scripts" list.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Remove the "file_naming_format" setting and provide a helper function to look up the file naming script from the list of scripts stored in the user settings, based on the "selected_file_naming_script_id" setting.  To improve the lookup efficiency, the "file_naming_scripts" list was converted to a dictionary and renamed "file_renaming_scripts".  Script items stored in the dictionary are stored as dictionaries of the settings of the `FileNamingScript` object rather than as a YAML dump of the settings.

This PR also includes: some cleanup and optimization of the information synchronization between the "File Naming" and "File Naming Script Editor" pages; moving the "File Naming Script Editor" page help URL to `picard.constants` with the other URL definitions; and uses the `DEFAULT_FILE_NAMING_FORMAT` constant for new file naming scripts rather than "`$noop()`".

Changes include:
- Remove "file_naming_format" setting.
- Add helper function to get the text of the currently selected file naming script.
- Change "file_naming_scripts" list of scripts in YAML format to "file_renaming_scripts" dictionary of `FileNamingScript().to_dict()` format items.
- Use script dictionary objects internally (e.g. in combo box items) rather than full `FileNamingScript` objects.
- Present script combo box lists in sorted order by title.
- Refactor synchronization between "File Naming" and "Script Editor" pages to reduce redundant (multiple) processing.
- Move "Script Editor" page help URL definition to `picard.constants` module with other URL definitions.
- Use `DEFAULT_FILE_NAMING_FORMAT` for new file naming scripts rather than `$noop()`.
- Update function docstrings


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Sorry for the large PR, but most of the changes are interrelated and I struggled trying to find a way to separate them into logical, stand-alone chunks.