### PR TITLE
PICARD-2232: Allow add cluster/files and disc ID submission to unofficial servers

### DIFF
--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -23,12 +23,11 @@ from secrets import token_bytes
 from PyQt5.QtCore import QCoreApplication
 
 from picard import log
-from picard.config import get_config
-from picard.const import MUSICBRAINZ_SERVERS
 from picard.util import (
     format_time,
     htmlescape,
 )
+from picard.util.mbserver import get_submission_host
 from picard.util.webbrowser2 import open
 
 
@@ -140,11 +139,9 @@ def _find_file(path):
 
 
 def _mbserver_url(path):
-    config = get_config()
-    host = config.setting["server_host"]
-    if host not in MUSICBRAINZ_SERVERS:
-        host = MUSICBRAINZ_SERVERS[0]  # Submission only works to official servers
-    return "https://%s%s" % (host, path)
+    host, port = get_submission_host()
+    protocol = 'https' if port == 443 else 'http'
+    return "%s://%s:%i%s" % (protocol, host, port, path)
 
 
 def _get_cluster_form(cluster):

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -27,7 +27,7 @@ from picard.util import (
     format_time,
     htmlescape,
 )
-from picard.util.mbserver import get_submission_host
+from picard.util.mbserver import build_submission_url
 from picard.util.webbrowser2 import open
 
 
@@ -138,12 +138,6 @@ def _find_file(path):
     return tagger.files.get(path, None)
 
 
-def _mbserver_url(path):
-    host, port = get_submission_host()
-    protocol = 'https' if port == 443 else 'http'
-    return "%s://%s:%i%s" % (protocol, host, port, path)
-
-
 def _get_cluster_form(cluster):
     return _get_form(
         _('Add cluster as release'),
@@ -246,7 +240,7 @@ def _get_form(title, action, label, form_data):
     return _form_template.format(
         title=htmlescape(title),
         submit_label=htmlescape(label),
-        action=htmlescape(_mbserver_url(action)),
+        action=htmlescape(build_submission_url(action)),
         form_data=_format_form_data(form_data),
     )
 

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -40,6 +40,7 @@ from picard.const import (
     MUSICBRAINZ_SERVERS,
     PROGRAM_UPDATE_LEVELS,
 )
+from picard.util.mbserver import is_official_server
 
 from picard.ui.options import (
     OptionsPage,
@@ -60,6 +61,7 @@ class GeneralOptionsPage(OptionsPage):
     options = [
         TextOption("setting", "server_host", MUSICBRAINZ_SERVERS[0]),
         IntOption("setting", "server_port", 443),
+        BoolOption("setting", "use_server_for_submission", False),
         TextOption("persist", "oauth_refresh_token", ""),
         BoolOption("setting", "analyze_new_files", False),
         BoolOption("setting", "ignore_file_mbids", False),
@@ -79,6 +81,7 @@ class GeneralOptionsPage(OptionsPage):
         self.ui = Ui_GeneralOptionsPage()
         self.ui.setupUi(self)
         self.ui.server_host.addItems(MUSICBRAINZ_SERVERS)
+        self.ui.server_host.currentTextChanged.connect(self.update_server_host)
         self.ui.login.clicked.connect(self.login)
         self.ui.logout.clicked.connect(self.logout)
         self.update_login_logout()
@@ -87,6 +90,8 @@ class GeneralOptionsPage(OptionsPage):
         config = get_config()
         self.ui.server_host.setEditText(config.setting["server_host"])
         self.ui.server_port.setValue(config.setting["server_port"])
+        self.ui.use_server_for_submission.setChecked(config.setting["use_server_for_submission"])
+        self.update_server_host()
         self.ui.analyze_new_files.setChecked(config.setting["analyze_new_files"])
         self.ui.ignore_file_mbids.setChecked(config.setting["ignore_file_mbids"])
         if self.tagger.autoupdate_enabled:
@@ -105,12 +110,20 @@ class GeneralOptionsPage(OptionsPage):
         config = get_config()
         config.setting["server_host"] = self.ui.server_host.currentText().strip()
         config.setting["server_port"] = self.ui.server_port.value()
+        config.setting["use_server_for_submission"] = self.ui.use_server_for_submission.isChecked()
         config.setting["analyze_new_files"] = self.ui.analyze_new_files.isChecked()
         config.setting["ignore_file_mbids"] = self.ui.ignore_file_mbids.isChecked()
         if self.tagger.autoupdate_enabled:
             config.setting["check_for_updates"] = self.ui.check_for_updates.isChecked()
             config.setting["update_level"] = self.ui.update_level.currentData(QtCore.Qt.UserRole)
             config.setting["update_check_days"] = self.ui.update_check_days.value()
+
+    def update_server_host(self):
+        host = self.ui.server_host.currentText().strip()
+        if host and is_official_server(host):
+            self.ui.server_host_primary_warning.hide()
+        else:
+            self.ui.server_host_primary_warning.show()
 
     def update_login_logout(self):
         if self.tagger.webservice.oauth_manager.is_logged_in():

--- a/picard/ui/ui_options_general.py
+++ b/picard/ui/ui_options_general.py
@@ -145,6 +145,14 @@ class Ui_GeneralOptionsPage(object):
         self.retranslateUi(GeneralOptionsPage)
         QtCore.QMetaObject.connectSlotsByName(GeneralOptionsPage)
         GeneralOptionsPage.setTabOrder(self.server_host, self.server_port)
+        GeneralOptionsPage.setTabOrder(self.server_port, self.use_server_for_submission)
+        GeneralOptionsPage.setTabOrder(self.use_server_for_submission, self.login)
+        GeneralOptionsPage.setTabOrder(self.login, self.logout)
+        GeneralOptionsPage.setTabOrder(self.logout, self.analyze_new_files)
+        GeneralOptionsPage.setTabOrder(self.analyze_new_files, self.ignore_file_mbids)
+        GeneralOptionsPage.setTabOrder(self.ignore_file_mbids, self.check_for_updates)
+        GeneralOptionsPage.setTabOrder(self.check_for_updates, self.update_check_days)
+        GeneralOptionsPage.setTabOrder(self.update_check_days, self.update_level)
 
     def retranslateUi(self, GeneralOptionsPage):
         _translate = QtCore.QCoreApplication.translate

--- a/picard/ui/ui_options_general.py
+++ b/picard/ui/ui_options_general.py
@@ -3,12 +3,14 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_GeneralOptionsPage(object):
     def setupUi(self, GeneralOptionsPage):
         GeneralOptionsPage.setObjectName("GeneralOptionsPage")
-        GeneralOptionsPage.resize(283, 435)
+        GeneralOptionsPage.resize(403, 584)
         self.vboxlayout = QtWidgets.QVBoxLayout(GeneralOptionsPage)
         self.vboxlayout.setObjectName("vboxlayout")
         self.groupBox = QtWidgets.QGroupBox(GeneralOptionsPage)
@@ -16,6 +18,28 @@ class Ui_GeneralOptionsPage(object):
         self.gridlayout = QtWidgets.QGridLayout(self.groupBox)
         self.gridlayout.setSpacing(2)
         self.gridlayout.setObjectName("gridlayout")
+        self.server_port = QtWidgets.QSpinBox(self.groupBox)
+        self.server_port.setMinimum(1)
+        self.server_port.setMaximum(65535)
+        self.server_port.setProperty("value", 80)
+        self.server_port.setObjectName("server_port")
+        self.gridlayout.addWidget(self.server_port, 1, 1, 1, 1)
+        self.server_host_primary_warning = QtWidgets.QFrame(self.groupBox)
+        self.server_host_primary_warning.setStyleSheet("QFrame { background-color: #ffc107; color: black }\n"
+"QCheckBox { color: black }")
+        self.server_host_primary_warning.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.server_host_primary_warning.setFrameShadow(QtWidgets.QFrame.Raised)
+        self.server_host_primary_warning.setObjectName("server_host_primary_warning")
+        self.verticalLayout_4 = QtWidgets.QVBoxLayout(self.server_host_primary_warning)
+        self.verticalLayout_4.setObjectName("verticalLayout_4")
+        self.label_4 = QtWidgets.QLabel(self.server_host_primary_warning)
+        self.label_4.setWordWrap(True)
+        self.label_4.setObjectName("label_4")
+        self.verticalLayout_4.addWidget(self.label_4)
+        self.use_server_for_submission = QtWidgets.QCheckBox(self.server_host_primary_warning)
+        self.use_server_for_submission.setObjectName("use_server_for_submission")
+        self.verticalLayout_4.addWidget(self.use_server_for_submission)
+        self.gridlayout.addWidget(self.server_host_primary_warning, 3, 0, 1, 2)
         self.server_host = QtWidgets.QComboBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -28,15 +52,11 @@ class Ui_GeneralOptionsPage(object):
         self.label_7 = QtWidgets.QLabel(self.groupBox)
         self.label_7.setObjectName("label_7")
         self.gridlayout.addWidget(self.label_7, 0, 1, 1, 1)
-        self.server_port = QtWidgets.QSpinBox(self.groupBox)
-        self.server_port.setMinimum(1)
-        self.server_port.setMaximum(65535)
-        self.server_port.setProperty("value", 80)
-        self.server_port.setObjectName("server_port")
-        self.gridlayout.addWidget(self.server_port, 1, 1, 1, 1)
         self.label = QtWidgets.QLabel(self.groupBox)
         self.label.setObjectName("label")
         self.gridlayout.addWidget(self.label, 0, 0, 1, 1)
+        spacerItem = QtWidgets.QSpacerItem(1, 4, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
+        self.gridlayout.addItem(spacerItem, 2, 0, 1, 1)
         self.vboxlayout.addWidget(self.groupBox)
         self.rename_files_2 = QtWidgets.QGroupBox(GeneralOptionsPage)
         self.rename_files_2.setObjectName("rename_files_2")
@@ -46,8 +66,8 @@ class Ui_GeneralOptionsPage(object):
         self.login = QtWidgets.QPushButton(self.rename_files_2)
         self.login.setObjectName("login")
         self.gridlayout1.addWidget(self.login, 1, 0, 1, 1)
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridlayout1.addItem(spacerItem, 1, 2, 1, 1)
+        spacerItem1 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        self.gridlayout1.addItem(spacerItem1, 1, 2, 1, 1)
         self.logout = QtWidgets.QPushButton(self.rename_files_2)
         self.logout.setObjectName("logout")
         self.gridlayout1.addWidget(self.logout, 1, 1, 1, 1)
@@ -119,9 +139,8 @@ class Ui_GeneralOptionsPage(object):
         self.gridLayout_2.addWidget(self.update_level, 0, 1, 1, 1)
         self.verticalLayout_2.addLayout(self.gridLayout_2)
         self.vboxlayout.addWidget(self.update_check_groupbox)
-
-        spacerItem1 = QtWidgets.QSpacerItem(181, 21, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-        self.vboxlayout.addItem(spacerItem1)
+        spacerItem2 = QtWidgets.QSpacerItem(181, 21, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        self.vboxlayout.addItem(spacerItem2)
 
         self.retranslateUi(GeneralOptionsPage)
         QtCore.QMetaObject.connectSlotsByName(GeneralOptionsPage)
@@ -130,6 +149,8 @@ class Ui_GeneralOptionsPage(object):
     def retranslateUi(self, GeneralOptionsPage):
         _translate = QtCore.QCoreApplication.translate
         self.groupBox.setTitle(_("MusicBrainz Server"))
+        self.label_4.setText(_("You have configured an unofficial database server. By default all data submission will go to the primary server on musicbrainz.org."))
+        self.use_server_for_submission.setText(_("Submit data to the configured server"))
         self.label_7.setText(_("Port:"))
         self.label.setText(_("Server address:"))
         self.rename_files_2.setTitle(_("MusicBrainz Account"))
@@ -142,4 +163,3 @@ class Ui_GeneralOptionsPage(object):
         self.check_for_updates.setText(_("Check for updates during start-up"))
         self.label_2.setText(_("Days between checks:"))
         self.label_3.setText(_("Updates to check:"))
-

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -18,9 +18,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import namedtuple
+
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.util import build_qurl
+
+
+ServerTuple = namedtuple('ServerTuple', ('host', 'port'))
 
 
 def is_official_server(host):
@@ -46,12 +51,12 @@ def get_submission_server():
     config = get_config()
     host = config.setting['server_host']
     if is_official_server(host):
-        return (host, 443)
+        return ServerTuple(host, 443)
     elif host and config.setting['use_server_for_submission']:
         port = config.setting['server_port']
-        return (host, port)
+        return ServerTuple(host, port)
     else:
-        return (MUSICBRAINZ_SERVERS[0], 443)
+        return ServerTuple(MUSICBRAINZ_SERVERS[0], 443)
 
 
 def build_submission_url(path=None, query_args=None):
@@ -63,6 +68,6 @@ def build_submission_url(path=None, query_args=None):
 
     Returns: The submission URL as a string
     """
-    host, port = get_submission_server()
-    url = build_qurl(host, port, path, query_args)
+    server = get_submission_server()
+    url = build_qurl(server.host, server.port, path, query_args)
     return url.toString()

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -34,7 +34,7 @@ def is_official_server(host):
     return host in MUSICBRAINZ_SERVERS
 
 
-def get_submission_host():
+def get_submission_server():
     """Returns the host and port used for data submission.
 
     Data submission usually should be done against the primary database. This function
@@ -63,6 +63,6 @@ def build_submission_url(path=None, query_args=None):
 
     Returns: The submission URL as a string
     """
-    host, port = get_submission_host()
+    host, port = get_submission_server()
     url = build_qurl(host, port, path, query_args)
     return url.toString()

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.config import get_config
+from picard.const import MUSICBRAINZ_SERVERS
+
+
+def is_official_server(host):
+    """Returns True, if host is an official MusicBrainz server for the primary database.
+
+    Args:
+        host: the hostname
+
+    Returns: True, if host is an official MusicBrainz server, False otherwise
+    """
+    return host in MUSICBRAINZ_SERVERS
+
+
+def get_submission_host():
+    """Returns the host and port used for data submission.
+
+    Data submission usually should be done against the primary database. This function
+    will return the hostname configured as `server_host` if it is an official MusicBrainz
+    server, otherwise it will return the primary official server.
+
+    Returns: Tuple of hostname and port number, e.g. `('musicbrainz.org', 443)`
+    """
+    config = get_config()
+    host = config.setting['server_host']
+    if is_official_server(host):
+        return (host, 443)
+    else:
+        return (MUSICBRAINZ_SERVERS[0], 443)

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -20,6 +20,7 @@
 
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
+from picard.util import build_qurl
 
 
 def is_official_server(host):
@@ -46,5 +47,22 @@ def get_submission_host():
     host = config.setting['server_host']
     if is_official_server(host):
         return (host, 443)
+    elif host and config.setting['use_server_for_submission']:
+        port = config.setting['server_port']
+        return (host, port)
     else:
         return (MUSICBRAINZ_SERVERS[0], 443)
+
+
+def build_submission_url(path=None, query_args=None):
+    """Builds a submission URL with path and query parameters.
+
+    Args:
+        path: The path for the URL
+        query_args: A dict of query parameters
+
+    Returns: The submission URL as a string
+    """
+    host, port = get_submission_host()
+    url = build_qurl(host, port, path, query_args)
+    return url.toString()

--- a/test/test_disc.py
+++ b/test/test_disc.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2020 Philipp Wolfer
+# Copyright (C) 2020-2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,10 +19,23 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import unittest
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 from test.picardtestcase import PicardTestCase
 
 import picard.disc
+
+
+class MockDisc:
+
+    id = 'lSOVc5h6IXSuzcamJS1Gp4_tRuA-'
+    mcn = '5029343070452'
+    tracks = list(range(0, 11))
+    toc_string = '1 11 242457 150 44942 61305 72755 96360 130485 147315 164275 190702 205412 220437'
+    submission_url = 'https://musicbrainz.org:443/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437'
 
 
 class DiscTest(PicardTestCase):
@@ -30,3 +43,41 @@ class DiscTest(PicardTestCase):
     def test_raise_disc_error(self):
         disc = picard.disc.Disc()
         self.assertRaises(picard.disc.discid.DiscError, disc.read, 'notadevice')
+
+    @patch.object(picard.disc, 'discid')
+    def test_read(self, mock_discid):
+        self.set_config_values(setting={
+            'server_host': 'musicbrainz.org',
+            'server_port': 443,
+            'use_server_for_submission': False,
+        })
+        mock_discid.read = Mock(return_value=MockDisc())
+        device = '/dev/cdrom1'
+        disc = picard.disc.Disc()
+        self.assertEqual(None, disc.id)
+        self.assertEqual(None, disc.mcn)
+        self.assertEqual(0, disc.tracks)
+        self.assertEqual(None, disc.toc_string)
+        self.assertEqual(None, disc.submission_url)
+        disc.read(device)
+        mock_discid.read.assert_called_with(device, features=['mcn'])
+        self.assertEqual(MockDisc.id, disc.id)
+        self.assertEqual(MockDisc.mcn, disc.mcn)
+        self.assertEqual(11, disc.tracks)
+        self.assertEqual(MockDisc.toc_string, disc.toc_string)
+        self.assertEqual(MockDisc.submission_url, disc.submission_url)
+
+    @patch.object(picard.disc, 'discid')
+    def test_submission_url(self, mock_discid):
+        self.set_config_values(setting={
+            'server_host': 'test.musicbrainz.org',
+            'server_port': 80,
+            'use_server_for_submission': True,
+        })
+        mock_discid.read = Mock(return_value=MockDisc())
+        disc = picard.disc.Disc()
+        disc.read()
+        self.assertEqual(
+            'http://test.musicbrainz.org:80/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437',
+            disc.submission_url
+        )

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from test.picardtestcase import PicardTestCase
+
+from picard.const import MUSICBRAINZ_SERVERS
+from picard.util.mbserver import (
+    get_submission_host,
+    is_official_server,
+)
+
+
+class IsOfficialServerTest(PicardTestCase):
+
+    def test_official(self):
+        for host in MUSICBRAINZ_SERVERS:
+            self.assertTrue(is_official_server(host))
+
+    def test_not_official(self):
+        self.assertFalse(is_official_server('test.musicbrainz.org'))
+        self.assertFalse(is_official_server('example.com'))
+        self.assertFalse(is_official_server('127.0.0.1'))
+        self.assertFalse(is_official_server('localhost'))
+
+
+class test_get_submission_host(PicardTestCase):
+
+    def test_official(self):
+        for host in MUSICBRAINZ_SERVERS:
+            self.set_config_values(setting={'server_host': host, 'server_port': 80})
+            self.assertEqual((host, 443), get_submission_host())
+
+    def test_unofficial(self):
+        self.set_config_values(setting={'server_host': 'test.musicbrainz.org', 'server_port': 80})
+        self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_host())

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -69,6 +69,16 @@ class GetSubmissionServerTest(PicardTestCase):
         })
         self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_server())
 
+    def test_named_tuple(self):
+        self.set_config_values(setting={
+            'server_host': 'example.com',
+            'server_port': 8042,
+            'use_server_for_submission': True,
+        })
+        server = get_submission_server()
+        self.assertEqual('example.com', server.host)
+        self.assertEqual(8042, server.port)
+
 
 class BuildSubmissionUrlTest(PicardTestCase):
 

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -24,7 +24,7 @@ from test.picardtestcase import PicardTestCase
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.util.mbserver import (
     build_submission_url,
-    get_submission_host,
+    get_submission_server,
     is_official_server,
 )
 
@@ -42,7 +42,7 @@ class IsOfficialServerTest(PicardTestCase):
         self.assertFalse(is_official_server('localhost'))
 
 
-class GetSubmissionHostTest(PicardTestCase):
+class GetSubmissionServerTest(PicardTestCase):
 
     def test_official(self):
         for host in MUSICBRAINZ_SERVERS:
@@ -51,7 +51,7 @@ class GetSubmissionHostTest(PicardTestCase):
                 'server_port': 80,
                 'use_server_for_submission': False,
             })
-            self.assertEqual((host, 443), get_submission_host())
+            self.assertEqual((host, 443), get_submission_server())
 
     def test_use_unofficial(self):
         self.set_config_values(setting={
@@ -59,7 +59,7 @@ class GetSubmissionHostTest(PicardTestCase):
             'server_port': 8042,
             'use_server_for_submission': True,
         })
-        self.assertEqual(('example.com', 8042), get_submission_host())
+        self.assertEqual(('example.com', 8042), get_submission_server())
 
     def test_unofficial_fallback(self):
         self.set_config_values(setting={
@@ -67,7 +67,7 @@ class GetSubmissionHostTest(PicardTestCase):
             'server_port': 80,
             'use_server_for_submission': False,
         })
-        self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_host())
+        self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_server())
 
 
 class BuildSubmissionUrlTest(PicardTestCase):

--- a/ui/options_general.ui
+++ b/ui/options_general.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>283</width>
-    <height>435</height>
+    <width>403</width>
+    <height>584</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
@@ -20,6 +20,52 @@
       <property name="spacing">
        <number>2</number>
       </property>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="server_port">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+        <property name="value">
+         <number>80</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QFrame" name="server_host_primary_warning">
+        <property name="styleSheet">
+         <string notr="true">QFrame { background-color: #ffc107; color: black }
+QCheckBox { color: black }</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>You have configured an unofficial database server. By default all data submission will go to the primary server on musicbrainz.org.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="use_server_for_submission">
+           <property name="text">
+            <string>Submit data to the configured server</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QComboBox" name="server_host">
         <property name="sizePolicy">
@@ -40,25 +86,28 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="server_port">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>65535</number>
-        </property>
-        <property name="value">
-         <number>80</number>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Server address:</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="0">
+       <spacer name="spacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>1</width>
+          <height>4</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/ui/options_general.ui
+++ b/ui/options_general.ui
@@ -287,6 +287,14 @@ QCheckBox { color: black }</string>
  <tabstops>
   <tabstop>server_host</tabstop>
   <tabstop>server_port</tabstop>
+  <tabstop>use_server_for_submission</tabstop>
+  <tabstop>login</tabstop>
+  <tabstop>logout</tabstop>
+  <tabstop>analyze_new_files</tabstop>
+  <tabstop>ignore_file_mbids</tabstop>
+  <tabstop>check_for_updates</tabstop>
+  <tabstop>update_check_days</tabstop>
+  <tabstop>update_level</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2232, PICARD-1645
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The new add cluster / files functionality added in #1839 always submits to main servers, regardless of what server has been configured. Likewise disc ID submission always submits to musicbrainz.org as well, see PICARD-1645.

In the majority of cases that is the wanted behavior. But sometimes they might want to submit to their local mirror, either for testing/debugging or because they actually want the submissions only to have locally.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The default behavior is that the main database is being used. As long as the user has configured the official servers (musicbrainz.org or beta.musicbrainz.org) those are used for submission of addrelease and discid as well.

![grafik](https://user-images.githubusercontent.com/29852/121964715-41db8680-cd6c-11eb-9ad5-40be868445b8.png)

But if the user enters an unofficial server host a warning is displayed:

![grafik](https://user-images.githubusercontent.com/29852/121964829-6899bd00-cd6c-11eb-9f86-12e55b9b2d45.png)

By default it shows the warning and for submission the primary server (musicbrainz.org) will be used. But the can enable "Submit data using the configured server" and addrelease / discid submission will use the custom server.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
This only handles data submission for the addrelease functionality and disc ID. Both of which are done via opening an URL in browser.

I guess we also should support other kind of data, but I'm not sure. Currently there is submission of ratings and managing collections. Theoretically we could extend to submission of tags / genres, ISRC and barcode. Some probably should go to official server. Not sure about personal data like collections and ratings.

Anyway, implementing this requires some more work because of authentication. Basically if the user uses an unofficial server but submission is done to primary server we need to maintain two separate logins, one for primary server for submission and one for querying the custom server.