### PR TITLE
Show script editor from main screen menu

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -485,7 +485,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.options_action.setMenuRole(QtWidgets.QAction.PreferencesRole)
         self.options_action.triggered.connect(self.show_options)
 
-        self.show_script_editor_action = QtWidgets.QAction(_("Open script &editor..."))
+        self.show_script_editor_action = QtWidgets.QAction(_("Open &file naming script editor..."))
         self.show_script_editor_action.triggered.connect(self.open_file_naming_script_editor)
 
         self.cut_action = QtWidgets.QAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), _("&Cut"), self)

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -402,6 +402,7 @@ class ScriptEditorDialog(PicardDialog):
     signal_update = QtCore.pyqtSignal()
     signal_selection_changed = QtCore.pyqtSignal()
     signal_update_scripts_list = QtCore.pyqtSignal()
+    signal_index_changed = QtCore.pyqtSignal()
 
     default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
     default_script_filename = "picard_naming_script.ptsp"
@@ -420,8 +421,6 @@ class ScriptEditorDialog(PicardDialog):
         self.FILE_TYPE_SCRIPT = _("Picard Script Files") + " (*.pts *.txt)"
         self.FILE_TYPE_PACKAGE = _("Picard Naming Script Package") + " (*.ptsp *.yaml)"
 
-        # TODO: Make this work properly so that it can be accessed from both the main window and the options window.
-        # self.setWindowFlags(QtCore.Qt.Window)
         self.setWindowTitle(self.TITLE)
         self.displaying = False
         self.loading = True
@@ -671,6 +670,7 @@ class ScriptEditorDialog(PicardDialog):
         self.ui.preset_naming_scripts.setCurrentIndex(idx)
         self.ui.preset_naming_scripts.blockSignals(False)
         self.selected_script_index = idx
+        self.signal_index_changed.emit()
 
     def _insert_item(self, script_item):
         """Insert a new item into the script selection combo box and update the script list in the settings.
@@ -747,6 +747,21 @@ class ScriptEditorDialog(PicardDialog):
             self._set_combobox_index(self.restore_selected_script_index)
             return False
         return True
+
+    def set_selected_script_id(self, id, skip_check=True):
+        """Select the script with the specified ID.
+
+        Args:
+            id (str): ID of the script to select
+            skip_check (bool, optional): Skip the check for unsaved edits. Defaults to True.
+        """
+        idx = 0
+        for i in range(self.ui.preset_naming_scripts.count()):
+            script_item = self.ui.preset_naming_scripts.itemData(i)
+            if script_item["id"] == id:
+                idx = i
+                break
+        self.set_selected_script_index(idx, skip_check=skip_check)
 
     def set_selected_script_index(self, idx, skip_check=True):
         """Select the script at the specified combo box index.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Enable opening the file naming script editor from the main window.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The file naming script editor could only be opened from the "File Naming" section of the "Options" ==> "Options..." screen.  This should also be available directly from Picard's main screen to accommodate quick changes to go along with the ability to quickly select the file naming script to be used.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Provide a new "Options" ==> "Open script editor..." menu item.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
In order to avoid possible issues with multiple copies of the script editor open simultaneously (one from the main screen and a second from the "File Naming" section of the "Options" ==> "Options..." screen), when it is opened from the main screen, the command to open the "Options" ==> "Options..." screen is disabled when the script editor is open.