### PR TITLE
Display profile setting items as tooltips

### DIFF
--- a/picard/ui/profileeditor.py
+++ b/picard/ui/profileeditor.py
@@ -60,6 +60,9 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
     POSITION_KEY = "last_selected_profile_pos"
     EXPANDED_KEY = "profile_settings_tree_expanded_list"
 
+    ITEMS_TEMPLATE = "\n  - %s"
+    NONE_TEXT = N_("None")
+
     TREEWIDGETITEM_COLUMN = 0
 
     options = [
@@ -248,16 +251,14 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         self.building_tree = False
 
     def make_setting_value_text(self, key, value):
-        ITEMS_TEMPLATE = "\n  - %s"
-        NONE_TEXT = _("None")
         if value is None:
             return _("Value not set")
         if key == "selected_file_naming_script_id":
             return self.get_file_naming_script_name(value)
         if key == "list_of_scripts":
-            return self.get_list_of_enabled_scripts(key, ITEMS_TEMPLATE, NONE_TEXT)
+            return self.get_list_of_enabled_scripts()
         if key == "ca_providers":
-            return self.get_list_of_enabled_ca_providers(key, ITEMS_TEMPLATE, NONE_TEXT)
+            return self.get_list_of_enabled_ca_providers()
         if isinstance(value, str):
             return '"%s"' % value
         if type(value) in {bool, int, float}:
@@ -275,33 +276,33 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
             return presets[script_id]
         return _("Unknown script")
 
-    def get_list_of_enabled_scripts(self, key, ITEMS_TEMPLATE, NONE_TEXT):
+    def get_list_of_enabled_scripts(self):
         config = get_config()
-        flag = False
-        if config.setting[key]:
-            scripts = config.setting[key]
+        scripts = config.setting["list_of_scripts"]
+        if scripts:
+            flag = False
             value_text = _("Enabled tagging scripts of %i found:") % len(scripts)
             for (pos, name, enabled, script) in scripts:
                 if enabled:
                     flag = True
-                    value_text += ITEMS_TEMPLATE % name
+                    value_text += self.ITEMS_TEMPLATE % name
             if not flag:
-                value_text += " %s" % NONE_TEXT
+                value_text += " %s" % _(self.NONE_TEXT)
         else:
             value_text = _("No scripts in list")
         return value_text
 
-    def get_list_of_enabled_ca_providers(self, key, ITEMS_TEMPLATE, NONE_TEXT):
+    def get_list_of_enabled_ca_providers(self):
         config = get_config()
-        flag = False
-        providers = config.setting[key]
+        providers = config.setting["ca_providers"]
         value_text = _("Enabled providers of %i listed:") % len(providers)
+        flag = False
         for (name, enabled) in providers:
             if enabled:
                 flag = True
-                value_text += ITEMS_TEMPLATE % name
+                value_text += self.ITEMS_TEMPLATE % name
         if not flag:
-            value_text += " %s" % NONE_TEXT
+            value_text += " %s" % _(self.NONE_TEXT)
         return value_text
 
     def current_item_changed(self, new_item, old_item):

--- a/picard/ui/profileeditor.py
+++ b/picard/ui/profileeditor.py
@@ -60,8 +60,8 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
     POSITION_KEY = "last_selected_profile_pos"
     EXPANDED_KEY = "profile_settings_tree_expanded_list"
 
-    ITEMS_TEMPLATE = "\n  - %s"
-    NONE_TEXT = N_("None")
+    ITEMS_TEMPLATE_CHECKED = "\n  ■ %s"
+    ITEMS_TEMPLATE_UNCHECKED = "\n  □ %s"
 
     TREEWIDGETITEM_COLUMN = 0
 
@@ -256,9 +256,9 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         if key == "selected_file_naming_script_id":
             return self.get_file_naming_script_name(value)
         if key == "list_of_scripts":
-            return self.get_list_of_enabled_scripts()
+            return self.get_list_of_scripts()
         if key == "ca_providers":
-            return self.get_list_of_enabled_ca_providers()
+            return self.get_list_of_ca_providers()
         if isinstance(value, str):
             return '"%s"' % value
         if type(value) in {bool, int, float}:
@@ -276,33 +276,29 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
             return presets[script_id]
         return _("Unknown script")
 
-    def get_list_of_enabled_scripts(self):
+    def get_list_of_scripts(self):
         config = get_config()
         scripts = config.setting["list_of_scripts"]
         if scripts:
-            flag = False
-            value_text = _("Enabled tagging scripts of %i found:") % len(scripts)
+            value_text = _("Tagging scripts (%i found):") % len(scripts)
             for (pos, name, enabled, script) in scripts:
                 if enabled:
-                    flag = True
-                    value_text += self.ITEMS_TEMPLATE % name
-            if not flag:
-                value_text += " %s" % _(self.NONE_TEXT)
+                    value_text += self.ITEMS_TEMPLATE_CHECKED % name
+                else:
+                    value_text += self.ITEMS_TEMPLATE_UNCHECKED % name
         else:
             value_text = _("No scripts in list")
         return value_text
 
-    def get_list_of_enabled_ca_providers(self):
+    def get_list_of_ca_providers(self):
         config = get_config()
         providers = config.setting["ca_providers"]
-        value_text = _("Enabled providers of %i listed:") % len(providers)
-        flag = False
+        value_text = _("CA providers (%i found):") % len(providers)
         for (name, enabled) in providers:
             if enabled:
-                flag = True
-                value_text += self.ITEMS_TEMPLATE % name
-        if not flag:
-            value_text += " %s" % _(self.NONE_TEXT)
+                value_text += self.ITEMS_TEMPLATE_CHECKED % name
+            else:
+                value_text += self.ITEMS_TEMPLATE_UNCHECKED % name
         return value_text
 
     def current_item_changed(self, new_item, old_item):

--- a/picard/ui/profileeditor.py
+++ b/picard/ui/profileeditor.py
@@ -251,22 +251,20 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         ITEMS_TEMPLATE = "\n  - %s"
         NONE_TEXT = _("None")
         if value is None:
-            value_text = "None"
-        elif key == "selected_file_naming_script_id":
-            value_text = self.get_file_naming_script_name(value)
-        elif key == "list_of_scripts":
-            value_text = self.get_list_of_enabled_scripts(key, ITEMS_TEMPLATE, NONE_TEXT)
-        elif key == "ca_providers":
-            value_text = self.get_list_of_enabled_ca_providers(key, ITEMS_TEMPLATE, NONE_TEXT)
-        elif isinstance(value, str):
-            value_text = '"%s"' % value
-        elif type(value) in {bool, int, float}:
-            value_text = str(value)
-        elif type(value) in {set, tuple, list, dict}:
-            value_text = _("List of %i items") % len(value)
-        else:
-            value_text = _("Unknown value format")
-        return value_text
+            return _("Value not set")
+        if key == "selected_file_naming_script_id":
+            return self.get_file_naming_script_name(value)
+        if key == "list_of_scripts":
+            return self.get_list_of_enabled_scripts(key, ITEMS_TEMPLATE, NONE_TEXT)
+        if key == "ca_providers":
+            return self.get_list_of_enabled_ca_providers(key, ITEMS_TEMPLATE, NONE_TEXT)
+        if isinstance(value, str):
+            return '"%s"' % value
+        if type(value) in {bool, int, float}:
+            return str(value)
+        if type(value) in {set, tuple, list, dict}:
+            return _("List of %i items") % len(value)
+        return _("Unknown value format")
 
     def get_file_naming_script_name(self, script_id):
         config = get_config()

--- a/picard/ui/profileeditor.py
+++ b/picard/ui/profileeditor.py
@@ -250,39 +250,14 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
     def make_setting_value_text(self, key, value):
         ITEMS_TEMPLATE = "\n  - %s"
         NONE_TEXT = _("None")
-        config = get_config()
-        flag = False
         if value is None:
             value_text = "None"
         elif key == "selected_file_naming_script_id":
-            presets = {x["id"]: x["title"] for x in get_file_naming_script_presets()}
-            if value in config.setting["file_renaming_scripts"]:
-                value_text = config.setting["file_renaming_scripts"][value]["title"]
-            elif value in presets:
-                value_text = presets[value]
-            else:
-                value_text = _("Unknown script")
+            value_text = self.get_file_naming_script_name(value)
         elif key == "list_of_scripts":
-            if config.setting[key]:
-                scripts = config.setting[key]
-                value_text = _("Enabled tagging scripts of %i found:") % len(scripts)
-                for (pos, name, enabled, script) in scripts:
-                    if enabled:
-                        flag = True
-                        value_text += ITEMS_TEMPLATE % name
-                if not flag:
-                    value_text += " %s" % NONE_TEXT
-            else:
-                value_text = _("No scripts in list")
+            value_text = self.get_list_of_enabled_scripts(key, ITEMS_TEMPLATE, NONE_TEXT)
         elif key == "ca_providers":
-            providers = config.setting[key]
-            value_text = _("Enabled providers of %i listed:") % len(providers)
-            for (name, enabled) in providers:
-                if enabled:
-                    flag = True
-                    value_text += ITEMS_TEMPLATE % name
-            if not flag:
-                value_text += " %s" % NONE_TEXT
+            value_text = self.get_list_of_enabled_ca_providers(key, ITEMS_TEMPLATE, NONE_TEXT)
         elif isinstance(value, str):
             value_text = '"%s"' % value
         elif type(value) in {bool, int, float}:
@@ -291,6 +266,44 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
             value_text = _("List of %i items") % len(value)
         else:
             value_text = _("Unknown value format")
+        return value_text
+
+    def get_file_naming_script_name(self, script_id):
+        config = get_config()
+        if script_id in config.setting["file_renaming_scripts"]:
+            return config.setting["file_renaming_scripts"][script_id]["title"]
+        presets = {x["id"]: x["title"] for x in get_file_naming_script_presets()}
+        if script_id in presets:
+            return presets[script_id]
+        return _("Unknown script")
+
+    def get_list_of_enabled_scripts(self, key, ITEMS_TEMPLATE, NONE_TEXT):
+        config = get_config()
+        flag = False
+        if config.setting[key]:
+            scripts = config.setting[key]
+            value_text = _("Enabled tagging scripts of %i found:") % len(scripts)
+            for (pos, name, enabled, script) in scripts:
+                if enabled:
+                    flag = True
+                    value_text += ITEMS_TEMPLATE % name
+            if not flag:
+                value_text += " %s" % NONE_TEXT
+        else:
+            value_text = _("No scripts in list")
+        return value_text
+
+    def get_list_of_enabled_ca_providers(self, key, ITEMS_TEMPLATE, NONE_TEXT):
+        config = get_config()
+        flag = False
+        providers = config.setting[key]
+        value_text = _("Enabled providers of %i listed:") % len(providers)
+        for (name, enabled) in providers:
+            if enabled:
+                flag = True
+                value_text += ITEMS_TEMPLATE % name
+        if not flag:
+            value_text += " %s" % NONE_TEXT
         return value_text
 
     def current_item_changed(self, new_item, old_item):

--- a/picard/ui/profileeditor.py
+++ b/picard/ui/profileeditor.py
@@ -60,9 +60,6 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
     POSITION_KEY = "last_selected_profile_pos"
     EXPANDED_KEY = "profile_settings_tree_expanded_list"
 
-    ITEMS_TEMPLATE_CHECKED = "\n  ■ %s"
-    ITEMS_TEMPLATE_UNCHECKED = "\n  □ %s"
-
     TREEWIDGETITEM_COLUMN = 0
 
     options = [
@@ -78,6 +75,11 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         super().__init__(parent)
 
         self.main_window = parent
+
+        self.ITEMS_TEMPLATES = {
+            True: "\n  ■ %s",
+            False:  "\n  □ %s",
+        }
 
         self.setWindowTitle(_(self.TITLE))
         self.displaying = False
@@ -264,16 +266,17 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
             return self.get_list_of_ca_providers()
         if isinstance(value, str):
             return '"%s"' % value
-        if type(value) in {bool, int, float}:
+        if isinstance(value, bool) or isinstance(value, int) or isinstance(value, float):
             return str(value)
-        if type(value) in {set, tuple, list, dict}:
+        if isinstance(value, set) or isinstance(value, tuple) or isinstance(value, list) or isinstance(value, dict):
             return _("List of %i items") % len(value)
         return _("Unknown value format")
 
     def get_file_naming_script_name(self, script_id):
         config = get_config()
-        if script_id in config.setting["file_renaming_scripts"]:
-            return config.setting["file_renaming_scripts"][script_id]["title"]
+        scripts = config.setting["file_renaming_scripts"]
+        if script_id in scripts:
+            return scripts[script_id]["title"]
         presets = {x["id"]: x["title"] for x in get_file_naming_script_presets()}
         if script_id in presets:
             return presets[script_id]
@@ -285,10 +288,7 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         if scripts:
             value_text = _("Tagging scripts (%i found):") % len(scripts)
             for (pos, name, enabled, script) in scripts:
-                if enabled:
-                    value_text += self.ITEMS_TEMPLATE_CHECKED % name
-                else:
-                    value_text += self.ITEMS_TEMPLATE_UNCHECKED % name
+                value_text += self.ITEMS_TEMPLATES[enabled] % name
         else:
             value_text = _("No scripts in list")
         return value_text
@@ -298,10 +298,7 @@ class ProfileEditorDialog(SingletonDialog, PicardDialog):
         providers = config.setting["ca_providers"]
         value_text = _("CA providers (%i found):") % len(providers)
         for (name, enabled) in providers:
-            if enabled:
-                value_text += self.ITEMS_TEMPLATE_CHECKED % name
-            else:
-                value_text += self.ITEMS_TEMPLATE_UNCHECKED % name
+            value_text += self.ITEMS_TEMPLATES[enabled] % name
         return value_text
 
     def get_controlling_profile(self, key):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:  Display profile setting override values as tooltips.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

There was no easy way of seeing what the settings override values were for a profile.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Provide the current override value for the profile as a tooltip on the setting in the settings tree.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

This currently uses tooltips, but could easily be converted to display the settings in a text box on the dialog when the setting is selected if that is preferred.