### PR TITLE
Modify date-related functions to optionally split on multiple chars

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1386,18 +1386,22 @@ def func_countryname(parser, country_code, translate=""):
 DateTuple = namedtuple('DateTuple', ('year', 'month', 'day'))
 
 
-def _split_date(date_to_parse, date_order="ymd"):
+def _split_date(date_to_parse, date_order="ymd", multi_char=False):
     """Split the specified date into parts.
 
     Args:
         date_to_parse (str): Date string to parse
         date_order (str, optional): Order of date elements. Can be "ymd", "mdy" or "dmy". Defaults to "ymd".
+        multi_char (bool, optional): Split on one or more non-digit character. Defaults to False (split at each character).
 
     Returns:
         tuple: Tuple of the date parts as (year, month, day)
     """
 
-    parts = re.split(r'\D+', date_to_parse.strip())
+    splitter = r'\D'
+    if multi_char:
+        splitter += '+'
+    parts = re.split(splitter, date_to_parse.strip())
     parts.extend(['', '', ''])
     date_order = date_order.lower()
     if date_order == 'dmy':
@@ -1409,43 +1413,49 @@ def _split_date(date_to_parse, date_order="ymd"):
 
 
 @script_function(documentation=N_(
-    """`$year(date,date_order="ymd")`
+    """`$year(date,date_order="ymd",multi_char=False)`
 
 Returns the year portion of the specified date.  The default order is "ymd".  This can be changed by specifying
-either "dmy" or "mdy".  If the date is invalid an empty string will be returned.
+either "dmy" or "mdy".  Splits at each non-digit character unless `multi_char` is specified.
+
+If the date is invalid an empty string will be returned.
 
 _Since Picard 2.7_"""
 ))
-def func_year(parser, date_to_parse, date_order='ymd'):
-    return _split_date(date_to_parse, date_order).year
+def func_year(parser, date_to_parse, date_order='ymd', multi_char=False):
+    return _split_date(date_to_parse, date_order, multi_char).year
 
 
 @script_function(documentation=N_(
-    """`$month(date,date_order="ymd")`
+    """`$month(date,date_order="ymd",multi_char=False)`
 
 Returns the month portion of the specified date.  The default order is "ymd".  This can be changed by specifying
-either "dmy" or "mdy".  If the date is invalid an empty string will be returned.
+either "dmy" or "mdy".  Splits at each non-digit character unless `multi_char` is specified.
+
+If the date is invalid an empty string will be returned.
 
 _Since Picard 2.7_"""
 ))
-def func_month(parser, date_to_parse, date_order='ymd'):
-    return _split_date(date_to_parse, date_order).month
+def func_month(parser, date_to_parse, date_order='ymd', multi_char=False):
+    return _split_date(date_to_parse, date_order, multi_char).month
 
 
 @script_function(documentation=N_(
-    """`$day(date,date_order="ymd")`
+    """`$day(date,date_order="ymd",multi_char=False)`
 
 Returns the day portion of the specified date.  The default order is "ymd".  This can be changed by specifying
-either "dmy" or "mdy".  If the date is invalid an empty string will be returned.
+either "dmy" or "mdy".  Splits at each non-digit character unless `multi_char` is specified.
+
+If the date is invalid an empty string will be returned.
 
 _Since Picard 2.7_"""
 ))
-def func_day(parser, date_to_parse, date_order='ymd'):
-    return _split_date(date_to_parse, date_order).day
+def func_day(parser, date_to_parse, date_order='ymd', multi_char=False):
+    return _split_date(date_to_parse, date_order, multi_char).day
 
 
 @script_function(documentation=N_(
-    """`$dateformat(date,format="%Y-%m-%d",date_order="ymd")`
+    """`$dateformat(date,format="%Y-%m-%d",date_order="ymd", multi_char=False)`
 
 Returns the input date in the specified `format`, which is based on the standard
     Python `strftime` [format codes](https://strftime.org/). If no `format` is
@@ -1454,6 +1464,9 @@ Returns the input date in the specified `format`, which is based on the standard
 
     The default order for the input date is "ymd".  This can be changed by specifying
     either "dmy" or "mdy".
+
+    The default is to split the input date at each non-digit character.  This can be
+    changed by specifying `multi_char`.
 Note: Platform-specific formatting codes should be avoided to help ensure the
     portability of scripts across the different platforms.  These codes include:
     remove zero-padding (e.g. `%-d` and `%-m` on Linux or macOS, and their
@@ -1462,11 +1475,11 @@ Note: Platform-specific formatting codes should be avoided to help ensure the
 
 _Since Picard 2.7_"""
 ))
-def func_dateformat(parser, date_to_parse, date_format=None, date_order='ymd'):
+def func_dateformat(parser, date_to_parse, date_format=None, date_order='ymd', multi_char=False):
     # Handle case where format evaluates to ''
     if not date_format:
         date_format = '%Y-%m-%d'
-    yr, mo, da = _split_date(date_to_parse, date_order)
+    yr, mo, da = _split_date(date_to_parse, date_order, multi_char)
     try:
         date_object = datetime.date(int(yr), int(mo), int(da))
     except ValueError:

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1645,8 +1645,9 @@ class ScriptParserTest(PicardTestCase):
 
     def test_cmd_year(self):
         context = Metadata()
-        context["foo"] = "07.21.2021"
+        context["foo"] = "07..21..2021"
         context["bar"] = "mdy"
+        context["baz"] = "1"
 
         # Test with default values
         self.assertScriptResultEquals("$year(2021 07 21)", "2021", context)
@@ -1655,27 +1656,36 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$year(21-07-21)", "21", context)
 
         # Test with overrides specified
-        self.assertScriptResultEquals("$year(%foo%,%bar%)", "2021", context)
+        self.assertScriptResultEquals("$year(%foo%,%bar%,%baz%)", "2021", context)
+
+        # Test multiple character splitter
+        self.assertScriptResultEquals("$year(21 - 07 - 2021,dmy)", "", context)
+        self.assertScriptResultEquals("$year(21 - 07 - 2021,dmy,1)", "2021", context)
+        self.assertScriptResultEquals("$year(07 - 21 - 2021,mdy,1)", "2021", context)
 
         # Test with invalid overrides
         self.assertScriptResultEquals("$year(2021-07-21,myd)", "2021", context)
 
         # Test missing elements
         self.assertScriptResultEquals("$year(,)", "", context)
+        self.assertScriptResultEquals("$year(-07-21,ymd)", "", context)
         self.assertScriptResultEquals("$year(07-21,mdy)", "", context)
+        self.assertScriptResultEquals("$year(07-21-,mdy)", "", context)
         self.assertScriptResultEquals("$year(21-07,dmy)", "", context)
+        self.assertScriptResultEquals("$year(21-07-,dmy)", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$year: Wrong number of arguments for \$year: Expected between 1 and 2, "
+        areg = r"^\d+:\d+:\$year: Wrong number of arguments for \$year: Expected between 1 and 3, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$year()")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$year(2021-07-21,,)")
+            self.parser.eval("$year(2021-07-21,,,)")
 
     def test_cmd_month(self):
         context = Metadata()
-        context["foo"] = "07.21.2021"
+        context["foo"] = "07..21..2021"
         context["bar"] = "mdy"
+        context["baz"] = "1"
 
         # Test with default values
         self.assertScriptResultEquals("$month(2021 07 21)", "07", context)
@@ -1684,7 +1694,12 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$month(2021-7-21)", "7", context)
 
         # Test with overrides specified
-        self.assertScriptResultEquals("$month(%foo%,%bar%)", "07", context)
+        self.assertScriptResultEquals("$month(%foo%,%bar%,%baz%)", "07", context)
+
+        # Test multiple character splitter
+        self.assertScriptResultEquals("$month(21 - 07 - 2021,dmy)", "", context)
+        self.assertScriptResultEquals("$month(21 - 07 - 2021,dmy,1)", "07", context)
+        self.assertScriptResultEquals("$month(2021 - 07 - 21,ymd,1)", "07", context)
 
         # Test with invalid overrides
         self.assertScriptResultEquals("$month(2021-07-21,myd)", "07", context)
@@ -1692,18 +1707,20 @@ class ScriptParserTest(PicardTestCase):
         # Test missing elements
         self.assertScriptResultEquals("$month(,)", "", context)
         self.assertScriptResultEquals("$month(-21-2021,mdy)", "", context)
+        self.assertScriptResultEquals("$month(2021--21,ymd)", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$month: Wrong number of arguments for \$month: Expected between 1 and 2, "
+        areg = r"^\d+:\d+:\$month: Wrong number of arguments for \$month: Expected between 1 and 3, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$month()")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$month(2021-07-21,,)")
+            self.parser.eval("$month(2021-07-21,,,)")
 
     def test_cmd_day(self):
         context = Metadata()
-        context["foo"] = "07.21.2021"
+        context["foo"] = "07..21..2021"
         context["bar"] = "mdy"
+        context["baz"] = "1"
 
         # Test with default values
         self.assertScriptResultEquals("$day(2021 07 21)", "21", context)
@@ -1712,27 +1729,29 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$day(2021-07-2)", "2", context)
 
         # Test with overrides specified
-        self.assertScriptResultEquals("$day(%foo%,%bar%)", "21", context)
+        self.assertScriptResultEquals("$day(%foo%,%bar%,%baz%)", "21", context)
 
         # Test with invalid overrides
         self.assertScriptResultEquals("$day(2021-07-21,myd)", "21", context)
 
         # Test missing elements
         self.assertScriptResultEquals("$day(,)", "", context)
+        self.assertScriptResultEquals("$day(07--2021,mdy)", "", context)
         self.assertScriptResultEquals("$day(-07-2021,dmy)", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$day: Wrong number of arguments for \$day: Expected between 1 and 2, "
+        areg = r"^\d+:\d+:\$day: Wrong number of arguments for \$day: Expected between 1 and 3, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$day()")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$day(2021-07-21,,)")
+            self.parser.eval("$day(2021-07-21,,,)")
 
     def test_cmd_dateformat(self):
         context = Metadata()
-        context["foo"] = "07.21.2021"
+        context["foo"] = "07..21..2021"
         context["bar"] = "mdy"
-        context["format"] = "%Y.%m.%d"
+        context["baz"] = "1"
+        context["format"] = "%Y - %m - %d"
 
         # Test with default values
         self.assertScriptResultEquals("$dateformat(2021 07 21)", "2021-07-21", context)
@@ -1741,25 +1760,26 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$dateformat(2021-7-21)", "2021-07-21", context)
 
         # Test with overrides specified
-        self.assertScriptResultEquals("$dateformat(%foo%,%format%,%bar%)", "2021.07.21", context)
+        self.assertScriptResultEquals("$dateformat(%foo%,%format%,%bar%,%baz%)", "2021 - 07 - 21", context)
 
         # Test with invalid overrides
         self.assertScriptResultEquals("$dateformat(2021-07-21,,myd)", "2021-07-21", context)
         self.assertScriptResultEquals("$dateformat(2021-07-21,,dmy)", "", context)
         self.assertScriptResultEquals("$dateformat(2021-07-21,,mdy)", "", context)
         self.assertScriptResultEquals("$dateformat(2021-July-21)", "", context)
-        self.assertScriptResultEquals("$dateformat(2021)", "", context)
-        self.assertScriptResultEquals("$dateformat(2021-07)", "", context)
 
         # Test missing elements
         self.assertScriptResultEquals("$dateformat(,)", "", context)
+        self.assertScriptResultEquals("$dateformat(2021)", "", context)
+        self.assertScriptResultEquals("$dateformat(2021-07)", "", context)
+        self.assertScriptResultEquals("$dateformat(2021--07)", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$dateformat: Wrong number of arguments for \$dateformat: Expected between 1 and 3, "
+        areg = r"^\d+:\d+:\$dateformat: Wrong number of arguments for \$dateformat: Expected between 1 and 4, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$dateformat()")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$dateformat(2021-07-21,,,)")
+            self.parser.eval("$dateformat(2021-07-21,,,,)")
 
     def test_cmd_is_multi(self):
         context = Metadata()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:  Add option to split input date string on single character (default) or multiple characters.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The current version (not yet released) of the `$year()`, `$month()`, `$day()` and `$dateformat()` scripting functions splits the input date string on one or more non-digit characters.  This leads to unexpected results such as `$month(2021--16)` returning "16" rather than the expected "".

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Split the input date string at each non-digit character and add an option to trigger the split at one or more non-digit character.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Remember to update the documentation.