### PR TITLE
PICARD-2204: Fixed unicode escape sequences on Windows copy paste

### DIFF
--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -296,7 +296,7 @@ def _replace_control_chars(text):
     simple_ctrl_chars = {'\n', '\r', '\t'}
     for ch in text:
         if ch not in simple_ctrl_chars and unicodedata.category(ch)[0] == "C":
-            yield '\\u' + hex(ord(ch))[2:]
+            yield '\\u' + hex(ord(ch))[2:].rjust(4, '0')
         else:
             yield ch
 

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -316,6 +316,7 @@ class ScriptTextEdit(QTextEdit):
         self.enable_completer()
         self.setFontFamily(FONT_FAMILY_MONOSPACE)
         self.setMouseTracking(True)
+        self.setAcceptRichText(False)
         self.wordwrap_action = QAction(_("&Word wrap script"), self)
         self.wordwrap_action.setToolTip(_("Word wrap long lines in the editor"))
         self.wordwrap_action.triggered.connect(self.update_wordwrap)
@@ -382,7 +383,11 @@ class ScriptTextEdit(QTextEdit):
         return None
 
     def insertFromMimeData(self, source):
-        source.setText(_clean_text(source.text()))
+        text = _clean_text(source.text())
+        # Create a new data object, as modifying the existing one does not
+        # work on Windows if copying from outside the Qt app.
+        source = QtCore.QMimeData()
+        source.setText(text)
         return super().insertFromMimeData(source)
 
     def setPlainText(self, text):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2204
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On Windows the existing QMimeData object cannot be modified, if the data was copied from outside the app itself. That meant replacing control characters with Unicode escape sequences on copy and paste did not work.

# Solution

Create a new QMimeData. Also generally ignore formatting, we only care about plain text. I have not verified, but it could help fix some issues were users had experienced external formatting being applied to the script window after copy and paste, such as smaller font sizes.