### PR TITLE
PICARD-2269: Fix "TypeError: arguments did not match any overloaded call" with Python 3.10

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -135,7 +135,7 @@ class CoverArtThumbnail(ActiveLabel):
             event.acceptProposedAction()
 
     def scaled(self, *dimensions):
-        return (self.pixel_ratio * dimension for dimension in dimensions)
+        return (round(self.pixel_ratio * dimension) for dimension in dimensions)
 
     def show(self):
         self.set_data(self.data, True)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -141,9 +141,9 @@ def get_match_color(similarity, basecolor):
     c1 = (basecolor.red(), basecolor.green(), basecolor.blue())
     c2 = (223, 125, 125)
     return QtGui.QColor(
-        c2[0] + (c1[0] - c2[0]) * similarity,
-        c2[1] + (c1[1] - c2[1]) * similarity,
-        c2[2] + (c1[2] - c2[2]) * similarity)
+        int(c2[0] + (c1[0] - c2[0]) * similarity),
+        int(c2[1] + (c1[1] - c2[1]) * similarity),
+        int(c2[2] + (c1[2] - c2[2]) * similarity))
 
 
 class MainPanel(QtWidgets.QSplitter):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -400,7 +400,7 @@ def throttle(interval):
             else:
                 decorator.args = args
                 decorator.kwargs = kwargs
-                QtCore.QTimer.singleShot(r, later)
+                QtCore.QTimer.singleShot(int(r), later)
                 decorator.is_ticking = True
             mutex.unlock()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix

* **Describe this change in 1-2 sentences**:
Fix `TypeError: arguments did not match any overloaded call` that occurs when running Picard with Python 3.10.

# Problem

Hi,
I tried running Picard with Python 3.10.0rc1, all tests pass but the GUI doesn't open because of errors such as:
```
  File "./picard/ui/coverartbox.py", line 74, in __init__
    self.shadow = self.shadow.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
TypeError: arguments did not match any overloaded call:
  scaled(self, int, int, aspectRatioMode: Qt.AspectRatioMode = Qt.IgnoreAspectRatio, transformMode: Qt.TransformationMode = Qt.FastTransformation): argument 1 has unexpected type 'float'
  scaled(self, QSize, aspectRatioMode: Qt.AspectRatioMode = Qt.IgnoreAspectRatio, transformMode: Qt.TransformationMode = Qt.FastTransformation): argument 1 has unexpected type 'float'
```

This is probably caused by the following change:
> Builtin and extension functions that take integer arguments no longer accept Decimals, Fractions and other objects that can be converted to integers only with a loss (e.g. that have the `__int__()` method but do not have the `__index__()` method). (Contributed by Serhiy Storchaka in [bpo-37999](https://bugs.python.org/issue37999).)

# Solution

Casting the result of `self.scaled` to `int` seems to be enough.

# Action

 I don't understand why that never failed with Python 3.9, if someone does, can they please explain this to me?
