### PR TITLE
AcousticBrainz fixes

### DIFF
--- a/picard/acousticbrainz/__init__.py
+++ b/picard/acousticbrainz/__init__.py
@@ -194,23 +194,15 @@ def ab_submit_features(tagger, file):
     with open(file.acousticbrainz_features_file, "r", encoding="utf-8") as f:
         features = json.load(f)
 
-    try:
-        musicbrainz_recordingid = features['metadata']['tags']['musicbrainz_trackid'][0]
-    except KeyError:
-        musicbrainz_recordingid = file.metadata['musicbrainz_recordingid']
-        features['metadata']['tags']['musicbrainz_trackid'] = [musicbrainz_recordingid]
-    # Check if extracted recording id matches the current file (recording ID may have been merged with others)
-    if musicbrainz_recordingid != file.metadata['musicbrainz_recordingid']:
-        # If it doesn't, skip the submission
-        log.debug("AcousticBrainz features recordingId do not match the file metadata: %s" % file.filename)
-        submit_features_callback(file, None, None, True)
-        return
+    # Always submit for currently matched recording ID
+    musicbrainz_recordingid = file.metadata['musicbrainz_recordingid']
+    features['metadata']['tags']['musicbrainz_trackid'] = [musicbrainz_recordingid]
 
     # Submit features to the server
     tagger.webservice.post(
         host=ACOUSTICBRAINZ_HOST,
         port=ACOUSTICBRAINZ_PORT,
-        path="/%s/low-level" % file.metadata["musicbrainz_recordingid"],
+        path="/%s/low-level" % musicbrainz_recordingid,
         data=json.dumps(features),
         handler=partial(submit_features_callback, file),
         priority=True,

--- a/picard/ui/options/acousticbrainz.py
+++ b/picard/ui/options/acousticbrainz.py
@@ -94,7 +94,10 @@ class AcousticBrainzOptionsPage(OptionsPage):
 
     def save(self):
         enabled = self.ui.acousticbrainz_settings.isEnabled()
-        self._config.setting["use_acousticbrainz"] = enabled
+        changed = self._config.setting["use_acousticbrainz"] != enabled
+        if changed:
+            self._config.setting["use_acousticbrainz"] = enabled
+            self.tagger.window.update_actions()
         if enabled:
             self._config.setting["acousticbrainz_extractor"] = self.ui.acousticbrainz_extractor.text()
             ab_setup_extractor()

--- a/picard/ui/options/acousticbrainz.py
+++ b/picard/ui/options/acousticbrainz.py
@@ -51,7 +51,7 @@ from picard.ui.ui_options_acousticbrainz import Ui_AcousticBrainzOptionsPage
 
 class AcousticBrainzOptionsPage(OptionsPage):
 
-    NAME = "AcousticBrainz"
+    NAME = "acousticbrainz"
     TITLE = N_("AcousticBrainz")
     PARENT = None
     SORT_ORDER = 45


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

This fixes a some issues encountered during testing:

1. Update the action status in main window if AcousticBrainz gets enabled / disabled
2. Fix submission failing if no recording ID is stored in the tags

The second issues requires some discussion. The issue I encountered was a KeyError exception in https://github.com/metabrainz/picard/blob/master/picard/acousticbrainz/__init__.py#L198 if the features file did not extract a recording ID from existing tags.

But the fix changes more. Previously the submission would not be done if the recording ID stored in tags differs from the currently matched recording ID. I think this is not very clear, because submission would fail, but the user would just assume they have the files matched and can submit them, and since feature extraction was performed the long time this takes gives the impression something was actually done. Basically we are using a mix of new and old data to do the submission.

We have two ways to improve this:

1. Always use the matched recording ID (i.e. the new metadata) for the submission. That means when I have matched a file to a recording the features will be submitted for this recording ID, regardless of existing metadata. This is what I have currently done. It is consistent with what we do for AcoustID fingerprint submission. But it might make it more likely that data gets submitted for wrong recording.

2. Only allow submission for saved files. That would mean we would not even enable submission for files with pending changes and would not start the analysis process for these files. Only the saved metadata gets used. It means we have a separate safety step that requires the user to actually save the files. Basically it is the same as if the user tagged the files with Picard and used the separate AB submission tool afterwards on the files. We might need to add some kind of info that unsaved files cannot be submitted to AB, not sure how this would be done best.