### PR TITLE
PICARD-2273: Always set acoustid_id, even if not linked to MB recordings

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -107,6 +107,11 @@ class AcoustIDClient(QtCore.QObject):
                                 parsed_recording['acoustid'] = result['id']
                                 recording_list.append(parsed_recording)
                         log.debug("AcoustID: Lookup successful for '%s'", file.filename)
+
+                    # Set AcoustID in tags if there was no matching recording
+                    if results and not recording_list:
+                        file.metadata['acoustid_id'] = results[0]['id']
+                        file.update()
                 else:
                     mparms = {
                         'error': document['error']['message'],


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution


Users are frequently confused if there are existing AcoustIDs that match a file's fingerprint, but the AcoustIDs are not linked to any recording. Users expect the AcoustID tag still to be filled, even if Picard failed to find a recording linked to this AcoustID.

Having the ID can also help the user to identify more details about the file, e.g. by looking up the AcoustID online they might be able to identify the file and then manually match it to a proper MB recording.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
If acoustid.org finds a matching AcoustID for a fingerprint, always set the acoustid_id tag.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
