### PR TITLE
PICARD-2274: Fix crashes when updating items without tree widget

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -901,9 +901,10 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         return super().setText(column, text)
 
     def __lt__(self, other):
-        if not self.sortable:
+        tree_widget = self.treeWidget()
+        if not self.sortable or not tree_widget:
             return False
-        column = self.treeWidget().sortColumn()
+        column = tree_widget.sortColumn()
         return self.sortkey(column) < other.sortkey(column)
 
     def sortkey(self, column):
@@ -990,11 +991,13 @@ class AlbumItem(TreeItem):
                 # insertChildren behaves differently if sorting is disabled / enabled, which results
                 # in different sort order of tracks in unsorted state. As we sort the tracks later
                 # anyway make sure sorting is disabled here.
-                tree_view = self.treeWidget()
-                sorting_enabled = tree_view.isSortingEnabled()
-                tree_view.setSortingEnabled(False)
+                tree_widget = self.treeWidget()
+                if tree_widget:
+                    sorting_enabled = tree_widget.isSortingEnabled()
+                    tree_widget.setSortingEnabled(False)
                 self.insertChildren(oldnum, items)
-                tree_view.setSortingEnabled(sorting_enabled)
+                if tree_widget:
+                    tree_widget.setSortingEnabled(sorting_enabled)
                 for item in items:  # Update after insertChildren so that setExpanded works
                     item.update(update_album=False)
         if album.errors:
@@ -1032,7 +1035,10 @@ class AlbumItem(TreeItem):
 class NatAlbumItem(AlbumItem):
     def __lt__(self, other):
         # Always show NAT entry on top
-        order = self.treeWidget().header().sortIndicatorOrder()
+        tree_widget = self.treeWidget()
+        if not tree_widget:
+            return True
+        order = tree_widget.header().sortIndicatorOrder()
         return order == QtCore.Qt.AscendingOrder
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2274
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

In some situations items from the tree views get updated without being attached to the tree widget. Avoid exceptions in this situation.

Picard can crash when updating widget items in the main tree view under some circumstances, see PICARD-2274 for how to reproduce.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Generally be aware that a `QTreeWidgetItem` is not always attached to a `QTreeWidget`, hence `treeWidget()`  might return `None`. Handle this case without crashing.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
