### PR TITLE
Only allow AB submission for saved files

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -707,9 +707,7 @@ class File(QtCore.QObject, Item):
         return True
 
     def can_extract(self):
-        if self.metadata["musicbrainz_recordingid"]:
-            return True
-        return False
+        return self.is_saved() and self.metadata["musicbrainz_recordingid"]
 
     def _info(self, metadata, file):
         if hasattr(file.info, 'length'):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is an extension to the discussion in https://github.com/metabrainz/picard/pull/1895 . There I fixed the issue of submission crashing when a file did not have a recording ID saved in the tags. In the fix I changed the behavior to always submit with currently matched files, that means overwriting the metadata the streaming extractor had read from the file with our currently matched recording ID.

But the original intention of the code was to ensure a file has been properly matched to only allow clean submissions. Similar to how the current AB submission tools are supposed to be run on files already properly tagged with MB tags.

# Solution
- Only allow submission of saved files
- Restore the original check that compared loaded metadata with existing metadata (removed previously in https://github.com/metabrainz/picard/pull/1895/commits/2534b9c59c2db018c66aa73675d3306f42c0375c)
- Handle the case that the loaded track ID is empty
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
Not fully sure about this, let's discuss. @Gabrielcarvfer , what's you take on this?
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
