### PR TITLE
PICARD-2279: Allow saving AcoustID fingerprint in acoustid_fingerprint tag

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -632,6 +632,9 @@ class File(QtCore.QObject, Item):
             self.acoustid_length = length or self.metadata.length // 1000
             self.tagger.acoustidmanager.add(self, None)
             self.acoustid_update()
+        config = get_config()
+        if config.setting['save_acoustid_fingerprints']:
+            self.metadata['acoustid_fingerprint'] = fingerprint
 
     def acoustid_update(self):
         recording_id = None

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -65,6 +65,7 @@ class FingerprintingOptionsPage(OptionsPage):
 
     options = [
         BoolOption("setting", "ignore_existing_acoustid_fingerprints", False),
+        BoolOption("setting", "save_acoustid_fingerprints", False),
         TextOption("setting", "fingerprinting_system", "acoustid"),
         TextOption("setting", "acoustid_fpcalc", ""),
         TextOption("setting", "acoustid_apikey", ""),
@@ -93,6 +94,7 @@ class FingerprintingOptionsPage(OptionsPage):
         self.ui.acoustid_fpcalc.setText(config.setting["acoustid_fpcalc"])
         self.ui.acoustid_apikey.setText(config.setting["acoustid_apikey"])
         self.ui.ignore_existing_acoustid_fingerprints.setChecked(config.setting["ignore_existing_acoustid_fingerprints"])
+        self.ui.save_acoustid_fingerprints.setChecked(config.setting["save_acoustid_fingerprints"])
         self.update_groupboxes()
 
     def save(self):
@@ -104,6 +106,7 @@ class FingerprintingOptionsPage(OptionsPage):
         config.setting["acoustid_fpcalc"] = self.ui.acoustid_fpcalc.text()
         config.setting["acoustid_apikey"] = self.ui.acoustid_apikey.text()
         config.setting["ignore_existing_acoustid_fingerprints"] = self.ui.ignore_existing_acoustid_fingerprints.isChecked()
+        config.setting["save_acoustid_fingerprints"] = self.ui.save_acoustid_fingerprints.isChecked()
 
     def update_groupboxes(self):
         if self.ui.use_acoustid.isChecked():

--- a/picard/ui/ui_options_fingerprinting.py
+++ b/picard/ui/ui_options_fingerprinting.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_FingerprintingOptionsPage(object):
     def setupUi(self, FingerprintingOptionsPage):
@@ -30,6 +32,9 @@ class Ui_FingerprintingOptionsPage(object):
         self.ignore_existing_acoustid_fingerprints = QtWidgets.QCheckBox(self.acoustid_settings)
         self.ignore_existing_acoustid_fingerprints.setObjectName("ignore_existing_acoustid_fingerprints")
         self.verticalLayout_2.addWidget(self.ignore_existing_acoustid_fingerprints)
+        self.save_acoustid_fingerprints = QtWidgets.QCheckBox(self.acoustid_settings)
+        self.save_acoustid_fingerprints.setObjectName("save_acoustid_fingerprints")
+        self.verticalLayout_2.addWidget(self.save_acoustid_fingerprints)
         self.label = QtWidgets.QLabel(self.acoustid_settings)
         self.label.setObjectName("label")
         self.verticalLayout_2.addWidget(self.label)
@@ -75,9 +80,9 @@ class Ui_FingerprintingOptionsPage(object):
         self.use_acoustid.setText(_("Use AcoustID"))
         self.acoustid_settings.setTitle(_("AcoustID Settings"))
         self.ignore_existing_acoustid_fingerprints.setText(_("Ignore existing AcoustID fingerprints"))
+        self.save_acoustid_fingerprints.setText(_("Save AcoustID fingerprints to file tags"))
         self.label.setText(_("Fingerprint calculator:"))
         self.acoustid_fpcalc_browse.setText(_("Browse..."))
         self.acoustid_fpcalc_download.setText(_("Download..."))
         self.label_2.setText(_("API key:"))
         self.acoustid_apikey_get.setText(_("Get API key..."))
-

--- a/ui/options_fingerprinting.ui
+++ b/ui/options_fingerprinting.ui
@@ -51,6 +51,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="save_acoustid_fingerprints">
+        <property name="text">
+         <string>Save AcoustID fingerprints to file tags</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Fingerprint calculator:</string>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2279
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard supports reading existing fingerprints from the `acoustid_fingerprint` tag, but it has no option to save calculated fingerprints there.

While usually this was considered to be not needed, as the fingerprint can always be calculated again from the audio and can add rather long data to the file, there are some use cases and some users using this. E.g. one user on the forums described a workflow where they add this tag directly after ripping to avoid having to redo the calculation later on.

See e.g. also discussions on the forums like https://community.metabrainz.org/t/picard-2-3-option-to-generate-fingerprints-automatically-to-submit-it/464069/5

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add an option for saving the fingerprint to `acoustid_fingerprint`, but keep it disabled by default.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
