### PR TITLE
PICARD-2189: Add appdirs module to fix getting proper cache location

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -34,28 +34,20 @@
 
 import builtins
 from collections import OrderedDict
-import os
 
-from PyQt5.QtCore import QStandardPaths
-
-from picard import (
-    PICARD_APP_NAME,
-    PICARD_ORG_NAME,
-    PICARD_VERSION,
-)
+from picard import PICARD_VERSION
 from picard.const.attributes import MB_ATTRIBUTES
+from picard.const import appdirs
 
 # Install gettext "noop" function in case const.py gets imported directly.
 builtins.__dict__['N_'] = lambda a: a
 
 
 # Config directory
-_appconfiglocation = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)
-USER_DIR = os.path.normpath(os.path.join(_appconfiglocation, PICARD_ORG_NAME, PICARD_APP_NAME))
-USER_PLUGIN_DIR = os.path.normpath(os.path.join(USER_DIR, "plugins"))
+USER_DIR = appdirs.config_folder()
+USER_PLUGIN_DIR = appdirs.plugin_folder()
 
 # Network Cache default settings
-CACHE_DIR = os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.CacheLocation))
 CACHE_SIZE_IN_BYTES = 100*1000*1000
 
 # AcousticBrainz

--- a/picard/const/appdirs.py
+++ b/picard/const/appdirs.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import os.path
+
+from PyQt5.QtCore import (
+    QCoreApplication,
+    QStandardPaths,
+)
+
+from picard import (
+    PICARD_APP_NAME,
+    PICARD_ORG_NAME,
+)
+
+
+# Ensure the application is properly configured for the paths to work
+QCoreApplication.setApplicationName(PICARD_APP_NAME)
+QCoreApplication.setOrganizationName(PICARD_ORG_NAME)
+
+
+def config_folder():
+    return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation))
+
+
+def cache_folder():
+    return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.CacheLocation))
+
+
+def plugin_folder():
+    # FIXME: This really should be in QStandardPaths.AppDataLocation instead,
+    # but this is a breaking change that requires data migration
+    return os.path.normpath(os.path.join(config_folder(), 'plugins'))

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -56,8 +56,8 @@ from picard import (
 )
 from picard.config import get_config
 from picard.const import (
-    CACHE_DIR,
     CACHE_SIZE_IN_BYTES,
+    appdirs,
 )
 from picard.oauth import OAuthManager
 from picard.util import (
@@ -324,7 +324,7 @@ class WebService(QtCore.QObject):
         if cache_size_in_bytes is None:
             cache_size_in_bytes = CACHE_SIZE_IN_BYTES
         cache = QtNetwork.QNetworkDiskCache()
-        cache.setCacheDirectory(os.path.join(CACHE_DIR, 'network'))
+        cache.setCacheDirectory(os.path.join(appdirs.cache_folder(), 'network'))
         cache.setMaximumCacheSize(cache_size_in_bytes)
         self.manager.setCache(cache)
         log.debug("NetworkDiskCache dir: %r current size: %s max size: %s",

--- a/scripts/pyinstaller/portable-hook.py
+++ b/scripts/pyinstaller/portable-hook.py
@@ -28,6 +28,7 @@ from picard import (
     PICARD_ORG_NAME,
 )
 import picard.const
+import picard.const.appdirs
 
 
 # The portable version stores all data in a folder beside the executable
@@ -41,9 +42,13 @@ if '--config-file' not in sys.argv and '-c' not in sys.argv:
     sys.argv.append(os.path.join(basedir, 'Config.ini'))
 
 # Setup plugin folder
-picard.const.USER_PLUGIN_DIR = os.path.normpath(os.path.join(basedir, 'Plugins'))
+plugindir = os.path.normpath(os.path.join(basedir, 'Plugins'))
+picard.const.USER_PLUGIN_DIR = plugindir
 
 # Set standard cache location
 cachedir = os.path.normpath(os.path.join(basedir, 'Cache'))
 os.makedirs(cachedir, exist_ok=True)
-picard.const.CACHE_DIR = cachedir
+
+picard.const.appdirs.config_folder = lambda: basedir
+picard.const.appdirs.cache_folder = lambda: cachedir
+picard.const.appdirs.plugin_folder = lambda: plugindir

--- a/test/test_const_appdirs.py
+++ b/test/test_const_appdirs.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import os.path
+import unittest
+
+from test.picardtestcase import PicardTestCase
+
+from picard.const.appdirs import (
+    cache_folder,
+    config_folder,
+    plugin_folder,
+)
+from picard.const.sys import (
+    IS_LINUX,
+    IS_MACOS,
+    IS_WIN,
+)
+
+
+class AppPathsTest(PicardTestCase):
+    def assert_home_path_equals(self, expected, actual):
+        self.assertEqual(os.path.normpath(os.path.expanduser(expected)), actual)
+
+    @unittest.skipUnless(IS_WIN, "Windows test")
+    def test_config_folder_win(self):
+        self.assert_home_path_equals('~/AppData/Local/MusicBrainz/Picard', config_folder())
+
+    @unittest.skipUnless(IS_MACOS, "macOS test")
+    def test_config_folder_macos(self):
+        self.assert_home_path_equals('~/Library/Preferences/MusicBrainz/Picard', config_folder())
+
+    @unittest.skipUnless(IS_LINUX, "Linux test")
+    def test_config_folder_linux(self):
+        self.assert_home_path_equals('~/.config/MusicBrainz/Picard', config_folder())
+
+    @unittest.skipUnless(IS_WIN, "Windows test")
+    def test_cache_folder_win(self):
+        self.assert_home_path_equals('~/AppData/Local/MusicBrainz/Picard/cache', cache_folder())
+
+    @unittest.skipUnless(IS_MACOS, "macOS test")
+    def test_cache_folder_macos(self):
+        self.assert_home_path_equals('~/Library/Caches/MusicBrainz/Picard', cache_folder())
+
+    @unittest.skipUnless(IS_LINUX, "Linux test")
+    def test_cache_folder_linux(self):
+        self.assert_home_path_equals('~/.cache/MusicBrainz/Picard', cache_folder())
+
+    @unittest.skipUnless(IS_WIN, "Windows test")
+    def test_plugin_folder_win(self):
+        self.assert_home_path_equals('~/AppData/Local/MusicBrainz/Picard/plugins', plugin_folder())
+
+    @unittest.skipUnless(IS_MACOS, "macOS test")
+    def test_plugin_folder_macos(self):
+        self.assert_home_path_equals('~/Library/Preferences/MusicBrainz/Picard/plugins', plugin_folder())
+
+    @unittest.skipUnless(IS_LINUX, "Linux test")
+    def test_plugin_folder_linux(self):
+        self.assert_home_path_equals('~/.config/MusicBrainz/Picard/plugins', plugin_folder())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2189
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The cache location previously was wrong because it was created before app and org name had been set. The new module fixes this and allows more flexible replacement of the implementation.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
- Fix cache location by ensuring `QCoreApplication.setApplicationName` and `QCoreApplication.setOrganizationName` get called before QStandardLocations are being used
- Introduce an new `picard.const.appdirs` module, to centralize the place where we deal with these directories. This makes it easier to test and to exchange the implementation in the future.
- Added platform specific tests, this will allow us to change implementation 

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
At it's core this PR only deals with fixing the cache location. But there are some inconsistencies in the way we use the paths, depending on platform. I think this PR makes it easier to address these in the future.

- On macOS the config file is stored at `~/.config/MusicBrainz`. Instead it should be placed in ` ~/Library/Preferences/MusicBrainz/Picard`. This needs a migration. I think this best is addressed when implementing PICARD-2227
- Likewise on Linux: We have both `~/.config/MusicBrainz/Picard.ini` and a `~/.config/MusicBrainz/Picard` folder. I think we should be consistent and place the configuration inside that Picard subfolder when doing PICARD-2227
- On Linux plugins are placed in the config folder at `~/.config/MusicBrainz/Picard/plugins`. Better would be to place the plugins folder in `QStandardPaths.AppDataLocation`, which would resolve to `.local/share/MusicBrainz/Picard/plugins`. We could address this by declaring the new folder the plugin folder, but still use the old path as legacy (as our plugin system supports using multiple paths). Should be investigated for other OS as well. PICARD-522