### PR TITLE
PICARD-2236: Fullwidth slash is treated as directory separator

### DIFF
--- a/test/test_textencoding.py
+++ b/test/test_textencoding.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2015, 2018, 2020 Laurent Monin
 # Copyright (C) 2017 Ville Skyttä
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2019, 2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -138,6 +138,9 @@ class CompatibilityTest(PicardTestCase):
         self.assertEqual(util.textencoding.unicode_simplify_compatibility(combinations_from), combinations_from)
         self.assertEqual(util.textencoding.unicode_simplify_compatibility(ascii_chars), ascii_chars)
 
+    def test_pathsave(self):
+        self.assertEqual(util.textencoding.unicode_simplify_compatibility('\uff0f', pathsave=True), '_')
+
     def test_incorrect(self):
         pass
 
@@ -225,13 +228,14 @@ class ReplaceNonAsciiTest(PicardTestCase):
         self.assertEqual(util.textencoding.replace_non_ascii("⑴⑵⑶"), "(1)(2)(3)")  # Parenthesised numbers
         self.assertEqual(util.textencoding.replace_non_ascii("⒈ ⒉ ⒊"), "1. 2. 3.")  # Digit full stop
         self.assertEqual(util.textencoding.replace_non_ascii("１２３"), "123")  # Fullwidth digits
+        self.assertEqual(util.textencoding.replace_non_ascii("\u2216\u2044\u2215\uff0f"), "\\///")  # Slashes
 
     def test_pathsave(self):
-        expected = '__/8 1_2\\' if IS_WIN else '\\_/8 1_2\\'
-        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044/8½\\', pathsave=True), expected)
+        expected = '____/8 1_2\\' if IS_WIN else '\\___/8 1_2\\'
+        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044\u2215\uff0f/8½\\', pathsave=True), expected)
 
     def test_win_compat(self):
-        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044/8½\\', pathsave=True, win_compat=True), '__/8 1_2\\')
+        self.assertEqual(util.textencoding.replace_non_ascii('\u2216\u2044\u2215\uff0f/8½\\', pathsave=True, win_compat=True), '____/8 1_2\\')
 
     def test_incorrect(self):
         self.assertNotEqual(util.textencoding.replace_non_ascii("Lukáš"), "Lukáš")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2236
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

A full width slash U+FF0F, e.g. in イニシエノウタ／デボル, in combination with replace non-ascii gets turned into an ASCII slash, leading to a directory being created.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Have `unicode_simplify_compatibility` honor the pathsave and win_compat settings.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
