### PR TITLE
PICARD-2261: Do not strip whitespace from file tags

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -198,14 +198,15 @@ class Track(DataObject, FileListItem):
             self.tagger.window.refresh_metadatabox()
 
     @staticmethod
-    def run_scripts(metadata):
+    def run_scripts(metadata, strip_whitespace=False):
         for s_name, s_text in enabled_tagger_scripts_texts():
             parser = ScriptParser()
             try:
                 parser.eval(s_text, metadata)
             except ScriptError:
                 log.exception("Failed to run tagger script %s on track", s_name)
-            metadata.strip_whitespace()
+            if strip_whitespace:
+                metadata.strip_whitespace()
 
     def update(self):
         if self.item:
@@ -416,7 +417,7 @@ class NonAlbumTrack(Track):
         self._customize_metadata()
         run_track_metadata_processors(self.album, m, recording)
         self.orig_metadata.copy(m)
-        self.run_scripts(m)
+        self.run_scripts(m, strip_whitespace=True)
         self.loaded = True
         self.status = None
         if self.callback:


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2261
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Fixes e.g. breaking tags with ending newlines, like e.g. some iTunes specific tags like `itunnorm`.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Do not run `Metadata.strip_whitespace` after applying scripts to tags.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
I am actually not sure if there is a need to run this at all. I kept the stripping when applying the scripts to the track metadata, because this is also done in https://github.com/metabrainz/picard/blob/master/picard/album.py#L383-L398 . But I'm not sure if this really is something that should be done.

It also means my change might cause slightly different results when scripts get applied to files, and this might cause differences in scripts having unintentional additional whitespace. It might even mean that in case of multiple scripts a follow up script does not behave as expected, as it might expect the tag without that additional whitespace.

The IMHO only clean solution to this would be to either do no whitespace stripping at all, or only for those tags actually modified by the script.

Originally there was whitespace trimming added in https://github.com/metabrainz/picard/commit/c165b10b4b913be64de0fb0cb295b9bf68f21974
and removed again for files only in https://github.com/metabrainz/picard/commit/c31c37fff3da2397e068e2b8b8b572dfe1e4a8ab , because it was causing issues like this.