### PR TITLE
PICARD-2199: Fix saving ratings to ID3 with non-latin1 characters in email

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -473,10 +473,10 @@ class ID3File(File):
             elif name == 'musicbrainz_recordingid':
                 tags.add(id3.UFID(owner='http://musicbrainz.org', data=bytes(values[0], 'ascii')))
             elif name == '~rating':
-                rating_email = id3text(config.setting['rating_user_email'], 0)
+                rating_user_email = id3text(config.setting['rating_user_email'], 0)
                 # Search for an existing POPM frame to get the current playcount
                 for frame in tags.values():
-                    if frame.FrameID == 'POPM' and frame.email == rating_email:
+                    if frame.FrameID == 'POPM' and frame.email == rating_user_email:
                         count = getattr(frame, 'count', 0)
                         break
                 else:
@@ -484,7 +484,7 @@ class ID3File(File):
 
                 # Convert rating to range between 0 and 255
                 rating = int(round(float(values[0]) * 255 / (config.setting['rating_steps'] - 1)))
-                tags.add(id3.POPM(email=rating_email, rating=rating, count=count))
+                tags.add(id3.POPM(email=rating_user_email, rating=rating, count=count))
             elif name == 'grouping':
                 if config.setting['itunes_compatible_grouping']:
                     tags.add(id3.GRP1(encoding=encoding, text=values))
@@ -597,9 +597,9 @@ class ID3File(File):
                     tags.delall(real_name)
                     tags.delall('TXXX:' + self.__rtranslate_freetext[name])
                 elif real_name == 'POPM':
-                    user_email = id3text(config.setting['rating_user_email'], 0)
+                    rating_user_email = id3text(config.setting['rating_user_email'], 0)
                     for key, frame in list(tags.items()):
-                        if frame.FrameID == 'POPM' and frame.email == user_email:
+                        if frame.FrameID == 'POPM' and frame.email == rating_user_email:
                             del tags[key]
                 elif real_name in self.__translate:
                     tags.delall(real_name)

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -541,6 +541,15 @@ class CommonId3Tests:
             loaded_metadata = save_and_load_metadata(self.filename, metadata)
             self.assertNotIn('website', loaded_metadata)
 
+        @skipUnlessTestfile
+        def test_rating_email_non_latin1(self):
+            for rating in range(6):
+                config.setting['rating_user_email'] = 'foo€'
+                rating = '3'
+                metadata = Metadata({'~rating': rating})
+                loaded_metadata = save_and_load_metadata(self.filename, metadata)
+                self.assertEqual(loaded_metadata['~rating'], rating, '~rating: %r != %r' % (loaded_metadata['~rating'], rating))
+
 
 class MP3Test(CommonId3Tests.Id3TestCase):
     testfile = 'test.mp3'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2199
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
If you configure Options > Metadata > Ratings > E-mail to include characters that cannot be encoded as latin-1 saving a file triggers an exception.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Use `id3text` helper function to ensure data stored in the file is encodable in latin1.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
