### PR TITLE
When serializing naming scripts to dict save description as text

### DIFF
--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -189,6 +189,7 @@ class PicardScript():
             dict: Dictionary of the object's OUTPUT_FIELDS
         """
         items = {key: getattr(self, key) for key in self.OUTPUT_FIELDS}
+        items["description"] = str(items["description"])
         items["script"] = str(items["script"])
         return items
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
When Scripts get saved to config the script description was a serialized `picard.script.serializer.MultilineLiteral` instead of a Python string.

# Solution
When serializing naming scripts to dict save description as text.
This avoid deserialization issues should older Picard versions try to read the config file.
