### PR TITLE
PICARD-2294: handle local cover art regex not having a group

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -84,16 +84,18 @@ class CoverArtProviderLocal(CoverArtProvider):
 
     def queue_images(self):
         config = get_config()
-        _match_re = re.compile(config.setting['local_cover_regex'], re.IGNORECASE)
-        dirs_done = set()
+        regex = config.setting['local_cover_regex']
+        if regex:
+            _match_re = re.compile(regex, re.IGNORECASE)
+            dirs_done = set()
 
-        for file in self.album.iterfiles():
-            current_dir = os.path.dirname(file.filename)
-            if current_dir in dirs_done:
-                continue
-            dirs_done.add(current_dir)
-            for image in self.find_local_images(current_dir, _match_re):
-                self.queue_put(image)
+            for file in self.album.iterfiles():
+                current_dir = os.path.dirname(file.filename)
+                if current_dir in dirs_done:
+                    continue
+                dirs_done.add(current_dir)
+                for image in self.find_local_images(current_dir, _match_re):
+                    self.queue_put(image)
         return CoverArtProvider.FINISHED
 
     def get_types(self, string):


### PR DESCRIPTION
When there's no group in the regex, just use default type ('front'), do not raise an exception.
Code was made cleaner in the process.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

If local file cover art regex was defined without a group (like default `(.*)`), an exception IndexError was raised.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket: PICARD-2294
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Handle this case, defaulting to 'front' type if no group exists
Code cleanup.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
