### PR TITLE
PICARD-2307: Fix ValueError for Vorbis when deleting invalid tags

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -323,7 +323,7 @@ class VCommentFile(File):
         """Remove the tags from the file that were deleted in the UI"""
         for tag in metadata.deleted_tags:
             real_name = self._get_tag_name(tag)
-            if real_name and real_name in tags:
+            if is_valid_key(real_name) and real_name in tags:
                 if real_name in ('performer', 'comment'):
                     parts = tag.split(':', 1)
                     if len(parts) == 2:

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -184,6 +184,15 @@ class CommonVorbisTests:
             self.assertNotIn('tracktotal', loaded_metadata)
             self.assertNotIn('totaltracks', loaded_metadata)
 
+        @skipUnlessTestfile
+        def test_delete_invalid_tagname(self):
+            # Deleting tags that are not valid Vorbis tag names must not trigger
+            # an error
+            for invalid_tag in INVALID_KEYS:
+                metadata = Metadata()
+                del metadata[invalid_tag]
+                save_metadata(self.filename, metadata)
+
 
 class FLACTest(CommonVorbisTests.VorbisTestCase):
     testfile = 'test.flac'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2307
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Deleting a tag with a tag name that is not valid in Vorbis comments raised a `ValueError` in mutagen. This can e.g. be done with `$delete(täg)` or similar.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Check for valid keys when deleting. Ignore the deletion if the tagname is not a valid key.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
