### PR TITLE
PICARD-2314: Fix ~length getting written to MP4 ----:com.apple.iTunes:~length

### DIFF
--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -285,6 +285,7 @@ class APEv2File(File):
     @classmethod
     def supports_tag(cls, name):
         return (bool(name) and name not in UNSUPPORTED_TAGS
+                and not name.startswith('~')
                 and (is_valid_key(name)
                     or name.startswith('comment:')
                     or name.startswith('lyrics:')

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -313,7 +313,7 @@ class ASFFile(File):
     def supports_tag(cls, name):
         return (name in cls.__TRANS
                 or name in cls.__TRANS_CI
-                or name in ('~rating', '~length', 'totaldiscs')
+                or name in ('~rating', 'totaldiscs')
                 or name.startswith('lyrics:'))
 
     def _get_tag_name(self, name):

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -637,7 +637,7 @@ class ID3File(File):
     def supports_tag(cls, name):
         unsupported_tags = ['r128_album_gain', 'r128_track_gain']
         return ((name and not name.startswith("~") and name not in unsupported_tags)
-                or name in ("~rating", "~length")
+                or name == "~rating"
                 or name.startswith("~id3"))
 
     def _get_tag_name(self, name):

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -342,13 +342,12 @@ class MP4File(File):
     @classmethod
     def supports_tag(cls, name):
         unsupported_tags = ['r128_album_gain', 'r128_track_gain']
-        return ((name
-                 and not name.startswith("~")
-                 and name not in unsupported_tags
-                 and not (name.startswith('comment:') and len(name) > 9)
-                 and not name.startswith('performer:')
-                 and _is_valid_key(name))
-                or name in ('~length'))
+        return (name
+                and not name.startswith("~")
+                and name not in unsupported_tags
+                and not (name.startswith('comment:') and len(name) > 9)
+                and not name.startswith('performer:')
+                and _is_valid_key(name))
 
     def _get_tag_name(self, name):
         if name.startswith('lyrics:'):

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -29,6 +29,7 @@ import mutagen
 from test.picardtestcase import PicardTestCase
 
 from picard import config
+from picard.file import FILE_INFO_TAGS
 import picard.formats
 from picard.formats import ext_to_format
 from picard.formats.mutagenext.aac import AACAPEv2
@@ -308,6 +309,11 @@ class CommonTests:
         @skipUnlessTestfile
         def test_unsupported_tags(self):
             self._test_unsupported_tags(self.unsupported_tags)
+
+        @skipUnlessTestfile
+        def test_unsupported_tags_info_tags(self):
+            for tag in FILE_INFO_TAGS:
+                self.assertFalse(self.format.supports_tag(tag), 'Tag "%s" must not be supported' % tag)
 
         @skipUnlessTestfile
         def test_preserve_unchanged_tags(self):

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -55,7 +55,6 @@ class CommonAsfTests:
             self.assertTrue(fmt.supports_tag('djmixer'))
             self.assertTrue(fmt.supports_tag('discnumber'))
             self.assertTrue(fmt.supports_tag('lyrics:lead'))
-            self.assertTrue(fmt.supports_tag('~length'))
             for tag in self.replaygain_tags.keys():
                 self.assertTrue(fmt.supports_tag(tag))
 

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -50,7 +50,6 @@ class CommonMP4Tests:
             self.assertTrue(fmt.supports_tag('djmixer'))
             self.assertTrue(fmt.supports_tag('discnumber'))
             self.assertTrue(fmt.supports_tag('lyrics:lead'))
-            self.assertTrue(fmt.supports_tag('~length'))
             self.assertTrue(fmt.supports_tag('Custom'))
             self.assertTrue(fmt.supports_tag('äöüéß\0'))  # Latin 1 is supported
             self.assertFalse(fmt.supports_tag('Б'))  # Unsupported custom tags


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2314
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Those values are taken from technical format information and are not part of the tags. This also fixes ~length getting written to MP4 as `----:com.apple.iTunes:~length` (PICARD-2314).

# Solution
Having `supports_tag(~length)` return True should never be the case, as this is not considered a proper metadata tag. This was originally added in https://github.com/metabrainz/picard/commit/c39384c7074e5e66483c8b905f29ec87abd2a6d6, to address a regression where the Length field did not show up in the metadatabox. But this is no longer necessary, the metadatabox deals with length separately.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
