### PR TITLE
PICARD-2321: Fix keep coverart for tracks and display of cover art changes for albums

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -408,6 +408,7 @@ class Album(DataObject, Item):
             self.status = None
             self.match_files(unmatched_files + self.unmatched_files.files)
             self.enable_update_metadata_images(True)
+            self.update_metadata_images()
             self.update()
             self.tagger.window.set_statusbar_message(
                 N_('Album %(id)s loaded: %(artist)s - %(album)s'),

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -377,11 +377,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
         metadata = self.item.metadata
         orig_metadata = None
-        if isinstance(self.item, Track):
-            track = self.item
-            if track.num_linked_files == 1:
-                orig_metadata = track.files[0].orig_metadata
-        elif hasattr(self.item, 'orig_metadata'):
+        if hasattr(self.item, 'orig_metadata'):
             orig_metadata = self.item.orig_metadata
 
         if not metadata or not metadata.images:

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2017 Sambhav Kothari
-# Copyright (C) 2018, 2020 Philipp Wolfer
+# Copyright (C) 2018, 2020-2021 Philipp Wolfer
 # Copyright (C) 2019-2020 Laurent Monin
 # Copyright (C) 2021 Gabriel Ferreira
 #
@@ -166,8 +166,7 @@ def _update_state(obj, state):
 # TODO: use functools.singledispatch when py3 is supported
 def _get_state(obj):
     from picard.album import Album
-    from picard.cluster import FileList
-    from picard.track import Track
+    from picard.ui.item import FileListItem
 
     state = ImageListState()
 
@@ -178,10 +177,7 @@ def _get_state(obj):
         state.sources += obj.unmatched_files.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
-    elif isinstance(obj, Track):
-        state.sources = obj.files
-        state.update_orig_metadata = True
-    elif isinstance(obj, FileList):
+    elif isinstance(obj, FileListItem):
         state.sources = obj.files
         state.update_new_metadata = True
         state.update_orig_metadata = True
@@ -278,7 +274,7 @@ def _remove_images(metadata, sources, removed_images):
         previous_images = set(source_metadata.images)  # Remember for next iteration
         removed_images = removed_images.difference(source_images)
         if not removed_images and not common_images:
-            return  # No images left to remove, abort immediatelly
+            return  # No images left to remove, abort immediately
 
     metadata.images = ImageList(current_images.difference(removed_images))
     metadata.has_common_images = common_images

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -216,7 +216,7 @@ def update_metadata_images(obj):
 
 def _add_images(metadata, added_images):
     if not added_images:
-        return
+        return False
 
     current_images = set(metadata.images)
     if added_images.isdisjoint(current_images):

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -219,9 +219,12 @@ def _add_images(metadata, added_images):
         return
 
     current_images = set(metadata.images)
-    if added_images != current_images:
+    if added_images.isdisjoint(current_images):
         metadata.images = ImageList(current_images.union(added_images))
         metadata.has_common_images = False
+        return True
+
+    return False
 
 
 def add_metadata_images(obj, added_sources):
@@ -233,11 +236,14 @@ def add_metadata_images(obj, added_sources):
     """
     state = _get_state(obj)
     (added_new_images, added_orig_images) = _get_metadata_images(state, added_sources)
+    changed = False
 
     if state.update_new_metadata:
-        _add_images(obj.metadata, added_new_images)
+        changed |= _add_images(obj.metadata, added_new_images)
     if state.update_orig_metadata:
-        _add_images(obj.orig_metadata, added_orig_images)
+        changed |= _add_images(obj.orig_metadata, added_orig_images)
+
+    return changed
 
 
 def _remove_images(metadata, sources, removed_images):

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2019, 2021 Philipp Wolfer
 # Copyright (C) 2018-2019 Wieland Hoffmann
 # Copyright (C) 2018-2020 Laurent Monin
 #
@@ -239,9 +239,18 @@ class AddMetadataImagesTest(PicardTestCase):
         cluster.files = [self.test_files[0]]
         update_metadata_images(cluster)
         cluster.files += self.test_files[1:]
-        add_metadata_images(cluster, self.test_files[1:])
+        added = add_metadata_images(cluster, self.test_files[1:])
+        self.assertTrue(added)
         self.assertEqual(set(self.test_images), set(cluster.metadata.images))
         self.assertFalse(cluster.metadata.has_common_images)
+
+    def test_add_no_changes(self):
+        cluster = Cluster('Test')
+        cluster.files = self.test_files
+        update_metadata_images(cluster)
+        added = add_metadata_images(cluster, [self.test_files[1]])
+        self.assertFalse(added)
+        self.assertEqual(set(self.test_images), set(cluster.metadata.images))
 
 
 class ImageListTest(PicardTestCase):

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -252,6 +252,13 @@ class AddMetadataImagesTest(PicardTestCase):
         self.assertFalse(added)
         self.assertEqual(set(self.test_images), set(cluster.metadata.images))
 
+    def test_add_nothing(self):
+        cluster = Cluster('Test')
+        cluster.files = self.test_files
+        update_metadata_images(cluster)
+        added = add_metadata_images(cluster, [])
+        self.assertFalse(added)
+
 
 class ImageListTest(PicardTestCase):
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2321, PICARD-2322
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

- On tracks with attached files cover art changes are not reset in cover art box when using "Keep original cover art"
- An album loaded with already matched files does not indicate cover art changes correctly


# Solution
- Fix updating tracks in d6435a894135db779e2b56a026a6623b0b690ef2 by remembering the original cover art for a file. This was important to not regress on the fix from 1cb8c77d6ed4737e34bdbeec48581d687531afe8 (after removing all files a track had no cover art attached anymore).
- Albums update their cover art after matching all files (5d2bde5b7a16638af454a23a66fd1c230d81d4fa)
- A small optimization of `imagelist.add_metadata_images` in d4ad11addf8806c18ed6041f27b80aaaf2cc3a8a to only construct a new `ImageList`  if the newly added images are not already present.
