### PR TITLE
PICARD-2324: Fix renaming of WavPack correction files

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -353,8 +353,7 @@ class File(QtCore.QObject, Item):
         if config.setting["rename_files"] or config.setting["move_files"]:
             new_filename = self._rename(old_filename, metadata, config.setting)
         # Move extra files (images, playlists, etc.)
-        if config.setting["move_files"] and config.setting["move_additional_files"]:
-            self._move_additional_files(old_filename, new_filename)
+        self._move_additional_files(old_filename, new_filename)
         # Delete empty directories
         if config.setting["delete_empty_dirs"]:
             dirname = os.path.dirname(old_filename)
@@ -554,6 +553,8 @@ class File(QtCore.QObject, Item):
             # skip, same directory, nothing to move
             return
         config = get_config()
+        if not config.setting["move_files"] or not config.setting["move_additional_files"]:
+            return
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()
         for pattern in patterns.split():

--- a/picard/file.py
+++ b/picard/file.py
@@ -353,7 +353,7 @@ class File(QtCore.QObject, Item):
         if config.setting["rename_files"] or config.setting["move_files"]:
             new_filename = self._rename(old_filename, metadata, config.setting)
         # Move extra files (images, playlists, etc.)
-        self._move_additional_files(old_filename, new_filename)
+        self._move_additional_files(old_filename, new_filename, config)
         # Delete empty directories
         if config.setting["delete_empty_dirs"]:
             dirname = os.path.dirname(old_filename)
@@ -545,15 +545,14 @@ class File(QtCore.QObject, Item):
         for image in images:
             image.save(dirname, metadata, counters)
 
-    def _move_additional_files(self, old_filename, new_filename):
+    def _move_additional_files(self, old_filename, new_filename, config):
         """Move extra files, like images, playlists..."""
+        if not config.setting["move_files"] or not config.setting["move_additional_files"]:
+            return
         new_path = os.path.dirname(new_filename)
         old_path = os.path.dirname(old_filename)
         if new_path == old_path:
             # skip, same directory, nothing to move
-            return
-        config = get_config()
-        if not config.setting["move_files"] or not config.setting["move_additional_files"]:
             return
         patterns = config.setting["move_additional_files_pattern"]
         pattern_regexes = set()

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -316,14 +316,19 @@ class WavPackFile(APEv2File):
     NAME = "WavPack"
     _File = mutagen.wavpack.WavPack
 
+    def _move_or_rename_wvc(self, old_filename, new_filename):
+        wvc_filename = replace_extension(old_filename, ".wvc")
+        if not isfile(wvc_filename):
+            return
+        wvc_new_filename = replace_extension(new_filename, ".wvc")
+        wvc_new_filename = get_available_filename(wvc_new_filename, wvc_filename)
+        log.debug('Moving Wavepack correction file %r => %r', wvc_filename, wvc_new_filename)
+        move_ensure_casing(wvc_filename, wvc_new_filename)
+
     def _move_additional_files(self, old_filename, new_filename, config):
         """Includes an additional check for WavPack correction files"""
-        wvc_filename = replace_extension(old_filename, ".wvc")
-        if (config.setting["rename_files"] or config.setting["move_files"]) and isfile(wvc_filename):
-            wvc_new_filename = replace_extension(new_filename, ".wvc")
-            wvc_new_filename = get_available_filename(wvc_new_filename, wvc_filename)
-            log.debug('Moving Wavepack correction file %r => %r', wvc_filename, wvc_new_filename)
-            move_ensure_casing(wvc_filename, wvc_new_filename)
+        if config.setting["rename_files"] or config.setting["move_files"]:
+            self._move_or_rename_wvc(old_filename, new_filename)
         return super()._move_additional_files(old_filename, new_filename, config)
 
 

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -316,16 +316,15 @@ class WavPackFile(APEv2File):
     NAME = "WavPack"
     _File = mutagen.wavpack.WavPack
 
-    def _save_and_rename(self, old_filename, metadata):
+    def _move_additional_files(self, old_filename, new_filename):
         """Includes an additional check for WavPack correction files"""
-        new_filename = super()._save_and_rename(old_filename, metadata)
         wvc_filename = replace_extension(old_filename, ".wvc")
         if isfile(wvc_filename):
             wvc_new_filename = replace_extension(new_filename, ".wvc")
             wvc_new_filename = get_available_filename(wvc_new_filename, wvc_filename)
             log.debug('Moving Wavepack correction file %r => %r', wvc_filename, wvc_new_filename)
             move_ensure_casing(wvc_filename, wvc_new_filename)
-        return new_filename
+        return super()._move_additional_files(old_filename, new_filename)
 
 
 class OptimFROGFile(APEv2File):

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -316,15 +316,15 @@ class WavPackFile(APEv2File):
     NAME = "WavPack"
     _File = mutagen.wavpack.WavPack
 
-    def _move_additional_files(self, old_filename, new_filename):
+    def _move_additional_files(self, old_filename, new_filename, config):
         """Includes an additional check for WavPack correction files"""
         wvc_filename = replace_extension(old_filename, ".wvc")
-        if isfile(wvc_filename):
+        if (config.setting["rename_files"] or config.setting["move_files"]) and isfile(wvc_filename):
             wvc_new_filename = replace_extension(new_filename, ".wvc")
             wvc_new_filename = get_available_filename(wvc_new_filename, wvc_filename)
             log.debug('Moving Wavepack correction file %r => %r', wvc_filename, wvc_new_filename)
             move_ensure_casing(wvc_filename, wvc_new_filename)
-        return super()._move_additional_files(old_filename, new_filename)
+        return super()._move_additional_files(old_filename, new_filename, config)
 
 
 class OptimFROGFile(APEv2File):

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -525,3 +525,18 @@ def get_available_filename(new_path, old_path=None):
         new_path = "%s (%d)%s" % (tmp_filename, i, ext)
         i += 1
     return new_path
+
+
+def replace_extension(filename, new_ext):
+    """Replaces the extension in filename with new_ext.
+
+    If the file has no extension the extension is added.
+
+    Args:
+        filename: A file name
+        new_ext: New file extension
+
+    Returns: filename with replaced file extension
+    """
+    name, ext = os.path.splitext(filename)
+    return name + '.' + new_ext.lstrip('.')

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -201,9 +201,10 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         open(source_file_wvc, 'a').close()
         # Open file and rename it
         f = open_(self.filename)
-        metadata = Metadata({'title': 'renamed_' + os.path.basename(self.filename)})
+        f._copy_loaded_metadata(f._load(self.filename))
+        f.metadata['title'] = 'renamed_' + os.path.basename(self.filename)
         self.assertTrue(os.path.isfile(self.filename))
-        target_file_wv = f._save_and_rename(self.filename, metadata)
+        target_file_wv = f._save_and_rename(self.filename, f.metadata)
         target_file_wvc = target_file_wv + 'c'
         # Register cleanups
         self.addCleanup(os.unlink, target_file_wv)

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -184,8 +184,8 @@ class WavPackTest(CommonApeTests.ApeTestCase):
     }
     unexpected_info = ['~video']
 
-    @skipUnlessTestfile
-    def test_save_wavpack_correction_file(self):
+    def setUp(self):
+        super().setUp()
         config.setting['rename_files'] = True
         config.setting['move_files'] = False
         config.setting['ascii_filenames'] = False
@@ -196,8 +196,9 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         config.setting['save_images_to_files'] = False
         config.setting['file_renaming_scripts'] = {'test_id': {'script': '%title%'}}
         config.setting['selected_file_naming_script_id'] = 'test_id'
+
+    def _save_with_wavpack_correction_file(self, source_file_wvc):
         # Create dummy WavPack correction file
-        source_file_wvc = self.filename + 'c'
         open(source_file_wvc, 'a').close()
         # Open file and rename it
         f = open_(self.filename)
@@ -209,6 +210,26 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         # Register cleanups
         self.addCleanup(os.unlink, target_file_wv)
         self.addCleanup(os.unlink, target_file_wvc)
+        return (target_file_wv, target_file_wvc)
+
+    @skipUnlessTestfile
+    def test_save_wavpack_correction_file(self):
+        source_file_wvc = self.filename + 'c'
+        (target_file_wv, target_file_wvc) = self._save_with_wavpack_correction_file(source_file_wvc)
+        # Check both the WavPack file and the correction file got moved
+        self.assertFalse(os.path.isfile(self.filename))
+        self.assertFalse(os.path.isfile(source_file_wvc))
+        self.assertTrue(os.path.isfile(target_file_wv))
+        self.assertTrue(os.path.isfile(target_file_wvc))
+
+    @skipUnlessTestfile
+    def test_save_wavpack_correction_file_with_move_additional_files(self):
+        config.setting['move_files'] = True
+        config.setting['move_files_to'] = self.mktmpdir()
+        config.setting['move_additional_files'] = True
+        config.setting['move_additional_files_pattern'] = '*.wvc'
+        source_file_wvc = self.filename + 'c'
+        (target_file_wv, target_file_wvc) = self._save_with_wavpack_correction_file(source_file_wvc)
         # Check both the WavPack file and the correction file got moved
         self.assertFalse(os.path.isfile(self.filename))
         self.assertFalse(os.path.isfile(source_file_wvc))

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -99,7 +99,7 @@ class TestFileSystem(PicardTestCase):
 
     def _move_additional_files(self, files):
         f = picard.formats.open_(files['old_mp3'])
-        f._move_additional_files(files['old_mp3'], files['new_mp3'])
+        f._move_additional_files(files['old_mp3'], files['new_mp3'], config)
 
     def _assert_additional_files_moved(self, files):
         self._move_additional_files(files)

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2018 Antonio Larrosa
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2018-2019 Philipp Wolfer
+# Copyright (C) 2018-2019, 2021 Philipp Wolfer
 # Copyright (C) 2018-2020 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -101,42 +101,49 @@ class TestFileSystem(PicardTestCase):
         f = picard.formats.open_(files['old_mp3'])
         f._move_additional_files(files['old_mp3'], files['new_mp3'])
 
+    def _assert_additional_files_moved(self, files):
+        self._move_additional_files(files)
         self._assertFile(files['new_img'])
         self._assertNoFile(files['old_img'])
 
+    def _assert_additional_files_not_moved(self, files):
+        self._move_additional_files(files)
+        self._assertNoFile(files['new_img'])
+        self._assertFile(files['old_img'])
+
     def test_move_additional_files_source_unicode(self):
         files = self._prepare_files(src_rel_path='música')
-
-        self._move_additional_files(files)
+        self._assert_additional_files_moved(files)
 
     def test_move_additional_files_target_unicode(self):
         files = self._prepare_files(tgt_rel_path='música')
-
-        self._move_additional_files(files)
+        self._assert_additional_files_moved(files)
 
     def test_move_additional_files_duplicate_patterns(self):
         files = self._prepare_files()
-
         config.setting['move_additional_files_pattern'] = 'cover.jpg *.jpg'
-
-        self._move_additional_files(files)
+        self._assert_additional_files_moved(files)
 
     def test_move_additional_files_hidden_nopattern(self):
         files = self._prepare_files()
-
         config.setting['move_additional_files_pattern'] = '*.jpg'
-
-        self._move_additional_files(files)
-
+        self._assert_additional_files_moved(files)
         self._assertNoFile(files['new_hidden_img'])
         self._assertFile(files['old_hidden_img'])
 
     def test_move_additional_files_hidden_pattern(self):
         files = self._prepare_files()
-
         config.setting['move_additional_files_pattern'] = '*.jpg .*.jpg'
-
-        self._move_additional_files(files)
-
+        self._assert_additional_files_moved(files)
         self._assertFile(files['new_hidden_img'])
         self._assertNoFile(files['old_hidden_img'])
+
+    def test_move_additional_files_disabled(self):
+        config.setting['move_additional_files'] = False
+        files = self._prepare_files(src_rel_path='música')
+        self._assert_additional_files_not_moved(files)
+
+    def test_move_files_disabled(self):
+        config.setting['move_files'] = False
+        files = self._prepare_files(src_rel_path='música')
+        self._assert_additional_files_not_moved(files)

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -44,6 +44,7 @@ from picard.util.filenaming import (
     make_save_path,
     make_short_filename,
     move_ensure_casing,
+    replace_extension,
     samefile_different_casing,
 )
 
@@ -245,3 +246,11 @@ class GetAvailableFilenameTest(PicardTestCase):
             oldname = self._add_number(filename, expected_number)
             new_filename = get_available_filename(filename, oldname)
             self.assertEqual(self._add_number(filename, expected_number), new_filename)
+
+
+class ReplaceExtensionTest(PicardTestCase):
+
+    def test_replace(self):
+        self.assertEqual('foo/bar.wvc', replace_extension('foo/bar.wv', '.wvc'))
+        self.assertEqual('foo/bar.wvc', replace_extension('foo/bar.wv', 'wvc'))
+        self.assertEqual('foo/bar.wvc', replace_extension('foo/bar', 'wvc'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2324
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Renaming / moving WavPack files is supposed to also rename / move a WavPack correction file (with the same filename, but .wvc extension). This broke with the changes for PICARD-1715 due to https://github.com/phw/picard/commit/bcc81d86eb1cfcbe1f72043feec8d50a9accc1f5#diff-8e9e6145ecc7e912b2d643f5064e6f196d3668bd010ffa6037775232c2aba236R357


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Re-implement renaming the .wvc file by using the actual new filename of the .wv file. This avoids the entire scripting logic to construct the filename, and hence avoids issues with using the `~extension` from metadata. Also avoids issues where a script might cause different naming due to e.g. extension checks.

Also extended the test so it actually fails with the original code.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
