### PR TITLE
PICARD-2328: Fix "arguments did not match any overloaded call" error with Python 3.10

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -329,7 +329,7 @@ def paint_column_icon(painter, rect, icon):
         return
     size = COLUMN_ICON_SIZE
     padding_h = COLUMN_ICON_BORDER
-    padding_v = (rect.height() - size) / 2
+    padding_v = (rect.height() - size) // 2
     target_rect = QtCore.QRect(rect.x() + padding_h, rect.y() + padding_v, size, size)
     painter.drawPixmap(target_rect, icon.pixmap(size, size))
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2328
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This adds another instance of the "arguments did not match any overloaded call" error with Python 3.10, for which we already had fixes in PICARD-2269.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Ensure integer values for 

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
