### PR TITLE
Revert "_match_files(): conversion to list isn't strictly needed"

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -550,7 +550,7 @@ class Album(DataObject, Item):
         SimMatchAlbum = namedtuple('SimMatchAlbum', 'similarity track')
         no_match = SimMatchAlbum(similarity=-1, track=unmatched_files)
 
-        for file in files:
+        for file in list(files):
             if file.state == File.REMOVED:
                 continue
             # if we have a recordingid to match against, use that in priority


### PR DESCRIPTION
This reverts commit 672c2c0733000ee30de0db4c657a1c0b99f68960.

This causes a bug when adding files to album in certain cases

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


![Peek 21-11-2021 15-31](https://user-images.githubusercontent.com/151042/142768918-bb0d6e46-3979-4210-8584-87beb542f1cb.gif)

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
