### PR TITLE
PICARD-2339: Perform file clustering in thread

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -56,14 +56,12 @@ from picard.util import (
     album_artist_from_path,
     find_best_match,
     format_time,
-    process_events_iter,
 )
 from picard.util.imagelist import (
     add_metadata_images,
     remove_metadata_images,
     update_metadata_images,
 )
-from picard.util.progresscheckpoints import ProgressCheckpoints
 
 from picard.ui.item import (
     FileListItem,
@@ -303,12 +301,11 @@ class Cluster(FileList):
             self.lookup_task = None
 
     @staticmethod
-    def cluster(files, tagger=None):
+    def cluster(files):
         """Group the provided files into clusters, based on album tag in metadata.
 
         Args:
             files: List of File objects.
-            tagger: Tagger instance (optional). Only needed for statusbar updates.
 
         Yields:
             FileCluster objects
@@ -316,12 +313,8 @@ class Cluster(FileList):
         cluster_list = defaultdict(FileCluster)
         config = get_config()
         win_compat = config.setting["windows_compatibility"] or IS_WIN
-        num_files = len(files)
 
-        # 10 evenly spaced indexes of files being clustered, used as checkpoints for every 10% progress
-        status_update_steps = ProgressCheckpoints(num_files, 10)
-
-        for i, file in process_events_iter(enumerate(files)):
+        for file in files:
             artist = file.metadata["albumartist"] or file.metadata["artist"]
             album = file.metadata["album"]
 
@@ -332,11 +325,6 @@ class Cluster(FileList):
             else:
                 filename = file.filename
             album, artist = album_artist_from_path(filename, album, artist)
-
-            if tagger and status_update_steps.is_checkpoint(i):
-                statusmsg = N_("Clustering: %(update)d%%")
-                mparams = {'update': status_update_steps.progress(i)}
-                tagger.window.set_statusbar_message(statusmsg, mparams)
 
             token = tokenize(album)
             if not token:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -911,11 +911,24 @@ class Tagger(QtWidgets.QApplication):
             files = list(self.unclustered_files.files)
         else:
             files = self.get_files_from_objects(objs)
+        thread.run_task(
+            partial(self._do_clustering, files),
+            self._clustering_finished)
+
+    def _do_clustering(self, files):
+        # The clustering algorithm should completely run in the thread,
+        # hence do not return the iterator.
+        return list(Cluster.cluster(files))
+
+    def _clustering_finished(self, result=None, error=None):
+        if error:
+            log.error('Error while clustering: %r', error)
+            return
 
         with self.window.ignore_selection_changes:
             self.window.set_sorting(False)
             cluster_files = defaultdict(list)
-            for file_cluster in Cluster.cluster(files, self):
+            for file_cluster in result:
                 cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
                 cluster_files[cluster].extend(file_cluster.files)
             for cluster, files in process_events_iter(cluster_files.items()):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -44,7 +44,6 @@
 
 
 import argparse
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 import logging
@@ -927,12 +926,9 @@ class Tagger(QtWidgets.QApplication):
 
         with self.window.ignore_selection_changes:
             self.window.set_sorting(False)
-            cluster_files = defaultdict(list)
-            for file_cluster in result:
+            for file_cluster in process_events_iter(result):
                 cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
-                cluster_files[cluster].extend(file_cluster.files)
-            for cluster, files in process_events_iter(cluster_files.items()):
-                cluster.add_files(files)
+                cluster.add_files(file_cluster.files)
             self.window.set_sorting(True)
 
     def load_cluster(self, name, artist):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2339
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Further improve on #1963 by moving the call to `Cluster.cluster` into a separate thread. This also removes the need to call `QCoreApplication.processEvents` (by `process_events_iter`)  in between to keep the UI responsive.

The raw execution time of `Cluster.cluster` and turning the result into a list is now again lowered. In my tests on my system it takes ~ 50ms for 4257 files.

In my tests this works well, I did not notice a regression to previous behavior.
