### PR TITLE
Have album_artist_from_path strip the Windows drive letter

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -39,7 +39,6 @@ from collections import (
     Counter,
     defaultdict,
 )
-import ntpath
 from operator import attrgetter
 import re
 
@@ -47,7 +46,6 @@ from PyQt5 import QtCore
 
 from picard.config import get_config
 from picard.const import QUERY_LIMIT
-from picard.const.sys import IS_WIN
 from picard.metadata import (
     Metadata,
     SimMatchRelease,
@@ -312,7 +310,6 @@ class Cluster(FileList):
         """
         cluster_list = defaultdict(FileCluster)
         config = get_config()
-        win_compat = config.setting["windows_compatibility"] or IS_WIN
 
         for file in files:
             artist = file.metadata["albumartist"] or file.metadata["artist"]
@@ -320,11 +317,7 @@ class Cluster(FileList):
 
             # Improve clustering from directory structure if no existing tags
             # Only used for grouping and to provide cluster title / artist - not added to file tags.
-            if win_compat:
-                filename = ntpath.splitdrive(file.filename)[1]
-            else:
-                filename = file.filename
-            album, artist = album_artist_from_path(filename, album, artist)
+            album, artist = album_artist_from_path(file.filename, album, artist)
 
             token = tokenize(album)
             if not token:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -48,6 +48,7 @@ import json
 import ntpath
 from operator import attrgetter
 import os
+from pathlib import PurePath
 import re
 import subprocess  # nosec: B404
 import sys
@@ -552,11 +553,10 @@ def album_artist_from_path(filename, album, artist):
         A tuple (album, artist)
     """
     if not album:
-        if IS_WIN:
-            filename = ntpath.splitdrive(filename)[1]
-        dirs = os.path.dirname(filename).replace('\\', '/').lstrip('/').split('/')
+        path = PurePath(filename)
+        dirs = list(path.relative_to(path.anchor).parent.parts)
         # Strip disc subdirectory from list
-        if re.search(r'\b(?:CD|DVD|Disc)\s*\d+\b', dirs[-1], re.I):
+        if dirs and re.search(r'\b(?:CD|DVD|Disc)\s*\d+\b', dirs[-1], re.I):
             del dirs[-1]
         if dirs:
             # For clustering assume %artist%/%album%/file or %artist% - %album%/file

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -541,9 +541,19 @@ def linear_combination_of_weights(parts):
 
 
 def album_artist_from_path(filename, album, artist):
-    """If album is not set, try to extract album and artist from path
+    """If album is not set, try to extract album and artist from path.
+
+    Args:
+        filename: The full file path
+        album: Default album name
+        artist: Default artist name
+
+    Returns:
+        A tuple (album, artist)
     """
     if not album:
+        if IS_WIN:
+            filename = ntpath.splitdrive(filename)[1]
         dirs = os.path.dirname(filename).replace('\\', '/').lstrip('/').split('/')
         # Strip disc subdirectory from list
         if re.search(r'\b(?:CD|DVD|Disc)\s*\d+\b', dirs[-1], re.I):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

`album_artist_from_path` is called by the clustering, which removes the Windows drive letter from the path to avoid that the drive gets detected as artist or album name.

This functionality should be part of `album_artist_from_path` itself. It also only applies to Windows, not for other systems, even in Windows compatibility mode (see discussion at https://github.com/metabrainz/picard/pull/1963#discussion_r755199555)

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Extend `album_artist_from_path` to use `ntpath.splitdrive` on Windows. Add tests.