### PR TITLE
PICARD-2335: Disallow saving a tagging script with errors

### DIFF
--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -132,6 +132,8 @@ class ScriptingOptionsPage(OptionsPage):
         self.FILE_TYPE_SCRIPT = _("Picard script files") + " (*.pts *.txt)"
         self.FILE_TYPE_PACKAGE = _("Picard tagging script package") + " (*.ptsp *.yaml)"
 
+        self.ui.script_list.signal_reset_selected_item.connect(self.reset_selected_item)
+
     def show_scripting_documentation(self):
         ScriptingDocumentationDialog.show_instance(parent=self)
 
@@ -219,9 +221,15 @@ class ScriptingOptionsPage(OptionsPage):
         try:
             self.check()
         except OptionsCheckError as e:
+            script.has_error = True
             self.ui.script_error.setStyleSheet(self.STYLESHEET_ERROR)
             self.ui.script_error.setText(e.info)
             return
+        script.has_error = False
+
+    def reset_selected_item(self):
+        widget = self.ui.script_list
+        widget.setCurrentRow(widget.bad_row)
 
     def check(self):
         parser = ScriptParser()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add `has_error` attribute to `ScriptListWidgetItem` class.  Check for error when selecting a new script and revert selection if current script has an error.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2335
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If you create a tagging script with an error, clicking "Make It So!" does nothing – it correctly doesn't allow saving the script with the error.  However; if you select a different script that doesn't have an error, "Make It So!" will save the script with the error.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add `has_error` attribute to `ScriptListWidgetItem` class.  Check for error when selecting a new script and revert selection if current script has an error.  This effectively blocks the user from executing "Make It So!" if there is an error in a tagging script.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
None.