### PR TITLE
PICARD-2342: Fix saving MP4 and ASF files with "clear tags" and "preserve images"

### DIFF
--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -265,7 +265,7 @@ class ASFFile(File):
         tags = file.tags
 
         if config.setting['clear_existing_tags']:
-            cover = tags['WM/Picture'] if config.setting['preserve_images'] else None
+            cover = tags.get('WM/Picture') if config.setting['preserve_images'] else None
             tags.clear()
             if cover:
                 tags['WM/Picture'] = cover

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -253,7 +253,7 @@ class MP4File(File):
         tags = file.tags
 
         if config.setting["clear_existing_tags"]:
-            cover = tags['covr'] if config.setting['preserve_images'] else None
+            cover = tags.get('covr') if config.setting['preserve_images'] else None
             tags.clear()
             if cover:
                 tags['covr'] = cover

--- a/test/formats/coverart.py
+++ b/test/formats/coverart.py
@@ -137,6 +137,15 @@ class CommonCoverArtTests:
             metadata = save_and_load_metadata(self.filename, Metadata())
             self.assertEqual(0, len(metadata.images))
 
+        @skipUnlessTestfile
+        def test_cover_art_clear_tags_preserve_images_no_existing_images(self):
+            config.setting['clear_existing_tags'] = True
+            config.setting['preserve_images'] = True
+            image = CoverArtImage(data=self.pngdata, types=['front'])
+            file_save_image(self.filename, image)
+            metadata = load_metadata(self.filename)
+            self.assertEqual(image, metadata.images[0])
+
         def _cover_metadata(self):
             imgdata = self.jpegdata
             metadata = Metadata()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2342
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Saving MP4 or ASF files failed if the files do not have existing embedded cover art and both "clear existing tags" and "keep embedded images when clearing tags" are active.


# Solution
Add a test for this specific case (for all formats) and fix the issue.