### PR TITLE
PICARD-2351: Fix system language detection on Windows

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -44,9 +44,7 @@ if IS_WIN:
     def _init_default_locale():
         try:
             current_locale = locale.windows_locale[windll.kernel32.GetUserDefaultUILanguage()]
-            current_locale += '.' + locale.getpreferredencoding()
-            locale.setlocale(locale.LC_ALL, current_locale)
-            return current_locale
+            return locale.setlocale(locale.LC_ALL, current_locale)
         except KeyError:
             return locale.setlocale(locale.LC_ALL, '')
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2351
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

System language detection for Windows broke in Picard 2.7.0b3 with https://github.com/metabrainz/picard/commit/0816eb61bfac1928611ce3b8c29b23479929560f

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

It turns out that the call to `locale.setlocale(locale.LC_ALL, current_locale)` on Windows did not work most of the time because of the encoding. E.g. on a German Windows 11 the locale we used was `de_DE.cp1252`, but passing this to `locale.setlocale`  raises an `locale.Error`  with "unsupported locale setting".

So let's just set the locale based on the language alone, only `de_DE`.

The reason why language selection worked anyway is because prior to 0816eb61bfac1928611ce3b8c29b23479929560f we set the `de_DE.cp1252` in `os.environ['LANGUAGE']` and `os.environ['LANG']` anyway, and that at least made gettext load the proper language.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
