### PR TITLE
PICARD-2349: Use consistent terminology for "standalone recordings"

### DIFF
--- a/picard/profile.py
+++ b/picard/profile.py
@@ -56,7 +56,7 @@ class UserProfileGroups():
         "title": N_("Metadata"),
         "settings": [
             SettingDesc("va_name", N_("Various Artists name"), ["va_name"]),
-            SettingDesc("nat_name", N_("Non-album tracks name"), ["nat_name"]),
+            SettingDesc("nat_name", N_("Standalone recordings name"), ["nat_name"]),
             SettingDesc("translate_artist_names", N_("Translate artist names"), ["translate_artist_names"]),
             SettingDesc("artist_locales", N_("Translation locales"), ["selected_locales"]),
             SettingDesc("translate_artist_names_script_exception", N_("Translate artist names exception"), ["translate_artist_names_script_exception"]),

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -83,7 +83,7 @@ class MetadataOptionsPage(OptionsPage):
 
     options = [
         TextOption("setting", "va_name", "Various Artists"),
-        TextOption("setting", "nat_name", "[non-album tracks]"),
+        TextOption("setting", "nat_name", "[standalone recordings]"),
         ListOption("setting", "artist_locales", ["en"]),
         BoolOption("setting", "translate_artist_names", False),
         BoolOption("setting", "translate_artist_names_script_exception", False),

--- a/picard/ui/ui_options_metadata.py
+++ b/picard/ui/ui_options_metadata.py
@@ -135,6 +135,6 @@ class Ui_MetadataOptionsPage(object):
         self.guess_tracknumber_and_title.setText(_("Guess track number and title from filename if empty"))
         self.custom_fields_groupbox.setTitle(_("Custom Fields"))
         self.label_6.setText(_("Various artists:"))
-        self.label_7.setText(_("Non-album tracks:"))
+        self.label_7.setText(_("Standalone recordings:"))
         self.nat_name_default.setText(_("Default"))
         self.va_name_default.setText(_("Default"))

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -772,7 +772,7 @@ class ScriptParserTest(PicardTestCase):
     def test_default_NAT_filenaming(self):
         context = Metadata()
         context['artist'] = 'artist'
-        context['album'] = '[non-album tracks]'
+        context['album'] = '[standalone recordings]'
         context['title'] = 'title'
         result = self.parser.eval(DEFAULT_FILE_NAMING_FORMAT, context)
         self.assertEqual(result, 'artist/\n\ntitle')

--- a/ui/options_metadata.ui
+++ b/ui/options_metadata.ui
@@ -167,7 +167,7 @@
       <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="label_7">
         <property name="text">
-         <string>Non-album tracks:</string>
+         <string>Standalone recordings:</string>
         </property>
         <property name="buddy">
          <cstring>nat_name_default</cstring>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Standardize on "Standalone recordings" rather than "Non-album tracks"

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2349
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

For historical reasons Picard uses both the terms "standalone recording" and the older "non-album tracks". We should unify this.

This requires updates to existing translations, even though some translations might end up being unchanged because they maybe already use consistent terms.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Standardize on "Standalone recordings" rather than "Non-album tracks".

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
