### PR TITLE
PICARD-2361: Fix clustering using removed files

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -927,8 +927,10 @@ class Tagger(QtWidgets.QApplication):
         with self.window.ignore_selection_changes:
             self.window.set_sorting(False)
             for file_cluster in process_events_iter(result):
-                cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
-                cluster.add_files(file_cluster.files)
+                files = set(file_cluster.files)
+                if len(files) > 1:
+                    cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
+                    cluster.add_files(files)
             self.window.set_sorting(True)
 
         if callback:

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -73,8 +73,7 @@ class ClusterTest(PicardTestCase):
             self._create_file('album foo', 'artist foo'),
         ]
         clusters = list(Cluster.cluster(files))
-        # No cluster is being created for single files
-        self.assertEqual(0, len(clusters))
+        self.assertEqual(1, len(clusters))
 
     def test_cluster_single_cluster(self):
         files = [
@@ -92,12 +91,13 @@ class ClusterTest(PicardTestCase):
             self._create_file('album cluster2', 'artist foo'),
             self._create_file('album cluster1', 'artist foo'),
             self._create_file('albumcluster2', 'artist bar'),
-            self._create_file('album nocluster', 'artist bar'),
+            self._create_file('album single', 'artist bar'),
         ]
         clusters = list(Cluster.cluster(files))
-        self.assertEqual(2, len(clusters))
+        self.assertEqual(3, len(clusters))
         self.assertClusterEqual('album cluster1', 'artist bar', {files[0], files[2]}, clusters[0])
         self.assertClusterEqual('album cluster2', 'artist foo', {files[1], files[3]}, clusters[1])
+        self.assertClusterEqual('album single', 'artist bar', {files[4]}, clusters[2])
 
     def test_cluster_by_path(self):
         files = [
@@ -105,13 +105,14 @@ class ClusterTest(PicardTestCase):
             self._create_file(None, None, 'album2/foo1.ogg'),
             self._create_file(None, None, 'artist1/album1/foo2.ogg'),
             self._create_file(None, None, 'album2/foo2.ogg'),
-            self._create_file(None, None, 'nocluster/foo.ogg'),
+            self._create_file(None, None, 'single/foo.ogg'),
             self._create_file(None, None, 'album1/foo3.ogg'),
         ]
         clusters = list(Cluster.cluster(files))
-        self.assertEqual(2, len(clusters))
+        self.assertEqual(3, len(clusters))
         self.assertClusterEqual('album1', 'artist1', {files[0], files[2], files[5]}, clusters[0])
         self.assertClusterEqual('album2', 'Diverse Interpreten', {files[1], files[3]}, clusters[1])
+        self.assertClusterEqual('single', 'Diverse Interpreten', {files[4]}, clusters[2])
 
     def test_cluster_no_metadata(self):
         files = [
@@ -143,7 +144,7 @@ class FileClusterTest(PicardTestCase):
         fc.add('album 1', 'artist 1', file)
         self.assertEqual('album 1', fc.title)
         self.assertEqual('artist 1', fc.artist)
-        self.assertEqual([file], fc.files)
+        self.assertEqual([file], list(fc.files))
 
     def test_multi(self):
         files = [
@@ -161,4 +162,4 @@ class FileClusterTest(PicardTestCase):
         fc.add('album 2', 'Artist 1', files[4])
         self.assertEqual('Album 1', fc.title)
         self.assertEqual('Artist 1', fc.artist)
-        self.assertEqual(files, fc.files)
+        self.assertEqual(files, list(fc.files))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2361
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Removing files while clustering can keep those files available, both confusing the file count and general file behavior. See PICARD-2361 for details.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Only use files for clusters if they are not marked as removed. Handle the check if there are valid files into the cluster on the main thread when creating the final cluster for the UI.