### PR TITLE
PICARD-2360: When comparing metadata to a release consider the actual medium track count

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -252,8 +252,15 @@ class Metadata(MutableMapping):
 
         try:
             a = int(self["totaltracks"])
-            b = release['track-count']
-            score = 0.0 if a > b else 0.3 if a < b else 1.0
+            if 'media' in release:
+                scores = []
+                for media in release['media']:
+                    b = media.get('track-count', 0)
+                    scores.append(0.0 if a > b else 0.3 if a < b else 1.0)
+                score = max(scores)
+            else:
+                b = release['track-count']
+                score = 0.0 if a > b else 0.3 if a < b else 1.0
             parts.append((score, weights["totaltracks"]))
         except (ValueError, KeyError):
             pass


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2360
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

tracktotal in a file is supposed to have the total number of tracks on the specific medium. Comparing to the total tracks of a release across all medium hence gives wrong results.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
