### PR TITLE
PICARD-2362: Do not include __pycache__ dirs in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,8 @@ include *.txt
 
 recursive-include test *.py
 recursive-include test/data *
+recursive-exclude test/data/testplugins/module/dummyplugin/__pycache__ *
+recursive-exclude test/data/testplugins/singlefile/__pycache__ *
 
 exclude org.musicbrainz.Picard.appdata.xml
 exclude win-version-info.txt


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2362
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The published sdist contains `__pycache__` directories in test/data. This breaks reproducible builds.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Exclude those __pycache__ directories


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

I'm not totally happy with that solution, as it needs to explicitly define the exact paths to exclude. I found no more generic way with wildcards or similar that would exclude them. The problem seems to be that the `recursive-include test/data *` includes everything regardless, and only explicitly excluding it helped in my testing. Suggestions for more generic fix welcome.