### PR TITLE
PICARD-2363: Fix ID3v2.3 showing as changed after saving

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -189,8 +189,8 @@ class File(QtCore.QObject, Item):
             deleted_tags=metadata.deleted_tags,
             images=metadata.images,
             length=metadata.length)
-        for name, value in metadata.rawitems():
-            copy.set(name, self.format_specific_metadata(metadata, name, settings))
+        for name in metadata:
+            copy[name] = self.format_specific_metadata(metadata, name, settings)
         return copy
 
     def load(self, callback):

--- a/picard/file.py
+++ b/picard/file.py
@@ -292,8 +292,7 @@ class File(QtCore.QObject, Item):
         if preserve_deleted:
             for tag in deleted_tags:
                 del self.metadata[tag]
-        for tag, values in saved_metadata.items():
-            self.metadata[tag] = values
+        self.metadata.update(saved_metadata)
 
         if acoustid and "acoustid_id" not in metadata.deleted_tags:
             self.metadata["acoustid_id"] = acoustid
@@ -415,8 +414,7 @@ class File(QtCore.QObject, Item):
             self.orig_metadata.clear_deleted()
             self.orig_metadata.length = length
             self.orig_metadata['~length'] = format_time(length)
-            for k, v in temp_info.items():
-                self.orig_metadata[k] = v
+            self.orig_metadata.update(temp_info)
             self.clear_errors()
             self.clear_pending(signal=False)
             self._add_path_to_metadata(self.orig_metadata)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2363
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Copying the new metadata over to the original metadata after saving must consider format specific conversions.

This was caused by a5fcde1 as part of PICARD-2174. This PR here actually complements the fix done in #1982.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
When copying new metadata to original metadata after saving apply the format conversions.

I chose this approach as it might avoid some other similar issues, and it matches the behavior before a5fcde1 . The alternative would be to have https://github.com/phw/picard/blob/40b2b76ce7f150321d40bdf8e2051023d97a8a6a/picard/file.py#L689 also use `self.format_specific_metadata()`, but that would add additional calls every time update is being called, something we should avoid. Doing this once on saving, when the values get copied anyway, is more efficient.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
