### PR TITLE
All Item.can_* methods must always return boolean values

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -611,7 +611,7 @@ class Album(DataObject, Item):
         return True
 
     def can_view_info(self):
-        return self.loaded or self.errors
+        return self.loaded or bool(self.errors)
 
     def can_extract(self):
         return any(track.can_extract() for track in self.tracks)

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -213,7 +213,7 @@ class Cluster(FileList):
         return bool(self.files)
 
     def can_submit(self):
-        return not self.special and self.files
+        return not self.special and bool(self.files)
 
     def is_album_like(self):
         return True

--- a/picard/file.py
+++ b/picard/file.py
@@ -732,7 +732,7 @@ class File(QtCore.QObject, Item):
         return (
             isinstance(self.parent, Track)
             and self.is_saved()
-            and self.metadata["musicbrainz_recordingid"]
+            and bool(self.metadata["musicbrainz_recordingid"])
         )
 
     def _info(self, metadata, file):

--- a/picard/track.py
+++ b/picard/track.py
@@ -242,7 +242,7 @@ class Track(DataObject, FileListItem):
         return True
 
     def can_view_info(self):
-        return self.num_linked_files == 1 or self.metadata.images
+        return self.num_linked_files == 1 or bool(self.metadata.images)
 
     def can_extract(self):
         """Return if this object has a linked file with a recordingId, required by the AcousticBrainz feature extractor."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Some of the `Item.can_*()`  implementations did not return boolean value. In combination with #1986 this has become an issue.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
