### PR TITLE
PICARD-2365: Allow PyYAML 6 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyobjc-core~=6.2; sys_platform == 'darwin'
 pyobjc-framework-Cocoa~=6.2; sys_platform == 'darwin'
 PyQt5~=5.10
 pywin32; sys_platform == 'win32'
-pyyaml~=5.1
+pyyaml>=5.1, <7


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2365
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

While PyYAML 6 has bumped major version due to some API changes, this does not affect usage in Picard, and it stays compatible.

This is also required for packaging in the upcoming Fedora 36

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Allow PyYAML 6 in requirements.txt. Keep the versions specified for the mac and win builds, as we should build with same versions for the 2.7.1 release. Just provide more flexibility for packagers.
