### PR TITLE
PICARD-2368: When comparing metadata to a release consider the actual medium track count

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -85,7 +85,7 @@ class FileList(QtCore.QObject, FileListItem):
     def iterfiles(self, save=False):
         yield from self.files
 
-    def update(self):
+    def update(self, signal=True):
         pass
 
     @property
@@ -99,7 +99,7 @@ class Cluster(FileList):
     comparison_weights = {
         'album': 17,
         'albumartist': 6,
-        'totaltracks': 5,
+        'totalalbumtracks': 5,
         'releasetype': 10,
         'releasecountry': 2,
         'format': 2,
@@ -152,7 +152,7 @@ class Cluster(FileList):
                 file.metadata_images_changed.connect(self.update_metadata_images)
         added_files = sorted(added_files, key=attrgetter('discnumber', 'tracknumber', 'base_filename'))
         self.files.extend(added_files)
-        self.metadata['totaltracks'] = len(self.files)
+        self.update(signal=False)
         if self.can_show_coverart:
             add_metadata_images(self, added_files)
         self.item.add_files(added_files)
@@ -166,7 +166,7 @@ class Cluster(FileList):
         self.tagger.window.set_processing(True)
         self.metadata.length -= file.metadata.length
         self.files.remove(file)
-        self.metadata['totaltracks'] = len(self.files)
+        self.update(signal=False)
         self.item.remove_file(file)
         if self.can_show_coverart:
             file.metadata_images_changed.disconnect(self.update_metadata_images)
@@ -177,8 +177,9 @@ class Cluster(FileList):
         if not self.special and self.get_num_files() == 0:
             self.tagger.remove_cluster(self)
 
-    def update(self):
-        if self.item:
+    def update(self, signal=True):
+        self.metadata['~totalalbumtracks'] = self.metadata['totaltracks'] = len(self.files)
+        if signal and self.item:
             self.item.update()
 
     def get_num_files(self):

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -252,8 +252,16 @@ class Metadata(MutableMapping):
 
         try:
             a = int(self["totaltracks"])
-            b = release['track-count']
-            score = 0.0 if a > b else 0.3 if a < b else 1.0
+            if 'media' in release:
+                score = 0.0
+                for media in release['media']:
+                    b = media.get('track-count', 0)
+                    score = max(score, 0.0 if a > b else 0.3 if a < b else 1.0)
+                    if score == 1.0:
+                        break
+            else:
+                b = release['track-count']
+                score = 0.0 if a > b else 0.3 if a < b else 1.0
             parts.append((score, weights["totaltracks"]))
         except (ValueError, KeyError):
             pass

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -145,6 +145,10 @@ def weights_from_preferred_formats(parts, release, preferred_formats, weight):
         parts.append((score, weight))
 
 
+def trackcount_score(actual, expected):
+    return 0.0 if actual > expected else 0.3 if actual < expected else 1.0
+
+
 class Metadata(MutableMapping):
 
     """List of metadata items with dict-like access."""
@@ -241,7 +245,7 @@ class Metadata(MutableMapping):
 
     def compare_to_release_parts(self, release, weights):
         parts = []
-        if "album" in self:
+        if "album" in self and "album" in weights:
             b = release['title']
             parts.append((similarity2(self["album"], b), weights["album"]))
 
@@ -250,66 +254,79 @@ class Metadata(MutableMapping):
             b = artist_credit_from_node(release['artist-credit'])[0]
             parts.append((similarity2(a, b), weights["albumartist"]))
 
-        try:
-            a = int(self["totaltracks"])
-            if 'media' in release:
-                score = 0.0
-                for media in release['media']:
-                    b = media.get('track-count', 0)
-                    score = max(score, 0.0 if a > b else 0.3 if a < b else 1.0)
-                    if score == 1.0:
-                        break
-            else:
+        if "totaltracks" in weights:
+            try:
+                a = int(self["totaltracks"])
+                if 'media' in release:
+                    score = 0.0
+                    for media in release['media']:
+                        b = media.get('track-count', 0)
+                        score = max(score, trackcount_score(a, b))
+                        if score == 1.0:
+                            break
+                else:
+                    b = release['track-count']
+                    score = trackcount_score(a, b)
+                parts.append((score, weights["totaltracks"]))
+            except (ValueError, KeyError):
+                pass
+
+        if "totalalbumtracks" in weights:
+            try:
+                a = int(self["~totalalbumtracks"] or self["totaltracks"])
                 b = release['track-count']
-                score = 0.0 if a > b else 0.3 if a < b else 1.0
-            parts.append((score, weights["totaltracks"]))
-        except (ValueError, KeyError):
-            pass
+                score = trackcount_score(a, b)
+                parts.append((score, weights["totalalbumtracks"]))
+            except (ValueError, KeyError):
+                pass
 
         # Date Logic
         date_match_factor = 0.0
-        if "date" in release and release['date'] != '':
-            release_date = release['date']
-            if "date" in self:
-                metadata_date = self['date']
-                if release_date == metadata_date:
-                    # release has a date and it matches what our metadata had exactly.
-                    date_match_factor = self.__date_match_factors['exact']
+        if "date" in weights:
+            if "date" in release and release['date'] != '':
+                release_date = release['date']
+                if "date" in self:
+                    metadata_date = self['date']
+                    if release_date == metadata_date:
+                        # release has a date and it matches what our metadata had exactly.
+                        date_match_factor = self.__date_match_factors['exact']
+                    else:
+                        release_year = extract_year_from_date(release_date)
+                        if release_year is not None:
+                            metadata_year = extract_year_from_date(metadata_date)
+                            if metadata_year is not None:
+                                if release_year == metadata_year:
+                                    # release has a date and it matches what our metadata had for year exactly.
+                                    date_match_factor = self.__date_match_factors['year']
+                                elif abs(release_year - metadata_year) <= 2:
+                                    # release has a date and it matches what our metadata had closely (year +/- 2).
+                                    date_match_factor = self.__date_match_factors['close_year']
+                                else:
+                                    # release has a date but it does not match ours (all else equal,
+                                    # its better to have an unknown date than a wrong date, since
+                                    # the unknown could actually be correct)
+                                    date_match_factor = self.__date_match_factors['differed']
                 else:
-                    release_year = extract_year_from_date(release_date)
-                    if release_year is not None:
-                        metadata_year = extract_year_from_date(metadata_date)
-                        if metadata_year is not None:
-                            if release_year == metadata_year:
-                                # release has a date and it matches what our metadata had for year exactly.
-                                date_match_factor = self.__date_match_factors['year']
-                            elif abs(release_year - metadata_year) <= 2:
-                                # release has a date and it matches what our metadata had closely (year +/- 2).
-                                date_match_factor = self.__date_match_factors['close_year']
-                            else:
-                                # release has a date but it does not match ours (all else equal,
-                                # its better to have an unknown date than a wrong date, since
-                                # the unknown could actually be correct)
-                                date_match_factor = self.__date_match_factors['differed']
+                    # release has a date but we don't have one (all else equal, we prefer
+                    # tracks that have non-blank date values)
+                    date_match_factor = self.__date_match_factors['exists_vs_null']
             else:
-                # release has a date but we don't have one (all else equal, we prefer
-                # tracks that have non-blank date values)
-                date_match_factor = self.__date_match_factors['exists_vs_null']
-        else:
-            # release has a no date (all else equal, we don't prefer this
-            # release since its date is missing)
-            date_match_factor = self.__date_match_factors['no_release_date']
+                # release has a no date (all else equal, we don't prefer this
+                # release since its date is missing)
+                date_match_factor = self.__date_match_factors['no_release_date']
 
-        parts.append((date_match_factor, weights['date']))
+            parts.append((date_match_factor, weights['date']))
 
         config = get_config()
-        weights_from_preferred_countries(parts, release,
-                                         config.setting["preferred_release_countries"],
-                                         weights["releasecountry"])
+        if "releasecountry" in weights:
+            weights_from_preferred_countries(parts, release,
+                                             config.setting["preferred_release_countries"],
+                                             weights["releasecountry"])
 
-        weights_from_preferred_formats(parts, release,
-                                       config.setting["preferred_release_formats"],
-                                       weights["format"])
+        if "format" in weights:
+            weights_from_preferred_formats(parts, release,
+                                           config.setting["preferred_release_formats"],
+                                           weights["format"])
 
         if "releasetype" in weights:
             weights_from_release_type_scores(parts, release,

--- a/test/data/ws_data/release_multidisc.json
+++ b/test/data/ws_data/release_multidisc.json
@@ -3,6 +3,7 @@
     "packaging": null,
     "disambiguation": "初回生産限定盤",
     "barcode": "4547366518764",
+    "track-count": 7,
     "media": [
         {
             "track-offset": 0,

--- a/test/data/ws_data/release_multidisc.json
+++ b/test/data/ws_data/release_multidisc.json
@@ -1,0 +1,178 @@
+{
+    "id": "6c4f766f-3351-4c10-a53d-b119452c27b2",
+    "packaging": null,
+    "disambiguation": "初回生産限定盤",
+    "barcode": "4547366518764",
+    "media": [
+        {
+            "track-offset": 0,
+            "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+            "format": "CD",
+            "tracks": [
+                {
+                    "length": 256000,
+                    "id": "7dfe7b51-32c7-42e7-9685-bad653319116",
+                    "recording": {
+                        "video": false,
+                        "title": "ケアレス",
+                        "first-release-date": "2021-08-08",
+                        "disambiguation": "",
+                        "length": 256000,
+                        "id": "9e1bd108-5e69-41cf-b744-ff7731293403"
+                    },
+                    "number": "1",
+                    "position": 1,
+                    "title": "ケアレス"
+                },
+                {
+                    "length": 263000,
+                    "id": "36b94d44-b672-4668-8b21-c8178520ca1b",
+                    "recording": {
+                        "first-release-date": "2021-09-15",
+                        "title": "Bye‐Bye Butterfly",
+                        "video": false,
+                        "id": "e7434e09-727e-4962-aa20-6c8b38431d31",
+                        "length": 263000,
+                        "disambiguation": ""
+                    },
+                    "number": "2",
+                    "position": 2,
+                    "title": "Bye-Bye Butterfly"
+                },
+                {
+                    "recording": {
+                        "title": "Starry",
+                        "first-release-date": "2021-09-15",
+                        "video": false,
+                        "id": "781f567c-04de-4690-81f8-b5e9396af231",
+                        "disambiguation": "",
+                        "length": 262000
+                    },
+                    "id": "86ff242d-77bb-4887-9fba-27be2647146b",
+                    "length": 262000,
+                    "title": "Starry",
+                    "number": "3",
+                    "position": 3
+                },
+                {
+                    "length": 254000,
+                    "id": "a8458b10-53b2-4a02-b218-f98ae42fec4e",
+                    "recording": {
+                        "id": "e337e1b6-818b-4923-9bf2-8256168ff95a",
+                        "disambiguation": "",
+                        "length": 254000,
+                        "title": "ケアレス -Instrumental-",
+                        "first-release-date": "2021-09-15",
+                        "video": false
+                    },
+                    "number": "4",
+                    "position": 4,
+                    "title": "ケアレス -Instrumental-"
+                }
+            ],
+            "position": 1,
+            "track-count": 4,
+            "title": ""
+        },
+        {
+            "track-count": 3,
+            "title": "",
+            "position": 2,
+            "tracks": [
+                {
+                    "number": "1",
+                    "position": 1,
+                    "title": "ケアレス (Music Video)",
+                    "id": "8cb416e1-4dea-4495-8761-7ecaf1df8b53",
+                    "length": 249000,
+                    "recording": {
+                        "first-release-date": "2021-09-15",
+                        "title": "ケアレス (Music Video)",
+                        "video": true,
+                        "id": "187a4c6f-3920-46ee-869a-30077ff7feb8",
+                        "length": 249000,
+                        "disambiguation": ""
+                    }
+                },
+                {
+                    "recording": {
+                        "video": true,
+                        "title": "ケアレス (15秒CM)",
+                        "first-release-date": "2021-09-15",
+                        "length": 14000,
+                        "disambiguation": "",
+                        "id": "5f6bf35e-98c4-4dad-af43-5b14c42544c8"
+                    },
+                    "length": 14000,
+                    "id": "dd28ec8b-ec2b-422a-87dc-7c8f0ea8d69d",
+                    "title": "ケアレス (15秒CM)",
+                    "number": "2",
+                    "position": 2
+                },
+                {
+                    "recording": {
+                        "title": "ケアレス (30秒メッセージコメント入りCM)",
+                        "first-release-date": "2021-09-15",
+                        "video": true,
+                        "id": "1a7faef4-6f9c-4579-9770-4da2e05b247c",
+                        "disambiguation": "",
+                        "length": 29000
+                    },
+                    "length": 29000,
+                    "id": "f63daba7-835f-4303-943f-097c34b58d02",
+                    "title": "ケアレス (30秒メッセージコメント入りCM)",
+                    "position": 3,
+                    "number": "3"
+                }
+            ],
+            "format": "DVD-Video",
+            "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+            "track-offset": 0
+        }
+    ],
+    "asin": "B09BGHWCW1",
+    "release-events": [
+        {
+            "date": "2021-09-15",
+            "area": {
+                "iso-3166-1-codes": [
+                    "JP"
+                ],
+                "type-id": null,
+                "name": "Japan",
+                "type": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "disambiguation": "",
+                "sort-name": "Japan"
+            }
+        }
+    ],
+    "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+    "date": "2021-09-15",
+    "quality": "normal",
+    "country": "JP",
+    "text-representation": {
+        "language": "jpn",
+        "script": "Jpan"
+    },
+    "title": "ケアレス",
+    "status": "Official",
+    "cover-art-archive": {
+        "artwork": false,
+        "front": false,
+        "darkened": false,
+        "count": 0,
+        "back": false
+    },
+    "packaging-id": null,
+    "release-group": {
+        "secondary-types": [],
+        "id": "b89c4dbd-1734-4536-a16d-dde648f735c0",
+        "secondary-type-ids": [],
+        "disambiguation": "",
+        "first-release-date": "2021-09-15",
+        "title": "ケアレス",
+        "primary-type": "Single",
+        "primary-type-id": "d6038452-8ee0-3f68-affc-2de9a1ede0b9"
+    }
+}

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -570,6 +570,22 @@ class CommonTests:
                 match = metadata.compare_to_release(release, Cluster.comparison_weights)
                 self.assertEqual(sim, match.similarity)
 
+        def test_compare_to_release_parts_match_totaltracks(self):
+            release = load_test_json('release_multidisc.json')
+            metadata = Metadata()
+            weights = {
+                "totaltracks": 30,
+                "album": 1,
+                "date": 1,
+                "format": 1,
+                "releasecountry": 1,
+            }
+            release_to_metadata(release, metadata)
+            for totaltracks, sim in ((4, 1.0), (3, 1.0), (2, 0.3), (5, 0.0)):
+                metadata['totaltracks'] = totaltracks
+                parts = metadata.compare_to_release_parts(release, weights)
+                self.assertIn((sim, 30), parts)
+
         def test_weights_from_release_type_scores(self):
             release = load_test_json('release.json')
             parts = []


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2368
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

tracktotal in a file is supposed to have the total number of tracks on the specific medium. Comparing to the total tracks of a release across all medium hence gives wrong results.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
This PR replaces #1996