### PR TITLE
Support --encoding parameter in fix-header.py

### DIFF
--- a/scripts/tools/fix-header.py
+++ b/scripts/tools/fix-header.py
@@ -113,13 +113,13 @@ def parse_copyright_text(text):
 EMPTY_LINE = ("\n", "#\n")
 
 
-def parse_file(path):
+def parse_file(path, encoding='utf-8'):
     authors_from_log = extract_authors_from_gitlog(path)
     start = end = None
     authors_from_file = {}
 
     skip_pattern = re.compile(r'^(?:#|/\*|//)\s+(fix-header:\s*skip|Automatically\s+generated)', re.IGNORECASE)
-    with open(path) as f:
+    with open(path, encoding=encoding) as f:
         lines = f.readlines()
         found = defaultdict(lambda: None)
         if lines and lines[0].startswith('#!'):
@@ -211,8 +211,8 @@ LICENSE_BOTTOM = """#
 """
 
 
-def fix_header(path):
-    found, authors_from_file, authors_from_log, before, after = parse_file(path)
+def fix_header(path, encoding='utf-8'):
+    found, authors_from_file, authors_from_log, before, after = parse_file(path, encoding)
     if found['skip'] is not None:
         return None, found['skip']
 
@@ -264,6 +264,7 @@ def main():
     parser.add_argument('-e', '--extension', default='.py', help='File extension to filter by')
     parser.add_argument('-i', '--in-place', action='store_true', default=False, help='Edit files in place')
     parser.add_argument('-r', '--recursive', action='store_true', default=False, help='Search through subfolders')
+    parser.add_argument('--encoding', default='utf-8', help='File encoding of the source files')
     args = parser.parse_args()
 
     paths = list(args.path)
@@ -281,13 +282,13 @@ def main():
         sys.exit(0)
 
     for path in files:
-        new_content, info = fix_header(path)
+        new_content, info = fix_header(path, encoding=args.encoding)
         if new_content is None:
             print("Skipping %s (%s)" % (path, info), file=sys.stderr)
             continue
         if args.in_place:
             print("Parsing and fixing %s (in place)" % path, file=sys.stderr)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding=args.encoding) as f:
                 print(new_content, file=f)
         else:
             # by default, we just output to stdout

--- a/scripts/tools/fix-header.py
+++ b/scripts/tools/fix-header.py
@@ -118,7 +118,7 @@ def parse_file(path, encoding='utf-8'):
     start = end = None
     authors_from_file = {}
 
-    skip_pattern = re.compile(r'^(?:#|/\*|//)\s+(fix-header:\s*skip|Automatically\s+generated)', re.IGNORECASE)
+    skip_pattern = re.compile(r'^(?:#|/\*|//)\s+(fix-header:\s*skip|Automatically\s+generated|Created\s+by:\s+The\s+Resource\s+Compiler\s+for\s+PyQt5)', re.IGNORECASE)
     with open(path, encoding=encoding) as f:
         lines = f.readlines()
         found = defaultdict(lambda: None)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

fix-headers.py uses the default encoding for reading / writing the source files, but this can differ based on the platform. E.g. on my Windows setup it defaults to cp1252


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The default encoding can be different based on the platform, but we expect UTF-8 for our source files. To stay flexible, make the default encoding UTF-8, but add a command line parameter to change it.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
