### PR TITLE
PICARD-2373: Make `$slice()` 'end' parameter optional

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1258,12 +1258,13 @@ Returns a multi-value variable containing the elements between the `start` and
 The following example will create a multi-value variable with all artists
     in `%artists%` except the first, which can be used to create a "feat." list.
 
-Example:
+Examples:
 
-    $setmulti(supporting_artists,$slice(%artists%,1,))
+    $setmulti(supporting_artists,$slice(%artists%,1))
+    $setmulti(supporting_artists,$slice(%artists%,1,-1))
 """
 ))
-def func_slice(parser, multi, start_index, end_index, separator=MULTI_VALUED_JOINER):
+def func_slice(parser, multi, start_index, end_index=None, separator=MULTI_VALUED_JOINER):
     try:
         start = int(start_index.eval(parser)) if start_index else None
     except ValueError:

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1354,6 +1354,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,-2,2)", output_1_2, context)
         # Tests with missing inputs
         self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,,1)", output_0_1, context)
+        self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,1)", output_1_3, context)
         self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,1,)", output_1_3, context)
         self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,,)", output_0_3, context)
         # Tests with invalid inputs (end < start)
@@ -1365,13 +1366,11 @@ class ScriptParserTest(PicardTestCase):
         # Tests with separator override
         self.assertScriptResultEquals("$slice(First:A; Second:B; Third:C,1,3,:)", alternate_output, context)
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$slice: Wrong number of arguments for \$slice: Expected between 3 and 4, "
+        areg = r"^\d+:\d+:\$slice: Wrong number of arguments for \$slice: Expected between 2 and 4, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$slice()")
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$slice(abc; def)")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$slice(abc; def,0)")
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$slice(abc; def),0,1,:,extra")
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Make the `$slice()` 'end' parameter optional.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2373
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The documentation for the `$slice()` scripting function is incorrect because it shows the `end` parameter as optional.  The parameter can be left empty, but it still requires that it be included (thus requiring an additional comma in the call).  In discussing corrections to the documentation on https://github.com/metabrainz/picard-docs/pull/141 it was decided to correct the operation of the function to make the `end` parameter truly optional.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Make the `$slice()` 'end' parameter optional.  Update tests.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Update documentation.