### PR TITLE
PICARD-2375: Fix progress indicator staying at 0% for pending network requests

### DIFF
--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -93,12 +93,10 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         total_pending = pending_files + pending_requests
         last_pending = self._last_pending_files + self._last_pending_requests
 
-        if self._max_pending_files == 0 or (self._max_pending_files > 0
-                                            and self._last_pending_files == 0
-                                            and pending_files == 0):
-            # update starting timestamp when pending_files appear in order to discard the idle time
-            # and when all previous file requests already finished but network requests still ongoing
-            self.reset_file_counters()
+        # Reset the counters if we had no pending progress before and receive new pending items.
+        # This resets the starting timestamp and starts a new round of measurement.
+        if total_pending > 0 and last_pending == 0:
+            self.reset_counters()
 
         previous_done_files = max(0, self._max_pending_files - self._last_pending_files)
         previous_done_requests = max(0, self._max_pending_requests - self._last_pending_requests)
@@ -137,9 +135,6 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self._last_progress = 0
         self._max_pending_requests = 0
         self._last_pending_requests = 0
-        self.reset_file_counters()
-
-    def reset_file_counters(self):
         self._max_pending_files = 0
         self._last_pending_files = 0
         self._prev_time = time.time()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2375
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If there are only pending network requests but no file requests the loading progress stays near 0%.

The issue is caused by https://github.com/metabrainz/picard/blob/master/picard/ui/infostatus.py#L96-L101

There the starting time gets reset on each call if there are no more pending files to load, ignoring any requests. So once there are only pending requests it always has basically 100% progress still to do.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Consider both file and network requests and only reset if they both reached zero.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
