### PR TITLE
PICARD-2374: Remove rate limit for archive.org

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -68,6 +68,7 @@ from picard.coverart.utils import (
     CAA_TYPES,
     translate_caa_type,
 )
+from picard.webservice import ratecontrol
 
 from picard.ui import PicardDialog
 from picard.ui.ui_provider_options_caa import Ui_CaaOptions
@@ -90,6 +91,9 @@ _CAA_IMAGE_SIZE_DEFAULT = 500
 
 _CAA_IMAGE_TYPE_DEFAULT_INCLUDE = ['front']
 _CAA_IMAGE_TYPE_DEFAULT_EXCLUDE = ['raw/unedited', 'watermark']
+
+ratecontrol.set_minimum_delay((CAA_HOST, CAA_PORT), 0)
+ratecontrol.set_minimum_delay(('archive.org', 443), 0)
 
 
 def caa_url_fallback_list(desired_size, thumbnails):

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -31,8 +31,6 @@ from picard.const import (
     ACOUSTID_HOST,
     ACOUSTID_KEY,
     ACOUSTID_PORT,
-    CAA_HOST,
-    CAA_PORT,
 )
 from picard.webservice import (
     CLIENT_STRING,
@@ -42,7 +40,6 @@ from picard.webservice import (
 
 
 ratecontrol.set_minimum_delay((ACOUSTID_HOST, ACOUSTID_PORT), 333)
-ratecontrol.set_minimum_delay((CAA_HOST, CAA_PORT), 0)
 
 
 def escape_lucene_query(text):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2374
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



Fetching cover art from cover art archive involves both requests to coverartarchive.org for the webservice and archive.org for the actual image downloads.

Picard currently does remove the default rate limit for coverartarchive.org, but keeps the 1 second ddefault delay for archive.org.

As archive.org does not apply a rate limit, we should remove this delay as well


# Solution
Set rate limit for archive.org to 0. This also applies to subdomains. While the ratecontrol module keeps the adjusted delays separate for each subdomain, it copies the minimum delay from the main domain.

Also moved setting the limit to the CAA implementation, as I think knowledge of which hosts get queried should be kept close to the modules using them.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
