### PR TITLE
PICARD-2377: Fix potential crash on emptydirs initialization

### DIFF
--- a/picard/util/emptydir.py
+++ b/picard/util/emptydir.py
@@ -39,7 +39,10 @@ PROTECTED_DIRECTORIES = set()
 for location in get_qt_enum(QStandardPaths, QStandardPaths.StandardLocation):
     value = getattr(QStandardPaths, location)
     for path in QStandardPaths.standardLocations(value):
-        PROTECTED_DIRECTORIES.add(os.path.realpath(path))
+        try:
+            PROTECTED_DIRECTORIES.add(os.path.realpath(path))
+        except OSError:  # Path might no longer exist, skip it
+            pass
 
 
 class SkipRemoveDir(Exception):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2377
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If one of the QStandardPaths pointed to a no longer available location Picard would crash on startup

# Solution
Handle the exception. The actual exception thrown was a `FileNotFoundError`, but https://docs.python.org/3/library/os.path.html#os.path.realpath documents it as throwing `OSError` (which is the superclass of `FileNotFoundError`), so handle that instead.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
