### PR TITLE
PICARD-2378: Ensure AB submission submits only base filename

### DIFF
--- a/picard/acousticbrainz/__init__.py
+++ b/picard/acousticbrainz/__init__.py
@@ -256,6 +256,13 @@ def ab_submit_features(tagger, file):
         submit_features_callback(file, None, None, True)
         return
 
+    # Set the filename. Especially on Windows the feature extractor fails to set the file basename only.
+    # As Picard already handles this just add the correct data ourselves.
+    try:
+        features['metadata']['tags']['file_name'] = file.base_filename
+    except KeyError:
+        log.warning('AcousticBrainz: Failed to set file_name in features data')
+
     # Submit features to the server
     tagger.webservice.post(
         host=ACOUSTICBRAINZ_HOST,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2378
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

AB submission on Windows submits the entire file path. It's essentially a bug in the extractor binary (https://github.com/MTG/essentia/issues/1209). But as this can reveal more information about the files than the user is comfortable with let's handle that on Picard side.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Set the `file_name` based on File.base_filename

# Action
If we choose to allow submission without saving (just matched files) then we would need to override the entire `.metadata.tags` dict anyway.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
