### PR TITLE
packaging: Verify SHA256 hashes of downloaded Windows dependencies

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -131,7 +131,10 @@ jobs:
         python-version: 3.8
     - name: Setup Windows build environment
       run: |
-        & .\scripts\package\win-setup.ps1 -DiscidVersion $Env:DISCID_VERSION -FpcalVersion $Env:FPCALC_VERSION -AbextractorVersion $Env:ABEXTRACTOR_VERSION
+        & .\scripts\package\win-setup.ps1 `
+          -DiscidVersion $Env:DISCID_VERSION -DiscidSha256Sum $Env:DISCID_SHA256SUM `
+          -FpcalcVersion $Env:FPCALC_VERSION -FpcalcSha256Sum $Env:FPCALC_SHA256SUM `
+          -AbextractorVersion $Env:ABEXTRACTOR_VERSION -AbextractorSha256Sum $Env:ABEXTRACTOR_SHA256SUM
         Write-Output "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
         $ReleaseTag = $(git describe --match "release-*" --abbrev=0 --always HEAD)
         $BuildNumber = $(git rev-list --count "$ReleaseTag..HEAD")
@@ -139,8 +142,11 @@ jobs:
         New-Item -Name .\artifacts -ItemType Directory
       env:
         DISCID_VERSION: 0.6.2
+        DISCID_SHA256SUM: 9fd815f6bd0c624f0f41dd81209aeaa3f2129dcd1d617f88b844b4503d12598e
         FPCALC_VERSION: 1.5.0
+        FPCALC_SHA256SUM: ce564a92aa9e13823379f2740624110e5f1bc5b25c10b031a5f9b8e71dce2fa9
         ABEXTRACTOR_VERSION: v2.1_beta2-1-ge3940c0
+        ABEXTRACTOR_SHA256SUM: eb4e64e4334ae5c63962fdc6b8bdfbdb53ba11e4705373feeb89503c08ee2688
     - name: Patch build version
       if: startsWith(github.ref, 'refs/tags/') != true
       run: |

--- a/scripts/package/win-setup.ps1
+++ b/scripts/package/win-setup.ps1
@@ -4,10 +4,19 @@ Param(
   $DiscidVersion,
   [Parameter(Mandatory=$true)]
   [String]
-  $FpcalVersion,
+  $DiscidSha256Sum,
   [Parameter(Mandatory=$true)]
   [String]
-  $AbextractorVersion
+  $FpcalcVersion,
+  [Parameter(Mandatory=$true)]
+  [String]
+  $FpcalcSha256Sum,
+  [Parameter(Mandatory=$true)]
+  [String]
+  $AbextractorVersion,
+  [Parameter(Mandatory=$true)]
+  [String]
+  $AbextractorSha256Sum
 )
 
 $ErrorActionPreference = "Stop"
@@ -25,25 +34,42 @@ Function DownloadFile {
   (New-Object System.Net.WebClient).DownloadFile($Url, "$OutputPath")
 }
 
+Function VerifyHash {
+  Param(
+    [Parameter(Mandatory = $true)]
+    [String]
+    $FileName,
+    [Parameter(Mandatory = $true)]
+    [String]
+    $Sha256Sum
+  )
+  If ((Get-FileHash "$FileName").hash -ne "$Sha256Sum") {
+    Throw "Invalid SHA256 hash for $FileName"
+  }
+}
+
 New-Item -Name .\build -ItemType Directory -ErrorAction Ignore
 
 $ArchiveFile = ".\build\libdiscid.zip"
 Write-Output "Downloading libdiscid $DiscidVersion to $ArchiveFile..."
 DownloadFile -Url "https://github.com/metabrainz/libdiscid/releases/download/v$DiscidVersion/libdiscid-$DiscidVersion-win64.zip" `
   -FileName $ArchiveFile
+VerifyHash -FileName $ArchiveFile -Sha256Sum $DiscidSha256Sum
 Expand-Archive -Path $ArchiveFile -DestinationPath .\build\libdiscid -Force
 Copy-Item .\build\libdiscid\discid.dll .
 
 $ArchiveFile = ".\build\fpcalc.zip"
-Write-Output "Downloading chromaprint-fpcalc $FpcalVersion to $ArchiveFile..."
-DownloadFile -Url "https://github.com/acoustid/chromaprint/releases/download/v$FpcalVersion/chromaprint-fpcalc-$FpcalVersion-windows-x86_64.zip" `
-    -FileName $ArchiveFile
+Write-Output "Downloading chromaprint-fpcalc $FpcalcVersion to $ArchiveFile..."
+DownloadFile -Url "https://github.com/acoustid/chromaprint/releases/download/v$FpcalcVersion/chromaprint-fpcalc-$FpcalcVersion-windows-x86_64.zip" `
+  -FileName $ArchiveFile
+VerifyHash -FileName $ArchiveFile -Sha256Sum $FpcalcSha256Sum
 Expand-Archive -Path $ArchiveFile -DestinationPath .\build\fpcalc -Force
-Copy-Item .\build\fpcalc\chromaprint-fpcalc-$FpcalVersion-windows-x86_64\fpcalc.exe .
+Copy-Item .\build\fpcalc\chromaprint-fpcalc-$FpcalcVersion-windows-x86_64\fpcalc.exe .
 
 $ArchiveFile = ".\build\abz.zip"
 Write-Output "Downloading AcousticBrainz extractor $AbextractorVersion to $ArchiveFile..."
 DownloadFile -Url "https://ftp.acousticbrainz.org/pub/acousticbrainz/essentia-extractor-$AbextractorVersion-win-i686.zip" `
-    -FileName $ArchiveFile
+  -FileName $ArchiveFile
+VerifyHash -FileName $ArchiveFile -Sha256Sum $AbextractorSha256Sum
 Expand-Archive -Path $ArchiveFile -DestinationPath .\build\abz -Force
 Copy-Item .\build\abz\streaming_extractor_music.exe .


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
Same as #2012, but for Windows.

As we are downloading third party components that we then code sign and bundle in our Windows builds, verify we got the right binaries by checking their SHA256 hash.