### PR TITLE
Ensure rating submission XML is valid

### DIFF
--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -29,6 +29,7 @@ from PyQt5 import (
     QtWidgets,
 )
 
+from picard import log
 from picard.config import get_config
 
 
@@ -101,7 +102,10 @@ class RatingWidget(QtWidgets.QWidget):
         config = get_config()
         if config.setting["submit_ratings"]:
             ratings = {("recording", track.id): self._rating}
-            self.tagger.mb_api.submit_ratings(ratings, None)
+            try:
+                self.tagger.mb_api.submit_ratings(ratings, None)
+            except ValueError:  # This should never happen as self._rating is always an integer
+                log.error("Failed to submit rating for recording %s", track.id, exc_info=True)
 
     def paintEvent(self, event=None):
         painter = QtGui.QPainter(self)

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -22,6 +22,7 @@
 
 
 import re
+from xml.sax.saxutils import quoteattr
 
 from PyQt5.QtCore import QUrl
 
@@ -206,10 +207,9 @@ class MBAPIHelper(APIHelper):
     @staticmethod
     def _xml_ratings(ratings):
         recordings = ''.join(
-            '<recording id="%s"><user-rating>%s</user-rating></recording>' %
-            (i[1], j*20) for i, j in ratings.items() if i[0] == 'recording'
+            '<recording id=%s><user-rating>%s</user-rating></recording>' %
+            (quoteattr(i[1]), int(j)*20) for i, j in ratings.items() if i[0] == 'recording'
         )
-
         return _wrap_xml_metadata('<recording-list>%s</recording-list>' % recordings)
 
     def submit_ratings(self, ratings, handler):

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -22,7 +22,7 @@
 
 
 import re
-from xml.sax.saxutils import quoteattr
+from xml.sax.saxutils import quoteattr  # nosec: B404
 
 from PyQt5.QtCore import QUrl
 

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -180,6 +180,23 @@ class MBAPITest(PicardTestCase):
             '</metadata>'
         )
 
+    def test_xml_ratings_encode(self):
+        ratings = {("recording", '<a&"\'>'): 0}
+        xmldata = self.api._xml_ratings(ratings)
+        self.assertEqual(
+            xmldata,
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">'
+            '<recording-list>'
+            '<recording id="&lt;a&amp;&quot;\'&gt;"><user-rating>0</user-rating></recording>'
+            '</recording-list>'
+            '</metadata>'
+        )
+
+    def test_xml_ratings_raises_value_error(self):
+        ratings = {("recording", 'a'): 'foo'}
+        self.assertRaises(ValueError, self.api._xml_ratings, ratings)
+
     def test_collection_request(self):
         releases = tuple("r"+str(i) for i in range(13))
         generator = self.api._collection_request("test", releases, batchsize=5)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

MBAPIHelper._xml_ratings does not handle encoding the input parameters.

# Solution
Properly XML encode provided data for rating submission. Also ensure rating is an integer as expected.

In the current implementation both should already be guaranteed. `track.id`  is always a MBID as given by MB service, and the rating widget's `self._rating`  is always an integer. But for a complete implementation in the context of `MBAPIHelper`  and to avoid potential issues both should be handled.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
