### PR TITLE
PICARD-2382: Add option to keep duplicates in `$copymerge()` function.

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -492,20 +492,22 @@ def func_copy(parser, new, old):
 
 
 @script_function(documentation=N_(
-    """`$copymerge(new,old)`
+    """`$copymerge(new,old[,keep_duplicates])`
 
 Merges metadata from variable `old` into `new`, removing duplicates and
     appending to the end, so retaining the original ordering. Like `$copy`, this
     will also copy multi-valued variables without flattening them.
 
+If `keep_duplicates` is set, then the duplicates will not be removed from the result.
+
 _Since Picard 1.0_"""
 ))
-def func_copymerge(parser, new, old):
+def func_copymerge(parser, new, old, keep_duplicates=False):
     new = normalize_tagname(new)
     old = normalize_tagname(old)
     newvals = parser.context.getall(new)
     oldvals = parser.context.getall(old)
-    parser.context[new] = uniqify(newvals + oldvals)
+    parser.context[new] = newvals + oldvals if keep_duplicates else uniqify(newvals + oldvals)
     return ""
 
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -700,6 +700,27 @@ class ScriptParserTest(PicardTestCase):
         context["source"] = "sourceval"
         self._eval_and_check_copymerge(context, ["targetval", "sourceval"])
 
+    def test_cmd_copymerge_empty_keepdupes(self):
+        context = Metadata()
+        context["target"] = ["tag1", "tag2", "tag1"]
+        context["source"] = ["tag2", "tag3", "tag2"]
+        self.parser.eval("$copymerge(target,source,)", context)
+        self.assertEqual(self.parser.context.getall("target"), ["tag1", "tag2", "tag3"])
+
+    def test_cmd_copymerge_keepdupes(self):
+        context = Metadata()
+        context["target"] = ["tag1", "tag2", "tag1"]
+        context["source"] = ["tag2", "tag3", "tag2"]
+        self.parser.eval("$copymerge(target,source,keep)", context)
+        self.assertEqual(self.parser.context.getall("target"), ["tag1", "tag2", "tag1", "tag2", "tag3", "tag2"])
+
+    def test_cmd_copymerge_nonlist_keepdupes(self):
+        context = Metadata()
+        context["target"] = "targetval"
+        context["source"] = "targetval"
+        self.parser.eval("$copymerge(target,source,keep)", context)
+        self.assertEqual(self.parser.context.getall("target"), ["targetval", "targetval"])
+
     def test_cmd_eq_any(self):
         self.assertScriptResultEquals("$eq_any(abc,def,ghi,jkl)", "")
         self.assertScriptResultEquals("$eq_any(abc,def,ghi,jkl,abc)", "1")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Add an option to the `$copymerge()` function to allow keeping duplicates.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2382
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

There is no (easy) way in Picard scripting to append one multi-value to another to keep the order without removing duplicates.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add an option to the `$copymerge()` function to allow keeping duplicates.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Hold merge until Picard v2.8 to avoid additional translation requirements.

Update documentation.
