### PR TITLE
PICARD-2386: Fix sorting of characters with diacritics

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -47,6 +47,7 @@ from heapq import (
     heappop,
     heappush,
 )
+from locale import strxfrm
 
 from PyQt5 import (
     QtCore,
@@ -919,9 +920,9 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         if column == MainPanel.LENGTH_COLUMN:
             sortkey = self.obj.metadata.length or 0
         elif column in MainPanel.NAT_SORT_COLUMNS:
-            sortkey = natsort.natkey(self.text(column).lower())
+            sortkey = natsort.natkey(self.text(column))
         else:
-            sortkey = self.text(column).lower()
+            sortkey = strxfrm(self.text(column))
         self._sortkeys[column] = sortkey
         return sortkey
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2386
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Columns in main list which were not using natural sorting had all characters with diacritics sorted after Z. 


# Solution
Use `locale.strxfrm` for locale aware sorting instead. This is still cheaper then the full natsort (which also uses strxfrm).

If we use `strxfrm` we should also not need the lower conversion.

Before:
![grafik](https://user-images.githubusercontent.com/29852/148254802-344176cb-d70e-41d5-9788-d31c7ac27158.png)


After:
![grafik](https://user-images.githubusercontent.com/29852/148254664-dc2dcb41-0f60-43ec-851d-e52f109021b1.png)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
