### PR TITLE
PICARD-2392: Allow empty strings in multi-value variables

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -433,8 +433,9 @@ class Metadata(MutableMapping):
         name = self.normalize_tag(name)
         if isinstance(values, str) or not isinstance(values, Iterable):
             values = [values]
-        values = [str(value) for value in values if value or value == 0]
-        if values:
+        values = [str(value) for value in values if value or value == 0 or value == '']
+        # Remove if there is only a single empty or blank element.
+        if values and (len(values) > 1 or values[0]):
             self._store[name] = values
             self.deleted_tags.discard(name)
         elif name in self._store:

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1503,8 +1503,8 @@ Removes all empty string elements from the multi-value variable.
 
 Example:
 
-    $$setmulti(test,one; ; two; three)
-    $cleanmulti(%test%)
+    $setmulti(test,one; ; two; three)
+    $cleanmulti(test)
 
 Result: Sets the value of 'test' to ["one", "two", "three"].
 

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1497,20 +1497,20 @@ def func_is_multi(parser, multi):
 
 
 @script_function(eval_args=True, documentation=N_(
-    """`$clean_multi(name)`
+    """`$cleanmulti(name)`
 
 Removes all empty string elements from the multi-value variable.
 
 Example:
 
     $$setmulti(test,one; ; two; three)
-    $clean_multi(%test%)
+    $cleanmulti(%test%)
 
 Result: Sets the value of 'test' to ["one", "two", "three"].
 
 _Since Picard 2.8_"""
 ))
-def func_clean_multi(parser, multi):
+def func_cleanmulti(parser, multi):
     name = normalize_tagname(multi)
     values = [str(value) for value in parser.context.getall(name) if value or value == 0]
     parser.context[multi] = values

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1494,3 +1494,24 @@ _Since Picard 2.7_"""
 def func_is_multi(parser, multi):
     multi_value = MultiValue(parser, multi, MULTI_VALUED_JOINER)
     return '' if len(multi_value) < 2 else '1'
+
+
+@script_function(eval_args=True, documentation=N_(
+    """`$clean_multi(name)`
+
+Removes all empty string elements from the multi-value variable.
+
+Example:
+
+    $$setmulti(test,one; ; two; three)
+    $clean_multi(%test%)
+
+Result: Sets the value of 'test' to ["one", "two", "three"].
+
+_Since Picard 2.8_"""
+))
+def func_clean_multi(parser, multi):
+    name = normalize_tagname(multi)
+    values = [str(value) for value in parser.context.getall(name) if value or value == 0]
+    parser.context[multi] = values
+    return ""

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1786,7 +1786,7 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$is_multi(a,)")
 
-    def test_cmd_clean_multi(self):
+    def test_cmd_cleanmulti(self):
         context = Metadata()
         context["foo"] = ["", "one", "two"]
         context["bar"] = ["one", "", "two"]
@@ -1797,9 +1797,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("%bar%", "one; ; two", context)
         self.assertScriptResultEquals("%baz%", "one; two; ", context)
         # Test cleaned values
-        self.assertScriptResultEquals("$clean_multi(foo)%foo%", "one; two", context)
-        self.assertScriptResultEquals("$clean_multi(bar)%bar%", "one; two", context)
-        self.assertScriptResultEquals("$clean_multi(baz)%baz%", "one; two", context)
+        self.assertScriptResultEquals("$cleanmulti(foo)%foo%", "one; two", context)
+        self.assertScriptResultEquals("$cleanmulti(bar)%bar%", "one; two", context)
+        self.assertScriptResultEquals("$cleanmulti(baz)%baz%", "one; two", context)
 
         # Text clean with only empty string elements
         context["foo"] = ["", "", ""]
@@ -1807,7 +1807,7 @@ class ScriptParserTest(PicardTestCase):
         # Confirm initial values
         self.assertScriptResultEquals("%foo%", "; ; ", context)
         # Test cleaned values
-        self.assertScriptResultEquals("$clean_multi(foo)%foo%", "", context)
+        self.assertScriptResultEquals("$cleanmulti(foo)%foo%", "", context)
 
         # Test clean with indirect argument
         context["foo"] = ["", "one", "two"]
@@ -1816,7 +1816,7 @@ class ScriptParserTest(PicardTestCase):
         # Confirm initial values
         self.assertScriptResultEquals("%foo%", "; one; two", context)
         # Test cleaned values
-        self.assertScriptResultEquals("$clean_multi(%bar%)%foo%", "one; two", context)
+        self.assertScriptResultEquals("$cleanmulti(%bar%)%foo%", "one; two", context)
 
         # Test clean with non-multi argument
         context["foo"] = "one"
@@ -1828,13 +1828,13 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("%bar%", "one; ; two", context)
         self.assertScriptResultEquals("%baz%", "", context)
         # Test cleaned values
-        self.assertScriptResultEquals("$clean_multi(foo)%foo%", "one", context)
-        self.assertScriptResultEquals("$clean_multi(bar)%bar%", "one; ; two", context)
-        self.assertScriptResultEquals("$clean_multi(baz)%baz%", "", context)
+        self.assertScriptResultEquals("$cleanmulti(foo)%foo%", "one", context)
+        self.assertScriptResultEquals("$cleanmulti(bar)%bar%", "one; ; two", context)
+        self.assertScriptResultEquals("$cleanmulti(baz)%baz%", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$clean_multi: Wrong number of arguments for \$clean_multi: Expected exactly 1, "
+        areg = r"^\d+:\d+:\$cleanmulti: Wrong number of arguments for \$cleanmulti: Expected exactly 1, "
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$clean_multi()")
+            self.parser.eval("$cleanmulti()")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$clean_multi(foo,)")
+            self.parser.eval("$cleanmulti(foo,)")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -559,6 +559,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$replacemulti(%genre%,Bardcore,Hardcore)", "Electronic; Jungle; Hardcore", context)
 
         context["test"] = ["One", "Two", "Three"]
+        self.assertScriptResultEquals("$replacemulti(%test%,Two,)", "One; Three", context)
+
+        context["test"] = ["One", "Two", "Three"]
         self.assertScriptResultEquals("$replacemulti(%test%,Four,Five)", "One; Two; Three", context)
 
         context["test"] = ["Four", "Five", "Six"]
@@ -926,6 +929,9 @@ class ScriptParserTest(PicardTestCase):
         context["baz"] = []
         self.assertScriptResultEquals("$lenmulti(%baz%)", "0", context)
         self.assertScriptResultEquals("$lenmulti(%baz%,:)", "0", context)
+        # Test empty multi-value elements
+        context["baz"] = ["one", "", "three"]
+        self.assertScriptResultEquals("$lenmulti(%baz%)", "3", context)
         # Test missing name
         self.assertScriptResultEquals("$lenmulti(,)", "0", context)
         self.assertScriptResultEquals("$lenmulti(,:)", "0", context)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:  Allow empty strings in multi-value variables.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2392
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard currently does not allow keeping empty strings in a multi-value variable, and automatically strips them out.  This can lead to problems for example if the user is trying to manage a list of artist join phrases, where the resulting multi-value may have elements removed so that it no longer matches the metadata.  This is the case with the changes to the ***AdditionalArtistsVariables*** plugin in https://github.com/metabrainz/picard-plugins/pull/320 requiring a non-blank placeholder to be substituted which would have to be removed by the user when processing the variable in a script.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The change includes the following:

- Keep empty strings in multi-value lists
- Add scripting function to remove empty strings from multi-value
- Update tests

In addition, the criteria for removing a variable (marking it as deleted in the metadata) is changed to only if the variable has zero or one element, and the element is an empty string.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Please review this to ensure that this new behavior is something that should actually be revised, and that it doesn't accidentally cause other problems not checked in the tests.

If approved, this could be held until the Picard 2.8 release to avoid additional translation requirements.

If approved, the documentation will need to be updated to include the new script function.