### PR TITLE
PICARD-2332: Use PyQt5 scoped enums 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,8 +67,7 @@ jobs:
           "PyQt5==5.14.2",
           "PyQt5==5.13.2",
           "PyQt5==5.12.3",
-          "PyQt5==5.11.3",
-          "PyQt5==5.10.1 sip==4.19.8 mutagen==1.37",
+          "PyQt5==5.11.3 sip==4.19.8 mutagen==1.37",
         ]
 
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ Before installing Picard from source, you need to check you have the following d
 Required:
 
 * [Python 3.6 or newer](http://python.org/download)
-* [PyQt 5.10 or newer](http://www.riverbankcomputing.co.uk/software/pyqt/download)
+* [PyQt 5.11 or newer](http://www.riverbankcomputing.co.uk/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)
 * [python-dateutil](https://dateutil.readthedocs.io/en/stable/)

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -124,9 +124,9 @@ def crash_handler():
     if not app:
         app = QApplication(sys.argv)
     msgbox = QMessageBox()
-    msgbox.setIcon(QMessageBox.Critical)
+    msgbox.setIcon(QMessageBox.Icon.Critical)
     msgbox.setWindowTitle("Picard terminated unexpectedly")
-    msgbox.setTextFormat(Qt.RichText)
+    msgbox.setTextFormat(Qt.TextFormat.RichText)
     msgbox.setText(
         'An unexpected error has caused Picard to crash. '
         'Please report this issue on the <a href="https://tickets.metabrainz.org/projects/PICARD">MusicBrainz bug tracker</a>.')
@@ -136,7 +136,7 @@ def crash_handler():
             'A logfile has been written to <a href="{0}">{1}</a>.'
             .format(logfile_url.url(), logfile))
     msgbox.setDetailedText(trace)
-    msgbox.setStandardButtons(QMessageBox.Close)
-    msgbox.setDefaultButton(QMessageBox.Close)
+    msgbox.setStandardButtons(QMessageBox.StandardButton.Close)
+    msgbox.setDefaultButton(QMessageBox.StandardButton.Close)
     msgbox.exec_()
     app.quit()

--- a/picard/album.py
+++ b/picard/album.py
@@ -260,7 +260,7 @@ class Album(DataObject, Item):
             if error:
                 self.error_append(http.errorString())
                 # Fix for broken NAT releases
-                if error == QtNetwork.QNetworkReply.ContentNotFoundError:
+                if error == QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError:
                     config = get_config()
                     nats = False
                     nat_name = config.setting["nat_name"]

--- a/picard/config.py
+++ b/picard/config.py
@@ -246,7 +246,7 @@ class Config(QtCore.QSettings):
         self._upgrade_hooks = dict()
 
     def event(self, event):
-        if event.type() == QtCore.QEvent.UpdateRequest:
+        if event.type() == QtCore.QEvent.Type.UpdateRequest:
             # Syncing the config file can trigger a deadlock between QSettings internal mutex and
             # the Python GIL in PyQt up to 5.15.2. Workaround this by handling this ourselves
             # with custom file locking.
@@ -274,8 +274,8 @@ class Config(QtCore.QSettings):
         """Build a Config object using the default configuration file
         location."""
         this = cls()
-        QtCore.QSettings.__init__(this, QtCore.QSettings.IniFormat,
-                                  QtCore.QSettings.UserScope, PICARD_ORG_NAME,
+        QtCore.QSettings.__init__(this, QtCore.QSettings.Format.IniFormat,
+                                  QtCore.QSettings.Scope.UserScope, PICARD_ORG_NAME,
                                   PICARD_APP_NAME, parent)
 
         # Check if there is a config file specifically for this version
@@ -300,7 +300,7 @@ class Config(QtCore.QSettings):
         """Build a Config object using a user-provided configuration file
         path."""
         this = cls()
-        QtCore.QSettings.__init__(this, filename, QtCore.QSettings.IniFormat,
+        QtCore.QSettings.__init__(this, filename, QtCore.QSettings.Format.IniFormat,
                                   parent)
         this.__initialize()
         return this

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -84,7 +84,7 @@ def upgrade_to_v1_0_0_final_0(config, interactive=True, merge=True):
                         "albums has been removed in this version of Picard.\n"
                         "Your file naming scheme has automatically been "
                         "merged with that of single artist albums."),
-                    QtWidgets.QMessageBox.Ok)
+                    QtWidgets.QMessageBox.StandardButton.Ok)
 
         elif (_s.value("va_file_naming_format", TextOption)
               != r"$if2(%albumartist%,%artist%)/%album%/$if($gt(%totaldis"
@@ -99,9 +99,9 @@ def upgrade_to_v1_0_0_final_0(config, interactive=True, merge=True):
                     "separate file naming scheme defined.\n"
                     "Do you want to remove it or merge it with your file "
                     "naming scheme for single artist albums?"))
-                msgbox.setIcon(QtWidgets.QMessageBox.Question)
-                merge_button = msgbox.addButton(_('Merge'), QtWidgets.QMessageBox.AcceptRole)
-                msgbox.addButton(_('Remove'), QtWidgets.QMessageBox.DestructiveRole)
+                msgbox.setIcon(QtWidgets.QMessageBox.Icon.Question)
+                merge_button = msgbox.addButton(_('Merge'), QtWidgets.QMessageBox.ButtonRole.AcceptRole)
+                msgbox.addButton(_('Remove'), QtWidgets.QMessageBox.ButtonRole.DestructiveRole)
                 msgbox.exec_()
                 merge = msgbox.clickedButton() == merge_button
             remove_va_file_naming_format(merge=merge)

--- a/picard/const/appdirs.py
+++ b/picard/const/appdirs.py
@@ -39,14 +39,14 @@ QCoreApplication.setOrganizationName(PICARD_ORG_NAME)
 
 
 def config_folder():
-    return os.path.normpath(os.environ.get('PICARD_CONFIG_DIR', QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)))
+    return os.path.normpath(os.environ.get('PICARD_CONFIG_DIR', QStandardPaths.writableLocation(QStandardPaths.StandardLocation.AppConfigLocation)))
 
 
 def cache_folder():
-    return os.path.normpath(os.environ.get('PICARD_CACHE_DIR', QStandardPaths.writableLocation(QStandardPaths.CacheLocation)))
+    return os.path.normpath(os.environ.get('PICARD_CACHE_DIR', QStandardPaths.writableLocation(QStandardPaths.StandardLocation.CacheLocation)))
 
 
 def plugin_folder():
-    # FIXME: This really should be in QStandardPaths.AppDataLocation instead,
+    # FIXME: This really should be in QStandardPaths.StandardLocation.AppDataLocation instead,
     # but this is a breaking change that requires data migration
     return os.path.normpath(os.environ.get('PICARD_PLUGIN_DIR', os.path.join(config_folder(), 'plugins')))

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -59,7 +59,7 @@ from picard.util.scripttofilename import script_to_filename
 
 
 _datafiles = dict()
-_datafile_mutex = QMutex(QMutex.Recursive)
+_datafile_mutex = QMutex(QMutex.RecursionMode.Recursive)
 
 
 class DataHash:
@@ -170,7 +170,7 @@ class CoverArtImage:
         self.url = QUrl(url)
         self.host = self.url.host()
         self.port = self.url.port(443 if self.url.scheme() == 'https' else 80)
-        self.path = self.url.path(QUrl.FullyEncoded)
+        self.path = self.url.path(QUrl.ComponentFormattingOption.FullyEncoded)
         if self.url.hasQuery():
             query = QUrlQuery(self.url.query())
             self.queryargs = dict(query.queryItems())

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -154,7 +154,7 @@ class ArrowsColumn(QtWidgets.QWidget):
         self.selection_list = selection_list
         self.ignore_list = ignore_list
         self.callback = callback
-        spacer_item = QtWidgets.QSpacerItem(20, 20, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacer_item = QtWidgets.QSpacerItem(20, 20, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
         arrows_layout = QtWidgets.QVBoxLayout()
         arrows_layout.addItem(QtWidgets.QSpacerItem(spacer_item))
         self.button_add = ArrowButton('go-next' if reverse else 'go-previous', self.move_from_ignore)
@@ -194,9 +194,9 @@ class ListBox(QtWidgets.QListWidget):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setMinimumSize(QtCore.QSize(self.LISTBOX_WIDTH, self.LISTBOX_HEIGHT))
-        self.setSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.Expanding)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.setSortingEnabled(True)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
 
     def move_item(self, item, target_list):
         """Move the specified item to another listbox."""
@@ -217,7 +217,7 @@ class ListBox(QtWidgets.QListWidget):
         if callback:
             callback()
 
-    def all_items_data(self, role=QtCore.Qt.UserRole):
+    def all_items_data(self, role=QtCore.Qt.ItemDataRole.UserRole):
         for index in range(self.count()):
             yield self.item(index).data(role)
 
@@ -241,9 +241,9 @@ class CAATypesSelectorDialog(PicardDialog):
             types_exclude = []
 
         self.setWindowTitle(_("Cover art types"))
-        self.setWindowModality(QtCore.Qt.WindowModal)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.layout = QtWidgets.QVBoxLayout(self)
-        self.layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
+        self.layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
 
         # Create list boxes for dialog
         self.list_include = ListBox()
@@ -262,7 +262,7 @@ class CAATypesSelectorDialog(PicardDialog):
         instructions = QtWidgets.QLabel()
         instructions.setText(_("Please select the contents of the image type 'Include' and 'Exclude' lists."))
         instructions.setWordWrap(True)
-        instructions.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)
 
         self.arrows_include = ArrowsColumn(
@@ -311,17 +311,17 @@ class CAATypesSelectorDialog(PicardDialog):
             "use a CAA image.\n")
         )
         instructions.setWordWrap(True)
-        instructions.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)
 
         self.buttonbox = QtWidgets.QDialogButtonBox(self)
-        self.buttonbox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonbox.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self.buttonbox.addButton(
-            StandardButton(StandardButton.OK), QtWidgets.QDialogButtonBox.AcceptRole)
+            StandardButton(StandardButton.OK), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         self.buttonbox.addButton(StandardButton(StandardButton.CANCEL),
-                                 QtWidgets.QDialogButtonBox.RejectRole)
+                                 QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         self.buttonbox.addButton(
-            StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.HelpRole)
+            StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.ButtonRole.HelpRole)
 
         extrabuttons = [
             (N_("I&nclude all"), self.move_all_to_include_list),
@@ -331,7 +331,7 @@ class CAATypesSelectorDialog(PicardDialog):
         ]
         for label, callback in extrabuttons:
             button = QtWidgets.QPushButton(_(label))
-            self.buttonbox.addButton(button, QtWidgets.QDialogButtonBox.ActionRole)
+            self.buttonbox.addButton(button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
             button.clicked.connect(callback)
 
         self.layout.addWidget(self.buttonbox)
@@ -375,7 +375,7 @@ class CAATypesSelectorDialog(PicardDialog):
             name = caa_type['name']
             title = translate_caa_type(name)
             item = QtWidgets.QListWidgetItem(title)
-            item.setData(QtCore.Qt.UserRole, name)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, name)
             if name in includes:
                 self.list_include.addItem(item)
             elif name in excludes:
@@ -427,7 +427,7 @@ class CAATypesSelectorDialog(PicardDialog):
             types_exclude = []
         dialog = CAATypesSelectorDialog(parent, types_include, types_exclude)
         result = dialog.exec_()
-        return (dialog.get_selected_types_include(), dialog.get_selected_types_exclude(), result == QtWidgets.QDialog.Accepted)
+        return (dialog.get_selected_types_include(), dialog.get_selected_types_exclude(), result == QtWidgets.QDialog.DialogCode.Accepted)
 
 
 class ProviderOptionsCaa(ProviderOptions):
@@ -588,7 +588,7 @@ class CoverArtProviderCaa(CoverArtProvider):
             self._caa_json_downloaded,
             priority=True,
             important=False,
-            cacheloadcontrol=QNetworkRequest.PreferNetwork
+            cacheloadcontrol=QNetworkRequest.CacheLoadControl.PreferNetwork
         )
         self.album._requests += 1
         # we will call next_in_queue() after json parsing
@@ -598,7 +598,7 @@ class CoverArtProviderCaa(CoverArtProvider):
         """Parse CAA JSON file and queue CAA cover art images for download"""
         self.album._requests -= 1
         if error:
-            if not (error == QNetworkReply.ContentNotFoundError and self.ignore_json_not_found_error):
+            if not (error == QNetworkReply.NetworkError.ContentNotFoundError and self.ignore_json_not_found_error):
                 self.error('CAA JSON error: %s' % (http.errorString()))
         else:
             if self.restrict_types:

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -200,7 +200,7 @@ class PicardScript():
         # return _export_script_dialog(script_item=self, parent=parent)
         FILE_ERROR_EXPORT = N_('Error exporting file "%s". %s.')
 
-        default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
+        default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
         default_script_extension = "ptsp"
         script_filename = ".".join((self.filename, default_script_extension))
         default_path = os.path.normpath(os.path.join(default_script_directory, script_filename))
@@ -226,10 +226,10 @@ class PicardScript():
         except OSError as error:
             raise ScriptImportExportError(format=FILE_ERROR_EXPORT, filename=filename, error_msg=error.strerror)
         dialog = QtWidgets.QMessageBox(
-            QtWidgets.QMessageBox.Information,
+            QtWidgets.QMessageBox.Icon.Information,
             _("Export Script"),
             _("Script successfully exported to %s") % filename,
-            QtWidgets.QMessageBox.Ok,
+            QtWidgets.QMessageBox.StandardButton.Ok,
             parent
         )
         dialog.exec_()
@@ -244,7 +244,7 @@ class PicardScript():
 
         dialog_title = _("Import Script File")
         dialog_file_types = cls._get_dialog_filetypes()
-        default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
+        default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
         options = QtWidgets.QFileDialog.Options()
         filename, file_type = QtWidgets.QFileDialog.getOpenFileName(parent, dialog_title, default_script_directory, dialog_file_types, options=options)
         if not filename:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -231,7 +231,7 @@ class Tagger(QtWidgets.QApplication):
             self.signalfd = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM, 0)
 
             self.signalnotifier = QtCore.QSocketNotifier(self.signalfd[1].fileno(),
-                                                         QtCore.QSocketNotifier.Read, self)
+                                                         QtCore.QSocketNotifier.Type.Read, self)
             self.signalnotifier.activated.connect(self.sighandler)
 
             signal.signal(signal.SIGHUP, self.signal)
@@ -302,7 +302,7 @@ class Tagger(QtWidgets.QApplication):
             self.updatecheckmanager = UpdateCheckManager(parent=self.window)
 
     def enable_menu_icons(self, enabled):
-        self.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus, not enabled)
+        self.setAttribute(QtCore.Qt.ApplicationAttribute.AA_DontShowIconsInMenus, not enabled)
 
     def register_cleanup(self, func):
         self.exit_cleanup.append(func)
@@ -319,11 +319,11 @@ class Tagger(QtWidgets.QApplication):
         if not parent:
             parent = self.window
         dialog = QtWidgets.QInputDialog(parent)
-        dialog.setWindowModality(QtCore.Qt.WindowModal)
+        dialog.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         dialog.setWindowTitle(_("MusicBrainz Account"))
         dialog.setLabelText(_("Authorization code:"))
         status = dialog.exec_()
-        if status == QtWidgets.QDialog.Accepted:
+        if status == QtWidgets.QDialog.DialogCode.Accepted:
             return dialog.textValue()
         else:
             return None
@@ -427,7 +427,7 @@ class Tagger(QtWidgets.QApplication):
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):
             event.run()
-        elif event.type() == QtCore.QEvent.FileOpen:
+        elif event.type() == QtCore.QEvent.Type.FileOpen:
             file = event.file()
             self.add_paths([file])
             if IS_HAIKU:
@@ -962,7 +962,7 @@ class Tagger(QtWidgets.QApplication):
     def set_wait_cursor(self):
         """Sets the waiting cursor."""
         super().setOverrideCursor(
-            QtGui.QCursor(QtCore.Qt.WaitCursor))
+            QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
 
     def restore_cursor(self):
         """Restores the cursor set by ``set_wait_cursor``."""
@@ -974,7 +974,7 @@ class Tagger(QtWidgets.QApplication):
                 obj.load(priority=True, refresh=True)
 
     def bring_tagger_front(self):
-        self.window.setWindowState(self.window.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+        self.window.setWindowState(self.window.windowState() & ~QtCore.Qt.WindowState.WindowMinimized | QtCore.Qt.WindowState.WindowActive)
         self.window.raise_()
         self.window.activateWindow()
 
@@ -1044,8 +1044,8 @@ def main(localedir=None, autoupdate=True):
     QtWidgets.QApplication.setDesktopFileName(PICARD_DESKTOP_NAME)
 
     # Allow High DPI Support
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.ApplicationAttribute.AA_EnableHighDpiScaling)
     # HighDpiScaleFactorRoundingPolicy is available since Qt 5.14. This is
     # required to support fractional scaling on Windows properly.
     # It causes issues without scaling on Linux, see https://tickets.metabrainz.org/browse/PICARD-1948
@@ -1076,7 +1076,7 @@ def main(localedir=None, autoupdate=True):
     # Initialize Qt default translations
     translator = QtCore.QTranslator()
     locale = QtCore.QLocale()
-    translation_path = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.TranslationsPath)
+    translation_path = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.LibraryLocation.TranslationsPath)
     log.debug("Looking for Qt locale %s in %s", locale.name(), translation_path)
     if translator.load(locale, "qtbase_", directory=translation_path):
         tagger.installTranslator(translator)

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -175,7 +175,7 @@ class SingletonDialog:
 class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     help_url = None
-    flags = QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowCloseButtonHint
+    flags = QtCore.Qt.WindowType.WindowSystemMenuHint | QtCore.Qt.WindowType.WindowTitleHint | QtCore.Qt.WindowType.WindowCloseButtonHint
     ready_for_display = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
@@ -184,9 +184,9 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
         self.ready_for_display.connect(self.restore_geometry)
 
     def keyPressEvent(self, event):
-        if event.matches(QtGui.QKeySequence.Close):
+        if event.matches(QtGui.QKeySequence.StandardKey.Close):
             self.close()
-        elif event.matches(QtGui.QKeySequence.HelpContents) and self.help_url:
+        elif event.matches(QtGui.QKeySequence.StandardKey.HelpContents) and self.help_url:
             self.show_help()
         else:
             super().keyPressEvent(event)

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -44,7 +44,7 @@ class AboutDialog(PicardDialog, SingletonDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.ui = Ui_AboutDialog()
         self.ui.setupUi(self)
         self._update_content()

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -66,7 +66,7 @@ class CDLookupDialog(PicardDialog):
         self.ui = Ui_Dialog()
         self.ui.setupUi(self)
         release_list = self.ui.release_list
-        release_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        release_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         release_list.setSortingEnabled(True)
         release_list.setAlternatingRowColors(True)
         release_list.setHeaderLabels([_("Album"), _("Artist"), _("Date"), _("Country"),
@@ -94,14 +94,14 @@ class CDLookupDialog(PicardDialog):
                 item.setText(5, myjoin(catalog_numbers))
                 item.setText(6, barcode)
                 item.setText(7, release.get('disambiguation', ''))
-                item.setData(0, QtCore.Qt.UserRole, release['id'])
+                item.setData(0, QtCore.Qt.ItemDataRole.UserRole, release['id'])
             release_list.setCurrentItem(selected or release_list.topLevelItem(0))
             self.ui.ok_button.setEnabled(True)
             for i in range(release_list.columnCount() - 1):
                 release_list.resizeColumnToContents(i)
             # Sort by descending date, then ascending country
-            release_list.sortByColumn(3, QtCore.Qt.AscendingOrder)
-            release_list.sortByColumn(2, QtCore.Qt.DescendingOrder)
+            release_list.sortByColumn(3, QtCore.Qt.SortOrder.AscendingOrder)
+            release_list.sortByColumn(2, QtCore.Qt.SortOrder.DescendingOrder)
         else:
             self.ui.results_view.setCurrentIndex(1)
         self.ui.lookup_button.clicked.connect(self.lookup)
@@ -112,7 +112,7 @@ class CDLookupDialog(PicardDialog):
     def accept(self):
         release_list = self.ui.release_list
         for index in release_list.selectionModel().selectedRows():
-            release_id = release_list.itemFromIndex(index).data(0, QtCore.Qt.UserRole)
+            release_id = release_list.itemFromIndex(index).data(0, QtCore.Qt.ItemDataRole.UserRole)
             self.tagger.load_album(release_id, discid=self.disc.id)
         super().accept()
 

--- a/picard/ui/checkbox_list_item.py
+++ b/picard/ui/checkbox_list_item.py
@@ -29,10 +29,10 @@ class CheckboxListItem(QListWidgetItem):
     def __init__(self, text='', checked=False, data=None):
         super().__init__()
         self.setText(text)
-        self.setFlags(self.flags() | Qt.ItemIsUserCheckable)
-        self.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+        self.setFlags(self.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+        self.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
         self.data = data
 
     @property
     def checked(self):
-        return self.checkState() == Qt.Checked
+        return self.checkState() == Qt.CheckState.Checked

--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -102,10 +102,10 @@ class CollectionMenuItem(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(self)
         style = self.style()
         layout.setContentsMargins(
-            style.pixelMetric(QtWidgets.QStyle.PM_LayoutLeftMargin),
-            style.pixelMetric(QtWidgets.QStyle.PM_FocusFrameVMargin),
-            style.pixelMetric(QtWidgets.QStyle.PM_LayoutRightMargin),
-            style.pixelMetric(QtWidgets.QStyle.PM_FocusFrameVMargin))
+            style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_LayoutLeftMargin),
+            style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_FocusFrameVMargin),
+            style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_LayoutRightMargin),
+            style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_FocusFrameVMargin))
         self.checkbox = CollectionCheckBox(self, menu, collection)
         layout.addWidget(self.checkbox)
 
@@ -118,7 +118,7 @@ class CollectionMenuItem(QtWidgets.QWidget):
         self.active = active
         palette = self.palette()
         textcolor = self.highlight_color if active else self.text_color
-        palette.setColor(QtGui.QPalette.WindowText, textcolor)
+        palette.setColor(QtGui.QPalette.ColorRole.WindowText, textcolor)
         self.checkbox.setPalette(palette)
 
     def enterEvent(self, e):
@@ -131,12 +131,12 @@ class CollectionMenuItem(QtWidgets.QWidget):
         painter = QtWidgets.QStylePainter(self)
         option = QtWidgets.QStyleOptionMenuItem()
         option.initFrom(self)
-        option.state = QtWidgets.QStyle.State_None
+        option.state = QtWidgets.QStyle.StateFlag.State_None
         if self.isEnabled():
-            option.state |= QtWidgets.QStyle.State_Enabled
+            option.state |= QtWidgets.QStyle.StateFlag.State_Enabled
         if self.active:
-            option.state |= QtWidgets.QStyle.State_Selected
-        painter.drawControl(QtWidgets.QStyle.CE_MenuItem, option)
+            option.state |= QtWidgets.QStyle.StateFlag.State_Selected
+        painter.drawControl(QtWidgets.QStyle.ControlElement.CE_MenuItem, option)
 
 
 class CollectionCheckBox(QtWidgets.QCheckBox):
@@ -148,11 +148,11 @@ class CollectionCheckBox(QtWidgets.QCheckBox):
 
         releases = collection.releases & menu.ids
         if len(releases) == len(menu.ids):
-            self.setCheckState(QtCore.Qt.Checked)
+            self.setCheckState(QtCore.Qt.CheckState.Checked)
         elif not releases:
-            self.setCheckState(QtCore.Qt.Unchecked)
+            self.setCheckState(QtCore.Qt.CheckState.Unchecked)
         else:
-            self.setCheckState(QtCore.Qt.PartiallyChecked)
+            self.setCheckState(QtCore.Qt.CheckState.PartiallyChecked)
 
     def nextCheckState(self):
         ids = self.menu.ids
@@ -161,10 +161,10 @@ class CollectionCheckBox(QtWidgets.QCheckBox):
         diff = ids - self.collection.releases
         if diff:
             self.collection.add_releases(diff, self.updateText)
-            self.setCheckState(QtCore.Qt.Checked)
+            self.setCheckState(QtCore.Qt.CheckState.Checked)
         else:
             self.collection.remove_releases(ids & self.collection.releases, self.updateText)
-            self.setCheckState(QtCore.Qt.Unchecked)
+            self.setCheckState(QtCore.Qt.CheckState.Unchecked)
 
     def updateText(self):
         self.setText(self.label())

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -72,11 +72,11 @@ class CoverArtThumbnail(ActiveLabel):
         self.shadow = QtGui.QPixmap(":/images/CoverArtShadow.png")
         self.pixel_ratio = self.tagger.primaryScreen().devicePixelRatio()
         w, h = self.scaled(128, 128)
-        self.shadow = self.shadow.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+        self.shadow = self.shadow.scaled(w, h, QtCore.Qt.AspectRatioMode.KeepAspectRatio, QtCore.Qt.TransformationMode.SmoothTransformation)
         self.shadow.setDevicePixelRatio(self.pixel_ratio)
         self.release = None
         self.setPixmap(self.shadow)
-        self.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
+        self.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter)
         self.setMargin(0)
         self.setAcceptDrops(drops)
         self.clicked.connect(self.open_release_page)
@@ -144,7 +144,7 @@ class CoverArtThumbnail(ActiveLabel):
     def decorate_cover(self, pixmap):
         offx, offy, w, h = self.scaled(1, 1, 121, 121)
         cover = QtGui.QPixmap(self.shadow)
-        pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+        pixmap = pixmap.scaled(w, h, QtCore.Qt.AspectRatioMode.KeepAspectRatio, QtCore.Qt.TransformationMode.SmoothTransformation)
         pixmap.setDevicePixelRatio(self.pixel_ratio)
         painter = QtGui.QPainter(cover)
         bgcolor = QtGui.QColor.fromRgb(0, 0, 0, 128)
@@ -192,7 +192,7 @@ class CoverArtThumbnail(ActiveLabel):
                     offset = displacements * (len(data_to_paint) - 1)
                 stack_width, stack_height = (w + offset, h + offset)
                 pixmap = QtGui.QPixmap(stack_width, stack_height)
-                bgcolor = self.palette().color(QtGui.QPalette.Window)
+                bgcolor = self.palette().color(QtGui.QPalette.ColorRole.Window)
                 painter = QtGui.QPainter(pixmap)
                 painter.fillRect(QtCore.QRectF(0, 0, stack_width, stack_height), bgcolor)
                 cx = stack_width - w // 2
@@ -232,7 +232,7 @@ class CoverArtThumbnail(ActiveLabel):
                         painter.setPen(bgcolor)
                         painter.drawLine(x + 121 + 2, y + 121 + 2 + k, x + 121 + border_length + 2, y + 121 + 2 + k)
                 painter.end()
-                pixmap = pixmap.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+                pixmap = pixmap.scaled(w, h, QtCore.Qt.AspectRatioMode.KeepAspectRatio, QtCore.Qt.TransformationMode.SmoothTransformation)
             self._pixmap_cache[key] = pixmap
 
         pixmap.setDevicePixelRatio(self.pixel_ratio)
@@ -312,13 +312,13 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.item = None
         self.pixmap_cache = LRUCache(40)
         self.cover_art_label = QtWidgets.QLabel('')
-        self.cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
+        self.cover_art_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter)
         self.cover_art = CoverArtThumbnail(False, True, self.pixmap_cache, parent)
         self.cover_art.image_dropped.connect(self.fetch_remote_image)
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
         self.orig_cover_art_label = QtWidgets.QLabel('')
         self.orig_cover_art = CoverArtThumbnail(False, False, self.pixmap_cache, parent)
-        self.orig_cover_art_label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignHCenter)
+        self.orig_cover_art_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter)
         self.show_details_button = QtWidgets.QPushButton(_('Show more details'), self)
         self.layout.addWidget(self.cover_art_label)
         self.layout.addWidget(self.cover_art)
@@ -425,7 +425,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             return
 
         data = bytes(data)
-        mime = reply.header(QtNetwork.QNetworkRequest.ContentTypeHeader)
+        mime = reply.header(QtNetwork.QNetworkRequest.KnownHeaders.ContentTypeHeader)
         # Some sites return a mime type with encoding like "image/jpeg; charset=UTF-8"
         mime = mime.split(';')[0]
         url_query = QtCore.QUrlQuery(url.query())
@@ -440,12 +440,12 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 pass
         if url_query.hasQueryItem("imgurl"):
             # This may be a google images result, try to get the URL which is encoded in the query
-            url = QtCore.QUrl(url_query.queryItemValue("imgurl", QtCore.QUrl.FullyDecoded))
+            url = QtCore.QUrl(url_query.queryItemValue("imgurl", QtCore.QUrl.ComponentFormattingOption.FullyDecoded))
             log.debug('Possible Google images result, trying to fetch imgurl=%s', url.toString())
             self.fetch_remote_image(url)
         elif url_query.hasQueryItem("mediaurl"):
             # Bing uses mediaurl
-            url = QtCore.QUrl(url_query.queryItemValue("mediaurl", QtCore.QUrl.FullyDecoded))
+            url = QtCore.QUrl(url_query.queryItemValue("mediaurl", QtCore.QUrl.ComponentFormattingOption.FullyDecoded))
             log.debug('Possible Bing images result, trying to fetch imgurl=%s', url.toString())
             self.fetch_remote_image(url)
         else:

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -59,7 +59,7 @@ class TagEditorDelegate(QtWidgets.QItemDelegate):
         tag = self.get_tag_name(index)
         if tag.partition(':')[0] in {'comment', 'lyrics'}:
             editor = QtWidgets.QPlainTextEdit(parent)
-            editor.setFrameStyle(editor.style().styleHint(QtWidgets.QStyle.SH_ItemView_DrawDelegateFrame, None, editor))
+            editor.setFrameStyle(editor.style().styleHint(QtWidgets.QStyle.StyleHint.SH_ItemView_DrawDelegateFrame, None, editor))
             editor.setMinimumSize(QtCore.QSize(0, 80))
         else:
             editor = super().createEditor(parent, option, index)
@@ -72,16 +72,16 @@ class TagEditorDelegate(QtWidgets.QItemDelegate):
             completer = QtWidgets.QCompleter(AUTOCOMPLETE_RELEASE_TYPES, editor)
         elif tag == 'releasestatus':
             completer = QtWidgets.QCompleter(AUTOCOMPLETE_RELEASE_STATUS, editor)
-            completer.setModelSorting(QtWidgets.QCompleter.CaseInsensitivelySortedModel)
+            completer.setModelSorting(QtWidgets.QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         elif tag == 'releasecountry':
             completer = QtWidgets.QCompleter(AUTOCOMPLETE_RELEASE_COUNTRIES, editor)
-            completer.setModelSorting(QtWidgets.QCompleter.CaseInsensitivelySortedModel)
+            completer.setModelSorting(QtWidgets.QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         elif tag == 'media':
             completer = QtWidgets.QCompleter(AUTOCOMPLETE_RELEASE_FORMATS, editor)
-            completer.setModelSorting(QtWidgets.QCompleter.CaseInsensitivelySortedModel)
+            completer.setModelSorting(QtWidgets.QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         if editor and completer:
-            completer.setCompletionMode(QtWidgets.QCompleter.UnfilteredPopupCompletion)
-            completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+            completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.UnfilteredPopupCompletion)
+            completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
             editor.setCompleter(completer)
         return editor
 
@@ -111,7 +111,7 @@ class EditTagDialog(PicardDialog):
         visible_tags = [tn for tn in self.default_tags if not tn.startswith("~")]
         tag_names.addItems(visible_tags)
         self.completer = QtWidgets.QCompleter(visible_tags, tag_names)
-        self.completer.setCompletionMode(QtWidgets.QCompleter.PopupCompletion)
+        self.completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
         tag_names.setCompleter(self.completer)
         self.value_list.model().rowsInserted.connect(self.on_rows_inserted)
         self.value_list.model().rowsRemoved.connect(self.on_rows_removed)
@@ -120,12 +120,12 @@ class EditTagDialog(PicardDialog):
         self.value_selection_changed()
 
     def keyPressEvent(self, event):
-        if event.modifiers() == QtCore.Qt.NoModifier and event.key() in {QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return}:
+        if event.modifiers() == QtCore.Qt.KeyboardModifier.NoModifier and event.key() in {QtCore.Qt.Key.Key_Enter, QtCore.Qt.Key.Key_Return}:
             self.add_or_edit_value()
             event.accept()
-        elif event.matches(QtGui.QKeySequence.Delete):
+        elif event.matches(QtGui.QKeySequence.StandardKey.Delete):
             self.remove_value()
-        elif event.key() == QtCore.Qt.Key_Insert:
+        elif event.key() == QtCore.Qt.Key.Key_Insert:
             self.add_value()
         else:
             super().keyPressEvent(event)
@@ -144,7 +144,7 @@ class EditTagDialog(PicardDialog):
 
     def add_value(self):
         item = QtWidgets.QListWidgetItem()
-        item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable)
+        item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsEditable)
         self.value_list.addItem(item)
         self.value_list.setCurrentItem(item)
         self.value_list.editItem(item)
@@ -206,7 +206,7 @@ class EditTagDialog(PicardDialog):
         tag_names.editTextChanged.disconnect(self.tag_changed)
         line_edit = tag_names.lineEdit()
         cursor_pos = line_edit.cursorPosition()
-        flags = QtCore.Qt.MatchFixedString | QtCore.Qt.MatchCaseSensitive
+        flags = QtCore.Qt.MatchFlag.MatchFixedString | QtCore.Qt.MatchFlag.MatchCaseSensitive
 
         # if the previous tag was new and has no value, remove it from the QComboBox.
         # e.g. typing "XYZ" should not leave "X" or "XY" in the QComboBox.
@@ -243,14 +243,14 @@ class EditTagDialog(PicardDialog):
         self.value_list.model().rowsInserted.disconnect(self.on_rows_inserted)
         self._add_value_items(values)
         self.value_list.model().rowsInserted.connect(self.on_rows_inserted)
-        self.value_list.setCurrentItem(self.value_list.item(0), QtCore.QItemSelectionModel.SelectCurrent)
+        self.value_list.setCurrentItem(self.value_list.item(0), QtCore.QItemSelectionModel.SelectionFlag.SelectCurrent)
         tag_names.editTextChanged.connect(self.tag_changed)
 
     def _add_value_items(self, values):
         values = [v for v in values if v] or [""]
         for value in values:
             item = QtWidgets.QListWidgetItem(value)
-            item.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable | QtCore.Qt.ItemIsDragEnabled)
+            item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsEditable | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
             font = item.font()
             font.setItalic(self.different)
             item.setFont(font)

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -68,7 +68,7 @@ def _macos_extend_root_volume_path(path):
     return path
 
 
-_default_current_browser_path = QStandardPaths.writableLocation(QStandardPaths.HomeLocation)
+_default_current_browser_path = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.HomeLocation)
 
 if IS_MACOS:
     _default_current_browser_path = _macos_extend_root_volume_path(_default_current_browser_path)
@@ -83,7 +83,7 @@ class FileBrowser(QtWidgets.QTreeView):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setDragEnabled(True)
         self.load_selected_files_action = QtWidgets.QAction(_("&Load selected files"), self)
         self.load_selected_files_action.triggered.connect(self.load_selected_files)
@@ -129,22 +129,22 @@ class FileBrowser(QtWidgets.QTreeView):
         model.setNameFilters(filters)
         # Hide unsupported files completely
         model.setNameFilterDisables(False)
-        model.sort(0, QtCore.Qt.AscendingOrder)
+        model.sort(0, QtCore.Qt.SortOrder.AscendingOrder)
         if IS_MACOS:
             self.setRootIndex(model.index("/Volumes"))
         header = self.header()
         header.hideSection(1)
         header.hideSection(2)
         header.hideSection(3)
-        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         header.setStretchLastSection(False)
         header.setVisible(False)
 
     def _set_model_filter(self):
         config = get_config()
-        model_filter = QtCore.QDir.AllDirs | QtCore.QDir.Files | QtCore.QDir.Drives | QtCore.QDir.NoDotAndDotDot
+        model_filter = QtCore.QDir.Filter.AllDirs | QtCore.QDir.Filter.Files | QtCore.QDir.Filter.Drives | QtCore.QDir.Filter.NoDotAndDotDot
         if config.persist["show_hidden_files"]:
-            model_filter |= QtCore.QDir.Hidden
+            model_filter |= QtCore.QDir.Filter.Hidden
         self.model().setFilter(model_filter)
 
     def _layout_changed(self):
@@ -159,7 +159,7 @@ class FileBrowser(QtWidgets.QTreeView):
             self.scrollTo(self.currentIndex())
         QtCore.QTimer.singleShot(0, scroll)
 
-    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.EnsureVisible):
+    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.ScrollHint.EnsureVisible):
         # QTreeView.scrollTo resets the horizontal scroll position to 0.
         # Reimplemented to instead scroll to horizontal parent position or keep previous position.
         config = get_config()
@@ -180,7 +180,7 @@ class FileBrowser(QtWidgets.QTreeView):
         super().mousePressEvent(event)
         index = self.indexAt(event.pos())
         if index.isValid():
-            self.selectionModel().setCurrentIndex(index, QtCore.QItemSelectionModel.NoUpdate)
+            self.selectionModel().setCurrentIndex(index, QtCore.QItemSelectionModel.SelectionFlag.NoUpdate)
 
     def focusInEvent(self, event):
         self.focused = True
@@ -205,10 +205,10 @@ class FileBrowser(QtWidgets.QTreeView):
         config = get_config()
         if config.setting["starting_directory"]:
             path = config.setting["starting_directory_path"]
-            scrolltype = QtWidgets.QAbstractItemView.PositionAtTop
+            scrolltype = QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop
         else:
             path = config.persist["current_browser_path"]
-            scrolltype = QtWidgets.QAbstractItemView.PositionAtCenter
+            scrolltype = QtWidgets.QAbstractItemView.ScrollHint.PositionAtCenter
         if path:
             index = self.model().index(find_existing_path(path))
             self.setCurrentIndex(index)

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -73,15 +73,15 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
         if pixmap is not None:
             image_label = QtWidgets.QLabel()
             image_label.setPixmap(pixmap.scaled(self.SIZE, self.SIZE,
-                                                QtCore.Qt.KeepAspectRatio,
-                                                QtCore.Qt.SmoothTransformation))
-            image_label.setAlignment(QtCore.Qt.AlignCenter)
+                                                QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                                                QtCore.Qt.TransformationMode.SmoothTransformation))
+            image_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(image_label)
 
         if text is not None:
             text_label = QtWidgets.QLabel()
             text_label.setText(text)
-            text_label.setAlignment(QtCore.Qt.AlignCenter)
+            text_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             text_label.setWordWrap(True)
             layout.addWidget(text_label)
 
@@ -140,7 +140,7 @@ class InfoDialog(PicardDialog):
             self.display_existing_artwork = False
         self.ui.setupUi(self)
         self.ui.buttonBox.addButton(
-            StandardButton(StandardButton.CLOSE), QtWidgets.QDialogButtonBox.AcceptRole)
+            StandardButton(StandardButton.CLOSE), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         self.ui.buttonBox.accepted.connect(self.accept)
 
         # Add the ArtworkTable to the ui
@@ -184,7 +184,7 @@ class InfoDialog(PicardDialog):
         for image in images:
             while row != row_count:
                 image_type = self.artwork_table.item(row, self.artwork_table._type_col)
-                if image_type and image_type.data(QtCore.Qt.UserRole) == image.types_as_string():
+                if image_type and image_type.data(QtCore.Qt.ItemDataRole.UserRole) == image.types_as_string():
                     break
                 row += 1
             if row == row_count:
@@ -202,7 +202,7 @@ class InfoDialog(PicardDialog):
                 log.error(traceback.format_exc())
                 continue
             item = QtWidgets.QTableWidgetItem()
-            item.setData(QtCore.Qt.UserRole, image)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, image)
             pixmap = QtGui.QPixmap()
             if data is not None:
                 pixmap.loadFromData(data)
@@ -240,7 +240,7 @@ class InfoDialog(PicardDialog):
         for row, artwork_type in enumerate(types):
             self.artwork_table.insertRow(row)
             item = QtWidgets.QTableWidgetItem()
-            item.setData(QtCore.Qt.UserRole, artwork_type)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, artwork_type)
             type_wgt = ArtworkCoverWidget(pixmap=pixmap_arrow, text=artwork_type)
             self.artwork_table.setCellWidget(row, self.artwork_table._type_col, type_wgt)
             self.artwork_table.setItem(row, self.artwork_table._type_col, item)
@@ -253,7 +253,7 @@ class InfoDialog(PicardDialog):
         if self.existing_images:
             self._display_artwork(self.existing_images, self.artwork_table._existing_cover_col)
         self.artwork_table.itemDoubleClicked.connect(self.show_item)
-        self.artwork_table.verticalHeader().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
+        self.artwork_table.verticalHeader().resizeSections(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
 
     def tab_hide(self, widget):
         tab = self.ui.tabWidget
@@ -261,7 +261,7 @@ class InfoDialog(PicardDialog):
         tab.removeTab(index)
 
     def show_item(self, item):
-        data = item.data(QtCore.Qt.UserRole)
+        data = item.data(QtCore.Qt.ItemDataRole.UserRole)
         # Check if this function isn't triggered by cell in Type column
         if isinstance(data, str):
             return

--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -56,7 +56,7 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self.label2.setPixmap(self.icon_file.pixmap(size))
         self.label3.setPixmap(self.icon_cd.pixmap(size))
         self.label4.setPixmap(self.icon_file_pending.pixmap(size))
-        self.label5.setPixmap(self.icon_download.pixmap(size, QtGui.QIcon.Disabled))
+        self.label5.setPixmap(self.icon_download.pixmap(size, QtGui.QIcon.Mode.Disabled))
         self._init_tooltips()
 
     def _create_icons(self):
@@ -165,8 +165,8 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
 
     def set_pending_requests(self, num):
         if num <= 0:
-            enabled = QtGui.QIcon.Disabled
+            enabled = QtGui.QIcon.Mode.Disabled
         else:
-            enabled = QtGui.QIcon.Normal
+            enabled = QtGui.QIcon.Mode.Normal
         self.label5.setPixmap(self.icon_download.pixmap(self._size, enabled))
         self.val5.setText(str(num))

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -214,7 +214,7 @@ class MainPanel(QtWidgets.QSplitter):
         TreeItem.base_color = self.palette().base().color()
         TreeItem.text_color = self.palette().text().color()
         TreeItem.text_color_secondary = self.palette() \
-            .brush(QtGui.QPalette.Disabled, QtGui.QPalette.Text).color()
+            .brush(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text).color()
         TrackItem.track_colors = defaultdict(lambda: TreeItem.text_color, {
             File.NORMAL: interface_colors.get_qcolor('entity_saved'),
             File.CHANGED: TreeItem.text_color,
@@ -244,7 +244,7 @@ class MainPanel(QtWidgets.QSplitter):
 
     def create_icons(self):
         if hasattr(QtWidgets.QStyle, 'SP_DirIcon'):
-            ClusterItem.icon_dir = self.style().standardIcon(QtWidgets.QStyle.SP_DirIcon)
+            ClusterItem.icon_dir = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DirIcon)
         else:
             ClusterItem.icon_dir = icontheme.lookup('folder', icontheme.ICON_SIZE_MENU)
         AlbumItem.icon_cd = icontheme.lookup('media-optical', icontheme.ICON_SIZE_MENU)
@@ -340,21 +340,21 @@ def paint_column_icon(painter, rect, icon):
 class ConfigurableColumnsHeader(TristateSortHeaderView):
 
     def __init__(self, parent=None):
-        super().__init__(QtCore.Qt.Horizontal, parent)
+        super().__init__(QtCore.Qt.Orientation.Horizontal, parent)
         self._visible_columns = set([0])
 
         # The following are settings applied to default headers
         # of QTreeView and QTreeWidget.
         self.setSectionsMovable(True)
         self.setStretchLastSection(True)
-        self.setDefaultAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        self.setDefaultAlignment(QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.setSectionsClickable(False)
         self.sortIndicatorChanged.connect(self.on_sort_indicator_changed)
 
         # enable sorting, but don't actually use it by default
         # XXX it would be nice to be able to go to the 'no sort' mode, but the
         #     internal model that QTreeWidget uses doesn't support it
-        self.setSortIndicator(-1, QtCore.Qt.AscendingOrder)
+        self.setSortIndicator(-1, QtCore.Qt.SortOrder.AscendingOrder)
         self.setDefaultSectionSize(100)
 
     def show_column(self, column, show):
@@ -366,10 +366,10 @@ class ConfigurableColumnsHeader(TristateSortHeaderView):
                 self.resizeSection(column, self.defaultSectionSize())
             self._visible_columns.add(column)
             if column in {MainPanel.FINGERPRINT_COLUMN, MainPanel.ACOUSTICBRAINZ_COLUMN}:
-                self.setSectionResizeMode(column, QtWidgets.QHeaderView.Fixed)
+                self.setSectionResizeMode(column, QtWidgets.QHeaderView.ResizeMode.Fixed)
                 self.resizeSection(column, COLUMN_ICON_SIZE)
             else:
-                self.setSectionResizeMode(column, QtWidgets.QHeaderView.Interactive)
+                self.setSectionResizeMode(column, QtWidgets.QHeaderView.ResizeMode.Interactive)
         elif column in self._visible_columns:
             self._visible_columns.remove(column)
 
@@ -425,13 +425,13 @@ class ConfigurableColumnsHeader(TristateSortHeaderView):
 
     def on_sort_indicator_changed(self, index, order):
         if index in {MainPanel.FINGERPRINT_COLUMN, MainPanel.ACOUSTICBRAINZ_COLUMN}:
-            self.setSortIndicator(-1, QtCore.Qt.AscendingOrder)
+            self.setSortIndicator(-1, QtCore.Qt.SortOrder.AscendingOrder)
 
     def lock(self, is_locked):
         super().lock(is_locked)
         for column_index in {MainPanel.FINGERPRINT_COLUMN, MainPanel.ACOUSTICBRAINZ_COLUMN}:
             if not self.is_locked and self.count() > column_index:
-                self.setSectionResizeMode(column_index, QtWidgets.QHeaderView.Fixed)
+                self.setSectionResizeMode(column_index, QtWidgets.QHeaderView.ResizeMode.Fixed)
 
 
 class BaseTreeView(QtWidgets.QTreeWidget):
@@ -450,7 +450,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         self.setAcceptDrops(True)
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
 
         self.setSortingEnabled(True)
 
@@ -681,10 +681,10 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             header.update_visible_columns([0, 1, 2])
             for i, size in enumerate([250, 50, 100]):
                 header.resizeSection(i, size)
-            self.sortByColumn(-1, QtCore.Qt.AscendingOrder)
+            self.sortByColumn(-1, QtCore.Qt.SortOrder.AscendingOrder)
 
     def supportedDropActions(self):
-        return QtCore.Qt.CopyAction | QtCore.Qt.MoveAction
+        return QtCore.Qt.DropAction.CopyAction | QtCore.Qt.DropAction.MoveAction
 
     def mimeTypes(self):
         """List of MIME types accepted by this view."""
@@ -692,7 +692,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():
-            event.setDropAction(QtCore.Qt.CopyAction)
+            event.setDropAction(QtCore.Qt.DropAction.CopyAction)
             event.accept()
         else:
             event.acceptProposedAction()
@@ -708,7 +708,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             pixmap = QtGui.QPixmap(rectangle.width(), rectangle.height())
             self.viewport().render(pixmap, QtCore.QPoint(), QtGui.QRegion(rectangle))
             drag.setPixmap(pixmap)
-            drag.exec_(QtCore.Qt.MoveAction)
+            drag.exec_(QtCore.Qt.DropAction.MoveAction)
 
     def mimeData(self, items):
         """Return MIME data for specified items."""
@@ -727,7 +727,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             mimeData.setUrls(files)
         return mimeData
 
-    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.EnsureVisible):
+    def scrollTo(self, index, scrolltype=QtWidgets.QAbstractItemView.ScrollHint.EnsureVisible):
         # QTreeView.scrollTo resets the horizontal scroll position to 0.
         # Reimplemented to maintain current horizontal scroll position.
         hscrollbar = self.horizontalScrollBar()
@@ -741,7 +741,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         new_paths = []
         tagger = QtCore.QObject.tagger
         for url in urls:
-            log.debug("Dropped the URL: %r", url.toString(QtCore.QUrl.RemoveUserInfo))
+            log.debug("Dropped the URL: %r", url.toString(QtCore.QUrl.UrlFormattingOption.RemoveUserInfo))
             if url.scheme() == "file" or not url.scheme():
                 filename = normpath(url.toLocalFile().rstrip("\0"))
                 file = tagger.files.get(filename)
@@ -760,7 +760,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
     def dropEvent(self, event):
         # Dropping with Alt key pressed forces all dropped files being
         # assigned to the same track.
-        if event.keyboardModifiers() == QtCore.Qt.AltModifier:
+        if event.keyboardModifiers() == QtCore.Qt.KeyboardModifier.AltModifier:
             self._move_to_multi_tracks = False
         return QtWidgets.QTreeView.dropEvent(self, event)
 
@@ -814,7 +814,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             cluster_item.add_files(cluster.files)
 
     def moveCursor(self, action, modifiers):
-        if action in {QtWidgets.QAbstractItemView.MoveUp, QtWidgets.QAbstractItemView.MoveDown}:
+        if action in {QtWidgets.QAbstractItemView.CursorAction.MoveUp, QtWidgets.QAbstractItemView.CursorAction.MoveDown}:
             item = self.currentItem()
             if item and not item.isSelected():
                 self.setCurrentItem(item)
@@ -897,7 +897,7 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
             MainPanel.TRACKNUMBER_COLUMN,
             MainPanel.DISCNUMBER_COLUMN,
         ]:
-            self.setTextAlignment(column, QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+            self.setTextAlignment(column, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.setSizeHint(MainPanel.FINGERPRINT_COLUMN, ICON_SIZE)
         self.setSizeHint(MainPanel.ACOUSTICBRAINZ_COLUMN, ICON_SIZE)
 
@@ -1044,7 +1044,7 @@ class NatAlbumItem(AlbumItem):
         if not tree_widget:
             return True
         order = tree_widget.header().sortIndicatorOrder()
-        return order == QtCore.Qt.AscendingOrder
+        return order == QtCore.Qt.SortOrder.AscendingOrder
 
 
 class TrackItem(TreeItem):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -59,7 +59,7 @@ class LogViewDialog(PicardDialog):
 
     def __init__(self, title, parent=None):
         super().__init__(parent)
-        self.setWindowFlags(QtCore.Qt.Window)
+        self.setWindowFlags(QtCore.Qt.WindowType.Window)
         self.setWindowTitle(title)
         self.doc = QtGui.QTextDocument()
         self.textCursor = QtGui.QTextCursor(self.doc)
@@ -81,7 +81,7 @@ class LogViewCommon(LogViewDialog):
     def _init_doc(self):
         self.prev = -1
         self.doc.clear()
-        self.textCursor.movePosition(QtGui.QTextCursor.Start)
+        self.textCursor.movePosition(QtGui.QTextCursor.MoveOperation.Start)
 
     def closeEvent(self, event):
         self.save_geometry()
@@ -112,7 +112,7 @@ class LogViewCommon(LogViewDialog):
         self.displaying = False
 
     def _add_entry(self, logitem):
-        self.textCursor.movePosition(QtGui.QTextCursor.End)
+        self.textCursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
         self.textCursor.insertText(logitem.message)
         self.textCursor.insertBlock()
         sb = self.browser.verticalScrollBar()
@@ -124,7 +124,7 @@ class Highlighter(QtGui.QSyntaxHighlighter):
         super().__init__(parent)
 
         self.fmt = QtGui.QTextCharFormat()
-        self.fmt.setBackground(QtCore.Qt.lightGray)
+        self.fmt.setBackground(QtCore.Qt.GlobalColor.lightGray)
         self.reg = re.compile(wildcards_to_regex_pattern(string), re.IGNORECASE)
 
     def highlightBlock(self, text):
@@ -252,7 +252,7 @@ class LogView(LogViewCommon):
         path, ok = QtWidgets.QFileDialog.getSaveFileName(
             self,
             caption=_("Save Log View to File"),
-            options=QtWidgets.QFileDialog.DontConfirmOverwrite
+            options=QtWidgets.QFileDialog.Option.DontConfirmOverwrite
         )
         if ok and path:
             if os.path.isfile(path):
@@ -260,9 +260,9 @@ class LogView(LogViewCommon):
                     self,
                     _("Save Log View to File"),
                     _("File already exists, do you really want to save to this file?"),
-                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+                    QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No
                 )
-                if reply != QtWidgets.QMessageBox.Yes:
+                if reply != QtWidgets.QMessageBox.StandardButton.Yes:
                     return
 
             writer = QtGui.QTextDocumentWriter(path)
@@ -276,7 +276,7 @@ class LogView(LogViewCommon):
                 )
 
     def show(self):
-        self.highlight_text.setFocus(QtCore.Qt.OtherFocusReason)
+        self.highlight_text.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
         super().show()
 
     def display(self, clear=False):
@@ -289,9 +289,9 @@ class LogView(LogViewCommon):
             self,
             _("Clear Log"),
             _("Are you sure you want to clear the log?"),
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No
         )
-        if reply != QtWidgets.QMessageBox.Yes:
+        if reply != QtWidgets.QMessageBox.StandardButton.Yes:
             return
         self.log_tail.clear()
         self.display(clear=True)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -255,7 +255,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if IS_MACOS:
             self.setUnifiedTitleAndToolBarOnMac(True)
 
-        main_layout = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        main_layout = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         main_layout.setObjectName('main_window_bottom_splitter')
         main_layout.setChildrenCollapsible(False)
         main_layout.setContentsMargins(0, 0, 0, 0)
@@ -303,14 +303,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         # On macOS Command+Backspace triggers the so called "Forward Delete".
         # It should be treated the same as the Delete button.
         is_forward_delete = IS_MACOS and \
-            event.key() == QtCore.Qt.Key_Backspace and \
-            event.modifiers() & QtCore.Qt.ControlModifier
-        if event.matches(QtGui.QKeySequence.Delete) or is_forward_delete:
+            event.key() == QtCore.Qt.Key.Key_Backspace and \
+            event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier
+        if event.matches(QtGui.QKeySequence.StandardKey.Delete) or is_forward_delete:
             if self.metadata_box.hasFocus():
                 self.metadata_box.remove_selected_tags()
             else:
                 self.remove()
-        elif event.matches(QtGui.QKeySequence.Find):
+        elif event.matches(QtGui.QKeySequence.StandardKey.Find):
             self.search_edit.setFocus(True)
         else:
             super().keyPressEvent(event)
@@ -360,8 +360,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         if unsaved_files > 0:
             msg = QMessageBox(self)
-            msg.setIcon(QMessageBox.Question)
-            msg.setWindowModality(QtCore.Qt.WindowModal)
+            msg.setIcon(QMessageBox.Icon.Question)
+            msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             msg.setWindowTitle(_("Unsaved Changes"))
             msg.setText(_("Are you sure you want to quit Picard?"))
             txt = ngettext(
@@ -369,12 +369,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 "There are %d unsaved files. Closing Picard will lose all unsaved changes.",
                 unsaved_files) % unsaved_files
             msg.setInformativeText(txt)
-            cancel = msg.addButton(QMessageBox.Cancel)
+            cancel = msg.addButton(QMessageBox.StandardButton.Cancel)
             msg.setDefaultButton(cancel)
-            msg.addButton(_("&Quit Picard"), QMessageBox.YesRole)
+            msg.addButton(_("&Quit Picard"), QMessageBox.ButtonRole.YesRole)
             ret = msg.exec_()
 
-            if ret == QMessageBox.Cancel:
+            if ret == QMessageBox.StandardButton.Cancel:
                 return False
 
         return True
@@ -382,7 +382,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def saveWindowState(self):
         config = get_config()
         config.persist["window_state"] = self.saveState()
-        isMaximized = int(self.windowState()) & QtCore.Qt.WindowMaximized != 0
+        isMaximized = int(self.windowState()) & QtCore.Qt.WindowState.WindowMaximized != 0
         self.save_geometry()
         config.persist["window_maximized"] = isMaximized
         config.persist["view_metadata_view"] = self.show_metadata_view_action.isChecked()
@@ -399,7 +399,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.restoreState(config.persist["window_state"])
         self.restore_geometry()
         if config.persist["window_maximized"]:
-            self.setWindowState(QtCore.Qt.WindowMaximized)
+            self.setWindowState(QtCore.Qt.WindowState.WindowMaximized)
         splitters = config.persist["splitters_MainWindow"]
         if splitters is None or 'main_window_bottom_splitter' not in splitters:
             self.centralWidget().setSizes([366, 194])
@@ -495,15 +495,15 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             config = get_config()
             if not config.setting["acoustid_apikey"]:
                 msg = QtWidgets.QMessageBox(self)
-                msg.setIcon(QtWidgets.QMessageBox.Information)
-                msg.setWindowModality(QtCore.Qt.WindowModal)
+                msg.setIcon(QtWidgets.QMessageBox.Icon.Information)
+                msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
                 msg.setWindowTitle(_("AcoustID submission not configured"))
                 msg.setText(_(
                     "You need to configure your AcoustID API key before you can submit fingerprints."))
                 open_options = QtWidgets.QPushButton(
                     icontheme.lookup('preferences-desktop'), _("Open AcoustID options"))
-                msg.addButton(QtWidgets.QMessageBox.Cancel)
-                msg.addButton(open_options, QtWidgets.QMessageBox.YesRole)
+                msg.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+                msg.addButton(open_options, QtWidgets.QMessageBox.ButtonRole.YesRole)
                 msg.exec_()
                 if msg.clickedButton() == open_options:
                     self.show_options("fingerprinting")
@@ -513,7 +513,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     @MainWindowActions.add()
     def _create_options_action(self):
         action = QtWidgets.QAction(icontheme.lookup('preferences-desktop'), _("&Options..."), self)
-        action.setMenuRole(QtWidgets.QAction.PreferencesRole)
+        action.setMenuRole(QtWidgets.QAction.MenuRole.PreferencesRole)
         action.triggered.connect(self.show_options)
         self.options_action = action
 
@@ -527,7 +527,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     @MainWindowActions.add()
     def _create_cut_action(self):
         action = QtWidgets.QAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), _("&Cut"), self)
-        action.setShortcut(QtGui.QKeySequence.Cut)
+        action.setShortcut(QtGui.QKeySequence.StandardKey.Cut)
         action.setEnabled(False)
         action.triggered.connect(self.cut)
         self.cut_action = action
@@ -535,7 +535,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     @MainWindowActions.add()
     def _create_paste_action(self):
         action = QtWidgets.QAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), _("&Paste"), self)
-        action.setShortcut(QtGui.QKeySequence.Paste)
+        action.setShortcut(QtGui.QKeySequence.StandardKey.Paste)
         action.setEnabled(False)
         action.triggered.connect(self.paste)
         self.paste_action = action
@@ -543,14 +543,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     @MainWindowActions.add()
     def _create_help_action(self):
         action = QtWidgets.QAction(_("&Help..."), self)
-        action.setShortcut(QtGui.QKeySequence.HelpContents)
+        action.setShortcut(QtGui.QKeySequence.StandardKey.HelpContents)
         action.triggered.connect(self.show_help)
         self.help_action = action
 
     @MainWindowActions.add()
     def _create_about_action(self):
         action = QtWidgets.QAction(_("&About..."), self)
-        action.setMenuRole(QtWidgets.QAction.AboutRole)
+        action.setMenuRole(QtWidgets.QAction.MenuRole.AboutRole)
         action.triggered.connect(self.show_about)
         self.about_action = action
 
@@ -577,7 +577,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         action = QtWidgets.QAction(icontheme.lookup('document-open'), _("&Add Files..."), self)
         action.setStatusTip(_("Add files to the tagger"))
         # TR: Keyboard shortcut for "Add Files..."
-        action.setShortcut(QtGui.QKeySequence.Open)
+        action.setShortcut(QtGui.QKeySequence.StandardKey.Open)
         action.triggered.connect(self.add_files)
         self.add_files_action = action
 
@@ -605,7 +605,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         action = QtWidgets.QAction(icontheme.lookup('document-save'), _("&Save"), self)
         action.setStatusTip(_("Save selected files"))
         # TR: Keyboard shortcut for "Save"
-        action.setShortcut(QtGui.QKeySequence.Save)
+        action.setShortcut(QtGui.QKeySequence.StandardKey.Save)
         action.setEnabled(False)
         action.triggered.connect(self.save)
         self.save_action = action
@@ -621,7 +621,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     @MainWindowActions.add()
     def _create_exit_action(self):
         action = QtWidgets.QAction(_("E&xit"), self)
-        action.setMenuRole(QtWidgets.QAction.QuitRole)
+        action.setMenuRole(QtWidgets.QAction.MenuRole.QuitRole)
         # TR: Keyboard shortcut for "Exit"
         action.setShortcut(QtGui.QKeySequence(_("Ctrl+Q")))
         action.triggered.connect(self.close)
@@ -913,7 +913,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _create_check_update_action(self):
         if self.tagger.autoupdate_enabled:
             action = QtWidgets.QAction(_("&Check for Update…"), self)
-            action.setMenuRole(QtWidgets.QAction.ApplicationSpecificRole)
+            action.setMenuRole(QtWidgets.QAction.MenuRole.ApplicationSpecificRole)
             action.triggered.connect(self.do_update_check)
         else:
             action = None
@@ -953,7 +953,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if len(self.cd_lookup_menu.actions()) > 1:
             button = self.toolbar.widgetForAction(self.cd_lookup_action)
             if button:
-                button.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
+                button.setPopupMode(QtWidgets.QToolButton.ToolButtonPopupMode.MenuButtonPopup)
             self.cd_lookup_action.setMenu(self.cd_lookup_menu)
         else:
             self.cd_lookup_action.setMenu(None)
@@ -1070,9 +1070,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def update_toolbar_style(self):
         config = get_config()
-        style = QtCore.Qt.ToolButtonIconOnly
+        style = QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly
         if config.setting["toolbar_show_labels"]:
-            style = QtCore.Qt.ToolButtonTextUnderIcon
+            style = QtCore.Qt.ToolButtonStyle.ToolButtonTextUnderIcon
         self.toolbar.setToolButtonStyle(style)
         if self.player:
             self.player.toolbar.setToolButtonStyle(style)
@@ -1097,8 +1097,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         def add_toolbar_action(action):
             toolbar.addAction(action)
             widget = toolbar.widgetForAction(action)
-            widget.setFocusPolicy(QtCore.Qt.TabFocus)
-            widget.setAttribute(QtCore.Qt.WA_MacShowFocusRect)
+            widget.setFocusPolicy(QtCore.Qt.FocusPolicy.TabFocus)
+            widget.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacShowFocusRect)
 
         config = get_config()
         for action in config.setting['toolbar_layout']:
@@ -1117,7 +1117,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def create_player_toolbar(self):
         """"Create a toolbar with internal player control elements"""
         toolbar = self.player.create_toolbar()
-        self.addToolBar(QtCore.Qt.BottomToolBarArea, toolbar)
+        self.addToolBar(QtCore.Qt.ToolBarArea.BottomToolBarArea, toolbar)
         self.player_toolbar_toggle_action = toolbar.toggleViewAction()
         toolbar.hide()  # Hide by default
 
@@ -1145,7 +1145,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.search_button.setAutoRaise(True)
         self.search_button.setDefaultAction(self.search_action)
         self.search_button.setIconSize(QtCore.QSize(22, 22))
-        self.search_button.setAttribute(QtCore.Qt.WA_MacShowFocusRect)
+        self.search_button.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacShowFocusRect)
 
         # search button contextual menu, shortcut to toggle search options
         def search_button_menu(position):
@@ -1166,7 +1166,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 menu.addAction(action)
             menu.exec_(self.search_button.mapToGlobal(position))
 
-        self.search_button.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.search_button.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.search_button.customContextMenuRequested.connect(search_button_menu)
         hbox.addWidget(self.search_button)
         toolbar.addWidget(search_panel)
@@ -1267,7 +1267,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 dir_list.append(directory)
         else:
             file_dialog = MultiDirsSelectDialog(self, "", current_directory)
-            if file_dialog.exec_() == QtWidgets.QDialog.Accepted:
+            if file_dialog.exec_() == QtWidgets.QDialog.DialogCode.Accepted:
                 dir_list = file_dialog.selectedFiles()
 
         dir_count = len(dir_list)
@@ -1392,9 +1392,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         ret = QtWidgets.QMessageBox.question(self,
             _("Configuration Required"),
             _("Audio fingerprinting is not yet configured. Would you like to configure it now?"),
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-            QtWidgets.QMessageBox.Yes)
-        return ret == QtWidgets.QMessageBox.Yes
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.Yes)
+        return ret == QtWidgets.QMessageBox.StandardButton.Yes
 
     def get_first_obj_with_type(self, type):
         for obj in self.selected_objects:
@@ -1482,9 +1482,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         ret = QtWidgets.QMessageBox.question(self,
             _("Browser integration not enabled"),
             _("Submitting releases to MusicBrainz requires the browser integration to be enabled. Do you want to enable the browser integration now?"),
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-            QtWidgets.QMessageBox.Yes)
-        if ret == QtWidgets.QMessageBox.Yes:
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.Yes)
+        if ret == QtWidgets.QMessageBox.StandardButton.Yes:
             config = get_config()
             config.setting["browser_integration"] = True
             self.tagger.update_browser_integration()
@@ -1679,9 +1679,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             ret = QtWidgets.QMessageBox.question(self,
                 _("Authentication Required"),
                 _("Picard needs authorization to access your personal data on the MusicBrainz server. Would you like to log in now?"),
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-                QtWidgets.QMessageBox.Yes)
-            if ret == QtWidgets.QMessageBox.Yes:
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+                QtWidgets.QMessageBox.StandardButton.Yes)
+            if ret == QtWidgets.QMessageBox.StandardButton.Yes:
                 self.tagger.mb_login(self.on_mb_login_finished)
         else:
             dialog = PasswordDialog(authenticator, reply, parent=self)

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -197,7 +197,7 @@ class TableTagEditorDelegate(TagEditorDelegate):
         return QtCore.QSize(size_hint.width(), min(160, size_hint.height()))
 
     def get_tag_name(self, index):
-        return index.data(QtCore.Qt.UserRole)
+        return index.data(QtCore.Qt.ItemDataRole.UserRole)
 
 
 class MetadataBox(QtWidgets.QTableWidget):
@@ -219,15 +219,15 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.setColumnCount(3)
         self.setHorizontalHeaderLabels((_("Tag"), _("Original Value"), _("New Value")))
         self.horizontalHeader().setStretchLastSection(True)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.horizontalHeader().setSectionsClickable(False)
         self.verticalHeader().setDefaultSectionSize(21)
         self.verticalHeader().setVisible(False)
-        self.setHorizontalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.setHorizontalScrollMode(QtWidgets.QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setTabKeyNavigation(False)
         self.setStyleSheet("QTableWidget {border: none;}")
-        self.setAttribute(QtCore.Qt.WA_MacShowFocusRect, 1)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacShowFocusRect, 1)
         self.setItemDelegate(TableTagEditorDelegate(self))
         self.setWordWrap(False)
         self.files = set()
@@ -287,10 +287,10 @@ class MetadataBox(QtWidgets.QTableWidget):
         if index.column() != self.COLUMN_NEW:
             return False
         item = self.itemFromIndex(index)
-        if item.flags() & QtCore.Qt.ItemIsEditable and \
-           trigger in {QtWidgets.QAbstractItemView.DoubleClicked,
-                       QtWidgets.QAbstractItemView.EditKeyPressed,
-                       QtWidgets.QAbstractItemView.AnyKeyPressed}:
+        if item.flags() & QtCore.Qt.ItemFlag.ItemIsEditable and \
+           trigger in {QtWidgets.QAbstractItemView.EditTrigger.DoubleClicked,
+                       QtWidgets.QAbstractItemView.EditTrigger.EditKeyPressed,
+                       QtWidgets.QAbstractItemView.EditTrigger.AnyKeyPressed}:
             tag = self.tag_diff.tag_names[item.row()]
             values = self.tag_diff.new[tag]
             if len(values) > 1:
@@ -303,9 +303,9 @@ class MetadataBox(QtWidgets.QTableWidget):
         return False
 
     def keyPressEvent(self, event):
-        if event.matches(QtGui.QKeySequence.Copy):
+        if event.matches(QtGui.QKeySequence.StandardKey.Copy):
             self.copy_value()
-        elif event.matches(QtGui.QKeySequence.Paste):
+        elif event.matches(QtGui.QKeySequence.StandardKey.Paste):
             self.paste_value()
         else:
             super().keyPressEvent(event)
@@ -436,11 +436,11 @@ class MetadataBox(QtWidgets.QTableWidget):
                     menu.addSeparator()
                     copy_action = QtWidgets.QAction(icontheme.lookup('edit-copy', icontheme.ICON_SIZE_MENU), _("&Copy"), self)
                     copy_action.triggered.connect(self.copy_value)
-                    copy_action.setShortcut(QtGui.QKeySequence.Copy)
+                    copy_action.setShortcut(QtGui.QKeySequence.StandardKey.Copy)
                     menu.addAction(copy_action)
                     paste_action = QtWidgets.QAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), _("&Paste"), self)
                     paste_action.triggered.connect(self.paste_value)
-                    paste_action.setShortcut(QtGui.QKeySequence.Paste)
+                    paste_action.setShortcut(QtGui.QKeySequence.StandardKey.Paste)
                     paste_action.setEnabled(editable)
                     menu.addAction(paste_action)
             if single_tag or removals or useorigs:
@@ -573,7 +573,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             return self.tag_diff
 
         self.colors = {
-            TagStatus.NOCHANGE: self.palette().color(QtGui.QPalette.Text),
+            TagStatus.NOCHANGE: self.palette().color(QtGui.QPalette.ColorRole.Text),
             TagStatus.REMOVED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_removed')),
             TagStatus.ADDED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_added')),
             TagStatus.CHANGED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_changed'))
@@ -660,8 +660,8 @@ class MetadataBox(QtWidgets.QTableWidget):
 
         self.setRowCount(len(result.tag_names))
 
-        orig_flags = QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled
-        new_flags = orig_flags | QtCore.Qt.ItemIsEditable
+        orig_flags = QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled
+        new_flags = orig_flags | QtCore.Qt.ItemFlag.ItemIsEditable
 
         for i, name in enumerate(result.tag_names):
             tag_item = self.item(i, 0)
@@ -702,7 +702,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             orig_item.setForeground(color)
             new_item.setForeground(color)
 
-            alignment = QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
+            alignment = QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
             tag_item.setTextAlignment(alignment)
             orig_item.setTextAlignment(alignment)
             new_item.setTextAlignment(alignment)
@@ -712,7 +712,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def set_item_value(self, item, tags, name):
         text, italic = tags.display_value(name)
-        item.setData(QtCore.Qt.UserRole, name)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, name)
         item.setText(text)
         font = item.font()
         font.setItalic(italic)
@@ -724,7 +724,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         state = config.persist["metadatabox_header_state"]
         header = self.horizontalHeader()
         header.restoreState(state)
-        header.setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
     def save_state(self):
         config = get_config()

--- a/picard/ui/moveable_list_view.py
+++ b/picard/ui/moveable_list_view.py
@@ -38,8 +38,8 @@ class MoveableListView:
         self.up_button.clicked.connect(partial(self.move_item, 1))
         self.down_button.clicked.connect(partial(self.move_item, -1))
         self.list_widget.currentRowChanged.connect(self.update_buttons)
-        self.list_widget.setDragDropMode(QtWidgets.QAbstractItemView.DragDrop)
-        self.list_widget.setDefaultDropAction(QtCore.Qt.MoveAction)
+        self.list_widget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.DragDrop)
+        self.list_widget.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
 
     def move_item(self, offset):
         current_index = self.list_widget.currentRow()

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -87,7 +87,7 @@ class OptionsPage(QtWidgets.QWidget):
             config.setting[key] = old_options[key]
 
     def display_error(self, error):
-        dialog = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Warning, error.title, error.info, QtWidgets.QMessageBox.Ok, self)
+        dialog = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Icon.Warning, error.title, error.info, QtWidgets.QMessageBox.StandardButton.Ok, self)
         dialog.exec_()
 
     def init_regex_checker(self, regex_edit, regex_error):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -106,7 +106,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 self.page_to_item[page.NAME] = item
                 self.ui.pages_stack.addWidget(page)
             else:
-                item.setFlags(QtCore.Qt.ItemIsEnabled)
+                item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
             self.add_pages(page.NAME, default_page, item)
             if page.NAME == default_page:
                 self.default_item = item
@@ -116,8 +116,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def __init__(self, default_page=None, parent=None):
         super().__init__(parent)
-        self.setWindowModality(QtCore.Qt.ApplicationModal)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         from picard.ui.ui_options import Ui_Dialog
         self.ui = Ui_Dialog()
@@ -130,11 +130,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
         ok = StandardButton(StandardButton.OK)
         ok.setText(_("Make It So!"))
-        self.ui.buttonbox.addButton(ok, QtWidgets.QDialogButtonBox.AcceptRole)
-        self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.RejectRole)
-        self.ui.buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.HelpRole)
-        self.ui.buttonbox.addButton(self.ui.reset_all_button, QtWidgets.QDialogButtonBox.ActionRole)
-        self.ui.buttonbox.addButton(self.ui.reset_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(ok, QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.ButtonRole.HelpRole)
+        self.ui.buttonbox.addButton(self.ui.reset_all_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
+        self.ui.buttonbox.addButton(self.ui.reset_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
 
         self.ui.buttonbox.accepted.connect(self.accept)
         self.ui.buttonbox.rejected.connect(self.reject)
@@ -144,7 +144,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
         self.ui.attached_profiles_button = QtWidgets.QPushButton(_("Attached Profiles"))
         self.ui.attached_profiles_button.setToolTip(_("Show which profiles are attached to the options on this page"))
-        self.ui.buttonbox.addButton(self.ui.attached_profiles_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(self.ui.attached_profiles_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
         self.ui.attached_profiles_button.clicked.connect(self.show_attached_profiles_dialog)
 
         config = get_config()
@@ -208,11 +208,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         page = self.item_to_page[items[0]]
         if not self.page_has_profile_options(page):
             message_box = QtWidgets.QMessageBox(self)
-            message_box.setIcon(QtWidgets.QMessageBox.Information)
-            message_box.setWindowModality(QtCore.Qt.WindowModal)
+            message_box.setIcon(QtWidgets.QMessageBox.Icon.Information)
+            message_box.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             message_box.setWindowTitle(window_title)
             message_box.setText(_("The options on this page are not currently available to be managed using profiles."))
-            message_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
+            message_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
             return message_box.exec_()
 
         override_profiles = self.profile_page._clean_and_get_all_profiles()
@@ -293,7 +293,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         """Process selected events.
         """
         evtype = event.type()
-        if evtype == QtCore.QEvent.Enter:
+        if evtype == QtCore.QEvent.Type.Enter:
             if self.first_enter:
                 self.first_enter = False
                 if self.tagger and self.tagger.window.script_editor_dialog is not None:
@@ -421,12 +421,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def _show_dialog(self, msg, function):
         message_box = QtWidgets.QMessageBox(self)
-        message_box.setIcon(QtWidgets.QMessageBox.Warning)
-        message_box.setWindowModality(QtCore.Qt.WindowModal)
+        message_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        message_box.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         message_box.setWindowTitle(_("Confirm Reset"))
         message_box.setText(_("Are you sure?") + "\n\n" + msg)
-        message_box.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
-        if message_box.exec_() == QtWidgets.QMessageBox.Yes:
+        message_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No)
+        if message_box.exec_() == QtWidgets.QMessageBox.StandardButton.Yes:
             function()
 
 
@@ -439,7 +439,7 @@ class AttachedProfilesDialog(PicardDialog):
         self.option_group = option_group
         self.ui = Ui_AttachedProfilesDialog()
         self.ui.setupUi(self)
-        self.ui.buttonBox.addButton(StandardButton(StandardButton.CLOSE), QtWidgets.QDialogButtonBox.RejectRole)
+        self.ui.buttonBox.addButton(StandardButton(StandardButton.CLOSE), QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         self.ui.buttonBox.rejected.connect(self.close_window)
 
         config = get_config()

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -51,7 +51,7 @@ class ApiKeyValidator(QtGui.QValidator):
 
     def validate(self, input, pos):
         # Strip whitespace to avoid typical copy and paste user errors
-        return (QtGui.QValidator.Acceptable, input.strip(), pos)
+        return (QtGui.QValidator.State.Acceptable, input.strip(), pos)
 
 
 class FingerprintingOptionsPage(OptionsPage):

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -121,7 +121,7 @@ class GeneralOptionsPage(OptionsPage):
         config.setting["ignore_file_mbids"] = self.ui.ignore_file_mbids.isChecked()
         if self.tagger.autoupdate_enabled:
             config.setting["check_for_updates"] = self.ui.check_for_updates.isChecked()
-            config.setting["update_level"] = self.ui.update_level.currentData(QtCore.Qt.UserRole)
+            config.setting["update_level"] = self.ui.update_level.currentData(QtCore.Qt.ItemDataRole.UserRole)
             config.setting["update_check_days"] = self.ui.update_check_days.value()
 
     def update_server_host(self):

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -114,10 +114,10 @@ class GenresOptionsPage(OptionsPage):
 
         # FIXME: colors aren't great from accessibility POV
         self.fmt_keep = QTextBlockFormat()
-        self.fmt_keep.setBackground(Qt.green)
+        self.fmt_keep.setBackground(Qt.GlobalColor.green)
 
         self.fmt_skip = QTextBlockFormat()
-        self.fmt_skip.setBackground(Qt.red)
+        self.fmt_skip.setBackground(Qt.GlobalColor.red)
 
         self.fmt_clear = QTextBlockFormat()
         self.fmt_clear.clearBackground()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -64,7 +64,7 @@ from picard.ui.ui_options_interface import Ui_InterfaceOptionsPage
 from picard.ui.util import enabledSlot
 
 
-_default_starting_dir = QStandardPaths.writableLocation(QStandardPaths.HomeLocation)
+_default_starting_dir = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.HomeLocation)
 
 
 class InterfaceOptionsPage(OptionsPage):
@@ -204,7 +204,7 @@ class InterfaceOptionsPage(OptionsPage):
             desc = self._UI_THEME_LABELS[theme]['desc']
             self.ui.ui_theme.addItem(_(label), theme)
             idx = self.ui.ui_theme.findData(theme)
-            self.ui.ui_theme.setItemData(idx, _(desc), QtCore.Qt.ToolTipRole)
+            self.ui.ui_theme.setItemData(idx, _(desc), QtCore.Qt.ItemDataRole.ToolTipRole)
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(UiTheme.DEFAULT))
 
         self.ui.ui_language.addItem(_('System default'), '')
@@ -286,10 +286,10 @@ class InterfaceOptionsPage(OptionsPage):
             restart_warning = _('You have changed the interface language. You have to restart Picard in order for the change to take effect.')
         if restart_warning:
             dialog = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Information,
+                QtWidgets.QMessageBox.Icon.Information,
                 restart_warning_title,
                 restart_warning,
-                QtWidgets.QMessageBox.Ok,
+                QtWidgets.QMessageBox.StandardButton.Ok,
                 self)
             dialog.exec_()
         config.setting["ui_theme"] = new_theme_setting
@@ -387,10 +387,10 @@ class ToolbarListItem(QtWidgets.QListWidgetItem):
 class AddActionDialog(PicardDialog):
     def __init__(self, action_list, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setWindowModality(QtCore.Qt.WindowModal)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
 
         layout = QtWidgets.QVBoxLayout(self)
-        layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
+        layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
 
         # TODO: Remove temporary workaround once https://github.com/python-babel/babel/issues/415 has been resolved.
         babel_415_workaround_list = []
@@ -404,8 +404,8 @@ class AddActionDialog(PicardDialog):
         layout.addWidget(self.combo_box)
 
         buttons = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
-            QtCore.Qt.Horizontal, self)
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            QtCore.Qt.Orientation.Horizontal, self)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -418,7 +418,7 @@ class AddActionDialog(PicardDialog):
         dialog = AddActionDialog(action_list, parent)
         result = dialog.exec_()
         selected_action = dialog.selected_action()
-        return (selected_action, result == QtWidgets.QDialog.Accepted)
+        return (selected_action, result == QtWidgets.QDialog.DialogCode.Accepted)
 
 
 register_options_page(InterfaceOptionsPage)

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -118,17 +118,17 @@ class InterfaceColorsOptionsPage(OptionsPage):
             hlayout.setContentsMargins(0, 0, 0, 0)
 
             label = QtWidgets.QLabel(interface_colors.get_color_description(color_key))
-            label.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+            label.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
             hlayout.addWidget(label)
 
             button = ColorButton(color_value)
             button.color_changed.connect(partial(color_changed, color_key))
-            hlayout.addWidget(button, 0, QtCore.Qt.AlignRight)
+            hlayout.addWidget(button, 0, QtCore.Qt.AlignmentFlag.AlignRight)
 
             widget.setLayout(hlayout)
             self.colors_list.addWidget(widget)
 
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
         self.colors_list.addItem(spacerItem1)
 
     def load(self):
@@ -138,10 +138,10 @@ class InterfaceColorsOptionsPage(OptionsPage):
     def save(self):
         if interface_colors.save_to_config():
             dialog = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Information,
+                QtWidgets.QMessageBox.Icon.Information,
                 _('Colors changed'),
                 _('You have changed the interface colors. You may have to restart Picard in order for the changes to take effect.'),
-                QtWidgets.QMessageBox.Ok,
+                QtWidgets.QMessageBox.StandardButton.Ok,
                 self)
             dialog.exec_()
 

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -91,8 +91,8 @@ class MaintenanceOptionsPage(OptionsPage):
         # Set the palette of the config file QLineEdit widget to inactive.
         palette_normal = self.ui.config_file.palette()
         palette_readonly = QtGui.QPalette(palette_normal)
-        disabled_color = palette_normal.color(QtGui.QPalette.Inactive, QtGui.QPalette.Window)
-        palette_readonly.setColor(QtGui.QPalette.Base, disabled_color)
+        disabled_color = palette_normal.color(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.Window)
+        palette_readonly.setColor(QtGui.QPalette.ColorRole.Base, disabled_color)
         self.ui.config_file.setPalette(palette_readonly)
 
     def load(self):
@@ -125,12 +125,12 @@ class MaintenanceOptionsPage(OptionsPage):
         self.ui.tableWidget.setRowCount(len(orphan_options))
         for row, option_name in enumerate(sorted(orphan_options)):
             tableitem = QtWidgets.QTableWidgetItem(option_name)
-            tableitem.setData(QtCore.Qt.UserRole, option_name)
-            tableitem.setFlags(tableitem.flags() | QtCore.Qt.ItemIsUserCheckable)
-            tableitem.setCheckState(QtCore.Qt.Unchecked)
+            tableitem.setData(QtCore.Qt.ItemDataRole.UserRole, option_name)
+            tableitem.setFlags(tableitem.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+            tableitem.setCheckState(QtCore.Qt.CheckState.Unchecked)
             self.ui.tableWidget.setItem(row, 0, tableitem)
             tableitem = QtWidgets.QTextEdit()
-            tableitem.setFrameStyle(QtWidgets.QFrame.NoFrame)
+            tableitem.setFrameStyle(QtWidgets.QFrame.Shape.NoFrame)
             text = self.make_setting_value_text(option_name)
             tableitem.setPlainText(text)
             tableitem.setReadOnly(True)
@@ -143,7 +143,7 @@ class MaintenanceOptionsPage(OptionsPage):
             self.ui.tableWidget.setRowHeight(row, row_height)
             self.ui.tableWidget.setCellWidget(row, 1, tableitem)
         self.ui.tableWidget.resizeColumnsToContents()
-        self.ui.select_all.setCheckState(QtCore.Qt.Unchecked)
+        self.ui.select_all.setCheckState(QtCore.Qt.CheckState.Unchecked)
         if not len(orphan_options):
             self.ui.select_all.setEnabled(False)
         self.enable_cleanup_changed()
@@ -159,8 +159,8 @@ class MaintenanceOptionsPage(OptionsPage):
 
     def selected_options(self):
         for item in self.column_items(0):
-            if item.checkState() == QtCore.Qt.Checked:
-                yield item.data(QtCore.Qt.UserRole)
+            if item.checkState() == QtCore.Qt.CheckState.Checked:
+                yield item.data(QtCore.Qt.ItemDataRole.UserRole)
 
     def select_all_changed(self):
         state = self.ui.select_all.checkState()
@@ -168,14 +168,14 @@ class MaintenanceOptionsPage(OptionsPage):
             item.setCheckState(state)
 
     def save(self):
-        if not self.ui.enable_cleanup.checkState() == QtCore.Qt.Checked:
+        if not self.ui.enable_cleanup.checkState() == QtCore.Qt.CheckState.Checked:
             return
         to_remove = set(self.selected_options())
         if to_remove and QtWidgets.QMessageBox.question(
             self,
             _('Confirm Remove'),
             _("Are you sure you want to remove the selected option settings?"),
-        ) == QtWidgets.QMessageBox.Yes:
+        ) == QtWidgets.QMessageBox.StandardButton.Yes:
             config = get_config()
             for item in to_remove:
                 Option.add_if_missing('setting', item, None)
@@ -188,7 +188,7 @@ class MaintenanceOptionsPage(OptionsPage):
         return repr(value)
 
     def enable_cleanup_changed(self):
-        state = self.ui.enable_cleanup.checkState() == QtCore.Qt.Checked
+        state = self.ui.enable_cleanup.checkState() == QtCore.Qt.CheckState.Checked
         self.ui.select_all.setEnabled(state)
         self.ui.tableWidget.setEnabled(state)
 

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -207,7 +207,7 @@ class MultiLocaleSelector(PicardDialog):
             # the specific locale.
             label = _(ALIAS_LOCALES[locale])
             item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.UserRole, locale)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, locale)
             self.ui.selected_locales.addItem(item)
         self.ui.selected_locales.setCurrentRow(0)
 
@@ -221,7 +221,7 @@ class MultiLocaleSelector(PicardDialog):
         for (locale, level) in iter_sorted_locales(ALIAS_LOCALES):
             label = indented_translated_locale(locale, level)
             item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.UserRole, locale)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, locale)
             self.ui.available_locales.addItem(item)
         self.ui.available_locales.setCurrentRow(0)
 
@@ -231,10 +231,10 @@ class MultiLocaleSelector(PicardDialog):
         item = self.ui.available_locales.currentItem()
         if item is None:
             return
-        locale = item.data(QtCore.Qt.UserRole)
+        locale = item.data(QtCore.Qt.ItemDataRole.UserRole)
         for row in range(self.ui.selected_locales.count()):
             selected_item = self.ui.selected_locales.item(row)
-            if selected_item.data(QtCore.Qt.UserRole) == locale:
+            if selected_item.data(QtCore.Qt.ItemDataRole.UserRole) == locale:
                 return
         new_item = item.clone()
         # Note that items in the selected locales list are not indented because
@@ -256,7 +256,7 @@ class MultiLocaleSelector(PicardDialog):
         locales = []
         for row in range(self.ui.selected_locales.count()):
             selected_item = self.ui.selected_locales.item(row)
-            locales.append(selected_item.data(QtCore.Qt.UserRole))
+            locales.append(selected_item.data(QtCore.Qt.ItemDataRole.UserRole))
         self.parent().current_locales = locales
         self.parent().make_locales_text()
         self.accept()
@@ -299,7 +299,7 @@ class ScriptExceptionSelector(PicardDialog):
         for script in self.parent().current_scripts:
             label = self.make_label(script_id=script[0], script_weighting=script[1])
             item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.UserRole, script)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, script)
             self.ui.selected_scripts.addItem(item)
         if self.ui.selected_scripts.count() > 0:
             self.ui.selected_scripts.setCurrentRow(0)
@@ -308,7 +308,7 @@ class ScriptExceptionSelector(PicardDialog):
         self.ui.available_scripts.clear()
         for script_id, label in scripts_sorted_by_localized_name():
             item = QtWidgets.QListWidgetItem(label)
-            item.setData(QtCore.Qt.UserRole, script_id)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, script_id)
             self.ui.available_scripts.addItem(item)
         self.ui.available_scripts.setCurrentRow(0)
 
@@ -318,13 +318,13 @@ class ScriptExceptionSelector(PicardDialog):
         item = self.ui.available_scripts.currentItem()
         if item is None:
             return
-        script_id = item.data(QtCore.Qt.UserRole)
+        script_id = item.data(QtCore.Qt.ItemDataRole.UserRole)
         for row in range(self.ui.selected_scripts.count()):
             selected_item = self.ui.selected_scripts.item(row)
-            if selected_item.data(QtCore.Qt.UserRole)[0] == script_id:
+            if selected_item.data(QtCore.Qt.ItemDataRole.UserRole)[0] == script_id:
                 return
         new_item = QtWidgets.QListWidgetItem(self.make_label(script_id, 0))
-        new_item.setData(QtCore.Qt.UserRole, (script_id, 0))
+        new_item.setData(QtCore.Qt.ItemDataRole.UserRole, (script_id, 0))
         self.ui.selected_scripts.addItem(new_item)
         self.ui.selected_scripts.setCurrentRow(self.ui.selected_scripts.count() - 1)
         self.set_weighting_selector()
@@ -349,7 +349,7 @@ class ScriptExceptionSelector(PicardDialog):
         row = self.ui.selected_scripts.currentRow()
         selected_item = self.ui.selected_scripts.item(row)
         if selected_item:
-            weighting = selected_item.data(QtCore.Qt.UserRole)[1]
+            weighting = selected_item.data(QtCore.Qt.ItemDataRole.UserRole)[1]
         else:
             weighting = 0
         self.ui.weighting_selector.setValue(weighting)
@@ -358,10 +358,10 @@ class ScriptExceptionSelector(PicardDialog):
         row = self.ui.selected_scripts.currentRow()
         selected_item = self.ui.selected_scripts.item(row)
         if selected_item:
-            item_data = selected_item.data(QtCore.Qt.UserRole)
+            item_data = selected_item.data(QtCore.Qt.ItemDataRole.UserRole)
             weighting = self.ui.weighting_selector.value()
             new_data = (item_data[0], weighting)
-            selected_item.setData(QtCore.Qt.UserRole, new_data)
+            selected_item.setData(QtCore.Qt.ItemDataRole.UserRole, new_data)
             label = self.make_label(script_id=item_data[0], script_weighting=weighting)
             selected_item.setText(label)
 
@@ -369,7 +369,7 @@ class ScriptExceptionSelector(PicardDialog):
         scripts = []
         for row in range(self.ui.selected_scripts.count()):
             selected_item = self.ui.selected_scripts.item(row)
-            scripts.append(selected_item.data(QtCore.Qt.UserRole))
+            scripts.append(selected_item.data(QtCore.Qt.ItemDataRole.UserRole))
         self.parent().current_scripts = scripts
         self.parent().make_scripts_text()
         self.accept()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -199,7 +199,7 @@ class PluginTreeWidgetItem(HashableTreeWidgetItem):
 
     @property
     def plugin(self):
-        return self.data(COLUMN_NAME, QtCore.Qt.UserRole)
+        return self.data(COLUMN_NAME, QtCore.Qt.ItemDataRole.UserRole)
 
     def enable(self, boolean, greyout=None):
         if boolean is not None:
@@ -225,7 +225,7 @@ class PluginsOptionsPage(OptionsPage):
         ListOption("setting", "enabled_plugins", []),
         Option("persist", "plugins_list_state", QtCore.QByteArray()),
         Option("persist", "plugins_list_sort_section", 0),
-        Option("persist", "plugins_list_sort_order", QtCore.Qt.AscendingOrder),
+        Option("persist", "plugins_list_sort_order", QtCore.Qt.SortOrder.AscendingOrder),
     ]
 
     def __init__(self, parent=None):
@@ -256,7 +256,7 @@ class PluginsOptionsPage(OptionsPage):
         self._preserve_selected = None
 
     def items(self):
-        iterator = QTreeWidgetItemIterator(self.ui.plugins, QTreeWidgetItemIterator.All)
+        iterator = QTreeWidgetItemIterator(self.ui.plugins, QTreeWidgetItemIterator.IteratorFlag.All)
         while iterator.value():
             item = iterator.value()
             iterator += 1
@@ -350,10 +350,10 @@ class PluginsOptionsPage(OptionsPage):
         self._user_interaction(True)
         header = self.ui.plugins.header()
         header.setStretchLastSection(False)
-        header.setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
-        header.setSectionResizeMode(COLUMN_NAME, QtWidgets.QHeaderView.Stretch)
-        header.setSectionResizeMode(COLUMN_VERSION, QtWidgets.QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(COLUMN_ACTIONS, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Fixed)
+        header.setSectionResizeMode(COLUMN_NAME, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(COLUMN_VERSION, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(COLUMN_ACTIONS, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
 
     def _remove_all(self):
         for item in self.items():
@@ -460,10 +460,10 @@ class PluginsOptionsPage(OptionsPage):
             self,
             _("Uninstall plugin '%s'?") % plugin.name,
             _("Do you really want to uninstall the plugin '%s' ?") % plugin.name,
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
-            QtWidgets.QMessageBox.No
+            QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+            QtWidgets.QMessageBox.StandardButton.No
         )
-        if buttonReply == QtWidgets.QMessageBox.Yes:
+        if buttonReply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.manager.remove_plugin(plugin.module_name, with_update=True)
 
     def update_plugin_item(self, item, plugin,
@@ -475,7 +475,7 @@ class PluginsOptionsPage(OptionsPage):
         if item is None:
             item = PluginTreeWidgetItem(self.ui.plugins)
         if plugin is not None:
-            item.setData(COLUMN_NAME, QtCore.Qt.UserRole, plugin)
+            item.setData(COLUMN_NAME, QtCore.Qt.ItemDataRole.UserRole, plugin)
         else:
             plugin = item.plugin
         if new_version is not None:
@@ -644,8 +644,8 @@ class PluginsOptionsPage(OptionsPage):
             msgbox = QtWidgets.QMessageBox(self)
             msgbox.setText(_("The plugin '%s' could not be downloaded.") % plugin.module_name)
             msgbox.setInformativeText(_("Please try again later."))
-            msgbox.setStandardButtons(QtWidgets.QMessageBox.Ok)
-            msgbox.setDefaultButton(QtWidgets.QMessageBox.Ok)
+            msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+            msgbox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
             msgbox.exec_()
             log.error("Error occurred while trying to download the plugin: '%s'" % plugin.module_name)
             return
@@ -665,7 +665,7 @@ class PluginsOptionsPage(OptionsPage):
         return ["text/uri-list"]
 
     def dragEnterEvent(self, event):
-        event.setDropAction(QtCore.Qt.CopyAction)
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
         event.accept()
 
     def dropEvent(self, event):

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -99,7 +99,7 @@ class ProfilesOptionsPage(OptionsPage):
         """Process selected events.
         """
         event_type = event.type()
-        if event_type == QtCore.QEvent.FocusOut and object == self.ui.settings_tree:
+        if event_type == QtCore.QEvent.Type.FocusOut and object == self.ui.settings_tree:
             if self.settings_changed:
                 self.settings_changed = False
                 self.update_values_in_profile_options()
@@ -112,17 +112,17 @@ class ProfilesOptionsPage(OptionsPage):
         self.new_profile_button = QtWidgets.QPushButton(_('New'))
         self.new_profile_button.setToolTip(_("Create a new profile"))
         self.new_profile_button.clicked.connect(self.new_profile)
-        self.ui.profile_list_buttonbox.addButton(self.new_profile_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.profile_list_buttonbox.addButton(self.new_profile_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
 
         self.copy_profile_button = QtWidgets.QPushButton(_('Copy'))
         self.copy_profile_button.setToolTip(_("Copy to a new profile"))
         self.copy_profile_button.clicked.connect(self.copy_profile)
-        self.ui.profile_list_buttonbox.addButton(self.copy_profile_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.profile_list_buttonbox.addButton(self.copy_profile_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
 
         self.delete_profile_button = QtWidgets.QPushButton(_('Delete'))
         self.delete_profile_button.setToolTip(_("Delete the profile"))
         self.delete_profile_button.clicked.connect(self.delete_profile)
-        self.ui.profile_list_buttonbox.addButton(self.delete_profile_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.profile_list_buttonbox.addButton(self.delete_profile_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
 
     def restore_defaults(self):
         """Remove all profiles and profile settings.
@@ -221,13 +221,13 @@ class ProfilesOptionsPage(OptionsPage):
             title = group["title"]
             group_settings = group["settings"]
             widget_item = QtWidgets.QTreeWidgetItem([title])
-            widget_item.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsAutoTristate)
-            widget_item.setCheckState(self.TREEWIDGETITEM_COLUMN, QtCore.Qt.Unchecked)
+            widget_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsAutoTristate)
+            widget_item.setCheckState(self.TREEWIDGETITEM_COLUMN, QtCore.Qt.CheckState.Unchecked)
             for setting in group_settings:
                 child_item = QtWidgets.QTreeWidgetItem([_(setting.title)])
-                child_item.setData(0, QtCore.Qt.UserRole, setting.name)
-                child_item.setFlags(QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsUserCheckable)
-                state = QtCore.Qt.Checked if settings and setting.name in settings else QtCore.Qt.Unchecked
+                child_item.setData(0, QtCore.Qt.ItemDataRole.UserRole, setting.name)
+                child_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+                state = QtCore.Qt.CheckState.Checked if settings and setting.name in settings else QtCore.Qt.CheckState.Unchecked
                 child_item.setCheckState(self.TREEWIDGETITEM_COLUMN, state)
                 if setting.name in settings and settings[setting.name] is not None:
                     value = settings[setting.name]
@@ -367,10 +367,10 @@ class ProfilesOptionsPage(OptionsPage):
             text = item.text().strip()
             if not text:
                 QtWidgets.QMessageBox(
-                    QtWidgets.QMessageBox.Warning,
+                    QtWidgets.QMessageBox.Icon.Warning,
                     _("Invalid Title"),
                     _("The profile title cannot be blank."),
-                    QtWidgets.QMessageBox.Ok,
+                    QtWidgets.QMessageBox.StandardButton.Ok,
                     self
                 ).exec_()
                 item.setText(self.ui.profile_list.unique_profile_name())
@@ -405,8 +405,8 @@ class ProfilesOptionsPage(OptionsPage):
             tl_item = self.ui.settings_tree.topLevelItem(i)
             for j in range(tl_item.childCount()):
                 item = tl_item.child(j)
-                if item.checkState(self.TREEWIDGETITEM_COLUMN) == QtCore.Qt.Checked:
-                    yield item.data(self.TREEWIDGETITEM_COLUMN, QtCore.Qt.UserRole)
+                if item.checkState(self.TREEWIDGETITEM_COLUMN) == QtCore.Qt.CheckState.Checked:
+                    yield item.data(self.TREEWIDGETITEM_COLUMN, QtCore.Qt.ItemDataRole.UserRole)
 
     def set_profile_settings_changed(self):
         """Set flag to trigger option page updates later (when focus is lost from the settings

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -72,7 +72,7 @@ class TipSlider(ClickableSlider):
         self.opt = QtWidgets.QStyleOptionSlider()
         self.setMinimum(self._minimum)
         self.setMaximum(self._maximum)
-        self.setOrientation(QtCore.Qt.Horizontal)
+        self.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self.setSingleStep(self._step)
         self.setTickInterval(self._step)
         self.setPageStep(self._pagestep)
@@ -192,7 +192,7 @@ class ReleasesOptionsPage(OptionsPage):
 
         reset_types_btn = QtWidgets.QPushButton(self.ui.type_group)
         reset_types_btn.setText(_("Reset all"))
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(reset_types_btn.sizePolicy().hasHeightForWidth())
@@ -214,10 +214,10 @@ class ReleasesOptionsPage(OptionsPage):
         self.ui.remove_countries.clicked.connect(self.remove_preferred_countries)
         self.ui.add_formats.clicked.connect(self.add_preferred_formats)
         self.ui.remove_formats.clicked.connect(self.remove_preferred_formats)
-        self.ui.country_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.ui.preferred_country_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.ui.format_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.ui.preferred_format_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.ui.country_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.ui.preferred_country_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.ui.format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.ui.preferred_format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
 
     def restore_defaults(self):
         # Clear lists
@@ -291,7 +291,7 @@ class ReleasesOptionsPage(OptionsPage):
         move = []
         for data, name in source_list:
             item = QtWidgets.QListWidgetItem(name)
-            item.setData(QtCore.Qt.UserRole, data)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, data)
             try:
                 i = saved_data.index(data)
                 move.append((i, item))
@@ -305,7 +305,7 @@ class ReleasesOptionsPage(OptionsPage):
         data = []
         for i in range(list1.count()):
             item = list1.item(i)
-            data.append(item.data(QtCore.Qt.UserRole))
+            data.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
         config = get_config()
         config.setting[setting] = data
 

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -67,7 +67,7 @@ from picard.ui.ui_options_renaming import Ui_RenamingOptionsPage
 from picard.ui.util import enabledSlot
 
 
-_default_music_dir = QStandardPaths.writableLocation(QStandardPaths.MusicLocation)
+_default_music_dir = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.MusicLocation)
 
 
 class RenamingOptionsPage(OptionsPage):
@@ -125,8 +125,8 @@ class RenamingOptionsPage(OptionsPage):
         script_edit = self.ui.move_additional_files_pattern
         self.script_palette_normal = script_edit.palette()
         self.script_palette_readonly = QPalette(self.script_palette_normal)
-        disabled_color = self.script_palette_normal.color(QPalette.Inactive, QPalette.Window)
-        self.script_palette_readonly.setColor(QPalette.Disabled, QPalette.Base, disabled_color)
+        disabled_color = self.script_palette_normal.color(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Window)
+        self.script_palette_readonly.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, disabled_color)
 
         self.ui.example_filename_sample_files_button.clicked.connect(self.update_example_files)
 

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -80,8 +80,8 @@ class ScriptingDocumentationDialog(PicardDialog, SingletonDialog):
         # on macOS having this not a dialog causes the window to be placed
         # behind the options dialog.
         if not IS_MACOS:
-            self.setWindowFlags(QtCore.Qt.Window)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+            self.setWindowFlags(QtCore.Qt.WindowType.Window)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.parent = parent
         self.ui = Ui_ScriptingDocumentationDialog()
         self.ui.setupUi(self)
@@ -108,7 +108,7 @@ class ScriptingOptionsPage(OptionsPage):
         IntOption("persist", "last_selected_script_pos", 0),
     ]
 
-    default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
+    default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
     default_script_extension = "ptsp"
 
     def __init__(self, parent=None):
@@ -204,7 +204,7 @@ class ScriptingOptionsPage(OptionsPage):
             item = items[0]
             self.ui.tagger_script.setEnabled(True)
             self.ui.tagger_script.setText(item.script)
-            self.ui.tagger_script.setFocus(QtCore.Qt.OtherFocusReason)
+            self.ui.tagger_script.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
             self.ui.export_button.setEnabled(True)
         else:
             self.ui.tagger_script.setEnabled(False)

--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -54,7 +54,7 @@ class RatingWidget(QtWidgets.QWidget):
         self._height = self._star_size + 6
         self.setMaximumSize(self._width, self._height)
         self.setMinimumSize(self._width, self._height)
-        self.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed))
+        self.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed))
         self.setMouseTracking(True)
 
     def sizeHint(self):
@@ -67,7 +67,7 @@ class RatingWidget(QtWidgets.QWidget):
             self.update()
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             x = event.x()
             if x < self._offset:
                 return

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -312,13 +312,13 @@ def confirmation_dialog(parent, message):
         bool: True if accepted, otherwise False.
     """
     dialog = QtWidgets.QMessageBox(
-        QtWidgets.QMessageBox.Warning,
+        QtWidgets.QMessageBox.Icon.Warning,
         _('Confirm'),
         message,
-        QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel,
+        QtWidgets.QMessageBox.StandardButton.Ok | QtWidgets.QMessageBox.StandardButton.Cancel,
         parent
     )
-    return dialog.exec_() == QtWidgets.QMessageBox.Ok
+    return dialog.exec_() == QtWidgets.QMessageBox.StandardButton.Ok
 
 
 def synchronize_vertical_scrollbars(widgets):
@@ -329,8 +329,8 @@ def synchronize_vertical_scrollbars(widgets):
     """
     # Set highlight colors for selected list items
     example_style = widgets[0].palette()
-    highlight_bg = example_style.color(QPalette.Active, QPalette.Highlight)
-    highlight_fg = example_style.color(QPalette.Active, QPalette.HighlightedText)
+    highlight_bg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.Highlight)
+    highlight_fg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText)
     stylesheet = "QListView::item:selected { color: " + highlight_fg.name() + "; background-color: " + highlight_bg.name() + "; }"
 
     def _sync_scrollbar_vert(widget, value):
@@ -399,9 +399,9 @@ def populate_script_selection_combo_box(naming_scripts, selected_script_id, comb
 class NotEmptyValidator(QtGui.QValidator):
     def validate(self, text: str, pos):
         if bool(text.strip()):
-            state = QtGui.QValidator.Acceptable
+            state = QtGui.QValidator.State.Acceptable
         else:
-            state = QtGui.QValidator.Intermediate  # so that field can be made empty temporarily
+            state = QtGui.QValidator.State.Intermediate  # so that field can be made empty temporarily
         return state, text, pos
 
 
@@ -429,7 +429,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
     signal_selection_changed = QtCore.pyqtSignal()
     signal_index_changed = QtCore.pyqtSignal()
 
-    default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation))
+    default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
     default_script_filename = "picard_naming_script.ptsp"
 
     Profile = namedtuple('Profile', ['id', 'title', 'script_id'])
@@ -477,22 +477,22 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         self.reset_button = QtWidgets.QPushButton(_('Reset'))
         self.reset_button.setToolTip(self.reset_action.toolTip())
         self.reset_button.clicked.connect(self.reload_from_config)
-        self.ui.buttonbox.addButton(self.reset_button, QtWidgets.QDialogButtonBox.ActionRole)
+        self.ui.buttonbox.addButton(self.reset_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
 
-        self.save_button = self.ui.buttonbox.addButton(_("Make It So!"), QtWidgets.QDialogButtonBox.AcceptRole)
+        self.save_button = self.ui.buttonbox.addButton(_("Make It So!"), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         self.save_button.setToolTip(self.save_action.toolTip())
         self.ui.buttonbox.accepted.connect(self.make_it_so)
 
-        self.close_button = self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.Cancel)
+        self.close_button = self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         self.close_button.setToolTip(self.close_action.toolTip())
         self.ui.buttonbox.rejected.connect(self.close)
 
-        self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.Help)
+        self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Help)
         self.ui.buttonbox.helpRequested.connect(self.show_help)
 
         # Add links to edit script metadata
         self.ui.script_title.installEventFilter(self)
-        self.ui.script_title.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
+        self.ui.script_title.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.ActionsContextMenu)
         self.ui.script_title.addAction(self.details_action)
 
         self.ui.file_naming_format.setEnabled(True)
@@ -535,7 +535,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
             parent (object): Parent to set for the instance
         """
         if self.parent() != parent:
-            flags = self.windowFlags() | QtCore.Qt.Window
+            flags = self.windowFlags() | QtCore.Qt.WindowType.Window
             super().setParent(parent, flags)
             # Set appropriate state of script selector in parent
             save_enabled = self.save_button.isEnabled()
@@ -634,7 +634,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         help_menu.setToolTipsVisible(True)
 
         self.help_action = QtWidgets.QAction(_("&Help..."), self)
-        self.help_action.setShortcut(QtGui.QKeySequence.HelpContents)
+        self.help_action.setShortcut(QtGui.QKeySequence.StandardKey.HelpContents)
         self.help_action.triggered.connect(self.show_help)
         help_menu.addAction(self.help_action)
 
@@ -704,9 +704,9 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         """Process selected events.
         """
         evtype = event.type()
-        if evtype in {QtCore.QEvent.WindowActivate, QtCore.QEvent.FocusIn}:
+        if evtype in {QtCore.QEvent.Type.WindowActivate, QtCore.QEvent.Type.FocusIn}:
             self.update_examples()
-        elif object == self.ui.script_title and evtype == QtCore.QEvent.MouseButtonDblClick:
+        elif object == self.ui.script_title and evtype == QtCore.QEvent.Type.MouseButtonDblClick:
             self.details_action.trigger()
             return True
         return False
@@ -1095,14 +1095,14 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         profile = self.is_used_in_profile()
         if profile is not None:
             QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Warning,
+                QtWidgets.QMessageBox.Icon.Warning,
                 _("Error Deleting Script"),
                 _(
                     "The script could not be deleted because it is used in one of the user profiles."
                     "\n\n"
                     "Profile: %s"
                 ) % profile.title,
-                QtWidgets.QMessageBox.Ok,
+                QtWidgets.QMessageBox.StandardButton.Ok,
                 self
             ).exec_()
             return
@@ -1209,7 +1209,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
                 if title != existing_script['title']:
                     continue
                 box = QtWidgets.QMessageBox()
-                box.setIcon(QtWidgets.QMessageBox.Question)
+                box.setIcon(QtWidgets.QMessageBox.Icon.Question)
                 box.setWindowTitle(_('Confirm'))
                 box.setText(
                     _(
@@ -1217,12 +1217,12 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
                         "\n"
                         "Do you want to overwrite it, add as a copy or cancel?"
                     ).format(script_name=title,))
-                box.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No | QtWidgets.QMessageBox.Cancel)
-                buttonY = box.button(QtWidgets.QMessageBox.Yes)
+                box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No | QtWidgets.QMessageBox.StandardButton.Cancel)
+                buttonY = box.button(QtWidgets.QMessageBox.StandardButton.Yes)
                 buttonY.setText(_("Overwrite"))
-                buttonN = box.button(QtWidgets.QMessageBox.No)
+                buttonN = box.button(QtWidgets.QMessageBox.StandardButton.No)
                 buttonN.setText(_("Copy"))
-                box.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+                box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
                 box.exec_()
 
                 if box.clickedButton() == buttonY:
@@ -1278,8 +1278,8 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         # Ignore scripting errors, those are handled inline
         if not isinstance(error, ScriptCheckError):
             dialog = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Warning, error.title,
-                error.info, QtWidgets.QMessageBox.Ok, self
+                QtWidgets.QMessageBox.Icon.Warning, error.title,
+                error.info, QtWidgets.QMessageBox.StandardButton.Ok, self
             )
             dialog.exec_()
 
@@ -1339,9 +1339,9 @@ class ScriptDetailsEditor(PicardDialog):
         self.ui.script_license.setReadOnly(self.readonly)
         self.ui.script_description.setReadOnly(self.readonly)
 
-        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Close).setVisible(self.readonly)
-        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel).setVisible(not self.readonly)
-        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Save).setVisible(not self.readonly)
+        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Close).setVisible(self.readonly)
+        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel).setVisible(not self.readonly)
+        self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Save).setVisible(not self.readonly)
         self.ui.last_updated_now.setVisible(not self.readonly)
         self.ui.buttonBox.setFocus()
 
@@ -1388,10 +1388,10 @@ class ScriptDetailsEditor(PicardDialog):
         title = self.ui.script_title.text().strip()
         if not title:
             QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Critical,
+                QtWidgets.QMessageBox.Icon.Critical,
                 _("Error"),
                 _("The script title must not be empty."),
-                QtWidgets.QMessageBox.Ok,
+                QtWidgets.QMessageBox.StandardButton.Ok,
                 self
             ).exec_()
             return

--- a/picard/ui/searchdialog/__init__.py
+++ b/picard/ui/searchdialog/__init__.py
@@ -76,7 +76,7 @@ class SearchBox(QtWidgets.QWidget):
         self.search_edit.setClearButtonEnabled(True)
         self.search_edit.returnPressed.connect(self.trigger_search_action)
         self.search_edit.textChanged.connect(self.enable_search)
-        self.search_edit.setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.search_edit.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
         self.search_edit.focusInEvent = self.focus_in_event
         self.search_row_layout.addWidget(self.search_edit)
         self.search_button = QtWidgets.QToolButton(self.search_row_widget)
@@ -88,7 +88,7 @@ class SearchBox(QtWidgets.QWidget):
         self.layout.addWidget(self.search_row_widget)
         self.adv_opt_row_widget = QtWidgets.QWidget(self)
         self.adv_opt_row_layout = QtWidgets.QHBoxLayout(self.adv_opt_row_widget)
-        self.adv_opt_row_layout.setAlignment(QtCore.Qt.AlignLeft)
+        self.adv_opt_row_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
         self.adv_opt_row_layout.setContentsMargins(1, 1, 1, 1)
         self.adv_opt_row_layout.setSpacing(1)
         self.use_adv_search_syntax = QtWidgets.QCheckBox(self.adv_opt_row_widget)
@@ -186,7 +186,7 @@ class SearchDialog(TableBasedDialog):
                 _("Search in browser"), self.buttonBox)
             self.buttonBox.addButton(
                 self.search_browser_button,
-                QtWidgets.QDialogButtonBox.ActionRole)
+                QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
             self.search_browser_button.clicked.connect(self.search_browser)
         self.accept_button = QtWidgets.QPushButton(
             self.accept_button_title,
@@ -194,10 +194,10 @@ class SearchDialog(TableBasedDialog):
         self.accept_button.setEnabled(False)
         self.buttonBox.addButton(
             self.accept_button,
-            QtWidgets.QDialogButtonBox.AcceptRole)
+            QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         self.buttonBox.addButton(
             StandardButton(StandardButton.CANCEL),
-            QtWidgets.QDialogButtonBox.RejectRole)
+            QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
         self.verticalLayout.addWidget(self.buttonBox)
@@ -207,12 +207,12 @@ class SearchDialog(TableBasedDialog):
         progress_widget.setObjectName("progress_widget")
         layout = QtWidgets.QVBoxLayout(progress_widget)
         text_label = QtWidgets.QLabel(_('<strong>Loading...</strong>'), progress_widget)
-        text_label.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignBottom)
+        text_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignBottom)
         gif_label = QtWidgets.QLabel(progress_widget)
         movie = QtGui.QMovie(":/images/loader.gif")
         gif_label.setMovie(movie)
         movie.start()
-        gif_label.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
+        gif_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignTop)
         layout.addWidget(text_label)
         layout.addWidget(gif_label)
         layout.setContentsMargins(1, 1, 1, 1)
@@ -231,17 +231,17 @@ class SearchDialog(TableBasedDialog):
         layout = QtWidgets.QVBoxLayout(error_widget)
         error_label = QtWidgets.QLabel(error, error_widget)
         error_label.setWordWrap(True)
-        error_label.setAlignment(QtCore.Qt.AlignCenter)
-        error_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        error_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        error_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
         layout.addWidget(error_label)
         if show_retry_button:
             retry_widget = QtWidgets.QWidget(error_widget)
             retry_layout = QtWidgets.QHBoxLayout(retry_widget)
             retry_button = QtWidgets.QPushButton(_("Retry"), error_widget)
             retry_button.clicked.connect(self.retry)
-            retry_button.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Fixed))
+            retry_button.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Fixed))
             retry_layout.addWidget(retry_button)
-            retry_layout.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
+            retry_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignTop)
             retry_widget.setLayout(retry_layout)
             layout.addWidget(retry_widget)
         error_widget.setLayout(layout)
@@ -250,11 +250,11 @@ class SearchDialog(TableBasedDialog):
     def network_error(self, reply, error):
         error_msg = _("<strong>Following error occurred while fetching results:<br><br></strong>"
                       "Network request error for %s:<br>%s (QT code %d, HTTP code %s)<br>") % (
-                          reply.request().url().toString(QtCore.QUrl.RemoveUserInfo),
+                          reply.request().url().toString(QtCore.QUrl.UrlFormattingOption.RemoveUserInfo),
                           reply.errorString(),
                           error,
                           repr(reply.attribute(
-                              QtNetwork.QNetworkRequest.HttpStatusCodeAttribute))
+                              QtNetwork.QNetworkRequest.Attribute.HttpStatusCodeAttribute))
         )
         self.show_error(error_msg, show_retry_button=True)
 

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -61,9 +61,9 @@ class CoverWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setAlignment(QtCore.Qt.AlignCenter)
+        self.layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.loading_gif_label = QtWidgets.QLabel(self)
-        self.loading_gif_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.loading_gif_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         loading_gif = QtGui.QMovie(":/images/loader.gif")
         self.loading_gif_label.setMovie(loading_gif)
         loading_gif.start()
@@ -76,8 +76,8 @@ class CoverWidget(QtWidgets.QWidget):
         if wid:
             wid.widget().deleteLater()
         cover_label = QtWidgets.QLabel(self)
-        pixmap = pixmap.scaled(self.__size, QtCore.Qt.KeepAspectRatio,
-                               QtCore.Qt.SmoothTransformation)
+        pixmap = pixmap.scaled(self.__size, QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                               QtCore.Qt.TransformationMode.SmoothTransformation)
         self.__sizehint = pixmap.size()
         cover_label.setPixmap(pixmap)
         self.layout.addWidget(cover_label)

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -50,19 +50,19 @@ class ResultTable(QtWidgets.QTableWidget):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
-        self.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
         self.horizontalHeader().setStretchLastSection(True)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
+        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
+        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
 
         @throttle(1000)  # only emit scrolled signal once per second
         def emit_scrolled(x):
             parent.scrolled.emit()
         self.horizontalScrollBar().valueChanged.connect(emit_scrolled)
         self.verticalScrollBar().valueChanged.connect(emit_scrolled)
-        self.setHorizontalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
+        self.setHorizontalScrollMode(QtWidgets.QAbstractItemView.ScrollMode.ScrollPerPixel)
 
     def prepare(self, headers):
         self.clear()
@@ -128,11 +128,11 @@ class TableBasedDialog(PicardDialog):
         if sortkey is None:
             sortkey = natsort.natkey(value)
         item = SortableTableWidgetItem(sortkey)
-        item.setData(QtCore.Qt.DisplayRole, value)
+        item.setData(QtCore.Qt.ItemDataRole.DisplayRole, value)
         pos = self.colpos(colname)
         if pos == 0:
             id = self.get_value_for_row_id(row, value)
-            item.setData(QtCore.Qt.UserRole, id)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, id)
         self.table.setItem(row, pos, item)
 
     @abstractmethod
@@ -170,7 +170,7 @@ class TableBasedDialog(PicardDialog):
         self.table.prepare(self.table_headers)
         self.restore_table_header_state()
 
-    def show_table(self, sort_column=None, sort_order=QtCore.Qt.DescendingOrder):
+    def show_table(self, sort_column=None, sort_order=QtCore.Qt.SortOrder.DescendingOrder):
         self.add_widget_to_center_layout(self.table)
         self.table.horizontalHeader().setSortIndicatorShown(self.sorting_enabled)
         self.table.setSortingEnabled(self.sorting_enabled)
@@ -185,7 +185,7 @@ class TableBasedDialog(PicardDialog):
         if self.table:
             selected_rows_user_values = []
             for idx in self.table.selectionModel().selectedRows():
-                row = self.table.itemFromIndex(idx).data(QtCore.Qt.UserRole)
+                row = self.table.itemFromIndex(idx).data(QtCore.Qt.ItemDataRole.UserRole)
                 selected_rows_user_values .append(row)
             self.accept_event(selected_rows_user_values)
         super().accept()
@@ -197,7 +197,7 @@ class TableBasedDialog(PicardDialog):
         state = config.persist[self.dialog_header_state]
         if state:
             header.restoreState(state)
-        header.setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
         log.debug("restore_state: %s", self.dialog_header_state)
 
     def save_state(self):

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -127,9 +127,9 @@ class TagsFromFileNamesDialog(PicardDialog):
             selected_index = items.index(tff_format)
         self.ui.format.addItems(items)
         self.ui.format.setCurrentIndex(selected_index)
-        self.ui.buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.HelpRole)
-        self.ui.buttonbox.addButton(StandardButton(StandardButton.OK), QtWidgets.QDialogButtonBox.AcceptRole)
-        self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.RejectRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.ButtonRole.HelpRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.OK), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        self.ui.buttonbox.addButton(StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         self.ui.buttonbox.accepted.connect(self.accept)
         self.ui.buttonbox.rejected.connect(self.reject)
         self.ui.buttonbox.helpRequested.connect(self.show_help)
@@ -153,7 +153,7 @@ class TagsFromFileNamesDialog(PicardDialog):
             for i, column in enumerate(columns):
                 values = matches.get(column, [])
                 item.setText(i + 1, '; '.join(values))
-        self.ui.files.header().resizeSections(QtWidgets.QHeaderView.ResizeToContents)
+        self.ui.files.header().resizeSections(QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         self.ui.files.header().setStretchLastSection(True)
 
     def accept(self):

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -75,11 +75,11 @@ elif not IS_HAIKU:
 SyntaxTheme = namedtuple('SyntaxTheme', 'func var escape special noop')
 
 light_syntax_theme = SyntaxTheme(
-    func=QtGui.QColor(QtCore.Qt.blue),
-    var=QtGui.QColor(QtCore.Qt.darkCyan),
-    escape=QtGui.QColor(QtCore.Qt.darkRed),
-    special=QtGui.QColor(QtCore.Qt.blue),
-    noop=QtGui.QColor(QtCore.Qt.darkGray),
+    func=QtGui.QColor(QtCore.Qt.GlobalColor.blue),
+    var=QtGui.QColor(QtCore.Qt.GlobalColor.darkCyan),
+    escape=QtGui.QColor(QtCore.Qt.GlobalColor.darkRed),
+    special=QtGui.QColor(QtCore.Qt.GlobalColor.blue),
+    noop=QtGui.QColor(QtCore.Qt.GlobalColor.darkGray),
 )
 
 dark_syntax_theme = SyntaxTheme(
@@ -110,7 +110,7 @@ class BaseTheme:
         )
 
         palette = QtGui.QPalette(app.palette())
-        base_color = palette.color(QtGui.QPalette.Active, QtGui.QPalette.Base)
+        base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
         self._dark_theme = base_color.lightness() < 128
         self.update_palette(palette, self.is_dark_theme, self.accent_color)
         app.setPalette(palette)
@@ -135,13 +135,13 @@ class BaseTheme:
     # pylint: disable=no-self-use
     def update_palette(self, palette, dark_theme, accent_color):
         if accent_color:
-            accent_text_color = QtCore.Qt.white if accent_color.lightness() < 160 else QtCore.Qt.black
-            palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.Highlight, accent_color)
-            palette.setColor(QtGui.QPalette.Active, QtGui.QPalette.HighlightedText, accent_text_color)
+            accent_text_color = QtCore.Qt.GlobalColor.white if accent_color.lightness() < 160 else QtCore.Qt.GlobalColor.black
+            palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight, accent_color)
+            palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.HighlightedText, accent_text_color)
 
             link_color = QtGui.QColor()
             link_color.setHsl(accent_color.hue(), accent_color.saturation(), 160, accent_color.alpha())
-            palette.setColor(QtGui.QPalette.Link, link_color)
+            palette.setColor(QtGui.QPalette.ColorRole.Link, link_color)
 
 
 if IS_WIN:
@@ -181,22 +181,22 @@ if IS_WIN:
             # Adapt to Windows 10 color scheme (dark / light theme and accent color)
             super().update_palette(palette, dark_theme, accent_color)
             if dark_theme:
-                palette.setColor(QtGui.QPalette.Window, QtGui.QColor(51, 51, 51))
-                palette.setColor(QtGui.QPalette.WindowText, QtCore.Qt.white)
-                palette.setColor(QtGui.QPalette.Base, QtGui.QColor(31, 31, 31))
-                palette.setColor(QtGui.QPalette.AlternateBase, QtGui.QColor(51, 51, 51))
-                palette.setColor(QtGui.QPalette.ToolTipBase, QtGui.QColor(51, 51, 51))
-                palette.setColor(QtGui.QPalette.ToolTipText, QtCore.Qt.white)
-                palette.setColor(QtGui.QPalette.Text, QtCore.Qt.white)
-                palette.setColor(QtGui.QPalette.Button, QtGui.QColor(51, 51, 51))
-                palette.setColor(QtGui.QPalette.ButtonText, QtCore.Qt.white)
-                palette.setColor(QtGui.QPalette.BrightText, QtCore.Qt.red)
-                palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Text, QtCore.Qt.darkGray)
-                palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Light, QtGui.QColor(0, 0, 0, 0))
-                palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, QtCore.Qt.darkGray)
-                palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Base, QtGui.QColor(60, 60, 60))
-                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.Highlight, QtGui.QColor(51, 51, 51))
-                palette.setColor(QtGui.QPalette.Inactive, QtGui.QPalette.HighlightedText, QtCore.Qt.white)
+                palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor(51, 51, 51))
+                palette.setColor(QtGui.QPalette.ColorRole.WindowText, QtCore.Qt.GlobalColor.white)
+                palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(31, 31, 31))
+                palette.setColor(QtGui.QPalette.ColorRole.AlternateBase, QtGui.QColor(51, 51, 51))
+                palette.setColor(QtGui.QPalette.ColorRole.ToolTipBase, QtGui.QColor(51, 51, 51))
+                palette.setColor(QtGui.QPalette.ColorRole.ToolTipText, QtCore.Qt.GlobalColor.white)
+                palette.setColor(QtGui.QPalette.ColorRole.Text, QtCore.Qt.GlobalColor.white)
+                palette.setColor(QtGui.QPalette.ColorRole.Button, QtGui.QColor(51, 51, 51))
+                palette.setColor(QtGui.QPalette.ColorRole.ButtonText, QtCore.Qt.GlobalColor.white)
+                palette.setColor(QtGui.QPalette.ColorRole.BrightText, QtCore.Qt.GlobalColor.red)
+                palette.setColor(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text, QtCore.Qt.GlobalColor.darkGray)
+                palette.setColor(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Light, QtGui.QColor(0, 0, 0, 0))
+                palette.setColor(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.ButtonText, QtCore.Qt.GlobalColor.darkGray)
+                palette.setColor(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Base, QtGui.QColor(60, 60, 60))
+                palette.setColor(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.Highlight, QtGui.QColor(51, 51, 51))
+                palette.setColor(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.HighlightedText, QtCore.Qt.GlobalColor.white)
 
     theme = WindowsTheme()
 

--- a/picard/ui/ui_cdlookup.py
+++ b/picard/ui/ui_cdlookup.py
@@ -72,11 +72,11 @@ class Ui_Dialog(object):
 
         self.retranslateUi(Dialog)
         self.results_view.setCurrentIndex(0)
-        self.ok_button.clicked.connect(Dialog.accept)
-        self.cancel_button.clicked.connect(Dialog.reject)
+        self.ok_button.clicked.connect(Dialog.accept) # type: ignore
+        self.cancel_button.clicked.connect(Dialog.reject) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(Dialog)
-        Dialog.setTabOrder(self.submit_button, self.release_list)
-        Dialog.setTabOrder(self.release_list, self.ok_button)
+        Dialog.setTabOrder(self.release_list, self.submit_button)
+        Dialog.setTabOrder(self.submit_button, self.ok_button)
         Dialog.setTabOrder(self.ok_button, self.lookup_button)
         Dialog.setTabOrder(self.lookup_button, self.cancel_button)
 

--- a/picard/ui/ui_edittagdialog.py
+++ b/picard/ui/ui_edittagdialog.py
@@ -92,17 +92,17 @@ class Ui_EditTagDialog(object):
         self.verticalLayout_2.addWidget(self.buttonbox)
 
         self.retranslateUi(EditTagDialog)
-        self.buttonbox.accepted.connect(EditTagDialog.accept)
-        self.buttonbox.rejected.connect(EditTagDialog.reject)
-        self.move_value_up.clicked.connect(EditTagDialog.move_row_up)
-        self.move_value_down.clicked.connect(EditTagDialog.move_row_down)
-        self.edit_value.clicked.connect(EditTagDialog.edit_value)
-        self.add_value.clicked.connect(EditTagDialog.add_value)
-        self.value_list.itemChanged['QListWidgetItem*'].connect(EditTagDialog.value_edited)
-        self.remove_value.clicked.connect(EditTagDialog.remove_value)
-        self.value_list.itemSelectionChanged.connect(EditTagDialog.value_selection_changed)
-        self.tag_names.editTextChanged['QString'].connect(EditTagDialog.tag_changed)
-        self.tag_names.activated['QString'].connect(EditTagDialog.tag_selected)
+        self.buttonbox.accepted.connect(EditTagDialog.accept) # type: ignore
+        self.buttonbox.rejected.connect(EditTagDialog.reject) # type: ignore
+        self.move_value_up.clicked.connect(EditTagDialog.move_row_up) # type: ignore
+        self.move_value_down.clicked.connect(EditTagDialog.move_row_down) # type: ignore
+        self.edit_value.clicked.connect(EditTagDialog.edit_value) # type: ignore
+        self.add_value.clicked.connect(EditTagDialog.add_value) # type: ignore
+        self.value_list.itemChanged['QListWidgetItem*'].connect(EditTagDialog.value_edited) # type: ignore
+        self.remove_value.clicked.connect(EditTagDialog.remove_value) # type: ignore
+        self.value_list.itemSelectionChanged.connect(EditTagDialog.value_selection_changed) # type: ignore
+        self.tag_names.editTextChanged['QString'].connect(EditTagDialog.tag_changed) # type: ignore
+        self.tag_names.activated['QString'].connect(EditTagDialog.tag_selected) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(EditTagDialog)
         EditTagDialog.setTabOrder(self.tag_names, self.value_list)
         EditTagDialog.setTabOrder(self.value_list, self.edit_value)

--- a/picard/ui/ui_infodialog.py
+++ b/picard/ui/ui_infodialog.py
@@ -24,7 +24,7 @@ class Ui_InfoDialog(object):
         self.info_scroll.setObjectName("info_scroll")
         self.scrollAreaWidgetContents = QtWidgets.QWidget()
         self.scrollAreaWidgetContents.setEnabled(True)
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 493, 358))
+        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 623, 361))
         self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
         self.verticalLayoutLabel = QtWidgets.QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayoutLabel.setObjectName("verticalLayoutLabel")

--- a/picard/ui/ui_options_cdlookup.py
+++ b/picard/ui/ui_options_cdlookup.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_CDLookupOptionsPage(object):
     def setupUi(self, CDLookupOptionsPage):
@@ -37,4 +39,3 @@ class Ui_CDLookupOptionsPage(object):
         _translate = QtCore.QCoreApplication.translate
         self.rename_files.setTitle(_("CD Lookup"))
         self.label_3.setText(_("CD-ROM device to use for lookups:"))
-

--- a/picard/ui/ui_options_cdlookup_select.py
+++ b/picard/ui/ui_options_cdlookup_select.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_CDLookupOptionsPage(object):
     def setupUi(self, CDLookupOptionsPage):
@@ -44,4 +46,3 @@ class Ui_CDLookupOptionsPage(object):
         _translate = QtCore.QCoreApplication.translate
         self.rename_files.setTitle(_("CD Lookup"))
         self.cd_lookup_.setText(_("Default CD-ROM drive to use for lookups:"))
-

--- a/picard/ui/ui_options_genres.py
+++ b/picard/ui/ui_options_genres.py
@@ -3,6 +3,7 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
@@ -127,5 +128,3 @@ class Ui_GenresOptionsPage(object):
         self.join_genres.setItemText(2, _(", "))
         self.label_genres_filter.setText(_("Genres or folksonomy tags to include or exclude, one per line:"))
         self.label_test_genres_filter.setText(_("Playground for genres or folksonomy tags filters (cleared on exit):"))
-
-

--- a/picard/ui/ui_options_interface_colors.py
+++ b/picard/ui/ui_options_interface_colors.py
@@ -3,6 +3,7 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
@@ -46,5 +47,3 @@ class Ui_InterfaceColorsOptionsPage(object):
     def retranslateUi(self, InterfaceColorsOptionsPage):
         _translate = QtCore.QCoreApplication.translate
         self.colors.setTitle(_("Colors"))
-
-

--- a/picard/ui/ui_options_matching.py
+++ b/picard/ui/ui_options_matching.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_MatchingOptionsPage(object):
     def setupUi(self, MatchingOptionsPage):
@@ -73,4 +75,3 @@ class Ui_MatchingOptionsPage(object):
         self.file_lookup_threshold.setSuffix(_(" %"))
         self.label_4.setText(_("Minimal similarity for file lookups:"))
         self.label_5.setText(_("Minimal similarity for cluster lookups:"))
-

--- a/picard/ui/ui_options_plugins.py
+++ b/picard/ui/ui_options_plugins.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_PluginsOptionsPage(object):
     def setupUi(self, PluginsOptionsPage):
@@ -134,4 +136,3 @@ class Ui_PluginsOptionsPage(object):
         self.folder_open.setText(_("Open plugin folder"))
         self.reload_list_of_plugins.setText(_("Reload List of Plugins"))
         self.groupBox.setTitle(_("Details"))
-

--- a/picard/ui/ui_options_ratings.py
+++ b/picard/ui/ui_options_ratings.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_RatingsOptionsPage(object):
     def setupUi(self, RatingsOptionsPage):
@@ -46,4 +48,3 @@ class Ui_RatingsOptionsPage(object):
         self.label.setText(_("Picard saves the ratings together with an e-mail address identifying the user who did the rating. That way different ratings for different users can be stored in the files. Please specify the e-mail you want to use to save your ratings."))
         self.ignore_tags_2.setText(_("E-mail:"))
         self.submit_ratings.setText(_("Submit ratings to MusicBrainz"))
-

--- a/picard/ui/ui_options_script.py
+++ b/picard/ui/ui_options_script.py
@@ -102,11 +102,11 @@ class Ui_ScriptingOptionsPage(object):
         self.vboxlayout.addWidget(self.enable_tagger_scripts)
 
         self.retranslateUi(ScriptingOptionsPage)
-        self.add_button.clicked.connect(self.script_list.add_script)
-        self.tagger_script.textChanged.connect(ScriptingOptionsPage.live_update_and_check)
-        self.script_list.itemSelectionChanged.connect(ScriptingOptionsPage.script_selected)
-        self.remove_button.clicked.connect(self.script_list.remove_selected_script)
-        self.enable_tagger_scripts.toggled['bool'].connect(ScriptingOptionsPage.enable_tagger_scripts_toggled)
+        self.add_button.clicked.connect(self.script_list.add_script) # type: ignore
+        self.tagger_script.textChanged.connect(ScriptingOptionsPage.live_update_and_check) # type: ignore
+        self.script_list.itemSelectionChanged.connect(ScriptingOptionsPage.script_selected) # type: ignore
+        self.remove_button.clicked.connect(self.script_list.remove_selected_script) # type: ignore
+        self.enable_tagger_scripts.toggled['bool'].connect(ScriptingOptionsPage.enable_tagger_scripts_toggled) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(ScriptingOptionsPage)
         ScriptingOptionsPage.setTabOrder(self.enable_tagger_scripts, self.script_list)
         ScriptingOptionsPage.setTabOrder(self.script_list, self.tagger_script)

--- a/picard/ui/ui_options_tags.py
+++ b/picard/ui/ui_options_tags.py
@@ -54,7 +54,7 @@ class Ui_TagsOptionsPage(object):
         self.vboxlayout.addWidget(self.before_tagging)
 
         self.retranslateUi(TagsOptionsPage)
-        self.clear_existing_tags.toggled['bool'].connect(self.preserve_images.setEnabled)
+        self.clear_existing_tags.toggled['bool'].connect(self.preserve_images.setEnabled) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(TagsOptionsPage)
         TagsOptionsPage.setTabOrder(self.write_tags, self.preserve_timestamps)
         TagsOptionsPage.setTabOrder(self.preserve_timestamps, self.clear_existing_tags)

--- a/picard/ui/ui_options_tags_compatibility_wave.py
+++ b/picard/ui/ui_options_tags_compatibility_wave.py
@@ -48,7 +48,7 @@ class Ui_TagsCompatibilityOptionsPage(object):
         self.vboxlayout.addItem(spacerItem2)
 
         self.retranslateUi(TagsCompatibilityOptionsPage)
-        self.write_wave_riff_info.toggled['bool'].connect(self.remove_wave_riff_info.setDisabled)
+        self.write_wave_riff_info.toggled['bool'].connect(self.remove_wave_riff_info.setDisabled) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(TagsCompatibilityOptionsPage)
 
     def retranslateUi(self, TagsCompatibilityOptionsPage):

--- a/picard/ui/ui_passworddialog.py
+++ b/picard/ui/ui_passworddialog.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_PasswordDialog(object):
     def setupUi(self, PasswordDialog):
@@ -52,7 +54,7 @@ class Ui_PasswordDialog(object):
         self.verticalLayout.addWidget(self.buttonbox)
 
         self.retranslateUi(PasswordDialog)
-        self.buttonbox.rejected.connect(PasswordDialog.reject)
+        self.buttonbox.rejected.connect(PasswordDialog.reject) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(PasswordDialog)
 
     def retranslateUi(self, PasswordDialog):
@@ -60,4 +62,3 @@ class Ui_PasswordDialog(object):
         PasswordDialog.setWindowTitle(_("Authentication required"))
         self.label.setText(_("Username:"))
         self.label_2.setText(_("Password:"))
-

--- a/picard/ui/ui_provider_options_local.py
+++ b/picard/ui/ui_provider_options_local.py
@@ -3,7 +3,9 @@
 # Automatically generated - don't edit.
 # Use `python setup.py build_ui` to update it.
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_LocalOptions(object):
     def setupUi(self, LocalOptions):
@@ -51,4 +53,3 @@ class Ui_LocalOptions(object):
         self.local_cover_regex_label.setText(_("Local cover art files match the following regular expression:"))
         self.local_cover_regex_default.setText(_("Default"))
         self.note.setText(_("First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."))
-

--- a/picard/ui/ui_widget_taglisteditor.py
+++ b/picard/ui/ui_widget_taglisteditor.py
@@ -57,10 +57,10 @@ class Ui_TagListEditor(object):
         self.horizontalLayout.addLayout(self.verticalLayout)
 
         self.retranslateUi(TagListEditor)
-        self.tags_add_btn.clicked.connect(self.tag_list_view.add_empty_row)
-        self.tags_remove_btn.clicked.connect(self.tag_list_view.remove_selected_rows)
-        self.tags_move_up_btn.clicked.connect(self.tag_list_view.move_selected_rows_up)
-        self.tags_move_down_btn.clicked.connect(self.tag_list_view.move_selected_rows_down)
+        self.tags_add_btn.clicked.connect(self.tag_list_view.add_empty_row) # type: ignore
+        self.tags_remove_btn.clicked.connect(self.tag_list_view.remove_selected_rows) # type: ignore
+        self.tags_move_up_btn.clicked.connect(self.tag_list_view.move_selected_rows_up) # type: ignore
+        self.tags_move_down_btn.clicked.connect(self.tag_list_view.move_selected_rows_down) # type: ignore
         QtCore.QMetaObject.connectSlotsByName(TagListEditor)
 
     def retranslateUi(self, TagListEditor):

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -98,4 +98,4 @@ class MultiDirsSelectDialog(QtWidgets.QFileDialog):
         self.setOption(self.DontUseNativeDialog)
         for view in self.findChildren((QtWidgets.QListView, QtWidgets.QTreeView)):
             if isinstance(view.model(), QtWidgets.QFileSystemModel):
-                view.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+                view.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)

--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -48,7 +48,7 @@ class ElidedLabel(QtWidgets.QLabel):
         # text does not properly fit into width(), as a workaround subtract
         # 2 pixels from the available width.
         elided_label = metrics.elidedText(self._full_label,
-                                          QtCore.Qt.ElideRight,
+                                          QtCore.Qt.TextElideMode.ElideRight,
                                           self.width() - 2)
         super().setText(elided_label)
         if self._full_label and elided_label != self._full_label:
@@ -69,12 +69,12 @@ class ActiveLabel(QtWidgets.QLabel):
     def setActive(self, active):
         self.active = active
         if self.active:
-            self.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
+            self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
         else:
             self.setCursor(QtGui.QCursor())
 
     def mouseReleaseEvent(self, event):
-        if self.active and event.button() == QtCore.Qt.LeftButton:
+        if self.active and event.button() == QtCore.Qt.MouseButton.LeftButton:
             self.clicked.emit()
 
 
@@ -102,7 +102,7 @@ class Popover(QtWidgets.QFrame):
 
     def __init__(self, parent, position='bottom'):
         super().__init__(parent)
-        self.setWindowFlags(QtCore.Qt.Popup | QtCore.Qt.FramelessWindowHint)
+        self.setWindowFlags(QtCore.Qt.WindowType.Popup | QtCore.Qt.WindowType.FramelessWindowHint)
         self.position = position
 
     def show(self):
@@ -140,11 +140,11 @@ class SliderPopover(Popover):
         super().__init__(parent, position)
         vbox = QtWidgets.QVBoxLayout(self)
         self.label = QtWidgets.QLabel(label, self)
-        self.label.setAlignment(QtCore.Qt.AlignCenter)
+        self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         vbox.addWidget(self.label)
 
         self.slider = ClickableSlider(self)
-        self.slider.setOrientation(QtCore.Qt.Horizontal)
+        self.slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self.slider.setValue(value)
         self.slider.valueChanged.connect(self.value_changed)
         vbox.addWidget(self.slider)

--- a/picard/ui/widgets/profilelistwidget.py
+++ b/picard/ui/widgets/profilelistwidget.py
@@ -49,9 +49,9 @@ class ProfileListWidget(QtWidgets.QListWidget):
             menu.exec_(event.globalPos())
 
     def keyPressEvent(self, event):
-        if event.matches(QtGui.QKeySequence.Delete):
+        if event.matches(QtGui.QKeySequence.StandardKey.Delete):
             self.remove_selected_profile()
-        elif event.key() == QtCore.Qt.Key_Insert:
+        elif event.key() == QtCore.Qt.Key.Key_Insert:
             self.add_profile()
         else:
             super().keyPressEvent(event)
@@ -66,10 +66,10 @@ class ProfileListWidget(QtWidgets.QListWidget):
         if name is None:
             name = self.unique_profile_name()
         list_item = ProfileListWidgetItem(name=name, profile_id=profile_id)
-        list_item.setCheckState(QtCore.Qt.Checked)
+        list_item.setCheckState(QtCore.Qt.CheckState.Checked)
         self.insertItem(0, list_item)
-        self.setCurrentItem(list_item, QtCore.QItemSelectionModel.Clear
-            | QtCore.QItemSelectionModel.SelectCurrent)
+        self.setCurrentItem(list_item, QtCore.QItemSelectionModel.SelectionFlag.Clear
+            | QtCore.QItemSelectionModel.SelectionFlag.SelectCurrent)
 
     def remove_selected_profile(self):
         items = self.selectedItems()
@@ -80,8 +80,8 @@ class ProfileListWidget(QtWidgets.QListWidget):
         row = self.row(item)
         msg = _("Are you sure you want to remove this profile?")
         reply = QtWidgets.QMessageBox.question(self, _('Confirm Remove'), msg,
-            QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
-        if item and reply == QtWidgets.QMessageBox.Yes:
+            QtWidgets.QMessageBox.StandardButton.Yes, QtWidgets.QMessageBox.StandardButton.No)
+        if item and reply == QtWidgets.QMessageBox.StandardButton.Yes:
             item = self.takeItem(row)
             del item
 
@@ -91,11 +91,11 @@ class ProfileListWidgetItem(HashableListWidgetItem):
 
     def __init__(self, name=None, enabled=True, profile_id=""):
         super().__init__(name)
-        self.setFlags(self.flags() | QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEditable)
+        self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsEditable)
         if name is None:
             name = _(DEFAULT_PROFILE_NAME)
         self.setText(name)
-        self.setCheckState(QtCore.Qt.Checked if enabled else QtCore.Qt.Unchecked)
+        self.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
         if not profile_id:
             profile_id = str(uuid.uuid4())
         self.profile_id = profile_id
@@ -110,7 +110,7 @@ class ProfileListWidgetItem(HashableListWidgetItem):
 
     @property
     def enabled(self):
-        return self.checkState() == QtCore.Qt.Checked
+        return self.checkState() == QtCore.Qt.CheckState.Checked
 
     def get_all(self):
         # tuples used to get pickle dump of settings to work

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -89,7 +89,7 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             postprocessor=process_html,
         )
 
-        if parent.layoutDirection() == QtCore.Qt.RightToLeft:
+        if parent.layoutDirection() == QtCore.Qt.LayoutDirection.RightToLeft:
             text_direction = 'rtl'
         else:
             text_direction = 'ltr'
@@ -122,14 +122,14 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.horizontalLayout.setContentsMargins(-1, 0, -1, -1)
         self.horizontalLayout.setObjectName("docs_horizontalLayout")
         self.scripting_doc_link = QtWidgets.QLabel(self)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.scripting_doc_link.sizePolicy().hasHeightForWidth())
         if include_link:
             self.scripting_doc_link.setSizePolicy(sizePolicy)
             self.scripting_doc_link.setMinimumSize(QtCore.QSize(0, 20))
-            self.scripting_doc_link.setAlignment(QtCore.Qt.AlignCenter)
+            self.scripting_doc_link.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             self.scripting_doc_link.setWordWrap(True)
             self.scripting_doc_link.setOpenExternalLinks(True)
             self.scripting_doc_link.setObjectName("docs_scripting_doc_link")

--- a/picard/ui/widgets/scriptlistwidget.py
+++ b/picard/ui/widgets/scriptlistwidget.py
@@ -60,9 +60,9 @@ class ScriptListWidget(QtWidgets.QListWidget):
             menu.exec_(event.globalPos())
 
     def keyPressEvent(self, event):
-        if event.matches(QtGui.QKeySequence.Delete):
+        if event.matches(QtGui.QKeySequence.StandardKey.Delete):
             self.remove_selected_script()
-        elif event.key() == QtCore.Qt.Key_Insert:
+        elif event.key() == QtCore.Qt.Key.Key_Insert:
             self.add_script()
         else:
             super().keyPressEvent(event)
@@ -74,10 +74,10 @@ class ScriptListWidget(QtWidgets.QListWidget):
     def add_script(self):
         numbered_name = self.unique_script_name()
         list_item = ScriptListWidgetItem(name=numbered_name)
-        list_item.setCheckState(QtCore.Qt.Checked)
+        list_item.setCheckState(QtCore.Qt.CheckState.Checked)
         self.addItem(list_item)
-        self.setCurrentItem(list_item, QtCore.QItemSelectionModel.Clear
-            | QtCore.QItemSelectionModel.SelectCurrent)
+        self.setCurrentItem(list_item, QtCore.QItemSelectionModel.SelectionFlag.Clear
+            | QtCore.QItemSelectionModel.SelectionFlag.SelectCurrent)
 
     def remove_selected_script(self):
         items = self.selectedItems()
@@ -88,8 +88,8 @@ class ScriptListWidget(QtWidgets.QListWidget):
         row = self.row(item)
         msg = _("Are you sure you want to remove this script?")
         reply = QtWidgets.QMessageBox.question(self, _('Confirm Remove'), msg,
-            QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
-        if item and reply == QtWidgets.QMessageBox.Yes:
+            QtWidgets.QMessageBox.StandardButton.Yes, QtWidgets.QMessageBox.StandardButton.No)
+        if item and reply == QtWidgets.QMessageBox.StandardButton.Yes:
             item = self.takeItem(row)
             del item
 
@@ -112,11 +112,11 @@ class ScriptListWidgetItem(HashableListWidgetItem):
 
     def __init__(self, name=None, enabled=True, script=""):
         super().__init__(name)
-        self.setFlags(self.flags() | QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsEditable)
+        self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsEditable)
         if name is None:
             name = _(DEFAULT_SCRIPT_NAME)
         self.setText(name)
-        self.setCheckState(QtCore.Qt.Checked if enabled else QtCore.Qt.Unchecked)
+        self.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
         self.script = script
         self.has_error = False
 
@@ -130,7 +130,7 @@ class ScriptListWidgetItem(HashableListWidgetItem):
 
     @property
     def enabled(self):
-        return self.checkState() == QtCore.Qt.Checked
+        return self.checkState() == QtCore.Qt.CheckState.Checked
 
     def get_all(self):
         # tuples used to get pickle dump of settings to work

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -104,7 +104,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         syntax_theme = theme.syntax_theme
         self.func_re = re.compile(r"\$(?!noop)[_a-zA-Z0-9]*\(")
         self.func_fmt = QtGui.QTextCharFormat()
-        self.func_fmt.setFontWeight(QtGui.QFont.Bold)
+        self.func_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
         self.func_fmt.setForeground(syntax_theme.func)
         self.var_re = re.compile(r"%[_a-zA-Z0-9:]*%")
         self.var_fmt = QtGui.QTextCharFormat()
@@ -121,7 +121,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         self.bracket_re = re.compile(r"[()]")
         self.noop_re = re.compile(r"\$noop\(")
         self.noop_fmt = QtGui.QTextCharFormat()
-        self.noop_fmt.setFontWeight(QtGui.QFont.Bold)
+        self.noop_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
         self.noop_fmt.setFontItalic(True)
         self.noop_fmt.setForeground(syntax_theme.noop)
         self.rules = [
@@ -179,7 +179,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 class ScriptCompleter(QCompleter):
     def __init__(self, parent=None):
         super().__init__(sorted(self.choices), parent)
-        self.setCompletionMode(QCompleter.UnfilteredPopupCompletion)
+        self.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
         self.highlighted.connect(self.set_highlighted)
         self.last_selected = ''
 
@@ -406,9 +406,9 @@ class ScriptTextEdit(QTextEdit):
         config = get_config()
         config.persist['script_editor_wordwrap'] = wordwrap
         if wordwrap:
-            self.setLineWrapMode(QTextEdit.WidgetWidth)
+            self.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
         else:
-            self.setLineWrapMode(QTextEdit.NoWrap)
+            self.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
 
     def update_show_tooltips(self):
         """Toggles wordwrap in the script editor
@@ -437,7 +437,7 @@ class ScriptTextEdit(QTextEdit):
         if not tc.atEnd():
             pos = tc.position()
             tc = self.textCursor()
-            tc.setPosition(pos + 1, QTextCursor.KeepAnchor)
+            tc.setPosition(pos + 1, QTextCursor.MoveMode.KeepAnchor)
             first_char = completion[0]
             next_char = tc.selectedText()
             if (first_char == '$' and next_char == '(') or (first_char == '%' and next_char == '%'):
@@ -453,13 +453,13 @@ class ScriptTextEdit(QTextEdit):
     def cursor_select_word(self, full_word=True):
         tc = self.textCursor()
         current_position = tc.position()
-        tc.select(QTextCursor.WordUnderCursor)
+        tc.select(QTextCursor.SelectionType.WordUnderCursor)
         selected_text = tc.selectedText()
         # Check for start of function or end of variable
         if current_position > 0 and selected_text and selected_text[0] in {'(', '%'}:
             current_position -= 1
             tc.setPosition(current_position)
-            tc.select(QTextCursor.WordUnderCursor)
+            tc.select(QTextCursor.SelectionType.WordUnderCursor)
             selected_text = tc.selectedText()
         start = tc.selectionStart()
         end = tc.selectionEnd()
@@ -473,19 +473,19 @@ class ScriptTextEdit(QTextEdit):
             # Update selection to include the character before the
             # selected word to include the $ or %.
             tc.setPosition(start - 1 if start > 0 else 0)
-            tc.setPosition(end, QTextCursor.KeepAnchor)
+            tc.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
             selected_text = tc.selectedText()
             # No match, reset position (otherwise we could replace an additional character)
             if not selected_text.startswith('$') and not selected_text.startswith('%'):
                 tc.setPosition(start)
-                tc.setPosition(end, QTextCursor.KeepAnchor)
+                tc.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
         if not full_word:
-            tc.setPosition(current_position, QTextCursor.KeepAnchor)
+            tc.setPosition(current_position, QTextCursor.MoveMode.KeepAnchor)
         return tc
 
     def keyPressEvent(self, event):
         if self.completer.popup().isVisible():
-            if event.key() in {Qt.Key_Tab, Qt.Key_Return, Qt.Key_Enter}:
+            if event.key() in {Qt.Key.Key_Tab, Qt.Key.Key_Return, Qt.Key.Key_Enter}:
                 self.completer.activated.emit(self.completer.get_selected())
                 return
 
@@ -495,10 +495,10 @@ class ScriptTextEdit(QTextEdit):
     def handle_autocomplete(self, event):
         # Only trigger autocomplete on actual text input or if the user explicitly
         # requested auto completion with Ctrl+Space (Control+Space on macOS)
-        modifier = QtCore.Qt.MetaModifier if IS_MACOS else QtCore.Qt.ControlModifier
-        force_completion_popup = event.key() == QtCore.Qt.Key_Space and event.modifiers() & modifier
+        modifier = QtCore.Qt.KeyboardModifier.MetaModifier if IS_MACOS else QtCore.Qt.KeyboardModifier.ControlModifier
+        force_completion_popup = event.key() == QtCore.Qt.Key.Key_Space and event.modifiers() & modifier
         if not (force_completion_popup
-                or event.key() in {Qt.Key_Backspace, Qt.Key_Delete}
+                or event.key() in {Qt.Key.Key_Backspace, Qt.Key.Key_Delete}
                 or self.autocomplete_trigger_chars.match(event.text())):
             self.popup_hide()
             return

--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -57,10 +57,10 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
             QtWidgets.QToolTip.showText(event.globalPos(), tooltip, self)
             return
 
-        if event.button() == QtCore.Qt.LeftButton:
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
             index = self.logicalIndexAt(event.pos())
             if (index != -1 and index == self.sortIndicatorSection()
-                and self.sortIndicatorOrder() == QtCore.Qt.DescendingOrder):
+                and self.sortIndicatorOrder() == QtCore.Qt.SortOrder.DescendingOrder):
                 # After a column was sorted descending we want to reset it
                 # to no sorting state. But we need to call the parent
                 # implementation of mouseReleaseEvent in order to handle
@@ -84,7 +84,7 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
         self.setSectionsClickable(not is_locked)
         self.setSectionsMovable(not is_locked)
         if is_locked:
-            resize_mode = QtWidgets.QHeaderView.Fixed
+            resize_mode = QtWidgets.QHeaderView.ResizeMode.Fixed
         else:
-            resize_mode = QtWidgets.QHeaderView.Interactive
+            resize_mode = QtWidgets.QHeaderView.ResizeMode.Interactive
         self.setSectionResizeMode(resize_mode)

--- a/picard/util/checkupdate.py
+++ b/picard/util/checkupdate.py
@@ -109,7 +109,7 @@ class UpdateCheckManager(QtCore.QObject):
                         url=PLUGINS_API['host'],
                         endpoint=PLUGINS_API['endpoint']['releases'],
                     ),
-                    QMessageBox.Ok, QMessageBox.Ok)
+                    QMessageBox.StandardButton.Ok, QMessageBox.StandardButton.Ok)
         else:
             if response and 'versions' in response:
                 self._available_versions = response['versions']
@@ -148,9 +148,9 @@ class UpdateCheckManager(QtCore.QObject):
                       picard_old_version=PICARD_FANCY_VERSION_STR,
                       picard_new_version=self._available_versions[key]['tag']
                 ),
-                QMessageBox.Ok | QMessageBox.Cancel,
-                QMessageBox.Cancel
-            ) == QMessageBox.Ok:
+                QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+                QMessageBox.StandardButton.Cancel
+            ) == QMessageBox.StandardButton.Ok:
                 webbrowser2.open(self._available_versions[key]['urls']['download'])
         else:
             if self._show_always:
@@ -166,5 +166,5 @@ class UpdateCheckManager(QtCore.QObject):
                         update_level=_(update_level),
                         picard_old_version=PICARD_FANCY_VERSION_STR,
                     ),
-                    QMessageBox.Ok, QMessageBox.Ok
+                    QMessageBox.StandardButton.Ok, QMessageBox.StandardButton.Ok
                 )

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -348,7 +348,7 @@ def make_short_filename(basedir, relpath, win_compat=False, relative_to=""):
     except FileNotFoundError:
         # os.path.abspath raises an exception if basedir is a relative path and
         # cwd doesn't exist anymore
-        basedir = QStandardPaths.writableLocation(QStandardPaths.MusicLocation)
+        basedir = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.MusicLocation)
     # also, make sure the relative path is clean
     relpath = os.path.normpath(relpath)
     if win_compat and relative_to:

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -41,7 +41,7 @@ from picard import log
 class ProxyToMainEvent(QEvent):
 
     def __init__(self, func, *args, **kwargs):
-        super().__init__(QEvent.User)
+        super().__init__(QEvent.Type.User)
         self.func = func
         self.args = args
         self.kwargs = kwargs

--- a/requirements-macos-10.14.txt
+++ b/requirements-macos-10.14.txt
@@ -6,5 +6,5 @@ mutagen==1.45.1
 PyJWT==2.1.0
 pyobjc-core==6.2.2
 pyobjc-framework-Cocoa==6.2.2
-PyQt5==5.15.4
+PyQt5==5.15.6
 pyyaml==5.4.1

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -4,6 +4,6 @@ fasteners==0.16.3
 markdown==3.3.4
 mutagen==1.45.1
 PyJWT==2.1.0
-PyQt5==5.15.4
+PyQt5==5.15.6
 pywin32==301
 pyyaml==5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ mutagen~=1.37
 PyJWT~=2.0
 pyobjc-core~=6.2; sys_platform == 'darwin'
 pyobjc-framework-Cocoa~=6.2; sys_platform == 'darwin'
-PyQt5~=5.10
+PyQt5~=5.11
 pywin32; sys_platform == 'win32'
 pyyaml>=5.1, <7

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -301,8 +301,8 @@ class WebServiceProxyTest(PicardTestCase):
 
     def test_proxy_setup(self):
         proxy_types = [
-            ('http', QNetworkProxy.HttpProxy),
-            ('socks', QNetworkProxy.Socks5Proxy),
+            ('http', QNetworkProxy.ProxyType.HttpProxy),
+            ('socks', QNetworkProxy.ProxyType.Socks5Proxy),
         ]
         for proxy_type, expected_qt_type in proxy_types:
             config.setting['proxy_type'] = proxy_type


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2332
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Since PyQt 5.11 Qt's enum values are also available as proper Python enum types. This will become the only way to access the enums in Qt6.

Making use of these scoped enums in some cases improves readability, allows better auto completion in IDEs and will ease the transition to Qt6.

See also https://www.riverbankcomputing.com/static/Docs/PyQt5/gotchas.html#enums

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Convert code to use scoped PyQt5 enums.

I used the replacement script in https://github.com/qutebrowser/qutebrowser/issues/5904 to update the code. The script to generate the replacement list did not work, but I used the list from that thread and manually skimmed over the code in case something was missed.

The automatically generated UI files still use the old method as they are generated this way by PyQt5.uic (likely to keep the generated code backwards compatible). That's ok, as this is still supported and the files will be automatically generated again with PyQt6.uic once we migrate. But II force all UI files to be re-generated by `python setup.py compile_ui`.

Also this change makes PyQt 5.11 the minimal supported version (previously 5.10).

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Going forward we should aim for using the scoped enums in all new code. But should we miss something it's not that bad, we'll notice once we migrate to Qt6.