### PR TITLE
PICARD-2398: Load recording relationships separately for huge releases

### DIFF
--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018, 2020-2021 Laurent Monin
-# Copyright (C) 2018-2021 Philipp Wolfer
+# Copyright (C) 2018-2022 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -191,18 +191,22 @@ class MBAPIHelper(APIHelper):
     def find_artists(self, handler, **kwargs):
         return self._find('artist', handler, **kwargs)
 
-    def _browse(self, entitytype, handler, inc=None, **kwargs):
+    def _browse(self, entitytype, handler, inc=None, queryargs=None, mblogin=False):
         path_list = (entitytype, )
-        queryargs = kwargs
+        if queryargs is None:
+            queryargs = {}
         if inc:
             queryargs["inc"] = "+".join(inc)
         return self.get(path_list, handler, queryargs=queryargs,
-                        priority=True, important=True, mblogin=False,
+                        priority=True, important=True, mblogin=mblogin,
                         refresh=False)
 
     def browse_releases(self, handler, **kwargs):
         inc = ("media", "labels")
-        return self._browse("release", handler, inc, **kwargs)
+        return self._browse("release", handler, inc, queryargs=kwargs)
+
+    def browse_recordings(self, handler, inc, **kwargs):
+        return self._browse('recording', handler, inc, queryargs=kwargs)
 
     @staticmethod
     def _xml_ratings(ratings):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2398
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The MB API for performance reasons does not include recording level relationships if an release contains too many tracks. This leads to missing data if the user has enabled track relationships.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Detect the case of missing recording relationships and issue separate requests to load the recordings for a release. Since these requests are limited to 100 results multiple requests with offsets need to be done.
