### PR TITLE
Set log level in tests to DEBUG

### DIFF
--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -21,7 +21,6 @@
 
 
 import base64
-import logging
 import os
 
 from mutagen.flac import (
@@ -35,10 +34,7 @@ from test.picardtestcase import (
     create_fake_png,
 )
 
-from picard import (
-    config,
-    log,
-)
+from picard import config
 from picard.coverart.image import CoverArtImage
 from picard.formats import vorbis
 from picard.formats.util import open_ as open_format
@@ -82,10 +78,7 @@ class CommonVorbisTests:
     class VorbisTestCase(CommonTests.TagFormatsTestCase):
         def test_invalid_rating(self):
             filename = os.path.join('test', 'data', 'test-invalid-rating.ogg')
-            old_log_level = log.get_effective_level()
-            log.set_level(logging.ERROR)
             metadata = load_metadata(filename)
-            log.set_level(old_log_level)
             self.assertEqual(metadata["~rating"], "THERATING")
 
         def test_supports_tags(self):

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2019-2021 Philipp Wolfer
+# Copyright (C) 2019-2022 Philipp Wolfer
 # Copyright (C) 2020 Laurent Monin
 # Copyright (C) 2021 Bob Swift
 #
@@ -21,8 +21,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
 import json
+import logging
 import os
 import shutil
 import struct
@@ -71,6 +71,7 @@ class FakeTagger(QtCore.QObject):
 
 class PicardTestCase(unittest.TestCase):
     def setUp(self):
+        log.set_level(logging.DEBUG)
         self.tagger = FakeTagger()
         QtCore.QObject.tagger = self.tagger
         self.addCleanup(self.tagger.run_cleanup)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Log output was not shown in failing tests, making some issues hard to figure out. See https://github.com/metabrainz/picard/pull/2038 for background.

# Solution

Lower log level for tests to `DEBUG`. This allows pytest to capture the log output and display it in context of the test.
