### PR TITLE
PICARD-2396: Do not link AcoustIDs to recordings if there is a large difference in length

### DIFF
--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -50,7 +50,7 @@ class Submission(object):
         # payload approximation
         # the length of all submitted data, plus a small overhead to account for
         # potential urlencode expansion
-        return int(sum((len(key) + len(value) + 2 for key, value in self.get_args().items())) * 1.03)
+        return int(sum((len(key) + len(value) + 2 for key, value in self.args.items())) * 1.03)
 
     @property
     def puid(self):
@@ -64,7 +64,8 @@ class Submission(object):
     def is_submitted(self):
         return not self.recordingid or self.orig_recordingid == self.recordingid
 
-    def get_args(self):
+    @property
+    def args(self):
         """Returns a dictionary of arguments suitable for submission to AcoustID."""
         args = {
             'fingerprint': self.fingerprint,

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -31,8 +31,8 @@ from picard import log
 from picard.util import load_json
 
 
-# Maximum difference between file duration and MB metadata length.
-# If the match is above this threshold the fingerprint will not get submitted.
+# Maximum difference between file duration and MB recording length.
+# If the match is above this threshold the MBID will not get submitted.
 # Compare also acoustid/const.py in acoustid-server sources
 FINGERPRINT_MAX_ALLOWED_LENGTH_DIFF_MS = 30000
 
@@ -111,7 +111,7 @@ class AcoustIDManager(QtCore.QObject):
 
     def _unsubmitted(self, reset=False):
         for file, submission in self._submissions.items():
-            if not submission.is_submitted and submission.valid_duration:
+            if not submission.is_submitted:
                 if reset:
                     submission.attempts = 0
                 yield (file, submission)

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -48,11 +48,9 @@ class Submission(object):
 
     def __len__(self):
         # payload approximation
-        # it is based on actual measures, as an example:
-        # with no puid, 2 fingerprints total size of 7501 bytes, post body was 7719 bytes (including all fields)
-        # so that's an overhead of ~3%
-        # we use 10% here, to be safe
-        return int((len(self.fingerprint) + len(self.puid)) * 1.1)
+        # the length of all submitted data, plus a small overhead to account for
+        # potential urlencode expansion
+        return int(sum((len(key) + len(value) + 2 for key, value in self.get_args().items())) * 1.03)
 
     @property
     def puid(self):

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -297,28 +297,10 @@ class AcoustIdAPIHelper(APIHelper):
     def _submissions_to_args(submissions):
         config = get_config()
         args = {'user': config.setting["acoustid_apikey"]}
-
-        def set_arg(name, i, value):
-            if value:
-                args[".".join((name, str(i)))] = value
-
         for i, submission in enumerate(submissions):
-            set_arg('fingerprint', i, submission.fingerprint)
-            set_arg('duration', i, str(submission.duration))
-            set_arg('puid', i, submission.puid)
-            if submission.valid_duration:
-                set_arg('mbid', i, submission.recordingid)
-            else:
-                metadata = submission.metadata
-                set_arg('track', i, metadata['title'])
-                set_arg('artist', i, metadata['artist'])
-                set_arg('album', i, metadata['album'])
-                set_arg('albumartist', i, metadata['albumartist'])
-                year = metadata['year'] or metadata['date'][:4]
-                if year and year.isdecimal():
-                    set_arg('year', i, year)
-                set_arg('trackno', i, metadata['tracknumber'])
-                set_arg('discno', i, metadata['discnumber'])
+            for key, value in submission.get_args().items():
+                if value:
+                    args[".".join((key, str(i)))] = value
         return args
 
     def submit_acoustid_fingerprints(self, submissions, handler):

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -298,7 +298,7 @@ class AcoustIdAPIHelper(APIHelper):
         config = get_config()
         args = {'user': config.setting["acoustid_apikey"]}
         for i, submission in enumerate(submissions):
-            for key, value in submission.get_args().items():
+            for key, value in submission.args.items():
                 if value:
                     args[".".join((key, str(i)))] = value
         return args

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -297,12 +297,28 @@ class AcoustIdAPIHelper(APIHelper):
     def _submissions_to_args(submissions):
         config = get_config()
         args = {'user': config.setting["acoustid_apikey"]}
+
+        def set_arg(name, i, value):
+            if value:
+                args[".".join((name, str(i)))] = value
+
         for i, submission in enumerate(submissions):
-            args['fingerprint.%d' % i] = submission.fingerprint
-            args['duration.%d' % i] = str(submission.duration)
-            args['mbid.%d' % i] = submission.recordingid
-            if submission.puid:
-                args['puid.%d' % i] = submission.puid
+            set_arg('fingerprint', i, submission.fingerprint)
+            set_arg('duration', i, str(submission.duration))
+            set_arg('puid', i, submission.puid)
+            if submission.valid_duration:
+                set_arg('mbid', i, submission.recordingid)
+            else:
+                metadata = submission.metadata
+                set_arg('track', i, metadata['title'])
+                set_arg('artist', i, metadata['artist'])
+                set_arg('album', i, metadata['album'])
+                set_arg('albumartist', i, metadata['albumartist'])
+                year = metadata['year'] or metadata['date'][:4]
+                if year and year.isdecimal():
+                    set_arg('year', i, year)
+                set_arg('trackno', i, metadata['tracknumber'])
+                set_arg('discno', i, metadata['discnumber'])
         return args
 
     def submit_acoustid_fingerprints(self, submissions, handler):

--- a/test/test_acoustidmanager.py
+++ b/test/test_acoustidmanager.py
@@ -260,3 +260,42 @@ class SubmissionTest(PicardTestCase):
         metadata.length = 500000
         submission = Submission('abc', 42, recordingid='rec1', metadata=metadata)
         self.assertNotIn('year', submission.get_args())
+
+    def test_len_mbid_puid(self):
+        fingerprint = 'abc' * 30
+        puid = 'p1'
+        recordingid = 'rec1'
+        duration = 42
+        metadata = Metadata(
+            musicip_puid=puid
+        )
+        metadata.length = 42000
+        submission = Submission(fingerprint, 42, recordingid=recordingid, metadata=metadata)
+        expected_min_length = len('&fingerprint=%s&duration=%s&mbid=%s&puid=%s' % (fingerprint, duration, recordingid, puid))
+        self.assertGreater(len(submission), expected_min_length)
+
+    def test_len_no_mbid(self):
+        metadata = Metadata({
+            'title': 'The Track',
+            'artist': 'The Artist',
+            'album': 'The Album',
+            'albumartist': 'The Album Artist',
+            'tracknumber': '4',
+            'discnumber': '2',
+            'date': '2022-01-22',
+        })
+        metadata.length = 500000
+        submission = Submission('abc', 42, recordingid='rec1', metadata=metadata)
+        expected_args = {
+            'fingerprint': 'abc',
+            'duration': '42',
+            'track': metadata['title'],
+            'artist': metadata['artist'],
+            'album': metadata['album'],
+            'albumartist': metadata['albumartist'],
+            'trackno': metadata['tracknumber'],
+            'discno': metadata['discnumber'],
+            'year': '2022',
+        }
+        expected_min_length = len('&'.join(('='.join([k, v]) for k, v in expected_args.items())))
+        self.assertGreater(len(submission), expected_min_length)

--- a/test/test_acoustidmanager.py
+++ b/test/test_acoustidmanager.py
@@ -196,16 +196,16 @@ class SubmissionTest(PicardTestCase):
         submission.recordingid = 'rec2'
         self.assertFalse(submission.is_submitted)
 
-    def test_get_args_with_mbid(self):
+    def test_args_with_mbid(self):
         submission = Submission('abc', 42, recordingid='rec1')
         expected = {
             'fingerprint': 'abc',
             'duration': '42',
             'mbid': 'rec1',
         }
-        self.assertEqual(expected, submission.get_args())
+        self.assertEqual(expected, submission.args)
 
-    def test_get_args_with_mbid_with_puid(self):
+    def test_args_with_mbid_with_puid(self):
         metadata = Metadata(
             musicip_puid='p1'
         )
@@ -217,9 +217,9 @@ class SubmissionTest(PicardTestCase):
             'mbid': 'rec1',
             'puid': 'p1'
         }
-        self.assertEqual(expected, submission.get_args())
+        self.assertEqual(expected, submission.args)
 
-    def test_get_args_without_mbid(self):
+    def test_args_without_mbid(self):
         metadata = Metadata({
             'title': 'The Track',
             'artist': 'The Artist',
@@ -242,24 +242,24 @@ class SubmissionTest(PicardTestCase):
             'discno': metadata['discnumber'],
             'year': '2022',
         }
-        self.assertEqual(expected, submission.get_args())
+        self.assertEqual(expected, submission.args)
 
-    def test_get_args_year(self):
+    def test_args_year(self):
         metadata = Metadata({
             'year': '2022',
         })
         metadata.length = 500000
         submission = Submission('abc', 42, recordingid='rec1', metadata=metadata)
-        args = submission.get_args()
+        args = submission.args
         self.assertEqual('2022', args['year'])
 
-    def test_get_args_invalid_year(self):
+    def test_args_invalid_year(self):
         metadata = Metadata({
             'year': 'NaN',
         })
         metadata.length = 500000
         submission = Submission('abc', 42, recordingid='rec1', metadata=metadata)
-        self.assertNotIn('year', submission.get_args())
+        self.assertNotIn('year', submission.args)
 
     def test_len_mbid_puid(self):
         fingerprint = 'abc' * 30

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -239,9 +239,11 @@ class AcoustdIdAPITest(PicardTestCase):
 
     def test_submissions_to_args(self):
         submissions = [
-            Submission('f1', 1, orig_recordingid='or1', recordingid='r1', puid='p1'),
-            Submission('f2', 2, orig_recordingid='or2', recordingid='r2', puid='p2'),
+            Submission('f1', 1, recordingid='r1', metadata={'musicip_puid': 'p1'}),
+            Submission('f2', 2, recordingid='r2', metadata={'musicip_puid': 'p2'}),
         ]
+        submissions[0].orig_recordingid = 'or1'
+        submissions[1].orig_recordingid = 'or2'
         result = self.api._submissions_to_args(submissions)
         expected = {
             'user': 'apikey',

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 from test.picardtestcase import PicardTestCase
 
 from picard.acoustid.manager import Submission
+from picard.metadata import Metadata
 from picard.webservice import WebService
 from picard.webservice.api_helpers import (
     AcoustIdAPIHelper,
@@ -239,15 +240,65 @@ class AcoustdIdAPITest(PicardTestCase):
 
     def test_submissions_to_args(self):
         submissions = [
-            Submission('f1', 1, recordingid='r1', metadata={'musicip_puid': 'p1'}),
-            Submission('f2', 2, recordingid='r2', metadata={'musicip_puid': 'p2'}),
+            Submission('f1', 1, recordingid='or1', metadata=Metadata(musicip_puid='p1')),
+            Submission('f2', 2, recordingid='or2', metadata=Metadata(musicip_puid='p2')),
         ]
-        submissions[0].orig_recordingid = 'or1'
-        submissions[1].orig_recordingid = 'or2'
+        submissions[0].recordingid = 'r1'
+        submissions[1].recordingid = 'r2'
         result = self.api._submissions_to_args(submissions)
         expected = {
             'user': 'apikey',
             'fingerprint.0': 'f1', 'duration.0': '1', 'mbid.0': 'r1', 'puid.0': 'p1',
             'fingerprint.1': 'f2', 'duration.1': '2', 'mbid.1': 'r2', 'puid.1': 'p2'
+        }
+        self.assertEqual(result, expected)
+
+    def test_submissions_to_args_invalid_duration(self):
+        metadata1 = Metadata({
+            'title': 'The Track',
+            'artist': 'The Artist',
+            'album': 'The Album',
+            'albumartist': 'The Album Artist',
+            'tracknumber': '4',
+            'discnumber': '2',
+        }, length=100000)
+        metadata2 = Metadata({
+            'year': '2022'
+        }, length=100000)
+        metadata3 = Metadata({
+            'date': '1980-08-30'
+        }, length=100000)
+        metadata4 = Metadata({
+            'date': '08-30'
+        }, length=100000)
+        submissions = [
+            Submission('f1', 500000, recordingid='or1', metadata=metadata1),
+            Submission('f2', 500000, recordingid='or2', metadata=metadata2),
+            Submission('f3', 500000, recordingid='or3', metadata=metadata3),
+            Submission('f4', 500000, recordingid='or4', metadata=metadata4),
+        ]
+        submissions[0].recordingid = 'r1'
+        submissions[1].recordingid = 'r2'
+        submissions[1].recordingid = 'r3'
+        submissions[1].recordingid = 'r4'
+        result = self.api._submissions_to_args(submissions)
+        expected = {
+            'user': 'apikey',
+            'fingerprint.0': 'f1',
+            'duration.0': '500000',
+            'track.0': metadata1['title'],
+            'artist.0': metadata1['artist'],
+            'album.0': metadata1['album'],
+            'albumartist.0': metadata1['albumartist'],
+            'trackno.0': metadata1['tracknumber'],
+            'discno.0': metadata1['discnumber'],
+            'fingerprint.1': 'f2',
+            'duration.1': '500000',
+            'year.1': '2022',
+            'fingerprint.2': 'f3',
+            'duration.2': '500000',
+            'year.2': '1980',
+            'fingerprint.3': 'f4',
+            'duration.3': '500000',
         }
         self.assertEqual(result, expected)

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2018, 2020 Laurent Monin
-# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2019-2020, 2022 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2396
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard currently submits the AcoustID fingerprint in combination with a recording MBID, to link the AcoustID and recording. This submission currently makes no further validation of the data.

The discussion at https://community.metabrainz.org/t/report-showing-acoustids-likely-to-be-bad-link-to-musicbrainz-recordings/551047 has identified that recordings linked to AcoustIDs with clearly wrong durations are a clear indication of wrong matching. This is something Picard can easily detect.

# Solution

If the duration difference between the MB recording and the fingerprint is larger than 30 seconds, than do not submit the MBID. Still submit the AcoustID fingerprint, but combine it with textual metadata only.

30 seconds where chose because this is also what the AcoustID server uses when considering if two fingerprints could be for the same recording (see https://github.com/acoustid/acoustid-server/blob/master/acoustid/const.py#L21)



<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
