### PR TITLE
Extend the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,50 @@
-MusicBrainz Picard
-==================
+# MusicBrainz Picard
+
 ![Github Actions Status](https://github.com/metabrainz/picard/workflows/Run%20tests/badge.svg)
 [![Codacy Grade](https://img.shields.io/codacy/grade/4dcabf0a13ed4b27b3a381ce9ba96ecc/master.svg?style=flat-square&label=Codacy)](https://app.codacy.com/gh/metabrainz/picard)
 
-[MusicBrainz Picard](http://picard.musicbrainz.org) is a cross-platform (Linux, macOS, Windows) application written in Python and is the official [MusicBrainz](http://musicbrainz.org) tagger.
+[MusicBrainz Picard](http://picard.musicbrainz.org) is a cross-platform (Linux, macOS, Windows) audio tagging application. It is the official [MusicBrainz](http://musicbrainz.org) tagger.
 
 Picard supports the majority of audio file formats, is capable of using audio fingerprints ([AcoustIDs](http://musicbrainz.org/doc/AcoustID)), performing CD lookups and [disc ID](http://musicbrainz.org/doc/Disc_ID) submissions, and it has excellent Unicode support. Additionally, there are several plugins available that extend Picard's features.
 
-When tagging files, Picard uses an album-oriented approach. This approach allows it to utilize the MusicBrainz data as effectively as possible and correctly tag your music. For more information, [see the illustrated quick start guide to tagging](https://picard.musicbrainz.org/quick-start/).
+When tagging files, Picard uses an album-oriented approach. This approach allows it to utilize the MusicBrainz data as effectively as possible and correctly tag your music. For more information, [see the illustrated quick start guide to tagging](https://picard.musicbrainz.org/quick-start/) and the [documentation](https://picard-docs.musicbrainz.org/).
 
-Picard is named after Captain Jean-Luc Picard from the TV series Star Trek: The Next Generation.
 
-Binary downloads are available [here](http://picard.musicbrainz.org/downloads/).
+## Features
 
-Support and issue reporting
----------------------------
+- **Multiple formats:** Picard supports all popular music formats,
+  including MP3, FLAC, OGG, M4A, WMA, WAV, and more.
+- **AcoustID:** Picard uses [AcoustID](http://musicbrainz.org/doc/AcoustID)
+  audio fingerprints, allowing files to be identified by the actual
+  music, even if they have no metadata.
+- **Comprehensive database:** Picard uses the open and
+  community-maintained [MusicBrainz database](http://musicbrainz.org)
+  to provide accurate information about millions of music releases.
+- **CD lookups:** Picard can lookup entire music CDs with a click.
+- **Plugin support:** If you need a particular feature, you can choose
+  from a selection of available plugins or write your own.
+- **Scripting:** A flexible and powerful, yet easy to learn, scripting language
+  allows you to exactly specify how your music files will be named and how the
+  tags will look like.
+- **Cover Art:** Picard can find and download the correct cover art for your albums.
+- **Open Source:** Picard is licensed under the
+  [GNU General Public License 2.0](COPYING.txt)
+  or later, and is hosted on GitHub where it is actively
+  developed.
+
+
+## Installation
+
+Binary downloads are available on the [Picard download page](http://picard.musicbrainz.org/downloads/).
+
+[INSTALL.md has instructions on building this codebase.](INSTALL.md)
+
+
+## Support and issue reporting
 
 Please report all bugs and feature requests in the [MusicBrainz issue tracker](https://tickets.metabrainz.org/browse/PICARD). If you need support in using Picard please read the [documentation](https://picard-docs.musicbrainz.org/) first and have a look at the [MusicBrainz community forums](https://community.metabrainz.org/c/picard).
 
-Installing
----------------------------
 
-[INSTALL.md has instructions on building this codebase.](INSTALL.md)
+## Trivia
+
+Picard is named after Captain Jean-Luc Picard from the TV series Star Trek: The Next Generation.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The README has most information in a single text block. Some less relevant information, like explanation for the name, comes before download and support instructions.


# Solution

Clarify the structure, add features and additional links. In particular:

- Added a "Features" section
- Link to binary downloads and source install instructions in one paragraph "Installation"
- Added name explanation to a separate "Trivia" section