### PR TITLE
Remove legacy genre tag translation

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -82,13 +82,6 @@ from picard.util.textencoding import asciipunct
 from picard.ui.item import FileListItem
 
 
-_TRANSLATE_TAGS = {
-    "hip hop": "Hip-Hop",
-    "synth-pop": "Synthpop",
-    "electronica": "Electronic",
-}
-
-
 class TagGenreFilter:
 
     def __init__(self, filters):
@@ -333,8 +326,7 @@ class Track(DataObject, FileListItem):
             percent = 100 * count // topcount
             if percent < minusage:
                 break
-            name = _TRANSLATE_TAGS.get(name, name.title())
-            genres_list.append(name)
+            genres_list.append(name.title())
         genres_list.sort()
 
         # And generate the genre metadata tag


### PR DESCRIPTION
The translation mapping was originally added as part of the last.fm
plugin in commit 99dc3e54, which was later used as the basis of the
initial folksonomy genre implementation.

This change fixes a bug where a track tagged with the "electronic" and
"electronica" genres would end up with "electronic" twice.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

# Problem

![Screenshot_2022-01-26_17-10-06](https://user-images.githubusercontent.com/59319/151220994-50183b94-f016-4aed-9bb7-ce4e59fc0ea4.png)

# Solution

Removed the genre translation dict as per the commit message. I've been unable to find any reasons to explain why this behaviour was added in the first place - my assumption is that it was to match the Last.fm tag schema?

Note that this change will cause tag changes for all tracks with the following genres:

* hip hop
* synth-pop
* electronica

This could cause some user confusion but I don't see any other reasonable option...