### PR TITLE
PICARD-2409: Search for cdtoc URL triggers CD lookup

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -51,7 +51,7 @@ from picard.ui.searchdialog.album import AlbumSearchDialog
 class FileLookup(object):
 
     RE_MB_ENTITY = re.compile(r"""
-        \b(?P<entity>release-group|release|recording|work|artist|label|url|area|track)?
+        \b(?P<entity>area|artist|instrument|label|place|recording|release|release-group|series|track|url|work)?
         \W*(?P<mbid>[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12})
     """, re.VERBOSE | re.IGNORECASE)
 

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -49,6 +49,11 @@ from picard.ui.searchdialog.album import AlbumSearchDialog
 
 class FileLookup(object):
 
+    RE_MB_ENTITY = re.compile(r"""
+        \b(?P<entity>release-group|release|recording|work|artist|label|url|area|track)?
+        \W*(?P<mbid>[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12})
+    """, re.VERBOSE | re.IGNORECASE)
+
     def __init__(self, parent, server, port, local_port):
         self.server = server
         self.local_port = int(local_port)
@@ -109,19 +114,17 @@ class FileLookup(object):
         If entity type is 'release', it will load corresponding release if
         possible.
         """
-        uuid = '[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}'
-        entity_type = '(?:release-group|release|recording|work|artist|label|url|area|track)'
-        regex = r"\b(%s)?\W*(%s)" % (entity_type, uuid)
-        m = re.search(regex, string, re.IGNORECASE)
+        m = self.RE_MB_ENTITY.search(string)
         if m is None:
             return False
-        if m.group(1) is None:
+        entity = m.group('entity')
+        if entity is None:
             if type_ is None:
                 return False
             entity = type_
         else:
-            entity = m.group(1).lower()
-        mbid = m.group(2).lower()
+            entity = entity.lower()
+        mbid = m.group('mbid').lower()
         if mbid_matched_callback:
             mbid_matched_callback(entity, mbid)
         if entity == 'release':

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -52,12 +52,12 @@ class FileLookup(object):
 
     RE_MB_ENTITY = re.compile(r"""
         \b(?P<entity>area|artist|instrument|label|place|recording|release|release-group|series|track|url|work)?
-        \W*(?P<mbid>[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12})
+        \W*(?P<id>[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12})
     """, re.VERBOSE | re.IGNORECASE)
 
     RE_MB_CDTOC = re.compile(r"""
         \b(?P<entity>cdtoc)
-        \W*(?P<mbid>[a-z0-9-_.]{28})
+        \W*(?P<id>[a-z0-9-_.]{28})
     """, re.VERBOSE | re.IGNORECASE)
 
     def __init__(self, parent, server, port, local_port):
@@ -132,29 +132,29 @@ class FileLookup(object):
             entity = type_
         else:
             entity = entity.lower()
-        mbid = m.group('mbid')
+        id = m.group('id')
         if entity != 'cdtoc':
-            mbid = mbid.lower()
-        log.debug('Lookup for %s:%s', entity, mbid)
+            id = id.lower()
+        log.debug('Lookup for %s:%s', entity, id)
         if mbid_matched_callback:
-            mbid_matched_callback(entity, mbid)
+            mbid_matched_callback(entity, id)
         if entity == 'release':
-            QtCore.QObject.tagger.load_album(mbid)
+            QtCore.QObject.tagger.load_album(id)
             return True
         elif entity == 'recording':
-            QtCore.QObject.tagger.load_nat(mbid)
+            QtCore.QObject.tagger.load_nat(id)
             return True
         elif entity == 'release-group':
             dialog = AlbumSearchDialog(QtCore.QObject.tagger.window, force_advanced_search=True)
-            dialog.search("rgid:{0}".format(mbid))
+            dialog.search("rgid:{0}".format(id))
             dialog.exec_()
             return True
         elif entity == 'cdtoc':
-            disc = Disc(id=mbid)
+            disc = Disc(id=id)
             disc.lookup()
             return True
         if browser_fallback:
-            return self._lookup(entity, mbid)
+            return self._lookup(entity, id)
         return False
 
     def tag_lookup(self, artist, release, track, tracknum, duration, filename):

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -83,11 +83,6 @@ class FileLookup(object):
         webbrowser2.open(url)
         return True
 
-    def disc_lookup(self, url):
-        if self.local_port:
-            url = "%s&tport=%d" % (url, self.local_port)
-        return self.launch(url)
-
     def _lookup(self, type_, id_):
         return self._build_launch("/%s/%s" % (type_, id_))
 
@@ -111,6 +106,11 @@ class FileLookup(object):
 
     def discid_lookup(self, discid):
         return self._lookup('cdtoc', discid)
+
+    def discid_submission(self, url):
+        if self.local_port:
+            url = "%s&tport=%d" % (url, self.local_port)
+        return self.launch(url)
 
     def acoust_lookup(self, acoust_id):
         return self.launch(PICARD_URLS['acoustid_track'] + acoust_id)
@@ -157,12 +157,12 @@ class FileLookup(object):
             return self._lookup(entity, mbid)
         return False
 
-    def tag_lookup(self, artist, release, track, trackNum, duration, filename):
+    def tag_lookup(self, artist, release, track, tracknum, duration, filename):
         params = {
             'artist': artist,
             'release': release,
             'track': track,
-            'tracknum': trackNum,
+            'tracknum': tracknum,
             'duration': duration,
             'filename': os.path.basename(filename),
         }

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -52,9 +52,9 @@ except ImportError:
 
 class Disc(QtCore.QObject):
 
-    def __init__(self):
+    def __init__(self, id=None):
         super().__init__()
-        self.id = None
+        self.id = id
         self.mcn = None
         self.tracks = 0
         self.toc_string = None
@@ -92,7 +92,7 @@ class Disc(QtCore.QObject):
 
     @property
     def submission_url(self):
-        if self.id:
+        if self.id and self.tracks and self.toc_string:
             return build_submission_url('/cdtoc/attach', query_args={
                 'id': self.id,
                 'tracks': self.tracks,

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2009, 2018-2021 Philipp Wolfer
+# Copyright (C) 2009, 2018-2022 Philipp Wolfer
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2013-2014, 2018, 2020-2021 Laurent Monin
@@ -104,8 +104,12 @@ class CDLookupDialog(PicardDialog):
             release_list.sortByColumn(2, QtCore.Qt.SortOrder.DescendingOrder)
         else:
             self.ui.results_view.setCurrentIndex(1)
-        self.ui.lookup_button.clicked.connect(self.lookup)
-        self.ui.submit_button.clicked.connect(self.lookup)
+        if self.disc.submission_url:
+            self.ui.lookup_button.clicked.connect(self.lookup)
+            self.ui.submit_button.clicked.connect(self.lookup)
+        else:
+            self.ui.lookup_button.hide()
+            self.ui.submit_button.hide()
         self.restore_header_state()
         self.finished.connect(self.save_header_state)
 
@@ -117,8 +121,12 @@ class CDLookupDialog(PicardDialog):
         super().accept()
 
     def lookup(self):
-        lookup = self.tagger.get_file_lookup()
-        lookup.disc_lookup(self.disc.submission_url)
+        submission_url = self.disc.submission_url
+        if submission_url:
+            lookup = self.tagger.get_file_lookup()
+            lookup.disc_lookup(submission_url)
+        else:
+            log.error('No submission URL for disc ID "%s"', self.disc.id)
         super().accept()
 
     @restore_method

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -124,7 +124,7 @@ class CDLookupDialog(PicardDialog):
         submission_url = self.disc.submission_url
         if submission_url:
             lookup = self.tagger.get_file_lookup()
-            lookup.disc_lookup(submission_url)
+            lookup.discid_submission(submission_url)
         else:
             log.error('No submission URL for disc ID "%s"', self.disc.id)
         super().accept()

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -133,7 +133,7 @@ class BrowserLookupTest(PicardTestCase):
 
     def test_mbid_lookup_browser_fallback(self):
         mbid = '4836aa50-a9ae-490a-983b-cfc8efca92de'
-        for entity in {'area', 'artist', 'label', 'url', 'work'}:
+        for entity in {'area', 'artist', 'instrument', 'label', 'place', 'series', 'url', 'work'}:
             with patch.object(webbrowser2, 'open') as mock_open:
                 uri = '%s:%s' % (entity, mbid)
                 result = self.lookup.mbid_lookup(uri)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2018, 2020 Laurent Monin
-# Copyright (C) 2019 Philipp Wolfer
+# Copyright (C) 2019, 2022 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -55,6 +55,7 @@ class BrowserLookupTest(PicardTestCase):
             "artist": {'function': self.lookup.artist_lookup, 'path': 'artist'},
             "albumartist": {'function': self.lookup.artist_lookup, 'path': 'artist'},
             "releasegroup": {'function': self.lookup.release_group_lookup, 'path': 'release-group'},
+            "cdtoc": {'function': self.lookup.discid_lookup, 'path': 'cdtoc'},
         }
         for i, type_ in enumerate(lookups):
             lookups[type_]['function']("123")
@@ -71,3 +72,12 @@ class BrowserLookupTest(PicardTestCase):
 
             self.assertIn('tport', query_args)
             self.assertEqual(query_args['tport'][0], '8000')
+
+    @patch('picard.browser.filelookup.Disc')
+    def test_mbid_lookup_cdtoc(self, mock_disc):
+        url = 'https://musicbrainz.org/cdtoc/vtlGcbJUaP_IFdBUC10NGIhu2E0-'
+        result = self.lookup.mbid_lookup(url)
+        self.assertTrue(result)
+        mock_disc.assert_called_once_with(id='vtlGcbJUaP_IFdBUC10NGIhu2E0-')
+        instance = mock_disc.return_value
+        instance.lookup.assert_called_once()

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -22,7 +22,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from unittest.mock import patch
+from unittest.mock import (
+    Mock,
+    patch,
+)
 from urllib.parse import (
     parse_qs,
     urlparse,
@@ -45,33 +48,106 @@ class BrowserLookupTest(PicardTestCase):
         super().setUp()
         self.lookup = FileLookup(None, SERVER, PORT, LOCAL_PORT)
 
+    def assert_mbid_url_matches(self, url, entity, mbid, expected_query_args=None):
+        url = urlparse(url)
+        path = url.path.split('/')[1:]
+        query_args = parse_qs(url.query)
+
+        self.assertEqual(url.netloc, "%s:%s" % (SERVER, PORT))
+
+        self.assertEqual(entity, path[0])
+        self.assertEqual(mbid, path[1])
+
+        if expected_query_args:
+            for key, value in expected_query_args.items():
+                self.assertIn(key, query_args)
+                self.assertEqual(value, query_args['tport'][0])
+
+
+    def test_entity_lookups(self):
+        lookups = (
+            {'function': self.lookup.recording_lookup, 'entity': 'recording'},
+            {'function': self.lookup.track_lookup, 'entity': 'track'},
+            {'function': self.lookup.album_lookup, 'entity': 'release'},
+            {'function': self.lookup.work_lookup, 'entity': 'work'},
+            {'function': self.lookup.artist_lookup, 'entity': 'artist'},
+            {'function': self.lookup.artist_lookup, 'entity': 'artist'},
+            {'function': self.lookup.release_group_lookup, 'entity': 'release-group'},
+            {'function': self.lookup.discid_lookup, 'entity': 'cdtoc'},
+        )
+        for case in lookups:
+            with patch.object(webbrowser2, 'open') as mock_open:
+                case['function']("123")
+                mock_open.assert_called_once()
+                url = mock_open.call_args[0][0]
+                query_args = {'tport': '8000'}
+                self.assert_mbid_url_matches(url, case['entity'], '123', query_args)
+
+    def test_mbid_lookup_invalid_url(self):
+        self.assertFalse(self.lookup.mbid_lookup('noentity:123'))
+
+    def test_mbid_lookup_no_entity(self):
+        self.assertFalse(self.lookup.mbid_lookup('F03D09B3-39DC-4083-AFD6-159E3F0D462F'))
+
     @patch.object(webbrowser2, 'open')
-    def test_entity_lookups(self, mock_open):
-        lookups = {
-            "recording": {'function': self.lookup.recording_lookup, 'path': 'recording'},
-            "track": {'function': self.lookup.track_lookup, 'path': 'track'},
-            "album": {'function': self.lookup.album_lookup, 'path': 'release'},
-            "work": {'function': self.lookup.work_lookup, 'path': 'work'},
-            "artist": {'function': self.lookup.artist_lookup, 'path': 'artist'},
-            "albumartist": {'function': self.lookup.artist_lookup, 'path': 'artist'},
-            "releasegroup": {'function': self.lookup.release_group_lookup, 'path': 'release-group'},
-            "cdtoc": {'function': self.lookup.discid_lookup, 'path': 'cdtoc'},
-        }
-        for i, type_ in enumerate(lookups):
-            lookups[type_]['function']("123")
+    def test_mbid_lookup_set_type(self, mock_open):
+        result = self.lookup.mbid_lookup('bd55aeb7-19d1-4607-a500-14b8479d3fed', 'place')
+        self.assertTrue(result)
+        mock_open.assert_called_once()
+        url = mock_open.call_args.args[0]
+        self.assert_mbid_url_matches(url, 'place', 'bd55aeb7-19d1-4607-a500-14b8479d3fed')
 
-            url = urlparse(mock_open.call_args[0][0])
-            path = url.path.split('/')[1:]
-            query_args = parse_qs(url.query)
+    @patch.object(webbrowser2, 'open')
+    def test_mbid_lookup_matched_callback(self, mock_open):
+        mock_matched_callback = Mock()
+        result = self.lookup.mbid_lookup('area:F03D09B3-39DC-4083-AFD6-159E3F0D462F', mbid_matched_callback=mock_matched_callback)
+        self.assertTrue(result)
+        mock_open.assert_called_once()
+        url = mock_open.call_args.args[0]
+        self.assert_mbid_url_matches(url, 'area', 'f03d09b3-39dc-4083-afd6-159e3f0d462f')
 
-            self.assertEqual(mock_open.call_count, i + 1)
-            self.assertEqual(url.netloc, "%s:%s" % (SERVER, PORT))
+    @patch('PyQt5.QtCore.QObject.tagger')
+    def test_mbid_lookup_release(self, mock_tagger):
+        url = 'https://musicbrainz.org/release/60dbf818-3058-41b9-bb53-25dbdb9d9bad'
+        result = self.lookup.mbid_lookup(url)
+        self.assertTrue(result)
+        mock_tagger.load_album.assert_called_once_with('60dbf818-3058-41b9-bb53-25dbdb9d9bad')
 
-            self.assertEqual(lookups[type_]['path'], path[0])
-            self.assertEqual("123", path[1])
+    @patch('PyQt5.QtCore.QObject.tagger')
+    def test_mbid_lookup_recording(self, mock_tagger):
+        url = 'https://musicbrainz.org/recording/511f3a33-ded8-4dc7-92d2-b913ec420dfc'
+        result = self.lookup.mbid_lookup(url)
+        self.assertTrue(result)
+        mock_tagger.load_nat.assert_called_once_with('511f3a33-ded8-4dc7-92d2-b913ec420dfc')
 
-            self.assertIn('tport', query_args)
-            self.assertEqual(query_args['tport'][0], '8000')
+    @patch('PyQt5.QtCore.QObject.tagger')
+    @patch('picard.browser.filelookup.AlbumSearchDialog')
+    def test_mbid_lookup_release_group(self, mock_dialog, mock_tagger):
+        url = 'https://musicbrainz.org/release-group/168615bf-f841-49f7-ac98-36a4eb25479c'
+        result = self.lookup.mbid_lookup(url)
+        self.assertTrue(result)
+        mock_dialog.assert_called_once_with(mock_tagger.window, force_advanced_search=True)
+        instance = mock_dialog.return_value
+        instance.search.assert_called_once_with('rgid:168615bf-f841-49f7-ac98-36a4eb25479c')
+        instance.exec_.assert_called_once()
+
+    def test_mbid_lookup_browser_fallback(self):
+        mbid = '4836aa50-a9ae-490a-983b-cfc8efca92de'
+        for entity in {'area', 'artist', 'label', 'url', 'work'}:
+            with patch.object(webbrowser2, 'open') as mock_open:
+                uri = '%s:%s' % (entity, mbid)
+                result = self.lookup.mbid_lookup(uri)
+                self.assertTrue(result, 'lookup failed for %s' % uri)
+                mock_open.assert_called_once()
+                url = mock_open.call_args.args[0]
+                self.assert_mbid_url_matches(url, entity, mbid)
+
+    @patch.object(webbrowser2, 'open')
+    def test_mbid_lookup_browser_fallback_disabled(self, mock_open):
+        url = 'https://musicbrainz.org/artist/4836aa50-a9ae-490a-983b-cfc8efca92de'
+        result = self.lookup.mbid_lookup(url, browser_fallback=False)
+        self.assertFalse(result)
+        mock_open.assert_not_called()
 
     @patch('picard.browser.filelookup.Disc')
     def test_mbid_lookup_cdtoc(self, mock_disc):

--- a/test/test_disc.py
+++ b/test/test_disc.py
@@ -48,6 +48,14 @@ class DiscTest(PicardTestCase):
         disc = picard.disc.Disc()
         self.assertRaises(picard.disc.discid.DiscError, disc.read, 'notadevice')
 
+    def test_init_with_id(self):
+        discid = 'theId'
+        disc = picard.disc.Disc(id=discid)
+        self.assertEqual(discid, disc.id)
+        self.assertEqual(0, disc.tracks)
+        self.assertIsNone(disc.toc_string)
+        self.assertIsNone(disc.submission_url)
+
     @patch.object(picard.disc, 'discid')
     def test_read(self, mock_discid):
         self.set_config_values(setting={


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2409
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Searching for or drag and dropping a disc ID URL (such as https://musicbrainz.org/cdtoc/vtlGcbJUaP_IFdBUC10NGIhu2E0-) should trigger the CD lookup dialog

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Handle this URL and show the CD lookup dialog.

One difference to a regular disc ID lookup is, that submission does not work. In this case we only have the disc ID, e.g. 
"vtlGcbJUaP_IFdBUC10NGIhu2E0-". For submission also the full TOC details would be needed. Hence the CD lookup dialog hides the submission buttons.

Also added tests for this and other untested methods in `FileLookup`.