### PR TITLE
PICARD-2410: Disc ID from Whipper log file

### DIFF
--- a/picard/disc/eaclog.py
+++ b/picard/disc/eaclog.py
@@ -25,6 +25,8 @@
 
 import re
 
+from picard.disc.utils import calculate_mb_toc_numbers
+
 
 RE_TOC_TABLE_HEADER = re.compile(r""" \s*
     \s*.+\s+ \| # track
@@ -51,10 +53,6 @@ RE_TOC_TABLE_LINE = re.compile(r"""
 PREGAP_LENGTH = 150
 
 
-class NotSupportedTOCError(Exception):
-    pass
-
-
 def filter_toc_entries(lines):
     """
     Take iterator of lines, return iterator of toc entries
@@ -74,25 +72,6 @@ def filter_toc_entries(lines):
         if not m:
             break
         yield m.groupdict()
-
-
-def calculate_mb_toc_numbers(eac_entries):
-    """
-    Take iterator of toc entries, return a tuple of numbers for musicbrainz disc id
-    """
-    eac = tuple(eac_entries)
-    num_tracks = len(eac)
-    if not num_tracks:
-        raise NotSupportedTOCError("Empty track list: %s", eac)
-
-    expected_tracknums = tuple(range(1, num_tracks+1))
-    tracknums = tuple(int(e['num']) for e in eac)
-    if expected_tracknums != tracknums:
-        raise NotSupportedTOCError("Non-standard track number sequence: %s", tracknums)
-
-    leadout_offset = int(eac[-1]['end_sector']) + PREGAP_LENGTH + 1
-    offsets = tuple((int(x['start_sector']) + PREGAP_LENGTH) for x in eac)
-    return (1, num_tracks, leadout_offset) + offsets
 
 
 def toc_from_file(path):

--- a/picard/disc/utils.py
+++ b/picard/disc/utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# MIT License
+#
+# Copyright(c) 2018 Konstantin Mochalov
+# Copyright(c) 2022 Philipp Wolfer
+#
+# Original code from https://gist.github.com/kolen/765526
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+PREGAP_LENGTH = 150
+
+
+class NotSupportedTOCError(Exception):
+    pass
+
+
+def calculate_mb_toc_numbers(toc_entries):
+    """
+    Take iterator of toc entries, return a tuple of numbers for musicbrainz disc id
+
+    Each toc entry is a dict with the following keys:
+    - num: track number
+    - start_sector: start sector of the track
+    - end_sector: end sector of the track
+    """
+    eac = tuple(toc_entries)
+    num_tracks = len(eac)
+    if not num_tracks:
+        raise NotSupportedTOCError("Empty track list: %s", eac)
+
+    expected_tracknums = tuple(range(1, num_tracks+1))
+    tracknums = tuple(int(e['num']) for e in eac)
+    if expected_tracknums != tracknums:
+        raise NotSupportedTOCError("Non-standard track number sequence: %s", tracknums)
+
+    leadout_offset = int(eac[-1]['end_sector']) + PREGAP_LENGTH + 1
+    offsets = tuple((int(x['start_sector']) + PREGAP_LENGTH) for x in eac)
+    return (1, num_tracks, leadout_offset) + offsets

--- a/picard/disc/whipperlog.py
+++ b/picard/disc/whipperlog.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2022 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import yaml
+
+from picard.disc.utils import calculate_mb_toc_numbers
+
+
+def toc_from_file(path):
+    """Reads whipper log files, generates musicbrainz disc TOC listing for use as discid.
+
+    Warning: may work wrong for discs having data tracks. May generate wrong
+    results on other non-standard cases."""
+    with open(path, encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+        toc_entries = (
+            {
+                'num': num,
+                'start_sector': t['Start sector'],
+                'end_sector': t['End sector'],
+            }
+            for num, t in data['TOC'].items()
+        )
+        return calculate_mb_toc_numbers(toc_entries)

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -953,7 +953,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _set_cd_lookup_from_file_actions(self):
         if len(self.cd_lookup_menu.actions()) > 0:
             self.cd_lookup_menu.addSeparator()
-        action = self.cd_lookup_menu.addAction(_('From EAC / XLD &log file...'))
+        action = self.cd_lookup_menu.addAction(_('From EAC / XLD / Whipper &log file...'))
         action.setData('logfile:eac')
 
     def _update_cd_lookup_button(self):

--- a/test/data/whipper.log
+++ b/test/data/whipper.log
@@ -1,0 +1,220 @@
+Log created by: whipper 0.0.0 (internal logger)
+Log creation date: 2022-01-30T09:52:15Z
+
+Ripping phase information:
+  Drive: TSSTcorpCDDVDW SE-218BB  (revision TS01)
+  Extraction engine: cdparanoia III 10.2 libcdio 2.1.0 x86_64-pc-linux-gnu
+  Defeat audio cache:
+  Read offset correction: 6
+  Overread into lead-out: false
+  Gap detection: cdrdao 1.2.4
+  CD-R detected: false
+
+CD metadata:
+  Release:
+    Artist: pornophonique
+    Title: Brave New World
+  CDDB Disc ID: 5407c408
+  MusicBrainz Disc ID: C2svSeTdtJVtN7VQR__XwmEScU8-
+  MusicBrainz lookup URL: https://musicbrainz.org/cdtoc/attach?toc=1+8+149323+150+25064+43611+60890+83090+100000+115057+135558&tracks=8&id=C2svSeTdtJVtN7VQR__XwmEScU8-
+  MusicBrainz Release URL: https://musicbrainz.org/release/d785183b-cb1c-4fda-8e0f-6d0864442479
+
+TOC:
+  1:
+    Start: 00:00:00
+    Length: 05:32:14
+    Start sector: 0
+    End sector: 24913
+
+  2:
+    Start: 05:32:14
+    Length: 04:07:22
+    Start sector: 24914
+    End sector: 43460
+
+  3:
+    Start: 09:39:36
+    Length: 03:50:29
+    Start sector: 43461
+    End sector: 60739
+
+  4:
+    Start: 13:29:65
+    Length: 04:56:00
+    Start sector: 60740
+    End sector: 82939
+
+  5:
+    Start: 18:25:65
+    Length: 03:45:35
+    Start sector: 82940
+    End sector: 99849
+
+  6:
+    Start: 22:11:25
+    Length: 03:20:57
+    Start sector: 99850
+    End sector: 114906
+
+  7:
+    Start: 25:32:07
+    Length: 04:33:26
+    Start sector: 114907
+    End sector: 135407
+
+  8:
+    Start: 30:05:33
+    Length: 03:03:40
+    Start sector: 135408
+    End sector: 149172
+
+Tracks:
+  1:
+    Filename: ./album/pornophonique - Brave New World/01. pornophonique - Coming Home.flac
+    Peak level: 0.948425
+    Pre-emphasis:
+    Extraction speed: 4.8 X
+    Extraction quality: 100.00 %
+    Test CRC: E924FB20
+    Copy CRC: E924FB20
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: 3182EB6A
+      Remote CRC: 3182EB6A
+    Status: Copy OK
+
+  2:
+    Filename: ./album/pornophonique - Brave New World/02. pornophonique - Save Game.flac
+    Pre-gap length: 00:00:34
+    Peak level: 0.981049
+    Pre-emphasis:
+    Extraction speed: 5.3 X
+    Extraction quality: 100.00 %
+    Test CRC: F19A6AFC
+    Copy CRC: F19A6AFC
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: 79A374E7
+      Remote CRC: 79A374E7
+    Status: Copy OK
+
+  3:
+    Filename: ./album/pornophonique - Brave New World/03. pornophonique - Voices in My Head.flac
+    Pre-gap length: 00:00:29
+    Peak level: 0.972351
+    Pre-emphasis:
+    Extraction speed: 5.7 X
+    Extraction quality: 100.00 %
+    Test CRC: 300DF15C
+    Copy CRC: 300DF15C
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: 77DE3AFE
+      Remote CRC: 77DE3AFE
+    Status: Copy OK
+
+  4:
+    Filename: ./album/pornophonique - Brave New World/04. pornophonique - The Songs We Sang Together.flac
+    Pre-gap length: 00:00:74
+    Peak level: 0.988586
+    Pre-emphasis:
+    Extraction speed: 6.2 X
+    Extraction quality: 100.00 %
+    Test CRC: 1657126F
+    Copy CRC: 1657126F
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: 4D824E2F
+      Remote CRC: 4D824E2F
+    Status: Copy OK
+
+  5:
+    Filename: ./album/pornophonique - Brave New World/05. pornophonique - Night Will Fall.flac
+    Pre-gap length: 00:00:74
+    Peak level: 0.92807
+    Pre-emphasis:
+    Extraction speed: 6.4 X
+    Extraction quality: 100.00 %
+    Test CRC: 66EFEA59
+    Copy CRC: 66EFEA59
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: D0D39055
+      Remote CRC: D0D39055
+    Status: Copy OK
+
+  6:
+    Filename: ./album/pornophonique - Brave New World/06. pornophonique - Brave New World.flac
+    Pre-gap length: 00:00:74
+    Peak level: 0.965851
+    Pre-emphasis:
+    Extraction speed: 6.8 X
+    Extraction quality: 100.00 %
+    Test CRC: 5D7B712B
+    Copy CRC: 5D7B712B
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: CD69B7FC
+      Remote CRC: CD69B7FC
+    Status: Copy OK
+
+  7:
+    Filename: ./album/pornophonique - Brave New World/07. pornophonique - Wave After Wave.flac
+    Pre-gap length: 00:00:74
+    Peak level: 0.975189
+    Pre-emphasis:
+    Extraction speed: 7.0 X
+    Extraction quality: 100.00 %
+    Test CRC: 694CDD79
+    Copy CRC: 694CDD79
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: FE6DBCBF
+      Remote CRC: FE6DBCBF
+    Status: Copy OK
+
+  8:
+    Filename: ./album/pornophonique - Brave New World/08. pornophonique - Awakening.flac
+    Pre-gap length: 00:00:41
+    Peak level: 0.9841
+    Pre-emphasis:
+    Extraction speed: 7.5 X
+    Extraction quality: 100.00 %
+    Test CRC: 629CC273
+    Copy CRC: 629CC273
+    AccurateRip v1:
+      Result: Track not present in AccurateRip database
+    AccurateRip v2:
+      Result: Found, exact match
+      Confidence: 2
+      Local CRC: 7EB7F715
+      Remote CRC: 7EB7F715
+    Status: Copy OK
+
+Conclusive status report:
+  AccurateRip summary: All tracks accurately ripped
+  Health Status: No errors occurred
+  EOF: End of status report
+
+SHA-256 hash: AFD2B29F82EF8104A359DDA9E52A4EB550919CCD6540E72AE68180E26D24D129

--- a/test/test_disc_whipper.py
+++ b/test/test_disc_whipper.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2022 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import (
+    PicardTestCase,
+    get_test_data_path,
+)
+
+from picard.disc.whipperlog import toc_from_file
+
+
+class TestTocFromFile(PicardTestCase):
+
+    def test_toc_from_file(self):
+        test_log = get_test_data_path('whipper.log')
+        toc = toc_from_file(test_log)
+        self.assertEqual((1, 8, 149323, 150, 25064, 43611, 60890, 83090, 100000, 115057, 135558), toc)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2410
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Similar to the EAC / XLD log file support added in #2048 allow generating the disc ID from Whipper log files

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Extend the existing ripping log file reading with an additional check for the Whipper log format. Whipper's logs are YAML based and hence especially easy to handle.

Note: There is also a EAC log output plugin for whipper, which mimics the format of the EAC log. This of course also works and it captured by the EAC / XLD log file implementation.