### PR TITLE
Omit standard ports in URLs constructed by build_qurl

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -580,13 +580,14 @@ def build_qurl(host, port=80, path=None, queryargs=None):
     """
     url = QtCore.QUrl()
     url.setHost(host)
-    url.setPort(port)
 
-    if host in MUSICBRAINZ_SERVERS or port == 443:
+    if port == 443 or host in MUSICBRAINZ_SERVERS:
         url.setScheme("https")
-        url.setPort(443)
+    elif port == 80:
+        url.setScheme("http")
     else:
         url.setScheme("http")
+        url.setPort(port)
 
     if path is not None:
         url.setPath(path)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -50,8 +50,9 @@ class BrowserLookupTest(PicardTestCase):
 
     def assert_mb_url_matches(self, url, path, query_args=None):
         parsed_url = urlparse(url)
-        expected_host = "%s:%s" % (SERVER, PORT)
+        expected_host = SERVER
         self.assertEqual(expected_host, parsed_url.netloc, '"%s" hostname does not match "%s"' % (url, expected_host))
+        self.assertEqual('https' if PORT == 443 else 'http', parsed_url.scheme)
         self.assertEqual(path, parsed_url.path, '"%s" path does not match "%s"' % (url, path))
         if query_args is not None:
             actual_query_args = {k: v[0] for k, v in parse_qs(parsed_url.query).items()}

--- a/test/test_disc.py
+++ b/test/test_disc.py
@@ -39,7 +39,7 @@ class MockDisc:
     mcn = '5029343070452'
     tracks = list(range(0, 11))
     toc_string = ' '.join(str(i) for i in test_toc)
-    submission_url = 'https://musicbrainz.org:443/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437'
+    submission_url = 'https://musicbrainz.org/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437'
 
 
 class DiscTest(PicardTestCase):
@@ -112,6 +112,6 @@ class DiscTest(PicardTestCase):
         disc = picard.disc.Disc()
         disc.read()
         self.assertEqual(
-            'http://test.musicbrainz.org:80/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437',
+            'http://test.musicbrainz.org/cdtoc/attach?id=lSOVc5h6IXSuzcamJS1Gp4_tRuA-&tracks=11&toc=1+11+242457+150+44942+61305+72755+96360+130485+147315+164275+190702+205412+220437',
             disc.submission_url
         )

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -90,9 +90,9 @@ class BuildSubmissionUrlTest(PicardTestCase):
                 'server_port': 80,
                 'use_server_for_submission': False,
             })
-            self.assertEqual('https://%s:443' % host, build_submission_url())
-            self.assertEqual('https://%s:443/' % host, build_submission_url('/'))
-            self.assertEqual('https://%s:443/some/path?foo=1&bar=baz' % host,
+            self.assertEqual('https://%s' % host, build_submission_url())
+            self.assertEqual('https://%s/' % host, build_submission_url('/'))
+            self.assertEqual('https://%s/some/path?foo=1&bar=baz' % host,
                 build_submission_url('/some/path', {'foo': 1, 'bar': 'baz'}))
 
     def test_use_unofficial(self):
@@ -112,7 +112,7 @@ class BuildSubmissionUrlTest(PicardTestCase):
             'server_port': 80,
             'use_server_for_submission': False,
         })
-        self.assertEqual('https://musicbrainz.org:443', build_submission_url())
-        self.assertEqual('https://musicbrainz.org:443/', build_submission_url('/'))
-        self.assertEqual('https://musicbrainz.org:443/some/path?foo=1&bar=baz',
+        self.assertEqual('https://musicbrainz.org', build_submission_url())
+        self.assertEqual('https://musicbrainz.org/', build_submission_url('/'))
+        self.assertEqual('https://musicbrainz.org/some/path?foo=1&bar=baz',
                 build_submission_url('/some/path', {'foo': 1, 'bar': 'baz'}))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

URLs constructed by `picard.util.build_qurl`  always contain the port, e.g. `https://musicbrainz.org:443/`. This is not necessary if the default ports 80 for http or 443 for https are being used.

# Solution

Skip setting the port if the default is being used. Only set the scheme.