### PR TITLE
PICARD-2411: Add option to fix seektable for flac files

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -250,7 +250,7 @@ class VCommentFile(File):
         if is_flac and config.setting["fix_missing_seekpoints_flac"]:
             if len(file.seektable.seekpoints) == 0:
                 if file.info.total_samples > 0:
-                    file.seektable.seekpoints = [mutagen.flac.SeekPoint(0,0,1)]
+                    file.seektable.seekpoints = [mutagen.flac.SeekPoint(0, 0, 1)]
                     file.seektable.write()
                 else:
                     log.error("Unable to fix seektable of file {} because the file has no samples!".format(filename))

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -247,6 +247,14 @@ class VCommentFile(File):
                     and not config.setting["preserve_images"])):
             file.clear_pictures()
         tags = {}
+        if is_flac and config.setting["fix_missing_seekpoints_flac"]:
+            if len(file.seektable.seekpoints) == 0:
+                if file.info.total_samples > 0:
+                    file.seektable.seekpoints = [mutagen.flac.SeekPoint(0,0,1)]
+                    file.seektable.write()
+                else:
+                    log.error("Unable to fix seektable of file {} because the file has no samples!".format(filename))
+
         for name, value in metadata.items():
             if name == '~rating':
                 # Save rating according to http://code.google.com/p/quodlibet/wiki/Specs_VorbisComments

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -79,6 +79,7 @@ class UserProfileGroups():
             SettingDesc("preserve_images", N_("Keep embedded images when clearing tags"), ["preserve_images"]),
             SettingDesc("remove_id3_from_flac", N_("Remove ID3 tags from FLAC files"), ["remove_id3_from_flac"]),
             SettingDesc("remove_ape_from_mp3", N_("Remove APEv2 tags from MP3 files"), ["remove_ape_from_mp3"]),
+            SettingDesc("fix_missing_seekpoints_flac", N_("Fix missing seekpoints for FLAC files"), ["fix_missing_seekpoints_flac"]),
             SettingDesc("preserved_tags", N_("Preserved tags list"), ["preserved_tags"]),
             SettingDesc("aac_save_ape", N_("Save APEv2 tags to AAC"), ["aac_save_ape", "aac_no_tags"]),
             SettingDesc("remove_ape_from_aac", N_("Remove APEv2 tags from AAC files"), ["remove_ape_from_aac"]),

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -56,6 +56,7 @@ class TagsOptionsPage(OptionsPage):
         BoolOption("setting", "preserve_images", False),
         BoolOption("setting", "remove_id3_from_flac", False),
         BoolOption("setting", "remove_ape_from_mp3", False),
+        BoolOption("setting", "fix_missing_seekpoints_flac", False),
         ListOption("setting", "preserved_tags", []),
     ]
 
@@ -72,6 +73,7 @@ class TagsOptionsPage(OptionsPage):
         self.ui.preserve_images.setChecked(config.setting["preserve_images"])
         self.ui.remove_ape_from_mp3.setChecked(config.setting["remove_ape_from_mp3"])
         self.ui.remove_id3_from_flac.setChecked(config.setting["remove_id3_from_flac"])
+        self.ui.fix_missing_seekpoints_flac.setChecked(config.setting["fix_missing_seekpoints_flac"])
         self.ui.preserved_tags.update(config.setting["preserved_tags"])
         self.ui.preserved_tags.set_user_sortable(False)
 
@@ -86,6 +88,7 @@ class TagsOptionsPage(OptionsPage):
         config.setting["preserve_images"] = self.ui.preserve_images.isChecked()
         config.setting["remove_ape_from_mp3"] = self.ui.remove_ape_from_mp3.isChecked()
         config.setting["remove_id3_from_flac"] = self.ui.remove_id3_from_flac.isChecked()
+        config.setting["fix_missing_seekpoints_flac"] = self.ui.fix_missing_seekpoints_flac.isChecked()
         config.setting["preserved_tags"] = list(self.ui.preserved_tags.tags)
         self.tagger.window.enable_tag_saving_action.setChecked(not config.setting["dont_write_tags"])
 

--- a/picard/ui/ui_options_tags.py
+++ b/picard/ui/ui_options_tags.py
@@ -38,6 +38,9 @@ class Ui_TagsOptionsPage(object):
         self.remove_ape_from_mp3 = QtWidgets.QCheckBox(self.before_tagging)
         self.remove_ape_from_mp3.setObjectName("remove_ape_from_mp3")
         self.vboxlayout1.addWidget(self.remove_ape_from_mp3)
+        self.fix_missing_seekpoints_flac = QtWidgets.QCheckBox(self.before_tagging)
+        self.fix_missing_seekpoints_flac.setObjectName("fix_missing_seekpoints_flac")
+        self.vboxlayout1.addWidget(self.fix_missing_seekpoints_flac)
         spacerItem = QtWidgets.QSpacerItem(20, 6, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
         self.vboxlayout1.addItem(spacerItem)
         self.preserved_tags_label = QtWidgets.QLabel(self.before_tagging)
@@ -61,6 +64,7 @@ class Ui_TagsOptionsPage(object):
         TagsOptionsPage.setTabOrder(self.clear_existing_tags, self.preserve_images)
         TagsOptionsPage.setTabOrder(self.preserve_images, self.remove_id3_from_flac)
         TagsOptionsPage.setTabOrder(self.remove_id3_from_flac, self.remove_ape_from_mp3)
+        TagsOptionsPage.setTabOrder(self.remove_ape_from_mp3, self.fix_missing_seekpoints_flac)
 
     def retranslateUi(self, TagsOptionsPage):
         _translate = QtCore.QCoreApplication.translate
@@ -71,5 +75,6 @@ class Ui_TagsOptionsPage(object):
         self.preserve_images.setText(_("Keep embedded images when clearing tags"))
         self.remove_id3_from_flac.setText(_("Remove ID3 tags from FLAC files"))
         self.remove_ape_from_mp3.setText(_("Remove APEv2 tags from MP3 files"))
+        self.fix_missing_seekpoints_flac.setText(_("Fix missing seekpoints for FLAC files"))
         self.preserved_tags_label.setText(_("Preserve these tags from being cleared or overwritten with MusicBrainz data:"))
 from picard.ui.widgets.taglisteditor import TagListEditor

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -50,6 +50,7 @@ settings = {
     'rating_user_email': 'users@musicbrainz.org',
     'remove_ape_from_mp3': False,
     'remove_id3_from_flac': False,
+    'fix_missing_seekpoints_flac': False,
     'remove_images_from_tags': False,
     'save_images_to_tags': True,
     'write_id3v1': True,

--- a/ui/options_tags.ui
+++ b/ui/options_tags.ui
@@ -72,6 +72,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="fix_missing_seekpoints_flac">
+        <property name="text">
+         <string>Fix missing seekpoints for FLAC files</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -124,6 +131,7 @@
   <tabstop>preserve_images</tabstop>
   <tabstop>remove_id3_from_flac</tabstop>
   <tabstop>remove_ape_from_mp3</tabstop>
+  <tabstop>fix_missing_seekpoints_flac</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This is to fix problem with Kodi which is unable to load files
that have empty SeekTable, so by default a single SeekPoint is added.
An error message is logged if the file has no samples.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2411
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
