### PR TITLE
PICARD-2417: Fix collapsing tree view items with LEFT key on macOS

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1073,6 +1073,19 @@ def process_picard_args():
     return picard_args, unparsed_args
 
 
+class OverrideStyle(QtWidgets.QProxyStyle):
+    """Override the default style to fix some platform specific issues"""
+
+    def styleHint(self, hint, option, widget, returnData):
+        # This is disabled on macOS, but prevents collapsing tree view items easily with
+        # left arrow key. Enable this consistently on all platforms.
+        # See https://tickets.metabrainz.org/browse/PICARD-2417
+        # and https://bugreports.qt.io/browse/QTBUG-100305
+        if hint == QtWidgets.QStyle.StyleHint.SH_ItemView_ArrowKeysNavigateIntoChildren:
+            return True
+        return super().styleHint(hint, option, widget, returnData)
+
+
 def main(localedir=None, autoupdate=True):
     # Some libs (ie. Phonon) require those to be set
     QtWidgets.QApplication.setApplicationName(PICARD_APP_NAME)
@@ -1108,6 +1121,7 @@ def main(localedir=None, autoupdate=True):
         pass
 
     tagger = Tagger(picard_args, unparsed_args, localedir, autoupdate)
+    tagger.setStyle(OverrideStyle())
 
     # Initialize Qt default translations
     translator = QtCore.QTranslator()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2417
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On macOS only in tree views the LEFT ARROW key does not move the selected item to the parent. This is a Qt5 issue. While this is default behavior it is always disabled on macOS. For details see https://bugreports.qt.io/browse/QTBUG-100305

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Force enabling the `SH_ItemView_ArrowKeysNavigateIntoChildren` style hint on all platforms.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
This change also enables on macOS the behavior that on RIGH ARROW press the first child item gets selected. This is Qt default behavior on other platforms, but since this is not common behavior on macOS Qt5 tries to disable it on macOS. But this is part of the same style hint `SH_ItemView_ArrowKeysNavigateIntoChildren`