### PR TITLE
Fix crash on loading files with ACOUSTID_FINGERPRINT tag.

### DIFF
--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -76,7 +76,7 @@ class Submission(object):
             puid = metadata['musicip_puid']
             if puid:
                 args['puid'] = puid
-        if self.valid_duration:
+        if self.valid_duration and self.recordingid:
             args['mbid'] = self.recordingid
         elif metadata:
             args['track'] = metadata['title']


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix crash introduced by https://github.com/metabrainz/picard/pull/2045 (PICARD-2396), specifically 62da04f831ca64e755ffdf76ac46956b4059c221.


# Problem

On loading some files, Picard crashes with the following message: 

```
  File "/home/user/picard/picard/acoustid/manager.py", line 53, in <genexpr>
    return int(sum((len(key) + len(value) + 2 for key, value in self.args.items())) * 1.03)
TypeError: object of type 'NoneType' has no len()
```

After some investigation, it seems that files with an ACOUSTID_FINGERPRINT tag cause this. To reproduce use e.g. this [testfile.zip](https://github.com/metabrainz/picard/files/8056446/testfile.zip) (public domain, see https://kimikoishizaka.bandcamp.com/album/bach-well-tempered-clavier-book-1) or take a random file with just basic metadata and add an ACOUSTID_FINGERPRINT tag (doesn't have to be a valid fingerprint.)

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->


<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

A debug `print(self.args.items())` (https://github.com/cybersphinx/picard/commit/2b25df9b2432b0f49d3860a6fa4d47012a66b975) before the offending line shows that `'mbid'` is `None`. So this fix checks if `self.recordingid` is `None` to make sure `'mbid'` isn't empty.

Incidentally, testing this fix with the abovementioned debug output, for files without a fingerprint tag that are not in Musicbrainz (after fingerprint scanning) the items to submit now contain all the regular tags (artist, album, …) while before `'mbid'` would be an empty string and so no other metadata included.

(Also, this seems to be called quite often, for the testfile the debug output is printed four times, for the source file directly from Bandcamp after fingerprint scanning it shows six times.)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
