### PR TITLE
Implement __bool__ and __repr__ for AcoustID Submission

### DIFF
--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -52,6 +52,12 @@ class Submission(object):
         # potential urlencode expansion
         return int(sum((len(key) + len(value) + 2 for key, value in self.args.items())) * 1.03)
 
+    def __bool__(self):
+        return bool(self.fingerprint and self.duration is not None)
+
+    def __repr__(self):
+        return '<%s %r, %d, %r>' % (self.__class__.__name__, self.fingerprint, self.duration, self.recordingid)
+
     @property
     def puid(self):
         return self.metadata.get('musicip_puid', '') if self.metadata else ''

--- a/test/test_acoustidmanager.py
+++ b/test/test_acoustidmanager.py
@@ -158,6 +158,13 @@ class SubmissionTest(PicardTestCase):
         self.assertEqual(metadata['musicip_puid'], submission.puid)
         self.assertEqual(0, submission.attempts)
 
+    def test_bool(self):
+        self.assertTrue(bool(Submission('foo', 1)))
+        self.assertTrue(bool(Submission('foo', 0)))
+        self.assertFalse(bool(Submission('foo', None)))
+        self.assertFalse(bool(Submission(None, 1)))
+        self.assertFalse(bool(Submission('', 1)))
+
     def test_valid_duration(self):
         duration_s = 342
         duration_ms = duration_s * 1000


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->


Implementing __bool__ avoids checks like `if submission` to use __len__. Checking `len(submission)` does not really tell about the object being considered True.
 
This is related to the dscussion on #2063

