### PR TITLE
Refactor similarity utils

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -688,7 +688,7 @@ class Album(DataObject, Item):
                             similarity = track.metadata.length_score(track.metadata.length, file.metadata.length)
                             yield SimMatchAlbum(similarity=similarity, track=track)
 
-            best_match = find_best_match(mbid_candidates, no_match)
+            best_match = find_best_match(mbid_candidates(), no_match)
             if best_match != no_match:
                 yield (file, best_match.result.track)
                 continue
@@ -700,7 +700,7 @@ class Album(DataObject, Item):
                     if similarity >= threshold:
                         yield SimMatchAlbum(similarity=similarity, track=track)
 
-            best_match = find_best_match(similarity_candidates, no_match)
+            best_match = find_best_match(similarity_candidates(), no_match)
             yield (file, best_match.result.track)
 
     def match_files(self, files):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2008, 2011 Lukáš Lalinský
 # Copyright (C) 2008 Hendrik van Antwerpen
 # Copyright (C) 2008 Will
-# Copyright (C) 2010-2011, 2014, 2018-2021 Philipp Wolfer
+# Copyright (C) 2010-2011, 2014, 2018-2022 Philipp Wolfer
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2012 Wieland Hoffmann
@@ -271,7 +271,7 @@ class Cluster(FileList):
                     yield match
 
         no_match = SimMatchRelease(similarity=-1, release=None)
-        best_match = find_best_match(candidates, no_match)
+        best_match = find_best_match(candidates(), no_match)
         return best_match.result.release
 
     def lookup_metadata(self):

--- a/picard/file.py
+++ b/picard/file.py
@@ -830,7 +830,7 @@ class File(QtCore.QObject, Item):
                 yield self.metadata.compare_to_track(track, self.comparison_weights)
 
         no_match = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
-        best_match = find_best_match(candidates, no_match)
+        best_match = find_best_match(candidates(), no_match)
 
         if best_match.similarity < threshold:
             return None

--- a/picard/file.py
+++ b/picard/file.py
@@ -825,12 +825,12 @@ class File(QtCore.QObject, Item):
 
     def _match_to_track(self, tracks, threshold=0):
         # multiple matches -- calculate similarities to each of them
-        def candidates():
-            for track in tracks:
-                yield self.metadata.compare_to_track(track, self.comparison_weights)
-
+        candidates = (
+            self.metadata.compare_to_track(track, self.comparison_weights)
+            for track in tracks
+        )
         no_match = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
-        best_match = find_best_match(candidates(), no_match)
+        best_match = find_best_match(candidates, no_match)
 
         if best_match.similarity < threshold:
             return None

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2016 Rahul Raturi
 # Copyright (C) 2018 Antonio Larrosa
 # Copyright (C) 2018-2021 Laurent Monin
-# Copyright (C) 2018-2021 Philipp Wolfer
+# Copyright (C) 2018-2022 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -134,7 +134,7 @@ class TrackSearchDialog(SearchDialog):
                 for track in tracks:
                     yield metadata.compare_to_track(track, File.comparison_weights)
 
-            tracks = [result.track for result in sort_by_similarity(candidates)]
+            tracks = [result.track for result in sort_by_similarity(candidates())]
 
         del self.search_results[:]  # Clear existing data
         self.parse_tracks(tracks)

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -129,12 +129,11 @@ class TrackSearchDialog(SearchDialog):
 
         if self.file_:
             metadata = self.file_.orig_metadata
-
-            def candidates():
-                for track in tracks:
-                    yield metadata.compare_to_track(track, File.comparison_weights)
-
-            tracks = [result.track for result in sort_by_similarity(candidates())]
+            candidates = (
+                metadata.compare_to_track(track, File.comparison_weights)
+                for track in tracks
+            )
+            tracks = (result.track for result in sort_by_similarity(candidates))
 
         del self.search_results[:]  # Clear existing data
         self.parse_tracks(tracks)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -724,15 +724,29 @@ BestMatch = namedtuple('BestMatch', ('similarity', 'result'))
 
 
 def sort_by_similarity(candidates):
+    """Sorts the objects in candidates by similarity.
+
+    Args:
+        candidates: Iterable with objects having a `similarity`  attribute
+    Returns: List of candidates sorted by similarity (highest similarity first)
+    """
     return sorted(
-        candidates(),
+        candidates,
         reverse=True,
         key=attrgetter('similarity')
     )
 
 
 def find_best_match(candidates, no_match):
-    best_match = max(candidates(), key=attrgetter('similarity'), default=no_match)
+    """Returns a BestMatch based on the similarity of candidates.
+
+    Args:
+        candidates: Iterable with objects having a `similarity`  attribute
+        no_match: Match to return if there was no candidate
+
+    Returns: `BestMatch` with the similarity and the matched object as result.
+    """
+    best_match = max(candidates, key=attrgetter('similarity'), default=no_match)
     return BestMatch(similarity=best_match.similarity, result=best_match)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -407,16 +407,13 @@ class SortBySimilarity(PicardTestCase):
             SimMatchTest(similarity=0.75, name='c'),
         ]
 
-    def candidates(self):
-        yield from self.test_values
-
     def test_sort_by_similarity(self):
-        results = [result.name for result in sort_by_similarity(self.candidates)]
+        results = [result.name for result in sort_by_similarity(self.test_values)]
         self.assertEqual(results, ['b', 'c', 'd', 'a'])
 
     def test_findbestmatch(self):
         no_match = SimMatchTest(similarity=-1, name='no_match')
-        best_match = find_best_match(self.candidates, no_match)
+        best_match = find_best_match(self.test_values, no_match)
 
         self.assertEqual(best_match.result.name, 'b')
         self.assertEqual(best_match.similarity, 0.75)
@@ -425,7 +422,7 @@ class SortBySimilarity(PicardTestCase):
         self.test_values = []
 
         no_match = SimMatchTest(similarity=-1, name='no_match')
-        best_match = find_best_match(self.candidates, no_match)
+        best_match = find_best_match(self.test_values, no_match)
 
         self.assertEqual(best_match.result.name, 'no_match')
         self.assertEqual(best_match.similarity, -1)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The utility functions `sort_by_similarity` and `find_best_match` currently expect as parameter a callable that returns an iterable. I think it is a cleaner API if they accept an iterable directly.


# Solution

Make the functions work on the iterable, move calling of the functions to the outside.