### PR TITLE
PICARD-2423: Fix moving all files from album to unclustered

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -782,7 +782,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             log.debug("Dropped albums = %r", album_ids)
             files = iter_files_from_objects(self.tagger.load_album(id) for id in album_ids)
             # Use QTimer.singleShot to run expensive processing outside of the drop handler.
-            move_files = partial(self.tagger.move_files, files, target)
+            move_files = partial(self.tagger.move_files, list(files), target)
             QtCore.QTimer.singleShot(0, move_files)
             handled = True
         self._move_to_multi_tracks = True  # Reset for next drop


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2423
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If you have loaded an album and attached multiple files to a track and drag the entire album back on unmtached files, only half of the files attached to a track get moved over.

This was caused by https://github.com/metabrainz/picard/commit/8f90884aed2da4d42e2267d821093660e9a23b05

@zas I remember we discussed this and were unsure but thought we could get away with passing the generator. But once this iterates over the tracks the moves modify the iterated file list and hence we loose every second file.


# Solution

Pass a list instead of a generator to `tagger.move_files`

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

