### PR TITLE
PICARD-2425: Handle possible exceptions with os.path.realpath

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -78,6 +78,7 @@ from picard.util import (
     find_best_match,
     format_time,
     is_absolute_path,
+    normpath,
     thread,
     tracknum_and_title_from_filename,
 )
@@ -506,14 +507,10 @@ class File(QtCore.QObject, Item):
         if settings["move_files"]:
             new_dirname = settings["move_files_to"]
             if not is_absolute_path(new_dirname):
-                new_dirname = os.path.normpath(os.path.join(os.path.dirname(filename), new_dirname))
+                new_dirname = os.path.join(os.path.dirname(filename), new_dirname)
         else:
             new_dirname = os.path.dirname(filename)
-        try:
-            new_dirname = os.path.realpath(new_dirname)
-        except FileNotFoundError:
-            # os.path.realpath can fail if cwd does not exist and path is relative
-            pass
+        new_dirname = normpath(new_dirname)
         new_filename = os.path.basename(filename)
 
         if settings["rename_files"] or settings["move_files"]:

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -55,7 +55,10 @@ from picard.coverart.image import (
 )
 from picard.file import File
 from picard.track import Track
-from picard.util import imageinfo
+from picard.util import (
+    imageinfo,
+    normpath,
+)
 from picard.util.lrucache import LRUCache
 
 from picard.ui.item import FileListItem
@@ -411,7 +414,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
                                        parse_response_type=None, queryargs=queryargs,
                                        priority=True, important=True)
         elif url.scheme() == 'file':
-            path = os.path.normpath(os.path.realpath(url.toLocalFile().rstrip("\0")))
+            path = normpath(url.toLocalFile().rstrip("\0"))
             if path and os.path.exists(path):
                 with open(path, 'rb') as f:
                     data = f.read()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -170,6 +170,8 @@ def normpath(path):
         path = os.path.realpath(path)
     except OSError as why:
         # realpath can fail if path does not exist or is not accessible
+        # or on Windows if drives are mounted without mount manager
+        # (see https://tickets.metabrainz.org/browse/PICARD-2425).
         log.warning('Failed getting realpath for "%s": %s', path, why)
     return os.path.normpath(path)
 

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -400,8 +400,15 @@ def samefile_different_casing(path1, path2):
     path2 = os.path.normpath(path2)
     if path1 == path2 or not os.path.exists(path1) or not os.path.exists(path2):
         return False
-    dir1 = os.path.realpath(os.path.normcase(os.path.dirname(path1)))
-    dir2 = os.path.realpath(os.path.normcase(os.path.dirname(path2)))
+    dir1 = os.path.normcase(os.path.dirname(path1))
+    dir2 = os.path.normcase(os.path.dirname(path2))
+    try:
+        dir1 = os.path.realpath(dir1)
+        dir2 = os.path.realpath(dir2)
+    except OSError:
+        # os.path.realpath can fail if cwd does not exist and path is relative
+        # or on Windows if drives are mounted without mount manager.
+        pass
     if dir1 != dir2 or not samefile(path1, path2):
         return False
     file1 = os.path.basename(path1)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2425
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`os.path.realpath` can throw `OSError`  for different reasons. E.g. PICARD-2425 reports an issue with drives mounted via SSHFS-Win. In general on Windows this can cause exceptions if drives are mounted without mount manager. https://github.com/billziss-gh/sshfs-win/issues/243 has some more info about this.

Due to missing exception handling this can cause crashes when saving files or when generating filename previews in options.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Handle `OSError`  on `os.path.realpath`  calls. If it makes sense use `picard.util.normpath`, which already handles this.

Note that we still log warnings in these cases, which I think makes sense.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
