### PR TITLE
Remove picard.util.htmlescape

### DIFF
--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -32,6 +32,7 @@ from collections import (
     defaultdict,
     namedtuple,
 )
+from html import escape
 import os.path
 import re
 import traceback
@@ -51,7 +52,6 @@ from picard.util import (
     bytes2human,
     encode_filename,
     format_time,
-    htmlescape,
     union_sorted_lists,
 )
 
@@ -298,16 +298,13 @@ def format_file_info(file_):
             ch = _('Stereo')
         info.append((_('Channels:'), ch))
     return '<br/>'.join(map(lambda i: '<b>%s</b> %s' %
-                            (htmlescape(i[0]),
-                             htmlescape(i[1])), info))
+                            (escape(i[0]), escape(i[1])), info))
 
 
 def format_tracklist(cluster):
     info = []
-    info.append("<b>%s</b> %s" % (_('Album:'),
-                                  htmlescape(cluster.metadata["album"])))
-    info.append("<b>%s</b> %s" % (_('Artist:'),
-                                  htmlescape(cluster.metadata["albumartist"])))
+    info.append("<b>%s</b> %s" % (_('Album:'), escape(cluster.metadata["album"])))
+    info.append("<b>%s</b> %s" % (_('Artist:'), escape(cluster.metadata["albumartist"])))
     info.append("")
     TrackListItem = namedtuple('TrackListItem', 'number, title, artist, length')
     tracklists = defaultdict(list)
@@ -340,12 +337,12 @@ def format_tracklist(cluster):
             info.append("<b>%s</b>" % (_('Disc %d') % discnumber))
         lines = ["%s %s - %s (%s)" % item for item in sorted(tracklist, key=sorttracknum)]
         info.append("<b>%s</b><br />%s<br />" % (_('Tracklist:'),
-                    '<br />'.join(htmlescape(s).replace(' ', '&nbsp;') for s in lines)))
+                    '<br />'.join(escape(s).replace(' ', '&nbsp;') for s in lines)))
     return '<br/>'.join(info)
 
 
 def text_as_html(text):
-    return '<br />'.join(htmlescape(str(text))
+    return '<br />'.join(escape(str(text))
         .replace('\t', ' ')
         .replace(' ', '&nbsp;')
         .splitlines())

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -42,7 +42,6 @@
 import builtins
 from collections import namedtuple
 from collections.abc import Mapping
-import html
 from itertools import chain
 import json
 import ntpath
@@ -655,10 +654,6 @@ def convert_to_string(obj):
 
 
 builtins.__dict__['string_'] = convert_to_string
-
-
-def htmlescape(string):
-    return html.escape(string, quote=False)
 
 
 def load_json(data):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
It is only a thin wrapper around `html.escape` only used at a single place, and it sets `quote=False`, which is a dangerous default and I see no good reason why this has been set at all.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Use `html.escape` directly.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
