### PR TITLE
PICARD-1570: Allow accessing files with long paths on Windows

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -588,7 +588,7 @@ class Tagger(QtWidgets.QApplication):
     def _scan_paths_recursive(paths, recursive, ignore_hidden):
         local_paths = list(paths)
         while local_paths:
-            current_path = local_paths.pop(0)
+            current_path = normpath(local_paths.pop(0))
             try:
                 if os.path.isdir(current_path):
                     for entry in os.scandir(current_path):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -57,6 +57,7 @@ from picard.util import (
     iter_unique,
     limited_join,
     make_filename_from_title,
+    normpath,
     pattern_as_regex,
     sort_by_similarity,
     tracknum_and_title_from_filename,
@@ -706,3 +707,23 @@ class BuildQUrlTest(PicardTestCase):
             self.assertEqual(expected, build_qurl(host, port=80).toDisplayString())
             self.assertEqual(expected, build_qurl(host, port=443).toDisplayString())
             self.assertEqual(expected, build_qurl(host, port=8080).toDisplayString())
+
+
+class NormpathTest(PicardTestCase):
+
+    @unittest.skipIf(IS_WIN, "non-windows test")
+    def test_normpath(self):
+        self.assertEqual('/foo/bar', normpath('/foo//bar'))
+        self.assertEqual('/bar', normpath('/foo/../bar'))
+
+    @unittest.skipUnless(IS_WIN, "windows test")
+    def test_normpath_windows(self):
+        self.assertEqual('C:\\Foo\\Bar.baz', normpath('C:/Foo/Bar.baz'))
+        self.assertEqual('C:\\Bar.baz', normpath('C:/Foo/../Bar.baz'))
+
+    @unittest.skipUnless(IS_WIN, "windows test")
+    def test_normpath_windows_longpath(self):
+        path = 'C:\\foo\\' + (252 * 'a')
+        self.assertEqual(path, normpath(path))
+        path += 'a'
+        self.assertEqual('\\\\?\\' + path, normpath(path))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1570
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On traditional Windows API the file path length is limited to 259 characters (+1 null character). Picard cannot read or write longer paths.

The Windows API however supports accessing longer paths, if the path gets prefixed with `\\?\`. This internally enables long path handling.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Extend `picard.util.normpath`  to extend paths with the long path prefix `\\?\` on Windows if the path exceeds 259 characters in length. This enables both reading and writing to such files

# Action
Please note a few things about this:

1. This solution works independent of the new long path support that can be enabled in Windows 10. If that is enabled Picard already can handle reading and writing long paths. But this change allows this also if on Windows 10 / 11 long path handling is disabled (the default) or even on on Windows 7 / 8.
2. This change does not affect that Picard enforces the path limit when creating path and file names. This will be handled in a separate PR (PICARD-2076) and requires some changes to the options to make this work nicely for the user. But this change is a prerequisite for this, and it allows the user to both load files with long path and save tags to them.
3. There is a related issue that long paths are not seen by Picard with drag and drop, see PICARD-2429 . I have a patch for that (work in progress), and also enabling long path support on Windows 10 resolves this issue as well.