### PR TITLE
PICARD-2420: Fix AcoustID submission getting enabled for files with fingerprint in tags

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -255,7 +255,7 @@ class File(QtCore.QObject, Item):
         if not config.setting["ignore_existing_acoustid_fingerprints"]:
             fingerprints = self.metadata.getall('acoustid_fingerprint')
             if fingerprints:
-                self.set_acoustid_fingerprint(fingerprints[0])
+                self.set_acoustid_fingerprint(fingerprints[0], recordingid=self.metadata['musicbrainz_recordingid'])
         run_file_post_load_processors(self)
         self.update()
         callback(self)
@@ -635,7 +635,7 @@ class File(QtCore.QObject, Item):
             self.parent = parent
             self.acoustid_update()
 
-    def set_acoustid_fingerprint(self, fingerprint, length=None):
+    def set_acoustid_fingerprint(self, fingerprint, length=None, recordingid=None):
         if not fingerprint:
             self.acoustid_fingerprint = None
             self.acoustid_length = 0
@@ -643,7 +643,7 @@ class File(QtCore.QObject, Item):
         elif fingerprint != self.acoustid_fingerprint:
             self.acoustid_fingerprint = fingerprint
             self.acoustid_length = length or self.metadata.length // 1000
-            self.tagger.acoustidmanager.add(self, None)
+            self.tagger.acoustidmanager.add(self, recordingid)
             self.acoustid_update()
         config = get_config()
         if config.setting['save_acoustid_fingerprints']:


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2420
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If one adds a file to Picard that has an existing `acoustid_fingerprint` and an existing `musicbrainz_recordingid` tag, that file will be loaded and assigned to the corresponding recording. This immediately will enable the fingerprint submission, because the file originally gets added to the AcoustId manager without recording ID, then gets assigned to the recording. This makes this a new combination.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The patch changes the behavior so on loading the file gets added to the AcoustId manager with the recording ID already assigned. That way it counts as already submitted.

I'd like to put this up for discussion, because I am unsure what expected behavior is. The current behavior can lead to a AcoustID / MBID combination submitted every time the user loads the file into Picard.

The new behavior will treat this already tagged combination as already submitted and won't submit.