### PR TITLE
An editable QComboBox automatically sets up a QCompleter

### DIFF
--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -110,9 +110,7 @@ class EditTagDialog(PicardDialog):
         tag_names.addItem("")
         visible_tags = [tn for tn in self.default_tags if not tn.startswith("~")]
         tag_names.addItems(visible_tags)
-        self.completer = QtWidgets.QCompleter(visible_tags, tag_names)
-        self.completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
-        tag_names.setCompleter(self.completer)
+        tag_names.completer().setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
         self.value_list.model().rowsInserted.connect(self.on_rows_inserted)
         self.value_list.model().rowsRemoved.connect(self.on_rows_removed)
         self.value_list.setItemDelegate(TagEditorDelegate(self))
@@ -268,12 +266,6 @@ class EditTagDialog(PicardDialog):
             self.ui.add_value.setEnabled(True)
         else:
             self._modified_tag()[row] = value
-            # add tags to the completer model once they get values
-            cm = self.completer.model()
-            if self.tag not in cm.stringList():
-                cm.insertRows(0, 1)
-                cm.setData(cm.index(0, 0), self.tag)
-                cm.sort(0)
 
     def value_selection_changed(self):
         selection = len(self.value_list.selectedItems()) > 0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

A `QComboBox`  which is set to being editable automatically sets up a `QCompleter` for the values in the combo box. No need to initialize a new completer, we just need to configure it for using popup auto completion (instead of default inline completion).

