### PR TITLE
PICARD-2451: Remove unicode zero-width space characters from file path

### DIFF
--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -494,6 +494,7 @@ def make_save_path(path, win_compat=False, mac_compat=False):
     - Leading dots in file and directory names will be removed. These files cannot be properly
       handled by Windows Explorer and on Unix like systems they count as hidden
     - If mac_compat is True, normalize precomposed Unicode characters on macOS
+    - Remove unicode zero-width space (\\u200B) from path
 
     Args:
         path: filename or path to clean
@@ -513,6 +514,8 @@ def make_save_path(path, win_compat=False, mac_compat=False):
     # Fix for precomposed characters on macOS.
     if mac_compat:
         path = unicodedata.normalize("NFD", path)
+    # Remove unicode zero-width space (\u200B) from path
+    path = path.replace("\u200B", "")
     return path
 
 

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -219,6 +219,10 @@ class MakeSavePathTest(PicardTestCase):
         path = 'foo/\u00E9bar'  # é
         self.assertEqual('foo/\u0065\u0301bar', make_save_path(path, mac_compat=True))
 
+    def test_remove_zero_length_space(self):
+        path = 'foo/\u200Bbar'
+        self.assertEqual('foo/bar', make_save_path(path))
+
 
 class GetAvailableFilenameTest(PicardTestCase):
 


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Removes unicode zero-width spaces from renaming file output path.

# Problem

As discussed in https://github.com/metabrainz/picard-plugins/pull/326 it is currently possible for Picard to create an output path which includes a unicode zero-length space character (\\u200B).  This can lead to unexpected consequences for the user.

* JIRA ticket (_optional_): PICARD-2451

# Solution

Automatically strip out the zero-width space character.  If there is a valid use case to keep the character in the output path, perhaps a setting can be added to the File Renaming Options to allow keeping the character.

# Action

None.