### PR TITLE
PICARD-2453: Allow submitting a catalog number without a corresponding label

### DIFF
--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2021 Laurent Monin
 # Copyright (C) 2021-2022 Philipp Wolfer
 # Copyright (C) 2022 jesus2099
+# Copyright (C) 2022 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -219,7 +220,7 @@ def _add_track_data(data, files):
             disc_counter += 1
             track_counter = 0
         last_discnumber = discnumber
-        if m['label']:
+        if m['label'] or m['catalognumber']:
             labels.add((m['label'], m['catalognumber']))
         if m['barcode']:
             barcode = m['barcode']


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Allow submitting a catalog number without an associated label when adding a cluster as a release.

# Problem

When adding a cluster as a release, Picard would only submit a catalog number if there was a corresponding label set.  MusicBrainz allows catalog numbers without a label.

* JIRA ticket (_optional_): PICARD-2453

# Solution

Allow submitting a catalog number without an associated label when adding a cluster as a release.

# Action

None.