### PR TITLE
PICARD-2462: Add functions to store and retrieve persistent script variables.

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -67,6 +67,29 @@ except ImportError:
 Bound = namedtuple("Bound", ["lower", "upper"])
 
 
+class PersistentVariables:
+    variables = {}
+
+    @classmethod
+    def clear_variables(cls):
+        cls.variables = {}
+
+    @classmethod
+    def set_variable(cls, key, value):
+        if key:
+            cls.variables[key] = value
+
+    @classmethod
+    def unset_variable(cls, key):
+        cls.variables.pop(key, None)
+
+    @classmethod
+    def get_variable(cls, key):
+        if key not in cls.variables:
+            return ""
+        return cls.variables[key]
+
+
 class FunctionRegistryItem:
     def __init__(self, function, eval_args, argcount, documentation=None,
                  name=None, module=None):
@@ -1516,4 +1539,54 @@ def func_cleanmulti(parser, multi):
     name = normalize_tagname(multi)
     values = [str(value) for value in parser.context.getall(name) if value or value == 0]
     parser.context[multi] = values
+    return ""
+
+
+@script_function(documentation=N_(
+    """`$setp(name,value)`
+
+Sets the persistent variable `name` to `value`.
+
+_Since Picard 2.8_"""
+))
+def func_setp(parser, name, value):
+    if value:
+        PersistentVariables.set_variable(normalize_tagname(name), value)
+    else:
+        func_unsetp(parser, name)
+    return ""
+
+
+@script_function(documentation=N_(
+    """`$unsetp(name)`
+
+Unsets the persistent variable `name`.
+
+_Since Picard 2.8_"""
+))
+def func_unsetp(parser, name):
+    PersistentVariables.unset_variable(normalize_tagname(name))
+    return ""
+
+
+@script_function(documentation=N_(
+    """`$getp(name)`
+
+Gets the persistent variable `name`.
+
+_Since Picard 2.8_"""
+))
+def func_getp(parser, name):
+    return PersistentVariables.get_variable(normalize_tagname(name))
+
+
+@script_function(documentation=N_(
+    """`$clearp()`
+
+Clears all persistent variables.
+
+_Since Picard 2.8_"""
+))
+def func_clearp(parser):
+    PersistentVariables.clear_variables()
     return ""


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds functions to store, retrieve and clear variable values that persist between tracks and albums.

# Problem

Picard does not provide the ability to persist script variable values between different tracks or albums.

* JIRA ticket (_optional_): PICARD-2462
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Add four new scripting functions to allow storing, retrieving and clearing persistent script variables:

- `$setp(name,value)` : Sets the persistent variable `name` to `value`.
- `$unsetp(name)` : Unsets the persistent variable `name`.
- `$getp(name)` : Gets the persistent variable `name`.
- `$clearp()` : Clears all persistent variables.

Add tests for the new functions.

# Action

If accepted, the documentation will need to be updated.