### PR TITLE
PICARD-2463: Fix coverart per screen pixel ratio

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -101,7 +101,7 @@ class CoverArtThumbnail(ActiveLabel):
             self.pixel_ratio = pixel_ratio
             self._update_default_pixmaps()
             if self.data:
-                self.set_data(self.data, self.has_common_images)
+                self.set_data(self.data, force=True, has_common_images=self.has_common_images)
             else:
                 self.setPixmap(self.shadow)
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -184,6 +184,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def __init__(self, parent=None, disable_player=False):
         super().__init__(parent)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_NativeWindow)
         self.__shown = False
         self.selected_objects = []
         self.ignore_selection_changes = IgnoreUpdatesContext(self.update_selection)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2463
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The cover art box considers the screen scaling to render the cover art in the proper resolution. E.g. on a High DPI / retina display with a scaling factor of 2 it will render the images in twice the displayed size.

But this code does not consider multiple screens with different scaling factors. If there are multiple screens the scaling factor of the primary will be used for all screens. This can result in pixelated cover art display if the Picard window is on a a screen with different scaling factor. E.g. the attached screenshot shows the Picard window on a screen with scaling factor set to 1.25, but rendered with a scaling factor of 1.0 (from primary screen). If the primary screen is changed to the one with 1.25 scaling factor the cover art will render nicely on this display, but when moving the window to the one with 1.0 it will look pixelated again.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
- Handle `screenChanged` events in cover art to detect Picard window changing the screen. This requires setting `WA_NativeWindow` on the main window to have a native window handle available. In case pixel ratio changed re-render the currently displayed cover art.
- Make the pixel ratio part of the key for the LRU cache, so changes in pixel ration invalidate current cache
- The default shadow and missing data pixmaps also get pushed in the cache now
- Apply some refactoring by moving the code to render the cover art stack pixmap into own method to improve readability
