### PR TITLE
PICARD-2459: Prevent macOS from removing temporary cover art files

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -54,6 +54,7 @@ from picard.util import (
     encode_filename,
     imageinfo,
     is_absolute_path,
+    periodictouch,
 )
 from picard.util.scripttofilename import script_to_filename
 
@@ -77,6 +78,7 @@ class DataHash:
                 with os.fdopen(fd, "wb") as imagefile:
                     imagefile.write(data)
                 _datafiles[self._hash] = self._filename
+                periodictouch.register_file(self._filename)
                 log.debug("Saving image data %s to %r" % (self._hash, self._filename))
             else:
                 self._filename = _datafiles[self._hash]
@@ -93,6 +95,7 @@ class DataHash:
         if self._filename:
             try:
                 os.unlink(self._filename)
+                periodictouch.unregister_file(self._filename)
             except BaseException:
                 pass
             else:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -302,7 +302,7 @@ class Tagger(QtWidgets.QApplication):
         # Touch these files regularly if Picard to keep them alive if Picard
         # is left running for a long time.
         if IS_MACOS:
-            periodictouch.setup_timer()
+            periodictouch.enable_timer()
 
         # Load release version information
         if self.autoupdate_enabled:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -96,6 +96,7 @@ from picard.const import (
 from picard.const.sys import (
     IS_FROZEN,
     IS_HAIKU,
+    IS_MACOS,
     IS_WIN,
 )
 from picard.dataobj import DataObject
@@ -121,6 +122,7 @@ from picard.util import (
     iter_files_from_objects,
     mbid_validate,
     normpath,
+    periodictouch,
     process_events_iter,
     system_supports_long_paths,
     thread,
@@ -295,6 +297,12 @@ class Tagger(QtWidgets.QApplication):
         self.window = MainWindow(disable_player=picard_args.no_player)
         self.exit_cleanup = []
         self.stopping = False
+
+        # On macOS temporary files get deleted after 3 days not being accessed.
+        # Touch these files regularly if Picard to keep them alive if Picard
+        # is left running for a long time.
+        if IS_MACOS:
+            periodictouch.setup_timer()
 
         # Load release version information
         if self.autoupdate_enabled:

--- a/picard/util/periodictouch.py
+++ b/picard/util/periodictouch.py
@@ -33,14 +33,16 @@ _files_to_touch = set()
 
 
 def register_file(filepath):
-    _files_to_touch.add(filepath)
+    if _touch_timer.isActive():
+        _files_to_touch.add(filepath)
 
 
 def unregister_file(filepath):
-    _files_to_touch.discard(filepath)
+    if _touch_timer.isActive():
+        _files_to_touch.discard(filepath)
 
 
-def setup_timer():
+def enable_timer():
     log.debug('Setup timer for touching files every %i seconds', TOUCH_FILES_DELAY_SECONDS)
     _touch_timer.timeout.connect(_touch_files)
     _touch_timer.start(TOUCH_FILES_DELAY_SECONDS * 1000)

--- a/picard/util/periodictouch.py
+++ b/picard/util/periodictouch.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2022 Laurent Monin
+# Copyright (C) 2022 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from pathlib import Path
+
+from PyQt5.QtCore import QTimer
+
+from picard import log
+
+
+TOUCH_FILES_DELAY_SECONDS = 4 * 3600
+
+_touch_timer = QTimer()
+_files_to_touch = set()
+
+
+def register_file(filepath):
+    _files_to_touch.add(filepath)
+
+
+def unregister_file(filepath):
+    _files_to_touch.discard(filepath)
+
+
+def setup_timer():
+    log.debug('Setup timer for touching files every %i seconds', TOUCH_FILES_DELAY_SECONDS)
+    _touch_timer.timeout.connect(_touch_files)
+    _touch_timer.start(TOUCH_FILES_DELAY_SECONDS * 1000)
+
+
+def _touch_files():
+    log.debug('Touching %i files', len(_files_to_touch))
+    for filepath in _files_to_touch.copy():
+        path = Path(filepath)
+        if path.exists():
+            try:
+                path.touch()
+            except OSError:
+                log.error('error touching file "%s"', filepath, exc_info=True)
+        else:
+            unregister_file(filepath)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2459
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

macOS cleans up temporary files if they haven't been accessed for three days. If Picard is left running for a longer period of time the files became missing.

# Solution

Add a module `picard.util.periodictouch` which sets up a timer to periodically touch a list of files. Register the cover art temp files there.
