### PR TITLE
Simplify album and track similarity search

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1376,8 +1376,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if not isinstance(obj, File):
             log.debug('show_more_tracks expected a File, got %r' % obj)
             return
-        dialog = TrackSearchDialog(self)
-        dialog.load_similar_tracks(obj)
+        dialog = TrackSearchDialog(self, force_advanced_search=True)
+        dialog.show_similar_tracks(obj)
         dialog.exec_()
 
     def show_more_albums(self):
@@ -1385,7 +1385,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if not obj:
             log.debug('show_more_albums expected a Cluster, got %r' % obj)
             return
-        dialog = AlbumSearchDialog(self)
+        dialog = AlbumSearchDialog(self, force_advanced_search=True)
         dialog.show_similar_albums(obj)
         dialog.exec_()
 

--- a/picard/webservice/api_helpers.py
+++ b/picard/webservice/api_helpers.py
@@ -47,6 +47,11 @@ def escape_lucene_query(text):
     return re.sub(r'([+\-&|!(){}\[\]\^"~*?:\\/])', r'\\\1', text)
 
 
+def build_lucene_query(args):
+    return ' '.join('%s:(%s)' % (item, escape_lucene_query(value))
+                    for item, value in args.items() if value)
+
+
 def _wrap_xml_metadata(data):
     return ('<?xml version="1.0" encoding="UTF-8"?>'
             '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#">%s</metadata>'
@@ -162,12 +167,7 @@ class MBAPIHelper(APIHelper):
                 query = escape_lucene_query(kwargs["query"]).strip().lower()
                 filters.append(("dismax", 'true'))
         else:
-            query = []
-            for name, value in kwargs.items():
-                value = escape_lucene_query(value).strip().lower()
-                if value:
-                    query.append('%s:(%s)' % (name, value))
-            query = ' '.join(query)
+            query = build_lucene_query(kwargs)
 
         if query:
             filters.append(("query", query))

--- a/test/test_api_helpers.py
+++ b/test/test_api_helpers.py
@@ -33,6 +33,8 @@ from picard.webservice.api_helpers import (
     AcoustIdAPIHelper,
     APIHelper,
     MBAPIHelper,
+    build_lucene_query,
+    escape_lucene_query,
 )
 
 
@@ -302,3 +304,21 @@ class AcoustdIdAPITest(PicardTestCase):
             'duration.3': '500000',
         }
         self.assertEqual(result, expected)
+
+
+class LuceneHelpersTest(PicardTestCase):
+
+    def test_escape_lucene_query(self):
+        self.assertEqual('', escape_lucene_query(''))
+        self.assertEqual(
+            '\\+\\-\\&\\|\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\/',
+            escape_lucene_query('+-&|!(){}[]^"~*?:\\/'))
+
+    def test_build_lucene_query(self):
+        args = {
+            'title': 'test',
+            'artist': 'foo:bar',
+            'tnum': '3'
+        }
+        query = build_lucene_query(args)
+        self.assertEqual('title:(test) artist:(foo\\:bar) tnum:(3)', query)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


Refactor `AlbumSearchDialog.show_similar_albums`  and  `TrackSearchDialog.show_similar_tracks()` 

# Solution

- De-duplicate code
- Reuse existing `search` method
- Set the dialog to have forced advanced search. Previously the search would initially be performed as an advanced search, but if the user had simple search active the search string was filled as only a simple title search. That meant if the user hit the search button there would be different results. In forced mode the dialog uses advanced search independent of user settings (and does also not alter user settings)
- Removed duplicated code by introducing `build_lucene_query`
- Added tests for API helpers `build_lucene_query` and `escape_lucene_query`
