### PR TITLE
PICARD-2415: Show other release versions in search dialog

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -145,9 +145,7 @@ class FileLookup(object):
             QtCore.QObject.tagger.load_nat(id)
             return True
         elif entity == 'release-group':
-            dialog = AlbumSearchDialog(QtCore.QObject.tagger.window, force_advanced_search=True)
-            dialog.search("rgid:{0}".format(id))
-            dialog.exec_()
+            AlbumSearchDialog.show_releasegroup_search(id)
             return True
         elif entity == 'cdtoc':
             disc = Disc(id=id)

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -351,7 +351,7 @@ def countries_from_node(node):
         country_code = _country_from_release_event(release_event)
         if country_code:
             countries.append(country_code)
-    return countries
+    return sorted(countries)
 
 
 def release_dates_and_countries_from_node(node):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -91,7 +91,6 @@ from picard.ui.collectionmenu import CollectionMenu
 from picard.ui.colors import interface_colors
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
-from picard.ui.searchdialog.album import AlbumSearchDialog
 from picard.ui.widgets.tristatesortheaderview import TristateSortHeaderView
 
 
@@ -545,7 +544,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             loading = releases_menu.addAction(_('Loading...'))
             loading.setDisabled(True)
             action_more = releases_menu.addAction(_('Show &more details...'))
-            action_more.triggered.connect(partial(AlbumSearchDialog.show_releasegroup_search, obj.release_group.id, obj))
+            action_more.triggered.connect(self.window.album_other_versions_action.trigger)
             bottom_separator = True
 
             if len(self.selectedItems()) == 1 and obj.release_group:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -91,6 +91,7 @@ from picard.ui.collectionmenu import CollectionMenu
 from picard.ui.colors import interface_colors
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
+from picard.ui.searchdialog.album import AlbumSearchDialog
 from picard.ui.widgets.tristatesortheaderview import TristateSortHeaderView
 
 
@@ -543,11 +544,14 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             menu.addMenu(releases_menu)
             loading = releases_menu.addAction(_('Loading...'))
             loading.setDisabled(True)
+            action_more = releases_menu.addAction(_('Show &more details...'))
+            action_more.triggered.connect(partial(AlbumSearchDialog.show_releasegroup_search, obj.release_group.id, obj))
             bottom_separator = True
 
             if len(self.selectedItems()) == 1 and obj.release_group:
                 def _add_other_versions():
                     releases_menu.removeAction(loading)
+                    releases_menu.removeAction(action_more)
                     heading = releases_menu.addAction(obj.release_group.version_headings)
                     heading.setDisabled(True)
                     font = heading.font()
@@ -594,6 +598,9 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                     versions_count = len(versions)
                     if versions_count > 1:
                         releases_menu.setTitle(_("&Other versions (%d)") % versions_count)
+
+                    releases_menu.addSeparator()
+                    action = releases_menu.addAction(action_more)
                 if obj.release_group.loaded:
                     _add_other_versions()
                 else:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -668,6 +668,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.track_search_action = action
 
     @MainWindowActions.add()
+    def _create_album_other_versions_action(self):
+        action = QtWidgets.QAction(_("Show &other album versions..."), self)
+        action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+O")))
+        action.triggered.connect(self.show_album_other_versions)
+        self.album_other_versions_action = action
+
+    @MainWindowActions.add()
     def _create_show_file_browser_action(self):
         config = get_config()
         action = QtWidgets.QAction(_("File &Browser"), self)
@@ -1016,6 +1023,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         menu.addAction(self.cluster_action)
         menu.addAction(self.browser_lookup_action)
         menu.addAction(self.track_search_action)
+        menu.addAction(self.album_other_versions_action)
         menu.addSeparator()
         menu.addAction(self.generate_fingerprints_action)
         menu.addAction(self.tags_from_filenames_action)
@@ -1389,6 +1397,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         dialog.show_similar_albums(obj)
         dialog.exec_()
 
+    def show_album_other_versions(self):
+        obj = self.get_first_obj_with_type(Album)
+        if obj and obj.release_group:
+            AlbumSearchDialog.show_releasegroup_search(obj.release_group.id, obj)
+
     def view_info(self, default_tab=0):
         try:
             selected = self.selected_objects[0]
@@ -1474,6 +1487,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         can_view_info = bool(single and single.can_view_info())
         can_browser_lookup = bool(single and single.can_browser_lookup())
         is_file = bool(single and isinstance(single, (File, Track)))
+        is_album = bool(single and isinstance(single, Album))
 
         if not self.selected_objects:
             have_objects = have_files = False
@@ -1525,6 +1539,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         files = self.get_selected_or_unmatched_files()
         self.tags_from_filenames_action.setEnabled(bool(files))
         self.track_search_action.setEnabled(is_file)
+        self.album_other_versions_action.setEnabled(is_album)
 
     def update_selection(self, objects=None, new_selection=True, drop_album_caches=False):
         if self.ignore_selection_changes:

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -45,6 +45,7 @@ from picard.util import (
 )
 
 from picard.ui import PicardDialog
+from picard.ui.theme import theme
 
 
 class ResultTable(QtWidgets.QTableWidget):
@@ -169,10 +170,17 @@ class TableBasedDialog(PicardDialog):
 
     def highlight_row(self, row):
         model = self.table.model()
-        highlight_color = QtGui.QBrush(QtGui.QColor('LightYellow'))
+        highlight_color = QtGui.QColor('LightYellow')
+        if theme.is_dark_theme:
+            highlight_color.setHsv(
+                highlight_color.hue(),
+                highlight_color.saturation(),
+                int(highlight_color.lightness() * .6),
+                highlight_color.alpha())
+        highlight_brush = QtGui.QBrush(highlight_color)
         for column in range(0, model.columnCount()):
             index = model.index(row, column)
-            model.setData(index, highlight_color, QtCore.Qt.ItemDataRole.BackgroundRole)
+            model.setData(index, highlight_brush, QtCore.Qt.ItemDataRole.BackgroundRole)
 
     def prepare_table(self):
         self.table.prepare(self.table_headers)

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -31,6 +31,7 @@ from collections import OrderedDict
 
 from PyQt5 import (
     QtCore,
+    QtGui,
     QtWidgets,
 )
 from PyQt5.QtCore import pyqtSignal
@@ -165,6 +166,13 @@ class TableBasedDialog(PicardDialog):
         def enable_accept_button():
             self.accept_button.setEnabled(True)
         self.table.itemSelectionChanged.connect(enable_accept_button)
+
+    def highlight_row(self, row):
+        model = self.table.model()
+        highlight_color = QtGui.QBrush(QtGui.QColor('LightYellow'))
+        for column in range(0, model.columnCount()):
+            index = model.index(row, column)
+            model.setData(index, highlight_color, QtCore.Qt.ItemDataRole.BackgroundRole)
 
     def prepare_table(self):
         self.table.prepare(self.table_headers)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -142,10 +142,7 @@ class BrowserLookupTest(PicardTestCase):
         url = 'https://musicbrainz.org/release-group/168615bf-f841-49f7-ac98-36a4eb25479c'
         result = self.lookup.mbid_lookup(url)
         self.assertTrue(result)
-        mock_dialog.assert_called_once_with(mock_tagger.window, force_advanced_search=True)
-        instance = mock_dialog.return_value
-        instance.search.assert_called_once_with('rgid:168615bf-f841-49f7-ac98-36a4eb25479c')
-        instance.exec_.assert_called_once()
+        mock_dialog.show_releasegroup_search.assert_called_once_with('168615bf-f841-49f7-ac98-36a4eb25479c')
 
     def test_mbid_lookup_browser_fallback(self):
         mbid = '4836aa50-a9ae-490a-983b-cfc8efca92de'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2415
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is something I wanted to add for a long time: Add the ability to open the "Other versions selection" in a dialog. This allows for better comparison and allows showing much more information without being restricted by the limitations of a menu. It also allows adding a keyboard shortcut for this


# Solution

- Have a dedicated action to open a album search dialog to show and select other versions of an album
- Inside the dialog also show the currently selected album, but highlight it
- Keep the "Other versions" submenu, but add an entry "Show more details..." to open the dialog

I have kept the submenu, as this keeps the functionality of quickly switching between different versions, so users used to this don't loose anything. But users looking for more details or preferring using a keyboard shortcut to open the selection can now do so.

Also this is a fully featured search dialog, hence users can actually refine their search and choose even something completely different to switch to.