### PR TITLE
PICARD-2465: Fixed potential recursion error when loading many releases

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -711,11 +711,11 @@ class Album(DataObject, Item):
             threshold = config.setting['track_matching_threshold']
             moves = self._match_files(files, self.tracks, self.unmatched_files, threshold=threshold)
             with self.tagger.window.metadata_box.ignore_updates:
-                for file, target in process_events_iter(moves):
+                for file, target in moves:
                     file.move(target)
         else:
             with self.tagger.window.metadata_box.ignore_updates:
-                for file in process_events_iter(list(files)):
+                for file in list(files):
                     file.move(self.unmatched_files)
 
     def can_save(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2465
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->


process_events_iter can cause unintended side effects. When loading many releases in parallel this can cause recursion depths errors.

This partially reverts changes done for PICARD-2454.