### PR TITLE
PICARD-2474: Revert "PICARD-2420: Fix AcoustID submission getting enabled for files with fingerprint in tags"

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -274,7 +274,7 @@ class File(QtCore.QObject, Item):
         if not config.setting["ignore_existing_acoustid_fingerprints"]:
             fingerprints = self.metadata.getall('acoustid_fingerprint')
             if fingerprints:
-                self.set_acoustid_fingerprint(fingerprints[0], recordingid=self.metadata['musicbrainz_recordingid'])
+                self.set_acoustid_fingerprint(fingerprints[0])
         run_file_post_load_processors(self)
         self.update()
         callback(self)
@@ -649,7 +649,7 @@ class File(QtCore.QObject, Item):
             self.parent = parent
             self.acoustid_update()
 
-    def set_acoustid_fingerprint(self, fingerprint, length=None, recordingid=None):
+    def set_acoustid_fingerprint(self, fingerprint, length=None):
         if not fingerprint:
             self.acoustid_fingerprint = None
             self.acoustid_length = 0
@@ -657,7 +657,7 @@ class File(QtCore.QObject, Item):
         elif fingerprint != self.acoustid_fingerprint:
             self.acoustid_fingerprint = fingerprint
             self.acoustid_length = length or self.metadata.length // 1000
-            self.tagger.acoustidmanager.add(self, recordingid)
+            self.tagger.acoustidmanager.add(self, None)
             self.acoustid_update()
         config = get_config()
         if config.setting['save_acoustid_fingerprints']:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2474
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The changes in [PICARD-2420](https://tickets.metabrainz.org/browse/PICARD-2420) / #2081 actually break the use were users have the AcoustID fingerprint in file tags that already also have been assigned MBIDs, but then want to use Picard to submit them

The assumption in PICARD-2420  was that this case would indicate the fingerprints have likely already been submitted, but this assumption is wrong. See discussion at

See https://community.metabrainz.org/t/picard-2-8-release-candidate/583657/2

# Solution
This reverts commit 40877f6e227a348ffba05c2154d5e8abbeed1466.