### PR TITLE
PICARD-2475: Fix "Lookup in browser" in search dialogs

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -169,8 +169,8 @@ class FileLookup(object):
     def collection_lookup(self, userid):
         return self._build_launch('/user/%s/collections' % userid)
 
-    def search_entity(self, type_, query, adv=False, mbid_matched_callback=None):
-        if self.mbid_lookup(query, type_, mbid_matched_callback=mbid_matched_callback):
+    def search_entity(self, type_, query, adv=False, mbid_matched_callback=None, force_browser=False):
+        if not force_browser and self.mbid_lookup(query, type_, mbid_matched_callback=mbid_matched_callback):
             return True
         params = {
             'limit': QUERY_LIMIT,

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -656,7 +656,9 @@ class Tagger(QtWidgets.QApplication):
                 dialog.search(text)
                 dialog.exec_()
         else:
-            lookup.search_entity(search['entity'], text, adv, mbid_matched_callback=mbid_matched_callback)
+            lookup.search_entity(search['entity'], text, adv,
+                                 mbid_matched_callback=mbid_matched_callback,
+                                 force_browser=force_browser)
 
     def collection_lookup(self):
         """Lookup the users collections on the MusicBrainz website."""

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -229,3 +229,21 @@ class BrowserLookupTest(PicardTestCase):
             result = self.lookup.search_entity(entity, mbid, mbid_matched_callback=callback)
             self.assertTrue(result)
             mock_lookup.assert_called_once_with(mbid, entity, mbid_matched_callback=callback)
+
+    @patch.object(webbrowser2, 'open')
+    def test_search_entity_mbid_lookup_force_browser(self, mock_open):
+        with patch.object(self.lookup, 'mbid_lookup') as mock_lookup:
+            entity = 'artist'
+            mbid = '4836aa50-a9ae-490a-983b-cfc8efca92de'
+            callback = Mock()
+            result = self.lookup.search_entity(entity, mbid, mbid_matched_callback=callback, force_browser=True)
+            self.assertTrue(result)
+            mock_lookup.assert_not_called()
+            url = mock_open.call_args[0][0]
+            query_args = {
+                'type': entity,
+                'query': mbid,
+                'limit': '25',
+                'tport': '8000',
+            }
+            self.assert_mb_url_matches(url, '/search/textsearch', query_args)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2475
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->


If the search in the dialog contained a MBID, the "Lookup in browser" button would attempt to load this MBID as album / recording instead of opening the browser.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
 `Tagger.search`   did call `FileLookup.search_entity`, but did not pass the `force_browser`  parameter. Because `FileLookup.search_entity` can again decide to handle the search inside Picard (e.g. loading release or opening a dialog) this could fail and ignore the original intention to force search in browser.