### PR TITLE
PICARD-2472: Cluster only unclustered files

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -331,11 +331,11 @@ class UnclusteredFiles(Cluster):
 
     def add_files(self, files, new_album=True):
         super().add_files(files, new_album=new_album)
-        self.tagger.window.enable_cluster(self.get_num_files() > 0)
+        self.tagger.window.enable_cluster(bool(self.files))
 
     def remove_file(self, file, new_album=True):
         super().remove_file(file, new_album=new_album)
-        self.tagger.window.enable_cluster(self.get_num_files() > 0)
+        self.tagger.window.enable_cluster(bool(self.files))
 
     def lookup_metadata(self):
         self.tagger.autotag(self.files)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -921,7 +921,10 @@ class Tagger(QtWidgets.QApplication):
     def cluster(self, objs, callback=None):
         """Group files with similar metadata to 'clusters'."""
         log.debug("Clustering %r", objs)
-        files = iter_files_from_objects(objs)
+        files = (
+            f for f in iter_files_from_objects(objs)
+            if f.parent == self.unclustered_files
+        )
         try:
             file = next(files)
         except StopIteration:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2472
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Clustering will apply to files selected in the right pane, which is rather unexpected. It should only apply to unclustered files. Furthermore the cluster action only is activated if there is at least one unclustered file, so only under this condition the user can also apply it to matched files.

# Solution
Limit clustering to unclustered files

@zas can you test this and see if this meets your expected behavior?