### PR TITLE
Removed unused process_events_iter from Album._match_files

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -83,7 +83,6 @@ from picard.util import (
     find_best_match,
     format_time,
     mbid_validate,
-    process_events_iter,
 )
 from picard.util.imagelist import (
     add_metadata_images,
@@ -636,16 +635,8 @@ class Album(DataObject, Item):
             remove_metadata_images(self, [file])
 
     @staticmethod
-    def _match_files(files, tracks, unmatched_files, threshold=0, use_events_iter=False):
+    def _match_files(files, tracks, unmatched_files, threshold=0):
         """Match files to tracks on this album, based on metadata similarity or recordingid."""
-        if use_events_iter:
-            #  TODO: get rid of this completely at some point
-            events_iter = process_events_iter
-        else:
-            def _events_iter(seq):
-                return seq
-            events_iter = _events_iter
-
         tracks_cache = defaultdict(lambda: None)
 
         def build_tracks_cache():
@@ -696,7 +687,7 @@ class Album(DataObject, Item):
 
             # try to match by similarity
             def similarity_candidates():
-                for track in events_iter(tracks):
+                for track in tracks:
                     similarity = track.metadata.compare(file.orig_metadata)
                     if similarity >= threshold:
                         yield SimMatchAlbum(similarity=similarity, track=track)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
No call to Album._match_files is using use_events_iter anymore.
