### PR TITLE
Build releases with PyJWT 2.4.0

### DIFF
--- a/requirements-macos-10.12.txt
+++ b/requirements-macos-10.12.txt
@@ -3,7 +3,7 @@ discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.6
 mutagen==1.45.1
-PyJWT==2.3.0
+PyJWT==2.4.0
 pyobjc-core==8.1
 pyobjc-framework-Cocoa==8.1
 PyQt5==5.13.1

--- a/requirements-macos-10.14.txt
+++ b/requirements-macos-10.14.txt
@@ -3,7 +3,7 @@ discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.6
 mutagen==1.45.1
-PyJWT==2.3.0
+PyJWT==2.4.0
 pyobjc-core==8.1
 pyobjc-framework-Cocoa==8.1
 PyQt5==5.15.6

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -3,7 +3,7 @@ discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.4
 mutagen==1.45.1
-PyJWT==2.3.0
+PyJWT==2.4.0
 PyQt5==5.15.6
 pywin32==303
 pyyaml==6.0


### PR DESCRIPTION
Update builds to PyJWT 2.4, mainly to address the CVE in https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-4-0

It's worth noting that Picard is even without this patch not affected by this issue, as it explicitly sets the algorithm.

Tested locally.