### PR TITLE
PICARD-2486: Add text-based comparison script functions

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -688,6 +688,7 @@ def _cmp(op, x, y, _type):
         _type = 'auto'
     _typer = None
     if _type == 'auto':
+        _type = 'text'
         for _test_type in [int, float]:
             try:
                 _type = (_test_type(x), _test_type(y))
@@ -695,8 +696,6 @@ def _cmp(op, x, y, _type):
                 break
             except ValueError:
                 pass
-        if _type == 'auto':
-            _type = 'text'
     if _type == 'text':
         return "1" if op(x, y) else ""
     elif _type == 'nocase':
@@ -1566,6 +1565,7 @@ def _type_args(_type, *args):
         _type = 'auto'
     _typer = None
     if _type == 'auto':
+        _type = 'text'
         for _test_type in [int, float]:
             try:
                 _type = set(_test_type(item) for item in haystack)
@@ -1573,8 +1573,6 @@ def _type_args(_type, *args):
                 break
             except ValueError:
                 pass
-        if _type == 'auto':
-            _type = 'text'
     _typer = None
     if _type == 'int':
         _typer = int

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1517,3 +1517,71 @@ def func_cleanmulti(parser, multi):
     values = [str(value) for value in parser.context.getall(name) if value or value == 0]
     parser.context[multi] = values
     return ""
+
+
+@script_function(documentation=N_(
+    """$textlt(x, y)
+
+Returns true if `x` is less than `y` using a text comparison.
+
+_Since Picard 3.0_"""
+))
+def func_textlt(parser, x, y):
+    return "1" if x < y else ""
+
+
+@script_function(documentation=N_(
+    """$textlte(x, y)
+
+Returns true if `x` is less than or equal to `y` using a text comparison.
+
+_Since Picard 3.0_"""
+))
+def func_textlte(parser, x, y):
+    return "" if x > y else "1"
+
+
+@script_function(documentation=N_(
+    """$textgt(x, y)
+
+Returns true if `x` is greater than `y` using a text comparison.
+
+_Since Picard 3.0_"""
+))
+def func_textgt(parser, x, y):
+    return "1" if x > y else ""
+
+
+@script_function(documentation=N_(
+    """$textgte(x, y)
+
+Returns true if `x` is greater than or equal to `y` using a text comparison.
+
+_Since Picard 3.0_"""
+))
+def func_textgte(parser, x, y):
+    return "" if x < y else "1"
+
+
+@script_function(documentation=N_(
+    """$textmin(x,...)
+
+Returns the minimum value using a text comparison.
+Can be used with an arbitrary number of arguments.
+
+_Since Picard 3.0_"""
+))
+def func_textmin(parser, x, *args):
+    return min((*args, x))
+
+
+@script_function(documentation=N_(
+    """$textmax(x,...)
+
+Returns the maximum value using a text comparison.
+Can be used with an arbitrary number of arguments.
+
+_Since Picard 3.0_"""
+))
+def func_textmax(parser, x, *args):
+    return max((*args, x))

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1560,7 +1560,7 @@ def _type_args(_type, *args):
     haystack = set()
     # Automatically expand multi-value arguments
     for item in args:
-        haystack = haystack.union(set(x for x in item.split('; ')))
+        haystack = haystack.union(set(x for x in item.split(MULTI_VALUED_JOINER)))
     if not _type:
         _type = 'auto'
     _typer = None

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -681,70 +681,110 @@ def func_ne(parser, x, y):
 
 
 @script_function(documentation=N_(
-    """`$lt(x,y[,text])`
+    """`$lt(x,y[,type])`
 
-Returns true if `x` is less than `y`.
-Values `x` and `y` are treated as integers unless `text` is set."""
+Returns true if `x` is less than `y` using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text), with "int" used as the default comparison method
+if `type` is not specified."""
 ))
-def func_lt(parser, x, y, text=None):
-    if text:
+def func_lt(parser, x, y, _type=None):
+    if not _type:
+        _type = 'int'
+    _typer = None
+    if _type == 'text':
         return "1" if x < y else ""
-    try:
-        if int(x) < int(y):
-            return "1"
-    except ValueError:
-        pass
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'int':
+        _typer = int
+    if _typer is not None:
+        try:
+            if _typer(x) < _typer(y):
+                return "1"
+        except ValueError:
+            pass
     return ""
 
 
 @script_function(documentation=N_(
-    """`$lte(x,y[,text])`
+    """`$lte(x,y[,type])`
 
-Returns true if `x` is less than or equal to `y`.
-Values `x` and `y` are treated as integers unless `text` is set."""
+Returns true if `x` is less than or equal to `y` using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text), with "int" used as the default comparison method
+if `type` is not specified."""
 ))
-def func_lte(parser, x, y, text=None):
-    if text:
+def func_lte(parser, x, y, _type=None):
+    if not _type:
+        _type = 'int'
+    _typer = None
+    if _type == 'text':
         return "" if x > y else "1"
-    try:
-        if int(x) <= int(y):
-            return "1"
-    except ValueError:
-        pass
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'int':
+        _typer = int
+    if _typer is not None:
+        try:
+            if _typer(x) <= _typer(y):
+                return "1"
+        except ValueError:
+            pass
     return ""
 
 
 @script_function(documentation=N_(
-    """`$gt(x,y[,text])`
+    """`$gt(x,y[,type])`
 
-Returns true if `x` is greater than `y`.
-Values `x` and `y` are treated as integers unless `text` is set."""
+Returns true if `x` is greater than `y` using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text), with "int" used as the default comparison method
+if `type` is not specified."""
 ))
-def func_gt(parser, x, y, text=None):
-    if text:
+def func_gt(parser, x, y, _type=None):
+    if not _type:
+        _type = 'int'
+    _typer = None
+    if _type == 'text':
         return "1" if x > y else ""
-    try:
-        if int(x) > int(y):
-            return "1"
-    except ValueError:
-        pass
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'int':
+        _typer = int
+    if _typer is not None:
+        try:
+            if _typer(x) > _typer(y):
+                return "1"
+        except ValueError:
+            pass
     return ""
 
 
 @script_function(documentation=N_(
-    """`$gte(x,y[,text])`
+    """`$gte(x,y[,type])`
 
-Returns true if `x` is greater than or equal to `y`.
-Values `x` and `y` are treated as integers unless `text` is set."""
+Returns true if `x` is greater than or equal to `y` using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text), with "int" used as the default comparison method
+if `type` is not specified."""
 ))
-def func_gte(parser, x, y, text=None):
-    if text:
+def func_gte(parser, x, y, _type=None):
+    if not _type:
+        _type = 'int'
+    _typer = None
+    if _type == 'text':
         return "" if x < y else "1"
-    try:
-        if int(x) >= int(y):
-            return "1"
-    except ValueError:
-        pass
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'int':
+        _typer = int
+    if _typer is not None:
+        try:
+            if _typer(x) >= _typer(y):
+                return "1"
+        except ValueError:
+            pass
     return ""
 
 
@@ -1532,24 +1572,62 @@ def func_cleanmulti(parser, multi):
 
 
 @script_function(documentation=N_(
-    """$textmin(x,...)
+    """$min(type,x,...)
 
-Returns the minimum value using a text comparison.
+Returns the minimum value using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text).
+
 Can be used with an arbitrary number of arguments.
 
 _Since Picard 3.0_"""
 ))
-def func_textmin(parser, x, *args):
-    return min((*args, x))
+def func_min(parser, _type, x, *args):
+    haystack = set((x, *args))
+    _typer = None
+    if _type == 'int':
+        _typer = int
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'text':
+        pass
+    else:
+        # Unknown processing type
+        return ""
+    if _typer is not None:
+        try:
+            haystack = set(_typer(item) for item in haystack)
+        except ValueError:
+            return ""
+    return str(min(haystack))
 
 
 @script_function(documentation=N_(
-    """$textmax(x,...)
+    """$max(type,x,...)
 
-Returns the maximum value using a text comparison.
+Returns the maximum value using the comparison specified in `type`.
+Possible values of `type` are "int" (integer), "float" (floating point) and
+"text" (case-sensitive text).
+
 Can be used with an arbitrary number of arguments.
 
 _Since Picard 3.0_"""
 ))
-def func_textmax(parser, x, *args):
-    return max((*args, x))
+def func_max(parser, _type, x, *args):
+    haystack = set((x, *args))
+    _typer = None
+    if _type == 'int':
+        _typer = int
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'text':
+        pass
+    else:
+        # Unknown processing type
+        return ""
+    if _typer is not None:
+        try:
+            haystack = set(_typer(item) for item in haystack)
+        except ValueError:
+            return ""
+    return str(max(haystack))

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -681,11 +681,14 @@ def func_ne(parser, x, y):
 
 
 @script_function(documentation=N_(
-    """`$lt(x,y)`
+    """`$lt(x,y[,text])`
 
-Returns true if `x` is less than `y`."""
+Returns true if `x` is less than `y`.
+Values `x` and `y` are treated as integers unless `text` is set."""
 ))
-def func_lt(parser, x, y):
+def func_lt(parser, x, y, text=None):
+    if text:
+        return "1" if x < y else ""
     try:
         if int(x) < int(y):
             return "1"
@@ -695,11 +698,14 @@ def func_lt(parser, x, y):
 
 
 @script_function(documentation=N_(
-    """`$lte(x,y)`
+    """`$lte(x,y[,text])`
 
-Returns true if `x` is less than or equal to `y`."""
+Returns true if `x` is less than or equal to `y`.
+Values `x` and `y` are treated as integers unless `text` is set."""
 ))
-def func_lte(parser, x, y):
+def func_lte(parser, x, y, text=None):
+    if text:
+        return "" if x > y else "1"
     try:
         if int(x) <= int(y):
             return "1"
@@ -709,11 +715,14 @@ def func_lte(parser, x, y):
 
 
 @script_function(documentation=N_(
-    """`$gt(x,y)`
+    """`$gt(x,y[,text])`
 
-Returns true if `x` is greater than `y`."""
+Returns true if `x` is greater than `y`.
+Values `x` and `y` are treated as integers unless `text` is set."""
 ))
-def func_gt(parser, x, y):
+def func_gt(parser, x, y, text=None):
+    if text:
+        return "1" if x > y else ""
     try:
         if int(x) > int(y):
             return "1"
@@ -723,11 +732,14 @@ def func_gt(parser, x, y):
 
 
 @script_function(documentation=N_(
-    """`$gte(x,y)`
+    """`$gte(x,y[,text])`
 
-Returns true if `x` is greater than or equal to `y`."""
+Returns true if `x` is greater than or equal to `y`.
+Values `x` and `y` are treated as integers unless `text` is set."""
 ))
-def func_gte(parser, x, y):
+def func_gte(parser, x, y, text=None):
+    if text:
+        return "" if x < y else "1"
     try:
         if int(x) >= int(y):
             return "1"
@@ -1517,50 +1529,6 @@ def func_cleanmulti(parser, multi):
     values = [str(value) for value in parser.context.getall(name) if value or value == 0]
     parser.context[multi] = values
     return ""
-
-
-@script_function(documentation=N_(
-    """$textlt(x, y)
-
-Returns true if `x` is less than `y` using a text comparison.
-
-_Since Picard 3.0_"""
-))
-def func_textlt(parser, x, y):
-    return "1" if x < y else ""
-
-
-@script_function(documentation=N_(
-    """$textlte(x, y)
-
-Returns true if `x` is less than or equal to `y` using a text comparison.
-
-_Since Picard 3.0_"""
-))
-def func_textlte(parser, x, y):
-    return "" if x > y else "1"
-
-
-@script_function(documentation=N_(
-    """$textgt(x, y)
-
-Returns true if `x` is greater than `y` using a text comparison.
-
-_Since Picard 3.0_"""
-))
-def func_textgt(parser, x, y):
-    return "1" if x > y else ""
-
-
-@script_function(documentation=N_(
-    """$textgte(x, y)
-
-Returns true if `x` is greater than or equal to `y` using a text comparison.
-
-_Since Picard 3.0_"""
-))
-def func_textgte(parser, x, y):
-    return "" if x < y else "1"
 
 
 @script_function(documentation=N_(

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -684,9 +684,9 @@ def func_ne(parser, x, y):
     """`$lt(x,y[,type])`
 
 Returns true if `x` is less than `y` using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point) and
-"text" (case-sensitive text), with "int" used as the default comparison method
-if `type` is not specified."""
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
+the default comparison method if `type` is not specified."""
 ))
 def func_lt(parser, x, y, _type=None):
     if not _type:
@@ -694,6 +694,8 @@ def func_lt(parser, x, y, _type=None):
     _typer = None
     if _type == 'text':
         return "1" if x < y else ""
+    elif _type == 'nocase':
+        return "1" if x.lower() < y.lower() else ""
     elif _type == 'float':
         _typer = float
     elif _type == 'int':
@@ -711,9 +713,9 @@ def func_lt(parser, x, y, _type=None):
     """`$lte(x,y[,type])`
 
 Returns true if `x` is less than or equal to `y` using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point) and
-"text" (case-sensitive text), with "int" used as the default comparison method
-if `type` is not specified."""
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
+the default comparison method if `type` is not specified."""
 ))
 def func_lte(parser, x, y, _type=None):
     if not _type:
@@ -721,6 +723,8 @@ def func_lte(parser, x, y, _type=None):
     _typer = None
     if _type == 'text':
         return "" if x > y else "1"
+    elif _type == 'nocase':
+        return "" if x.lower() > y.lower() else "1"
     elif _type == 'float':
         _typer = float
     elif _type == 'int':
@@ -738,9 +742,9 @@ def func_lte(parser, x, y, _type=None):
     """`$gt(x,y[,type])`
 
 Returns true if `x` is greater than `y` using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point) and
-"text" (case-sensitive text), with "int" used as the default comparison method
-if `type` is not specified."""
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
+the default comparison method if `type` is not specified."""
 ))
 def func_gt(parser, x, y, _type=None):
     if not _type:
@@ -748,6 +752,8 @@ def func_gt(parser, x, y, _type=None):
     _typer = None
     if _type == 'text':
         return "1" if x > y else ""
+    elif _type == 'nocase':
+        return "1" if x.lower() > y.lower() else ""
     elif _type == 'float':
         _typer = float
     elif _type == 'int':
@@ -765,9 +771,9 @@ def func_gt(parser, x, y, _type=None):
     """`$gte(x,y[,type])`
 
 Returns true if `x` is greater than or equal to `y` using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point) and
-"text" (case-sensitive text), with "int" used as the default comparison method
-if `type` is not specified."""
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
+the default comparison method if `type` is not specified."""
 ))
 def func_gte(parser, x, y, _type=None):
     if not _type:
@@ -775,6 +781,8 @@ def func_gte(parser, x, y, _type=None):
     _typer = None
     if _type == 'text':
         return "" if x < y else "1"
+    elif _type == 'nocase':
+        return "" if x.lower() < y.lower() else "1"
     elif _type == 'float':
         _typer = float
     elif _type == 'int':

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -689,7 +689,7 @@ def _cmp(op, x, y, _type):
     _typer = None
     if _type == 'auto':
         _type = 'text'
-        for _test_type in [int, float]:
+        for _test_type in (int, float):
             try:
                 _type = (_test_type(x), _test_type(y))
                 _type = _test_type.__name__
@@ -1566,7 +1566,7 @@ def _type_args(_type, *args):
     _typer = None
     if _type == 'auto':
         _type = 'text'
-        for _test_type in [int, float]:
+        for _test_type in (int, float):
             try:
                 _type = set(_test_type(item) for item in haystack)
                 _type = _test_type.__name__

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1535,6 +1535,30 @@ def func_cleanmulti(parser, multi):
     return ""
 
 
+def _type_args(_type, *args):
+    haystack = set((args))
+    _typer = None
+    if _type == 'int':
+        _typer = int
+    elif _type == 'float':
+        _typer = float
+    elif _type == 'text':
+        pass
+    else:
+        # Unknown processing type
+        raise ValueError
+    if _typer is not None:
+        haystack = set(_typer(item) for item in haystack)
+    return haystack
+
+
+def _extract(_func, _type, *args):
+    try:
+        return str(_func(_type_args(_type, *args)))
+    except ValueError:
+        return ""
+
+
 @script_function(documentation=N_(
     """$min(type,x,...)
 
@@ -1547,23 +1571,7 @@ Can be used with an arbitrary number of arguments.
 _Since Picard 3.0_"""
 ))
 def func_min(parser, _type, x, *args):
-    haystack = set((x, *args))
-    _typer = None
-    if _type == 'int':
-        _typer = int
-    elif _type == 'float':
-        _typer = float
-    elif _type == 'text':
-        pass
-    else:
-        # Unknown processing type
-        return ""
-    if _typer is not None:
-        try:
-            haystack = set(_typer(item) for item in haystack)
-        except ValueError:
-            return ""
-    return str(min(haystack))
+    return _extract(min, _type, x, *args)
 
 
 @script_function(documentation=N_(
@@ -1578,20 +1586,4 @@ Can be used with an arbitrary number of arguments.
 _Since Picard 3.0_"""
 ))
 def func_max(parser, _type, x, *args):
-    haystack = set((x, *args))
-    _typer = None
-    if _type == 'int':
-        _typer = int
-    elif _type == 'float':
-        _typer = float
-    elif _type == 'text':
-        pass
-    else:
-        # Unknown processing type
-        return ""
-    if _typer is not None:
-        try:
-            haystack = set(_typer(item) for item in haystack)
-        except ValueError:
-            return ""
-    return str(max(haystack))
+    return _extract(max, _type, x, *args)

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -685,8 +685,18 @@ def _cmp(op, x, y, _type):
        op is expected to be a method from operator module
     """
     if not _type:
-        _type = 'int'
+        _type = 'auto'
     _typer = None
+    if _type == 'auto':
+        for _test_type in [int, float]:
+            try:
+                _type = (_test_type(x), _test_type(y))
+                _type = _test_type.__name__
+                break
+            except ValueError:
+                pass
+        if _type == 'auto':
+            _type = 'text'
     if _type == 'text':
         return "1" if op(x, y) else ""
     elif _type == 'nocase':
@@ -709,8 +719,11 @@ def _cmp(op, x, y, _type):
 
 Returns true if `x` is less than `y` using the comparison specified in `type`.
 Possible values of `type` are "int" (integer), "float" (floating point), "text"
-(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
-the default comparison method if `type` is not specified."""
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text"."""
 ))
 def func_lt(parser, x, y, _type=None):
     return _cmp(operator.lt, x, y, _type)
@@ -721,8 +734,11 @@ def func_lt(parser, x, y, _type=None):
 
 Returns true if `x` is less than or equal to `y` using the comparison specified in `type`.
 Possible values of `type` are "int" (integer), "float" (floating point), "text"
-(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
-the default comparison method if `type` is not specified."""
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text"."""
 ))
 def func_lte(parser, x, y, _type=None):
     return _cmp(operator.le, x, y, _type)
@@ -733,8 +749,11 @@ def func_lte(parser, x, y, _type=None):
 
 Returns true if `x` is greater than `y` using the comparison specified in `type`.
 Possible values of `type` are "int" (integer), "float" (floating point), "text"
-(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
-the default comparison method if `type` is not specified."""
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text"."""
 ))
 def func_gt(parser, x, y, _type=None):
     return _cmp(operator.gt, x, y, _type)
@@ -745,8 +764,11 @@ def func_gt(parser, x, y, _type=None):
 
 Returns true if `x` is greater than or equal to `y` using the comparison specified in `type`.
 Possible values of `type` are "int" (integer), "float" (floating point), "text"
-(case-sensitive text) and "nocase" (case-insensitive text), with "int" used as
-the default comparison method if `type` is not specified."""
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text"."""
 ))
 def func_gte(parser, x, y, _type=None):
     return _cmp(operator.ge, x, y, _type)
@@ -1540,12 +1562,25 @@ def _type_args(_type, *args):
     # Automatically expand multi-value arguments
     for item in args:
         haystack = haystack.union(set(x for x in item.split('; ')))
+    if not _type:
+        _type = 'auto'
+    _typer = None
+    if _type == 'auto':
+        for _test_type in [int, float]:
+            try:
+                _type = set(_test_type(item) for item in haystack)
+                _type = _test_type.__name__
+                break
+            except ValueError:
+                pass
+        if _type == 'auto':
+            _type = 'text'
     _typer = None
     if _type == 'int':
         _typer = int
     elif _type == 'float':
         _typer = float
-    elif _type in ('text', 'ncase'):
+    elif _type in ('text', 'nocase'):
         pass
     else:
         # Unknown processing type
@@ -1561,7 +1596,7 @@ def _extract(_func, _type, *args):
     except ValueError:
         return ""
 
-    if _type == 'ncase':
+    if _type == 'nocase':
         op = operator.lt if _func == min else operator.gt
         val = None
         for item in haystack:
@@ -1576,8 +1611,13 @@ def _extract(_func, _type, *args):
     """$min(type,x,...)
 
 Returns the minimum value using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point),
-"text" (case-sensitive text) and "ncase" (case-insensitive text).
+
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text".
 
 Can be used with an arbitrary number of arguments.  Multi-value arguments
 will be expanded automatically.
@@ -1592,8 +1632,13 @@ def func_min(parser, _type, x, *args):
     """$max(type,x,...)
 
 Returns the maximum value using the comparison specified in `type`.
-Possible values of `type` are "int" (integer), "float" (floating point),
-"text" (case-sensitive text) and "ncase" (case-insensitive text).
+
+Possible values of `type` are "int" (integer), "float" (floating point), "text"
+(case-sensitive text), "nocase" (case-insensitive text) and "auto" (automatically
+determine the type of arguments provided), with "auto" used as the default
+comparison method if `type` is not specified.  The "auto" type will use the
+first type that applies to both arguments in the following order of preference:
+"int", "float" and "text".
 
 Can be used with an arbitrary number of arguments.  Multi-value arguments
 will be expanded automatically.

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -2242,13 +2242,27 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$min(float,2,3)", "2.0", context)
         self.assertScriptResultEquals("$min(float,2,1,3)", "1.0", context)
         self.assertScriptResultEquals("$min(float,2,1.1,3)", "1.1", context)
+        self.assertScriptResultEquals("$min(float,1.11,1.1,1.111)", "1.1", context)
         self.assertScriptResultEquals("$min(float,2,1,a)", "", context)
         self.assertScriptResultEquals("$min(float,2,,1)", "", context)
         self.assertScriptResultEquals("$min(float,2,1,)", "", context)
 
-        # Test case sensitive arguments
+        # Test 'ncase' processing
+        self.assertScriptResultEquals("$min(ncase,a,B)", "a", context)
+        self.assertScriptResultEquals("$min(ncase,c,A,b)", "A", context)
+
+        # Test case sensitive arguments with 'text' processing
         self.assertScriptResultEquals("$min(text,A,a)", "A", context)
         self.assertScriptResultEquals("$min(text,a,B)", "B", context)
+
+        # Test multi-value arguments
+        context['mv'] = ['y', 'z', 'x']
+        self.assertScriptResultEquals("$min(text,%mv%)", "x", context)
+        self.assertScriptResultEquals("$min(text,y; z; x)", "x", context)
+        self.assertScriptResultEquals("$min(text,a,%mv%)", "a", context)
+        self.assertScriptResultEquals("$min(text,a,y; z; x)", "a", context)
+        self.assertScriptResultEquals("$min(int,5,4; 6; 3)", "3", context)
+        self.assertScriptResultEquals("$min(float,5.9,4.2; 6; 3.35)", "3.35", context)
 
         # Test invalid processing types
         self.assertScriptResultEquals("$min(,A,a)", "", context)
@@ -2297,13 +2311,27 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$max(float,2,3)", "3.0", context)
         self.assertScriptResultEquals("$max(float,2,1.1,3)", "3.0", context)
         self.assertScriptResultEquals("$max(float,2,1,3.1)", "3.1", context)
+        self.assertScriptResultEquals("$max(float,2.1,2.11,2.111)", "2.111", context)
         self.assertScriptResultEquals("$max(float,2,1,a)", "", context)
         self.assertScriptResultEquals("$max(float,2,,1)", "", context)
         self.assertScriptResultEquals("$max(float,2,1,)", "", context)
 
-        # Test case sensitive arguments
+        # Test 'ncase' processing
+        self.assertScriptResultEquals("$max(ncase,a,B)", "B", context)
+        self.assertScriptResultEquals("$max(ncase,c,a,B)", "c", context)
+
+        # Test case sensitive arguments with 'text' processing
         self.assertScriptResultEquals("$max(text,A,a)", "a", context)
         self.assertScriptResultEquals("$max(text,a,B)", "a", context)
+
+        # Test multi-value arguments
+        context['mv'] = ['y', 'z', 'x']
+        self.assertScriptResultEquals("$max(text,%mv%)", "z", context)
+        self.assertScriptResultEquals("$max(text,y; z; x)", "z", context)
+        self.assertScriptResultEquals("$max(text,a,%mv%)", "z", context)
+        self.assertScriptResultEquals("$max(text,a,y; z; x)", "z", context)
+        self.assertScriptResultEquals("$max(int,5,4; 6; 3)", "6", context)
+        self.assertScriptResultEquals("$max(float,5.9,4.2; 6; 3.35)", "6.0", context)
 
         # Test invalid processing types
         self.assertScriptResultEquals("$max(,A,a)", "", context)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -589,8 +589,6 @@ class ScriptParserTest(PicardTestCase):
                 r"$set(bleh,$rsearch(test \(disc 1\),\\\(disc \(\\d+\)\\\)))) $set(wer,1)"))
 
     def test_cmd_gt(self):
-        context = Metadata()
-
         # Test with default processing
         self.assertScriptResultEquals("$gt(10,4)", "1")
         self.assertScriptResultEquals("$gt(6,6)", "")
@@ -621,57 +619,51 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$gt(a,b,float)", "")
 
         # Test date type arguments with "text" processing
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$gt(%foo%,%bar%,text)", "", context)
-        self.assertScriptResultEquals("$gt(%bar%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%baz%,text)", "", context)
-        self.assertScriptResultEquals("$gt(%baz%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$gt(2020-01-01,2020-01-02,text)", "")
+        self.assertScriptResultEquals("$gt(2020-01-02,2020-01-01,text)", "1")
+        self.assertScriptResultEquals("$gt(2020-01-01,2020-02,text)", "")
+        self.assertScriptResultEquals("$gt(2020-02,2020-01-01,text)", "1")
+        self.assertScriptResultEquals("$gt(2020-01-01,2020-01-01,text)", "")
 
         # Test text type arguments with "text" processing
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$gt(%foo%,%bar%,text)", "", context)
-        self.assertScriptResultEquals("$gt(%bar%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%baz%,text)", "", context)
-        self.assertScriptResultEquals("$gt(%baz%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$gt(abc,abcd,text)", "")
+        self.assertScriptResultEquals("$gt(abcd,abc,text)", "1")
+        self.assertScriptResultEquals("$gt(abc,ac,text)", "")
+        self.assertScriptResultEquals("$gt(ac,abc,text)", "1")
+        self.assertScriptResultEquals("$gt(abc,abc,text)", "")
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$gt(,1)", "", context)
-        self.assertScriptResultEquals("$gt(1,)", "1", context)
-        self.assertScriptResultEquals("$gt(,)", "", context)
+        self.assertScriptResultEquals("$gt(,1)", "")
+        self.assertScriptResultEquals("$gt(1,)", "1")
+        self.assertScriptResultEquals("$gt(,)", "")
 
         # Test with empty arguments ("int" processing)
-        self.assertScriptResultEquals("$gt(,1,int)", "", context)
-        self.assertScriptResultEquals("$gt(1,,int)", "", context)
-        self.assertScriptResultEquals("$gt(,,int)", "", context)
+        self.assertScriptResultEquals("$gt(,1,int)", "")
+        self.assertScriptResultEquals("$gt(1,,int)", "")
+        self.assertScriptResultEquals("$gt(,,int)", "")
 
         # Test with empty arguments ("float" processing)
-        self.assertScriptResultEquals("$gt(,1.1,float)", "", context)
-        self.assertScriptResultEquals("$gt(1.1,float)", "", context)
-        self.assertScriptResultEquals("$gt(,,float)", "", context)
+        self.assertScriptResultEquals("$gt(,1.1,float)", "")
+        self.assertScriptResultEquals("$gt(1.1,float)", "")
+        self.assertScriptResultEquals("$gt(,,float)", "")
 
         # Test with empty arguments ("text" processing)
-        self.assertScriptResultEquals("$gt(,a,text)", "", context)
-        self.assertScriptResultEquals("$gt(a,,text)", "1", context)
-        self.assertScriptResultEquals("$gt(,,text)", "", context)
+        self.assertScriptResultEquals("$gt(,a,text)", "")
+        self.assertScriptResultEquals("$gt(a,,text)", "1")
+        self.assertScriptResultEquals("$gt(,,text)", "")
 
         # Test case sensitive arguments ("text" processing)
-        self.assertScriptResultEquals("$gt(A,a,text)", "", context)
-        self.assertScriptResultEquals("$gt(a,A,text)", "1", context)
+        self.assertScriptResultEquals("$gt(A,a,text)", "")
+        self.assertScriptResultEquals("$gt(a,A,text)", "1")
 
         # Test case insensitive arguments ("nocase" processing)
-        self.assertScriptResultEquals("$gt(a,B,nocase)", "", context)
-        self.assertScriptResultEquals("$gt(A,b,nocase)", "", context)
-        self.assertScriptResultEquals("$gt(B,a,nocase)", "1", context)
-        self.assertScriptResultEquals("$gt(b,A,nocase)", "1", context)
+        self.assertScriptResultEquals("$gt(a,B,nocase)", "")
+        self.assertScriptResultEquals("$gt(A,b,nocase)", "")
+        self.assertScriptResultEquals("$gt(B,a,nocase)", "1")
+        self.assertScriptResultEquals("$gt(b,A,nocase)", "1")
 
         # Test unknown processing type
-        self.assertScriptResultEquals("$gt(2,1,unknown)", "", context)
+        self.assertScriptResultEquals("$gt(2,1,unknown)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$gt: Wrong number of arguments for \$gt: Expected between 2 and 3, "
@@ -683,8 +675,6 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$gt(foo,bar,text,)")
 
     def test_cmd_gte(self):
-        context = Metadata()
-
         # Test with default processing
         self.assertScriptResultEquals("$gte(10,9)", "1")
         self.assertScriptResultEquals("$gte(10,10)", "1")
@@ -718,59 +708,53 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$gte(a,b,float)", "")
 
         # Test date type arguments ("text" processing)
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$gte(%foo%,%bar%,text)", "", context)
-        self.assertScriptResultEquals("$gte(%bar%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%baz%,text)", "", context)
-        self.assertScriptResultEquals("$gte(%baz%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(2020-01-01,2020-01-02,text)", "")
+        self.assertScriptResultEquals("$gte(2020-01-02,2020-01-01,text)", "1")
+        self.assertScriptResultEquals("$gte(2020-01-01,2020-02,text)", "")
+        self.assertScriptResultEquals("$gte(2020-02,2020-01-01,text)", "1")
+        self.assertScriptResultEquals("$gte(2020-01-01,2020-01-01,text)", "1")
 
         # Test text type arguments ("text" processing)
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$gte(%foo%,%bar%,text)", "", context)
-        self.assertScriptResultEquals("$gte(%bar%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%baz%,text)", "", context)
-        self.assertScriptResultEquals("$gte(%baz%,%foo%,text)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(abc,abcd,text)", "")
+        self.assertScriptResultEquals("$gte(abcd,abc,text)", "1")
+        self.assertScriptResultEquals("$gte(abc,ac,text)", "")
+        self.assertScriptResultEquals("$gte(ac,abc,text)", "1")
+        self.assertScriptResultEquals("$gte(abc,abc,text)", "1")
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$gte(,1)", "", context)
-        self.assertScriptResultEquals("$gte(1,)", "1", context)
-        self.assertScriptResultEquals("$gte(,)", "1", context)
+        self.assertScriptResultEquals("$gte(,1)", "")
+        self.assertScriptResultEquals("$gte(1,)", "1")
+        self.assertScriptResultEquals("$gte(,)", "1")
 
         # Test with empty arguments ("int" processing)
-        self.assertScriptResultEquals("$gte(,1,int)", "", context)
-        self.assertScriptResultEquals("$gte(1,,int)", "", context)
-        self.assertScriptResultEquals("$gte(,,int)", "", context)
+        self.assertScriptResultEquals("$gte(,1,int)", "")
+        self.assertScriptResultEquals("$gte(1,,int)", "")
+        self.assertScriptResultEquals("$gte(,,int)", "")
 
         # Test with empty arguments ("float" processing)
-        self.assertScriptResultEquals("$gte(,1,float)", "", context)
-        self.assertScriptResultEquals("$gte(1,float)", "", context)
-        self.assertScriptResultEquals("$gte(,,float)", "", context)
+        self.assertScriptResultEquals("$gte(,1,float)", "")
+        self.assertScriptResultEquals("$gte(1,float)", "")
+        self.assertScriptResultEquals("$gte(,,float)", "")
 
         # Test with empty arguments ("text" processing)
-        self.assertScriptResultEquals("$gte(,a,text)", "", context)
-        self.assertScriptResultEquals("$gte(a,,text)", "1", context)
-        self.assertScriptResultEquals("$gte(,,text)", "1", context)
+        self.assertScriptResultEquals("$gte(,a,text)", "")
+        self.assertScriptResultEquals("$gte(a,,text)", "1")
+        self.assertScriptResultEquals("$gte(,,text)", "1")
 
         # Test case sensitive arguments ("text" processing)
-        self.assertScriptResultEquals("$gte(A,a,text)", "", context)
-        self.assertScriptResultEquals("$gte(a,A,text)", "1", context)
+        self.assertScriptResultEquals("$gte(A,a,text)", "")
+        self.assertScriptResultEquals("$gte(a,A,text)", "1")
 
         # Test case insensitive arguments ("nocase" processing)
-        self.assertScriptResultEquals("$gte(a,B,nocase)", "", context)
-        self.assertScriptResultEquals("$gte(A,b,nocase)", "", context)
-        self.assertScriptResultEquals("$gte(B,a,nocase)", "1", context)
-        self.assertScriptResultEquals("$gte(b,A,nocase)", "1", context)
-        self.assertScriptResultEquals("$gte(a,A,nocase)", "1", context)
-        self.assertScriptResultEquals("$gte(A,a,nocase)", "1", context)
+        self.assertScriptResultEquals("$gte(a,B,nocase)", "")
+        self.assertScriptResultEquals("$gte(A,b,nocase)", "")
+        self.assertScriptResultEquals("$gte(B,a,nocase)", "1")
+        self.assertScriptResultEquals("$gte(b,A,nocase)", "1")
+        self.assertScriptResultEquals("$gte(a,A,nocase)", "1")
+        self.assertScriptResultEquals("$gte(A,a,nocase)", "1")
 
         # Test unknown processing type
-        self.assertScriptResultEquals("$gte(2,1,unknown)", "", context)
+        self.assertScriptResultEquals("$gte(2,1,unknown)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$gte: Wrong number of arguments for \$gte: Expected between 2 and 3, "
@@ -782,8 +766,6 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$gte(foo,bar,text,)")
 
     def test_cmd_lt(self):
-        context = Metadata()
-
         # Test with default processing
         self.assertScriptResultEquals("$lt(10,4)", "")
         self.assertScriptResultEquals("$lt(6,6)", "")
@@ -817,57 +799,51 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lt(a,b,float)", "")
 
         # Test date type arguments ("text" processing)
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$lt(%foo%,%bar%,text)", "1", context)
-        self.assertScriptResultEquals("$lt(%bar%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%baz%,text)", "1", context)
-        self.assertScriptResultEquals("$lt(%baz%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(2020-01-01,2020-01-02,text)", "1")
+        self.assertScriptResultEquals("$lt(2020-01-02,2020-01-01,text)", "")
+        self.assertScriptResultEquals("$lt(2020-01-01,2020-02,text)", "1")
+        self.assertScriptResultEquals("$lt(2020-02,2020-01-01,text)", "")
+        self.assertScriptResultEquals("$lt(2020-01-01,2020-01-01,text)", "")
 
         # Test text type arguments ("text" processing)
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$lt(%foo%,%bar%,text)", "1", context)
-        self.assertScriptResultEquals("$lt(%bar%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%baz%,text)", "1", context)
-        self.assertScriptResultEquals("$lt(%baz%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(abc,abcd,text)", "1")
+        self.assertScriptResultEquals("$lt(abcd,abc,text)", "")
+        self.assertScriptResultEquals("$lt(abc,ac,text)", "1")
+        self.assertScriptResultEquals("$lt(ac,abc,text)", "")
+        self.assertScriptResultEquals("$lt(abc,abc,text)", "")
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$lt(,1)", "1", context)
-        self.assertScriptResultEquals("$lt(1,)", "", context)
-        self.assertScriptResultEquals("$lt(,)", "", context)
+        self.assertScriptResultEquals("$lt(,1)", "1")
+        self.assertScriptResultEquals("$lt(1,)", "")
+        self.assertScriptResultEquals("$lt(,)", "")
 
         # Test with empty arguments ("int" processing)
-        self.assertScriptResultEquals("$lt(,1,int)", "", context)
-        self.assertScriptResultEquals("$lt(1,,int)", "", context)
-        self.assertScriptResultEquals("$lt(,,int)", "", context)
+        self.assertScriptResultEquals("$lt(,1,int)", "")
+        self.assertScriptResultEquals("$lt(1,,int)", "")
+        self.assertScriptResultEquals("$lt(,,int)", "")
 
         # Test with empty arguments ("float" processing)
-        self.assertScriptResultEquals("$lt(,1,float)", "", context)
-        self.assertScriptResultEquals("$lt(1,,float)", "", context)
-        self.assertScriptResultEquals("$lt(,,float)", "", context)
+        self.assertScriptResultEquals("$lt(,1,float)", "")
+        self.assertScriptResultEquals("$lt(1,,float)", "")
+        self.assertScriptResultEquals("$lt(,,float)", "")
 
         # Test with empty arguments ("text" processing)
-        self.assertScriptResultEquals("$lt(,a,text)", "1", context)
-        self.assertScriptResultEquals("$lt(a,,text)", "", context)
-        self.assertScriptResultEquals("$lt(,,text)", "", context)
+        self.assertScriptResultEquals("$lt(,a,text)", "1")
+        self.assertScriptResultEquals("$lt(a,,text)", "")
+        self.assertScriptResultEquals("$lt(,,text)", "")
 
         # Test case sensitive arguments ("text" processing)
-        self.assertScriptResultEquals("$lt(A,a,text)", "1", context)
-        self.assertScriptResultEquals("$lt(a,A,text)", "", context)
+        self.assertScriptResultEquals("$lt(A,a,text)", "1")
+        self.assertScriptResultEquals("$lt(a,A,text)", "")
 
         # Test case insensitive arguments ("nocase" processing)
-        self.assertScriptResultEquals("$lt(a,B,nocase)", "1", context)
-        self.assertScriptResultEquals("$lt(A,b,nocase)", "1", context)
-        self.assertScriptResultEquals("$lt(B,a,nocase)", "", context)
-        self.assertScriptResultEquals("$lt(b,A,nocase)", "", context)
+        self.assertScriptResultEquals("$lt(a,B,nocase)", "1")
+        self.assertScriptResultEquals("$lt(A,b,nocase)", "1")
+        self.assertScriptResultEquals("$lt(B,a,nocase)", "")
+        self.assertScriptResultEquals("$lt(b,A,nocase)", "")
 
         # Test unknown processing type
-        self.assertScriptResultEquals("$lt(1,2,unknown)", "", context)
+        self.assertScriptResultEquals("$lt(1,2,unknown)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$lt: Wrong number of arguments for \$lt: Expected between 2 and 3, "
@@ -879,8 +855,6 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$lt(foo,bar,text,)")
 
     def test_cmd_lte(self):
-        context = Metadata()
-
         # Test with default processing
         self.assertScriptResultEquals("$lte(10,4)", "")
         self.assertScriptResultEquals("$lte(6,6)", "1")
@@ -913,59 +887,53 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lte(a,b,float)", "")
 
         # Test date type arguments ("text" processing)
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$lte(%foo%,%bar%,text)", "1", context)
-        self.assertScriptResultEquals("$lte(%bar%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%baz%,text)", "1", context)
-        self.assertScriptResultEquals("$lte(%baz%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(2020-01-01,2020-01-02,text)", "1")
+        self.assertScriptResultEquals("$lte(2020-01-02,2020-01-01,text)", "")
+        self.assertScriptResultEquals("$lte(2020-01-01,2020-02,text)", "1")
+        self.assertScriptResultEquals("$lte(2020-02,2020-01-01,text)", "")
+        self.assertScriptResultEquals("$lte(2020-01-01,2020-01-01,text)", "1")
 
         # Test text type arguments ("text" processing)
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$lte(%foo%,%bar%,text)", "1", context)
-        self.assertScriptResultEquals("$lte(%bar%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%baz%,text)", "1", context)
-        self.assertScriptResultEquals("$lte(%baz%,%foo%,text)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(abc,abcd,text)", "1")
+        self.assertScriptResultEquals("$lte(abcd,abc,text)", "")
+        self.assertScriptResultEquals("$lte(abc,ac,text)", "1")
+        self.assertScriptResultEquals("$lte(ac,abc,text)", "")
+        self.assertScriptResultEquals("$lte(abc,abc,text)", "1")
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$lte(,1)", "1", context)
-        self.assertScriptResultEquals("$lte(1,)", "", context)
-        self.assertScriptResultEquals("$lte(,)", "1", context)
+        self.assertScriptResultEquals("$lte(,1)", "1")
+        self.assertScriptResultEquals("$lte(1,)", "")
+        self.assertScriptResultEquals("$lte(,)", "1")
 
         # Test with empty arguments ("int" processing)
-        self.assertScriptResultEquals("$lte(,1,int)", "", context)
-        self.assertScriptResultEquals("$lte(1,,int)", "", context)
-        self.assertScriptResultEquals("$lte(,,int)", "", context)
+        self.assertScriptResultEquals("$lte(,1,int)", "")
+        self.assertScriptResultEquals("$lte(1,,int)", "")
+        self.assertScriptResultEquals("$lte(,,int)", "")
 
         # Test with empty arguments ("float" processing)
-        self.assertScriptResultEquals("$lte(,1,float)", "", context)
-        self.assertScriptResultEquals("$lte(1,,float)", "", context)
-        self.assertScriptResultEquals("$lte(,,float)", "", context)
+        self.assertScriptResultEquals("$lte(,1,float)", "")
+        self.assertScriptResultEquals("$lte(1,,float)", "")
+        self.assertScriptResultEquals("$lte(,,float)", "")
 
         # Test with empty arguments ("text" processing)
-        self.assertScriptResultEquals("$lte(,a,text)", "1", context)
-        self.assertScriptResultEquals("$lte(a,,text)", "", context)
-        self.assertScriptResultEquals("$lte(,,text)", "1", context)
+        self.assertScriptResultEquals("$lte(,a,text)", "1")
+        self.assertScriptResultEquals("$lte(a,,text)", "")
+        self.assertScriptResultEquals("$lte(,,text)", "1")
 
         # Test case sensitive arguments ("text" processing)
-        self.assertScriptResultEquals("$lte(A,a,text)", "1", context)
-        self.assertScriptResultEquals("$lte(a,A,text)", "", context)
+        self.assertScriptResultEquals("$lte(A,a,text)", "1")
+        self.assertScriptResultEquals("$lte(a,A,text)", "")
 
         # Test case insensitive arguments ("nocase" processing)
-        self.assertScriptResultEquals("$lte(a,B,nocase)", "1", context)
-        self.assertScriptResultEquals("$lte(A,b,nocase)", "1", context)
-        self.assertScriptResultEquals("$lte(B,a,nocase)", "", context)
-        self.assertScriptResultEquals("$lte(b,A,nocase)", "", context)
-        self.assertScriptResultEquals("$lte(a,A,nocase)", "1", context)
-        self.assertScriptResultEquals("$lte(A,a,nocase)", "1", context)
+        self.assertScriptResultEquals("$lte(a,B,nocase)", "1")
+        self.assertScriptResultEquals("$lte(A,b,nocase)", "1")
+        self.assertScriptResultEquals("$lte(B,a,nocase)", "")
+        self.assertScriptResultEquals("$lte(b,A,nocase)", "")
+        self.assertScriptResultEquals("$lte(a,A,nocase)", "1")
+        self.assertScriptResultEquals("$lte(A,a,nocase)", "1")
 
         # Test unknown processing type
-        self.assertScriptResultEquals("$lte(1,2,unknown)", "", context)
+        self.assertScriptResultEquals("$lte(1,2,unknown)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$lte: Wrong number of arguments for \$lte: Expected between 2 and 3, "
@@ -2235,75 +2203,74 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$cleanmulti(foo,)")
 
     def test_cmd_min(self):
-        context = Metadata()
-
         # Test "text" processing
-        self.assertScriptResultEquals("$min(text,abc)", "abc", context)
-        self.assertScriptResultEquals("$min(text,abc,abcd,ac)", "abc", context)
-        self.assertScriptResultEquals("$min(text,ac,abcd,abc)", "abc", context)
-        self.assertScriptResultEquals("$min(text,,a)", "", context)
-        self.assertScriptResultEquals("$min(text,a,)", "", context)
-        self.assertScriptResultEquals("$min(text,,)", "", context)
+        self.assertScriptResultEquals("$min(text,abc)", "abc")
+        self.assertScriptResultEquals("$min(text,abc,abcd,ac)", "abc")
+        self.assertScriptResultEquals("$min(text,ac,abcd,abc)", "abc")
+        self.assertScriptResultEquals("$min(text,,a)", "")
+        self.assertScriptResultEquals("$min(text,a,)", "")
+        self.assertScriptResultEquals("$min(text,,)", "")
 
         # Test date type arguments using "text" processing
-        self.assertScriptResultEquals("$min(text,2020-01-01)", "2020-01-01", context)
-        self.assertScriptResultEquals("$min(text,2020-01-01,2020-01-02,2020-02)", "2020-01-01", context)
-        self.assertScriptResultEquals("$min(text,2020-02,2020-01-02,2020-01-01)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,2020-01-01)", "2020-01-01")
+        self.assertScriptResultEquals("$min(text,2020-01-01,2020-01-02,2020-02)", "2020-01-01")
+        self.assertScriptResultEquals("$min(text,2020-02,2020-01-02,2020-01-01)", "2020-01-01")
 
         # Test "int" processing
-        self.assertScriptResultEquals("$min(int,1)", "1", context)
-        self.assertScriptResultEquals("$min(int,2,3)", "2", context)
-        self.assertScriptResultEquals("$min(int,2,1,3)", "1", context)
-        self.assertScriptResultEquals("$min(int,2,1,3.1)", "", context)
-        self.assertScriptResultEquals("$min(int,2,1,a)", "", context)
-        self.assertScriptResultEquals("$min(int,2,,1)", "", context)
-        self.assertScriptResultEquals("$min(int,2,1,)", "", context)
+        self.assertScriptResultEquals("$min(int,1)", "1")
+        self.assertScriptResultEquals("$min(int,2,3)", "2")
+        self.assertScriptResultEquals("$min(int,2,1,3)", "1")
+        self.assertScriptResultEquals("$min(int,2,1,3.1)", "")
+        self.assertScriptResultEquals("$min(int,2,1,a)", "")
+        self.assertScriptResultEquals("$min(int,2,,1)", "")
+        self.assertScriptResultEquals("$min(int,2,1,)", "")
 
         # Test "float" processing
-        self.assertScriptResultEquals("$min(float,1)", "1.0", context)
-        self.assertScriptResultEquals("$min(float,2,3)", "2.0", context)
-        self.assertScriptResultEquals("$min(float,2,1,3)", "1.0", context)
-        self.assertScriptResultEquals("$min(float,2,1.1,3)", "1.1", context)
-        self.assertScriptResultEquals("$min(float,1.11,1.1,1.111)", "1.1", context)
-        self.assertScriptResultEquals("$min(float,2,1,a)", "", context)
-        self.assertScriptResultEquals("$min(float,2,,1)", "", context)
-        self.assertScriptResultEquals("$min(float,2,1,)", "", context)
+        self.assertScriptResultEquals("$min(float,1)", "1.0")
+        self.assertScriptResultEquals("$min(float,2,3)", "2.0")
+        self.assertScriptResultEquals("$min(float,2,1,3)", "1.0")
+        self.assertScriptResultEquals("$min(float,2,1.1,3)", "1.1")
+        self.assertScriptResultEquals("$min(float,1.11,1.1,1.111)", "1.1")
+        self.assertScriptResultEquals("$min(float,2,1,a)", "")
+        self.assertScriptResultEquals("$min(float,2,,1)", "")
+        self.assertScriptResultEquals("$min(float,2,1,)", "")
 
         # Test 'nocase' processing
-        self.assertScriptResultEquals("$min(nocase,a,B)", "a", context)
-        self.assertScriptResultEquals("$min(nocase,c,A,b)", "A", context)
+        self.assertScriptResultEquals("$min(nocase,a,B)", "a")
+        self.assertScriptResultEquals("$min(nocase,c,A,b)", "A")
 
         # Test case sensitive arguments with 'text' processing
-        self.assertScriptResultEquals("$min(text,A,a)", "A", context)
-        self.assertScriptResultEquals("$min(text,a,B)", "B", context)
+        self.assertScriptResultEquals("$min(text,A,a)", "A")
+        self.assertScriptResultEquals("$min(text,a,B)", "B")
 
         # Test multi-value arguments
+        context = Metadata()
         context['mv'] = ['y', 'z', 'x']
         self.assertScriptResultEquals("$min(text,%mv%)", "x", context)
-        self.assertScriptResultEquals("$min(text,y; z; x)", "x", context)
         self.assertScriptResultEquals("$min(text,a,%mv%)", "a", context)
-        self.assertScriptResultEquals("$min(text,a,y; z; x)", "a", context)
-        self.assertScriptResultEquals("$min(int,5,4; 6; 3)", "3", context)
-        self.assertScriptResultEquals("$min(float,5.9,4.2; 6; 3.35)", "3.35", context)
+        self.assertScriptResultEquals("$min(text,y; z; x)", "x")
+        self.assertScriptResultEquals("$min(text,a,y; z; x)", "a")
+        self.assertScriptResultEquals("$min(int,5,4; 6; 3)", "3")
+        self.assertScriptResultEquals("$min(float,5.9,4.2; 6; 3.35)", "3.35")
 
         # Test 'auto' processing
-        self.assertScriptResultEquals("$min(,1,2)", "1", context)
-        self.assertScriptResultEquals("$min(,2,1)", "1", context)
-        self.assertScriptResultEquals("$min(auto,1,2)", "1", context)
-        self.assertScriptResultEquals("$min(auto,2,1)", "1", context)
-        self.assertScriptResultEquals("$min(,1,2.1)", "1.0", context)
-        self.assertScriptResultEquals("$min(,2.1,1)", "1.0", context)
-        self.assertScriptResultEquals("$min(auto,1,2.1)", "1.0", context)
-        self.assertScriptResultEquals("$min(auto,2.1,1)", "1.0", context)
-        self.assertScriptResultEquals("$min(,2.1,1,a)", "1", context)
-        self.assertScriptResultEquals("$min(auto,2.1,1,a)", "1", context)
-        self.assertScriptResultEquals("$min(,a,A)", "A", context)
-        self.assertScriptResultEquals("$min(,A,a)", "A", context)
-        self.assertScriptResultEquals("$min(auto,a,A)", "A", context)
-        self.assertScriptResultEquals("$min(auto,A,a)", "A", context)
+        self.assertScriptResultEquals("$min(,1,2)", "1")
+        self.assertScriptResultEquals("$min(,2,1)", "1")
+        self.assertScriptResultEquals("$min(auto,1,2)", "1")
+        self.assertScriptResultEquals("$min(auto,2,1)", "1")
+        self.assertScriptResultEquals("$min(,1,2.1)", "1.0")
+        self.assertScriptResultEquals("$min(,2.1,1)", "1.0")
+        self.assertScriptResultEquals("$min(auto,1,2.1)", "1.0")
+        self.assertScriptResultEquals("$min(auto,2.1,1)", "1.0")
+        self.assertScriptResultEquals("$min(,2.1,1,a)", "1")
+        self.assertScriptResultEquals("$min(auto,2.1,1,a)", "1")
+        self.assertScriptResultEquals("$min(,a,A)", "A")
+        self.assertScriptResultEquals("$min(,A,a)", "A")
+        self.assertScriptResultEquals("$min(auto,a,A)", "A")
+        self.assertScriptResultEquals("$min(auto,A,a)", "A")
 
         # Test invalid processing types
-        self.assertScriptResultEquals("$min(unknown,a,B)", "", context)
+        self.assertScriptResultEquals("$min(unknown,a,B)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$min: Wrong number of arguments for \$min: Expected at least 2, "
@@ -2313,81 +2280,74 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$min(text)")
 
     def test_cmd_max(self):
-        context = Metadata()
-
         # Test "text" processing
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$max(text,%foo%)", "abc", context)
-        self.assertScriptResultEquals("$max(text,%foo%,%bar%,%baz%)", "ac", context)
-        self.assertScriptResultEquals("$max(text,%baz%,%bar%,%foo%)", "ac", context)
-        self.assertScriptResultEquals("$max(text,,a)", "a", context)
-        self.assertScriptResultEquals("$max(text,a,)", "a", context)
-        self.assertScriptResultEquals("$max(text,,)", "", context)
+        self.assertScriptResultEquals("$max(text,abc)", "abc")
+        self.assertScriptResultEquals("$max(text,abc,abcd,ac)", "ac")
+        self.assertScriptResultEquals("$max(text,ac,abcd,abc)", "ac")
+        self.assertScriptResultEquals("$max(text,,a)", "a")
+        self.assertScriptResultEquals("$max(text,a,)", "a")
+        self.assertScriptResultEquals("$max(text,,)", "")
 
         # Test date type arguments using "text" processing
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$max(text,%foo%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$max(text,%foo%,%bar%,%baz%)", "2020-02", context)
-        self.assertScriptResultEquals("$max(text,%baz%,%bar%,%foo%)", "2020-02", context)
+        self.assertScriptResultEquals("$max(text,2020-01-01)", "2020-01-01")
+        self.assertScriptResultEquals("$max(text,2020-01-01,2020-01-02,2020-02)", "2020-02")
+        self.assertScriptResultEquals("$max(text,2020-02,2020-01-02,2020-01-01)", "2020-02")
 
         # Test "int" processing
-        self.assertScriptResultEquals("$max(int,1)", "1", context)
-        self.assertScriptResultEquals("$max(int,2,3)", "3", context)
-        self.assertScriptResultEquals("$max(int,2,1,3)", "3", context)
-        self.assertScriptResultEquals("$max(int,2,1,3.1)", "", context)
-        self.assertScriptResultEquals("$max(int,2,1,a)", "", context)
-        self.assertScriptResultEquals("$max(int,2,,1)", "", context)
-        self.assertScriptResultEquals("$max(int,2,1,)", "", context)
+        self.assertScriptResultEquals("$max(int,1)", "1")
+        self.assertScriptResultEquals("$max(int,2,3)", "3")
+        self.assertScriptResultEquals("$max(int,2,1,3)", "3")
+        self.assertScriptResultEquals("$max(int,2,1,3.1)", "")
+        self.assertScriptResultEquals("$max(int,2,1,a)", "")
+        self.assertScriptResultEquals("$max(int,2,,1)", "")
+        self.assertScriptResultEquals("$max(int,2,1,)", "")
 
         # Test "float" processing
-        self.assertScriptResultEquals("$max(float,1)", "1.0", context)
-        self.assertScriptResultEquals("$max(float,2,3)", "3.0", context)
-        self.assertScriptResultEquals("$max(float,2,1.1,3)", "3.0", context)
-        self.assertScriptResultEquals("$max(float,2,1,3.1)", "3.1", context)
-        self.assertScriptResultEquals("$max(float,2.1,2.11,2.111)", "2.111", context)
-        self.assertScriptResultEquals("$max(float,2,1,a)", "", context)
-        self.assertScriptResultEquals("$max(float,2,,1)", "", context)
-        self.assertScriptResultEquals("$max(float,2,1,)", "", context)
+        self.assertScriptResultEquals("$max(float,1)", "1.0")
+        self.assertScriptResultEquals("$max(float,2,3)", "3.0")
+        self.assertScriptResultEquals("$max(float,2,1.1,3)", "3.0")
+        self.assertScriptResultEquals("$max(float,2,1,3.1)", "3.1")
+        self.assertScriptResultEquals("$max(float,2.1,2.11,2.111)", "2.111")
+        self.assertScriptResultEquals("$max(float,2,1,a)", "")
+        self.assertScriptResultEquals("$max(float,2,,1)", "")
+        self.assertScriptResultEquals("$max(float,2,1,)", "")
 
         # Test 'nocase' processing
-        self.assertScriptResultEquals("$max(nocase,a,B)", "B", context)
-        self.assertScriptResultEquals("$max(nocase,c,a,B)", "c", context)
+        self.assertScriptResultEquals("$max(nocase,a,B)", "B")
+        self.assertScriptResultEquals("$max(nocase,c,a,B)", "c")
 
         # Test case sensitive arguments with 'text' processing
-        self.assertScriptResultEquals("$max(text,A,a)", "a", context)
-        self.assertScriptResultEquals("$max(text,a,B)", "a", context)
+        self.assertScriptResultEquals("$max(text,A,a)", "a")
+        self.assertScriptResultEquals("$max(text,a,B)", "a")
 
         # Test multi-value arguments
+        context = Metadata()
         context['mv'] = ['y', 'z', 'x']
         self.assertScriptResultEquals("$max(text,%mv%)", "z", context)
-        self.assertScriptResultEquals("$max(text,y; z; x)", "z", context)
         self.assertScriptResultEquals("$max(text,a,%mv%)", "z", context)
-        self.assertScriptResultEquals("$max(text,a,y; z; x)", "z", context)
-        self.assertScriptResultEquals("$max(int,5,4; 6; 3)", "6", context)
-        self.assertScriptResultEquals("$max(float,5.9,4.2; 6; 3.35)", "6.0", context)
+        self.assertScriptResultEquals("$max(text,y; z; x)", "z")
+        self.assertScriptResultEquals("$max(text,a,y; z; x)", "z")
+        self.assertScriptResultEquals("$max(int,5,4; 6; 3)", "6")
+        self.assertScriptResultEquals("$max(float,5.9,4.2; 6; 3.35)", "6.0")
 
         # Test 'auto' processing
-        self.assertScriptResultEquals("$max(,1,2)", "2", context)
-        self.assertScriptResultEquals("$max(,2,1)", "2", context)
-        self.assertScriptResultEquals("$max(auto,1,2)", "2", context)
-        self.assertScriptResultEquals("$max(auto,2,1)", "2", context)
-        self.assertScriptResultEquals("$max(,1.1,2)", "2.0", context)
-        self.assertScriptResultEquals("$max(,2,1.1)", "2.0", context)
-        self.assertScriptResultEquals("$max(auto,1.1,2)", "2.0", context)
-        self.assertScriptResultEquals("$max(auto,2,1.1)", "2.0", context)
-        self.assertScriptResultEquals("$max(,2.1,1,a)", "a", context)
-        self.assertScriptResultEquals("$max(auto,2.1,1,a)", "a", context)
-        self.assertScriptResultEquals("$max(,a,A)", "a", context)
-        self.assertScriptResultEquals("$max(,A,a)", "a", context)
-        self.assertScriptResultEquals("$max(auto,a,A)", "a", context)
-        self.assertScriptResultEquals("$max(auto,A,a)", "a", context)
+        self.assertScriptResultEquals("$max(,1,2)", "2")
+        self.assertScriptResultEquals("$max(,2,1)", "2")
+        self.assertScriptResultEquals("$max(auto,1,2)", "2")
+        self.assertScriptResultEquals("$max(auto,2,1)", "2")
+        self.assertScriptResultEquals("$max(,1.1,2)", "2.0")
+        self.assertScriptResultEquals("$max(,2,1.1)", "2.0")
+        self.assertScriptResultEquals("$max(auto,1.1,2)", "2.0")
+        self.assertScriptResultEquals("$max(auto,2,1.1)", "2.0")
+        self.assertScriptResultEquals("$max(,2.1,1,a)", "a")
+        self.assertScriptResultEquals("$max(auto,2.1,1,a)", "a")
+        self.assertScriptResultEquals("$max(,a,A)", "a")
+        self.assertScriptResultEquals("$max(,A,a)", "a")
+        self.assertScriptResultEquals("$max(auto,a,A)", "a")
+        self.assertScriptResultEquals("$max(auto,A,a)", "a")
 
         # Test invalid processing types
-        self.assertScriptResultEquals("$max(unknown,a,B)", "", context)
+        self.assertScriptResultEquals("$max(unknown,a,B)", "")
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$max: Wrong number of arguments for \$max: Expected at least 2, "

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -589,26 +589,216 @@ class ScriptParserTest(PicardTestCase):
                 r"$set(bleh,$rsearch(test \(disc 1\),\\\(disc \(\\d+\)\\\)))) $set(wer,1)"))
 
     def test_cmd_gt(self):
+        context = Metadata()
+
+        # Test with integer values (default processing)
         self.assertScriptResultEquals("$gt(10,4)", "1")
         self.assertScriptResultEquals("$gt(6,4)", "1")
+        self.assertScriptResultEquals("$gt(6,7)", "")
+        self.assertScriptResultEquals("$gt(6,6)", "")
         self.assertScriptResultEquals("$gt(a,b)", "")
 
+        # Test date type arguments (text processing)
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$gt(%foo%,%bar%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%bar%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%baz%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%baz%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%foo%,1)", "", context)
+
+        # Test text type arguments (text processing)
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$gt(%foo%,%bar%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%bar%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%baz%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%baz%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%foo%,1)", "", context)
+
+        # Test with empty arguments (integer processing)
+        self.assertScriptResultEquals("$gt(,1)", "", context)
+        self.assertScriptResultEquals("$gt(1,)", "", context)
+        self.assertScriptResultEquals("$gt(,)", "", context)
+
+        # Test with empty arguments (text processing)
+        self.assertScriptResultEquals("$gt(,a,1)", "", context)
+        self.assertScriptResultEquals("$gt(a,,1)", "1", context)
+        self.assertScriptResultEquals("$gt(,,1)", "", context)
+
+        # Test case sensitive arguments (text processing)
+        self.assertScriptResultEquals("$gt(A,a,1)", "", context)
+        self.assertScriptResultEquals("$gt(a,A,1)", "1", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$gt: Wrong number of arguments for \$gt: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gt()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gt(1)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gt(foo,bar,1,)")
+
     def test_cmd_gte(self):
+        context = Metadata()
+
+        # Test with integer values (default processing)
         self.assertScriptResultEquals("$gte(10,10)", "1")
         self.assertScriptResultEquals("$gte(10,4)", "1")
         self.assertScriptResultEquals("$gte(6,4)", "1")
+        self.assertScriptResultEquals("$gte(6,7)", "")
         self.assertScriptResultEquals("$gte(a,b)", "")
 
+        # Test date type arguments (text processing)
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$gte(%foo%,%bar%,1)", "", context)
+        self.assertScriptResultEquals("$gte(%bar%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%baz%,1)", "", context)
+        self.assertScriptResultEquals("$gte(%baz%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%foo%,1)", "1", context)
+
+        # Test text type arguments (text processing)
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$gte(%foo%,%bar%,1)", "", context)
+        self.assertScriptResultEquals("$gte(%bar%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%baz%,1)", "", context)
+        self.assertScriptResultEquals("$gte(%baz%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%foo%,1)", "1", context)
+
+        # Test with empty arguments (integer processing)
+        self.assertScriptResultEquals("$gte(,1)", "", context)
+        self.assertScriptResultEquals("$gte(1,)", "", context)
+        self.assertScriptResultEquals("$gte(,)", "", context)
+
+        # Test with empty arguments (text processing)
+        self.assertScriptResultEquals("$gte(,a,1)", "", context)
+        self.assertScriptResultEquals("$gte(a,,1)", "1", context)
+        self.assertScriptResultEquals("$gte(,,1)", "1", context)
+
+        # Test case sensitive arguments (text processing)
+        self.assertScriptResultEquals("$gte(A,a,1)", "", context)
+        self.assertScriptResultEquals("$gte(a,A,1)", "1", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$gte: Wrong number of arguments for \$gte: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gte()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gte(1)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$gte(foo,bar,1,)")
+
     def test_cmd_lt(self):
+        context = Metadata()
+
+        # Test with integer values (default processing)
         self.assertScriptResultEquals("$lt(4,10)", "1")
         self.assertScriptResultEquals("$lt(4,6)", "1")
+        self.assertScriptResultEquals("$lt(4,3)", "")
+        self.assertScriptResultEquals("$lt(4,4)", "")
         self.assertScriptResultEquals("$lt(a,b)", "")
 
+        # Test date type arguments (text processing)
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$lt(%foo%,%bar%,1)", "1", context)
+        self.assertScriptResultEquals("$lt(%bar%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%baz%,1)", "1", context)
+        self.assertScriptResultEquals("$lt(%baz%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%foo%,1)", "", context)
+
+        # Test text type arguments (text processing)
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$lt(%foo%,%bar%,1)", "1", context)
+        self.assertScriptResultEquals("$lt(%bar%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%baz%,1)", "1", context)
+        self.assertScriptResultEquals("$lt(%baz%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%foo%,1)", "", context)
+
+        # Test with empty arguments (integer processing)
+        self.assertScriptResultEquals("$lt(,1)", "", context)
+        self.assertScriptResultEquals("$lt(1,)", "", context)
+        self.assertScriptResultEquals("$lt(,)", "", context)
+
+        # Test with empty arguments (text processing)
+        self.assertScriptResultEquals("$lt(,a,1)", "1", context)
+        self.assertScriptResultEquals("$lt(a,,1)", "", context)
+        self.assertScriptResultEquals("$lt(,,1)", "", context)
+
+        # Test case sensitive arguments (text processing)
+        self.assertScriptResultEquals("$lt(A,a,1)", "1", context)
+        self.assertScriptResultEquals("$lt(a,A,1)", "", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$lt: Wrong number of arguments for \$lt: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lt()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lt(1)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lt(foo,bar,1,)")
+
     def test_cmd_lte(self):
+        context = Metadata()
+
+        # Test with integer values (default processing)
         self.assertScriptResultEquals("$lte(10,10)", "1")
         self.assertScriptResultEquals("$lte(4,10)", "1")
         self.assertScriptResultEquals("$lte(4,6)", "1")
+        self.assertScriptResultEquals("$lte(4,3)", "")
         self.assertScriptResultEquals("$lte(a,b)", "")
+
+        # Test date type arguments (text processing)
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$lte(%foo%,%bar%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%bar%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%baz%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%baz%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%foo%,1)", "1", context)
+
+        # Test text type arguments (text processing)
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$lte(%foo%,%bar%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%bar%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%baz%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%baz%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%foo%,1)", "1", context)
+
+        # Test with empty arguments (integer processing)
+        self.assertScriptResultEquals("$lte(,1)", "", context)
+        self.assertScriptResultEquals("$lte(1,)", "", context)
+        self.assertScriptResultEquals("$lte(,)", "", context)
+
+        # Test with empty arguments (text processing)
+        self.assertScriptResultEquals("$lte(,a,1)", "1", context)
+        self.assertScriptResultEquals("$lte(a,,1)", "", context)
+        self.assertScriptResultEquals("$lte(,,1)", "1", context)
+
+        # Test case sensitive arguments (text processing)
+        self.assertScriptResultEquals("$lte(A,a,1)", "1", context)
+        self.assertScriptResultEquals("$lte(a,A,1)", "", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$lte: Wrong number of arguments for \$lte: Expected between 2 and 3, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lte()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lte(1)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$lte(foo,bar,1,)")
 
     def test_cmd_len(self):
         self.assertScriptResultEquals("$len(abcdefg)", "7")
@@ -1867,170 +2057,6 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$cleanmulti()")
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$cleanmulti(foo,)")
-
-    def test_cmd_textlt(self):
-        context = Metadata()
-
-        # Test date type arguments
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textlt(%foo%,%bar%)", "1", context)
-        self.assertScriptResultEquals("$textlt(%bar%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlt(%foo%,%baz%)", "1", context)
-        self.assertScriptResultEquals("$textlt(%baz%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlt(%foo%,%foo%)", "", context)
-
-        # Test text type arguments
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$textlt(%foo%,%bar%)", "1", context)
-        self.assertScriptResultEquals("$textlt(%bar%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlt(%foo%,%baz%)", "1", context)
-        self.assertScriptResultEquals("$textlt(%baz%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlt(%foo%,%foo%)", "", context)
-
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textlt(,a)", "1", context)
-        self.assertScriptResultEquals("$textlt(a,)", "", context)
-        self.assertScriptResultEquals("$textlt(,)", "", context)
-
-        # Test case sensitive arguments
-        self.assertScriptResultEquals("$textlt(A,a)", "1", context)
-        self.assertScriptResultEquals("$textlt(a,A)", "", context)
-
-        # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textlt: Wrong number of arguments for \$textlt: Expected exactly 2, "
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlt()")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlt(foo)")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlt(foo,bar,)")
-
-    def test_cmd_textlte(self):
-        context = Metadata()
-
-        # Test date type arguments
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textlte(%foo%,%bar%)", "1", context)
-        self.assertScriptResultEquals("$textlte(%bar%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlte(%foo%,%baz%)", "1", context)
-        self.assertScriptResultEquals("$textlte(%baz%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlte(%foo%,%foo%)", "1", context)
-
-        # Test text type arguments
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$textlte(%foo%,%bar%)", "1", context)
-        self.assertScriptResultEquals("$textlte(%bar%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlte(%foo%,%baz%)", "1", context)
-        self.assertScriptResultEquals("$textlte(%baz%,%foo%)", "", context)
-        self.assertScriptResultEquals("$textlte(%foo%,%foo%)", "1", context)
-
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textlte(,a)", "1", context)
-        self.assertScriptResultEquals("$textlte(a,)", "", context)
-        self.assertScriptResultEquals("$textlte(,)", "1", context)
-
-        # Test case sensitive arguments
-        self.assertScriptResultEquals("$textlte(A,a)", "1", context)
-        self.assertScriptResultEquals("$textlte(a,A)", "", context)
-
-        # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textlte: Wrong number of arguments for \$textlte: Expected exactly 2, "
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlte()")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlte(foo)")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textlte(foo,bar,)")
-
-    def test_cmd_textgt(self):
-        context = Metadata()
-
-        # Test date type arguments
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textgt(%foo%,%bar%)", "", context)
-        self.assertScriptResultEquals("$textgt(%bar%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgt(%foo%,%baz%)", "", context)
-        self.assertScriptResultEquals("$textgt(%baz%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgt(%foo%,%foo%)", "", context)
-
-        # Test text type arguments
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$textgt(%foo%,%bar%)", "", context)
-        self.assertScriptResultEquals("$textgt(%bar%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgt(%foo%,%baz%)", "", context)
-        self.assertScriptResultEquals("$textgt(%baz%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgt(%foo%,%foo%)", "", context)
-
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textgt(,a)", "", context)
-        self.assertScriptResultEquals("$textgt(a,)", "1", context)
-        self.assertScriptResultEquals("$textgt(,)", "", context)
-
-        # Test case sensitive arguments
-        self.assertScriptResultEquals("$textgt(A,a)", "", context)
-        self.assertScriptResultEquals("$textgt(a,A)", "1", context)
-
-        # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textgt: Wrong number of arguments for \$textgt: Expected exactly 2, "
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgt()")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgt(foo)")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgt(foo,bar,)")
-
-    def test_cmd_textgte(self):
-        context = Metadata()
-
-        # Test date type arguments
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textgte(%foo%,%bar%)", "", context)
-        self.assertScriptResultEquals("$textgte(%bar%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgte(%foo%,%baz%)", "", context)
-        self.assertScriptResultEquals("$textgte(%baz%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgte(%foo%,%foo%)", "1", context)
-
-        # Test text type arguments
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$textgte(%foo%,%bar%)", "", context)
-        self.assertScriptResultEquals("$textgte(%bar%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgte(%foo%,%baz%)", "", context)
-        self.assertScriptResultEquals("$textgte(%baz%,%foo%)", "1", context)
-        self.assertScriptResultEquals("$textgte(%foo%,%foo%)", "1", context)
-
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textgte(,a)", "", context)
-        self.assertScriptResultEquals("$textgte(a,)", "1", context)
-        self.assertScriptResultEquals("$textgte(,)", "1", context)
-
-        # Test case sensitive arguments
-        self.assertScriptResultEquals("$textgte(A,a)", "", context)
-        self.assertScriptResultEquals("$textgte(a,A)", "1", context)
-
-        # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textgte: Wrong number of arguments for \$textgte: Expected exactly 2, "
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgte()")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgte(foo)")
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textgte(foo,bar,)")
 
     def test_cmd_textmin(self):
         context = Metadata()

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -591,46 +591,75 @@ class ScriptParserTest(PicardTestCase):
     def test_cmd_gt(self):
         context = Metadata()
 
-        # Test with integer values (default processing)
+        # Test with default processing
         self.assertScriptResultEquals("$gt(10,4)", "1")
         self.assertScriptResultEquals("$gt(6,4)", "1")
+        self.assertScriptResultEquals("$gt(6.5,4)", "")
         self.assertScriptResultEquals("$gt(6,7)", "")
         self.assertScriptResultEquals("$gt(6,6)", "")
         self.assertScriptResultEquals("$gt(a,b)", "")
 
-        # Test date type arguments (text processing)
+        # Test with "int" processing
+        self.assertScriptResultEquals("$gt(10,4,int)", "1")
+        self.assertScriptResultEquals("$gt(6,4,int)", "1")
+        self.assertScriptResultEquals("$gt(6.5,4,int)", "")
+        self.assertScriptResultEquals("$gt(6,7,int)", "")
+        self.assertScriptResultEquals("$gt(6,6,int)", "")
+        self.assertScriptResultEquals("$gt(a,b,int)", "")
+
+        # Test with "float" processing
+        self.assertScriptResultEquals("$gt(1.2,1,float)", "1")
+        self.assertScriptResultEquals("$gt(1.2,1.1,float)", "1")
+        self.assertScriptResultEquals("$gt(1.2,1.3,float)", "")
+        self.assertScriptResultEquals("$gt(1.2,1.2,float)", "")
+        self.assertScriptResultEquals("$gt(a,b,float)", "")
+
+        # Test date type arguments with "text" processing
         context["foo"] = "2020-01-01"
         context["bar"] = "2020-01-02"
         context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$gt(%foo%,%bar%,1)", "", context)
-        self.assertScriptResultEquals("$gt(%bar%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%baz%,1)", "", context)
-        self.assertScriptResultEquals("$gt(%baz%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%foo%,%bar%,text)", "", context)
+        self.assertScriptResultEquals("$gt(%bar%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%baz%,text)", "", context)
+        self.assertScriptResultEquals("$gt(%baz%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%foo%,text)", "", context)
 
-        # Test text type arguments (text processing)
+        # Test text type arguments with "text" processing
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$gt(%foo%,%bar%,1)", "", context)
-        self.assertScriptResultEquals("$gt(%bar%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%baz%,1)", "", context)
-        self.assertScriptResultEquals("$gt(%baz%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gt(%foo%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$gt(%foo%,%bar%,text)", "", context)
+        self.assertScriptResultEquals("$gt(%bar%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%baz%,text)", "", context)
+        self.assertScriptResultEquals("$gt(%baz%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gt(%foo%,%foo%,text)", "", context)
 
-        # Test with empty arguments (integer processing)
+        # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$gt(,1)", "", context)
         self.assertScriptResultEquals("$gt(1,)", "", context)
         self.assertScriptResultEquals("$gt(,)", "", context)
 
-        # Test with empty arguments (text processing)
-        self.assertScriptResultEquals("$gt(,a,1)", "", context)
-        self.assertScriptResultEquals("$gt(a,,1)", "1", context)
-        self.assertScriptResultEquals("$gt(,,1)", "", context)
+        # Test with empty arguments ("int" processing)
+        self.assertScriptResultEquals("$gt(,1,int)", "", context)
+        self.assertScriptResultEquals("$gt(1,,int)", "", context)
+        self.assertScriptResultEquals("$gt(,,int)", "", context)
 
-        # Test case sensitive arguments (text processing)
-        self.assertScriptResultEquals("$gt(A,a,1)", "", context)
-        self.assertScriptResultEquals("$gt(a,A,1)", "1", context)
+        # Test with empty arguments ("float" processing)
+        self.assertScriptResultEquals("$gt(,1.1,float)", "", context)
+        self.assertScriptResultEquals("$gt(1.1,float)", "", context)
+        self.assertScriptResultEquals("$gt(,,float)", "", context)
+
+        # Test with empty arguments ("text" processing)
+        self.assertScriptResultEquals("$gt(,a,text)", "", context)
+        self.assertScriptResultEquals("$gt(a,,text)", "1", context)
+        self.assertScriptResultEquals("$gt(,,text)", "", context)
+
+        # Test case sensitive arguments ("text" processing)
+        self.assertScriptResultEquals("$gt(A,a,text)", "", context)
+        self.assertScriptResultEquals("$gt(a,A,text)", "1", context)
+
+        # Test unknown processing type
+        self.assertScriptResultEquals("$gt(2,1,unknown)", "", context)
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$gt: Wrong number of arguments for \$gt: Expected between 2 and 3, "
@@ -639,51 +668,82 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$gt(1)")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$gt(foo,bar,1,)")
+            self.parser.eval("$gt(foo,bar,text,)")
 
     def test_cmd_gte(self):
         context = Metadata()
 
-        # Test with integer values (default processing)
+        # Test with default processing
+        self.assertScriptResultEquals("$gte(10,10.1)", "")
         self.assertScriptResultEquals("$gte(10,10)", "1")
         self.assertScriptResultEquals("$gte(10,4)", "1")
         self.assertScriptResultEquals("$gte(6,4)", "1")
         self.assertScriptResultEquals("$gte(6,7)", "")
         self.assertScriptResultEquals("$gte(a,b)", "")
 
-        # Test date type arguments (text processing)
+        # Test with "int" processing
+        self.assertScriptResultEquals("$gte(10,10.1,int)", "")
+        self.assertScriptResultEquals("$gte(10,10,int)", "1")
+        self.assertScriptResultEquals("$gte(10,4,int)", "1")
+        self.assertScriptResultEquals("$gte(6,4,int)", "1")
+        self.assertScriptResultEquals("$gte(6,7,int)", "")
+        self.assertScriptResultEquals("$gte(a,b,int)", "")
+
+        # Test with "float" processing
+        self.assertScriptResultEquals("$gte(10.2,10.1,float)", "1")
+        self.assertScriptResultEquals("$gte(10.2,10.2,float)", "1")
+        self.assertScriptResultEquals("$gte(6,4,float)", "1")
+        self.assertScriptResultEquals("$gte(10,10.1,float)", "")
+        self.assertScriptResultEquals("$gte(10.2,10.3,float)", "")
+        self.assertScriptResultEquals("$gte(6,7,float)", "")
+        self.assertScriptResultEquals("$gte(a,b,float)", "")
+
+        # Test date type arguments ("text" processing)
         context["foo"] = "2020-01-01"
         context["bar"] = "2020-01-02"
         context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$gte(%foo%,%bar%,1)", "", context)
-        self.assertScriptResultEquals("$gte(%bar%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%baz%,1)", "", context)
-        self.assertScriptResultEquals("$gte(%baz%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%bar%,text)", "", context)
+        self.assertScriptResultEquals("$gte(%bar%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%baz%,text)", "", context)
+        self.assertScriptResultEquals("$gte(%baz%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%foo%,text)", "1", context)
 
-        # Test text type arguments (text processing)
+        # Test text type arguments ("text" processing)
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$gte(%foo%,%bar%,1)", "", context)
-        self.assertScriptResultEquals("$gte(%bar%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%baz%,1)", "", context)
-        self.assertScriptResultEquals("$gte(%baz%,%foo%,1)", "1", context)
-        self.assertScriptResultEquals("$gte(%foo%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%bar%,text)", "", context)
+        self.assertScriptResultEquals("$gte(%bar%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%baz%,text)", "", context)
+        self.assertScriptResultEquals("$gte(%baz%,%foo%,text)", "1", context)
+        self.assertScriptResultEquals("$gte(%foo%,%foo%,text)", "1", context)
 
-        # Test with empty arguments (integer processing)
+        # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$gte(,1)", "", context)
         self.assertScriptResultEquals("$gte(1,)", "", context)
         self.assertScriptResultEquals("$gte(,)", "", context)
 
-        # Test with empty arguments (text processing)
-        self.assertScriptResultEquals("$gte(,a,1)", "", context)
-        self.assertScriptResultEquals("$gte(a,,1)", "1", context)
-        self.assertScriptResultEquals("$gte(,,1)", "1", context)
+        # Test with empty arguments ("int" processing)
+        self.assertScriptResultEquals("$gte(,1,int)", "", context)
+        self.assertScriptResultEquals("$gte(1,,int)", "", context)
+        self.assertScriptResultEquals("$gte(,,int)", "", context)
 
-        # Test case sensitive arguments (text processing)
-        self.assertScriptResultEquals("$gte(A,a,1)", "", context)
-        self.assertScriptResultEquals("$gte(a,A,1)", "1", context)
+        # Test with empty arguments ("float" processing)
+        self.assertScriptResultEquals("$gte(,1,float)", "", context)
+        self.assertScriptResultEquals("$gte(1,float)", "", context)
+        self.assertScriptResultEquals("$gte(,,float)", "", context)
+
+        # Test with empty arguments ("text" processing)
+        self.assertScriptResultEquals("$gte(,a,text)", "", context)
+        self.assertScriptResultEquals("$gte(a,,text)", "1", context)
+        self.assertScriptResultEquals("$gte(,,text)", "1", context)
+
+        # Test case sensitive arguments ("text" processing)
+        self.assertScriptResultEquals("$gte(A,a,text)", "", context)
+        self.assertScriptResultEquals("$gte(a,A,text)", "1", context)
+
+        # Test unknown processing type
+        self.assertScriptResultEquals("$gte(2,1,unknown)", "", context)
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$gte: Wrong number of arguments for \$gte: Expected between 2 and 3, "
@@ -692,51 +752,83 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$gte(1)")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$gte(foo,bar,1,)")
+            self.parser.eval("$gte(foo,bar,text,)")
 
     def test_cmd_lt(self):
         context = Metadata()
 
-        # Test with integer values (default processing)
-        self.assertScriptResultEquals("$lt(4,10)", "1")
+        # Test with default processing
         self.assertScriptResultEquals("$lt(4,6)", "1")
+        self.assertScriptResultEquals("$lt(4,6.1)", "")
         self.assertScriptResultEquals("$lt(4,3)", "")
+        self.assertScriptResultEquals("$lt(4,4.1)", "")
+        self.assertScriptResultEquals("$lt(4.1,4.2)", "")
         self.assertScriptResultEquals("$lt(4,4)", "")
         self.assertScriptResultEquals("$lt(a,b)", "")
 
-        # Test date type arguments (text processing)
+        # Test with "int" processing
+        self.assertScriptResultEquals("$lt(4,6,int)", "1")
+        self.assertScriptResultEquals("$lt(4,6.1,int)", "")
+        self.assertScriptResultEquals("$lt(4,3,int)", "")
+        self.assertScriptResultEquals("$lt(4,4.1,int)", "")
+        self.assertScriptResultEquals("$lt(4.1,4.2,int)", "")
+        self.assertScriptResultEquals("$lt(4,4,int)", "")
+        self.assertScriptResultEquals("$lt(a,b,int)", "")
+
+        # Test with "float" processing
+        self.assertScriptResultEquals("$lt(4,4.1,float)", "1")
+        self.assertScriptResultEquals("$lt(4.1,4.2,float)", "1")
+        self.assertScriptResultEquals("$lt(4,6,float)", "1")
+        self.assertScriptResultEquals("$lt(4.2,4.1,float)", "")
+        self.assertScriptResultEquals("$lt(4.1,4.1,float)", "")
+        self.assertScriptResultEquals("$lt(a,b,float)", "")
+
+        # Test date type arguments ("text" processing)
         context["foo"] = "2020-01-01"
         context["bar"] = "2020-01-02"
         context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$lt(%foo%,%bar%,1)", "1", context)
-        self.assertScriptResultEquals("$lt(%bar%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%baz%,1)", "1", context)
-        self.assertScriptResultEquals("$lt(%baz%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%bar%,text)", "1", context)
+        self.assertScriptResultEquals("$lt(%bar%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%baz%,text)", "1", context)
+        self.assertScriptResultEquals("$lt(%baz%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%foo%,text)", "", context)
 
-        # Test text type arguments (text processing)
+        # Test text type arguments ("text" processing)
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$lt(%foo%,%bar%,1)", "1", context)
-        self.assertScriptResultEquals("$lt(%bar%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%baz%,1)", "1", context)
-        self.assertScriptResultEquals("$lt(%baz%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lt(%foo%,%foo%,1)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%bar%,text)", "1", context)
+        self.assertScriptResultEquals("$lt(%bar%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%baz%,text)", "1", context)
+        self.assertScriptResultEquals("$lt(%baz%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lt(%foo%,%foo%,text)", "", context)
 
-        # Test with empty arguments (integer processing)
+        # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$lt(,1)", "", context)
         self.assertScriptResultEquals("$lt(1,)", "", context)
         self.assertScriptResultEquals("$lt(,)", "", context)
 
-        # Test with empty arguments (text processing)
-        self.assertScriptResultEquals("$lt(,a,1)", "1", context)
-        self.assertScriptResultEquals("$lt(a,,1)", "", context)
-        self.assertScriptResultEquals("$lt(,,1)", "", context)
+        # Test with empty arguments ("int" processing)
+        self.assertScriptResultEquals("$lt(,1,int)", "", context)
+        self.assertScriptResultEquals("$lt(1,,int)", "", context)
+        self.assertScriptResultEquals("$lt(,,int)", "", context)
 
-        # Test case sensitive arguments (text processing)
-        self.assertScriptResultEquals("$lt(A,a,1)", "1", context)
-        self.assertScriptResultEquals("$lt(a,A,1)", "", context)
+        # Test with empty arguments ("float" processing)
+        self.assertScriptResultEquals("$lt(,1,float)", "", context)
+        self.assertScriptResultEquals("$lt(1,,float)", "", context)
+        self.assertScriptResultEquals("$lt(,,float)", "", context)
+
+        # Test with empty arguments ("text" processing)
+        self.assertScriptResultEquals("$lt(,a,text)", "1", context)
+        self.assertScriptResultEquals("$lt(a,,text)", "", context)
+        self.assertScriptResultEquals("$lt(,,text)", "", context)
+
+        # Test case sensitive arguments ("text" processing)
+        self.assertScriptResultEquals("$lt(A,a,text)", "1", context)
+        self.assertScriptResultEquals("$lt(a,A,text)", "", context)
+
+        # Test unknown processing type
+        self.assertScriptResultEquals("$lt(1,2,unknown)", "", context)
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$lt: Wrong number of arguments for \$lt: Expected between 2 and 3, "
@@ -745,51 +837,79 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$lt(1)")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$lt(foo,bar,1,)")
+            self.parser.eval("$lt(foo,bar,text,)")
 
     def test_cmd_lte(self):
         context = Metadata()
 
-        # Test with integer values (default processing)
+        # Test with default processing
         self.assertScriptResultEquals("$lte(10,10)", "1")
+        self.assertScriptResultEquals("$lte(10.1,10.2)", "")
         self.assertScriptResultEquals("$lte(4,10)", "1")
-        self.assertScriptResultEquals("$lte(4,6)", "1")
         self.assertScriptResultEquals("$lte(4,3)", "")
         self.assertScriptResultEquals("$lte(a,b)", "")
 
-        # Test date type arguments (text processing)
+        # Test with "int" processing
+        self.assertScriptResultEquals("$lte(10,10,int)", "1")
+        self.assertScriptResultEquals("$lte(10.1,10.2,int)", "")
+        self.assertScriptResultEquals("$lte(4,10,int)", "1")
+        self.assertScriptResultEquals("$lte(4,3,int)", "")
+        self.assertScriptResultEquals("$lte(a,b,int)", "")
+
+        # Test with "float" processing
+        self.assertScriptResultEquals("$lte(10,10,float)", "1")
+        self.assertScriptResultEquals("$lte(10.1,10.1,float)", "1")
+        self.assertScriptResultEquals("$lte(10.1,10.2,float)", "1")
+        self.assertScriptResultEquals("$lte(10.2,10.1,float)", "")
+        self.assertScriptResultEquals("$lte(4,3,float)", "")
+        self.assertScriptResultEquals("$lte(a,b,float)", "")
+
+        # Test date type arguments ("text" processing)
         context["foo"] = "2020-01-01"
         context["bar"] = "2020-01-02"
         context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$lte(%foo%,%bar%,1)", "1", context)
-        self.assertScriptResultEquals("$lte(%bar%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%baz%,1)", "1", context)
-        self.assertScriptResultEquals("$lte(%baz%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%foo%,%bar%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(%bar%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%baz%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(%baz%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%foo%,text)", "1", context)
 
-        # Test text type arguments (text processing)
+        # Test text type arguments ("text" processing)
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$lte(%foo%,%bar%,1)", "1", context)
-        self.assertScriptResultEquals("$lte(%bar%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%baz%,1)", "1", context)
-        self.assertScriptResultEquals("$lte(%baz%,%foo%,1)", "", context)
-        self.assertScriptResultEquals("$lte(%foo%,%foo%,1)", "1", context)
+        self.assertScriptResultEquals("$lte(%foo%,%bar%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(%bar%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%baz%,text)", "1", context)
+        self.assertScriptResultEquals("$lte(%baz%,%foo%,text)", "", context)
+        self.assertScriptResultEquals("$lte(%foo%,%foo%,text)", "1", context)
 
-        # Test with empty arguments (integer processing)
+        # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$lte(,1)", "", context)
         self.assertScriptResultEquals("$lte(1,)", "", context)
         self.assertScriptResultEquals("$lte(,)", "", context)
 
-        # Test with empty arguments (text processing)
-        self.assertScriptResultEquals("$lte(,a,1)", "1", context)
-        self.assertScriptResultEquals("$lte(a,,1)", "", context)
-        self.assertScriptResultEquals("$lte(,,1)", "1", context)
+        # Test with empty arguments ("int" processing)
+        self.assertScriptResultEquals("$lte(,1,int)", "", context)
+        self.assertScriptResultEquals("$lte(1,,int)", "", context)
+        self.assertScriptResultEquals("$lte(,,int)", "", context)
 
-        # Test case sensitive arguments (text processing)
-        self.assertScriptResultEquals("$lte(A,a,1)", "1", context)
-        self.assertScriptResultEquals("$lte(a,A,1)", "", context)
+        # Test with empty arguments ("float" processing)
+        self.assertScriptResultEquals("$lte(,1,float)", "", context)
+        self.assertScriptResultEquals("$lte(1,,float)", "", context)
+        self.assertScriptResultEquals("$lte(,,float)", "", context)
+
+        # Test with empty arguments ("text" processing)
+        self.assertScriptResultEquals("$lte(,a,text)", "1", context)
+        self.assertScriptResultEquals("$lte(a,,text)", "", context)
+        self.assertScriptResultEquals("$lte(,,text)", "1", context)
+
+        # Test case sensitive arguments ("text" processing)
+        self.assertScriptResultEquals("$lte(A,a,text)", "1", context)
+        self.assertScriptResultEquals("$lte(a,A,text)", "", context)
+
+        # Test unknown processing type
+        self.assertScriptResultEquals("$lte(1,2,unknown)", "", context)
 
         # Tests with invalid number of arguments
         areg = r"^\d+:\d+:\$lte: Wrong number of arguments for \$lte: Expected between 2 and 3, "
@@ -798,7 +918,7 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$lte(1)")
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$lte(foo,bar,1,)")
+            self.parser.eval("$lte(foo,bar,text,)")
 
     def test_cmd_len(self):
         self.assertScriptResultEquals("$len(abcdefg)", "7")
@@ -2058,68 +2178,112 @@ class ScriptParserTest(PicardTestCase):
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$cleanmulti(foo,)")
 
-    def test_cmd_textmin(self):
+    def test_cmd_min(self):
         context = Metadata()
 
-        # Test date type arguments
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textmin(%foo%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$textmin(%foo%,%bar%,%baz%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$textmin(%baz%,%bar%,%foo%)", "2020-01-01", context)
-
-        # Test text type arguments
+        # Test "text" processing
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$textmin(%foo%)", "abc", context)
-        self.assertScriptResultEquals("$textmin(%foo%,%bar%,%baz%)", "abc", context)
-        self.assertScriptResultEquals("$textmin(%baz%,%bar%,%foo%)", "abc", context)
+        self.assertScriptResultEquals("$min(text,%foo%)", "abc", context)
+        self.assertScriptResultEquals("$min(text,%foo%,%bar%,%baz%)", "abc", context)
+        self.assertScriptResultEquals("$min(text,%baz%,%bar%,%foo%)", "abc", context)
+        self.assertScriptResultEquals("$min(text,,a)", "", context)
+        self.assertScriptResultEquals("$min(text,a,)", "", context)
+        self.assertScriptResultEquals("$min(text,,)", "", context)
 
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textmin(,a)", "", context)
-        self.assertScriptResultEquals("$textmin(a,)", "", context)
-        self.assertScriptResultEquals("$textmin(,)", "", context)
-
-        # Test case sensitive arguments
-        self.assertScriptResultEquals("$textmin(A,a)", "A", context)
-        self.assertScriptResultEquals("$textmin(a,B)", "B", context)
-
-        # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textmin: Wrong number of arguments for \$textmin: Expected at least 1, "
-        with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textmin()")
-
-    def test_cmd_textmax(self):
-        context = Metadata()
-
-        # Test date type arguments
+        # Test date type arguments using "text" processing
         context["foo"] = "2020-01-01"
         context["bar"] = "2020-01-02"
         context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$textmax(%foo%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$textmax(%foo%,%bar%,%baz%)", "2020-02", context)
-        self.assertScriptResultEquals("$textmax(%baz%,%bar%,%foo%)", "2020-02", context)
+        self.assertScriptResultEquals("$min(text,%foo%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,%foo%,%bar%,%baz%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,%baz%,%bar%,%foo%)", "2020-01-01", context)
 
-        # Test text type arguments
+        # Test "int" processing
+        self.assertScriptResultEquals("$min(int,1)", "1", context)
+        self.assertScriptResultEquals("$min(int,2,3)", "2", context)
+        self.assertScriptResultEquals("$min(int,2,1,3)", "1", context)
+        self.assertScriptResultEquals("$min(int,2,1,3.1)", "", context)
+        self.assertScriptResultEquals("$min(int,2,1,a)", "", context)
+        self.assertScriptResultEquals("$min(int,2,,1)", "", context)
+        self.assertScriptResultEquals("$min(int,2,1,)", "", context)
+
+        # Test "float" processing
+        self.assertScriptResultEquals("$min(float,1)", "1.0", context)
+        self.assertScriptResultEquals("$min(float,2,3)", "2.0", context)
+        self.assertScriptResultEquals("$min(float,2,1,3)", "1.0", context)
+        self.assertScriptResultEquals("$min(float,2,1.1,3)", "1.1", context)
+        self.assertScriptResultEquals("$min(float,2,1,a)", "", context)
+        self.assertScriptResultEquals("$min(float,2,,1)", "", context)
+        self.assertScriptResultEquals("$min(float,2,1,)", "", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$min(text,A,a)", "A", context)
+        self.assertScriptResultEquals("$min(text,a,B)", "B", context)
+
+        # Test invalid processing types
+        self.assertScriptResultEquals("$min(,A,a)", "", context)
+        self.assertScriptResultEquals("$min(unknown,a,B)", "", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$min: Wrong number of arguments for \$min: Expected at least 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$min()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$min(text)")
+
+    def test_cmd_max(self):
+        context = Metadata()
+
+        # Test "text" processing
         context["foo"] = "abc"
         context["bar"] = "abcd"
         context["baz"] = "ac"
-        self.assertScriptResultEquals("$textmax(%foo%)", "abc", context)
-        self.assertScriptResultEquals("$textmax(%foo%,%bar%,%baz%)", "ac", context)
-        self.assertScriptResultEquals("$textmax(%baz%,%bar%,%foo%)", "ac", context)
+        self.assertScriptResultEquals("$max(text,%foo%)", "abc", context)
+        self.assertScriptResultEquals("$max(text,%foo%,%bar%,%baz%)", "ac", context)
+        self.assertScriptResultEquals("$max(text,%baz%,%bar%,%foo%)", "ac", context)
+        self.assertScriptResultEquals("$max(text,,a)", "a", context)
+        self.assertScriptResultEquals("$max(text,a,)", "a", context)
+        self.assertScriptResultEquals("$max(text,,)", "", context)
 
-        # Test with empty arguments
-        self.assertScriptResultEquals("$textmax(,a)", "a", context)
-        self.assertScriptResultEquals("$textmax(a,)", "a", context)
-        self.assertScriptResultEquals("$textmax(,)", "", context)
+        # Test date type arguments using "text" processing
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$max(text,%foo%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$max(text,%foo%,%bar%,%baz%)", "2020-02", context)
+        self.assertScriptResultEquals("$max(text,%baz%,%bar%,%foo%)", "2020-02", context)
+
+        # Test "int" processing
+        self.assertScriptResultEquals("$max(int,1)", "1", context)
+        self.assertScriptResultEquals("$max(int,2,3)", "3", context)
+        self.assertScriptResultEquals("$max(int,2,1,3)", "3", context)
+        self.assertScriptResultEquals("$max(int,2,1,3.1)", "", context)
+        self.assertScriptResultEquals("$max(int,2,1,a)", "", context)
+        self.assertScriptResultEquals("$max(int,2,,1)", "", context)
+        self.assertScriptResultEquals("$max(int,2,1,)", "", context)
+
+        # Test "float" processing
+        self.assertScriptResultEquals("$max(float,1)", "1.0", context)
+        self.assertScriptResultEquals("$max(float,2,3)", "3.0", context)
+        self.assertScriptResultEquals("$max(float,2,1.1,3)", "3.0", context)
+        self.assertScriptResultEquals("$max(float,2,1,3.1)", "3.1", context)
+        self.assertScriptResultEquals("$max(float,2,1,a)", "", context)
+        self.assertScriptResultEquals("$max(float,2,,1)", "", context)
+        self.assertScriptResultEquals("$max(float,2,1,)", "", context)
 
         # Test case sensitive arguments
-        self.assertScriptResultEquals("$textmax(A,a)", "a", context)
-        self.assertScriptResultEquals("$textmax(a,B)", "a", context)
+        self.assertScriptResultEquals("$max(text,A,a)", "a", context)
+        self.assertScriptResultEquals("$max(text,a,B)", "a", context)
+
+        # Test invalid processing types
+        self.assertScriptResultEquals("$max(,A,a)", "", context)
+        self.assertScriptResultEquals("$max(unknown,a,B)", "", context)
 
         # Tests with invalid number of arguments
-        areg = r"^\d+:\d+:\$textmax: Wrong number of arguments for \$textmax: Expected at least 1, "
+        areg = r"^\d+:\d+:\$max: Wrong number of arguments for \$max: Expected at least 2, "
         with self.assertRaisesRegex(ScriptError, areg):
-            self.parser.eval("$textmax()")
+            self.parser.eval("$max()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$max(text)")

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -593,11 +593,17 @@ class ScriptParserTest(PicardTestCase):
 
         # Test with default processing
         self.assertScriptResultEquals("$gt(10,4)", "1")
-        self.assertScriptResultEquals("$gt(6,4)", "1")
-        self.assertScriptResultEquals("$gt(6.5,4)", "")
-        self.assertScriptResultEquals("$gt(6,7)", "")
         self.assertScriptResultEquals("$gt(6,6)", "")
+        self.assertScriptResultEquals("$gt(6,7)", "")
+        self.assertScriptResultEquals("$gt(6.5,4)", "1")
+        self.assertScriptResultEquals("$gt(6.5,4.5)", "1")
+        self.assertScriptResultEquals("$gt(6.5,6.5)", "")
         self.assertScriptResultEquals("$gt(a,b)", "")
+        self.assertScriptResultEquals("$gt(b,a)", "1")
+        self.assertScriptResultEquals("$gt(a,6)", "1")
+        self.assertScriptResultEquals("$gt(a,6.5)", "1")
+        self.assertScriptResultEquals("$gt(6,a)", "")
+        self.assertScriptResultEquals("$gt(6.5,a)", "")
 
         # Test with "int" processing
         self.assertScriptResultEquals("$gt(10,4,int)", "1")
@@ -636,7 +642,7 @@ class ScriptParserTest(PicardTestCase):
 
         # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$gt(,1)", "", context)
-        self.assertScriptResultEquals("$gt(1,)", "", context)
+        self.assertScriptResultEquals("$gt(1,)", "1", context)
         self.assertScriptResultEquals("$gt(,)", "", context)
 
         # Test with empty arguments ("int" processing)
@@ -680,12 +686,19 @@ class ScriptParserTest(PicardTestCase):
         context = Metadata()
 
         # Test with default processing
-        self.assertScriptResultEquals("$gte(10,10.1)", "")
+        self.assertScriptResultEquals("$gte(10,9)", "1")
         self.assertScriptResultEquals("$gte(10,10)", "1")
-        self.assertScriptResultEquals("$gte(10,4)", "1")
-        self.assertScriptResultEquals("$gte(6,4)", "1")
-        self.assertScriptResultEquals("$gte(6,7)", "")
+        self.assertScriptResultEquals("$gte(10,11)", "")
+        self.assertScriptResultEquals("$gte(10.1,10)", "1")
+        self.assertScriptResultEquals("$gte(10.1,10.1)", "1")
+        self.assertScriptResultEquals("$gte(10.1,10.2)", "")
         self.assertScriptResultEquals("$gte(a,b)", "")
+        self.assertScriptResultEquals("$gte(b,a)", "1")
+        self.assertScriptResultEquals("$gte(a,a)", "1")
+        self.assertScriptResultEquals("$gte(a,6)", "1")
+        self.assertScriptResultEquals("$gte(a,6.5)", "1")
+        self.assertScriptResultEquals("$gte(6,a)", "")
+        self.assertScriptResultEquals("$gte(6.5,a)", "")
 
         # Test with "int" processing
         self.assertScriptResultEquals("$gte(10,10.1,int)", "")
@@ -726,8 +739,8 @@ class ScriptParserTest(PicardTestCase):
 
         # Test with empty arguments (default processing)
         self.assertScriptResultEquals("$gte(,1)", "", context)
-        self.assertScriptResultEquals("$gte(1,)", "", context)
-        self.assertScriptResultEquals("$gte(,)", "", context)
+        self.assertScriptResultEquals("$gte(1,)", "1", context)
+        self.assertScriptResultEquals("$gte(,)", "1", context)
 
         # Test with empty arguments ("int" processing)
         self.assertScriptResultEquals("$gte(,1,int)", "", context)
@@ -772,13 +785,19 @@ class ScriptParserTest(PicardTestCase):
         context = Metadata()
 
         # Test with default processing
-        self.assertScriptResultEquals("$lt(4,6)", "1")
-        self.assertScriptResultEquals("$lt(4,6.1)", "")
-        self.assertScriptResultEquals("$lt(4,3)", "")
-        self.assertScriptResultEquals("$lt(4,4.1)", "")
-        self.assertScriptResultEquals("$lt(4.1,4.2)", "")
-        self.assertScriptResultEquals("$lt(4,4)", "")
-        self.assertScriptResultEquals("$lt(a,b)", "")
+        self.assertScriptResultEquals("$lt(10,4)", "")
+        self.assertScriptResultEquals("$lt(6,6)", "")
+        self.assertScriptResultEquals("$lt(6,7)", "1")
+        self.assertScriptResultEquals("$lt(6.5,4)", "")
+        self.assertScriptResultEquals("$lt(6.5,4.5)", "")
+        self.assertScriptResultEquals("$lt(6.5,6.5)", "")
+        self.assertScriptResultEquals("$lt(6.5,6.6)", "1")
+        self.assertScriptResultEquals("$lt(a,b)", "1")
+        self.assertScriptResultEquals("$lt(b,a)", "")
+        self.assertScriptResultEquals("$lt(a,6)", "")
+        self.assertScriptResultEquals("$lt(a,6.5)", "")
+        self.assertScriptResultEquals("$lt(6,a)", "1")
+        self.assertScriptResultEquals("$lt(6.5,a)", "1")
 
         # Test with "int" processing
         self.assertScriptResultEquals("$lt(4,6,int)", "1")
@@ -818,7 +837,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lt(%foo%,%foo%,text)", "", context)
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$lt(,1)", "", context)
+        self.assertScriptResultEquals("$lt(,1)", "1", context)
         self.assertScriptResultEquals("$lt(1,)", "", context)
         self.assertScriptResultEquals("$lt(,)", "", context)
 
@@ -863,11 +882,20 @@ class ScriptParserTest(PicardTestCase):
         context = Metadata()
 
         # Test with default processing
-        self.assertScriptResultEquals("$lte(10,10)", "1")
-        self.assertScriptResultEquals("$lte(10.1,10.2)", "")
-        self.assertScriptResultEquals("$lte(4,10)", "1")
-        self.assertScriptResultEquals("$lte(4,3)", "")
-        self.assertScriptResultEquals("$lte(a,b)", "")
+        self.assertScriptResultEquals("$lte(10,4)", "")
+        self.assertScriptResultEquals("$lte(6,6)", "1")
+        self.assertScriptResultEquals("$lte(6,7)", "1")
+        self.assertScriptResultEquals("$lte(6.5,4)", "")
+        self.assertScriptResultEquals("$lte(6.5,4.5)", "")
+        self.assertScriptResultEquals("$lte(6.5,6.5)", "1")
+        self.assertScriptResultEquals("$lte(6.5,6.6)", "1")
+        self.assertScriptResultEquals("$lte(a,b)", "1")
+        self.assertScriptResultEquals("$lte(a,a)", "1")
+        self.assertScriptResultEquals("$lte(b,a)", "")
+        self.assertScriptResultEquals("$lte(a,6)", "")
+        self.assertScriptResultEquals("$lte(a,6.5)", "")
+        self.assertScriptResultEquals("$lte(6,a)", "1")
+        self.assertScriptResultEquals("$lte(6.5,a)", "1")
 
         # Test with "int" processing
         self.assertScriptResultEquals("$lte(10,10,int)", "1")
@@ -905,9 +933,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lte(%foo%,%foo%,text)", "1", context)
 
         # Test with empty arguments (default processing)
-        self.assertScriptResultEquals("$lte(,1)", "", context)
+        self.assertScriptResultEquals("$lte(,1)", "1", context)
         self.assertScriptResultEquals("$lte(1,)", "", context)
-        self.assertScriptResultEquals("$lte(,)", "", context)
+        self.assertScriptResultEquals("$lte(,)", "1", context)
 
         # Test with empty arguments ("int" processing)
         self.assertScriptResultEquals("$lte(,1,int)", "", context)
@@ -1600,13 +1628,13 @@ class ScriptParserTest(PicardTestCase):
         loop_output = "Output: 1 2 3 4 5"
         # Tests with context
         context["output"] = "Output:"
-        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,%max_value%),$set(output,%output% %_loop_count%))%output%", loop_output, context)
+        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,%max_value%,int),$set(output,%output% %_loop_count%))%output%", loop_output, context)
         # Tests with static inputs
         context["output"] = "Output:"
-        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,5),$set(output,%output% %_loop_count%))%output%", loop_output, context)
+        self.assertScriptResultEquals("$set(_loop_count,1)$while($lt(%_loop_count%,5,int),$set(output,%output% %_loop_count%))%output%", loop_output, context)
         # Tests with invalid conditional input
         context["output"] = "Output:"
-        self.assertScriptResultEquals("$while($lt(%_loop_count%,5),$set(output,%output% %_loop_count%))%output%", "Output:", context)
+        self.assertScriptResultEquals("$while($lt(%_loop_count%,5,int),$set(output,%output% %_loop_count%))%output%", "Output:", context)
         # Tests with forced conditional (runaway condition)
         context["output"] = "Output:"
         self.assertScriptResultEquals("$while(1,$set(output,%output% %_loop_count%))$right(%output%,4)", "1000", context)
@@ -1614,7 +1642,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$while(0,$set(output,%output% %_loop_count%))$right(%output%,4)", "1000", context)
         # Tests with missing inputs
         context["output"] = "Output:"
-        self.assertScriptResultEquals("$while($lt(%_loop_count%,5),)%output%", "Output:", context)
+        self.assertScriptResultEquals("$while($lt(%_loop_count%,5,int),)%output%", "Output:", context)
         context["output"] = "Output:"
         self.assertScriptResultEquals("$while(,$set(output,%output% %_loop_count%))%output%", "Output:", context)
         # Tests with invalid number of arguments
@@ -2210,23 +2238,17 @@ class ScriptParserTest(PicardTestCase):
         context = Metadata()
 
         # Test "text" processing
-        context["foo"] = "abc"
-        context["bar"] = "abcd"
-        context["baz"] = "ac"
-        self.assertScriptResultEquals("$min(text,%foo%)", "abc", context)
-        self.assertScriptResultEquals("$min(text,%foo%,%bar%,%baz%)", "abc", context)
-        self.assertScriptResultEquals("$min(text,%baz%,%bar%,%foo%)", "abc", context)
+        self.assertScriptResultEquals("$min(text,abc)", "abc", context)
+        self.assertScriptResultEquals("$min(text,abc,abcd,ac)", "abc", context)
+        self.assertScriptResultEquals("$min(text,ac,abcd,abc)", "abc", context)
         self.assertScriptResultEquals("$min(text,,a)", "", context)
         self.assertScriptResultEquals("$min(text,a,)", "", context)
         self.assertScriptResultEquals("$min(text,,)", "", context)
 
         # Test date type arguments using "text" processing
-        context["foo"] = "2020-01-01"
-        context["bar"] = "2020-01-02"
-        context["baz"] = "2020-02"
-        self.assertScriptResultEquals("$min(text,%foo%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$min(text,%foo%,%bar%,%baz%)", "2020-01-01", context)
-        self.assertScriptResultEquals("$min(text,%baz%,%bar%,%foo%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,2020-01-01)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,2020-01-01,2020-01-02,2020-02)", "2020-01-01", context)
+        self.assertScriptResultEquals("$min(text,2020-02,2020-01-02,2020-01-01)", "2020-01-01", context)
 
         # Test "int" processing
         self.assertScriptResultEquals("$min(int,1)", "1", context)
@@ -2247,9 +2269,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$min(float,2,,1)", "", context)
         self.assertScriptResultEquals("$min(float,2,1,)", "", context)
 
-        # Test 'ncase' processing
-        self.assertScriptResultEquals("$min(ncase,a,B)", "a", context)
-        self.assertScriptResultEquals("$min(ncase,c,A,b)", "A", context)
+        # Test 'nocase' processing
+        self.assertScriptResultEquals("$min(nocase,a,B)", "a", context)
+        self.assertScriptResultEquals("$min(nocase,c,A,b)", "A", context)
 
         # Test case sensitive arguments with 'text' processing
         self.assertScriptResultEquals("$min(text,A,a)", "A", context)
@@ -2264,8 +2286,23 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$min(int,5,4; 6; 3)", "3", context)
         self.assertScriptResultEquals("$min(float,5.9,4.2; 6; 3.35)", "3.35", context)
 
+        # Test 'auto' processing
+        self.assertScriptResultEquals("$min(,1,2)", "1", context)
+        self.assertScriptResultEquals("$min(,2,1)", "1", context)
+        self.assertScriptResultEquals("$min(auto,1,2)", "1", context)
+        self.assertScriptResultEquals("$min(auto,2,1)", "1", context)
+        self.assertScriptResultEquals("$min(,1,2.1)", "1.0", context)
+        self.assertScriptResultEquals("$min(,2.1,1)", "1.0", context)
+        self.assertScriptResultEquals("$min(auto,1,2.1)", "1.0", context)
+        self.assertScriptResultEquals("$min(auto,2.1,1)", "1.0", context)
+        self.assertScriptResultEquals("$min(,2.1,1,a)", "1", context)
+        self.assertScriptResultEquals("$min(auto,2.1,1,a)", "1", context)
+        self.assertScriptResultEquals("$min(,a,A)", "A", context)
+        self.assertScriptResultEquals("$min(,A,a)", "A", context)
+        self.assertScriptResultEquals("$min(auto,a,A)", "A", context)
+        self.assertScriptResultEquals("$min(auto,A,a)", "A", context)
+
         # Test invalid processing types
-        self.assertScriptResultEquals("$min(,A,a)", "", context)
         self.assertScriptResultEquals("$min(unknown,a,B)", "", context)
 
         # Tests with invalid number of arguments
@@ -2316,9 +2353,9 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$max(float,2,,1)", "", context)
         self.assertScriptResultEquals("$max(float,2,1,)", "", context)
 
-        # Test 'ncase' processing
-        self.assertScriptResultEquals("$max(ncase,a,B)", "B", context)
-        self.assertScriptResultEquals("$max(ncase,c,a,B)", "c", context)
+        # Test 'nocase' processing
+        self.assertScriptResultEquals("$max(nocase,a,B)", "B", context)
+        self.assertScriptResultEquals("$max(nocase,c,a,B)", "c", context)
 
         # Test case sensitive arguments with 'text' processing
         self.assertScriptResultEquals("$max(text,A,a)", "a", context)
@@ -2333,8 +2370,23 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$max(int,5,4; 6; 3)", "6", context)
         self.assertScriptResultEquals("$max(float,5.9,4.2; 6; 3.35)", "6.0", context)
 
+        # Test 'auto' processing
+        self.assertScriptResultEquals("$max(,1,2)", "2", context)
+        self.assertScriptResultEquals("$max(,2,1)", "2", context)
+        self.assertScriptResultEquals("$max(auto,1,2)", "2", context)
+        self.assertScriptResultEquals("$max(auto,2,1)", "2", context)
+        self.assertScriptResultEquals("$max(,1.1,2)", "2.0", context)
+        self.assertScriptResultEquals("$max(,2,1.1)", "2.0", context)
+        self.assertScriptResultEquals("$max(auto,1.1,2)", "2.0", context)
+        self.assertScriptResultEquals("$max(auto,2,1.1)", "2.0", context)
+        self.assertScriptResultEquals("$max(,2.1,1,a)", "a", context)
+        self.assertScriptResultEquals("$max(auto,2.1,1,a)", "a", context)
+        self.assertScriptResultEquals("$max(,a,A)", "a", context)
+        self.assertScriptResultEquals("$max(,A,a)", "a", context)
+        self.assertScriptResultEquals("$max(auto,a,A)", "a", context)
+        self.assertScriptResultEquals("$max(auto,A,a)", "a", context)
+
         # Test invalid processing types
-        self.assertScriptResultEquals("$max(,A,a)", "", context)
         self.assertScriptResultEquals("$max(unknown,a,B)", "", context)
 
         # Tests with invalid number of arguments

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -658,6 +658,12 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$gt(A,a,text)", "", context)
         self.assertScriptResultEquals("$gt(a,A,text)", "1", context)
 
+        # Test case insensitive arguments ("nocase" processing)
+        self.assertScriptResultEquals("$gt(a,B,nocase)", "", context)
+        self.assertScriptResultEquals("$gt(A,b,nocase)", "", context)
+        self.assertScriptResultEquals("$gt(B,a,nocase)", "1", context)
+        self.assertScriptResultEquals("$gt(b,A,nocase)", "1", context)
+
         # Test unknown processing type
         self.assertScriptResultEquals("$gt(2,1,unknown)", "", context)
 
@@ -741,6 +747,14 @@ class ScriptParserTest(PicardTestCase):
         # Test case sensitive arguments ("text" processing)
         self.assertScriptResultEquals("$gte(A,a,text)", "", context)
         self.assertScriptResultEquals("$gte(a,A,text)", "1", context)
+
+        # Test case insensitive arguments ("nocase" processing)
+        self.assertScriptResultEquals("$gte(a,B,nocase)", "", context)
+        self.assertScriptResultEquals("$gte(A,b,nocase)", "", context)
+        self.assertScriptResultEquals("$gte(B,a,nocase)", "1", context)
+        self.assertScriptResultEquals("$gte(b,A,nocase)", "1", context)
+        self.assertScriptResultEquals("$gte(a,A,nocase)", "1", context)
+        self.assertScriptResultEquals("$gte(A,a,nocase)", "1", context)
 
         # Test unknown processing type
         self.assertScriptResultEquals("$gte(2,1,unknown)", "", context)
@@ -827,6 +841,12 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$lt(A,a,text)", "1", context)
         self.assertScriptResultEquals("$lt(a,A,text)", "", context)
 
+        # Test case insensitive arguments ("nocase" processing)
+        self.assertScriptResultEquals("$lt(a,B,nocase)", "1", context)
+        self.assertScriptResultEquals("$lt(A,b,nocase)", "1", context)
+        self.assertScriptResultEquals("$lt(B,a,nocase)", "", context)
+        self.assertScriptResultEquals("$lt(b,A,nocase)", "", context)
+
         # Test unknown processing type
         self.assertScriptResultEquals("$lt(1,2,unknown)", "", context)
 
@@ -907,6 +927,14 @@ class ScriptParserTest(PicardTestCase):
         # Test case sensitive arguments ("text" processing)
         self.assertScriptResultEquals("$lte(A,a,text)", "1", context)
         self.assertScriptResultEquals("$lte(a,A,text)", "", context)
+
+        # Test case insensitive arguments ("nocase" processing)
+        self.assertScriptResultEquals("$lte(a,B,nocase)", "1", context)
+        self.assertScriptResultEquals("$lte(A,b,nocase)", "1", context)
+        self.assertScriptResultEquals("$lte(B,a,nocase)", "", context)
+        self.assertScriptResultEquals("$lte(b,A,nocase)", "", context)
+        self.assertScriptResultEquals("$lte(a,A,nocase)", "1", context)
+        self.assertScriptResultEquals("$lte(A,a,nocase)", "1", context)
 
         # Test unknown processing type
         self.assertScriptResultEquals("$lte(1,2,unknown)", "", context)

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1867,3 +1867,233 @@ class ScriptParserTest(PicardTestCase):
             self.parser.eval("$cleanmulti()")
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$cleanmulti(foo,)")
+
+    def test_cmd_textlt(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textlt(%foo%,%bar%)", "1", context)
+        self.assertScriptResultEquals("$textlt(%bar%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlt(%foo%,%baz%)", "1", context)
+        self.assertScriptResultEquals("$textlt(%baz%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlt(%foo%,%foo%)", "", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textlt(%foo%,%bar%)", "1", context)
+        self.assertScriptResultEquals("$textlt(%bar%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlt(%foo%,%baz%)", "1", context)
+        self.assertScriptResultEquals("$textlt(%baz%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlt(%foo%,%foo%)", "", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textlt(,a)", "1", context)
+        self.assertScriptResultEquals("$textlt(a,)", "", context)
+        self.assertScriptResultEquals("$textlt(,)", "", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textlt(A,a)", "1", context)
+        self.assertScriptResultEquals("$textlt(a,A)", "", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textlt: Wrong number of arguments for \$textlt: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlt()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlt(foo)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlt(foo,bar,)")
+
+    def test_cmd_textlte(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textlte(%foo%,%bar%)", "1", context)
+        self.assertScriptResultEquals("$textlte(%bar%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlte(%foo%,%baz%)", "1", context)
+        self.assertScriptResultEquals("$textlte(%baz%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlte(%foo%,%foo%)", "1", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textlte(%foo%,%bar%)", "1", context)
+        self.assertScriptResultEquals("$textlte(%bar%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlte(%foo%,%baz%)", "1", context)
+        self.assertScriptResultEquals("$textlte(%baz%,%foo%)", "", context)
+        self.assertScriptResultEquals("$textlte(%foo%,%foo%)", "1", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textlte(,a)", "1", context)
+        self.assertScriptResultEquals("$textlte(a,)", "", context)
+        self.assertScriptResultEquals("$textlte(,)", "1", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textlte(A,a)", "1", context)
+        self.assertScriptResultEquals("$textlte(a,A)", "", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textlte: Wrong number of arguments for \$textlte: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlte()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlte(foo)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textlte(foo,bar,)")
+
+    def test_cmd_textgt(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textgt(%foo%,%bar%)", "", context)
+        self.assertScriptResultEquals("$textgt(%bar%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgt(%foo%,%baz%)", "", context)
+        self.assertScriptResultEquals("$textgt(%baz%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgt(%foo%,%foo%)", "", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textgt(%foo%,%bar%)", "", context)
+        self.assertScriptResultEquals("$textgt(%bar%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgt(%foo%,%baz%)", "", context)
+        self.assertScriptResultEquals("$textgt(%baz%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgt(%foo%,%foo%)", "", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textgt(,a)", "", context)
+        self.assertScriptResultEquals("$textgt(a,)", "1", context)
+        self.assertScriptResultEquals("$textgt(,)", "", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textgt(A,a)", "", context)
+        self.assertScriptResultEquals("$textgt(a,A)", "1", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textgt: Wrong number of arguments for \$textgt: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgt()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgt(foo)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgt(foo,bar,)")
+
+    def test_cmd_textgte(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textgte(%foo%,%bar%)", "", context)
+        self.assertScriptResultEquals("$textgte(%bar%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgte(%foo%,%baz%)", "", context)
+        self.assertScriptResultEquals("$textgte(%baz%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgte(%foo%,%foo%)", "1", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textgte(%foo%,%bar%)", "", context)
+        self.assertScriptResultEquals("$textgte(%bar%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgte(%foo%,%baz%)", "", context)
+        self.assertScriptResultEquals("$textgte(%baz%,%foo%)", "1", context)
+        self.assertScriptResultEquals("$textgte(%foo%,%foo%)", "1", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textgte(,a)", "", context)
+        self.assertScriptResultEquals("$textgte(a,)", "1", context)
+        self.assertScriptResultEquals("$textgte(,)", "1", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textgte(A,a)", "", context)
+        self.assertScriptResultEquals("$textgte(a,A)", "1", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textgte: Wrong number of arguments for \$textgte: Expected exactly 2, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgte()")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgte(foo)")
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textgte(foo,bar,)")
+
+    def test_cmd_textmin(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textmin(%foo%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$textmin(%foo%,%bar%,%baz%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$textmin(%baz%,%bar%,%foo%)", "2020-01-01", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textmin(%foo%)", "abc", context)
+        self.assertScriptResultEquals("$textmin(%foo%,%bar%,%baz%)", "abc", context)
+        self.assertScriptResultEquals("$textmin(%baz%,%bar%,%foo%)", "abc", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textmin(,a)", "", context)
+        self.assertScriptResultEquals("$textmin(a,)", "", context)
+        self.assertScriptResultEquals("$textmin(,)", "", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textmin(A,a)", "A", context)
+        self.assertScriptResultEquals("$textmin(a,B)", "B", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textmin: Wrong number of arguments for \$textmin: Expected at least 1, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textmin()")
+
+    def test_cmd_textmax(self):
+        context = Metadata()
+
+        # Test date type arguments
+        context["foo"] = "2020-01-01"
+        context["bar"] = "2020-01-02"
+        context["baz"] = "2020-02"
+        self.assertScriptResultEquals("$textmax(%foo%)", "2020-01-01", context)
+        self.assertScriptResultEquals("$textmax(%foo%,%bar%,%baz%)", "2020-02", context)
+        self.assertScriptResultEquals("$textmax(%baz%,%bar%,%foo%)", "2020-02", context)
+
+        # Test text type arguments
+        context["foo"] = "abc"
+        context["bar"] = "abcd"
+        context["baz"] = "ac"
+        self.assertScriptResultEquals("$textmax(%foo%)", "abc", context)
+        self.assertScriptResultEquals("$textmax(%foo%,%bar%,%baz%)", "ac", context)
+        self.assertScriptResultEquals("$textmax(%baz%,%bar%,%foo%)", "ac", context)
+
+        # Test with empty arguments
+        self.assertScriptResultEquals("$textmax(,a)", "a", context)
+        self.assertScriptResultEquals("$textmax(a,)", "a", context)
+        self.assertScriptResultEquals("$textmax(,)", "", context)
+
+        # Test case sensitive arguments
+        self.assertScriptResultEquals("$textmax(A,a)", "a", context)
+        self.assertScriptResultEquals("$textmax(a,B)", "a", context)
+
+        # Tests with invalid number of arguments
+        areg = r"^\d+:\d+:\$textmax: Wrong number of arguments for \$textmax: Expected at least 1, "
+        with self.assertRaisesRegex(ScriptError, areg):
+            self.parser.eval("$textmax()")


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds new text-based comparison scriping functions.

# Problem

The current scripting comparison functions `$gt()`, `$gte()`, `$lt()` and `$lte()` operate on interger values only. This does not support things like date comparisons. See the discussion at https://community.metabrainz.org/t/how-set-date-to-minimum-of-recording-firstreleasedate-and-originaldate/585648 and https://community.metabrainz.org/t/feature-request-numeric-functions-min-and-max-in-picards-scripting-language/585669 for more information.

* JIRA ticket (_optional_): PICARD-2486
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

~Adds four new text-based comparison scripting functions `$textlt()`, `$textlte()`, `$textgt()` and `$textgte()`, plus text-based `$textmin()` and `$textmax()` functions.~

Adds an optional argument to the existing `$lt()`, `$lte()`, `$gt()` and `$gte()` functions to specify whether the arguments should be processed as **int**, **float**, **text** (case-sensitive text) or **nocase** (case-insensitive text).  If no argument is provided the comparison will be processed as **int** to maintain backward compatibility.

Also adds two new functions `$min()` and `$max()`, with the type of processing specified as one of **int**, **float** or **text** (case-sensitive text) as the first argument.

# Action

I assume that, if accepted, these changes would be applied to Picard v3.0 (or v2.9 if there is such a release).  If accepted for other than v3.0 then the function description docstrings will need to be updated accordingly.

I wasn't sure which branch to merge into, so I used the `master` branch.  We can change the target if necessary.

If accepted, the Picard documentation will need to be updated.
