### PR TITLE
PICARD-2493: Ensure translation domains get used even if some translation files are missing

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -80,6 +80,15 @@ def _try_set_locale(language):
     return language  # Just return the language, so at least UI translation works
 
 
+def _load_translation(domain, localedir, logger):
+    try:
+        logger("Loading gettext translation for %s, localedir=%r", domain, localedir)
+        return gettext.translation(domain, localedir)
+    except OSError as e:
+        logger(e)
+        return gettext.NullTranslations()
+
+
 def setup_gettext(localedir, ui_language=None, logger=None):
     """Setup locales, load translations, install gettext functions."""
     if not logger:
@@ -95,18 +104,10 @@ def setup_gettext(localedir, ui_language=None, logger=None):
     os.environ['LANGUAGE'] = os.environ['LANG'] = current_locale
     QLocale.setDefault(QLocale(current_locale))
     logger("Using locale %r", current_locale)
-    try:
-        logger("Loading gettext translation, localedir=%r", localedir)
-        trans = gettext.translation("picard", localedir)
-        logger("Loading gettext translation (picard-countries), localedir=%r", localedir)
-        trans_countries = gettext.translation("picard-countries", localedir)
-        logger("Loading gettext translation (picard-attributes), localedir=%r", localedir)
-        trans_attributes = gettext.translation("picard-attributes", localedir)
-    except OSError as e:
-        logger(e)
-        trans = gettext.NullTranslations()
-        trans_countries = gettext.NullTranslations()
-        trans_attributes = gettext.NullTranslations()
+
+    trans = _load_translation('picard', localedir, logger)
+    trans_countries = _load_translation('picard-countries', localedir, logger)
+    trans_attributes = _load_translation('picard-attributes', localedir, logger)
 
     trans.install(['ngettext'])
     builtins.__dict__['gettext_countries'] = trans_countries.gettext


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2493
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If for the configured UI language any of the locale files (picard, picard-countries, picard-attributes) is missing, Picard will completely fail to load the translations and will fall back to no translation for all three translation domains.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Fail loading each domain individually and only set `NullTranslations` for that domain. That way if e.g. translations for attributes are missing the translations for the UI and for countries will still be used.