### PR TITLE
PICARD-2489: Handle strxfrm raising OSError

### DIFF
--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -23,8 +23,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import locale
-
 from PyQt5 import (
     QtCore,
     QtGui,
@@ -35,6 +33,7 @@ from picard.collection import (
     load_user_collections,
     user_collections,
 )
+from picard.util import strxfrm
 
 
 class CollectionMenu(QtWidgets.QMenu):
@@ -51,7 +50,7 @@ class CollectionMenu(QtWidgets.QMenu):
         self.actions = []
         for id_, collection in sorted(user_collections.items(),
                                       key=lambda k_v:
-                                      (locale.strxfrm(str(k_v[1])), k_v[0])):
+                                      (strxfrm(str(k_v[1])), k_v[0])):
             action = QtWidgets.QWidgetAction(self)
             action.setDefaultWidget(CollectionMenuItem(self, collection))
             self.addAction(action)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -47,7 +47,6 @@ from heapq import (
     heappop,
     heappush,
 )
-from locale import strxfrm
 
 from PyQt5 import (
     QtCore,
@@ -85,6 +84,7 @@ from picard.util import (
     natsort,
     normpath,
     restore_method,
+    strxfrm,
 )
 
 from picard.ui.collectionmenu import CollectionMenu

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -29,7 +29,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import locale
 import os.path
 
 from PyQt5 import (
@@ -46,7 +45,10 @@ from picard.config import (
 )
 from picard.const import UI_LANGUAGES
 from picard.const.sys import IS_MACOS
-from picard.util import icontheme
+from picard.util import (
+    icontheme,
+    strxfrm,
+)
 
 from picard.ui import PicardDialog
 from picard.ui.moveable_list_view import MoveableListView
@@ -204,7 +206,7 @@ class InterfaceOptionsPage(OptionsPage):
         language_list = [(lang[0], lang[1], _(lang[2])) for lang in UI_LANGUAGES]
 
         def fcmp(x):
-            return locale.strxfrm(x[2])
+            return strxfrm(x[2])
         for lang_code, native, translation in sorted(language_list, key=fcmp):
             if native and native != translation:
                 name = '%s (%s)' % (translation, native)

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -25,7 +25,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from locale import strxfrm
 from operator import itemgetter
 
 from PyQt5 import (
@@ -44,6 +43,7 @@ from picard.const import (
     RELEASE_SECONDARY_GROUPS,
 )
 from picard.const.sys import IS_WIN
+from picard.util import strxfrm
 
 from picard.ui.options import (
     OptionsPage,

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -44,6 +44,7 @@ from collections import namedtuple
 from collections.abc import Mapping
 from itertools import chain
 import json
+from locale import strxfrm as _strxfrm
 import ntpath
 from operator import attrgetter
 import os
@@ -1084,3 +1085,21 @@ def iter_exception_chain(err):
 def any_exception_isinstance(error, type_):
     """Returns True, if any exception in the exception chain is instance of type_."""
     return any(isinstance(err, type_) for err in iter_exception_chain(error))
+
+
+def strxfrm(string):
+    """Transforms a string to one that can be used in locale-aware comparisons.
+
+    Wrapper around locale.strxfrm, that never throws OSError. If an OSError
+    occurs this function will return the string converted to lower case.
+
+    Args:
+        string: The string to convert
+
+    Returns: A string that can be compared locale-aware
+    """
+    try:
+        return _strxfrm(string)
+    except OSError as err:
+        log.warning('strxfrm(%r) failed: %r', string, err)
+        return string.lower()

--- a/picard/util/natsort.py
+++ b/picard/util/natsort.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2019-2020, 2022 Philipp Wolfer
 # Copyright (C) 2020-2021 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -23,8 +23,9 @@
 """Functions for natural sorting of strings containing numbers.
 """
 
-from locale import strxfrm
 import re
+
+from picard.util import strxfrm
 
 
 RE_NUMBER = re.compile(r'(\d+)')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2489
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

locale.strxfrm can raise OSError on some systems. Handle this gracefully to avoid Picard crashing.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add a function `picard.util.strxfrm` that wraps `locale.strxfrm`, but never raises `OSError` but only returns the original string (converted to lowercase for some normalization). Worst case strxfrm will fail on a string and sorting will not be fully correct, but Picard continues to function. OSError will be logged.