### PR TITLE
PICARD-2494: The view info dialog is not needed for NatAlbum

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -875,6 +875,9 @@ class NatAlbum(Album):
     def can_browser_lookup(self):
         return False
 
+    def can_view_info(self):
+        return False
+
 
 _album_post_removal_processors = PluginFunctions(label='album_post_removal_processors')
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2494
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



The "[standalone-reccordings]"  special album instance shown to hold the standalone recordings does have the info dialog, which just opens an empty dialog.


# Solution

Implement `NatAlbum.can_view_info` 