### PR TITLE
PICARD-2498: HTML escape plugin metadata before display in options

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -614,9 +614,10 @@ class PluginsOptionsPage(OptionsPage):
     @staticmethod
     def link_authors(authors):
         formatted_authors = []
-        re_author = re.compile(r"(?P<author>.*?)\s*<(?P<email>.*?)>")
+        re_author = re.compile(r"(?P<author>.*?)\s*<(?P<email>.*?@.*?)>")
         for author in authors.split(','):
-            match = re_author.match(author.strip())
+            author = author.strip()
+            match = re_author.fullmatch(author)
             if match:
                 author_str = '<a href="mailto:{email}">{author}</a>'.format(
                     email=escape(match['email']),

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -34,6 +34,7 @@ from functools import partial
 from html import escape
 from operator import attrgetter
 import os.path
+import re
 
 from PyQt5 import (
     QtCore,
@@ -601,7 +602,7 @@ class PluginsOptionsPage(OptionsPage):
             text.append(plugin.description + "<hr width='90%'/>")
         infos = [
             (_("Name"), escape(plugin.name)),
-            (_("Authors"), escape(plugin.author)),
+            (_("Authors"), self.link_authors(plugin.author)),
             (_("License"), plugin.license),
             (_("Files"), escape(plugin.files_list)),
         ]
@@ -609,6 +610,22 @@ class PluginsOptionsPage(OptionsPage):
             if value:
                 text.append("<b>{0}:</b> {1}".format(label, value))
         self.ui.details.setText("<p>{0}</p>".format("<br/>\n".join(text)))
+
+    @staticmethod
+    def link_authors(authors):
+        formatted_authors = []
+        re_author = re.compile(r"(?P<author>.*?)\s*<(?P<email>.*?)>")
+        for author in authors.split(','):
+            match = re_author.match(author.strip())
+            if match:
+                author_str = '<a href="mailto:{email}">{author}</a>'.format(
+                    email=escape(match['email']),
+                    author=escape(match['author']),
+                )
+                formatted_authors.append(author_str)
+            else:
+                formatted_authors.append(escape(author))
+        return ', '.join(formatted_authors)
 
     def change_details(self):
         item = self.selected_item()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -31,6 +31,7 @@
 
 
 from functools import partial
+from html import escape
 from operator import attrgetter
 import os.path
 
@@ -599,10 +600,10 @@ class PluginsOptionsPage(OptionsPage):
         if plugin.description:
             text.append(plugin.description + "<hr width='90%'/>")
         infos = [
-            (_("Name"), plugin.name),
-            (_("Authors"), plugin.author),
+            (_("Name"), escape(plugin.name)),
+            (_("Authors"), escape(plugin.author)),
             (_("License"), plugin.license),
-            (_("Files"), plugin.files_list),
+            (_("Files"), escape(plugin.files_list)),
         ]
         for label, value in infos:
             if value:

--- a/test/test_ui_options_plugins.py
+++ b/test/test_ui_options_plugins.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2022 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.options.plugins import PluginsOptionsPage
+
+
+class PluginsOptionsPageTest(PicardTestCase):
+
+    def test_link_authors(self):
+        self.assertEqual(
+            '<a href="mailto:coyote@acme.com">Wile E. Coyote</a>, Road &lt;Runner&gt;',
+            PluginsOptionsPage.link_authors('Wile E. Coyote <coyote@acme.com>, Road <Runner>'),
+        )


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2498
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



Currently all plugin metadata can potentially contain HTML which gets rendered when displaying the plugin details in options. This is not intentional, the only field that can currently contain HTML is the description.

This was revealed because the author list in the acousticbrainz plugin uses the format "Author Name <email>".


# Solution
HTML escape all plugin metadata fields except for the description.

For authors also try to detect the "Author Name <email>" and convert the author names into mailto links.