### PR TITLE
PICARD-2505: Sanitize cover art type before using it as filename

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -43,6 +43,7 @@ from PyQt5.QtCore import (
 from picard import log
 from picard.config import get_config
 from picard.const import DEFAULT_COVER_IMAGE_FILENAME
+from picard.const.sys import IS_WIN
 from picard.coverart.utils import (
     Id3ImageType,
     image_type_as_id3_num,
@@ -55,6 +56,7 @@ from picard.util import (
     imageinfo,
     is_absolute_path,
     periodictouch,
+    sanitize_filename,
 )
 from picard.util.scripttofilename import script_to_filename
 
@@ -331,7 +333,8 @@ class CoverArtImage:
             return
         config = get_config()
         if config.setting["image_type_as_filename"] and not self.is_front_image():
-            filename = self.maintype
+            win_compat = IS_WIN or config.setting["windows_compatibility"]
+            filename = sanitize_filename(self.maintype, win_compat=win_compat)
             log.debug("Make cover filename from types: %r -> %r",
                       self.types, filename)
         else:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2505
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Fixes accidental folder creation for types "matrix/runout" or "raw/unedited" when saving cover art images of those types with the option "Always use the primary image type as the file name for non-front images" enabled.


# Solution
Call `sanitize_filename`  on the cover art types before using them for the file name.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
