### PR TITLE
timeout added to pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
       env:
         DEPENDENCIES: ${{ matrix.dependencies }}
     - name: Test with pytest
-    	timeout-minutes: 30
+      timeout-minutes: 30
       run: |
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,7 @@ jobs:
         isort --check-only --diff --recursive picard test
     - name: Test with pytest
       if: always()
+      timeout-minutes: 30
       run: |
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose --cov=picard --cov-report xml:coverage.xml test
@@ -81,6 +82,7 @@ jobs:
       env:
         DEPENDENCIES: ${{ matrix.dependencies }}
     - name: Test with pytest
+    	timeout-minutes: 30
       run: |
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose test


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Use timeout in workflows for unit tests to prevent tests from going into an infinite loop. Admins won't need to cancel tests themselves, contributors will receive a quicker feedback.

# Problem
My GSoC PR made me think that timeout in the tests is a useful feature so here it is :)

# Solution
`timeout-minutes` set to 30, the exact value is a subject of discussion.
