### PR TITLE
PICARD-2507: Include pregap track in medium's totaltracks count

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -75,7 +75,6 @@ _MEDIUM_TO_METADATA = {
     'format': 'media',
     'position': 'discnumber',
     'title': 'discsubtitle',
-    'track-count': 'totaltracks',
 }
 
 _RECORDING_TO_METADATA = {
@@ -478,6 +477,11 @@ def medium_to_metadata(node, m):
     for key, value in _node_skip_empty_iter(node):
         if key in _MEDIUM_TO_METADATA:
             m[_MEDIUM_TO_METADATA[key]] = value
+    totaltracks = node.get('track-count', 0)
+    if node.get('pregap'):
+        totaltracks += 1
+    if totaltracks:
+        m['totaltracks'] = totaltracks
 
 
 def artist_to_metadata(node, m):

--- a/test/data/ws_data/media_pregap.json
+++ b/test/data/ws_data/media_pregap.json
@@ -1,0 +1,83 @@
+{
+    "track-count": 8,
+    "discs": [
+        {
+            "sectors": 134481,
+            "offset-count": 8,
+            "id": "7v3LmtkMIT49mHs7LobaAwBNsck-",
+            "offsets": [
+                6824,
+                18966,
+                37134,
+                52930,
+                69024,
+                80329,
+                98814,
+                117353
+            ]
+        }
+    ],
+    "format-id": "8a08dc62-1aa2-34de-a904-fa467c53052c",
+    "position": 1,
+    "track-offset": 0,
+    "format": "Enhanced CD",
+    "title": "",
+    "pregap": {
+        "number": "0",
+        "position": 0,
+        "artist-credit": [
+            {
+                "name": "Lemon Demon",
+                "joinphrase": "",
+                "artist": {
+                    "type": "Person",
+                    "sort-name": "Lemon Demon",
+                    "disambiguation": "",
+                    "id": "6b014cfd-4927-4187-a741-715998e6d785",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "aliases": [
+                        {
+                            "name": "Deporitaz",
+                            "primary": null,
+                            "type-id": null,
+                            "locale": null,
+                            "begin": null,
+                            "ended": false,
+                            "end": null,
+                            "sort-name": "Deporitaz",
+                            "type": null
+                        }
+                    ],
+                    "name": "Lemon Demon"
+                }
+            }
+        ],
+        "recording": {
+            "video": false,
+            "id": "a6f68447-7810-4d1e-a5a2-d10ff0943aee",
+            "first-release-date": "2019",
+            "aliases": [],
+            "title": "Sexy DVD",
+            "length": 88000,
+            "disambiguation": "",
+            "artist-credit": [
+                {
+                    "artist": {
+                        "id": "6b014cfd-4927-4187-a741-715998e6d785",
+                        "type": "Person",
+                        "sort-name": "Lemon Demon",
+                        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                        "disambiguation": "",
+                        "name": "Lemon Demon"
+                    },
+                    "joinphrase": "",
+                    "name": "Lemon Demon"
+                }
+            ]
+        },
+        "length": 88000,
+        "title": "Sexy DVD",
+        "id": "74fa2a03-325a-4a6b-bcfd-12f95ba30d16"
+    },
+    "tracks": []
+}

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -402,6 +402,18 @@ class MediaTest(MBJSONTest):
         self.assertEqual(m['totaltracks'], '10')
 
 
+class MediaPregapTest(MBJSONTest):
+
+    filename = 'media_pregap.json'
+
+    def test_track(self):
+        m = Metadata()
+        medium_to_metadata(self.json_doc, m)
+        self.assertEqual(m['discnumber'], '1')
+        self.assertEqual(m['media'], 'Enhanced CD')
+        self.assertEqual(m['totaltracks'], '9')
+
+
 class NullMediaTest(MBJSONTest):
 
     filename = 'media_null.json'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2507
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

A medium's pregap track is not considered for the `totaltracks`  count of that medium.


# Solution

Increase `totaltracks`  by 1 if there is a pregap track.