### PR TITLE
PICARD-2506: Fixed calling fpcalc with long path filename

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2017-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018-2021 Laurent Monin
-# Copyright (C) 2018-2021 Philipp Wolfer
+# Copyright (C) 2018-2022 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -36,8 +36,12 @@ from picard import log
 from picard.acoustid.json_helpers import parse_recording
 from picard.config import get_config
 from picard.const import FPCALC_NAMES
+from picard.const.sys import IS_WIN
 from picard.file import File
-from picard.util import find_executable
+from picard.util import (
+    find_executable,
+    win_prefix_longpath,
+)
 
 
 def get_score(node):
@@ -248,7 +252,10 @@ class AcoustIDClient(QtCore.QObject):
         process.setProperty('picard_finished', False)
         process.finished.connect(partial(self._on_fpcalc_finished, task))
         process.error.connect(partial(self._on_fpcalc_error, task))
-        process.start(self._fpcalc, ["-json", "-length", "120", task.file.filename])
+        file_path = task.file.filename
+        if IS_WIN:
+            file_path = win_prefix_longpath(file_path)
+        process.start(self._fpcalc, ["-json", "-length", "120", file_path])
         log.debug("Starting fingerprint calculator %r %r", self._fpcalc, task.file.filename)
 
     def analyze(self, file, next_func):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -228,8 +228,13 @@ def normpath(path):
     # If the path is longer than 259 characters on Windows, prepend the \\?\
     # prefix. This enables access to long paths using the Windows API. See
     # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-    if (IS_WIN and len(path) > WIN_MAX_FILEPATH_LEN and not system_supports_long_paths()
-        and not path.startswith(WIN_LONGPATH_PREFIX)):
+    if IS_WIN and not system_supports_long_paths():
+        path = win_prefix_longpath(path)
+    return path
+
+
+def win_prefix_longpath(path):
+    if len(path) > WIN_MAX_FILEPATH_LEN and not path.startswith(WIN_LONGPATH_PREFIX):
         path = WIN_LONGPATH_PREFIX + path
     return path
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -71,6 +71,7 @@ from picard.util import (
     tracknum_from_filename,
     uniqify,
     wildcards_to_regex_pattern,
+    win_prefix_longpath,
 )
 
 
@@ -736,6 +737,17 @@ class NormpathTest(PicardTestCase):
         self.assertEqual(path, normpath(path))
         path += 'a'
         self.assertEqual('\\\\?\\' + path, normpath(path))
+
+
+class WinPrefixLongpathTest(PicardTestCase):
+
+    def test_win_prefix_longpath_is_long(self):
+        path = 'C:\\foo\\' + (253 * 'a')
+        self.assertEqual('\\\\?\\' + path, win_prefix_longpath(path))
+
+    def test_win_prefix_longpath_is_short(self):
+        path = 'C:\\foo\\' + (252 * 'a')
+        self.assertEqual(path, win_prefix_longpath(path))
 
 
 class SystemSupportsLongPathsTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2506
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Calls to fpcalc on Windows 10 / 11 fail, if the path to the audio file exceeds the 259 character path name limit and Windows is configured for long path support. The reason is that on Windows with long path support Picard keeps the path as is. But fpcalc (due to ffmpeg, see https://trac.ffmpeg.org/ticket/8885) does not support long paths yet and hence fails.

The solution is to enforce the Windows long path prefix `\\?\` whenever passing paths to fpcalc.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

On Windows always add the long path prefix \\?\ if the path exceeds this limit, independent of the OS configuration for long path supports. This fixes ffmpeg currently not being able to handle long paths.

Added util method win_prefix_longpath() to help with that.