### PR TITLE
unparsed_args removed from `tagger.py`

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1047,7 +1047,7 @@ def process_picard_args():
     parser.add_argument("-V", "--long-version", action='store_true',
                         help="display long version information and exit")
     parser.add_argument('FILE', nargs='*')
-    
+
     return parser.parse_known_args()[0]
 
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -186,7 +186,7 @@ class Tagger(QtWidgets.QApplication):
     _debug = False
     _no_restore = False
 
-    def __init__(self, picard_args, unparsed_args, localedir, autoupdate):
+    def __init__(self, picard_args, localedir, autoupdate):
 
         super().__init__(sys.argv)
         self.__class__.__instance = self
@@ -1047,8 +1047,8 @@ def process_picard_args():
     parser.add_argument("-V", "--long-version", action='store_true',
                         help="display long version information and exit")
     parser.add_argument('FILE', nargs='*')
-    picard_args, unparsed_args = parser.parse_known_args()
-    return picard_args, unparsed_args
+    
+    return parser.parse_known_args()[0]
 
 
 class OverrideStyle(QtWidgets.QProxyStyle):
@@ -1085,7 +1085,7 @@ def main(localedir=None, autoupdate=True):
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    picard_args, unparsed_args = process_picard_args()
+    picard_args = process_picard_args()
     if picard_args.version:
         return version()
     if picard_args.long_version:
@@ -1098,7 +1098,7 @@ def main(localedir=None, autoupdate=True):
     except ImportError:
         pass
 
-    tagger = Tagger(picard_args, unparsed_args, localedir, autoupdate)
+    tagger = Tagger(picard_args, localedir, autoupdate)
 
     # Initialize Qt default translations
     translator = QtCore.QTranslator()


### PR DESCRIPTION
# Summary
* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Since the variable wasn't used anywhere (wasn't even stored as `Tagger`'s attribute), I'd suggest to remove it, unless you have some reason to still keep it there.

# Problem
Unused variable returned, stored and passed to the `Tagger`'s constructor just to be left untouched

* JIRA ticket (_optional_): *None*

# Solution

I've safely removed all the `unparsed_args`'s ocurrences.

