### PR TITLE
PICARD-2515: Ensure color chooser buttons can be styled on macOS

### DIFF
--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -29,6 +29,7 @@ from PyQt5 import (
 )
 
 from picard.config import Option
+from picard.const.sys import IS_MACOS
 
 from picard.ui.colors import (
     InterfaceColors,
@@ -47,7 +48,10 @@ class ColorButton(QtWidgets.QPushButton):
 
     def __init__(self, initial_color=None, parent=None):
         super().__init__('    ', parent=parent)
-
+        # On macOS the style override in picard.ui.theme breaks styling these
+        # buttons. Explicitly reset the style for this widget only.
+        if IS_MACOS:
+            self.setStyle(QtWidgets.QStyleFactory.create('macintosh'))
         color = QtGui.QColor(initial_color)
         if not color.isValid():
             color = QtGui.QColor("black")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2515
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
On macOS the style override prevents styling these buttons. Hence explicitly reset the style for these widgets only.




# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
