### PR TITLE
PICARD-2519: Allow passing supported URLs on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Please report all bugs and feature requests in the [MusicBrainz issue tracker](h
 
 ## Trivia
 
-Picard is named after Captain Jean-Luc Picard from the TV series Star Trek: The Next Generation.
+Picard is named after [Captain Jean-Luc Picard](https://en.wikipedia.org/wiki/Jean-Luc_Picard) from the TV series [Star Trek: The Next Generation](https://en.wikipedia.org/wiki/Star_Trek:_The_Next_Generation).

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -197,7 +197,7 @@ class Tagger(QtWidgets.QApplication):
         config = get_config()
         theme.setup(self)
 
-        self._cmdline_files = picard_args.FILE
+        self._cmdline_files = picard_args.FILE_OR_URL
         self.autoupdate_enabled = autoupdate
         self._no_restore = picard_args.no_restore
         self._no_plugins = picard_args.no_plugins
@@ -1097,7 +1097,7 @@ If a new instance will not be spawned:
                         help="display version information and exit")
     parser.add_argument("-V", "--long-version", action='store_true',
                         help="display long version information and exit")
-    parser.add_argument('FILE', nargs='*')
+    parser.add_argument('FILE_OR_URL', nargs='*')
 
     return parser.parse_known_args()[0]
 
@@ -1139,7 +1139,7 @@ def main(localedir=None, autoupdate=True):
     }
 
     to_be_added = []
-    for x in picard_args.FILE:
+    for x in picard_args.FILE_OR_URL:
         if not urlparse(x).netloc:
             x = os.path.abspath(x)
         to_be_added.append(x)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -334,7 +334,7 @@ class Tagger(QtWidgets.QApplication):
             if not parsed.scheme:
                 files.append(item)
             elif parsed.scheme == "file":
-                files.append(item.replace("file://", ''))
+                files.append(parsed.path)
             elif parsed.scheme in {"http", "https"}:
                 # .path returns / before actual link
                 urls.append(parsed.path[1:])

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -332,7 +332,7 @@ class Tagger(QtWidgets.QApplication):
             if not parsed.netloc:
                 files.append(item)
             else:
-                # .path returns / before actual cdtoc
+                # .path returns / before actual link
                 urls.append(parsed.path[1:])
 
         if files:
@@ -341,7 +341,7 @@ class Tagger(QtWidgets.QApplication):
             print(urls)
             file_lookup = self.get_file_lookup()
             for url in urls:
-                file_lookup.mbid_lookup(url, browser_fallback=False)
+                thread.to_main(file_lookup.mbid_lookup, url, None, None, False)
 
     def enable_menu_icons(self, enabled):
         self.setAttribute(QtCore.Qt.ApplicationAttribute.AA_DontShowIconsInMenus, not enabled)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -142,7 +142,6 @@ from picard.webservice.api_helpers import (
 import picard.resources  # noqa: F401 # pylint: disable=unused-import
 
 from picard.ui import theme
-from picard.ui.itemviews import BaseTreeView
 from picard.ui.mainwindow import MainWindow
 from picard.ui.searchdialog.album import AlbumSearchDialog
 from picard.ui.searchdialog.artist import ArtistSearchDialog

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -339,7 +339,7 @@ class Tagger(QtWidgets.QApplication):
                 # .path returns / before actual link
                 urls.append(parsed.path[1:])
             elif parsed.scheme == "mbid":
-                mbids.append(item.replace("mbid://", ''))
+                mbids.append(parsed.netloc + parsed.path)
 
         if files:
             self.add_paths(files)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1140,13 +1140,13 @@ def main(localedir=None, autoupdate=True):
         picard_args.stand_alone_instance,
     }
 
-    to_be_added = []
-    for x in picard_args.FILE_OR_URL:
-        if not urlparse(x).netloc:
-            x = os.path.abspath(x)
-        to_be_added.append(x)
-
     if not should_start:
+        to_be_added = []
+        for x in picard_args.FILE_OR_URL:
+            if not urlparse(x).netloc:
+                x = os.path.abspath(x)
+            to_be_added.append(x)
+
         try:
             pipe_handler = pipe.Pipe(app_name=PICARD_APP_NAME, app_version=PICARD_FANCY_VERSION_STR, args=to_be_added)
             should_start = pipe_handler.is_pipe_owner

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1107,7 +1107,8 @@ If a new instance will not be spawned:
                         help="display version information and exit")
     parser.add_argument("-V", "--long-version", action='store_true',
                         help="display long version information and exit")
-    parser.add_argument('FILE_OR_URL', nargs='*')
+    parser.add_argument('FILE_OR_URL', nargs='*',
+                        help="the file(s), URL(s) and MBID(s) to load")
 
     return parser.parse_known_args()[0]
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -325,21 +325,21 @@ class Tagger(QtWidgets.QApplication):
                 self.load_to_picard(messages)
 
     def load_to_picard(self, items):
-        files = []
-        mbids = []
-        urls = []
+        files = set()
+        mbids = set()
+        urls = set()
 
         for item in items:
             parsed = urlparse(item)
             if not parsed.scheme:
-                files.append(item)
+                files.add(item)
             elif parsed.scheme == "file":
-                files.append(parsed.path)
+                files.add(parsed.path)
             elif parsed.scheme in {"http", "https"}:
                 # .path returns / before actual link
-                urls.append(parsed.path[1:])
+                urls.add(parsed.path[1:])
             elif parsed.scheme == "mbid":
-                mbids.append(parsed.netloc + parsed.path)
+                mbids.add(parsed.netloc + parsed.path)
 
         if files:
             self.add_paths(files)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -334,7 +334,8 @@ class Tagger(QtWidgets.QApplication):
             if not parsed.scheme:
                 files.add(item)
             elif parsed.scheme == "file":
-                files.add(parsed.path)
+                # remove file:// prefix safely
+                files.add(item[7:])
             elif parsed.scheme in {"http", "https"}:
                 # .path returns / before actual link
                 urls.add(parsed.path[1:])

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -333,12 +333,13 @@ class Tagger(QtWidgets.QApplication):
             if not parsed.netloc:
                 files.append(item)
             else:
-                print(parsed.netloc)
-                urls.append(parsed.path)
+                # .path returns / before actual cdtoc
+                urls.append(parsed.path[1:])
 
         if files:
             self.add_paths(files)
         if urls:
+            print(urls)
             file_lookup = self.get_file_lookup()
             for url in urls:
                 file_lookup.mbid_lookup(url, browser_fallback=False)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -326,7 +326,7 @@ class Tagger(QtWidgets.QApplication):
                 self.load_to_picard(messages)
 
     @staticmethod
-    def _parse_file_or_url_items(items):
+    def _parse_items_to_load(items):
         out = {
             "files": set(),
             "mbids": set(),

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -325,23 +325,31 @@ class Tagger(QtWidgets.QApplication):
                 self.load_to_picard(messages)
 
     def load_to_picard(self, items):
-        urls = []
         files = []
+        mbids = []
+        urls = []
+
         for item in items:
             parsed = urlparse(item)
-            if not parsed.netloc:
+            if not parsed.scheme:
                 files.append(item)
-            else:
+            elif parsed.scheme == "file":
+                files.append(item.replace("file://", ''))
+            elif parsed.scheme in {"http", "https"}:
                 # .path returns / before actual link
                 urls.append(parsed.path[1:])
+            elif parsed.scheme == "mbid":
+                mbids.append(item.replace("mbid://", ''))
 
         if files:
             self.add_paths(files)
-        if urls:
-            print(urls)
+        if urls or mbids:
             file_lookup = self.get_file_lookup()
             for url in urls:
                 thread.to_main(file_lookup.mbid_lookup, url, None, None, False)
+            for mbid in mbids:
+                thread.to_main(file_lookup.mbid_lookup, mbid, None, None, False)
+
 
     def enable_menu_icons(self, enabled):
         self.setAttribute(QtCore.Qt.ApplicationAttribute.AA_DontShowIconsInMenus, not enabled)

--- a/test/test_tagger_message_parsing.py
+++ b/test/test_tagger_message_parsing.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2022 skelly37
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.tagger import Tagger
+
+
+class TestMessageParsing(PicardTestCase):
+    def test(self):
+        test_cases = {
+            "test_case.mp3",
+            "file:///home/picard/music/test.flac",
+            "mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+            "https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+            "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+        }
+
+        result = Tagger._parse_items_to_load(test_cases)
+        self.assertSetEqual(result["file"], {"test_case.mp3", "file:///home/picard/music/test.flac"}, "Files test")
+        self.assertSetEqual(result["mbid"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
+        self.assertSetEqual(result["url"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+            "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")

--- a/test/test_tagger_message_parsing.py
+++ b/test/test_tagger_message_parsing.py
@@ -35,6 +35,6 @@ class TestMessageParsing(PicardTestCase):
 
         result = Tagger._parse_items_to_load(test_cases)
         self.assertSetEqual(result["files"], {"test_case.mp3", "/home/picard/music/test.flac"}, "Files test")
-        self.assertSetEqual(result["mbids"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
-        self.assertSetEqual(result["urls"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
-            "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")
+        self.assertSetEqual(result["mbids"], {"recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
+        self.assertSetEqual(result["urls"], {"recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+            "recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")

--- a/test/test_tagger_message_parsing.py
+++ b/test/test_tagger_message_parsing.py
@@ -36,5 +36,5 @@ class TestMessageParsing(PicardTestCase):
         result = Tagger._parse_items_to_load(test_cases)
         self.assertSetEqual(result["file"], {"test_case.mp3", "file:///home/picard/music/test.flac"}, "Files test")
         self.assertSetEqual(result["mbid"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
-        self.assertSetEqual(result["url"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+        self.assertSetEqual(result["urls"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
             "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")

--- a/test/test_tagger_message_parsing.py
+++ b/test/test_tagger_message_parsing.py
@@ -34,7 +34,7 @@ class TestMessageParsing(PicardTestCase):
         }
 
         result = Tagger._parse_items_to_load(test_cases)
-        self.assertSetEqual(result["file"], {"test_case.mp3", "file:///home/picard/music/test.flac"}, "Files test")
-        self.assertSetEqual(result["mbid"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
+        self.assertSetEqual(result["files"], {"test_case.mp3", "file:///home/picard/music/test.flac"}, "Files test")
+        self.assertSetEqual(result["mbids"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
         self.assertSetEqual(result["urls"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
             "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")

--- a/test/test_tagger_message_parsing.py
+++ b/test/test_tagger_message_parsing.py
@@ -34,7 +34,7 @@ class TestMessageParsing(PicardTestCase):
         }
 
         result = Tagger._parse_items_to_load(test_cases)
-        self.assertSetEqual(result["files"], {"test_case.mp3", "file:///home/picard/music/test.flac"}, "Files test")
+        self.assertSetEqual(result["files"], {"test_case.mp3", "/home/picard/music/test.flac"}, "Files test")
         self.assertSetEqual(result["mbids"], {"mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "MBIDs test")
         self.assertSetEqual(result["urls"], {"https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
             "http://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94"}, "URLs test")

--- a/test/test_util_pipe.py
+++ b/test/test_util_pipe.py
@@ -64,6 +64,8 @@ class TestPipe(PicardTestCase):
             "https://test-ca.se/index.html",
             "file:///data/test.py",
             "www.wikipedia.mp3",
+            "mbid://recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
+            "https://musicbrainz.org/recording/7cd3782d-86dc-4dd1-8d9b-e37f9cbe6b94",
         )
 
         pipe_listener_handler = pipe.Pipe(self.NAME, self.VERSION)

--- a/test/test_util_pipe.py
+++ b/test/test_util_pipe.py
@@ -63,7 +63,7 @@ class TestPipe(PicardTestCase):
             "last-case",
             "https://test-ca.se/index.html",
             "file:///data/test.py",
-            ""
+            "www.wikipedia.mp3",
         )
 
         pipe_listener_handler = pipe.Pipe(self.NAME, self.VERSION)

--- a/test/test_util_pipe.py
+++ b/test/test_util_pipe.py
@@ -61,6 +61,9 @@ class TestPipe(PicardTestCase):
             "my_music_file.mp3",
             TestPipe.NAME, TestPipe.VERSION,
             "last-case",
+            "https://test-ca.se/index.html",
+            "file:///data/test.py",
+            ""
         )
 
         pipe_listener_handler = pipe.Pipe(self.NAME, self.VERSION)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Currently Picard supports passing file paths on command line to open the respective files. Picard also supports handling some URL patterns by drag and drop, e.g. MusicBrainz recordings, releases, release group and cdtoc URLs.

Extend Picard to also handle these supported URLs when passed via command line.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2519
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
call urllib.parse.urlparse on each argument marked as FILE to determine whether it's a file or URL, then pass it to the actual Tagger.


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
