### PR TITLE
Use macos-11 image for Github actions, upgrade to latest PyInstaller

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,7 +66,8 @@ jobs:
         cd pyinstaller/bootloader
         python3 ./waf --verbose all
         cd ..
-        pip3 install .
+        pip3 install -r requirements.txt
+        python3 setup.py install
       env:
         PYINSTALLER_VERSION: v5.2
         CFLAGS: -mmacosx-version-min=${{ matrix.macos-deployment-version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,10 +66,9 @@ jobs:
         cd pyinstaller/bootloader
         python3 ./waf --verbose all
         cd ..
-        rm pyinstaller.py  # workaround for https://github.com/pyinstaller/pyinstaller/pull/6701
         pip3 install .
       env:
-        PYINSTALLER_VERSION: v4.10
+        PYINSTALLER_VERSION: v5.2
         CFLAGS: -mmacosx-version-min=${{ matrix.macos-deployment-version }}
         CPPFLAGS: -mmacosx-version-min=${{ matrix.macos-deployment-version }}
         LDFLAGS: -mmacosx-version-min=${{ matrix.macos-deployment-version }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   package-macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         macos-deployment-version: [10.12, 10.14]

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -73,11 +73,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019]
+        os: [macos-11, windows-2019]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         exclude:
         # pyobjc is not yet compatible with Python 3.10
-        - os: macos-10.15
+        - os: macos-11
           python-version: '3.10'
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         - os: macos-latest
           python-version: '3.6'
         include:
-        - os: macos-10.15
+        - os: macos-11
           python-version: '3.6'
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/picard.spec
+++ b/picard.spec
@@ -42,6 +42,7 @@ def get_locale_messages():
 
 block_cipher = None
 os_name = platform.system()
+build_portable = bool(os.environ.get('PICARD_BUILD_PORTABLE'))
 binaries = []
 
 data_files = get_locale_messages()
@@ -63,7 +64,7 @@ if os_name == 'Windows':
     runtime_hooks.append('scripts/pyinstaller/win-startup-hook.py')
 elif os_name == 'Darwin':
     runtime_hooks.append('scripts/pyinstaller/macos-library-path-hook.py')
-if '--onefile' in sys.argv:
+if build_portable:
     runtime_hooks.append('scripts/pyinstaller/portable-hook.py')
 
 
@@ -84,7 +85,7 @@ pyz = PYZ(a.pure, a.zipped_data,
           cipher=block_cipher)
 
 
-if '--onefile' in sys.argv:
+if build_portable:
     exe = EXE(pyz,
               a.scripts,
               a.binaries,

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,3 +1,3 @@
 Babel==2.9.1
-PyInstaller==4.10
+PyInstaller==5.2
 setuptools<45.0.0

--- a/scripts/package/win-package-portable.ps1
+++ b/scripts/package/win-package-portable.ps1
@@ -30,6 +30,7 @@ python setup.py build_ext -i 2>&1 | %{ "$_" }
 ThrowOnExeError "setup.py build_ext -i failed"
 
 # Package application
-pyinstaller --noconfirm --clean --onefile picard.spec 2>&1 | %{ "$_" }
+$env:PICARD_BUILD_PORTABLE = '1'
+pyinstaller --noconfirm --clean picard.spec 2>&1 | %{ "$_" }
 ThrowOnExeError "PyInstaller failed"
 CodeSignBinary dist\MusicBrainz-Picard-*.exe


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

- Github has deprecated the macOS-10.15 package and will completely remove support for it soon, see https://github.com/actions/virtual-environments/issues/5583
- macOS packaging is currently failing with some issue building pyinstaller, see e.g. https://github.com/metabrainz/picard/runs/7447653204 . It's unclear whether this is related to the macOS-10.15 deprecation

# Todo

Check whether the build packages are still usable on older macOS.