### PR TITLE
PICARD-2354: DeprecationWarning: the imp module is deprecated in favour of importlib

### DIFF
--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -229,7 +229,6 @@ class PluginManager(QtCore.QObject):
         return (None, None)
 
     def _load_plugin_from_directory(self, name, plugindir):
-        module_file = None
         info = None
         zipfilename = os.path.join(plugindir, name + '.zip')
         (zip_importer, module_name, manifest_data) = zip_import(zipfilename)
@@ -274,6 +273,8 @@ class PluginManager(QtCore.QObject):
                 plugin_module = zip_importer.load_module(full_module_name)
             else:
                 plugin_module = importlib.util.module_from_spec(info)
+                info.loader.exec_module(plugin_module)
+
             plugin = PluginWrapper(plugin_module, plugindir,
                                    file=module_pathname, manifest_data=manifest_data)
             compatible_versions = _compatible_api_versions(plugin.api_versions)

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -254,8 +254,7 @@ class PluginManager(QtCore.QObject):
                 self.plugin_error(name, error, name, [plugindir])
                 return None
 
-            module_file = info.loader
-            module_pathname = info.origin
+            module_pathname = os.path.dirname(info.origin)
 
         plugin = None
         try:
@@ -298,8 +297,6 @@ class PluginManager(QtCore.QObject):
         except BaseException:
             error = _("Plugin %r")
             self.plugin_error(name, error, name, log_func=log.exception)
-        if module_file is not None:
-            module_file.close()
         return plugin
 
     def _get_existing_paths(self, plugin_name, fileexts):

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -122,10 +122,8 @@ def _plugin_name_from_path(path):
 
 def load_manifest(archive_path):
     archive = zipfile.ZipFile(archive_path)
-    manifest_data = None
     with archive.open('MANIFEST.json') as f:
-        manifest_data = json.loads(str(f.read().decode()))
-    return manifest_data
+        return json.loads(str(f.read().decode()))
 
 
 def zip_import(path):
@@ -258,7 +256,6 @@ class PluginManager(QtCore.QObject):
 
             module_file = info["loader"]
             module_pathname = info["origin"]
-
 
         plugin = None
         try:

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -248,8 +248,7 @@ class PluginManager(QtCore.QObject):
             # deprecated since 3.4
             #
             # comment to be deleted, just for the PR purposes
-            info = importlib.util.spec_from_file_location(name, os.path.join(plugindir, name + ".py")) or \
-                   importlib.util.spec_from_file_location(name, os.path.join(plugindir, name, "__init__.py"))
+            info = importlib.util.find_spec(name)
             if not info:
                 error = _("Failed loading plugin %r in %r")
                 self.plugin_error(name, error, name, [plugindir])

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -248,7 +248,8 @@ class PluginManager(QtCore.QObject):
             # deprecated since 3.4
             #
             # comment to be deleted, just for the PR purposes
-            info = importlib.util.spec_from_file_location(name, os.path.join(plugindir, name + ".py"))
+            info = importlib.util.spec_from_file_location(name, os.path.join(plugindir, name + ".py")) or \
+                   importlib.util.spec_from_file_location(name, os.path.join(plugindir, name, "__init__.py"))
             if not info:
                 error = _("Failed loading plugin %r in %r")
                 self.plugin_error(name, error, name, [plugindir])

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -250,14 +250,14 @@ class PluginManager(QtCore.QObject):
             # deprecated since 3.4
             #
             # comment to be deleted, just for the PR purposes
-            info = importlib.util.find_spec(name)
-            if not info:
+            info = importlib.machinery.PathFinder().find_spec(name, [plugindir])
+            if not info.loader:
                 error = _("Failed loading plugin %r in %r")
                 self.plugin_error(name, error, name, [plugindir])
                 return None
 
-            module_file = info["loader"]
-            module_pathname = info["origin"]
+            module_file = info.loader
+            module_pathname = info.origin
 
         plugin = None
         try:

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -28,7 +28,6 @@ import importlib
 import json
 import os.path
 import shutil
-import sys
 import tempfile
 import zipfile
 import zipimport
@@ -230,7 +229,6 @@ class PluginManager(QtCore.QObject):
         return (None, None)
 
     def _load_plugin_from_directory(self, name, plugindir):
-        sys.path.append(plugindir)
         module_file = None
         info = None
         zipfilename = os.path.join(plugindir, name + '.zip')

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -254,7 +254,9 @@ class PluginManager(QtCore.QObject):
                 self.plugin_error(name, error, name, [plugindir])
                 return None
 
-            module_pathname = os.path.dirname(info.origin)
+            module_pathname = info.origin
+            if module_pathname.endswith("__init__.py"):
+                module_pathname = os.path.dirname(module_pathname)
 
         plugin = None
         try:

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -28,6 +28,7 @@ import importlib
 import json
 import os.path
 import shutil
+import sys
 import tempfile
 import zipfile
 import zipimport
@@ -229,6 +230,7 @@ class PluginManager(QtCore.QObject):
         return (None, None)
 
     def _load_plugin_from_directory(self, name, plugindir):
+        sys.path.append(plugindir)
         module_file = None
         info = None
         zipfilename = os.path.join(plugindir, name + '.zip')


### PR DESCRIPTION

# Summary

The `imp` module will be removed in Python 3.12 so we have to switch to `importlib`

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

`imp` is used only in `pluginmanager.py` in 2 places, so it doesn't change much of the codebase. 

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2354
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

I've found some way to replace it in importlib examples but I'm not sure if they're the best way to achieve this.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
