### PR TITLE
PICARD-2521: Cannot exit properly after removing the pipe file

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -49,7 +49,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 import itertools
 import logging
-import os.path
+import os
 import platform
 import re
 import shutil
@@ -426,6 +426,7 @@ class Tagger(QtWidgets.QApplication):
         self.webservice.stop()
         self.run_cleanup()
         QtCore.QCoreApplication.processEvents()
+        os._exit(0)
 
     def _run_init(self):
         if self._cmdline_files:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -432,7 +432,6 @@ class Tagger(QtWidgets.QApplication):
         self.run_cleanup()
         QtCore.QCoreApplication.processEvents()
 
-
     def _run_init(self):
         if self._cmdline_files:
             files = [decode_filename(f) for f in self._cmdline_files]

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -46,7 +46,6 @@
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures._base import TimeoutError
 from functools import partial
 import itertools
 import logging

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -154,6 +154,9 @@ class AbstractPipe(metaclass=ABCMeta):
         self.__thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=6)
 
         self.pipe_running = False
+
+        self.unexpected_removal = False
+
         for path in self._paths:
             self.path = path
             for arg in self._args:
@@ -329,6 +332,7 @@ class UnixPipe(AbstractPipe):
             except FileNotFoundError:
                 log.error("Pipe file removed unexpectedly")
                 self.pipe_running = False
+                self.unexpected_removal = True
                 raise PipeErrorNotFound from None
             except BrokenPipeError:
                 log.warning("BrokenPipeError happened while listening to the pipe")


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

The single instance mode via named pipes got merged and works almost perfectly. Almost... because when the pipe file gets deleted (outside of the Picard, e.g. `rm`), Picard cannot exit properly and gets stuck during the exit function's call.

# Problem

* JIRA ticket (_optional_): PICARD-2521

# Solution

1) save the tagger's exit code
2) check whether the pipe file was removed unexpectedly (new `Pipe` attribute)
- if yes: `os._exit(exit_code)`
- if no: `sys.exit(exit_code)`


# Action

(https://github.com/metabrainz/picard/pull/2133) included since they're both about fixing the exit process, so they could be in a single PR
