### PR TITLE
Build with latest setuptools again

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,3 +1,2 @@
 Babel==2.9.1
 PyInstaller==5.3
-setuptools<45.0.0


### PR DESCRIPTION
setuptools made some changes, causing the error `[AttributeError: module '_distutils_hack' has no attribute 'ensure_shim'](https://github.com/pypa/setuptools/issues/2983#)`  when trying to install the old version of setuptools during build.

Try building with the latest setuptools instead.