### PR TITLE
PICARD-2526: Allow starting processing actions from the command line

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -162,6 +162,9 @@ class Album(DataObject, Item):
         if not save:
             yield from self.unmatched_files.iterfiles()
 
+    def iter_correctly_matched_tracks(self):
+        yield from (track for track in self.tracks if track.num_linked_files == 1)
+
     def enable_update_metadata_images(self, enabled):
         self.update_metadata_images_enabled = enabled
 
@@ -756,12 +759,12 @@ class Album(DataObject, Item):
         return not self.get_num_unmatched_files()
 
     def is_modified(self):
-        return any(self.iter_unsaved_files())
+        return any(self._iter_unsaved_files())
 
     def get_num_unsaved_files(self):
-        return sum(1 for file in self.iter_unsaved_files())
+        return sum(1 for file in self._iter_unsaved_files())
 
-    def iter_unsaved_files(self):
+    def _iter_unsaved_files(self):
         yield from (file for file in self.iterfiles(save=True) if not file.is_saved())
 
     def column(self, column):

--- a/picard/album.py
+++ b/picard/album.py
@@ -22,6 +22,7 @@
 # Copyright (C) 2019 Joel Lintunen
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021 Petit Minion
+# Copyright (C) 2022 skelly37
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -755,12 +756,12 @@ class Album(DataObject, Item):
         return not self.get_num_unmatched_files()
 
     def is_modified(self):
-        return any(self._iter_unsaved_files())
+        return any(self.iter_unsaved_files())
 
     def get_num_unsaved_files(self):
-        return sum(1 for file in self._iter_unsaved_files())
+        return sum(1 for file in self.iter_unsaved_files())
 
-    def _iter_unsaved_files(self):
+    def iter_unsaved_files(self):
         yield from (file for file in self.iterfiles(save=True) if not file.is_saved())
 
     def column(self, column):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -374,6 +374,11 @@ class Tagger(QtWidgets.QApplication):
         if parsed_items.non_executable_items():
             self.bring_tagger_front()
 
+    def get_album_pane_tracks(self):
+        for album in self.albums.values():
+            for track in album.iterfiles():
+                yield track
+
     def enable_menu_icons(self, enabled):
         self.setAttribute(QtCore.Qt.ApplicationAttribute.AA_DontShowIconsInMenus, not enabled)
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -256,9 +256,9 @@ REMOTE_COMMANDS = {
         "handle_command_remove_saved",
         help_text="Remove all saved releases from the album pane.",
     ),
-    "SAVE_COMPLETE": RemoteCommand(
-        "handle_command_save_complete",
-        help_text="Save all completely matched releases in the album pane.",
+    "SAVE_MODIFIED": RemoteCommand(
+        "handle_command_save_modified",
+        help_text="Save all modified files from the album pane.",
     ),
     "SCAN": RemoteCommand(
         "handle_command_scan",
@@ -519,7 +519,7 @@ class Tagger(QtWidgets.QApplication):
             if track.state == File.NORMAL:
                 track.remove()
 
-    def handle_command_save_complete(self, argstring):
+    def handle_command_save_modified(self, argstring):
         for track in self.get_album_pane_tracks():
             if track.state == File.CHANGED:
                 track.save()

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1217,6 +1217,9 @@ List of the commands available to execute in Picard from the command-line:
                                       files in the album pane
 
 - Commands are case insensitive (not args!), i.e. SHOW == show == ShOw
+- If there is no running instance, picard -e blocks Picards startup and does nothing
+- If there is an existing instance, picard -e will send all the positional arguments in the given order.
+  Then the commands. So the files passed to the new instance with a command will be processed as well.
 - Arguments are optional and not providing them will not cause Picard to crash
   - LOOKUP_CD without the argument will default to the first (alphabetically) available disc drive
   - REMOVE without the argument will not do anything

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1215,7 +1215,10 @@ List of the commands available to execute in Picard from the command-line:
                                       files in the album pane
 
 - Commands are case insensitive (not args!), i.e. SHOW == show == ShOw
-- Arguments do not have to be entered, as they are required only for the two of commands
+- Arguments are optional and not providing them will not cause Picard to crash
+  - LOOKUP_CD without the argument will default to the first (alphabetically) available disc drive
+  - REMOVE without the argument will not do anything
+  - other commands ignore the arguments and act the same regardless of their amount
 - Only one path can be send per one REMOVE command""")
 
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -456,7 +456,7 @@ class Tagger(QtWidgets.QApplication):
     def handle_command_remove(self, argstring):
         for file in self.get_all_file_objects():
             if argstring == file.filename:
-                argstring.remove()
+                file.remove()
                 return
 
     def handle_command_remove_all(self, argstring):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -386,12 +386,18 @@ class Tagger(QtWidgets.QApplication):
             for track in album.iterfiles():
                 yield track
 
+    def get_all_file_objects(self):
+        return self.unclustered_files.files + [x for x in self.get_album_pane_tracks()] + [x for x in self.clusters.iterfiles()]
+
     def _init_remote_commands(self):
         self.commands = {
             "CLUSTER": self.handle_command_cluster,
             "FINGERPRINT": self.handle_command_fingerprint,
             "LOOKUP": self.handle_command_lookup,
             "QUIT": self.handle_command_quit,
+            # due to the pipe protocol limitations
+            # we currently can handle only one file per `remove` command
+            "REMOVE": self.handle_command_remove,
             "REMOVE_SAVED": self.handle_command_remove_saved,
             "SAVE_COMPLETE": self.handle_command_save_complete,
             "SCAN": self.handle_command_scan,
@@ -420,6 +426,12 @@ class Tagger(QtWidgets.QApplication):
     def handle_command_quit(self, argstring):
         self.exit()
         self.quit()
+
+    def handle_command_remove(self, argstring):
+        for file in self.get_all_file_objects():
+            if argstring == file.filename:
+                argstring.remove()
+                return
 
     def handle_command_remove_saved(self, argstring):
         for track in self.get_album_pane_tracks():

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -428,14 +428,14 @@ class Tagger(QtWidgets.QApplication):
 
     def handle_command_lookup_cd(self, argstring):
         disc = Disc()
+        devices = get_cdrom_drives()
 
         if not argstring:
-            devices = get_cdrom_drives()
             if devices:
                 device = devices[0]
             else:
                 device = None
-        elif argstring.startswith("/dev/"):
+        elif argstring in devices:
             device = argstring
         else:
             thread.run_task(

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1192,6 +1192,33 @@ def longversion():
     print(versions.as_string())
 
 
+def print_help_for_commands():
+    print("""usage: picard -e [command] [arguments ...]
+or
+picard -e [command 1] [arguments ...] -e [commands 2] [arguments ...]
+
+List of the commands available to execute in Picard from the command-line:
+
+  - CLUSTER                           cluster all files in the cluster pane
+  - FINGERPRINT                       calculate acoustic fingerprints for all (matched) files in
+                                      the album pane
+  - LOOKUP                            lookup all clusters in the cluster pane.
+  - LOOKUP_CD [device/log file]       read CD from the selected drive and lookup on MusicBrainz.
+  - QUIT                              exit the running instance of Picard
+  - REMOVE [absolute path (1 file)]   remove the file from Picard
+  - REMOVE_ALL                        remove all files from Picard
+  - REMOVE_SAVED                      remove all saved releases from the album pane
+  - SAVE_COMPLETE                     save all completely matched releases in the album pane
+  - SCAN                              scan all files in the cluster pane
+  - SHOW                              make the running instance the currently active window
+  - SUBMIT_FINGERPRINTS               submit outstanding acoustic fingerprints for all (matched)
+                                      files in the album pane
+
+- Commands are case insensitive (not args!), i.e. SHOW == show == ShOw
+- Arguments do not have to be entered, as they are required only for the two of commands
+- Only one path can be send per one REMOVE command""")
+
+
 def process_picard_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1282,6 +1309,10 @@ def main(localedir=None, autoupdate=True):
 
         if picard_args.exec:
             for e in picard_args.exec:
+                if "help" in [x.lower().strip() for x in e]:
+                    print_help_for_commands()
+                    to_be_added.clear()
+                    break
                 to_be_added.append("command://" + " ".join(e))
 
         if to_be_added:
@@ -1299,8 +1330,8 @@ def main(localedir=None, autoupdate=True):
 
         # pipe has sent its args to existing one, doesn't need to start
         if not should_start:
+            log.debug("No need for spawning a new instance, exiting...")
             # just a custom exit code to show that picard instance wasn't created
-            log.info("No need for spawning a new instance, exiting...")
             sys.exit(EXIT_NO_NEW_INSTANCE)
     else:
         pipe_handler = None

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -649,7 +649,6 @@ class Tagger(QtWidgets.QApplication):
         QtCore.QCoreApplication.processEvents()
 
     def _run_init(self):
-        print(self._to_load)
         if self._to_load:
             self.load_to_picard(self._to_load)
         del self._to_load

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -459,13 +459,14 @@ class Tagger(QtWidgets.QApplication):
         self.commands = {name: getattr(self, remcmd.method_name) for name, remcmd in REMOTE_COMMANDS.items()}
 
     def handle_command(self, command):
+        cmd, *args = command.split(' ', 1)
+        argstring = next(iter(args), "")
+        cmd = cmd.upper()
+        log.debug("Executing command: %r", cmd)
         try:
-            cmd, *args = command.split(' ', 1)
-            argstring = next(iter(args), "")
-            log.debug("Executing command: %r", cmd.upper())
-            thread.to_main(self.commands[cmd.upper()], argstring.strip())
+            thread.to_main(self.commands[cmd], argstring.strip())
         except KeyError:
-            log.error("Unknown command: %r", command)
+            log.error("Unknown command: %r", cmd)
 
     def handle_command_cluster(self, argstring):
         self.cluster(self.unclustered_files.files)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -398,6 +398,7 @@ class Tagger(QtWidgets.QApplication):
             # due to the pipe protocol limitations
             # we currently can handle only one file per `remove` command
             "REMOVE": self.handle_command_remove,
+            "REMOVE_ALL": self.handle_command_remove_all,
             "REMOVE_SAVED": self.handle_command_remove_saved,
             "SAVE_COMPLETE": self.handle_command_save_complete,
             "SCAN": self.handle_command_scan,
@@ -432,6 +433,10 @@ class Tagger(QtWidgets.QApplication):
             if argstring == file.filename:
                 argstring.remove()
                 return
+
+    def handle_command_remove_all(self, argstring):
+        for file in self.get_all_file_objects():
+            file.remove()
 
     def handle_command_remove_saved(self, argstring):
         for track in self.get_album_pane_tracks():

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -256,6 +256,10 @@ REMOTE_COMMANDS = {
         "handle_command_remove_saved",
         help_text="Remove all saved releases from the album pane.",
     ),
+    "SAVE_MATCHED": RemoteCommand(
+        "handle_command_save_matched",
+        help_text="Remove all matched releases from the album pane."
+    ),
     "SAVE_MODIFIED": RemoteCommand(
         "handle_command_save_modified",
         help_text="Save all modified files from the album pane.",
@@ -519,6 +523,11 @@ class Tagger(QtWidgets.QApplication):
         for track in self.get_album_pane_tracks():
             if track.state == File.NORMAL:
                 track.remove()
+
+    def handle_command_save_matched(self, argstring):
+        for album in self.albums.values():
+            for track in album.iter_unsaved_files():
+                track.save()
 
     def handle_command_save_modified(self, argstring):
         for track in self.get_album_pane_tracks():

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1214,7 +1214,9 @@ If a new instance will not be spawned:
     parser.add_argument("-d", "--debug", action='store_true',
                         help="enable debug-level logging")
     parser.add_argument("-e", "--exec", nargs="+", action='append',
-                        help="send command (arguments can be entered after space) to a running instance")
+                        help="send command (arguments can be entered after space) to a running instance "
+                        "(use `-e help` for a list of the available commands",
+                        metavar="COMMAND")
     parser.add_argument("-M", "--no-player", action='store_true',
                         help="disable built-in media player")
     parser.add_argument("-N", "--no-restore", action='store_true',

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -451,14 +451,13 @@ class Tagger(QtWidgets.QApplication):
         if parsed_items.non_executable_items():
             self.bring_tagger_front()
 
-    def get_album_pane_tracks(self):
+    def iter_album_files(self):
         for album in self.albums.values():
-            for track in album.iterfiles():
-                yield track
+            yield from album.iterfiles()
 
     def iter_all_files(self):
         yield from self.unclustered_files.files
-        yield from self.get_album_pane_tracks()
+        yield from self.iter_album_files()
         yield from self.clusters.iterfiles()
 
     def _init_remote_commands(self):
@@ -522,7 +521,7 @@ class Tagger(QtWidgets.QApplication):
             file.remove()
 
     def handle_command_remove_saved(self, argstring):
-        for track in self.get_album_pane_tracks():
+        for track in self.iter_album_files():
             if track.state == File.NORMAL:
                 track.remove()
 
@@ -532,7 +531,7 @@ class Tagger(QtWidgets.QApplication):
                 track.files[0].save()
 
     def handle_command_save_modified(self, argstring):
-        for track in self.get_album_pane_tracks():
+        for track in self.iter_album_files():
             if track.state == File.CHANGED:
                 track.save()
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -526,8 +526,8 @@ class Tagger(QtWidgets.QApplication):
 
     def handle_command_save_matched(self, argstring):
         for album in self.albums.values():
-            for track in album.iter_unsaved_files():
-                track.save()
+            for track in album.iter_correctly_matched_tracks():
+                track.files[0].save()
 
     def handle_command_save_modified(self, argstring):
         for track in self.get_album_pane_tracks():

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1264,9 +1264,10 @@ List of the commands available to execute in Picard from the command-line:
         print(fill(s, width=maxwidth, initial_indent=' '*2))
 
     fmt("Commands are case insensitive.")
-    fmt("If there is no running instance, picard -e blocks Picards startup and does nothing.")
-    fmt("If there is an existing instance, picard -e will send all the positional arguments in the given order "
-    "followed by the commands, so the files passed to the new instance with a command will be processed as well.")
+    fmt("Picard will try to load all the positional arguments before processing commands.")
+    fmt("If there is no instance to pass the arguments to, Picard will start and process the commands after the"
+        "positional arguments are loaded, as mentioned above. Otherwise they will be handled by the running"
+        "Picard instance")
     fmt("Arguments are optional, but some commands may require one or more arguments to actually do something.")
 
 
@@ -1359,10 +1360,9 @@ def main(localedir=None, autoupdate=True):
 
         if picard_args.exec:
             for e in picard_args.exec:
-                if "help" in [x.lower().strip() for x in e]:
+                if "HELP" in [x.upper().strip() for x in e]:
                     print_help_for_commands()
-                    to_be_added.clear()
-                    break
+                    sys.exit(0)
                 to_be_added.append("command://" + " ".join(e))
 
         if to_be_added:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -388,7 +388,7 @@ class Tagger(QtWidgets.QApplication):
                 yield track
 
     def get_all_file_objects(self):
-        return self.unclustered_files.files + [x for x in self.get_album_pane_tracks()] + [x for x in self.clusters.iterfiles()]
+        return self.unclustered_files.files + list(self.get_album_pane_tracks()) + list(self.clusters.iterfiles())
 
     def _init_remote_commands(self):
         self.commands = {

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1215,7 +1215,7 @@ If a new instance will not be spawned:
                         help="enable debug-level logging")
     parser.add_argument("-e", "--exec", nargs="+", action='append',
                         help="send command (arguments can be entered after space) to a running instance "
-                        "(use `-e help` for a list of the available commands",
+                        "(use `-e help` for a list of the available commands)",
                         metavar="COMMAND")
     parser.add_argument("-M", "--no-player", action='store_true',
                         help="disable built-in media player")
@@ -1288,13 +1288,14 @@ def main(localedir=None, autoupdate=True):
             # note: log level isn't defined yet, it defaults to info, log.debug() would not work here
             log.info("Sending messages to main instance: %r" % to_be_added)
 
-        try:
-            pipe_handler = pipe.Pipe(app_name=PICARD_APP_NAME, app_version=PICARD_FANCY_VERSION_STR, args=to_be_added)
-            should_start = pipe_handler.is_pipe_owner and (picard_args.exec is None)
-        except pipe.PipeErrorNoPermission as err:
-            log.error(err)
-            pipe_handler = None
-            should_start = True
+        if picard_args.exec is None:
+            try:
+                pipe_handler = pipe.Pipe(app_name=PICARD_APP_NAME, app_version=PICARD_FANCY_VERSION_STR, args=to_be_added)
+                should_start = pipe_handler.is_pipe_owner
+            except pipe.PipeErrorNoPermission as err:
+                log.error(err)
+                pipe_handler = None
+                should_start = True
 
         # pipe has sent its args to existing one, doesn't need to start
         if not should_start:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -456,7 +456,7 @@ class Tagger(QtWidgets.QApplication):
             for track in album.iterfiles():
                 yield track
 
-    def get_all_file_objects(self):
+    def iter_all_files(self):
         yield from self.unclustered_files.files
         yield from self.get_album_pane_tracks()
         yield from self.clusters.iterfiles()
@@ -512,13 +512,13 @@ class Tagger(QtWidgets.QApplication):
         self.quit()
 
     def handle_command_remove(self, argstring):
-        for file in self.get_all_file_objects():
+        for file in self.iter_all_files():
             if argstring == file.filename:
                 file.remove()
                 return
 
     def handle_command_remove_all(self, argstring):
-        for file in self.get_all_file_objects():
+        for file in self.iter_all_files():
             file.remove()
 
     def handle_command_remove_saved(self, argstring):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -457,7 +457,9 @@ class Tagger(QtWidgets.QApplication):
                 yield track
 
     def get_all_file_objects(self):
-        return self.unclustered_files.files + list(self.get_album_pane_tracks()) + list(self.clusters.iterfiles())
+        yield from self.unclustered_files.files
+        yield from self.get_album_pane_tracks()
+        yield from self.clusters.iterfiles()
 
     def _init_remote_commands(self):
         self.commands = {name: getattr(self, remcmd.method_name) for name, remcmd in REMOTE_COMMANDS.items()}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Users will be able to pass some commands to the existing instance with `-e`/`--exec` flag.

# Problem

It would be useful to tell the existing Picard instance what to do, e.g. QUIT, useful in combination with the other single-instance mode improvements

* JIRA ticket (_optional_): PICARD-2526
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

- add command:// prefix to the commands
- send them as any other arg
- parse with urlparse, split by ";"
- execute

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
