### PR TITLE
PICARD-2520: Null bytes in tag values can cause crashes when sorting

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1086,8 +1086,9 @@ def any_exception_isinstance(error, type_):
 def strxfrm(string):
     """Transforms a string to one that can be used in locale-aware comparisons.
 
-    Wrapper around locale.strxfrm, that never throws OSError. If an OSError
-    occurs this function will return the string converted to lower case.
+    Wrapper around locale.strxfrm, that never throws OSError or ValueError. If an
+    error occurs this function will return the string converted to lower case.
+    Also null bytes in the input string will be ignored.
 
     Args:
         string: The string to convert
@@ -1095,7 +1096,7 @@ def strxfrm(string):
     Returns: A string that can be compared locale-aware
     """
     try:
-        return _strxfrm(string)
-    except OSError as err:
+        return _strxfrm(string.replace('\0', ''))
+    except (OSError, ValueError) as err:
         log.warning('strxfrm(%r) failed: %r', string, err)
         return string.lower()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -33,6 +33,7 @@
 import builtins
 from collections import namedtuple
 from collections.abc import Iterator
+from locale import strxfrm as system_strxfrm
 import re
 import subprocess  # nosec: B404
 from tempfile import NamedTemporaryFile
@@ -66,6 +67,7 @@ from picard.util import (
     normpath,
     pattern_as_regex,
     sort_by_similarity,
+    strxfrm,
     system_supports_long_paths,
     tracknum_and_title_from_filename,
     tracknum_from_filename,
@@ -748,6 +750,20 @@ class WinPrefixLongpathTest(PicardTestCase):
     def test_win_prefix_longpath_is_short(self):
         path = 'C:\\foo\\' + (252 * 'a')
         self.assertEqual(path, win_prefix_longpath(path))
+
+
+class StrxfrmTest(PicardTestCase):
+
+    def test_strxfrm(self):
+        value = 'Motörhead'
+        self.assertEqual(
+            system_strxfrm(value),
+            strxfrm(value)
+        )
+
+    def test_strxfrm_ignore_null_chars(self):
+        result = strxfrm('Foo\0bar\0')
+        self.assertEqual(system_strxfrm('Foobar'), result)
 
 
 class SystemSupportsLongPathsTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2520
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When a audio file contains unexpected null bytes in the tag values this can cause Picard to crash when sorting by this tag value. This is due `strxfrm`  not allowing null bytes as part of the input.


# Solution
strxfrm fails if a string contains a null char. Sanizize the input strings for strxfrm by removing any null chars.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
