### PR TITLE
PICARD-2544: Use UUID for pipes in tests

### DIFF
--- a/test/test_util_pipe.py
+++ b/test/test_util_pipe.py
@@ -20,7 +20,7 @@
 
 import concurrent.futures
 from platform import python_version
-from random import randint
+import uuid
 
 from test.picardtestcase import PicardTestCase
 
@@ -45,8 +45,8 @@ def pipe_writer(pipe_handler, to_send):
 
 
 class TestPipe(PicardTestCase):
-    # we don't need any strong and secure random numbers, just anything that is different on each run
-    NAME = str(randint(0, 99999999))  # nosec
+    # some random name that is different on each run
+    NAME = str(uuid.uuid4())
     VERSION = python_version()
 
     def test_invalid_args(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2544
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

As suggested by zas in PICARD-2544 use UUID for the pipe name in the tests.