### PR TITLE
PICARD-2549: Fixed similarity not getting updated if only difference is cover art

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -709,12 +709,12 @@ class File(QtCore.QObject, Item):
                         self.state = File.CHANGED
                     break
             else:
-                if (self.metadata.images
+                self.similarity = 1.0
+                if self.state in (File.CHANGED, File.NORMAL):
+                    if (self.metadata.images
                         and self.orig_metadata.images != self.metadata.images):
-                    self.state = File.CHANGED
-                else:
-                    self.similarity = 1.0
-                    if self.state == File.CHANGED:
+                        self.state = File.CHANGED
+                    else:
                         self.state = File.NORMAL
         if signal:
             log.debug("Updating file %r", self)

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2018-2021 Philipp Wolfer
+# Copyright (C) 2018-2022 Philipp Wolfer
 # Copyright (C) 2019-2022 Laurent Monin
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Sophist-UK
@@ -459,7 +459,7 @@ class FileUpdateTest(PicardTestCase):
         self.file.state = File.NORMAL
 
         self.file.update(signal=False)
-        self.assertEqual(self.file.similarity, self.INVALIDSIMVAL)  # it shouldbn't be modified
+        self.assertEqual(self.file.similarity, 1.0)
         self.assertEqual(self.file.state, File.CHANGED)
 
     def test_signal(self):


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2549
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If a file is moved to a track where the metadata matches perfectly but only cover art is different, then the similarity score of this file was not recalculated. That means the file retains the similarity of the previous (probably bad) match.


# Solution

Reset the similarity to 1.0 in all cases when metadata match was successful. This matches the existing behavior when such files would be matched directly to the perfect match: The file shows as changed, but with metadata similariry set to 100%.

We could consider showing a lower score in all cases where only cover art does not match. But given that we have many cases where the cover art known for the file does not match the loaded cover art (see e.g. PICARD-1001) I think this would not be helpful. 