### PR TITLE
PICARD-2548: Trigger cover art box update for selected albums after loading

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -528,6 +528,7 @@ class Album(DataObject, Item):
         self._after_load_callbacks = []
         if self.item.isSelected():
             self.tagger.window.refresh_metadatabox()
+            self.tagger.window.cover_art_box.update_metadata()
 
     def _finalize_loading(self, error):
         if self.loaded:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2548
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Cover art box is for performance reasons disabled during album loading (similar to metadata box updates). But if a loading album is selected and after it has fully loaded the metadata box updates with the new information, but cover art box stays empty until selection changes.


# Solution

Trigger an update of the cover art box if the currently loaded album is selected