### PR TITLE
PICARD-2556: fix player popover dialogs on Wayland

### DIFF
--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -116,7 +116,7 @@ class Popover(QtWidgets.QFrame):
             y = -self.height()
         else:  # bottom
             y = parent.height()
-        pos = parent.mapToGlobal(QtCore.QPoint(x, y))
+        pos = parent.mapToGlobal(QtCore.QPoint(int(x), int(y)))
         screen_number = QtWidgets.QApplication.desktop().screenNumber()
         screen = QtGui.QGuiApplication.screens()[screen_number]
         screen_size = screen.availableVirtualSize()
@@ -145,6 +145,6 @@ class SliderPopover(Popover):
 
         self.slider = ClickableSlider(self)
         self.slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.slider.setValue(value)
+        self.slider.setValue(int(value))
         self.slider.valueChanged.connect(self.value_changed)
         vbox.addWidget(self.slider)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2556
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Under Wayland the player toolbar popover dialogs, used for audio volume and playback speed settings, are

1. causing a crash due to wrong data type of coordinates
2. not properly positioned

# Solution

1. Ensure position and slider value are set as integer
2. Add custom handling for calculating the popover position on Wayland

Note that there is a small difference in behavior: On systems other then Wayland the code makes sure the popover is shown centered above / below the parent widget if possible, but repositions it to ensure it is on screen. This is relevant if the parent is near the screen edges.

On Wayland that's no possible, because the position relative to the screen cannot be determined. Hence instead of the screen the logic now repositions the popovers so they are inside the main window. That ensures the popovers are fully visible in e.g. maximized state.
