### PR TITLE
PICARD-2557: Revert "An editable QComboBox automatically sets up a QCompleter"

### DIFF
--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -110,7 +110,9 @@ class EditTagDialog(PicardDialog):
         tag_names.addItem("")
         visible_tags = [tn for tn in self.default_tags if not tn.startswith("~")]
         tag_names.addItems(visible_tags)
-        tag_names.completer().setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
+        self.completer = QtWidgets.QCompleter(visible_tags, tag_names)
+        self.completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
+        tag_names.setCompleter(self.completer)
         self.value_list.model().rowsInserted.connect(self.on_rows_inserted)
         self.value_list.model().rowsRemoved.connect(self.on_rows_removed)
         self.value_list.setItemDelegate(TagEditorDelegate(self))
@@ -266,6 +268,12 @@ class EditTagDialog(PicardDialog):
             self.ui.add_value.setEnabled(True)
         else:
             self._modified_tag()[row] = value
+            # add tags to the completer model once they get values
+            cm = self.completer.model()
+            if self.tag not in cm.stringList():
+                cm.insertRows(0, 1)
+                cm.setData(cm.index(0, 0), self.tag)
+                cm.sort(0)
 
     def value_selection_changed(self):
         selection = len(self.value_list.selectedItems()) > 0


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2557
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The edit tag dialog's auto completion for the tag name will show the currently typed value as the first suggestion in autocomplete, which is not helpful for the user and always requires an extra button press to skip it.

This was caused by removing the custom QCompleter implementation and using the default QComboBox  completer implementation.


# Solution
This reverts commit e0d58d50987a3f9c7cf52e23d728f1f2cf0a153f and restores the custom implementation.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
