### PR TITLE
PICARD-2558: Disable floatable toolbars on Wayland

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -452,6 +452,10 @@ class Tagger(QtWidgets.QApplication):
         if self.autoupdate_enabled:
             self.updatecheckmanager = UpdateCheckManager(parent=self.window)
 
+    @property
+    def is_wayland(self):
+        return self.platformName() == 'wayland'
+
     def pipe_server(self):
         IGNORED = {pipe.Pipe.MESSAGE_TO_IGNORE, pipe.Pipe.NO_RESPONSE_MESSAGE}
         while self.pipe_handler.pipe_running:

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1077,7 +1077,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.insertToolBar(self.search_toolbar, self.toolbar)
         toolbar.setObjectName("main_toolbar")
         if self._is_wayland:
-            toolbar.setFloatable(False)
+            toolbar.setFloatable(False)  # https://bugreports.qt.io/browse/QTBUG-92191
         if IS_MACOS:
             toolbar.setMovable(False)
 
@@ -1106,7 +1106,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         toolbar = self.player.create_toolbar()
         self.addToolBar(QtCore.Qt.ToolBarArea.BottomToolBarArea, toolbar)
         if self._is_wayland:
-            toolbar.setFloatable(False)
+            toolbar.setFloatable(False)  # https://bugreports.qt.io/browse/QTBUG-92191
         self.player_toolbar_toggle_action = toolbar.toggleViewAction()
         toolbar.hide()  # Hide by default
 
@@ -1116,7 +1116,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.search_toolbar_toggle_action = self.search_toolbar.toggleViewAction()
         toolbar.setObjectName("search_toolbar")
         if self._is_wayland:
-            toolbar.setFloatable(False)
+            toolbar.setFloatable(False)  # https://bugreports.qt.io/browse/QTBUG-92191
         if IS_MACOS:
             self.search_toolbar.setMovable(False)
 

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -187,6 +187,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_NativeWindow)
         self.__shown = False
+        app = QtCore.QCoreApplication.instance()
+        self._is_wayland = app.is_wayland
         self.selected_objects = []
         self.ignore_selection_changes = IgnoreUpdatesContext(self.update_selection)
         self.toolbar = None
@@ -1065,6 +1067,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if self.player:
             self.create_player_toolbar()
         self.create_action_toolbar()
+        self.update_toolbar_style()
 
     def create_action_toolbar(self):
         if self.toolbar:
@@ -1072,10 +1075,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.removeToolBar(self.toolbar)
         self.toolbar = toolbar = QtWidgets.QToolBar(_("Actions"))
         self.insertToolBar(self.search_toolbar, self.toolbar)
-        self.update_toolbar_style()
         toolbar.setObjectName("main_toolbar")
+        if self._is_wayland:
+            toolbar.setFloatable(False)
         if IS_MACOS:
-            self.toolbar.setMovable(False)
+            toolbar.setMovable(False)
 
         def add_toolbar_action(action):
             toolbar.addAction(action)
@@ -1101,6 +1105,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """"Create a toolbar with internal player control elements"""
         toolbar = self.player.create_toolbar()
         self.addToolBar(QtCore.Qt.ToolBarArea.BottomToolBarArea, toolbar)
+        if self._is_wayland:
+            toolbar.setFloatable(False)
         self.player_toolbar_toggle_action = toolbar.toggleViewAction()
         toolbar.hide()  # Hide by default
 
@@ -1109,6 +1115,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.search_toolbar = toolbar = self.addToolBar(_("Search"))
         self.search_toolbar_toggle_action = self.search_toolbar.toggleViewAction()
         toolbar.setObjectName("search_toolbar")
+        if self._is_wayland:
+            toolbar.setFloatable(False)
         if IS_MACOS:
             self.search_toolbar.setMovable(False)
 

--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -105,7 +105,7 @@ class Popover(QtWidgets.QFrame):
         self.setWindowFlags(QtCore.Qt.WindowType.Popup | QtCore.Qt.WindowType.FramelessWindowHint)
         self.position = position
         app = QtCore.QCoreApplication.instance()
-        self._is_wayland = app.platformName() == 'wayland'
+        self._is_wayland = app.is_wayland
         self._main_window = app.window
 
     def show(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2558
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Floatable toolbars are not fully supported by Qt, see https://bugreports.qt.io/browse/QTBUG-92191 . The user can make a toolbar floating, but it will always be displayed in the middle of the screen and cannot be moved by the user anymore (and also not docked again).


# Solution
On Wayland set `QToolBar.floatable`  to `False`