### PR TITLE
PICARD-2564: Keep option UI for ascii_filenames and windows_compatibility activated

### DIFF
--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -105,6 +105,7 @@ class RenamingOptionsPage(OptionsPage):
 
         self.ui.move_files.toggled.connect(self.toggle_file_naming_format)
         self.ui.rename_files.toggled.connect(self.toggle_file_naming_format)
+        self.toggle_file_naming_format(None)
         self.ui.open_script_editor.clicked.connect(self.show_script_editing_page)
         self.ui.move_files_to_browse.clicked.connect(self.move_files_to_browse)
 
@@ -198,9 +199,6 @@ class RenamingOptionsPage(OptionsPage):
     def toggle_file_naming_format(self, state):
         active = self.ui.move_files.isChecked() or self.ui.rename_files.isChecked()
         self.ui.open_script_editor.setEnabled(active)
-        self.ui.ascii_filenames.setEnabled(active)
-        if not IS_WIN:
-            self.ui.windows_compatibility.setEnabled(active)
 
     def toggle_windows_long_paths(self, state):
         if state and not system_supports_long_paths():


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2564
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The options screen for file renaming currently attempts to set the two options "ascii_filenames" and "windows_compatibility" to inactive, when neither rename nor move files is active. There are two problems with this:

The code does not set the initial state correctly, so the options are changeable by the user initially, but when both rename and move files get deactivated then the other options suddenly get grayed out
The options are also used for cover art file naming, independent of the renaming or moving of music files.

I hence propose to completely remove this graying out of these two options and instead allow the user to always change them.


# Solution

Allow the user to always change these settings, independent of file renaming / moving, as the same settings are also used for cover art files and in theory all file saving done by Picard.

Also run `toggle_file_naming_format`  initially to ensure the UI state is properly initialized.
