### PR TITLE
PICARD-2570: Always cluster files dragged to "Clusters"

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -48,7 +48,6 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from hashlib import md5
-import itertools
 import logging
 import os
 import platform
@@ -1252,16 +1251,7 @@ class Tagger(QtWidgets.QApplication):
     def cluster(self, objs, callback=None):
         """Group files with similar metadata to 'clusters'."""
         log.debug("Clustering %r", objs)
-        files = (
-            f for f in iter_files_from_objects(objs)
-            if f.parent == self.unclustered_files
-        )
-        try:
-            file = next(files)
-        except StopIteration:
-            files = self.unclustered_files.files
-        else:
-            files = itertools.chain([file], files)
+        files = iter_files_from_objects(objs)
         thread.run_task(
             partial(self._do_clustering, list(files)),
             partial(self._clustering_finished, callback))

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -49,6 +49,7 @@ from collections import OrderedDict
 from copy import deepcopy
 import datetime
 from functools import partial
+import itertools
 import os.path
 
 from PyQt5 import (
@@ -1439,7 +1440,19 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         dialog.exec_()
 
     def cluster(self):
-        self.tagger.cluster(self.selected_objects, self._cluster_finished)
+        # Cluster all selected unclustered files. If there are no selected
+        # unclustered files cluster all unclustered files.
+        files = (
+            f for f in iter_files_from_objects(self.selected_objects)
+            if f.parent == self.tagger.unclustered_files
+        )
+        try:
+            file = next(files)
+        except StopIteration:
+            files = self.tagger.unclustered_files.files
+        else:
+            files = itertools.chain([file], files)
+        self.tagger.cluster(files, self._cluster_finished)
 
     def _cluster_finished(self):
         self.panel.update_current_view()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2570
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Dragging files to "Clusters" does not cluster those files, if the dropped files are not in the "Unclustered files" list. This was caused by the fix for [PICARD-2472](https://tickets.metabrainz.org/browse/PICARD-2472) in https://github.com/metabrainz/picard/commit/913325ca003d1f51520773501e554b7d5649c725

# Solution

Make sure the "Cluster" button itself behaves as before and only clusters selected "Unclustered files", but explicitly dragging any files to "Clusters" must always cluster exactly those files.