### PR TITLE
PICARD-2568: Fix $cleanmulti with hidden variables

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1552,7 +1552,7 @@ _Since Picard 2.8_"""
 def func_cleanmulti(parser, multi):
     name = normalize_tagname(multi)
     values = [str(value) for value in parser.context.getall(name) if value or value == 0]
-    parser.context[multi] = values
+    parser.context[name] = values
     return ""
 
 

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -2164,7 +2164,17 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$cleanmulti(bar)%bar%", "one; two", context)
         self.assertScriptResultEquals("$cleanmulti(baz)%baz%", "one; two", context)
 
-        # Text clean with only empty string elements
+    def test_cmd_cleanmulti_with_hidden_var(self):
+        context = Metadata()
+        context["~foo"] = ["one", "", "two"]
+
+        # Confirm initial values
+        self.assertScriptResultEquals("%_foo%", "one; ; two", context)
+        # Test cleaned values
+        self.assertScriptResultEquals("$cleanmulti(_foo)%_foo%", "one; two", context)
+
+    def test_cmd_cleanmulti_only_empty_strings(self):
+        context = Metadata()
         context["foo"] = ["", "", ""]
 
         # Confirm initial values
@@ -2172,7 +2182,8 @@ class ScriptParserTest(PicardTestCase):
         # Test cleaned values
         self.assertScriptResultEquals("$cleanmulti(foo)%foo%", "", context)
 
-        # Test clean with indirect argument
+    def test_cmd_cleanmulti_indirect_argument(self):
+        context = Metadata()
         context["foo"] = ["", "one", "two"]
         context["bar"] = "foo"
 
@@ -2181,7 +2192,8 @@ class ScriptParserTest(PicardTestCase):
         # Test cleaned values
         self.assertScriptResultEquals("$cleanmulti(%bar%)%foo%", "one; two", context)
 
-        # Test clean with non-multi argument
+    def test_cmd_cleanmulti_non_multi_argument(self):
+        context = Metadata()
         context["foo"] = "one"
         context["bar"] = "one; ; two"
         context["baz"] = ""
@@ -2195,7 +2207,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$cleanmulti(bar)%bar%", "one; ; two", context)
         self.assertScriptResultEquals("$cleanmulti(baz)%baz%", "", context)
 
-        # Tests with invalid number of arguments
+    def test_cmd_cleanmulti_invalid_number_of_arguments(self):
         areg = r"^\d+:\d+:\$cleanmulti: Wrong number of arguments for \$cleanmulti: Expected exactly 1, "
         with self.assertRaisesRegex(ScriptError, areg):
             self.parser.eval("$cleanmulti()")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2568
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`$cleanmulti`  does not write back hidden variables properly, instead creates a new visible tag starting with underscore.

# Solution
Fix tag name when writing back the changed values, updated tests.