### PR TITLE
Upgrade to mutagen 1.46

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2019]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
         # pyobjc is not yet compatible with Python 3.10
         - os: macos-11

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,13 +8,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        exclude:
-        - os: macos-latest
-          python-version: '3.6'
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
         - os: macos-11
-          python-version: '3.6'
+          python-version: '3.7'
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Before installing Picard from source, you need to check you have the following d
 
 Required:
 
-* [Python 3.6 or newer](https://python.org/download)
+* [Python 3.7 or newer](https://python.org/download)
 * [PyQt 5.11 or newer](https://riverbankcomputing.com/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)

--- a/requirements-macos-10.12.txt
+++ b/requirements-macos-10.12.txt
@@ -2,7 +2,7 @@ python-dateutil==2.8.2
 discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.6
-mutagen==1.45.1
+mutagen==1.46.0
 PyJWT==2.4.0
 pyobjc-core==8.1
 pyobjc-framework-Cocoa==8.1

--- a/requirements-macos-10.14.txt
+++ b/requirements-macos-10.14.txt
@@ -2,7 +2,7 @@ python-dateutil==2.8.2
 discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.6
-mutagen==1.45.1
+mutagen==1.46.0
 PyJWT==2.4.0
 pyobjc-core==8.1
 pyobjc-framework-Cocoa==8.1

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -2,7 +2,7 @@ python-dateutil==2.8.2
 discid==1.2.0
 fasteners==0.17.2
 markdown==3.3.4
-mutagen==1.45.1
+mutagen==1.46.0
 PyJWT==2.4.0
 PyQt5==5.15.6
 pywin32==303

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ from picard import (
 )
 
 
-if sys.version_info < (3, 6):
-    sys.exit("ERROR: You need Python 3.6 or higher to use Picard.")
+if sys.version_info < (3, 7):
+    sys.exit("ERROR: You need Python 3.7 or higher to use Picard.")
 
 PACKAGE_NAME = "picard"
 APPDATA_FILE = PICARD_APP_ID + '.appdata.xml'
@@ -783,7 +783,7 @@ args = {
     },
     'scripts': ['scripts/' + PACKAGE_NAME],
     'install_requires': _get_requirements(),
-    'python_requires': '~=3.6',
+    'python_requires': '~=3.7',
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Development Status :: 5 - Production/Stable',
@@ -792,7 +792,6 @@ args = {
         'Environment :: X11 Applications :: Qt',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2018-2020, 2022 Philipp Wolfer
 # Copyright (C) 2020-2021 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -19,6 +19,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from mutagen import version as mutagen_version
 
 from picard import config
 from picard.formats import WAVFile
@@ -66,11 +67,15 @@ if WAVFile.supports_tag('artist'):
 
     class WAVTest(CommonId3Tests.Id3TestCase):
         testfile = 'test.wav'
-        expected_info = {**expected_info, **{
-            '~bitrate': '352.8',
-        }}
+        expected_info = expected_info
         unexpected_info = ['~video']
         supports_ratings = True
+
+        def setUp(self):
+            super().setUp()
+            # mutagen < 1.46 has broken bitrate calculation for WAVE files
+            if mutagen_version >= (1, 46, 0):
+                self.expected_info['~bitrate'] = '1411.2'
 
         @skipUnlessTestfile
         def test_invalid_track_and_discnumber(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Use latest mutagen 1.46.0 for official builds.

Also drop official support for Python 3.6, just like mutagen did. We need to do this for PyQt6 (#2154) anyway.