### PR TITLE
CI: Build and test with Python 3.11

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         exclude:
         # pyobjc is not yet compatible with Python 3.10
         - os: macos-11

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
         - os: macos-11
           python-version: '3.7'
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8']
+        python-version: ['3.8', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Do CI builds with Python 3.11