### PR TITLE
PICARD-2582: Get rid of legacy distutils imports in setup.py

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -144,15 +144,15 @@ jobs:
         DISCID_SHA256SUM: 9fd815f6bd0c624f0f41dd81209aeaa3f2129dcd1d617f88b844b4503d12598e
         FPCALC_VERSION: 1.5.1
         FPCALC_SHA256SUM: 36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc
-    - name: Patch build version
-      if: startsWith(github.ref, 'refs/tags/') != true
-      run: |
-        python setup.py patch_version --platform=$Env:BUILD_NUMBER.$(git rev-parse --short HEAD)
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-build.txt
         pip install -r requirements-win.txt
+    - name: Patch build version
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        python setup.py patch_version --platform=$Env:BUILD_NUMBER.$(git rev-parse --short HEAD)
     - name: Run tests
       timeout-minutes: 30
       run: python setup.py test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade setuptools
         pip install -r requirements.txt
     - name: Check coding style
       run: |
@@ -119,5 +120,6 @@ jobs:
       if: runner.os != 'Windows'
       timeout-minutes: 30
       run: |
+        pip install --upgrade setuptools
         pip install pytest
         scripts/package/run-sdist-test.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,2 +1,3 @@
 Babel==2.9.1
 PyInstaller==5.5
+setuptools>=62.4.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2582
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard's `setup.py` was still importing some legacy distutils components to achieve some functionality.

Also these distutils imports are imported before setuptools gets imported, which is actively discouraged as setuptools might provide modified distutils.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Replace all distutils imports with proper replacements (see also [PEP 632](https://peps.python.org/pep-0632/))


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

This needs a newer setuptools which provides the `build` command implementation (was added sometime in August this year).
