### PR TITLE
Windows code signing: Set publisher from certificate subject for sign…

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -182,6 +182,8 @@ jobs:
       if: matrix.type == 'signed-app' && env.CODESIGN == '1'
       run: |
         $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_PFX_PASSWORD -Force -AsPlainText
+        $env:PICARD_APPX_PUBLISHER = (Get-PfxCertificate -FilePath .\codesign.pfx -Password $CertPassword).Subject
+        Write-Output "Publisher: $env:PICARD_APPX_PUBLISHER"
         & .\scripts\package\win-package-appx.ps1 -BuildNumber $Env:BUILD_NUMBER -CertificateFile .\codesign.pfx -CertificatePassword $CertPassword
         Move-Item .\dist\*.msix .\artifacts
       env:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The subject for the new code signing certificate changed. But the subject must match the publisher used for building Windows APPX package. 

# Solution

Instead of hard coding the value read it from the certificate