### PR TITLE
Fix executable `LOOKUP` command text.  Add `LOOKUP_CLUSTERS` command.

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -246,6 +246,10 @@ REMOTE_COMMANDS = {
     ),
     "LOOKUP": RemoteCommand(
         "handle_command_lookup",
+        help_text="Lookup all unclustered files in the cluster pane.",
+    ),
+    "LOOKUP_CLUSTERS": RemoteCommand(
+        "handle_command_lookup_clusters",
         help_text="Lookup all clusters in the cluster pane.",
     ),
     "LOOKUP_CD": RemoteCommand(
@@ -546,6 +550,9 @@ class Tagger(QtWidgets.QApplication):
 
     def handle_command_lookup(self, argstring):
         self.autotag(self.unclustered_files.files)
+
+    def handle_command_lookup_clusters(self, argstring):
+        self.autotag(self.clusters)
 
     def handle_command_lookup_cd(self, argstring):
         disc = Disc()

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -246,8 +246,8 @@ REMOTE_COMMANDS = {
     ),
     "LOOKUP": RemoteCommand(
         "handle_command_lookup",
-        help_text="Lookup files in the clustering pane.",
-        help_args="[clustered|unclustered]"
+        help_text="Lookup files in the clustering pane. Defaults to all files.",
+        help_args="[clustered|unclustered|all]"
     ),
     "LOOKUP_CD": RemoteCommand(
         "handle_command_lookup_cd",
@@ -546,8 +546,12 @@ class Tagger(QtWidgets.QApplication):
         self.load_to_picard((argstring,))
 
     def handle_command_lookup(self, argstring):
-        argstring = argstring.upper()
-        if argstring == 'CLUSTERED':
+        if argstring:
+            argstring = argstring.upper()
+        if not argstring or argstring == 'ALL':
+            self.autotag(self.clusters)
+            self.autotag(self.unclustered_files.files)
+        elif argstring == 'CLUSTERED':
             self.autotag(self.clusters)
         elif argstring == 'UNCLUSTERED':
             self.autotag(self.unclustered_files.files)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -246,11 +246,8 @@ REMOTE_COMMANDS = {
     ),
     "LOOKUP": RemoteCommand(
         "handle_command_lookup",
-        help_text="Lookup all unclustered files in the cluster pane.",
-    ),
-    "LOOKUP_CLUSTERS": RemoteCommand(
-        "handle_command_lookup_clusters",
-        help_text="Lookup all clusters in the cluster pane.",
+        help_text="Lookup files in the clustering pane.",
+        help_args="[clustered|unclustered]"
     ),
     "LOOKUP_CD": RemoteCommand(
         "handle_command_lookup_cd",
@@ -549,10 +546,13 @@ class Tagger(QtWidgets.QApplication):
         self.load_to_picard((argstring,))
 
     def handle_command_lookup(self, argstring):
-        self.autotag(self.unclustered_files.files)
-
-    def handle_command_lookup_clusters(self, argstring):
-        self.autotag(self.clusters)
+        argstring = argstring.upper()
+        if argstring == 'CLUSTERED':
+            self.autotag(self.clusters)
+        elif argstring == 'UNCLUSTERED':
+            self.autotag(self.unclustered_files.files)
+        else:
+            log.error("Invalid LOOKUP command argument: '%s'", argstring)
 
     def handle_command_lookup_cd(self, argstring):
         disc = Disc()


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The recently added `LOOKUP` executable command indicated in the help text that it would "Lookup all clusters in the cluster pane", but in fact it actually would "Lookup all unclustered files in the cluster pane".  There was no executable command that would "Lookup all clusters in the cluster pane."

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Change the help text on the existing `LOOKUP` command, and add a new `LOOKUP_CLUSTERS` command.

# Action

If accepted, the documentation will need to be updated to reflect the changes.
