### PR TITLE
PICARD-2588: Revert "Replace QThread with Python treads using concurrent.futures"

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -214,7 +214,8 @@ class File(QtCore.QObject, Item):
     def load(self, callback):
         thread.run_task(
             partial(self._load_check, self.filename),
-            partial(self._loading_finished, callback))
+            partial(self._loading_finished, callback),
+            priority=QtCore.QThread.Priority.LowestPriority)
 
     def _load_check(self, filename):
         # Check that file has not been removed since thread was queued
@@ -334,6 +335,7 @@ class File(QtCore.QObject, Item):
         thread.run_task(
             partial(self._save_and_rename, self.filename, metadata),
             self._saving_finished,
+            priority=QtCore.QThread.Priority.LowPriority,
             thread_pool=self.tagger.save_thread_pool)
 
     def _preserve_times(self, filename, func):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -45,7 +45,6 @@
 
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from hashlib import md5
 import logging
@@ -347,14 +346,15 @@ class Tagger(QtWidgets.QApplication):
         if picard_args.debug or "PICARD_DEBUG" in os.environ:
             self.set_log_level(logging.DEBUG)
 
-        # Default thread pool
-        self.thread_pool = ThreadPoolExecutor()
+        # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
+        # It's a valid reference, but its start() method doesn't work.
+        self.thread_pool = QtCore.QThreadPool(self)
 
         self.pipe_handler = pipe_handler
 
         if self.pipe_handler:
             self.pipe_handler.pipe_running = True
-            self.thread_pool.submit(self.pipe_server)
+            self.thread_pool.start(self.pipe_server)
 
         self._init_remote_commands()
 
@@ -362,11 +362,13 @@ class Tagger(QtWidgets.QApplication):
         # delayed by longer background processing tasks, e.g. because the user
         # expects instant feedback instead of waiting for a long list of
         # operations to finish.
-        self.priority_thread_pool = ThreadPoolExecutor(max_workers=1)
+        self.priority_thread_pool = QtCore.QThreadPool(self)
+        self.priority_thread_pool.setMaxThreadCount(1)
 
         # Use a separate thread pool for file saving, with a thread count of 1,
         # to avoid race conditions in File._save_and_rename.
-        self.save_thread_pool = ThreadPoolExecutor(max_workers=1)
+        self.save_thread_pool = QtCore.QThreadPool(self)
+        self.save_thread_pool.setMaxThreadCount(1)
 
         if not IS_WIN:
             # Set up signal handling
@@ -741,9 +743,9 @@ class Tagger(QtWidgets.QApplication):
         self._acoustid.done()
         if self.pipe_handler:
             self.pipe_handler.pipe_running = False
-        self.thread_pool.shutdown()
-        self.save_thread_pool.shutdown()
-        self.priority_thread_pool.shutdown()
+        self.thread_pool.waitForDone()
+        self.save_thread_pool.waitForDone()
+        self.priority_thread_pool.waitForDone()
         self.browser_integration.stop()
         self.webservice.stop()
         self.run_cleanup()

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -26,13 +26,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from functools import partial
 import sys
 import traceback
 
 from PyQt5.QtCore import (
     QCoreApplication,
     QEvent,
+    QRunnable,
+    QThread,
 )
 
 from picard import log
@@ -50,25 +51,33 @@ class ProxyToMainEvent(QEvent):
         self.func(*self.args, **self.kwargs)
 
 
-def future_callback(callback, future, log_traceback=True):
-    try:
-        result = future.result()
-        error = None
-    except BaseException:
-        if log_traceback:
-            log.error(traceback.format_exc())
-        result = None
-        error = sys.exc_info()[1]
-    to_main(callback, result=result, error=error)
+class Runnable(QRunnable):
+
+    def __init__(self, func, next_func, traceback=True):
+        super().__init__()
+        self.func = func
+        self.next_func = next_func
+        self.traceback = traceback
+
+    def run(self):
+        try:
+            result = self.func()
+        except BaseException:
+            if self.traceback:
+                log.error(traceback.format_exc())
+            to_main(self.next_func, error=sys.exc_info()[1])
+        else:
+            to_main(self.next_func, result=result)
 
 
-def run_task(func, next_func, thread_pool=None, traceback=True):
+def run_task(func, next_func, priority=QThread.Priority.IdlePriority, thread_pool=None, traceback=True):
     """Schedules func to be run on a separate thread
 
     Args:
         func: Function to run on a separate thread.
         next_func: Callback function to run after the thread has been completed.
           The callback will be run on the main thread.
+        priority: Thread priority (QThread.Priority)
         thread_pool: Instance of concurrent.futures.Executor to run this task.
         traceback: If set to true the stack trace will be logged to the error log
           if an exception was raised.
@@ -78,9 +87,7 @@ def run_task(func, next_func, thread_pool=None, traceback=True):
     """
     if not thread_pool:
         thread_pool = QCoreApplication.instance().thread_pool
-    future = thread_pool.submit(func)
-    future.add_done_callback(partial(future_callback, next_func, log_traceback=traceback))
-    return future
+    thread_pool.start(Runnable(func, next_func, traceback), priority)
 
 
 def to_main(func, *args, **kwargs):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2588
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This declares 96f492c357457f60504ebf75b0ab1a5b8747edd7 to be a stupid idea and reverts back to using QThread for all threads. Mixing threading between Qt and Python's is going to cause all kinds of incompatibility issue, see PICARD-2588 for a bit. As we are running a Qt app we must rely on Qt's event loop.


# Solution

This reverts commit 96f492c357457f60504ebf75b0ab1a5b8747edd7 and fixes PICARD-2588.

Also reintroduces the priority parameter, using the values initially set for the various operations. I just wen with using the Qt enum instead of its integer values (something that I think will be mandatory for Qt6 anyway).
