### PR TITLE
Limit worker threads based on CPUs

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -453,6 +453,13 @@ class Tagger(QtWidgets.QApplication):
         # FIXME: Figure out what's wrong with QThreadPool.globalInstance().
         # It's a valid reference, but its start() method doesn't work.
         self.thread_pool = QtCore.QThreadPool(self)
+        # Limit threads to ideal thread count (based on CPUs), but reserve
+        # threads for the main thread and the priority and save thread pools.
+        # Also keep always at least 2 threads, as one will be used for the
+        # pipe server for interprocess communication.
+        max_threads = max(2, QtCore.QThread.idealThreadCount() - 3)
+        log.debug(f'Using {max_threads} worker threads.')
+        self.thread_pool.setMaxThreadCount(max_threads)
 
         # Provide a separate thread pool for operations that should not be
         # delayed by longer background processing tasks, e.g. because the user


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The default thread pool by default has a max. thread count based on [`QThread.idealThreadCount()`](https://doc.qt.io/qt-5/qthread.html#idealThreadCount), which basically sets the thread count based on the system's available CPU cores.

Especially during file loading this number of threads gets exhausted. But this means there are 8 loading threads running, but there is always at least the main UI thread. Also there are the save thread pool (which might be used when the user is saving files in parallel) and the priority thread pool (which currently is used in metadatabox updates only and is meant for everything that should not be blocked by normal background tasks).


# Solution

Limit number of threads in the main pol to `QThread.idealThreadCount()` minus 3 (main thread, priority pool + save pool). Keep at least 2, as one thread gets used up by the new pipe config.

In my tests with 8 cores this gave 5. It improved responsiveness during loading of many files significantly. But we might consider going a bit higher. We have one thread reserved for the pipe handling, which usually isn't doing much. Then save thread pool is usually idle. Priority gets used if the user clicks some item with metadata.