### PR TITLE
PICARD-2590: Fix saving cover art images with relative paths

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -324,11 +324,17 @@ class CoverArtImage:
         filename = script_to_filename(filename, metadata)
         if not filename:
             filename = DEFAULT_COVER_IMAGE_FILENAME
-        if is_absolute_path(filename):
-            dirname = os.path.dirname(filename)
-        filename = make_short_filename(
-            dirname, os.path.basename(filename), win_shorten_path=win_shorten_path)
-        filename = os.path.join(dirname, filename)
+        dirname = os.path.normpath(dirname)
+        if not is_absolute_path(filename):
+            filename = os.path.normpath(os.path.join(dirname, filename))
+        try:
+            basedir = os.path.commonpath((dirname, os.path.dirname(filename)))
+            relpath = os.path.relpath(filename, start=basedir)
+        except ValueError:
+            basedir = os.path.dirname(filename)
+            relpath = os.path.basename(filename)
+        relpath = make_short_filename(basedir, relpath, win_shorten_path=win_shorten_path)
+        filename = os.path.join(basedir, relpath)
         filename = make_save_path(filename, win_compat=win_compat, mac_compat=IS_MACOS)
         return encode_filename(filename)
 

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -38,6 +38,7 @@ from picard.coverart.image import (
 from picard.coverart.utils import Id3ImageType
 from picard.metadata import Metadata
 from picard.util import encode_filename
+from picard.util.filenaming import WinPathTooLong
 
 
 def create_image(extra_data, types=None, support_types=False,
@@ -53,6 +54,7 @@ def create_image(extra_data, types=None, support_types=False,
 
 
 class CoverArtImageTest(PicardTestCase):
+
     def test_is_front_image_no_types(self):
         image = create_image(b'a')
         self.assertTrue(image.is_front_image())
@@ -184,6 +186,68 @@ class CoverArtImageTest(PicardTestCase):
             self.assertTrue(os.path.exists(expected_filename_2))
             self.assertEqual(len(image2.data), os.path.getsize(expected_filename_2))
             self.assertEqual(2, counters[counter_filename])
+
+
+class CoverArtImageMakeFilenameTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.image = create_image(b'a', types=['back'], support_types=True)
+        self.metadata = Metadata()
+        self.set_config_values({
+            'windows_compatibility': False,
+            'enabled_plugins': [],
+            'ascii_filenames': False,
+        })
+
+    def compare_paths(self, path1, path2):
+        self.assertEqual(
+            encode_filename(os.path.normpath(path1)),
+            encode_filename(os.path.normpath(path2)),
+        )
+
+    def test_make_image_filename(self):
+        filename = self.image._make_image_filename("cover", "/music/albumart",
+            self.metadata, win_compat=False, win_shorten_path=False)
+        self.compare_paths('/music/albumart/cover', filename)
+
+    def test_make_image_filename_absolute_path(self):
+        filename = self.image._make_image_filename("/foo/bar/cover", "/music/albumart",
+            self.metadata, win_compat=False, win_shorten_path=False)
+        self.compare_paths('/foo/bar/cover', filename)
+
+    @unittest.skipUnless(IS_WIN, "windows test")
+    def test_make_image_filename_absolute_path_no_common_base(self):
+        filename = self.image._make_image_filename("D:/foo/cover", "C:/music",
+            self.metadata, win_compat=False, win_shorten_path=False)
+        self.compare_paths('D:\\foo\\cover', filename)
+
+    def test_make_image_filename_script(self):
+        cover_script = '%album%-$if($eq(%coverart_maintype%,front),cover,%coverart_maintype%)'
+        self.metadata['album'] = 'TheAlbum'
+        filename = self.image._make_image_filename(cover_script, "/music/",
+            self.metadata, win_compat=False, win_shorten_path=False)
+        self.compare_paths('/music/TheAlbum-back', filename)
+
+    def test_make_image_filename_save_path(self):
+        self.set_config_values({
+            'windows_compatibility': True,
+        })
+        filename = self.image._make_image_filename(".co:ver", "/music/albumart",
+            self.metadata, win_compat=True, win_shorten_path=False)
+        self.compare_paths('/music/albumart/_co_ver', filename)
+
+    def test_make_image_filename_win_shorten_path(self):
+        requested_path = "/" + 300 * "a" + "/cover"
+        expected_path = "/" + 226 * "a" + "/cover"
+        filename = self.image._make_image_filename(requested_path, "/music/albumart",
+            self.metadata, win_compat=False, win_shorten_path=True)
+        self.compare_paths(expected_path, filename)
+
+    def test_make_image_filename_win_shorten_path_too_long_base_path(self):
+        base_path = '/' + 244*'a'
+        with self.assertRaises(WinPathTooLong):
+            self.image._make_image_filename("cover", base_path,
+                self.metadata, win_compat=False, win_shorten_path=True)
 
 
 class LocalFileCoverArtImageTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2590
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard 2.8.4 broke saving coverart files if the coverart naming was specifying a relative path. In this case the path portion of the generated file name got ignored and the file was directly saved into the target directory.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


Fix the handling of relative paths and add tests to ensure proper working if the file name generation for cover art files.