### PR TITLE
PICARD-2591: Accessing CD Lookup crashes Picard if there is no cdtoc module loaded

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -135,6 +135,7 @@ from picard.util import (
     webbrowser2,
 )
 from picard.util.cdrom import (
+    DISCID_NOT_LOADED_MESSAGE,
     discid as _discid,
     get_cdrom_drives,
 )
@@ -577,7 +578,7 @@ class Tagger(QtWidgets.QApplication):
 
     def handle_command_lookup_cd(self, argstring):
         if not _discid:
-            log.error("CDROM: discid library not found - Lookup CD functionality disabled")
+            log.error(DISCID_NOT_LOADED_MESSAGE)
             return
         disc = Disc()
         devices = get_cdrom_drives()

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -99,6 +99,7 @@ from picard.util import (
     webbrowser2,
 )
 from picard.util.cdrom import (
+    DISCID_NOT_LOADED_MESSAGE,
     discid,
     get_cdrom_drives,
 )
@@ -913,7 +914,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.cd_lookup_menu.clear()
         self.cd_lookup_action.setEnabled(discid is not None)
         if not drives:
-            log.warning("CDROM: No CD-ROM drives found - Lookup CD functionality disabled")
+            log.warning(DISCID_NOT_LOADED_MESSAGE)
         else:
             config = get_config()
             shortcut_drive = config.setting["cd_lookup_device"].split(",")[0] if len(drives) > 1 else ""

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -47,6 +47,7 @@ except ImportError:
     except (ImportError, OSError):
         discid = None
 
+DISCID_NOT_LOADED_MESSAGE = "CDROM: discid library not found - Lookup CD functionality disabled"
 
 DEFAULT_DRIVES = []
 if discid is not None:


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Disable executable `LOOKUP_CD` commands if there is no `discid` module loaded.

# Problem

The main interface deactivates the Lookup CD items from the tools menu, but they can still be initiated using the executable command processing.

* JIRA ticket (_optional_): PICARD-2591
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Check if `picard.util.cdrom.discid` is `None` and if so disable the `LOOKUP_CD` executable command.


# Action

None.
