### PR TITLE
PICARD-2593: Fix toolbar button style resetting when saving options

### DIFF
--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -364,6 +364,7 @@ class InterfaceOptionsPage(OptionsPage):
             widget = widget.parent()
         # Call the main window's create toolbar method
         widget.create_action_toolbar()
+        widget.update_toolbar_style()
         widget.set_tab_order()
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
When saving options the toolbar buttons style always changes to buttons without labels, independent of setting