### PR TITLE
CI: Validate AppStream metadata on Linux

### DIFF
--- a/.github/workflows/validate-appstream.yml
+++ b/.github/workflows/validate-appstream.yml
@@ -1,0 +1,28 @@
+name: Validate AppStream
+
+on:
+  push:
+    paths:
+    - '.github/workflows/validate-appstream.yml'
+    - 'org.musicbrainz.Picard.appdata.xml.in'
+    - 'po/appstream/*.po'
+    - 'setup.py'
+  pull_request:
+
+jobs:
+  validate-appstream:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install appstream-util
+      run: |
+        sudo apt-get update
+        sudo apt-get install appstream-util gettext
+    - name: Validate AppStream metadata
+      run: |
+        python setup.py build_appdata
+        appstream-util validate-relax org.musicbrainz.Picard.appdata.xml


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

Validate the AppStream metadata XML with Github Actions using appstream-validate. Currently using `validate-relax`, as the screenshots we currently provide barely miss the minimum size requirements of 624px width. Once we have updated them we can be more strict and use the `validate` command.
