### PR TITLE
PICARD-2599: Avoid crash when options close before plugin download ends

### DIFF
--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -659,6 +659,8 @@ class PluginsOptionsPage(OptionsPage):
         )
 
     def download_handler(self, update, response, reply, error, plugin):
+        if self.deleted:
+            return
         if error:
             msgbox = QtWidgets.QMessageBox(self)
             msgbox.setText(_("The plugin '%s' could not be downloaded.") % plugin.module_name)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2599
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Picard can crash on plugin install or upgrade if the network request takes longer and returns after the options dialog has already been closed.


# Solution
Abort plugin installation if dialog has already been closed