### PR TITLE
PICARD-2605: Ensure packaged Qt5 DLLs get loaded

### DIFF
--- a/scripts/pyinstaller/win-startup-hook.py
+++ b/scripts/pyinstaller/win-startup-hook.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019, 2021 Philipp Wolfer
+# Copyright (C) 2019, 2021, 2023 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -20,6 +20,7 @@
 
 from ctypes import windll
 import os
+import os.path
 import sys
 
 
@@ -32,4 +33,8 @@ if windll.kernel32.AttachConsole(-1):
     sys.stderr = open('CON', 'w')
 
 # Ensure bundled DLLs are loaded
-os.environ['PATH'] = sys._MEIPASS + os.pathsep + os.environ['PATH']
+os.environ['PATH'] = os.pathsep.join((
+    os.path.normpath(sys._MEIPASS),
+    os.path.normpath(os.path.join(sys._MEIPASS, 'PyQt5\\Qt5\\bin')),
+    os.environ['PATH'],
+))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2605
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
PyInstaller 5.4 changed the location of the Qt5 DLLs. This bypassed our prioritization of packaged DLLs.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add install dir `PyQt5/Qt5/bin`  to `PATH`.