### PR TITLE
PICARD-2606: Add writer and lyricist sort names as variables

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2017-2022 Laurent Monin
 # Copyright (C) 2018-2022 Philipp Wolfer
 # Copyright (C) 2019 Michael Wiencek
-# Copyright (C) 2020 David Kellner
+# Copyright (C) 2020, 2023 David Kellner
 # Copyright (C) 2020 dukeyin
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
@@ -180,6 +180,10 @@ def _relations_to_metadata(relations, m, instrumental=False, config=None):
             m.add_unique(name, value)
             if name == 'composer':
                 m.add_unique('composersort', valuesort)
+            elif name == 'lyricist':
+                m.add_unique('~lyricistsort', valuesort)
+            elif name == 'writer':
+                m.add_unique('~writersort', valuesort)
         elif relation['target-type'] == 'work':
             if relation['type'] == 'performance':
                 performance_attributes = _relation_attributes(relation)

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -9,6 +9,7 @@
 # Copyright (C) 2020 dukeyin
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
+# Copyright (C) 2023 David Kellner
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -216,6 +217,7 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['work'], 'Thinking Out Loud')
         self.assertEqual(m['~workcomment'], 'Ed Sheeran song')
         self.assertEqual(m['writer'], 'Ed Sheeran; Amy Wadge')
+        self.assertEqual(m['~writersort'], 'Sheeran, Ed; Wadge, Amy')
         self.assertEqual(m['~artists_sort'], 'Sheeran, Ed')
         self.assertEqual(m['~length'], '4:41')
         self.assertEqual(m['~recordingtitle'], 'Thinking Out Loud')
@@ -295,6 +297,7 @@ class MultiWorkRecordingTest(MBJSONTest):
         self.assertIn('instrumental', m.getall('~performance_attributes'))
         self.assertEqual(m['language'], 'jpn; eng; zxx')
         self.assertEqual(m['lyricist'], 'Satoru Kōsaki; Aki Hata; Minoru Shiraishi')
+        self.assertEqual(m['~lyricistsort'], 'Kōsaki, Satoru; Hata, Aki; Shiraishi, Minoru')
 
 
 class RecordingVideoTest(MBJSONTest):


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Adds two new variables `_writersort` and `_lyricistsort`.

# Problem

* Picard only provides the sort names of composers but not of lyricists and writers, probably because only `composersort` has a specified tag mapping for various tag formats.
* JIRA ticket (_optional_): PICARD-2606

# Solution

Instead of defining non-standard tag mappings for `writersort` and `lyricistsort`, this PR only provides them as hidden variables, which can still be mapped to custom tags by the users or be used in filenaming scripts.

# Action

In my original implementation as a Picard plugin, I had also [defined display names](https://github.com/kellnerd/picard-plugins/blob/0ea52b5a55658f6e0ed9c1f7f72799fde4375439/plugins/additional_sort_names/additional_sort_names.py#L50-L54) for the internal tag names which are most likely to be used.
It certainly looks better in the tag view if one maps the hidden sort name variables to tags, but I'm not sure if the `TAG_NAMES` mapping is used for anything else but display purposes. I could easily add these two tag names for future use, so just let me know what you think.