### PR TITLE
Debugging Codacy analysis CI errors

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -42,8 +42,14 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: results
+          path: results.sarif
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif
+


### PR DESCRIPTION
Trying to handle

```
Error: Code Scanning could not process the submitted SARIF file:
rejecting SARIF, as there are more runs than allowed (16 > 15)
```

See https://github.com/github/codeql-action/issues/1245