### PR TITLE
PICARD-2611: Do not ignore selection changes during clustering

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1243,16 +1243,15 @@ class Tagger(QtWidgets.QApplication):
             log.error('Error while clustering: %r', error)
             return
 
-        with self.window.ignore_selection_changes:
-            self.window.set_sorting(False)
-            for file_cluster in process_events_iter(result):
-                files = set(file_cluster.files)
-                if len(files) > 1:
-                    cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
-                else:
-                    cluster = self.unclustered_files
-                cluster.add_files(files)
-            self.window.set_sorting(True)
+        self.window.set_sorting(False)
+        for file_cluster in process_events_iter(result):
+            files = set(file_cluster.files)
+            if len(files) > 1:
+                cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
+            else:
+                cluster = self.unclustered_files
+            cluster.add_files(files)
+        self.window.set_sorting(True)
 
         if callback:
             callback()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2611
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

As this was combined with process_events_iter all user evens where still processed during clustering, which can lead to actions (e.g. save) being performed on the previous instead of current selection.

See https://community.metabrainz.org/t/all-files-are-saved-instead-of-just-the-one-album-i-select-when-picard-was-still-busy-clustering/619241

# Solution

Remove the `ignore_selection_changes`

In my testing not using ignore_selection_changes made no significant difference in perceived performance.