### PR TITLE
PICARD-2615: Picard does not check for unsaved files when using the QUIT command

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -547,6 +547,10 @@ class Tagger(QtWidgets.QApplication):
             log.error("No command pause time specified.")
 
     def handle_command_quit(self, argstring):
+        if not argstring.upper() == 'FORCE' and self.window.show_quit_confirmation():
+            log.info("QUIT command cancelled by the user.")
+            RemoteCommands.set_quit(False)  # Allow queueing more commands.
+            return
         self.exit()
         self.quit()
 

--- a/picard/util/remotecommands.py
+++ b/picard/util/remotecommands.py
@@ -64,7 +64,7 @@ REMOTE_COMMANDS = {
     "LOOKUP_CD": RemoteCommand(
         "handle_command_lookup_cd",
         help_text="Read CD from the selected drive and lookup on MusicBrainz. "
-        "Without argument, it defaults to the first (alphabetically) available disc drive",
+        "Without argument, it defaults to the first (alphabetically) available disc drive.",
         help_args="[device/log file]",
     ),
     "PAUSE": RemoteCommand(
@@ -74,7 +74,9 @@ REMOTE_COMMANDS = {
     ),
     "QUIT": RemoteCommand(
         "handle_command_quit",
-        help_text="Exit the running instance of Picard.",
+        help_text="Exit the running instance of Picard. "
+        "Use the argument 'FORCE' to bypass Picard's unsaved files check.",
+        help_args="[FORCE]",
     ),
     "REMOVE": RemoteCommand(
         "handle_command_remove",

--- a/picard/util/remotecommands.py
+++ b/picard/util/remotecommands.py
@@ -64,7 +64,7 @@ REMOTE_COMMANDS = {
     "LOOKUP_CD": RemoteCommand(
         "handle_command_lookup_cd",
         help_text="Read CD from the selected drive and lookup on MusicBrainz. "
-        "Without argument, it defaults to the first (alphabetically) available disc drive.",
+        "Without argument, it defaults to the first (alphabetically) available disc drive",
         help_args="[device/log file]",
     ),
     "PAUSE": RemoteCommand(


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Have `QUIT` command do unsaved files check, with option to bypass the check.

# Problem

When the 'QUIT' command is executed, Picard exits without performing the unsaved files check.

* JIRA ticket (_optional_): PICARD-2615

# Solution

Update the `QUIT` command processing to perform the unsaved files check, allowing the command to be cancelled by the user.  Modify the command to allow an optional argument to force Picard to bypass the unsaved files check.


# Action

Update documentation.