### PR TITLE
Make LOOKUP_CD help text format consistent with other commands

### DIFF
--- a/picard/util/remotecommands.py
+++ b/picard/util/remotecommands.py
@@ -64,7 +64,7 @@ REMOTE_COMMANDS = {
     "LOOKUP_CD": RemoteCommand(
         "handle_command_lookup_cd",
         help_text="Read CD from the selected drive and lookup on MusicBrainz. "
-        "Without argument, it defaults to the first (alphabetically) available disc drive",
+        "Without argument, it defaults to the first (alphabetically) available disc drive.",
         help_args="[device/log file]",
     ),
     "PAUSE": RemoteCommand(


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add a period to the end of the `LOOKUP_CD` command help text to make the format consistent with all of the other executable commands.

# Problem

The format of the `LOOKUP_CD` executable command help text is inconsistent with all of the other executable commands.  It does not end with a period while all others do.

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Add a period to the end of the `LOOKUP_CD` command help text to make the format consistent with all of the other executable commands.

# Action

None.