### PR TITLE
PICARD-2617: Add file variables for file creation and modification timestamps

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
-# Copyright (C) 2018, 2021 Bob Swift
+# Copyright (C) 2018, 2021, 2023 Bob Swift
 # Copyright (C) 2020 RomFouq
 # Copyright (C) 2021 Gabriel Ferreira
 # Copyright (C) 2021 Vladislav Karbovskii
@@ -196,3 +196,5 @@ DEFAULT_NUMBERED_TITLE_FORMAT = N_("{title} ({count})")
 DEFAULT_NAMING_PRESET_ID = "Preset 1"
 
 SCRIPT_LANGUAGE_VERSION = '1.1'
+
+DEFAULT_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'

--- a/picard/file.py
+++ b/picard/file.py
@@ -25,7 +25,7 @@
 # Copyright (C) 2019 Joel Lintunen
 # Copyright (C) 2020 Ray Bouchard
 # Copyright (C) 2020-2021 Gabriel Ferreira
-# Copyright (C) 2021 Bob Swift
+# Copyright (C) 2021, 2023 Bob Swift
 # Copyright (C) 2021 Petit Minion
 #
 # This program is free software; you can redistribute it and/or
@@ -54,6 +54,7 @@ import os
 import os.path
 import re
 import shutil
+import time
 
 from PyQt5 import QtCore
 
@@ -62,6 +63,7 @@ from picard import (
     log,
 )
 from picard.config import get_config
+from picard.const import DEFAULT_TIME_FORMAT
 from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
@@ -778,6 +780,17 @@ class File(QtCore.QObject, Item):
         filename, extension = os.path.splitext(os.path.basename(self.filename))
         metadata['~filename'] = filename
         metadata['~extension'] = extension.lower()[1:]
+
+        try:
+            created = os.path.getctime(self.filename)
+            created_timestamp = time.strftime(DEFAULT_TIME_FORMAT, time.localtime(created))
+            metadata['~file_created_timestamp'] = created_timestamp
+
+            modified = os.path.getmtime(self.filename)
+            modified_timestamp = time.strftime(DEFAULT_TIME_FORMAT, time.localtime(modified))
+            metadata['~file_modified_timestamp'] = modified_timestamp
+        except OSError as ex:
+            log.error(f"File Timestamps Error: {ex}")
 
     @property
     def state(self):

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -11,6 +11,7 @@
 # Copyright (C) 2013-2014, 2019-2021 Laurent Monin
 # Copyright (C) 2013-2015, 2017 Sophist-UK
 # Copyright (C) 2019 Zenara Daley
+# Copyright (C) 2023 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -134,6 +135,8 @@ PRESERVED_TAGS = (
     '~dirname',
     '~extension',
     '~filename',
+    '~file_created_timestamp',
+    '~file_modified_timestamp',
     '~format',
     '~sample_rate',
     '~video',


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds new `_file_created_timestamp` and `_file_modified_timestamp` file variables.

# Problem

Please refer to the discussion in the ticket, which requests the creation of file variables to be able to add date tracking information into the file metadata for use in scripting.

* JIRA ticket (_optional_): PICARD-2617

# Solution

Add new `_file_created_timestamp` and `_file_modified_timestamp` file variables.

# Action

Update documentation to include the new file variables.