### PR TITLE
PICARD-2625: Improve file naming script editing and new script creation

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -13,7 +13,7 @@
 # Copyright (C) 2016-2017 Wieland Hoffmann
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017 Ville Skyttä
-# Copyright (C) 2018, 2021 Bob Swift
+# Copyright (C) 2018, 2021, 2023 Bob Swift
 # Copyright (C) 2021 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
@@ -39,7 +39,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 9, 0, 'alpha', 1)
+PICARD_VERSION = Version(2, 9, 0, 'alpha', 2)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -9,7 +9,7 @@
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
-# Copyright (C) 2021 Bob Swift
+# Copyright (C) 2021, 2023 Bob Swift
 # Copyright (C) 2021 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
@@ -457,6 +457,15 @@ def upgrade_to_v2_8_0_dev_2(config):
         pass
 
 
+def upgrade_to_v2_9_0_alpha_2(config):
+    """Add preset file naming scripts to editable user scripts disctionary"""
+    from picard.script import get_file_naming_script_presets
+    scripts = config.setting["file_renaming_scripts"]
+    for item in get_file_naming_script_presets():
+        scripts[item["id"]] = item.to_dict()
+    config.setting["file_renaming_scripts"] = scripts
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -501,4 +510,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_4)
     cfg.register_upgrade_hook(upgrade_to_v2_7_0_dev_5)
     cfg.register_upgrade_hook(upgrade_to_v2_8_0_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v2_9_0_alpha_2)
     cfg.run_upgrade_hooks(log.debug)

--- a/picard/script/__init__.py
+++ b/picard/script/__init__.py
@@ -18,7 +18,7 @@
 # Copyright (C) 2017-2018 Antonio Larrosa
 # Copyright (C) 2018 Calvin Walton
 # Copyright (C) 2018 virusMac
-# Copyright (C) 2020-2021 Bob Swift
+# Copyright (C) 2020-2021, 2023 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -148,8 +148,6 @@ def get_file_naming_script_presets():
         id=DEFAULT_NAMING_PRESET_ID,
         title=preset_title(1, N_("Default file naming script")),
         script=DEFAULT_FILE_NAMING_FORMAT,
-        readonly=True,
-        deletable=False,
         author=AUTHOR,
         description=DESCRIPTION,
         version="1.0",
@@ -164,8 +162,6 @@ def get_file_naming_script_presets():
         script="%albumartist%/\n"
                "%album%/\n"
                "%tracknumber%. %title%",
-        readonly=True,
-        deletable=False,
         author=AUTHOR,
         description=DESCRIPTION,
         version="1.0",
@@ -183,8 +179,6 @@ def get_file_naming_script_presets():
                "$if($and(%albumartist%,%tracknumber%),$num(%tracknumber%,2) ,)\n"
                "$if(%_multiartist%,%artist% - ,)\n"
                "%title%",
-        readonly=True,
-        deletable=False,
         author=AUTHOR,
         description=DESCRIPTION,
         version="1.0",

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2021 Bob Swift
+# Copyright (C) 2021, 2023 Bob Swift
 # Copyright (C) 2021 Laurent Monin
 # Copyright (C) 2021-2022 Philipp Wolfer
 #
@@ -398,14 +398,13 @@ class FileNamingScript(PicardScript):
         script='',
         title='',
         id=None,
-        readonly=False,
-        deletable=True,
         author='',
         description='',
         license='',
         version='',
         last_updated=None,
-        script_language_version=None
+        script_language_version=None,
+        **kwargs,   # Catch additional (deprecated) arguments to avoid error in prior version config_upgrade functions.
     ):
         """Creates a Picard file naming script object.
 
@@ -413,8 +412,6 @@ class FileNamingScript(PicardScript):
             script (str): Text of the script.
             title (str): Title of the script.
             id (str): ID code for the script. Defaults to a system generated uuid.
-            readonly (bool): Identifies if the script is readonly. Defaults to False.
-            deletable (bool): Identifies if the script can be deleted from the selection list. Defaults to True.
             author (str): The author of the script. Defaults to ''.
             description (str): A description of the script, typically including type of output and any required plugins or settings. Defaults to ''.
             license (str): The license under which the script is being distributed. Defaults to ''.
@@ -423,8 +420,6 @@ class FileNamingScript(PicardScript):
             script_language_version (str): The version of the script language supported by the script.
         """
         super().__init__(script=script, title=title, id=id, last_updated=last_updated, script_language_version=script_language_version)
-        self.readonly = readonly    # for presets
-        self.deletable = deletable  # Allow removal from list of scripts
         self.author = author
         self.description = description
         self.license = license


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Allow editing of all scripts and allow selecting template for creation of new file naming scripts.

# Problem

We have received multiple reports by users struggling to edit the file naming scripts. Those users open the script editor and find themselves unable to edit the script. The reason is that by default they are on one of the Picard presets, which is not editable. The user is expected to either create a new custom script (either an empty one from scratch or as a copy of the preset) and then edit this new custom script.

This is not obvious, and users fail to understand this mechanic. It should be more discoverable how to make a edited custom script from a preset.

* JIRA ticket (_optional_): PICARD-2625

# Solution

Make all scripts editable as "User Scripts" and do away with the read-only "System Scripts" entirely.

The process automatically converts the system scripts to user scripts for existing installations, and create the (currently three) preset scripts as user scripts for new installations (or when the user chooses to reset all option settings).  The current system preset scripts are kept as "Naming Script Templates" which could optionally be selected by the user as a starting point when creating a new script as an option rather than just starting with a blank script.  This should simplify the user interface, because there would only be one type of script and all scripts would be editable (as one would expect in the "File Naming Script Editor").

The current functionality of adding, deleting, copying, importing and exporting scripts would be retained, with the only difference being a sub-menu for selecting the template to use (i.e. blank or one of the standard script templates) when creating a new script.

# Action

If accepted, the documentation will need to be updated.
