### PR TITLE
PICARD-2630: Fix potential crash on config upgrade

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2013-2014 Michael Wiencek
 # Copyright (C) 2013-2016, 2018-2021 Laurent Monin
 # Copyright (C) 2014, 2017 Lukáš Lalinský
-# Copyright (C) 2014, 2018-2022 Philipp Wolfer
+# Copyright (C) 2014, 2018-2023 Philipp Wolfer
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
@@ -306,7 +306,9 @@ def upgrade_to_v2_4_0_beta_3(config):
     """Convert preserved tags to list"""
     _s = config.setting
     opt = 'preserved_tags'
-    _s[opt] = [t.strip() for t in _s.raw_value(opt, qtype='QString').split(',')]
+    value = _s.raw_value(opt, qtype='QString')
+    if not isinstance(value, list):
+        _s[opt] = [t.strip() for t in value.split(',')]
 
 
 def upgrade_to_v2_5_0_dev_1(config):

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2019-2021 Laurent Monin
-# Copyright (C) 2019-2022 Philipp Wolfer
+# Copyright (C) 2019-2023 Philipp Wolfer
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Gabriel Ferreira
 #
@@ -271,6 +271,12 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
     def test_upgrade_to_v2_4_0_beta_3(self):
         ListOption("setting", "preserved_tags", [])
         self.config.setting['preserved_tags'] = 'foo,bar'
+        upgrade_to_v2_4_0_beta_3(self.config)
+        self.assertEqual(['foo', 'bar'], self.config.setting['preserved_tags'])
+
+    def test_upgrade_to_v2_4_0_beta_3_already_done(self):
+        ListOption("setting", "preserved_tags", [])
+        self.config.setting['preserved_tags'] = ['foo', 'bar']
         upgrade_to_v2_4_0_beta_3(self.config)
         self.assertEqual(['foo', 'bar'], self.config.setting['preserved_tags'])
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2630
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Fix a potential crash on config upgrade for `preserved_tags`.


# Solution

I don't know how the reporting user's configuration ended up in this state. But by checking the existing type of the value this crash can be avoided.