### PR TITLE
PICARD-2535: Strip trailing null chars for Vorbis / FLAC

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -137,6 +137,7 @@ class VCommentFile(File):
         metadata = Metadata()
         for origname, values in file.tags.items():
             for value in values:
+                value = value.rstrip('\0')
                 name = origname
                 if name == "date" or name == "originaldate":
                     # YYYY-00-00 => YYYY
@@ -289,7 +290,7 @@ class VCommentFile(File):
                 value = "MusicMagic Fingerprint%s" % value
             elif name in self.__rtranslate:
                 name = self.__rtranslate[name]
-            tags.setdefault(name.upper(), []).append(value)
+            tags.setdefault(name.upper(), []).append(value.rstrip('\0'))
 
         if "totaltracks" in metadata:
             tags.setdefault("TRACKTOTAL", []).append(metadata["totaltracks"])

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -189,6 +189,16 @@ class CommonVorbisTests:
                 del metadata[invalid_tag]
                 save_metadata(self.filename, metadata)
 
+        @skipUnlessTestfile
+        def test_load_strip_trailing_null_char(self):
+            save_raw(self.filename, {
+                'date': '2023-04-18\0',
+                'title': 'foo\0',
+            })
+            metadata = load_metadata(self.filename)
+            self.assertEqual('2023-04-18', metadata['date'])
+            self.assertEqual('foo', metadata['title'])
+
 
 class FLACTest(CommonVorbisTests.VorbisTestCase):
     testfile = 'test.flac'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2535, PICARD-2534
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Remove trailing null chars in Vorbis / FLAC tags when loading and saving. This fixes specifically the reported issue with loading dates with trailing null char (PICARD-2534), but might also help in other cases.


# Solution
Remove trailing null char when loading and saving Vorbis comments.

I for now limited this to Vorbis, as all reported cases involved FLAC files. I was thinking about adding this to the `Metadata`  class in general, but was hesitant. For MP4 and ID3 we have some very specific values, e.g. the iTunes values, and I'm not fully sure we might break something here.