### PR TITLE
id3v2.4 TDRL -> releasedate mapping

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -110,6 +110,7 @@ class ID3File(File):
         'TXXX:ALBUMARTISTSORT': 'TSO2',
         'TXXX:COMPOSERSORT': 'TSOC',
         'TXXX:mood': 'TMOO',
+        'TXXX:releasedate': 'TDRL',
     }
 
     __translate = {
@@ -506,6 +507,8 @@ class ID3File(File):
                             tags.add(self.build_TXXX(encoding, 'mood', values))
                     # No need to care about the TMOO tag being added again as it is
                     # automatically deleted by Mutagen if id2v23 is selected
+                        if frameid == 'TDRL':
+                            tags.add(self.build_TXXX(encoding, 'releasedate', values))
                     tags.add(getattr(id3, frameid)(encoding=encoding, text=values))
                     if frameid == 'TSOA':
                         tags.delall('XSOA')

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -137,6 +137,7 @@ class ID3File(File):
         'TPUB': 'label',
         'TDOR': 'originaldate',
         'TDRC': 'date',
+        'TDRL': 'releasedate',
         'TSSE': 'encodersettings',
         'TSOA': 'albumsort',
         'TSOP': 'artistsort',

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -139,7 +139,7 @@ class VCommentFile(File):
             for value in values:
                 value = value.rstrip('\0')
                 name = origname
-                if name == "date" or name == "originaldate":
+                if name == "date" or name == "originaldate" or name == "releasedate":
                     # YYYY-00-00 => YYYY
                     value = sanitize_date(value)
                 elif name == 'performer' or name == 'comment':
@@ -277,7 +277,7 @@ class VCommentFile(File):
                 continue
             elif name.startswith('lyrics:'):
                 name = 'lyrics'
-            elif name == "date" or name == "originaldate":
+            elif name == "date" or name == "originaldate" or name == "releasedate":
                 # YYYY-00-00 => YYYY
                 value = sanitize_date(value)
             elif name.startswith('performer:') or name.startswith('comment:'):

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -64,7 +64,7 @@ class TagEditorDelegate(QtWidgets.QItemDelegate):
         else:
             editor = super().createEditor(parent, option, index)
         completer = None
-        if tag in {'date', 'originaldate'}:
+        if tag in {'date', 'originaldate', 'releasedate'}:
             editor.setPlaceholderText(_('YYYY-MM-DD'))
         elif tag == 'originalyear':
             editor.setPlaceholderText(_('YYYY'))

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -173,6 +173,7 @@ class MainPanel(QtWidgets.QSplitter):
         (N_('Fingerprint status'), '~fingerprint'),
         (N_('Date'), 'date'),
         (N_('Original Release Date'), 'originaldate'),
+        (N_('Release Date'), 'releasedate'),
         (N_('Cover'), 'covercount'),
     ]
 

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -103,6 +103,7 @@ TAG_NAMES = {
     'r128_track_gain': N_('R128 Track Gain'),
     '~rating': N_('Rating'),
     'releasecountry': N_('Release Country'),
+    'releasedate': N_('Release Date'),
     'releasestatus': N_('Release Status'),
     'releasetype': N_('Release Type'),
     'remixer': N_('Remixer'),


### PR DESCRIPTION
# Summary
* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

Picard currently cannot read or write the official spec Release Time (`TDRL` frame) in id3v2.4 due to a missing mapping of `TDRL` to the internal variable `releasedate` (analogous to `TDRC` -> `date` and `TDOR` -> `originaldate`).

This PR fixes it and provides a gracious fallback + upgrade path for id3v2.3.

# Problem

1. When Picard is instructed to write the variable `releasedate` to id3v2.4, it currently writes the frame `TXXX:releasedate` and not `TDRL`. While this is compliant with id3v2.3 (which does not have the `TDRL` frame defined), this is not compliant with id3v2.4, where it is part of the official standard.

2. With Vorbis Comments, the `RELEASEDATE` frame is written correctly, albeit without date sanitation.

Most other tag editors (mp3tag, Yate, kid3, Ex Falso, ffmpeg, TagLib, etc) have a mapping `releasedate` -> `TDRL`, Picard is the only modern tag editor I'm aware of that is not able to read or write this frame.

* JIRA ticket (_optional_): PICARD-2616

# Solution

I have deliberately not touched any of the default MusicBrainz JSON -> Picard tag mappings, as I understand it is a deliberate decision that Picard does not write anything to the `TDRL` frame by default. However, this mapping at least makes the `releasedate` internal variable accessible to scripts that do.

- added a `TDRL` -> `releasedate` mapping for id3v2.4
- added a `TXXX:releasedate` custom frame fallback for id3v2.3 + upgrade path for v2.3 -> v2.4
- added date sanitation of the `releasedate` field for Vorbis Comments, like Picard already does with `originaldate` and `date`

Note: id3v2.3 fallback is done in the same way Picard currently handles Mood (`TMOO`) which is another frame that exists in v2.4 but not v2.3)

# Action

Please review & comment

FYI: this test script that writes a MusicBrainz release date to the TDRL can be useful for testing:
`$set(releasedate,%date%)`