### PR TITLE
PICARD-2642: Open "submit cluster" always on 127.0.0.1

### DIFF
--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -123,8 +123,7 @@ def _open_url_with_token(payload):
     if isinstance(token, bytes):  # For compatibility with PyJWT 1.x
         token = token.decode()
     browser_integration = QCoreApplication.instance().browser_integration
-    url = 'http://%s:%s/add?token=%s' % (
-        browser_integration.host_address, browser_integration.port, token)
+    url = f'http://127.0.0.1:{browser_integration.port}/add?token={token}'
     open(url)
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

PICARD-2642

The old implementation would open on 0.0.0.0 if browser_integration_localhost_only was disabled.