### PR TITLE
Refactor log string substitution

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -304,7 +304,7 @@ class Album(DataObject, Item):
                     parse_result = self._parse_release(document)
                     config = get_config()
                     if parse_result == ParseResult.MISSING_TRACK_RELS:
-                        log.debug('Recording relationships not loaded in initial request for %r, issuing separate requests' % self)
+                        log.debug('Recording relationships not loaded in initial request for %r, issuing separate requests', self)
                         self._request_recording_relationships(config=config)
                     elif parse_result == ParseResult.PARSED:
                         self._run_album_metadata_processors()
@@ -329,7 +329,7 @@ class Album(DataObject, Item):
             'work-rels',
             'work-level-rels',
         )
-        log.debug('Loading recording relationships for %r (offset=%i, limit=%i)' % (self, offset, limit))
+        log.debug('Loading recording relationships for %r (offset=%i, limit=%i)', self, offset, limit)
         self._requests += 1
         self.load_task = self.tagger.mb_api.browse_recordings(
             self._recordings_request_finished,

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -77,7 +77,7 @@ class FileLookup(object):
         return self.launch(self._url(path, params))
 
     def launch(self, url):
-        log.debug("webbrowser2: %s" % url)
+        log.debug("webbrowser2: %s", url)
         webbrowser2.open(url)
         return True
 

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -70,10 +70,8 @@ class CoverArt:
         try:
             coverartimage.set_data(data)
             if coverartimage.can_be_saved_to_metadata:
-                log.debug("Cover art image stored to metadata: %r [%s]" % (
-                    coverartimage,
-                    coverartimage.imageinfo_as_string())
-                )
+                log.debug("Cover art image stored to metadata: %r [%s]",
+                    coverartimage, coverartimage.imageinfo_as_string())
                 self.metadata.images.append(coverartimage)
                 for track in self.album._new_tracks:
                     track.metadata.images.append(coverartimage)
@@ -83,10 +81,8 @@ class CoverArt:
                 if not self.front_image_found:
                     self.front_image_found = coverartimage.is_front_image()
             else:
-                log.debug("Thumbnail for cover art image: %r [%s]" % (
-                    coverartimage,
-                    coverartimage.imageinfo_as_string())
-                )
+                log.debug("Thumbnail for cover art image: %r [%s]",
+                    coverartimage, coverartimage.imageinfo_as_string())
         except CoverArtImageIOError as e:
             self.album.error_append(e)
             self.album._finalize_loading(error=True)
@@ -99,9 +95,9 @@ class CoverArt:
         self.album._requests -= 1
 
         if error:
-            self.album.error_append('Coverart error: %s' % (http.errorString()))
+            self.album.error_append('Coverart error: %s', http.errorString())
         elif len(data) < 1000:
-            log.warning("Not enough data, skipping %s" % coverartimage)
+            log.warning("Not enough data, skipping %s", coverartimage)
         else:
             self._message(
                 N_("Cover art of type '%(type)s' downloaded for %(albumid)s from %(host)s"),
@@ -146,12 +142,10 @@ class CoverArt:
                 try:
                     instance = provider.cls(self)
                     if provider.enabled and instance.enabled():
-                        log.debug("Trying cover art provider %s ..." %
-                                  provider.name)
+                        log.debug("Trying cover art provider %s ...", provider.name)
                         ret = instance.queue_images()
                     else:
-                        log.debug("Skipping cover art provider %s ..." %
-                                  provider.name)
+                        log.debug("Skipping cover art provider %s ...", provider.name)
                 except BaseException:
                     log.error(traceback.format_exc())
                     raise
@@ -182,8 +176,7 @@ class CoverArt:
                     self._set_metadata(coverartimage, file.read())
             except OSError as exc:
                 (errnum, errmsg) = exc.args
-                log.error("Failed to read %r: %s (%d)" %
-                          (path, errmsg, errnum))
+                log.error("Failed to read %r: %s (%d)", path, errmsg, errnum)
             except CoverArtImageIOError:
                 # It doesn't make sense to store/download more images if we can't
                 # save them in the temporary folder, abort.
@@ -201,7 +194,7 @@ class CoverArt:
             },
             echo=None
         )
-        log.debug("Downloading %r" % coverartimage)
+        log.debug("Downloading %r", coverartimage)
         self.album.tagger.webservice.download(
             coverartimage.host,
             coverartimage.port,

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -88,7 +88,7 @@ class DataHash:
                     imagefile.write(data)
                 _datafiles[self._hash] = self._filename
                 periodictouch.register_file(self._filename)
-                log.debug("Saving image data %s to %r" % (self._hash, self._filename))
+                log.debug("Saving image data %s to %r", self._hash, self._filename)
             else:
                 self._filename = _datafiles[self._hash]
         finally:

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -525,14 +525,14 @@ class CoverArtProviderCaa(CoverArtProvider):
         # MB web service indicates if CAA has artwork
         # https://tickets.metabrainz.org/browse/MBS-4536
         if 'cover-art-archive' not in self.release:
-            log.debug('No Cover Art Archive information for {release_id}'.format(release_id=self.release['id']))
+            log.debug('No Cover Art Archive information for %s', self.release['id'])
             return False
 
         caa_node = self.release['cover-art-archive']
         caa_has_suitable_artwork = caa_node['artwork']
 
         if not caa_has_suitable_artwork:
-            log.debug('There are no images in the Cover Art Archive for {release_id}'.format(release_id=self.release['id']))
+            log.debug('There are no images in the Cover Art Archive for %s', self.release['id'])
             return False
 
         if self.restrict_types:
@@ -561,9 +561,9 @@ class CoverArtProviderCaa(CoverArtProvider):
                 caa_has_suitable_artwork = front_in_caa or back_in_caa
 
         if not caa_has_suitable_artwork:
-            log.debug('There are no suitable images in the Cover Art Archive for {release_id}'.format(release_id=self.release['id']))
+            log.debug('There are no suitable images in the Cover Art Archive for %s', self.release['id'])
         else:
-            log.debug('There are suitable images in the Cover Art Archive for {release_id}'.format(release_id=self.release['id']))
+            log.debug('There are suitable images in the Cover Art Archive for %s', self.release['id'])
 
         return caa_has_suitable_artwork
 
@@ -602,7 +602,7 @@ class CoverArtProviderCaa(CoverArtProvider):
                 self.error('CAA JSON error: %s' % (http.errorString()))
         else:
             if self.restrict_types:
-                log.debug('CAA types: included: %s, excluded: %s' % (self.caa_types, self.caa_types_to_omit,))
+                log.debug('CAA types: included: %s, excluded: %s', self.caa_types, self.caa_types_to_omit)
             try:
                 config = get_config()
                 for image in data["images"]:
@@ -610,8 +610,7 @@ class CoverArtProviderCaa(CoverArtProvider):
                         continue
                     is_pdf = image["image"].endswith('.pdf')
                     if is_pdf and not config.setting["save_images_to_files"]:
-                        log.debug("Skipping pdf cover art : %s" %
-                                  image["image"])
+                        log.debug("Skipping pdf cover art : %s", image["image"])
                         continue
                     # if image has no type set, we still want it to match
                     # pseudo type 'unknown'
@@ -626,10 +625,10 @@ class CoverArtProviderCaa(CoverArtProvider):
                         if types and self.caa_types_to_omit:
                             types = not set(image["types"]).intersection(
                                 set(self.caa_types_to_omit))
-                        log.debug('CAA image {status}: {image_name}  {image_types}'.format(
-                            status=('accepted' if types else 'rejected'),
-                            image_name=image['image'],
-                            image_types=image['types'],)
+                        log.debug('CAA image %s: %s  %s',
+                            ('accepted' if types else 'rejected'),
+                            image['image'],
+                            image['types']
                         )
                     else:
                         types = True

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -67,7 +67,7 @@ class Disc(QtCore.QObject):
             disc = discid.read(device, features=['mcn'])
             self._set_disc_details(disc)
         except discid.DiscError as e:
-            log.error("Error while reading %r: %s" % (device, str(e)))
+            log.error("Error while reading %r: %s", device, e)
             raise
 
     def put(self, toc):
@@ -77,10 +77,10 @@ class Disc(QtCore.QObject):
             disc = discid.put(first, last, sectors, offsets)
             self._set_disc_details(disc)
         except discid.TOCError as e:
-            log.error("Error while processing TOC %r: %s" % (toc, str(e)))
+            log.error("Error while processing TOC %r: %s", toc, e)
             raise
         except ValueError as e:
-            log.error("Error while processing TOC %r: %s" % (toc, str(e)))
+            log.error("Error while processing TOC %r: %s", toc, e)
             raise discid.TOCError(e)
 
     def _set_disc_details(self, disc):

--- a/picard/file.py
+++ b/picard/file.py
@@ -252,7 +252,7 @@ class File(QtCore.QObject, Item):
             if alternative_file:
                 # Do not retry reloading exactly the same file format
                 if type(alternative_file) != type(self):  # pylint: disable=unidiomatic-typecheck
-                    log.debug('Loading %r failed, retrying as %r' % (self, alternative_file))
+                    log.debug('Loading %r failed, retrying as %r', self, alternative_file)
                     self.remove()
                     alternative_file.load(callback)
                     return

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -148,8 +148,7 @@ class APEv2File(File):
                                 data=data,
                             )
                         except CoverArtImageError as e:
-                            log.error('Cannot load image from %r: %s' %
-                                      (filename, e))
+                            log.error('Cannot load image from %r: %s', filename, e)
                         else:
                             metadata.images.append(coverartimage)
 

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -229,8 +229,7 @@ class ASFFile(File):
                             id3_type=image_type,
                         )
                     except CoverArtImageError as e:
-                        log.error('Cannot load image from %r: %s' %
-                                  (filename, e))
+                        log.error('Cannot load image from %r: %s', filename, e)
                     else:
                         metadata.images.append(coverartimage)
 

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -349,7 +349,7 @@ class ID3File(File):
                         id3_type=frame.type,
                     )
                 except CoverArtImageError as e:
-                    log.error('Cannot load image from %r: %s' % (filename, e))
+                    log.error('Cannot load image from %r: %s', filename, e)
                 else:
                     metadata.images.append(coverartimage)
             elif frameid == 'POPM':

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -225,8 +225,7 @@ class MP4File(File):
                             data=value,
                         )
                     except CoverArtImageError as e:
-                        log.error('Cannot load image from %r: %s' %
-                                  (filename, e))
+                        log.error('Cannot load image from %r: %s', filename, e)
                     else:
                         metadata.images.append(coverartimage)
             # Read other freeform tags always case insensitive

--- a/picard/formats/util.py
+++ b/picard/formats/util.py
@@ -95,5 +95,5 @@ def open_(filename):
         # None is returned if both the methods fail
         return None
     except Exception as error:
-        log.error("Error occurred:\n{}".format(error))
+        log.error("Error occurred:\n%s", error)
         return None

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -193,7 +193,7 @@ class VCommentFile(File):
                             id3_type=image.type
                         )
                     except (CoverArtImageError, TypeError, ValueError, mutagen.flac.error) as e:
-                        log.error('Cannot load image from %r: %s' % (filename, e))
+                        log.error('Cannot load image from %r: %s', filename, e)
                     else:
                         metadata.images.append(coverartimage)
                     continue
@@ -213,7 +213,7 @@ class VCommentFile(File):
                         id3_type=image.type
                     )
                 except CoverArtImageError as e:
-                    log.error('Cannot load image from %r: %s' % (filename, e))
+                    log.error('Cannot load image from %r: %s', filename, e)
                 else:
                     metadata.images.append(coverartimage)
 
@@ -228,7 +228,7 @@ class VCommentFile(File):
                             data=base64.standard_b64decode(data)
                         )
                     except (CoverArtImageError, TypeError, ValueError) as e:
-                        log.error('Cannot load image from %r: %s' % (filename, e))
+                        log.error('Cannot load image from %r: %s', filename, e)
                     else:
                         metadata.images.append(coverartimage)
             except KeyError:

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -78,7 +78,7 @@ class ExtensionPoint(object):
     def register(self, module, item):
         if module.startswith(_PLUGIN_MODULE_PREFIX):
             name = module[_PLUGIN_MODULE_PREFIX_LEN:]
-            log.debug("ExtensionPoint: %s register <- plugin=%r item=%r" % (self.label, name, item))
+            log.debug("ExtensionPoint: %s register <- plugin=%r item=%r", self.label, name, item)
         else:
             name = None
             # uncomment to debug internal extensions loaded at startup

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -397,7 +397,7 @@ class PluginManager(QtCore.QObject):
                 elif os.path.isdir(path):
                     self._install_plugin_dir(plugin_name, path, update=update)
             except OSError as why:
-                log.error("Unable to copy plugin '%s' to %r: %s" % (plugin_name, self.plugins_directory, why))
+                log.error("Unable to copy plugin '%s' to %r: %s", plugin_name, self.plugins_directory, why)
                 return
 
             if not update:

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -216,7 +216,7 @@ class PicardScript():
         (name, ext) = os.path.splitext(filename)
         if ext and str(name).endswith('.' + ext):
             filename = name
-        log.debug('Exporting script file: %s' % filename)
+        log.debug('Exporting script file: %s', filename)
         if file_type == self._file_types()['package']:
             script_text = self.to_yaml()
         else:
@@ -250,7 +250,7 @@ class PicardScript():
         filename, file_type = QtWidgets.QFileDialog.getOpenFileName(parent, dialog_title, default_script_directory, dialog_file_types, options=options)
         if not filename:
             return None
-        log.debug('Importing script file: %s' % filename)
+        log.debug('Importing script file: %s', filename)
         try:
             with open(filename, 'r', encoding='utf8') as i_file:
                 file_content = i_file.read()

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -539,7 +539,7 @@ class Tagger(QtWidgets.QApplication):
                 delay = float(arg)
                 if delay < 0:
                     raise ValueError
-                log.debug(f"Pausing command execution by {delay} seconds.")
+                log.debug("Pausing command execution by %d seconds.", delay)
                 thread.run_task(partial(time.sleep, delay))
             except ValueError:
                 log.error(f"Invalid command pause time specified: {repr(argstring)}")

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -101,7 +101,7 @@ class PreserveGeometry:
         name = widget.objectName()
         if not name:
             name = '.'.join(self._get_lineage(widget))
-            log.debug("Splitter does not have objectName(): %s" % name)
+            log.debug("Splitter does not have objectName(): %s", name)
         return name
 
     @property

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -137,11 +137,11 @@ class CDLookupDialog(PicardDialog):
             state = config.persist[self.dialog_header_state]
             if state:
                 header.restoreState(state)
-                log.debug("restore_state: %s" % self.dialog_header_state)
+                log.debug("restore_state: %s", self.dialog_header_state)
 
     def save_header_state(self):
         if self.ui.release_list:
             state = self.ui.release_list.header().saveState()
             config = get_config()
             config.persist[self.dialog_header_state] = state
-            log.debug("save_state: %s" % self.dialog_header_state)
+            log.debug("save_state: %s", self.dialog_header_state)

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -528,7 +528,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             self._try_load_remote_image(url, data)
             return
         except CoverArtImageError as e:
-            log.debug("Unable to identify dropped data format: %s" % e)
+            log.debug("Unable to identify dropped data format: %s", e)
 
         # Try getting image out of HTML (e.g. for Google image search detail view)
         try:
@@ -537,7 +537,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             if match:
                 url = QtCore.QUrl(match.group(1))
         except UnicodeDecodeError as e:
-            log.warning("Unable to decode dropped data format: %s" % e)
+            log.warning("Unable to decode dropped data format: %s", e)
         else:
             log.debug("Trying URL parsed from HTML: %s", url.toString())
             self.fetch_remote_image(url)
@@ -546,7 +546,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         try:
             self._try_load_remote_image(url, data)
         except CoverArtImageError as e:
-            log.warning("Can't load image: %s" % e)
+            log.warning("Can't load image: %s", e)
             return
 
     def _try_load_remote_image(self, url, data):

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1423,7 +1423,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if isinstance(obj, Track) and obj.files:
             obj = obj.files[0]
         if not isinstance(obj, File):
-            log.debug('show_more_tracks expected a File, got %r' % obj)
+            log.debug('show_more_tracks expected a File, got %r', obj)
             return
         dialog = TrackSearchDialog(self, force_advanced_search=True)
         dialog.show_similar_tracks(obj)
@@ -1432,7 +1432,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def show_more_albums(self):
         obj = self.get_first_obj_with_type(Cluster)
         if not obj:
-            log.debug('show_more_albums expected a Cluster, got %r' % obj)
+            log.debug('show_more_albums expected a Cluster, got %r', obj)
             return
         dialog = AlbumSearchDialog(self, force_advanced_search=True)
         dialog.show_similar_albums(obj)
@@ -1768,14 +1768,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         update_level = config.setting['update_level']
         today = datetime.date.today().toordinal()
         do_auto_update_check = check_for_updates and update_check_days > 0 and today >= last_update_check + update_check_days
-        log.debug('{check_status} start-up check for program updates.  Today: {today_date}, Last check: {last_check} (Check interval: {check_interval} days), Update level: {update_level} ({update_level_name})'.format(
-            check_status='Initiating' if do_auto_update_check else 'Skipping',
-            today_date=datetime.date.today(),
-            last_check=str(datetime.date.fromordinal(last_update_check)) if last_update_check > 0 else 'never',
-            check_interval=update_check_days,
-            update_level=update_level,
-            update_level_name=PROGRAM_UPDATE_LEVELS[update_level]['name'] if update_level in PROGRAM_UPDATE_LEVELS else 'unknown',
-        ))
+        log.debug('%(check_status)s start-up check for program updates.  Today: %(today_date)s, Last check: %(last_check)s (Check interval: %(check_interval)s days), Update level: %(update_level)s (%(update_level_name)s)', {
+            'check_status': 'Initiating' if do_auto_update_check else 'Skipping',
+            'today_date': datetime.date.today(),
+            'last_check': str(datetime.date.fromordinal(last_update_check)) if last_update_check > 0 else 'never',
+            'check_interval': update_check_days,
+            'update_level': update_level,
+            'update_level_name': PROGRAM_UPDATE_LEVELS[update_level]['name'] if update_level in PROGRAM_UPDATE_LEVELS else 'unknown',
+        })
         if do_auto_update_check:
             self.check_for_update(False)
 

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -248,7 +248,7 @@ class MaintenanceOptionsPage(OptionsPage):
         filename, file_type = QtWidgets.QFileDialog.getOpenFileName(self, dialog_title, directory, dialog_file_types, options=options)
         if not filename:
             return
-        log.warning('Loading configuration from %s' % filename)
+        log.warning('Loading configuration from %s', filename)
         if load_new_config(filename):
             config = get_config()
             upgrade_config(config)

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -677,7 +677,7 @@ class PluginsOptionsPage(OptionsPage):
             msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
             msgbox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
             msgbox.exec_()
-            log.error("Error occurred while trying to download the plugin: '%s'" % plugin.module_name)
+            log.error("Error occurred while trying to download the plugin: '%s'", plugin.module_name)
             return
 
         self.manager.install_plugin(

--- a/picard/util/checkupdate.py
+++ b/picard/util/checkupdate.py
@@ -87,7 +87,7 @@ class UpdateCheckManager(QtCore.QObject):
 
     def _query_available_updates(self, callback=None):
         """Gets list of releases from specified website api."""
-        log.debug("Getting Picard release information from {host_url}".format(host_url=PLUGINS_API['host'],))
+        log.debug("Getting Picard release information from %s", PLUGINS_API['host'])
         self.tagger.webservice.get(
             PLUGINS_API['host'],
             PLUGINS_API['port'],
@@ -116,8 +116,7 @@ class UpdateCheckManager(QtCore.QObject):
             else:
                 self._available_versions = {}
             for key in self._available_versions:
-                log.debug("Version key '{version_key}' --> {version_information}".format(
-                    version_key=key, version_information=self._available_versions[key],))
+                log.debug("Version key '%s' -> %s", key, self._available_versions[key])
             self._display_results()
         if callback:
             callback(not error)
@@ -132,7 +131,7 @@ class UpdateCheckManager(QtCore.QObject):
             try:
                 test_version = Version(*version_tuple)
             except (TypeError, VersionError):
-                log.error('Invalid version %r for update level %s.' % (version_tuple, update_level))
+                log.error('Invalid version %r for update level %s.', version_tuple, update_level)
                 continue
             if self._update_level >= test_key and test_version > high_version:
                 key = PROGRAM_UPDATE_LEVELS[test_key]['name']

--- a/picard/util/remotecommands.py
+++ b/picard/util/remotecommands.py
@@ -262,7 +262,7 @@ class RemoteCommands:
         try:
             lines = open(filepath).readlines()
         except Exception as e:
-            log.error("Error reading command file '%s': %s" % (filepath, e))
+            log.error("Error reading command file '%s': %s", filepath, e)
             return commands
         for line in lines:
             line = line.strip()

--- a/setup.py
+++ b/setup.py
@@ -346,7 +346,7 @@ class picard_build_ui(Command):
                 if m:
                     name = m.group(1)
                 else:
-                    log.warn('ignoring %r (cannot extract base name)' % f)
+                    log.warn('ignoring %r (cannot extract base name)', f)
                     continue
                 uiname = name + '.ui'
                 uifile = os.path.join(head, uiname)
@@ -360,7 +360,7 @@ class picard_build_ui(Command):
                         files.append((uifile,
                                       py_from_ui_with_defaultdir(uifile)))
                     else:
-                        log.warn('ignoring %r' % f)
+                        log.warn('ignoring %r', f)
             self.files = files
 
     def run(self):
@@ -664,8 +664,7 @@ class picard_update_constants(Command):
             for code, name in sorted(countries.items(), key=lambda t: t[0]):
                 write(line, code=code, name=name.replace("'", "\\'"))
             write(footer)
-            log.info("%s was rewritten (%d countries)" % (filename,
-                                                          len(countries)))
+            log.info("%s was rewritten (%d countries)", filename, len(countries))
 
     def attributes_py_file(self, attributes):
         header = ("# -*- coding: utf-8 -*-\n"
@@ -684,8 +683,7 @@ class picard_update_constants(Command):
             for key, value in sorted(attributes.items(), key=lambda i: i[0]):
                 write(line, key=key, value=value.replace("'", "\\'"))
             write(footer)
-            log.info("%s was rewritten (%d attributes)" % (filename,
-                                                           len(attributes)))
+            log.info("%s was rewritten (%d attributes)", filename, len(attributes))
 
 
 class picard_patch_version(Command):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

For log output Picard often does variable substitutions in the logging strings. In many cases these used the string formatting options provided by Python (all of % operator, `.format()`  and f-strings are used).

This means that the string substitutions are applied even if due to the log level the string never gets outputted. This is especially true for debug log messages in normal operation. This ads an unnecessary overhead.



# Solution
Rely on the string substitutions of the logging module to avoid unnecessary substitutions if log output never gets written.