### PR TITLE
PICARD-900: Use ID3v2.4 UTF-8 by default

### DIFF
--- a/picard/ui/options/tags_compatibility_id3.py
+++ b/picard/ui/options/tags_compatibility_id3.py
@@ -49,8 +49,8 @@ class TagsCompatibilityID3OptionsPage(OptionsPage):
 
     options = [
         BoolOption("setting", "write_id3v1", True),
-        BoolOption("setting", "write_id3v23", True),
-        TextOption("setting", "id3v2_encoding", "utf-16"),
+        BoolOption("setting", "write_id3v23", False),
+        TextOption("setting", "id3v2_encoding", "utf-8"),
         TextOption("setting", "id3v23_join_with", "/"),
         BoolOption("setting", "itunes_compatible_grouping", False),
     ]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-900
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Folks, it's time. It has been 6 years since this was attempted the last time in #559 . But I think in 2023 it is finally time to change Picard to default to ID3v2.4.

Since the last discussion Windows has gained ID3v2.4 support. All Windows version not supporting it are officially no longer supported (which includes older Windows 10 versions).

Also there are more issues discussed were ID3v2.3 is the problem, not the solution. In regards to user support it seems to me it is easier to tell those few people having issues with ID3v2.4 on older devices to change to v2.3 than it is to explain users why they should better use v2.4 and trying to argue why Picard still considers 2.3 the default.

One of the major issues is the lack of proper multi-value support in v2.3. This causes issues like https://community.metabrainz.org/t/certain-albums-not-scrobbling/630833/12

# Solution

Switch the default for new installs to ID3v2.4 UTF-8.