### PR TITLE
PICARD-2627: Ensure pipe listener threads closes on quit

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2009, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 amckinle
-# Copyright (C) 2008-2010, 2014-2015, 2018-2022 Philipp Wolfer
+# Copyright (C) 2008-2010, 2014-2015, 2018-2023 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2010 Andrew Barnert
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -704,7 +704,7 @@ class Tagger(QtWidgets.QApplication):
         log.debug("Picard stopping")
         self._acoustid.done()
         if self.pipe_handler:
-            self.pipe_handler.pipe_running = False
+            self.pipe_handler.stop()
         self.webservice.stop()
         self.thread_pool.waitForDone()
         self.save_thread_pool.waitForDone()

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2022 skelly37
-# Copyright (C) 2022 Philipp Wolfer
+# Copyright (C) 2022-2023 Philipp Wolfer
 # Copyright (C) 2022 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
@@ -275,6 +275,11 @@ class AbstractPipe(metaclass=ABCMeta):
             self.read_from_pipe()
 
         return False
+
+    def stop(self):
+        log.debug("Stopping pipe")
+        self.pipe_running = False
+        self.send_to_pipe(self.MESSAGE_TO_IGNORE)
 
 
 class UnixPipe(AbstractPipe):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2627
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

It can happen that `Tagger.pipe_server` hangs waiting getting data from the pipe. If this happens when Picard is closing the `pipe_server` thread keeps running in the background until it reveives data, which likely won't happen.


# Solution
To fix this write a MESSAGE_TO_IGNORE to the pipe when closing. This causes the pipe read call to return and the loop inside `Tagger.pipe_server`  will stop properly.
