### PR TITLE
PICARD-2645: Fix handle the quit confirmation when reveiving QUIT command

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -547,12 +547,13 @@ class Tagger(QtWidgets.QApplication):
             log.error("No command pause time specified.")
 
     def handle_command_quit(self, argstring):
-        if not argstring.upper() == 'FORCE' and self.window.show_quit_confirmation():
+        if argstring.upper() == 'FORCE' or self.window.show_quit_confirmation():
+            self.exit()
+            self.quit()
+        else:
             log.info("QUIT command cancelled by the user.")
             RemoteCommands.set_quit(False)  # Allow queueing more commands.
             return
-        self.exit()
-        self.quit()
 
     def handle_command_remove(self, argstring):
         for file in self.iter_all_files():


### PR DESCRIPTION
…mand

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2645
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Sending the QUIT command to Picard with "picard -e QUIT" wrongly handles the quit confirmation dialog. If there are no files to save, the QUIT is ignored. If there are files to save the QUIT is only acknowledged if the user cancels, not confirms, the quit.


# Solution

Properly handle the return value of `show_quit_confirmation` (`True`  means do quit Picard, `False`  don't). Also refactor `Tagger.handle_command_quit` for readability.