### PR TITLE
PICARD-711: Add support for series variables

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -609,15 +609,15 @@ class Album(DataObject, Item):
             inc |= {
                 'artist-rels',
                 'recording-rels',
+                'release-group-level-rels',
                 'release-rels',
                 'series-rels',
                 'url-rels',
-                'work-rels'
+                'work-rels',
             }
             if config.setting['track_ars']:
                 inc |= {
                     'recording-level-rels',
-                    'release-group-level-rels',
                     'work-level-rels',
                 }
         require_authentication = self.set_genre_inc_params(inc, config) or require_authentication

--- a/picard/album.py
+++ b/picard/album.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 Hendrik van Antwerpen
 # Copyright (C) 2008 ojnkpjg
-# Copyright (C) 2008-2011, 2014, 2018-2022 Philipp Wolfer
+# Copyright (C) 2008-2011, 2014, 2018-2023 Philipp Wolfer
 # Copyright (C) 2009 Nikolai Prokoschenko
 # Copyright (C) 2011-2012 Chad Wilson
 # Copyright (C) 2011-2013, 2019 Michael Wiencek
@@ -610,12 +610,14 @@ class Album(DataObject, Item):
                 'artist-rels',
                 'recording-rels',
                 'release-rels',
+                'series-rels',
                 'url-rels',
                 'work-rels'
             }
             if config.setting['track_ars']:
                 inc |= {
                     'recording-level-rels',
+                    'release-group-level-rels',
                     'work-level-rels',
                 }
         require_authentication = self.set_genre_inc_params(inc, config) or require_authentication

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -50,7 +50,65 @@
         "secondary-type-ids": [],
         "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
         "secondary-types": [],
-        "aliases": []
+        "aliases": [],
+        "relations": [
+            {
+                "ordering-key": 15,
+                "begin": null,
+                "type": "part of",
+                "attributes": [
+                    "number"
+                ],
+                "series": {
+                    "type": "Release group series",
+                    "type-id": "4c1c4949-7b6c-3a2d-9d54-a50a27e4fa77",
+                    "name": "Absolute Radio's The 100 Collection",
+                    "id": "4bf41050-6fa9-41a6-8398-15bdab4b0352",
+                    "disambiguation": ""
+                },
+                "ended": false,
+                "target-credit": "",
+                "attribute-ids": {
+                    "number": "a59c5830-5ec7-38fe-9a21-c7ea54f6650a"
+                },
+                "type-id": "01018437-91d8-36b9-bf89-3f885d53b5bd",
+                "attribute-values": {
+                    "number": "15"
+                },
+                "end": null,
+                "direction": "forward",
+                "target-type": "series",
+                "source-credit": ""
+            },
+            {
+                "direction": "forward",
+                "attribute-values": {
+                    "number": "291"
+                },
+                "end": null,
+                "source-credit": "",
+                "target-type": "series",
+                "ordering-key": 352,
+                "type": "part of",
+                "begin": null,
+                "target-credit": "",
+                "type-id": "01018437-91d8-36b9-bf89-3f885d53b5bd",
+                "attribute-ids": {
+                    "number": "a59c5830-5ec7-38fe-9a21-c7ea54f6650a"
+                },
+                "series": {
+                    "name": "1001 Albums You Must Hear Before You Die",
+                    "disambiguation": "2005 edition",
+                    "id": "4bc2a338-e1d8-4546-8a61-640da8aaf888",
+                    "type-id": "4c1c4949-7b6c-3a2d-9d54-a50a27e4fa77",
+                    "type": "Release group series"
+                },
+                "ended": false,
+                "attributes": [
+                    "number"
+                ]
+            }
+        ]
     },
     "aliases": [],
     "cover-art-archive": {
@@ -439,6 +497,28 @@
             "end": null,
             "direction": "backward",
             "type-id": "8bf377ba-8d71-4ecc-97f2-7bb2d8a2a75f"
+        },
+        {
+            "type": "part of",
+            "attributes": [],
+            "source-credit": "",
+            "attribute-values": {},
+            "target-type": "series",
+            "ordering-key": 1,
+            "type-id": "3fa29f01-8e13-3e49-9b0a-ad212aa2f81d",
+            "end": null,
+            "ended": false,
+            "direction": "forward",
+            "target-credit": "",
+            "begin": null,
+            "attribute-ids": {},
+            "series": {
+                "type": "Release series",
+                "type-id": "52b90f1e-ff62-3bd0-b254-5d91ced5d757",
+                "disambiguation": "Pink Floyed special editions",
+                "name": "Why Pink Floyd?",
+                "id": "7421b602-a413-4151-bcf4-d831debc3f27"
+            }
         }
     ],
     "id": "b84ee12a-09ef-421b-82de-0441a926375b",

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2017, 2019-2022 Laurent Monin
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2018-2022 Philipp Wolfer
+# Copyright (C) 2018-2023 Philipp Wolfer
 # Copyright (C) 2020 dukeyin
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
@@ -123,6 +123,10 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~releaseannotation'], 'Original Vinyl release')
         self.assertEqual(m['~releaselanguage'], 'eng')
         self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
+        self.assertEqual(m['~release_series'], 'Why Pink Floyd?')
+        self.assertEqual(m['~release_seriesid'], '7421b602-a413-4151-bcf4-d831debc3f27')
+        self.assertEqual(m['~release_seriescomment'], 'Pink Floyed special editions')
+        self.assertEqual(m['~release_seriesnumber'], '')
         self.assertEqual(a.genres, {
             'genre1': 6, 'genre2': 3,
             'tag1': 6, 'tag2': 3})
@@ -177,6 +181,22 @@ class ReleaseTest(MBJSONTest):
     def test_media_formats_from_node(self):
         formats = media_formats_from_node(self.json_doc['media'])
         self.assertEqual(formats, '12" Vinyl')
+
+    def test_release_group_rels(self):
+        m = Metadata()
+        release_group_to_metadata(self.json_doc['release-group'], m)
+        self.assertEqual(m.getall('~releasegroup_series'), [
+            "Absolute Radio's The 100 Collection",
+            '1001 Albums You Must Hear Before You Die'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriesid'), [
+            '4bf41050-6fa9-41a6-8398-15bdab4b0352',
+            '4bc2a338-e1d8-4546-8a61-640da8aaf888'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriescomment'), [
+            '2005 edition'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriesnumber'), ['15', '291'])
 
 
 class NullReleaseTest(MBJSONTest):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-711
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Adds support for series variables for release group, release, recording and work series. 

# Solution
Make the series name, id, disambiguation comment and number available as variables. The following variables are getting set:

- ~recording_series
- ~recording_series_id
- ~recording_seriescomment
- ~recording_seriesnumber
- ~release_series
- ~release_series_id
- ~release_seriescomment
- ~release_seriesnumber
- ~releasegroup_series
- ~releasegroup_series_id
- ~releasegroup_seriescomment
- ~releasegroup_seriesnumber
- ~work_series
- ~work_series_id
- ~work_seriescomment
- ~work_seriesnumber

The variable names are modeled after https://github.com/kellnerd/picard-plugins/blob/release_series/plugins/release_series/release_series.py

I thought about adding actual tags instead of just variables. But series are often rather arbitrary. E.g. https://musicbrainz.org/release/b84ee12a-09ef-421b-82de-0441a926375b is part of 8 series.

Having this as variables allows the users to decide if and how they make use of this information. I expect this to be used mostly by advanced users in any case.