### PR TITLE
Enforce keywords arguments only for WSRequest and drop WS*Request sub…

### DIFF
--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -144,14 +144,20 @@ class WSRequest(QNetworkRequest):
 
         # mandatory parameters
         self.method = method
-        assert self.method in {'GET', 'PUT', 'DELETE', 'POST'}
+        if self.method not in {'GET', 'PUT', 'DELETE', 'POST'}:
+            raise AssertionError('invalid method')
         self.host = host
-        assert self.host is not None
+        if self.host is None:
+            raise AssertionError('host undefined')
         self.port = int(port)
-        assert self.port >= 0
-
+        if self.port < 0:
+            raise AssertionError('port invalid')
         self.path = path
+        if self.path is None:
+            raise AssertionError('path undefined')
         self.handler = handler
+        if self.handler is None:
+            raise AssertionError('handler undefined')
 
         # optional parameter, must be set before calling build_qurl()
         self.queryargs = queryargs

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -639,10 +639,19 @@ class WebService(QtCore.QObject):
     def download(self, host, port, path, handler, priority=False,
                  important=False, cacheloadcontrol=None, refresh=False,
                  queryargs=None):
-        return self.get(host, port, path, handler, parse_response_type=None,
-                        priority=priority, important=important,
-                        cacheloadcontrol=cacheloadcontrol, refresh=refresh,
-                        queryargs=queryargs)
+        request = WSRequest(
+            method='GET',
+            host=host,
+            port=port,
+            path=path,
+            handler=handler,
+            priority=priority,
+            important=important,
+            cacheloadcontrol=cacheloadcontrol,
+            refresh=refresh,
+            queryargs=queryargs,
+        )
+        return self.add_request(request)
 
     def stop(self):
         for reply in list(self._active_requests):

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -97,10 +97,24 @@ class UnknownResponseParserError(Exception):
 class WSRequest(QNetworkRequest):
     """Represents a single HTTP request."""
 
-    def __init__(self, method, host, port, path, handler, parse_response_type=None, data=None,
-                 mblogin=False, cacheloadcontrol=None, refresh=False,
-                 queryargs=None, priority=False, important=False,
-                 request_mimetype=None):
+    def __init__(
+        self,
+        *,
+        method=None,
+        host=None,
+        port=-1,
+        path=None,
+        handler=None,
+        parse_response_type=None,
+        data=None,
+        mblogin=False,
+        cacheloadcontrol=None,
+        refresh=False,
+        queryargs=None,
+        priority=False,
+        important=False,
+        request_mimetype=None,
+    ):
         """
         Args:
             method: HTTP method.  One of ``GET``, ``POST``, ``PUT``, or ``DELETE``.
@@ -108,49 +122,64 @@ class WSRequest(QNetworkRequest):
             port: TCP port number (80 or 443).
             path: Path component.
             handler: Callback which takes a 3-tuple of `(str:document,
-            QNetworkReply:reply, QNetworkReply.Error:error)`.
+                QNetworkReply:reply, QNetworkReply.Error:error)`.
             parse_response_type: Specifies that request either sends or accepts
-            data as ``application/{{response_mimetype}}``.
+                data as ``application/{{response_mimetype}}``.
             data: Data to include with ``PUT`` or ``POST`` requests.
             mblogin: Hints that this request should be tied to a MusicBrainz
             account, requiring that we obtain an OAuth token first.
             cacheloadcontrol: See `QNetworkRequest.Attribute.CacheLoadControlAttribute`.
             refresh: Indicates a user-specified resource refresh, such as when
-            the user wishes to reload a release.  Marks the request as high priority
-            and disables caching.
+                the user wishes to reload a release.  Marks the request as high priority
+                and disables caching.
             queryargs: `dict` of query arguments.
-            retries: Current retry attempt number.
             priority: Indicates that this is a high priority request.
             important: Indicates that this is an important request.
             request_mimetype: Set the Content-Type header.
         """
-        url = build_qurl(host, port, path=path, queryargs=queryargs)
-        super().__init__(url)
-
         # These two are codependent (see _update_authorization_header) and must
         # be initialized explicitly.
         self._access_token = None
         self._mblogin = None
 
-        self._retries = 0
-
+        # mandatory parameters
         self.method = method
+        assert self.method in {'GET', 'PUT', 'DELETE', 'POST'}
         self.host = host
-        self.port = port
+        assert self.host is not None
+        self.port = int(port)
+        assert self.port >= 0
+
         self.path = path
         self.handler = handler
+
+        # optional parameter, must be set before calling build_qurl()
+        self.queryargs = queryargs
+
+        # must be called before setting mblogin
+        url = build_qurl(self.host, self.port, path=self.path, queryargs=self.queryargs)
+        super().__init__(url)
+
+        # optional parameters
         self.parse_response_type = parse_response_type
-        self.response_parser = None
-        self.response_mimetype = None
         self.request_mimetype = request_mimetype
         self.data = data
         self.mblogin = mblogin
         self.cacheloadcontrol = cacheloadcontrol
         self.refresh = refresh
-        self.queryargs = queryargs
         self.priority = priority
         self.important = important
-        self._high_prio_no_cache = False
+
+        # setup
+        self._retries = 0
+        if self.method == 'GET':
+            self._high_prio_no_cache = self.refresh
+            self.setAttribute(QNetworkRequest.Attribute.HttpPipeliningAllowedAttribute, True)
+        else:
+            self._high_prio_no_cache = True
+
+        self.response_parser = None
+        self.response_mimetype = None
 
         self.access_token = None
         self._init_headers()
@@ -216,48 +245,6 @@ class WSRequest(QNetworkRequest):
         self.priority = priority
         self._retries += 1
         return self._retries
-
-
-class WSGetRequest(WSRequest):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__("GET", *args, **kwargs)
-
-    def _init_headers(self):
-        self._high_prio_no_cache = self.refresh
-        super()._init_headers()
-        self.setAttribute(QNetworkRequest.Attribute.HttpPipeliningAllowedAttribute,
-                          True)
-
-
-class WSPutRequest(WSRequest):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__("PUT", *args, **kwargs)
-
-    def _init_headers(self):
-        self._high_prio_no_cache = True
-        super()._init_headers()
-
-
-class WSDeleteRequest(WSRequest):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__("DELETE", *args, **kwargs)
-
-    def _init_headers(self):
-        self._high_prio_no_cache = True
-        super()._init_headers()
-
-
-class WSPostRequest(WSRequest):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__("POST", *args, **kwargs)
-
-    def _init_headers(self):
-        self._high_prio_no_cache = True
-        super()._init_headers()
 
 
 class RequestTask(namedtuple('RequestTask', 'hostkey func priority')):
@@ -577,31 +564,70 @@ class WebService(QtCore.QObject):
     def get(self, host, port, path, handler, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
             priority=False, important=False, mblogin=False, cacheloadcontrol=None, refresh=False,
             queryargs=None):
-        request = WSGetRequest(host, port, path, handler, parse_response_type=parse_response_type,
-                               mblogin=mblogin, cacheloadcontrol=cacheloadcontrol, refresh=refresh,
-                               queryargs=queryargs, priority=priority, important=important)
+        request = WSRequest(
+            method='GET',
+            host=host,
+            port=port,
+            path=path,
+            handler=handler,
+            parse_response_type=parse_response_type,
+            priority=priority,
+            important=important,
+            mblogin=mblogin,
+            cacheloadcontrol=cacheloadcontrol,
+            refresh=refresh,
+            queryargs=queryargs,
+        )
         return self.add_request(request)
 
     def post(self, host, port, path, data, handler, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
              priority=False, important=False, mblogin=True, queryargs=None, request_mimetype=None):
-        request = WSPostRequest(host, port, path, handler, parse_response_type=parse_response_type,
-                                data=data, mblogin=mblogin, queryargs=queryargs,
-                                priority=priority, important=important,
-                                request_mimetype=request_mimetype)
+        request = WSRequest(
+            method='POST',
+            host=host,
+            port=port,
+            path=path,
+            handler=handler,
+            parse_response_type=parse_response_type,
+            priority=priority,
+            important=important,
+            mblogin=mblogin,
+            queryargs=queryargs,
+            data=data,
+            request_mimetype=request_mimetype,
+        )
         log.debug("POST-DATA %r", data)
         return self.add_request(request)
 
     def put(self, host, port, path, data, handler, priority=True, important=False, mblogin=True,
             queryargs=None, request_mimetype=None):
-        request = WSPutRequest(host, port, path, handler, data=data, mblogin=mblogin,
-                               queryargs=queryargs, priority=priority,
-                               important=important, request_mimetype=request_mimetype)
+        request = WSRequest(
+            method='PUT',
+            host=host,
+            port=port,
+            path=path,
+            handler=handler,
+            priority=priority,
+            important=important,
+            mblogin=mblogin,
+            queryargs=queryargs,
+            data=data,
+            request_mimetype=request_mimetype,
+        )
         return self.add_request(request)
 
     def delete(self, host, port, path, handler, priority=True, important=False, mblogin=True,
                queryargs=None):
-        request = WSDeleteRequest(host, port, path, handler, mblogin=mblogin,
-                                  queryargs=queryargs, priority=priority, important=important)
+        request = WSRequest(
+            method='DELETE',
+            host=host,
+            port=port,
+            path=path,
+            handler=handler,
+            priority=priority,
+            important=important,
+            mblogin=mblogin,
+        )
         return self.add_request(request)
 
     def download(self, host, port, path, handler, priority=False,

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -108,7 +108,13 @@ class WebServiceTaskTest(PicardTestCase):
         self.ws._timer_count_pending_requests = MagicMock()
 
     def test_add_task(self):
-        request = WSRequest("", "abc.xyz", 80, "", None)
+        request = WSRequest(
+            method='GET',
+            host='abc.xyz',
+            port=80,
+            path="",
+            handler=None,
+        )
         func = 1
         task = self.ws.add_task(func, request)
         self.assertEqual((request.get_host_key(), func, 0), task)
@@ -120,8 +126,13 @@ class WebServiceTaskTest(PicardTestCase):
     def test_add_task_calls_timers(self):
         mock_timer1 = self.ws._timer_run_next_task
         mock_timer2 = self.ws._timer_count_pending_requests
-        request = WSRequest("", "abc.xyz", 80, "", None)
-
+        request = WSRequest(
+            method='GET',
+            host='abc.xyz',
+            port=80,
+            path="",
+            handler=None,
+        )
         self.ws.add_task(0, request)
         mock_timer1.start.assert_not_called()
         mock_timer2.start.assert_not_called()
@@ -166,7 +177,14 @@ class WebServiceTaskTest(PicardTestCase):
 class RequestTaskTest(PicardTestCase):
 
     def test_from_request(self):
-        request = WSRequest('', 'example.com', 443, '', None, priority=True)
+        request = WSRequest(
+            method='GET',
+            host='example.com',
+            port=443,
+            path='',
+            handler=None,
+            priority=True,
+        )
         func = 1
         task = RequestTask.from_request(request, func)
         self.assertEqual(request.get_host_key(), task.hostkey)

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -54,6 +54,10 @@ PROXY_SETTINGS = {
 }
 
 
+def dummy_handler(*args, **kwargs):
+    """Dummy handler method for tests"""
+
+
 class WebServiceTest(PicardTestCase):
 
     def setUp(self):
@@ -70,7 +74,7 @@ class WebServiceTest(PicardTestCase):
         host = "abc.xyz"
         port = 80
         path = ""
-        handler = None
+        handler = dummy_handler
         data = None
 
         def get_wsreq(mock_add_task):
@@ -113,7 +117,7 @@ class WebServiceTaskTest(PicardTestCase):
             host='abc.xyz',
             port=80,
             path="",
-            handler=None,
+            handler=dummy_handler,
         )
         func = 1
         task = self.ws.add_task(func, request)
@@ -131,7 +135,7 @@ class WebServiceTaskTest(PicardTestCase):
             host='abc.xyz',
             port=80,
             path="",
-            handler=None,
+            handler=dummy_handler,
         )
         self.ws.add_task(0, request)
         mock_timer1.start.assert_not_called()
@@ -145,13 +149,13 @@ class WebServiceTaskTest(PicardTestCase):
         mock_timer2.start.assert_called_with(0)
 
     def test_remove_task(self):
-        task = RequestTask(('example.com', 80), lambda: 1, priority=0)
+        task = RequestTask(('example.com', 80), dummy_handler, priority=0)
         self.ws.remove_task(task)
         self.ws._queue.remove_task.assert_called_with(task)
 
     def test_remove_task_calls_timers(self):
         mock_timer = self.ws._timer_count_pending_requests
-        task = RequestTask(('example.com', 80), lambda: 1, priority=0)
+        task = RequestTask(('example.com', 80), dummy_handler, priority=0)
         self.ws.remove_task(task)
         mock_timer.start.assert_not_called()
         mock_timer.isActive.return_value = False
@@ -182,7 +186,7 @@ class RequestTaskTest(PicardTestCase):
             host='example.com',
             port=443,
             path='',
-            handler=None,
+            handler=dummy_handler,
             priority=True,
         )
         func = 1
@@ -199,13 +203,13 @@ class RequestPriorityQueueTest(PicardTestCase):
         queue = RequestPriorityQueue(ratecontrol)
         key = ("abc.xyz", 80)
 
-        task1 = RequestTask(key, lambda: 1, priority=0)
+        task1 = RequestTask(key, dummy_handler, priority=0)
         queue.add_task(task1)
-        task2 = RequestTask(key, lambda: 1, priority=1)
+        task2 = RequestTask(key, dummy_handler, priority=1)
         queue.add_task(task2)
-        task3 = RequestTask(key, lambda: 1, priority=0)
+        task3 = RequestTask(key, dummy_handler, priority=0)
         queue.add_task(task3, important=True)
-        task4 = RequestTask(key, lambda: 1, priority=1)
+        task4 = RequestTask(key, dummy_handler, priority=1)
         queue.add_task(task4, important=True)
 
         # Test if 2 requests were added in each queue
@@ -223,7 +227,7 @@ class RequestPriorityQueueTest(PicardTestCase):
         key = ("abc.xyz", 80)
 
         # Add a task and check for its existence
-        task = RequestTask(key, lambda: 1, priority=0)
+        task = RequestTask(key, dummy_handler, priority=0)
         task = queue.add_task(task)
         self.assertIn(key, queue._queues[0])
         self.assertEqual(len(queue._queues[0][key]), 1)
@@ -289,16 +293,16 @@ class RequestPriorityQueueTest(PicardTestCase):
         key = ("abc.xyz", 80)
 
         self.assertEqual(0, queue.count())
-        task1 = RequestTask(key, lambda: 1, priority=0)
+        task1 = RequestTask(key, dummy_handler, priority=0)
         queue.add_task(task1)
         self.assertEqual(1, queue.count())
-        task2 = RequestTask(key, lambda: 1, priority=1)
+        task2 = RequestTask(key, dummy_handler, priority=1)
         queue.add_task(task2)
         self.assertEqual(2, queue.count())
-        task3 = RequestTask(key, lambda: 1, priority=0)
+        task3 = RequestTask(key, dummy_handler, priority=0)
         queue.add_task(task3, important=True)
         self.assertEqual(3, queue.count())
-        task4 = RequestTask(key, lambda: 1, priority=1)
+        task4 = RequestTask(key, dummy_handler, priority=1)
         queue.add_task(task4, important=True)
         self.assertEqual(4, queue.count())
         queue.remove_task(task1)


### PR DESCRIPTION
…classes

- using only keyword arguments will ease future changes
- order of arguments do not matter anymore
- this class isn't used directly for now, I don't think any plugin uses it
- subclasses aren't strictly needed
- since methods have a lot of parameters, making them obvious is much easier to read
- we can pass a dict (**kwargs)
- note the use of * in __init__() enforcing keyword args only.
- use few asserts as safety for "mandatory" arguments

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
