### PR TITLE
Update calculation of patch versions for Windows store

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,10 @@ class picard_build(build):
             generate_file('win-version-info.txt.in', 'win-version-info.txt', {**args, **version_args})
 
             default_publisher = 'CN=Metabrainz Foundation Inc., O=Metabrainz Foundation Inc., L=San Luis Obispo, S=California, C=US'
-            store_version = (PICARD_VERSION.major, PICARD_VERSION.minor, PICARD_VERSION.patch * 10000 + self.build_number, 0)
+            # Combine patch version with build number. As Windows store apps require continuously
+            # growing version numbers we combine the patch version with a build number set by the
+            # build script.
+            store_version = (PICARD_VERSION.major, PICARD_VERSION.minor, PICARD_VERSION.patch * 1000 + min(self.build_number, 999), 0)
             generate_file('appxmanifest.xml.in', 'appxmanifest.xml', {
                 'app-id': "MetaBrainzFoundationInc." + PICARD_APP_ID,
                 'display-name': PICARD_DISPLAY_NAME,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

For Windows store we combine the patch version with the build number to ensure continuously growing version numbers for upgrades. Only this allows upgrades also for the development builds of the .msix package.

Currently the patch version gets multiplied by 10000, which means Picard version 2.9.2 becomes 2.9.20000. As Windows  limits the patch number to max. 65535 this means we can only release Picard 2.9.6 and not 2.9.7.


# Solution
Reduce the version numbers to be multiplied to 1000 to allow for two digit patch version numbers. This still leaves us 999 build numbers. As the build numbers are counted as commits since last release tag this should mostly give us enough room (worst case we get stuck at build version 999, which only affects development builds for local testing anyway).

The highest version by this patter is Picard x.x.65 build 535.

Release versions always are for the release tag and hence the build version is set to 0, so the highest release version for e.g. Picard 2.9 will be 2.9.65000.


Compare also previous changes in 1948f0c1164fed590d16dafe9c6bcfd21fe7122f