### PR TITLE
Avoid a warning on Picard start-up about send_to_pipe

### DIFF
--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -273,7 +273,8 @@ class AbstractPipe(metaclass=ABCMeta):
             if sender.result(timeout=timeout_secs):
                 return True
         except concurrent.futures._base.TimeoutError:
-            log.warning("Couldn't send: %r", message)
+            if self.pipe_running:
+                log.warning("Couldn't send: %r", message)
             # hacky way to kill the sender
             self.read_from_pipe()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Before this patch, Picard is logging a warning before anything else that looks like:

`W: pipe.send_to_pipe:276: Couldn't send: '\x00'`

At this point, the pipe isn't fully functional, and this message is expected, as Picard sends a message to pipe to see if it's the owner or not (in `AbstractPipe.__init__()`). The behavior is normal, the warning isn't.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


To fix it, check if the pipe is marked as running before logging such warning.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
