### PR TITLE
Use notarytool for macOS notarization

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -109,6 +109,7 @@ jobs:
         mv dist/*.dmg artifacts/
       env:
         APPLE_ID_USER: ${{ secrets.APPLE_ID_USER }}
+        APPLE_ID_TEAM: ${{ secrets.APPLE_ID_TEAM }}
         APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         CODESIGN_MACOS_P12_PASSWORD: ${{ secrets.CODESIGN_MACOS_P12_PASSWORD }}
     - name: Archive production artifacts

--- a/scripts/package/macos-notarize-app.sh
+++ b/scripts/package/macos-notarize-app.sh
@@ -30,13 +30,14 @@ ditto -c -k --rsrc --keepParent "$APP_BUNDLE" "${APP_BUNDLE}.zip"
 
 # Submit for notarization
 echo "Submitting $APP_BUNDLE for notarization..."
-RESULT=$(xcrun altool --notarize-app --type osx \
-  --file "${APP_BUNDLE}.zip" \
-  --primary-bundle-id org.musicbrainz.Picard \
-  --username "$APPLE_ID_USER" \
-  --password @env:APPLE_ID_PASSWORD \
-  -itc_provider MetaBrainzFoundationInc \
-  --output-format xml)
+RESULT=$(xcrun notarytool submit \
+  --apple-id "$APPLE_ID_USER" \
+  --team-id "$APPLE_ID_TEAM" \
+  --password "$APPLE_ID_PASSWORD" \
+  --output-format plist \
+  --wait \
+  --timeout 10m \
+  "${APP_BUNDLE}.zip")
 
 if [ $? -ne 0 ]; then
   echo "Submitting $APP_BUNDLE failed:"
@@ -44,42 +45,16 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-REQUEST_UUID=$(echo "$RESULT" | xpath \
-  "//key[normalize-space(text()) = 'RequestUUID']/following-sibling::string[1]/text()" 2> /dev/null)
+STATUS=$(echo "$RESULT" | xpath \
+  "//key[normalize-space(text()) = 'status']/following-sibling::string[1]/text()" 2> /dev/null)
 
-if [ -z "$REQUEST_UUID" ]; then
-  echo "Submitting $APP_BUNDLE failed:"
+if [ "$STATUS" = "Accepted" ]; then
+  echo "Notarization of $APP_BUNDLE succeeded!"
+else
+  echo "Notarization of $APP_BUNDLE failed:"
   echo "$RESULT"
   exit 1
 fi
-
-echo "$(echo "$RESULT" | xpath \
-  "//key[normalize-space(text()) = 'success-message']/following-sibling::string[1]/text()" 2> /dev/null)"
-
-# Poll for notarization status
-echo "Submitted notarization request $REQUEST_UUID, waiting for response..."
-sleep 60
-while :
-do
-  RESULT=$(xcrun altool --notarization-info "$REQUEST_UUID" \
-    --username "$APPLE_ID_USER" \
-    --password @env:APPLE_ID_PASSWORD \
-    --output-format xml)
-  STATUS=$(echo "$RESULT" | xpath \
-    "//key[normalize-space(text()) = 'Status']/following-sibling::string[1]/text()" 2> /dev/null)
-
-  if [ "$STATUS" = "success" ]; then
-    echo "Notarization of $APP_BUNDLE succeeded!"
-    break
-  elif [ "$STATUS" = "in progress" ]; then
-    echo "Notarization in progress..."
-    sleep 20
-  else
-    echo "Notarization of $APP_BUNDLE failed:"
-    echo "$RESULT"
-    exit 1
-  fi
-done
 
 # Staple the notary ticket
 xcrun stapler staple "$APP_BUNDLE"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Apple has deprecated using `altool`  for the app notarization. Instead the new `notarytool`  should be used. See https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool for background.

# Solution

Perform the notarization with the new `notarytool`. This also has the advantage that there is now a clear way to specify the MetaBrainz team by specifying the team ID. In addition we can get rid of the polling because `notarytool`  supports a [`--wait` parameter](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool#Submit-a-file).

The entire process is also faster.

Tested successfully on my repo phw/picard . See https://github.com/phw/picard/actions/runs/5264236895