### PR TITLE
Fix appstream XML and use appstreamcli for validation

### DIFF
--- a/.github/workflows/validate-appstream.yml
+++ b/.github/workflows/validate-appstream.yml
@@ -19,11 +19,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: Install appstream
+    - name: Install appstream-util
       run: |
         sudo apt-get update
-        sudo apt-get install appstream gettext
+        sudo apt-get install appstream-util gettext
     - name: Validate AppStream metadata
       run: |
         python setup.py build_appdata
-        appstreamcli validate --pedantic --explain org.musicbrainz.Picard.appdata.xml
+        appstream-util validate-relax org.musicbrainz.Picard.appdata.xml
+        # TODO: Consider using appstreamcli once ubuntu-latest provides
+        #       appstreamcli>=0.16, as this tool catches more issues.
+        #appstreamcli validate --pedantic --explain org.musicbrainz.Picard.appdata.xml

--- a/.github/workflows/validate-appstream.yml
+++ b/.github/workflows/validate-appstream.yml
@@ -19,11 +19,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: Install appstream-util
+    - name: Install appstream
       run: |
         sudo apt-get update
-        sudo apt-get install appstream-util gettext
+        sudo apt-get install appstream gettext
     - name: Validate AppStream metadata
       run: |
         python setup.py build_appdata
-        appstream-util validate-relax org.musicbrainz.Picard.appdata.xml
+        appstreamcli validate --pedantic --explain org.musicbrainz.Picard.appdata.xml

--- a/org.musicbrainz.Picard.appdata.xml.in
+++ b/org.musicbrainz.Picard.appdata.xml.in
@@ -76,11 +76,7 @@
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>
-  </recommends>
-  <recommends>
     <display_length compare="ge">medium</display_length>
-  </recommends>
-  <recommends>
     <internet>always</internet>
   </recommends>
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The AppStream metadata was invalid (multiple `<recommends>` , should be only one).

We have AppStream validation already. But it was using the older ` appstream-util` which did not catch that issue. Replaced this with `appstreamcli`.