### PR TITLE
Do not require fpcalc when on first start (no config)

### DIFF
--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -69,7 +69,7 @@ class FingerprintingOptionsPage(OptionsPage):
     options = [
         BoolOption("setting", "ignore_existing_acoustid_fingerprints", False),
         BoolOption("setting", "save_acoustid_fingerprints", False),
-        TextOption("setting", "fingerprinting_system", "acoustid"),
+        TextOption("setting", "fingerprinting_system", ""),
         TextOption("setting", "acoustid_fpcalc", ""),
         TextOption("setting", "acoustid_apikey", ""),
         IntOption("setting", "fpcalc_threads", DEFAULT_FPCALC_THREADS),


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem


When starting Picard from sources, without any config file, Options requires to set up `fpcalc` path.
Though that's not a strict requirement, Picard can run without having AcoustID enabled.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution


Set option `fingerprinting_system` default to `"'` instead of `"acoustid"`.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
