### PR TITLE
PICARD-2665: Revert "PICARD-2634: Use standardized artist names by default"

### DIFF
--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2008-2009, 2018-2022 Philipp Wolfer
 # Copyright (C) 2011 Johannes Weißl
 # Copyright (C) 2011-2013 Michael Wiencek
-# Copyright (C) 2013, 2018, 2020-2023 Laurent Monin
+# Copyright (C) 2013, 2018, 2020-2021 Laurent Monin
 # Copyright (C) 2014 Wieland Hoffmann
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2021 Vladislav Karbovskii
@@ -91,7 +91,7 @@ class MetadataOptionsPage(OptionsPage):
         BoolOption("setting", "release_ars", True),
         BoolOption("setting", "track_ars", False),
         BoolOption("setting", "convert_punctuation", False),
-        BoolOption("setting", "standardize_artists", True),
+        BoolOption("setting", "standardize_artists", False),
         BoolOption("setting", "standardize_instruments", True),
         BoolOption("setting", "guess_tracknumber_and_title", True),
     ]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2665
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

As discussed in PICARD-2665 and [on the forums](https://community.metabrainz.org/t/artist-aliases-for-past-names-vs-picards-use-standardized-artist-names-option/642755) this commit reverts enabling the artist name standardization. This avoids the issues coming with this change for the 2.9 release.

For a future release a more sophisticated handling of artist aliases as suggested in PICARD-2673 should be attempted instead.

# Solution
This reverts commit 5a9d6b9581abd31cdb340444c6066a722f354374.