### PR TITLE
PICARD-2658: fix macos 10.12 build

### DIFF
--- a/requirements-macos-10.12.txt
+++ b/requirements-macos-10.12.txt
@@ -6,5 +6,5 @@ mutagen==1.46.0
 PyJWT==2.7.0
 pyobjc-core==9.0.1
 pyobjc-framework-Cocoa==9.0.1
-PyQt5==5.13.2
+PyQt5==5.13.1
 pyyaml==6.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2658
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The macOS 10.12 build of Picard 2.9.0b1  does not show the main window. It's some issue with PyQt 5.13.2. Downgrade to 5.12.1 again (which is the newest usable version still running on macOS 5.12 and 5.13.
