### PR TITLE
Pipe reintroduce thread pool

### DIFF
--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -107,7 +107,8 @@ class PipeErrorNoDestination(PipeError):
 class AbstractPipe(metaclass=ABCMeta):
     NO_RESPONSE_MESSAGE: str = "No response from FIFO"
     MESSAGE_TO_IGNORE: str = '\0'
-    TIMEOUT_SECS: float = 1.5
+    TIMEOUT_SECS_READ: float = 5.0
+    TIMEOUT_SECS_WRITE: float = 1.5
 
     @classmethod
     @property
@@ -234,7 +235,7 @@ class AbstractPipe(metaclass=ABCMeta):
         :rtype: List[str]
         """
         if timeout_secs is None:
-            timeout_secs = self.TIMEOUT_SECS
+            timeout_secs = self.TIMEOUT_SECS_READ
 
         try:
             reader = self.__thread_pool.submit(self._reader)
@@ -263,7 +264,7 @@ class AbstractPipe(metaclass=ABCMeta):
         :rtype: bool
         """
         if timeout_secs is None:
-            timeout_secs = self.TIMEOUT_SECS
+            timeout_secs = self.TIMEOUT_SECS_WRITE
 
         # we're sending only filepaths, so we have to create some kind of separator
         # to avoid any potential conflicts and mixing the data


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

@zas: This ads back the thread pool instance to the pipe implementation that we removed in #2247 . The reasoning is that currently a new thread pool is created on every call to `read_from_pipe` and `send_to_pipe` to then only use a single thread. This is quite some overhead and not how a pool of threads should be handled.

This also increases the timeout for the reading thread. Generally it is ok for the reading thread to wait for a while and block reading as it waits for input data. We need the timeout to be able to interrupt the thread, though, and it should be short enough to be not annoying for the user by having to wait too long for exit.

This change in timeout might also help with PICARD-2660, but I'm not totally sure. I first thought we could get rid of the call to the opposite method in read_from_pipe and send_to_pipe. But we need those to ensure the timed out thread exits. Otherwise we get either blocks or unhandled reader threads that "eat" messages.

And we also need the timeout, otherwise we end up in totally blocking situations.