### PR TITLE
Pipe refactor thread pool

### DIFF
--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -279,7 +279,10 @@ class AbstractPipe(metaclass=ABCMeta):
         log.debug("Stopping pipe")
         self.pipe_running = False
         self.send_to_pipe(self.MESSAGE_TO_IGNORE)
-        self.__thread_pool.shutdown(wait=True, cancel_futures=True)
+        try:
+            self.__thread_pool.shutdown(wait=True, cancel_futures=True)
+        except TypeError:  # cancel_futures is not supported on Python < 3.9
+            self.__thread_pool.shutdown(wait=True)
 
 
 class UnixPipe(AbstractPipe):

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -107,7 +107,8 @@ class PipeErrorNoDestination(PipeError):
 class AbstractPipe(metaclass=ABCMeta):
     NO_RESPONSE_MESSAGE: str = "No response from FIFO"
     MESSAGE_TO_IGNORE: str = '\0'
-    TIMEOUT_SECS: float = 1.5
+    TIMEOUT_SECS_READ: float = 5.0
+    TIMEOUT_SECS_WRITE: float = 1.5
 
     @classmethod
     @property
@@ -234,7 +235,7 @@ class AbstractPipe(metaclass=ABCMeta):
         :rtype: List[str]
         """
         if timeout_secs is None:
-            timeout_secs = self.TIMEOUT_SECS
+            timeout_secs = self.TIMEOUT_SECS_READ
 
         try:
             reader = self.__thread_pool.submit(self._reader)
@@ -263,7 +264,7 @@ class AbstractPipe(metaclass=ABCMeta):
         :rtype: bool
         """
         if timeout_secs is None:
-            timeout_secs = self.TIMEOUT_SECS
+            timeout_secs = self.TIMEOUT_SECS_WRITE
 
         # we're sending only filepaths, so we have to create some kind of separator
         # to avoid any potential conflicts and mixing the data

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -160,6 +160,8 @@ class AbstractPipe(metaclass=ABCMeta):
 
         self.unexpected_removal = False
 
+        self.__thread_pool = concurrent.futures.ThreadPoolExecutor()
+
         for path in self._paths:
             self.path = path
             for arg in self._args:
@@ -234,21 +236,20 @@ class AbstractPipe(metaclass=ABCMeta):
         if timeout_secs is None:
             timeout_secs = self.TIMEOUT_SECS
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            reader = executor.submit(self._reader)
-            try:
-                res = reader.result(timeout=timeout_secs)
-                if res:
-                    out = [r for r in res.split(self.MESSAGE_TO_IGNORE) if r]
-                    if out:
-                        return out
-            except concurrent.futures._base.TimeoutError:
-                # hacky way to kill the file-opening loop
-                self.send_to_pipe(self.MESSAGE_TO_IGNORE)
-            except Exception as e:
-                # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result
-                # If the call raised an exception, this method will raise the same exception.
-                log.error("pipe reader exception: %s", e)
+        try:
+            reader = self.__thread_pool.submit(self._reader)
+            res = reader.result(timeout=timeout_secs)
+            if res:
+                out = [r for r in res.split(self.MESSAGE_TO_IGNORE) if r]
+                if out:
+                    return out
+        except concurrent.futures._base.TimeoutError:
+            # hacky way to kill the file-opening loop
+            self.send_to_pipe(self.MESSAGE_TO_IGNORE)
+        except Exception as e:
+            # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result
+            # If the call raised an exception, this method will raise the same exception.
+            log.error("pipe reader exception: %s", e)
 
         return [self.NO_RESPONSE_MESSAGE]
 
@@ -264,22 +265,21 @@ class AbstractPipe(metaclass=ABCMeta):
         if timeout_secs is None:
             timeout_secs = self.TIMEOUT_SECS
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            # we're sending only filepaths, so we have to create some kind of separator
-            # to avoid any potential conflicts and mixing the data
-            sender = executor.submit(self._sender, message + self.MESSAGE_TO_IGNORE)
-            try:
-                if sender.result(timeout=timeout_secs):
-                    return True
-            except concurrent.futures._base.TimeoutError:
-                if self.pipe_running:
-                    log.warning("Couldn't send: %r", message)
-                # hacky way to kill the sender
-                self.read_from_pipe()
-            except Exception as e:
-                # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result
-                # If the call raised an exception, this method will raise the same exception.
-                log.error("pipe sender exception: %s", e)
+        # we're sending only filepaths, so we have to create some kind of separator
+        # to avoid any potential conflicts and mixing the data
+        try:
+            sender = self.__thread_pool.submit(self._sender, message + self.MESSAGE_TO_IGNORE)
+            if sender.result(timeout=timeout_secs):
+                return True
+        except concurrent.futures._base.TimeoutError:
+            if self.pipe_running:
+                log.warning("Couldn't send: %r", message)
+            # hacky way to kill the sender
+            self.read_from_pipe()
+        except Exception as e:
+            # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result
+            # If the call raised an exception, this method will raise the same exception.
+            log.error("pipe sender exception: %s", e)
 
         return False
 
@@ -287,6 +287,7 @@ class AbstractPipe(metaclass=ABCMeta):
         log.debug("Stopping pipe")
         self.pipe_running = False
         self.send_to_pipe(self.MESSAGE_TO_IGNORE)
+        self.__thread_pool.shutdown(wait=True, cancel_futures=True)
 
 
 class UnixPipe(AbstractPipe):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

@zas: This ads back the thread pool instance to the pipe implementation that we removed in #2247 . The reasoning is that currently a new thread pool is created on every call to `send_to_pipe` to then only use a single thread. This is quite some overhead and not how a pool of threads should be handled.

Furthermore the thread pool is no longer used at all in `read_from_pipe`. It's not needed as the pipe server already runs in a separate thread. This allows us to keep reading from the pipe without timeout, avoiding the constant looping (which only consumes CPU for no good reason). We also don't need any workarounds to close the timed out thread but just need closing the reader thread on application exit.

This change should also avoid the issue at [PICARD-2660](https://tickets.metabrainz.org/browse/PICARD-2660).

~~This also increases the timeout for the reading thread. Generally it is ok for the reading thread to wait for a while and block reading as it waits for input data. We need the timeout to be able to interrupt the thread, though, and it should be short enough to be not annoying for the user by having to wait too long for exit.~~

~~This change in timeout might also help with PICARD-2660, but I'm not totally sure. I first thought we could get rid of the call to the opposite method in read_from_pipe and send_to_pipe. But we need those to ensure the timed out thread exits. Otherwise we get either blocks or unhandled reader threads that "eat" messages.~~