### PR TITLE
PICARD-2669: Revert "PICARD-2609: Run metadata comparison on file.update in a thread"

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -697,13 +697,6 @@ class File(QtCore.QObject, Item):
             yield name
 
     def update(self, signal=True):
-        thread.run_task(
-            self._compare_metadata,
-            partial(self._compare_metadata_finished, signal),
-            thread_pool=self.tagger.priority_thread_pool
-        )
-
-    def _compare_metadata(self):
         if not (self.state == File.ERROR and self.errors):
             config = get_config()
             clear_existing_tags = config.setting["clear_existing_tags"]
@@ -731,10 +724,6 @@ class File(QtCore.QObject, Item):
                         self.state = File.CHANGED
                     else:
                         self.state = File.NORMAL
-
-    def _compare_metadata_finished(self, signal, result=None, error=None):
-        if error:
-            log.error("Comparing file metadata for %r failed: %s", self, error)
         if signal:
             log.debug("Updating file %r", self)
             self.update_item()


### PR DESCRIPTION
This reverts commit 8a3a3424b913635bd36302a8b67d9901c3fc040e.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The threaded file update for PICARD-2609 causes wrong status icons to displayed for files in rare cases. Revert the change for now to ensure correctness. Introducing more threading requires a more intensive refactoring