### PR TITLE
PICARD-2680: Modal first use and save confirmation dialogs

### DIFF
--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1354,7 +1354,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         config = get_config()
         if config.setting["file_save_warning"]:
             count = len(self.tagger.get_files_from_objects(self.selected_objects))
-            msg = SaveWarningDialog(count)
+            msg = SaveWarningDialog(self, count)
             proceed_with_save, disable_warning = msg.show()
             config.setting["file_save_warning"] = not disable_warning
         else:
@@ -1989,7 +1989,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def show_new_user_dialog(self):
         config = get_config()
         if config.setting["show_new_user_dialog"]:
-            msg = NewUserDialog()
+            msg = NewUserDialog(self)
             config.setting["show_new_user_dialog"] = msg.show()
 
 

--- a/picard/ui/newuserdialog.py
+++ b/picard/ui/newuserdialog.py
@@ -19,14 +19,17 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt5 import QtWidgets
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
 
 from picard.const import PICARD_URLS
 
 
 class NewUserDialog():
 
-    def __init__(self):
+    def __init__(self, parent):
 
         dialog_text = _(
             "<h2 align=center>READ THIS BEFORE USING PICARD</h2>"
@@ -50,10 +53,11 @@ class NewUserDialog():
         self.show_again = True
         show_again_text = _("Show this message again the next time you start Picard.")
 
-        self.msg = QtWidgets.QMessageBox()
+        self.msg = QtWidgets.QMessageBox(parent)
         self.msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         self.msg.setText(dialog_text)
         self.msg.setWindowTitle(_("New User Information"))
+        self.msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
 
         self.cb = QtWidgets.QCheckBox(show_again_text)
         self.cb.setChecked(self.show_again)

--- a/picard/ui/savewarningdialog.py
+++ b/picard/ui/savewarningdialog.py
@@ -19,14 +19,17 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt5 import QtWidgets
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
 
 from picard.config import get_config
 
 
 class SaveWarningDialog():
 
-    def __init__(self, file_count=None):
+    def __init__(self, parent, file_count=None):
 
         actions = []
         config = get_config()
@@ -56,10 +59,11 @@ class SaveWarningDialog():
         disable_text = _("Don't show this warning again.")
 
         self.disable = False
-        self.msg = QtWidgets.QMessageBox()
+        self.msg = QtWidgets.QMessageBox(parent)
         self.msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         self.msg.setText(warning_text)
         self.msg.setWindowTitle(_("File Save Warning"))
+        self.msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
 
         self.cb = QtWidgets.QCheckBox(disable_text)
         self.cb.setChecked(False)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2680
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



When starting Picard or saving the new warning dialogs might open dislocated from the main window and on some system even show up behind the main window.


# Solution

Make the dialogs application modal and transient to the main window. This is how most of Picards dialogs are being opened already, specifically those message boxes.