### PR TITLE
PICARD-2011: Avoid "RuntimeError: dictionary changed size during iteration" errors

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -89,7 +89,11 @@ class ConfigSection(QtCore.QObject):
         return self.__qt_config.contains(self.key(name))
 
     def as_dict(self):
-        return {key: self[key] for section, key in Option.registry if section == self.__name}
+        return {
+            key: self[key] for section, key
+            in list(Option.registry)
+            if section == self.__name
+        }
 
     def remove(self, name):
         key = self.key(name)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -96,8 +96,19 @@ WIN_LONGPATH_PREFIX = '\\\\?\\'
 class ReadWriteLockContext:
     """Context for releasing a locked QReadWriteLock
     """
-    def __init__(self, lock: QtCore.QReadWriteLock):
-        self.__lock = lock
+    def __init__(self):
+        self.__lock = QtCore.QReadWriteLock()
+
+    def lock_for_read(self):
+        self.__lock.lockForRead()
+        return self
+
+    def lock_for_write(self):
+        self.__lock.lockForWrite()
+        return self
+
+    def unlock(self):
+        self.__lock.unlock()
 
     def __enter__(self):
         pass
@@ -114,21 +125,21 @@ class LockableObject(QtCore.QObject):
 
     def __init__(self):
         super().__init__()
-        self.__lock = QtCore.QReadWriteLock()
+        self.__context = ReadWriteLockContext()
 
     def lock_for_read(self):
         """Lock the object for read operations."""
-        self.__lock.lockForRead()
-        return ReadWriteLockContext(self.__lock)
+        self.__context.lock_for_read()
+        return self.__context
 
     def lock_for_write(self):
         """Lock the object for write operations."""
-        self.__lock.lockForWrite()
-        return ReadWriteLockContext(self.__lock)
+        self.__context.lock_for_write()
+        return self.__context
 
     def unlock(self):
         """Unlock the object."""
-        self.__lock.unlock()
+        self.__context.unlock()
 
 
 def process_events_iter(iterable, interval=0.1):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -93,8 +93,23 @@ WIN_MAX_NODE_LEN = 255
 WIN_LONGPATH_PREFIX = '\\\\?\\'
 
 
-class LockableObject(QtCore.QObject):
+class ReadWriteLockContext:
+    """Context for releasing a locked QReadWriteLock
+    """
+    def __init__(self, lock: QtCore.QReadWriteLock):
+        self.__lock = lock
 
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, tb):
+        self.__lock.unlock()
+
+    def __bool__(self):
+        return self._entered > 0
+
+
+class LockableObject(QtCore.QObject):
     """Read/write lockable object."""
 
     def __init__(self):
@@ -104,10 +119,12 @@ class LockableObject(QtCore.QObject):
     def lock_for_read(self):
         """Lock the object for read operations."""
         self.__lock.lockForRead()
+        return ReadWriteLockContext(self.__lock)
 
     def lock_for_write(self):
         """Lock the object for write operations."""
         self.__lock.lockForWrite()
+        return ReadWriteLockContext(self.__lock)
 
     def unlock(self):
         """Unlock the object."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2011
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The `Metadata`  class is not thread safe. If it is accessed in a thread this can lead to errors. E.g. the metadatabox can throw "RuntimeError: dictionary changed size during iteration" when iterating over the metadata while another thread changes it.

Similar `ConfigSection.as_dict()` can throw if `Object.registry` changes. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Make `Metadata` thread safe by introducing a read / write lock
- Have `ConfigSection.as_dict()` operate on a copy of `Object.registry` 
