### PR TITLE
CI: Remove openssl install for macOS PyPI packaging

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -54,14 +54,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install gettext and openssl (macOS)
+    - name: Install gettext (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install gettext openssl@1.1
+        brew install gettext
         brew link gettext --force
-        brew link openssl@1.1 --force
         echo "/usr/local/opt/gettext/bin" >> $GITHUB_PATH
-        echo "/usr/local/opt/openssl@1.1/bin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

Installing openssl for the macOS PyPI builds is no longer needed since the code signing got removed. This solves build issues on latest Github Actions images.
