### PR TITLE
PICARD-2689: Render the actually dragged element instead of the first selected

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -708,8 +708,9 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         if items:
             drag = QtGui.QDrag(self)
             drag.setMimeData(self.mimeData(items))
-            # Render the first selected element as drag representation
-            rectangle = self.visualItemRect(items[0])
+            # Render the dragged element as drag representation
+            item = self.currentItem()
+            rectangle = self.visualItemRect(item)
             pixmap = QtGui.QPixmap(rectangle.width(), rectangle.height())
             self.viewport().render(pixmap, QtCore.QPoint(), QtGui.QRegion(rectangle))
             drag.setPixmap(pixmap)


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Fixes issues with an empty rectangle being shown during dragging of items if the first selected item is not visible.


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2689
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
https://community.metabrainz.org/t/possible-bug-found-dragn-dropping-items-from-the-right-pane-results-in-a-white-box-if-they-are-outside-the-visible-part/646711


# Solution

Instead of taking the first selected element take the currently active one. The item becomes active when clicking on it while starting the drag. This is probably even more intuitive for the user, as it shows the actual dragged element.