### PR TITLE
Picard-2685:  Preserve calculated from audio file tags when moving files

### DIFF
--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2007-2008, 2011 Lukáš Lalinský
-# Copyright (C) 2008-2009, 2018-2021 Philipp Wolfer
+# Copyright (C) 2008-2009, 2018-2021, 2023 Philipp Wolfer
 # Copyright (C) 2011 Johannes Weißl
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
@@ -143,6 +143,23 @@ PRESERVED_TAGS = (
     '~sample_rate',
     '~video',
 )
+
+# Tags that got generated in some way from the audio content.
+# Those can be set by Picard but the new values usually should be kept
+# when moving the file between tags.
+CALCULATED_TAGS = {
+    'acoustid_fingerprint',
+    'acoustid_id',
+    'replaygain_album_gain',
+    'replaygain_album_peak',
+    'replaygain_album_range',
+    'replaygain_reference_loudness',
+    'replaygain_track_gain',
+    'replaygain_track_peak',
+    'replaygain_track_range',
+    'r128_album_gain',
+    'r128_track_gain',
+}
 
 
 def display_tag_name(name):

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -38,6 +38,7 @@ from picard.const.sys import (
 )
 from picard.file import File
 from picard.metadata import Metadata
+from picard.util.tags import CALCULATED_TAGS
 
 
 class DataObjectTest(PicardTestCase):
@@ -671,11 +672,15 @@ class FileCopyMetadataTest(PicardTestCase):
         self.assertEqual(self.file.metadata, new_metadata)
         self.assertEqual(self.file.metadata.deleted_tags, {'foo'})
 
-    def test_copy_metadata_must_not_clear_acoustid_id(self):
-        self.file.metadata['acoustid_id'] = 'foo'
+    def test_copy_metadata_must_keep_file_content_specific_tags(self):
+        for tag in CALCULATED_TAGS:
+            self.file.metadata[tag] = 'foo'
         new_metadata = Metadata()
         self.file.copy_metadata(new_metadata)
-        self.assertEqual(self.file.metadata['acoustid_id'], 'foo')
+        for tag in CALCULATED_TAGS:
+            self.assertEqual(
+                self.file.metadata[tag], 'foo',
+                f'Tag {tag}: {self.file.metadata[tag]!r} != "foo"')
 
     def test_copy_metadata_must_remove_deleted_acoustid_id(self):
         self.file.metadata['acoustid_id'] = 'foo'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2685
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

1. Have files loaded matched to a track
2. Generate AcoustID fingerprint or ReplayGain tags (with the replaygain2 plugin)
3. Move the file to another track or unmatched files

Result: The AcoustID fingerprint or ReplayGain tags get removed

Expected result: As these tags are generated from audio content it would be expected that they move with the file instead of being replaced by the new track's data.

For the `acoustid_id` tag this is already handled.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Preserve calculated AcoustID fingerprint and ReplayGain tags set on a file
object when that file object gets moved between tracks.

This generalized the mechanism already in place for `acoustid_id`  and extends it to `acoustid_fingerprint` and all the ReplayGain tags.