### PR TITLE
PICARD-2694: Clear instance of SingletonDialog if destroyed

### DIFF
--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -148,7 +148,7 @@ class SingletonDialog:
     def get_instance(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = cls(*args, **kwargs)
-            cls._instance.finished.connect(cls._on_dialog_finished)
+            cls._instance.destroyed.connect(cls._on_dialog_destroyed)
         return cls._instance
 
     @classmethod
@@ -171,7 +171,7 @@ class SingletonDialog:
         return instance
 
     @classmethod
-    def _on_dialog_finished(cls):
+    def _on_dialog_destroyed(cls):
         cls._instance = None
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2694
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If the ScriptingDocumentationDialog gets closed not explicitly but because its parent (the OptionsDialog) gets closed and destroys child widgets then reopening it again crashes Picard.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Clear the instance of `SingletonDialog` on `destroyed` instead of `finished`

That fixes issues where the dialog does not get closed as a dialog but the widget just get cleared because the parent gets removed.