### PR TITLE
PICARD-2693: Do not continue Win installation if uninstall got cancelled

### DIFF
--- a/installer/i18n/sources/de.json
+++ b/installer/i18n/sources/de.json
@@ -2,6 +2,7 @@
     "MsgAlreadyInstalled": "${PRODUCT_NAME} ist bereits installiert und muss vor der Installation dieses Upgrades auf Version ${PRODUCT_VERSION} deinstalliert werden. \n\nKlicken Sie „OK“ um fortzufahren oder „Abbrechen“ um das Upgrade abzubrechen.",
     "MsgApplicationRunning": "Die Anwendung ${PRODUCT_NAME} wird ausgeführt. Bitte schließen und erneut versuchen.",
     "MsgRequires64Bit": "Diese Version von ${PRODUCT_NAME} erfordert ein 64-bit Windows-System.",
+    "MsgUninstallFailed": "Deinstallation der vorherigen Version fehlgeschlagen.",
     "MuiDescriptionRequired": "Installiert ${PRODUCT_NAME} mit den für die Ausführung erforderlichen Dateien.",
     "MuiDescriptionLang": "Installiert Übersetzungen von ${PRODUCT_NAME} in verschiedenen Sprachen.",
     "MuiDescriptionShortcuts": "Installiert Verknüpfungen, um ${PRODUCT_NAME} zu starten.",

--- a/installer/i18n/sources/en.json
+++ b/installer/i18n/sources/en.json
@@ -2,6 +2,7 @@
     "MsgAlreadyInstalled": "${PRODUCT_NAME} is already installed and must be uninstalled before installing this upgrade to version ${PRODUCT_VERSION}. \n\nClick \"OK\" to proceed or \"Cancel\" to cancel this upgrade.",
     "MsgApplicationRunning": "The application ${PRODUCT_NAME} is running. Please close it and try again.",
     "MsgRequires64Bit": "This version of ${PRODUCT_NAME} requires a 64-bit Windows system.",
+    "MsgUninstallFailed": "Uninstall of previous version failed.",
     "MuiDescriptionRequired": "Installs ${PRODUCT_NAME} along with the necessary files for it run.",
     "MuiDescriptionLang": "Installs translations of ${PRODUCT_NAME} in different languages.",
     "MuiDescriptionShortcuts": "Installs shortcuts to launch ${PRODUCT_NAME}.",

--- a/installer/picard-setup.nsi.in
+++ b/installer/picard-setup.nsi.in
@@ -253,11 +253,14 @@ Function .onInit
     silentUninstall:
     ExecWait '"$0" /S _?=$1' $2
   finalizeUninstall:
-    ; Delete the uninstaller if it finished with success (exit code 0)
-    IntCmp $2 0 "" endUninstall endUninstall
+    ; Delete the uninstaller if it finished with success (exit code 0),
+    ; otherwise abort
+    IntCmp $2 0 endUninstall "" ""
+    MessageBox MB_ICONSTOP|MB_OK "$(MsgUninstallFailed)" /SD IDOK
+    Abort
+  endUninstall:
     Delete "$0"
     RMDir "$1"  ; Try to delete installation dir
-  endUninstall:
 
   ; Check if previous install location was inside $PROGRAMFILES32
   ; If so, rewrite $INSTDIR to $PROGRAMFILES64


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2693
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On Windows when installing Picard with the installer package we trigger the uninstaller in order to completely remove the previous version. This avoids issues with leftover files, especially DLLs for dependencies, from previous install causing version conflicts.

However, it was possible for the user to cancel the uninstall and continue with the installation anyway.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

When the user cancels the uninstall also abort the installer. Show a prompt informing the user.

Note: As an alternative I had thought about making the uninstaller run automatically non-interactive. However, NSIS does not support runnning non-interactive with UI. If you launch the uninstaller in automatic mode it just would run without UI, causing the installer Window to hang and wait for it to finish without visual feedback. Also I think interactive use is more user friendly overall.