### PR TITLE
PICARD-2695: Fix crash in script editor on some unicode escape tooltips

### DIFF
--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -287,9 +287,12 @@ class UnicodeEscapeScriptToken(DocumentedScriptToken):
         if self.unicode_escape_sequence.match(text):
             codepoint = int(text[2:], 16)
             char = chr(codepoint)
-            tooltip = unicodedata.name(char)
+            try:
+                tooltip = unicodedata.name(char)
+            except ValueError:
+                tooltip = f'U+{text[2:].upper():04}'
             if unicodedata.category(char)[0] != "C":
-                tooltip += ': "%s"' % char
+                tooltip += f': "{char}"'
             return tooltip
         return None
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2695
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

For some code points, e.g. \u0000, unicodedata.name does not return a name but raises a ValueError.

# Solution

Catch the ValueError and as an alternative just output the unicode code point in the format "U+0000" (as it is common).
