### PR TITLE
PICARD-2697: fix Restore all Defaults for General option page

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -185,6 +185,9 @@ PROGRAM_UPDATE_LEVELS = OrderedDict(
 )
 
 
+DEFAULT_PROGRAM_UPDATE_LEVEL = 0
+
+
 DEFAULT_FILE_NAMING_FORMAT = "$if2(%albumartist%,%artist%)/\n" \
     "$if(%albumartist%,%album%/,)\n" \
     "$if($gt(%totaldiscs%,1),$if($gt(%totaldiscs%,9),$num(%discnumber%,2),%discnumber%)-,)" \

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -27,6 +27,7 @@ import re
 
 from PyQt5 import QtWidgets
 
+from picard import log
 from picard.config import get_config
 from picard.plugin import ExtensionPoint
 
@@ -82,6 +83,7 @@ class OptionsPage(QtWidgets.QWidget):
         old_options = {}
         for option in options:
             if option.section == 'setting' and config.setting[option.name] != option.default:
+                log.debug("Option %s %s: %r -> %r" % (self.NAME, option.name, config.setting[option.name], option.default))
                 old_options[option.name] = config.setting[option.name]
                 config.setting[option.name] = option.default
         self.load()

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -81,7 +81,7 @@ class OptionsPage(QtWidgets.QWidget):
         config = get_config()
         old_options = {}
         for option in options:
-            if option.section == 'setting':
+            if option.section == 'setting' and config.setting[option.name] != option.default:
                 old_options[option.name] = config.setting[option.name]
                 config.setting[option.name] = option.default
         self.load()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -412,7 +412,10 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def restore_all_defaults(self):
         for page in self.pages:
-            page.restore_defaults()
+            try:
+                page.restore_defaults()
+            except Exception as e:
+                log.error('Failed restoring all defaults for page %r: %s', page, e)
         self.highlight_enabled_profile_options()
 
     def restore_page_defaults(self):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -416,11 +416,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 page.restore_defaults()
             except Exception as e:
                 log.error('Failed restoring all defaults for page %r: %s', page, e)
-        self.highlight_enabled_profile_options()
+        self.highlight_enabled_profile_options(load_settings=False)
+        self.suspend_signals = False
 
     def restore_page_defaults(self):
         self.ui.pages_stack.currentWidget().restore_defaults()
-        self.highlight_enabled_profile_options()
+        self.highlight_enabled_profile_options(load_settings=False)
 
     def confirm_reset(self):
         msg = _("You are about to reset your options for this page.")

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -96,6 +96,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         ListOption("persist", "options_pages_tree_state", []),
     ]
 
+    suspend_signals = False
+
     def add_pages(self, parent, default_page, parent_item):
         pages = [(p.SORT_ORDER, p.NAME, p) for p in self.pages if p.PARENT == parent]
         items = []
@@ -243,7 +245,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         return _('Unknown profile')
 
     def update_from_profile_changes(self):
-        self.highlight_enabled_profile_options(load_settings=True)
+        if not self.suspend_signals:
+            self.highlight_enabled_profile_options(load_settings=True)
 
     def get_working_profile_data(self):
         profile_page = self.get_page('profiles')
@@ -411,6 +414,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 item.setExpanded(is_expanded)
 
     def restore_all_defaults(self):
+        self.suspend_signals = True
         for page in self.pages:
             try:
                 page.restore_defaults()

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -37,6 +37,7 @@ from picard.config import (
     get_config,
 )
 from picard.const import (
+    DEFAULT_PROGRAM_UPDATE_LEVEL,
     MUSICBRAINZ_SERVERS,
     PROGRAM_UPDATE_LEVELS,
 )
@@ -72,7 +73,7 @@ class GeneralOptionsPage(OptionsPage):
         TextOption("persist", "oauth_username", ""),
         BoolOption("setting", "check_for_updates", True),
         IntOption("setting", "update_check_days", 7),
-        IntOption("setting", "update_level", 0),
+        IntOption("setting", "update_level", DEFAULT_PROGRAM_UPDATE_LEVEL),
         IntOption("persist", "last_update_check", 0),
     ]
 
@@ -100,15 +101,23 @@ class GeneralOptionsPage(OptionsPage):
         self.ui.cluster_new_files.setChecked(config.setting["cluster_new_files"])
         self.ui.ignore_file_mbids.setChecked(config.setting["ignore_file_mbids"])
         self.ui.check_for_updates.setChecked(config.setting["check_for_updates"])
+        self.set_update_level(config.setting["update_level"])
+        self.ui.update_check_days.setValue(config.setting["update_check_days"])
+        if not self.tagger.autoupdate_enabled:
+            self.ui.update_check_groupbox.hide()
+
+    def set_update_level(self, value):
+        if value not in PROGRAM_UPDATE_LEVELS:
+            value = DEFAULT_PROGRAM_UPDATE_LEVEL
         self.ui.update_level.clear()
         for level, description in PROGRAM_UPDATE_LEVELS.items():
             # TODO: Remove temporary workaround once https://github.com/python-babel/babel/issues/415 has been resolved.
             babel_415_workaround = description['title']
             self.ui.update_level.addItem(_(babel_415_workaround), level)
-        self.ui.update_level.setCurrentIndex(self.ui.update_level.findData(config.setting["update_level"]))
-        self.ui.update_check_days.setValue(config.setting["update_check_days"])
-        if not self.tagger.autoupdate_enabled:
-            self.ui.update_check_groupbox.hide()
+        idx = self.ui.update_level.findData(value)
+        if idx == -1:
+            idx = self.ui.update_level.findData(DEFAULT_PROGRAM_UPDATE_LEVEL)
+        self.ui.update_level.setCurrentIndex(idx)
 
     def save(self):
         config = get_config()

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -99,16 +99,15 @@ class GeneralOptionsPage(OptionsPage):
         self.ui.analyze_new_files.setChecked(config.setting["analyze_new_files"])
         self.ui.cluster_new_files.setChecked(config.setting["cluster_new_files"])
         self.ui.ignore_file_mbids.setChecked(config.setting["ignore_file_mbids"])
-        if self.tagger.autoupdate_enabled:
-            self.ui.check_for_updates.setChecked(config.setting["check_for_updates"])
-            self.ui.update_level.clear()
-            for level, description in PROGRAM_UPDATE_LEVELS.items():
-                # TODO: Remove temporary workaround once https://github.com/python-babel/babel/issues/415 has been resolved.
-                babel_415_workaround = description['title']
-                self.ui.update_level.addItem(_(babel_415_workaround), level)
-            self.ui.update_level.setCurrentIndex(self.ui.update_level.findData(config.setting["update_level"]))
-            self.ui.update_check_days.setValue(config.setting["update_check_days"])
-        else:
+        self.ui.check_for_updates.setChecked(config.setting["check_for_updates"])
+        self.ui.update_level.clear()
+        for level, description in PROGRAM_UPDATE_LEVELS.items():
+            # TODO: Remove temporary workaround once https://github.com/python-babel/babel/issues/415 has been resolved.
+            babel_415_workaround = description['title']
+            self.ui.update_level.addItem(_(babel_415_workaround), level)
+        self.ui.update_level.setCurrentIndex(self.ui.update_level.findData(config.setting["update_level"]))
+        self.ui.update_check_days.setValue(config.setting["update_check_days"])
+        if not self.tagger.autoupdate_enabled:
             self.ui.update_check_groupbox.hide()
 
     def save(self):
@@ -119,10 +118,9 @@ class GeneralOptionsPage(OptionsPage):
         config.setting["analyze_new_files"] = self.ui.analyze_new_files.isChecked()
         config.setting["cluster_new_files"] = self.ui.cluster_new_files.isChecked()
         config.setting["ignore_file_mbids"] = self.ui.ignore_file_mbids.isChecked()
-        if self.tagger.autoupdate_enabled:
-            config.setting["check_for_updates"] = self.ui.check_for_updates.isChecked()
-            config.setting["update_level"] = self.ui.update_level.currentData(QtCore.Qt.ItemDataRole.UserRole)
-            config.setting["update_check_days"] = self.ui.update_check_days.value()
+        config.setting["check_for_updates"] = self.ui.check_for_updates.isChecked()
+        config.setting["update_level"] = self.ui.update_level.currentData(QtCore.Qt.ItemDataRole.UserRole)
+        config.setting["update_check_days"] = self.ui.update_check_days.value()
 
     def update_server_host(self):
         host = self.ui.server_host.currentText().strip()


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem


*Restore all Defaults* button doesn't have same effect as *Restore Defaults* button on *General* page.

When *Updates to check* is set to anything but the default value, pressing and accepting *Restore Defaults* will reset it to default value, but that's not the case for *Restore all Defaults*.

One of the call comes from `update_from_profile_changes()` which calls `update_from_profile_changes()` which in turn calls General Option Page `load()` method.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2697
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Calling `OptionPage.load()` multiple times actually cancels the reset to default value for some options, so ensure it is called only once.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
