### PR TITLE
PICARD-2696: Fix file deletion when shift-dropping files on Windows

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -127,13 +127,9 @@ class CoverArtThumbnail(ActiveLabel):
         else:
             return True
 
-    @staticmethod
-    def dragEnterEvent(event):
-        event.acceptProposedAction()
-
-    @staticmethod
-    def dragMoveEvent(event):
-        event.acceptProposedAction()
+    def dragEnterEvent(self, event):
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
 
     def dropEvent(self, event):
         accepted = False
@@ -170,7 +166,8 @@ class CoverArtThumbnail(ActiveLabel):
                 self.image_dropped.emit(QtCore.QUrl(''), dropped_data)
 
         if accepted:
-            event.acceptProposedAction()
+            event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+            event.accept()
 
     def scaled(self, *dimensions):
         return (round(self.pixel_ratio * dimension) for dimension in dimensions)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2696
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When dropping while pressing shift on Windows the files get sent as a "move" event to the application. Accepting this results in file deletion. Picard must always handle such events as "copy" to avoid this.

This replaces #2269

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

For itemview override the acceptance done in `QAbstractItemView.dropEvent` and only do a "copy" if the drop originates from outside Picard (no source widget) or is providing URLs.

For the cover art box generally handle all drops as copy.
