### PR TITLE
Handle Qt drag and drop IgnoreAction

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -132,6 +132,10 @@ class CoverArtThumbnail(ActiveLabel):
         event.accept()
 
     def dropEvent(self, event):
+        if event.proposedAction() == QtCore.Qt.DropAction.IgnoreAction:
+            event.acceptProposedAction()
+            return
+
         accepted = False
         # Chromium includes the actual data of the dragged image in the drop event. This
         # is useful for Google Images, where the url links to the page that contains the image

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -695,11 +695,16 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         return ["text/uri-list", "application/picard.album-list"]
 
     def dragEnterEvent(self, event):
-        if not event.source() or event.mimeData().hasUrls():
+        super().dragEnterEvent(event)
+        if event.isAccepted() and (not event.source() or event.mimeData().hasUrls()):
             event.setDropAction(QtCore.Qt.DropAction.CopyAction)
             event.accept()
-        else:
-            event.acceptProposedAction()
+
+    def dragMoveEvent(self, event):
+        super().dragMoveEvent(event)
+        if event.isAccepted() and (not event.source() or event.mimeData().hasUrls()):
+            event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+            event.accept()
 
     def startDrag(self, supportedActions):
         """Start drag, *without* using pixmap."""
@@ -763,6 +768,9 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             tagger.add_paths(new_paths, target=target)
 
     def dropEvent(self, event):
+        if event.proposedAction() == QtCore.Qt.DropAction.IgnoreAction:
+            event.acceptProposedAction()
+            return
         # Dropping with Alt key pressed forces all dropped files being
         # assigned to the same track.
         if event.keyboardModifiers() == QtCore.Qt.KeyboardModifier.AltModifier:

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -696,12 +696,13 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
     def dragEnterEvent(self, event):
         super().dragEnterEvent(event)
-        if event.isAccepted() and (not event.source() or event.mimeData().hasUrls()):
-            event.setDropAction(QtCore.Qt.DropAction.CopyAction)
-            event.accept()
+        self._handle_external_drag(event)
 
     def dragMoveEvent(self, event):
         super().dragMoveEvent(event)
+        self._handle_external_drag(event)
+
+    def _handle_external_drag(self, event):
         if event.isAccepted() and (not event.source() or event.mimeData().hasUrls()):
             event.setDropAction(QtCore.Qt.DropAction.CopyAction)
             event.accept()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -247,6 +247,7 @@ class PluginsOptionsPage(OptionsPage):
         plugins.mimeTypes = self.mimeTypes
         plugins.dropEvent = self.dropEvent
         plugins.dragEnterEvent = self.dragEnterEvent
+        plugins.dragMoveEvent = self.dragMoveEvent
 
         self.ui.install_plugin.clicked.connect(self.open_plugins)
         self.ui.folder_open.clicked.connect(self.open_plugin_dir)
@@ -700,9 +701,20 @@ class PluginsOptionsPage(OptionsPage):
         event.setDropAction(QtCore.Qt.DropAction.CopyAction)
         event.accept()
 
+    def dragMoveEvent(self, event):
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
+
     def dropEvent(self, event):
+        if event.proposedAction() == QtCore.Qt.DropAction.IgnoreAction:
+            event.acceptProposedAction()
+            return
+
         for path in (os.path.normpath(u.toLocalFile()) for u in event.mimeData().urls()):
             self.manager.install_plugin(path)
+
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
 
 
 register_options_page(PluginsOptionsPage)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

In places where Picard handles drag and drop handle the Qt `IgnoreAction`. See discussion at https://github.com/metabrainz/picard/pull/2270#pullrequestreview-1575294513
