### PR TITLE
PICARD-2713: Fix --stand-alone-instance handling

### DIFF
--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -294,7 +294,7 @@ class UnixPipe(AbstractPipe):
 
     def __init__(self, app_name: str, app_version: str, args: Optional[Iterable[str]] = None,
                  forced_path: Optional[str] = None, identifier: Optional[str] = None):
-        super().__init__(app_name, app_version, args, forced_path)
+        super().__init__(app_name, app_version, args, forced_path, identifier)
 
         if not self.path:
             raise PipeErrorNoPermission
@@ -391,7 +391,7 @@ class WinPipe(AbstractPipe):
             app_version = app_version.replace(".", "-")
         except AttributeError:
             pass
-        super().__init__(app_name, app_version, args, forced_path)
+        super().__init__(app_name, app_version, args, forced_path, identifier)
 
         self._remove_temp_attributes()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2713
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Starting Picard with the `--stand-alone-instance` parameter has no affect. Picard starts normally with the main instance.


# Solution
The pipe server ignored the provided identifier.