### PR TITLE
PICARD-2691: provide signed source archives

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
     - '.github/workflows/package.yml'
+    - '.github/workflows/pypi-release.yml'
     - 'installer/**'
     - 'picard/**'
     - 'po/**.po'
@@ -239,12 +240,17 @@ jobs:
         name: windows-${{ matrix.type }}
         path: artifacts/
 
+  package-pypi:
+    uses: ./.github/workflows/pypi-release.yml
+    secrets: inherit
+
   github-release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - package-macos
       - package-windows
+      - package-pypi
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -273,6 +279,10 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: windows-portable
+        path: artifacts/
+    - uses: actions/download-artifact@v3
+      with:
+        name: picard-sdist
         path: artifacts/
     - name: Generate checksums
       run: |

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -65,7 +65,7 @@ jobs:
         name: picard-sdist
         path: dist/*
     - name: Publish Python distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/') && env.TWINE_PASSWORD
       run: |
         pip install --upgrade twine
         twine upload --non-interactive dist/*.tar.gz
@@ -110,7 +110,7 @@ jobs:
         name: picard-bdist-${{ runner.os }}
         path: dist/*.whl
     - name: Publish Python distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/') && env.TWINE_PASSWORD
       run: |
         pip install --upgrade twine>=3.0
         twine upload --non-interactive dist/*

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,6 +1,6 @@
 name: Package for PyPI
 
-on: [push]
+on: [workflow_call]
 
 defaults:
   run:
@@ -9,6 +9,8 @@ defaults:
 jobs:
   pypi-sdist:
     runs-on: ubuntu-latest
+    env:
+      CODESIGN: 0
 
     steps:
     - uses: actions/checkout@v3
@@ -26,7 +28,37 @@ jobs:
         python setup.py test
     - name: Build Python source distribution
       run: |
-        python setup.py clean sdist
+        python setup.py clean sdist --formats=gztar,zip
+    - name: Prepare GPG signing key
+      run: |
+        if [ -n "$CODESIGN_GPG_URL" ] && [ -n "$AWS_ACCESS_KEY_ID" ]; then
+          pip3 install awscli
+          aws s3 cp "$CODESIGN_GPG_URL" signkey.asc.enc
+          openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -in signkey.asc.enc -out signkey.asc -k "$CODESIGN_GPG_PASSWORD"
+          gpg --import signkey.asc
+          rm signkey.asc*
+          echo "CODESIGN=1" >> $GITHUB_ENV
+        else
+          echo "::warning::No signing key available, skipping code signing."
+        fi
+      env:
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        CODESIGN_GPG_URL: ${{ secrets.CODESIGN_GPG_URL }}
+        CODESIGN_GPG_PASSWORD: ${{ secrets.CODESIGN_GPG_PASSWORD }}
+    - name: Sign source archives
+      if: env.CODESIGN == '1'
+      run: |
+        for f in dist/*.{zip,tar.gz}; do
+          gpg --armor --local-user "$CODESIGN_GPG_IDENTITY" --output "${f}.asc" --detach-sig "$f"
+        done
+      env:
+        CODESIGN_GPG_IDENTITY: 68990DD0B1EDC129B856958167997E14D563DA7C
+    - name: Cleanup
+      if: env.CODESIGN == '1'
+      run: |
+        rm -rf "$HOME/.gnupg"
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -36,7 +68,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         pip install --upgrade twine
-        twine upload --non-interactive dist/*
+        twine upload --non-interactive dist/*.tar.gz
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2691
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Since PyPI stopped providing signed source files we did no longer provide signed sources automatically.

Also we always relied on source files automatically generated by Github for our official release. This causes two source files to exist for Picard (on PyPI and official download). Also the Github generated source files are not stable. They can get regenerated later resulting in changed checksum.


# Solution

- Re-activate GPG source file signing in the PyPI builds
- Extend the build to generate both tar.gz and zip
- Make the release-pypi workflow a dependency of the package workflow and publish the resulting artifacts (source archives .tar.gz and .zip + their signatures) on Github release

I did perform a full test deployment cycle on my fork (please ignore the version number mixup and old changelog here, this is still using old number). The workflow run is at https://github.com/phw/picard/actions/runs/5858950764/job/15884133636

See how the picard-sdist artifact contains the .asc signatures.

~The deployment result is at https://github.com/phw/picard/releases/tag/release-2.9.1a0~ I did a test release,  but accidentally already cleaned it up. Anyway, it did successfully deploy the source artifacts to the Github release.

The source files provided there are `picard-2.9.tar.gz` and ` picard-2.9.zip`, and the corresponding .asc files are also included.