### PR TITLE
Disable plugin updates by default

### DIFF
--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -75,7 +75,7 @@ class GeneralOptionsPage(OptionsPage):
         IntOption("setting", "update_check_days", 7),
         IntOption("setting", "update_level", DEFAULT_PROGRAM_UPDATE_LEVEL),
         IntOption("persist", "last_update_check", 0),
-        BoolOption("setting", "check_for_plugin_updates", True),
+        BoolOption("setting", "check_for_plugin_updates", False),
     ]
 
     def __init__(self, parent=None):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

The new plugin update feature is something that I think we can ship in the 2.9.1 release. But as we want to get this release out soon due to the important bug fixes I would feel better if we could make this disabled for now by default.

That way we can ship the feature to interested users and hopefully can get feedback on it, but don't cause unexpected interruption for existing users.

Once we have extended the feature and improved the UI we can consider making it the default.