### PR TITLE
PICARD-2715: Show plugins with updates and add button to open plugin options window

### DIFF
--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -451,24 +451,51 @@ class PluginManager(QtCore.QObject):
     def _plugins_have_new_versions(self):
         """Compare available plugins versions with installed plugins ones and return True
         if at least one needs to be updated, or False if no update is needed"""
+        plugins_with_updates = []
         if self.available_plugins is not None:
             available_versions = {p.module_name: p.version for p in self.available_plugins}
             for plugin in self.plugins:
                 if plugin.module_name not in available_versions:
                     continue
                 if available_versions[plugin.module_name] > plugin.version:
-                    return True
-        return False
+                    plugins_with_updates.append(plugin.name)
+        return plugins_with_updates
 
     def check_update(self, parent=None):
         def _display_update():
-            if self._plugins_have_new_versions():
-                QMessageBox.information(
+            update_lines_to_show = 3
+            plugins_with_updates = self._plugins_have_new_versions()
+            if plugins_with_updates:
+                file_count = len(plugins_with_updates)
+                extra_file_count = file_count - update_lines_to_show
+                header = '<p>' + ngettext(
+                    "There are updates available for your currently installed plugin:",
+                    "There are updates available for your currently installed plugins:",
+                    file_count
+                ) + '</p><ul>'
+                footer = '</ul><p>' + ngettext(
+                    "Do you want to update the plugin now?",
+                    "Do you want to update the plugins now?",
+                    file_count
+                ) + '</p>'
+                if extra_file_count > 0:
+                    extra_plugins = '<p>' + ngettext(
+                        "plus {extra_file_count:,d} other plugin.",
+                        "plus {extra_file_count:,d} other plugins.",
+                        extra_file_count).format(extra_file_count=extra_file_count) + '</p>'
+                else:
+                    extra_plugins = ''
+                plugin_list = ''
+                for plugin_name in plugins_with_updates[:min(len(plugins_with_updates), update_lines_to_show)]:
+                    plugin_list += f"<li>{plugin_name}</li>"
+                if QMessageBox.information(
                     parent,
                     _("Picard Plugins Update"),
-                    _("There are updates available for your currently installed plugins."),
-                    QMessageBox.StandardButton.Ok, QMessageBox.StandardButton.Ok
-                )
+                    header + plugin_list + '</ul>' + extra_plugins + footer,
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+                    QMessageBox.StandardButton.Cancel
+                ) == QMessageBox.StandardButton.Yes and parent:
+                    parent.show_plugins_options_page()
 
         if self.available_plugins is None:
             self.query_available_plugins(_display_update)

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -525,12 +525,12 @@ class PluginManager(QtCore.QObject):
                 msg = PluginUpdatesDialog(parent, f'{header}<ul>{plugin_list}</ul>{extra_plugins}{footer}')
 
                 show_options_page, perform_check = msg.show()
-                if parent:
-                    config = get_config()
-                    config.setting['check_for_plugin_updates'] = perform_check
 
-                    if show_options_page:
-                        parent.show_plugins_options_page()
+                config = get_config()
+                config.setting['check_for_plugin_updates'] = perform_check
+
+                if parent and show_options_page:
+                    parent.show_plugins_options_page()
 
         if self.available_plugins is None:
             self.query_available_plugins(_display_update)

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -90,6 +90,7 @@ class PluginUpdatesDialog():
 
         self.msg.setCheckBox(self.cb)
         self.msg.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
+        self.msg.setDefaultButton(QMessageBox.StandardButton.Cancel)
 
     def _set_state(self):
         self.show_again = not self.show_again

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -1998,6 +1998,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if config.setting['check_for_plugin_updates']:
             self.tagger.pluginmanager.check_update(self)
 
+    def show_plugins_options_page(self):
+        self.show_options(page='plugins')
+
 
 def update_last_check_date(is_success):
     if is_success:


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds list of plugin updates available and a button to open the Options -> Plugins screen directly from the plugin update notification dialog

# Problem

The plugin updates available notification dialog did not provide any details or allow easy updating.

* JIRA ticket (_optional_): PICARD-2715

# Solution

Add a list of plugin updates available and a button to open the Options -> Plugins screen directly from the plugin update notification dialog.  Examples:

![image](https://github.com/metabrainz/picard/assets/16990904/d523803d-506f-47fe-9b09-c64fe15a3810)

![image](https://github.com/metabrainz/picard/assets/16990904/cc789a82-9648-4475-8a37-35d2eb32ea88)

Note that the displayed list is limited to a maximum of 3 plugins, with a note indicating if there are more.

# Action

None.