### PR TITLE
PICARD-2718: Fix file filter for ripper log file picker

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1187,7 +1187,7 @@ class Tagger(QtWidgets.QApplication):
     def lookup_discid_from_logfile(self):
         file_chooser = QtWidgets.QFileDialog(self.window)
         file_chooser.setNameFilters([
-            _("All supported log files") + " (*.log, *.txt)",
+            _("All supported log files") + " (*.log *.txt)",
             _("EAC / XLD / Whipper / fre:ac log files") + " (*.log)",
             _("dBpoweramp log files") + " (*.txt)",
             _("All files") + " (*)",


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2718
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

*.log files where ignored with the "All supported log files" filter

# Solution

Qt file dialog filters must separate the extensions only by space.