### PR TITLE
PICARD-2720: Add .desktop file action to explicitly open new window

### DIFF
--- a/org.musicbrainz.Picard.desktop
+++ b/org.musicbrainz.Picard.desktop
@@ -9,3 +9,8 @@ StartupWMClass=Picard
 Icon=org.musicbrainz.Picard
 Categories=AudioVideo;Audio;AudioVideoEditing;
 MimeType=application/ogg;application/x-flac;audio/aac;audio/ac3;audio/aiff;audio/ape;audio/dsf;audio/flac;audio/midi;audio/mp4;audio/mpeg;audio/mpeg4;audio/mpg;audio/ogg;audio/vorbis;audio/x-aac;audio/x-aiff;audio/x-ape;audio/x-flac;audio/x-flac+ogg;audio/x-m4a;audio/x-midi;audio/x-mp3;audio/x-mpc;audio/x-mpeg;audio/x-ms-wma;audio/x-ms-wmv;audio/x-musepack;audio/x-oggflac;audio/x-speex;audio/x-speex+ogg;audio/x-tak;audio/x-tta;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-wma;video/x-ms-asf;video/x-theora;video/x-wmv;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Exec=picard --stand-alone-instance %F


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2720
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



XDG desktop entries allow specifying additional actions as alternative ways to launch an application.

We can use this to add a new option to explicitly open a new standalone window / instance of Picard.

See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#extra-actions


# Solution
Add a new action to launch `picard --stand-alone-instance`.

![grafik](https://github.com/metabrainz/picard/assets/29852/2176ff6b-ba84-4e9f-a702-e932986a51ed)
