### PR TITLE
PICARD-2712: Fix sanitize date removing 0 values

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -312,18 +312,23 @@ def format_time(ms, display_zero=False):
 def sanitize_date(datestr):
     """Sanitize date format.
 
-    e.g.: "YYYY-00-00" -> "YYYY"
-          "YYYY-  -  " -> "YYYY"
+    e.g.: "1980-00-00" -> "1980"
+          "1980-  -  " -> "1980"
+          "1980-00-23" -> "1980-00-23"
           ...
     """
     date = []
-    for num in datestr.split("-"):
+    for num in reversed(datestr.split("-")):
         try:
             num = int(num.strip())
         except ValueError:
-            break
-        if num:
+            if num == '':
+                num = 0
+            else:
+                break
+        if num or (num == 0 and date):
             date.append(num)
+    date.reverse()
     return ("", "%04d", "%04d-%02d", "%04d-%02d-%02d")[len(date)] % tuple(date)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -188,15 +188,26 @@ class ExtractYearTest(PicardTestCase):
 class SanitizeDateTest(PicardTestCase):
 
     def test_correct(self):
+        self.assertEqual(util.sanitize_date(""), "")
+        self.assertEqual(util.sanitize_date("0"), "")
+        self.assertEqual(util.sanitize_date("0000"), "")
+        self.assertEqual(util.sanitize_date("2006"), "2006")
         self.assertEqual(util.sanitize_date("2006--"), "2006")
-        self.assertEqual(util.sanitize_date("2006--02"), "2006")
+        self.assertEqual(util.sanitize_date("2006-00-02"), "2006-00-02")
         self.assertEqual(util.sanitize_date("2006   "), "2006")
         self.assertEqual(util.sanitize_date("2006 02"), "")
         self.assertEqual(util.sanitize_date("2006.02"), "")
         self.assertEqual(util.sanitize_date("2006-02"), "2006-02")
+        self.assertEqual(util.sanitize_date("2006-02-00"), "2006-02")
+        self.assertEqual(util.sanitize_date("2006-00-00"), "2006")
+        self.assertEqual(util.sanitize_date("2006-02-23"), "2006-02-23")
+        self.assertEqual(util.sanitize_date("2006-00-23"), "2006-00-23")
+        self.assertEqual(util.sanitize_date("0000-00-23"), "0000-00-23")
+        self.assertEqual(util.sanitize_date("0000-02"), "0000-02")
+        self.assertEqual(util.sanitize_date("--23"), "0000-00-23")
 
     def test_incorrect(self):
-        self.assertNotEqual(util.sanitize_date("2006--02"), "2006-02")
+        self.assertNotEqual(util.sanitize_date("2006--02"), "2006")
         self.assertNotEqual(util.sanitize_date("2006.03.02"), "2006-03-02")
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2712
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Sanitize date cleared zero values in between, such turning "YYYY-00-DD" into "YYYY-DD", which would be a completely different date.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Fix this by keeping empty values if they are not the last element.

It changes the behavior for some strings with e.g. double slashes, as the empty string in between those is now considered a valid value and treated as `0`.