### PR TITLE
PICARD-2724: Fix potential crash in artist alias translation

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -246,11 +246,11 @@ def _locales_from_aliases(aliases):
     full_locales = {}
     root_locales = {}
     for alias in aliases:
-        if not alias['primary']:
+        if not alias.get('primary'):
             continue
-        if 'locale' not in alias:
+        full_locale = alias.get('locale')
+        if not full_locale:
             continue
-        full_locale = alias['locale']
         root_locale = full_locale.split('_')[0]
         full_parts = []
         root_parts = []
@@ -259,9 +259,10 @@ def _locales_from_aliases(aliases):
         if '_' in full_locale:
             score = 0.4
         root_parts.append((score, 5))
-        if alias['type-id'] == ALIAS_TYPE_ARTIST_NAME_ID:
+        type_id = alias.get('type-id')
+        if type_id == ALIAS_TYPE_ARTIST_NAME_ID:
             score = 0.8
-        elif alias['type-id'] == ALIAS_TYPE_LEGAL_NAME_ID:
+        elif type_id == ALIAS_TYPE_LEGAL_NAME_ID:
             score = 0.5
         else:
             # as 2014/09/19, only Artist or Legal names should have the


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2724
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Fix potential crash in artist alias translation

This crash requires very specific circumstances:

- Option `translate_artist_names` must be enabled
- Option `translate_artist_names_script_exception` must be set
- The track search dialog must be opened on a file
- The search result must contain artist aliases
- An artist alias must:
  - be in a script not catched by `translate_artist_names_script_exception` 
  - be set to "primary"
  - have a "locale" set
  - have no type set

In this case the result does not contain the `type-id` key but Picard still tries to read it.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make the code around reading the alias node more robust:

- handle non existent `type-id`
- handle non-existent `primary` (should not happen)
- handle another case where `primary` is set but `locale` is `null`. This actually should not happen as the MB server does not allow setting primary without locale. But it might well be possible that some data exists with this condition