### PR TITLE
PICARD-2700: fix accumulating series metadata on refresh

### DIFF
--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -206,6 +206,46 @@ class ReleaseTest(MBJSONTest):
         ])
         self.assertEqual(m.getall('~releasegroup_seriesnumber'), ['15', '291'])
 
+    def test_release_group_rels_double(self):
+        m = Metadata()
+        release_group_to_metadata(self.json_doc['release-group'], m)
+
+        # load it twice and check for duplicates
+        release_group_to_metadata(self.json_doc['release-group'], m)
+        self.assertEqual(m.getall('~releasegroup_series'), [
+            "Absolute Radio's The 100 Collection",
+            '1001 Albums You Must Hear Before You Die'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriesid'), [
+            '4bf41050-6fa9-41a6-8398-15bdab4b0352',
+            '4bc2a338-e1d8-4546-8a61-640da8aaf888'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriescomment'), [
+            '2005 edition'
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriesnumber'), ['15', '291'])
+
+    def test_release_group_rels_removed(self):
+        m = Metadata()
+        release_group_to_metadata(self.json_doc['release-group'], m)
+
+        # remove one of the series from original metadata
+        for i, rel in enumerate(self.json_doc['release-group']['relations']):
+            if not rel['type'] == 'part of':
+                continue
+            if rel['series']['name'] == '1001 Albums You Must Hear Before You Die':
+                del self.json_doc['release-group']['relations'][i]
+                break
+        release_group_to_metadata(self.json_doc['release-group'], m)
+        self.assertEqual(m.getall('~releasegroup_series'), [
+            "Absolute Radio's The 100 Collection",
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriesid'), [
+            '4bf41050-6fa9-41a6-8398-15bdab4b0352',
+        ])
+        self.assertEqual(m.getall('~releasegroup_seriescomment'), [])
+        self.assertEqual(m.getall('~releasegroup_seriesnumber'), ['15'])
+
 
 class NullReleaseTest(MBJSONTest):
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2700
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When refreshing series are added once again (and so on), because of the use of `Metadata.add()` over same tags.

# Solution

Call `Metadata.unset()` for series before adding first tag value.

This fix is limited to `*series` tags, but the issue is perhaps concerning more, the whole process of refreshing will need to be reviewed.


<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
