### PR TITLE
PICARD-2690: move const translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db:encryptable
 *.pyc
 *.pyd
 *.so
+*.mo
 appxmanifest.xml
 build/
 coverage.xml

--- a/.pylintrc
+++ b/.pylintrc
@@ -283,8 +283,8 @@ min-similarity-lines=4
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid defining new builtins when possible.
-additional-builtins=_, N_, ngettext, gettext_countries,
-                    gettext_attributes, pgettext_attributes
+additional-builtins=_, N_, ngettext, gettext_attributes, pgettext_attributes,
+                    gettext_constants, gettext_countries
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -229,7 +229,12 @@ def upgrade_to_v1_4_0_dev_6(config):
     if old_script_text_option in _s:
         old_script_text = _s.value(old_script_text_option, TextOption, "")
         if old_script_text:
-            old_script = (0, unique_numbered_title(_(DEFAULT_SCRIPT_NAME), list_of_scripts), _s["enable_tagger_scripts"], old_script_text)
+            old_script = (
+                0,
+                unique_numbered_title(gettext_constants(DEFAULT_SCRIPT_NAME), list_of_scripts),
+                _s["enable_tagger_scripts"],
+                old_script_text,
+            )
             list_of_scripts.append(old_script)
     _s["list_of_scripts"] = list_of_scripts
     _s.remove(old_enabled_option)

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -172,12 +172,14 @@ def setup_gettext(localedir, ui_language=None, logger=None):
     QLocale.setDefault(QLocale(current_locale))
 
     trans = _load_translation('picard', localedir, language=current_locale)
-    trans_countries = _load_translation('picard-countries', localedir, language=current_locale)
     trans_attributes = _load_translation('picard-attributes', localedir, language=current_locale)
+    trans_constants = _load_translation('picard-constants', localedir, language=current_locale)
+    trans_countries = _load_translation('picard-countries', localedir, language=current_locale)
 
     trans.install(['ngettext'])
-    builtins.__dict__['gettext_countries'] = trans_countries.gettext
     builtins.__dict__['gettext_attributes'] = trans_attributes.gettext
+    builtins.__dict__['gettext_constants'] = trans_constants.gettext
+    builtins.__dict__['gettext_countries'] = trans_countries.gettext
 
     if hasattr(trans_attributes, 'pgettext'):
         builtins.__dict__['pgettext_attributes'] = trans_attributes.pgettext

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -115,7 +115,7 @@ class GeneralOptionsPage(OptionsPage):
         for level, description in PROGRAM_UPDATE_LEVELS.items():
             # TODO: Remove temporary workaround once https://github.com/python-babel/babel/issues/415 has been resolved.
             babel_415_workaround = description['title']
-            self.ui.update_level.addItem(_(babel_415_workaround), level)
+            self.ui.update_level.addItem(gettext_constants(babel_415_workaround), level)
         idx = self.ui.update_level.findData(value)
         if idx == -1:
             idx = self.ui.update_level.findData(DEFAULT_PROGRAM_UPDATE_LEVEL)

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -122,7 +122,7 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(UiTheme.DEFAULT))
 
         self.ui.ui_language.addItem(_('System default'), '')
-        language_list = [(lang[0], lang[1], _(lang[2])) for lang in UI_LANGUAGES]
+        language_list = [(lang[0], lang[1], gettext_constants(lang[2])) for lang in UI_LANGUAGES]
 
         def fcmp(x):
             return strxfrm(x[2])

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -130,7 +130,7 @@ class MetadataOptionsPage(OptionsPage):
     def make_locales_text(self):
         def translated_locales():
             for locale in self.current_locales:
-                yield _(ALIAS_LOCALES[locale])
+                yield gettext_constants(ALIAS_LOCALES[locale])
 
         self.ui.selected_locales.setText('; '.join(translated_locales()))
 
@@ -205,7 +205,7 @@ class MultiLocaleSelector(PicardDialog):
             # Note that items in the selected locales list are not indented because
             # the root locale may not be in the list, or may not immediately precede
             # the specific locale.
-            label = _(ALIAS_LOCALES[locale])
+            label = gettext_constants(ALIAS_LOCALES[locale])
             item = QtWidgets.QListWidgetItem(label)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, locale)
             self.ui.selected_locales.addItem(item)
@@ -214,7 +214,7 @@ class MultiLocaleSelector(PicardDialog):
         def indented_translated_locale(locale, level):
             return _("{indent}{locale}").format(
                 indent="    " * level,
-                locale=_(ALIAS_LOCALES[locale])
+                locale=gettext_constants(ALIAS_LOCALES[locale])
             )
 
         self.ui.available_locales.clear()
@@ -240,7 +240,7 @@ class MultiLocaleSelector(PicardDialog):
         # Note that items in the selected locales list are not indented because
         # the root locale may not be in the list, or may not immediately precede
         # the specific locale.
-        new_item.setText(_(ALIAS_LOCALES[locale]))
+        new_item.setText(gettext_constants(ALIAS_LOCALES[locale]))
         self.ui.selected_locales.addItem(new_item)
         self.ui.selected_locales.setCurrentRow(self.ui.selected_locales.count() - 1)
 
@@ -290,7 +290,7 @@ class ScriptExceptionSelector(PicardDialog):
     @staticmethod
     def make_label(script_id, script_weighting):
         return "{script} ({weighting}%)".format(
-            script=_(SCRIPTS[script_id]),
+            script=gettext_constants(SCRIPTS[script_id]),
             weighting=script_weighting,
         )
 

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -424,7 +424,7 @@ class ProfilesOptionsPage(OptionsPage):
         id = str(uuid.uuid4())
         settings = deepcopy(self.profile_settings[self.current_profile_id])
         self.profile_settings[id] = settings
-        base_title = "%s %s" % (get_base_title(item.name), _(DEFAULT_COPY_TEXT))
+        base_title = "%s %s" % (get_base_title(item.name), gettext_constants(DEFAULT_COPY_TEXT))
         name = self.ui.profile_list.unique_profile_name(base_title)
         self.ui.profile_list.add_profile(name=name, profile_id=id)
         self.update_config_overrides()

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -931,7 +931,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
     def new_script_name(self, base_title=None):
         """Get new unique script name.
         """
-        default_title = base_title if base_title is not None else _(DEFAULT_SCRIPT_NAME)
+        default_title = base_title if base_title is not None else gettext_constants(DEFAULT_SCRIPT_NAME)
         existing_titles = set(script['title'] for script in self.naming_scripts.values())
         return unique_numbered_title(default_title, existing_titles)
 
@@ -949,7 +949,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         script_item = self.ui.preset_naming_scripts.itemData(selected)
         new_item = FileNamingScript.create_from_dict(script_dict=script_item).copy()
 
-        base_title = "%s %s" % (get_base_title(script_item['title']), _(DEFAULT_COPY_TEXT))
+        base_title = "%s %s" % (get_base_title(script_item['title']), gettext_constants(DEFAULT_COPY_TEXT))
         new_item.title = self.new_script_name(base_title)
 
         self._insert_item(new_item.to_dict())

--- a/picard/ui/widgets/profilelistwidget.py
+++ b/picard/ui/widgets/profilelistwidget.py
@@ -60,7 +60,7 @@ class ProfileListWidget(QtWidgets.QListWidget):
 
     def unique_profile_name(self, base_name=None):
         if base_name is None:
-            base_name = _(DEFAULT_PROFILE_NAME)
+            base_name = gettext_constants(DEFAULT_PROFILE_NAME)
         existing_titles = [self.item(i).name for i in range(self.count())]
         return unique_numbered_title(base_name, existing_titles)
 
@@ -95,7 +95,7 @@ class ProfileListWidgetItem(HashableListWidgetItem):
         super().__init__(name)
         self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsEditable)
         if name is None:
-            name = _(DEFAULT_PROFILE_NAME)
+            name = gettext_constants(DEFAULT_PROFILE_NAME)
         self.setText(name)
         self.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
         if not profile_id:

--- a/picard/ui/widgets/scriptlistwidget.py
+++ b/picard/ui/widgets/scriptlistwidget.py
@@ -69,7 +69,7 @@ class ScriptListWidget(QtWidgets.QListWidget):
 
     def unique_script_name(self):
         existing_titles = [self.item(i).name for i in range(self.count())]
-        return unique_numbered_title(_(DEFAULT_SCRIPT_NAME), existing_titles)
+        return unique_numbered_title(gettext_constants(DEFAULT_SCRIPT_NAME), existing_titles)
 
     def add_script(self):
         numbered_name = self.unique_script_name()
@@ -114,7 +114,7 @@ class ScriptListWidgetItem(HashableListWidgetItem):
         super().__init__(name)
         self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsEditable)
         if name is None:
-            name = _(DEFAULT_SCRIPT_NAME)
+            name = gettext_constants(DEFAULT_SCRIPT_NAME)
         self.setText(name)
         self.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
         self.script = script

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1093,7 +1093,7 @@ def unique_numbered_title(default_title, existing_titles, fmt=None):
        based on given default title and existing titles
     """
     if fmt is None:
-        fmt = _(DEFAULT_NUMBERED_TITLE_FORMAT)
+        fmt = gettext_constants(DEFAULT_NUMBERED_TITLE_FORMAT)
 
     escaped_title = re.escape(default_title)
     reg_count = r'(\d+)'
@@ -1116,7 +1116,7 @@ def get_base_title_with_suffix(title, suffix, fmt=None):
        removing the suffix and number portion from the end.
     """
     if fmt is None:
-        fmt = _(DEFAULT_NUMBERED_TITLE_FORMAT)
+        fmt = gettext_constants(DEFAULT_NUMBERED_TITLE_FORMAT)
 
     escaped_suffix = re.escape(suffix)
     reg_title = r'(?P<title>.*?)(?:\s*' + escaped_suffix + ')?'
@@ -1131,7 +1131,7 @@ def get_base_title_with_suffix(title, suffix, fmt=None):
 def get_base_title(title):
     """Extract the base portion of a title, using the standard suffix.
     """
-    suffix = _(DEFAULT_COPY_TEXT)
+    suffix = gettext_constants(DEFAULT_COPY_TEXT)
     return get_base_title_with_suffix(title, suffix)
 
 

--- a/picard/util/checkupdate.py
+++ b/picard/util/checkupdate.py
@@ -159,7 +159,7 @@ class UpdateCheckManager(QtCore.QObject):
                     _("Picard Update"),
                     _("There is no update currently available for your subscribed update level: {update_level}\n\n"
                       "Your version: {picard_old_version}\n").format(
-                        update_level=_(update_level),
+                        update_level=gettext_constants(update_level),
                         picard_old_version=PICARD_FANCY_VERSION_STR,
                     ),
                     QMessageBox.StandardButton.Ok, QMessageBox.StandardButton.Ok

--- a/po/constants/constants.pot
+++ b/po/constants/constants.pot
@@ -1,0 +1,4186 @@
+# Translations template for picard.
+# Copyright (C) 2023 ORGANIZATION
+# This file is distributed under the same license as the picard project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: picard 2.9.1\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2023-08-24 09:20+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.12.1\n"
+
+#: picard/const/__init__.py:169
+msgid "Stable releases only"
+msgstr ""
+
+#: picard/const/__init__.py:175
+msgid "Stable and Beta releases"
+msgstr ""
+
+#: picard/const/__init__.py:181
+msgid "Stable, Beta and Dev releases"
+msgstr ""
+
+#: picard/const/__init__.py:199
+msgid "My script"
+msgstr ""
+
+#: picard/const/__init__.py:201
+msgid "My profile"
+msgstr ""
+
+#: picard/const/__init__.py:202
+msgid "(copy)"
+msgstr ""
+
+#: picard/const/__init__.py:203
+msgid "{title} ({count})"
+msgstr ""
+
+#: picard/const/languages.py:29 picard/const/locales.py:48
+#: picard/const/scripts.py:29
+msgid "Arabic"
+msgstr ""
+
+#: picard/const/languages.py:32 picard/const/locales.py:147
+msgid "Catalan"
+msgstr ""
+
+#: picard/const/languages.py:33 picard/const/locales.py:177
+msgid "Czech"
+msgstr ""
+
+#: picard/const/languages.py:35 picard/const/locales.py:185
+msgid "Danish"
+msgstr ""
+
+#: picard/const/languages.py:36 picard/const/locales.py:190
+msgid "German"
+msgstr ""
+
+#: picard/const/languages.py:37 picard/const/locales.py:193
+msgid "German (Switzerland)"
+msgstr ""
+
+#: picard/const/languages.py:38 picard/const/locales.py:217
+#: picard/const/scripts.py:26
+msgid "Greek"
+msgstr ""
+
+#: picard/const/languages.py:39 picard/const/locales.py:221
+msgid "English"
+msgstr ""
+
+#: picard/const/languages.py:40 picard/const/locales.py:229
+msgid "English (Australia)"
+msgstr ""
+
+#: picard/const/languages.py:41 picard/const/locales.py:237
+msgid "English (Canada)"
+msgstr ""
+
+#: picard/const/languages.py:42 picard/const/locales.py:255
+msgid "English (United Kingdom)"
+msgstr ""
+
+#: picard/const/languages.py:44 picard/const/locales.py:334
+msgid "Spanish"
+msgstr ""
+
+#: picard/const/languages.py:45 picard/const/locales.py:363
+msgid "Estonian"
+msgstr ""
+
+#: picard/const/languages.py:47 picard/const/locales.py:399
+msgid "Finnish"
+msgstr ""
+
+#: picard/const/languages.py:49 picard/const/locales.py:406
+msgid "French"
+msgstr ""
+
+#: picard/const/languages.py:50 picard/const/locales.py:412
+msgid "French (Canada)"
+msgstr ""
+
+#: picard/const/languages.py:52 picard/const/locales.py:469
+msgid "Galician"
+msgstr ""
+
+#: picard/const/languages.py:53 picard/const/locales.py:497
+#: picard/const/scripts.py:30
+msgid "Hebrew"
+msgstr ""
+
+#: picard/const/languages.py:55 picard/const/locales.py:511
+msgid "Hungarian"
+msgstr ""
+
+#: picard/const/languages.py:57 picard/const/locales.py:526
+msgid "Icelandic"
+msgstr ""
+
+#: picard/const/languages.py:58 picard/const/locales.py:528
+msgid "Italian"
+msgstr ""
+
+#: picard/const/languages.py:59 picard/const/locales.py:537
+msgid "Japanese"
+msgstr ""
+
+#: picard/const/languages.py:61 picard/const/locales.py:585
+msgid "Korean"
+msgstr ""
+
+#: picard/const/languages.py:63 picard/const/locales.py:689
+msgid "Malay (Malaysia)"
+msgstr ""
+
+#: picard/const/languages.py:64 picard/const/locales.py:705
+msgid "Norwegian Bokmål"
+msgstr ""
+
+#: picard/const/languages.py:66 picard/const/locales.py:716
+msgid "Dutch"
+msgstr ""
+
+#: picard/const/languages.py:67 picard/const/locales.py:745
+msgid "Occitan"
+msgstr ""
+
+#: picard/const/languages.py:68 picard/const/locales.py:772
+msgid "Polish"
+msgstr ""
+
+#: picard/const/languages.py:69 picard/const/locales.py:779
+msgid "Portuguese"
+msgstr ""
+
+#: picard/const/languages.py:70 picard/const/locales.py:781
+msgid "Portuguese (Brazil)"
+msgstr ""
+
+#: picard/const/languages.py:71 picard/const/locales.py:810
+msgid "Romanian"
+msgstr ""
+
+#: picard/const/languages.py:72 picard/const/locales.py:815
+msgid "Russian"
+msgstr ""
+
+#: picard/const/languages.py:74 picard/const/locales.py:873
+msgid "Slovak"
+msgstr ""
+
+#: picard/const/languages.py:75 picard/const/locales.py:875
+msgid "Slovenian"
+msgstr ""
+
+#: picard/const/languages.py:76 picard/const/locales.py:894
+msgid "Albanian"
+msgstr ""
+
+#: picard/const/languages.py:78 picard/const/locales.py:920
+msgid "Swedish"
+msgstr ""
+
+#: picard/const/languages.py:80 picard/const/locales.py:966
+msgid "Turkish"
+msgstr ""
+
+#: picard/const/languages.py:81 picard/const/locales.py:983
+msgid "Ukrainian"
+msgstr ""
+
+#: picard/const/languages.py:82
+msgid "Chinese (China)"
+msgstr ""
+
+#: picard/const/languages.py:83
+msgid "Chinese (Taiwan)"
+msgstr ""
+
+#: picard/const/locales.py:27
+msgid "Afar"
+msgstr ""
+
+#: picard/const/locales.py:28
+msgid "Afar (Djibouti)"
+msgstr ""
+
+#: picard/const/locales.py:29
+msgid "Afar (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:30
+msgid "Afar (Eritrea) (Saho)"
+msgstr ""
+
+#: picard/const/locales.py:31
+msgid "Afar (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:32
+msgid "Abkhazian"
+msgstr ""
+
+#: picard/const/locales.py:33
+msgid "Abkhazian (Georgia)"
+msgstr ""
+
+#: picard/const/locales.py:34
+msgid "Afrikaans"
+msgstr ""
+
+#: picard/const/locales.py:35
+msgid "Afrikaans (Namibia)"
+msgstr ""
+
+#: picard/const/locales.py:36
+msgid "Afrikaans (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:37
+msgid "Aghem"
+msgstr ""
+
+#: picard/const/locales.py:38
+msgid "Aghem (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:39
+msgid "Akan"
+msgstr ""
+
+#: picard/const/locales.py:40
+msgid "Akan (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:41
+msgid "Amharic"
+msgstr ""
+
+#: picard/const/locales.py:42
+msgid "Amharic (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:43
+msgid "Aragonese"
+msgstr ""
+
+#: picard/const/locales.py:44
+msgid "Aragonese (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:45
+msgid "Obolo"
+msgstr ""
+
+#: picard/const/locales.py:46
+msgid "Obolo (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:47
+msgid "Syria"
+msgstr ""
+
+#: picard/const/locales.py:49
+msgid "Arabic (world)"
+msgstr ""
+
+#: picard/const/locales.py:50
+msgid "Arabic (United Arab Emirates)"
+msgstr ""
+
+#: picard/const/locales.py:51
+msgid "Arabic (Bahrain)"
+msgstr ""
+
+#: picard/const/locales.py:52
+msgid "Arabic (Djibouti)"
+msgstr ""
+
+#: picard/const/locales.py:53
+msgid "Arabic (Algeria)"
+msgstr ""
+
+#: picard/const/locales.py:54
+msgid "Arabic (Egypt)"
+msgstr ""
+
+#: picard/const/locales.py:55
+msgid "Arabic (Western Sahara)"
+msgstr ""
+
+#: picard/const/locales.py:56
+msgid "Arabic (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:57
+msgid "Arabic (Israel)"
+msgstr ""
+
+#: picard/const/locales.py:58
+msgid "Arabic (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:59
+msgid "Arabic (Jordan)"
+msgstr ""
+
+#: picard/const/locales.py:60
+msgid "Arabic (Comoros)"
+msgstr ""
+
+#: picard/const/locales.py:61
+msgid "Arabic (Kuwait)"
+msgstr ""
+
+#: picard/const/locales.py:62
+msgid "Arabic (Lebanon)"
+msgstr ""
+
+#: picard/const/locales.py:63
+msgid "Arabic (Libya)"
+msgstr ""
+
+#: picard/const/locales.py:64
+msgid "Arabic (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:65
+msgid "Arabic (Mauritania)"
+msgstr ""
+
+#: picard/const/locales.py:66
+msgid "Arabic (Oman)"
+msgstr ""
+
+#: picard/const/locales.py:67
+msgid "Arabic (Palestinian Territories)"
+msgstr ""
+
+#: picard/const/locales.py:68
+msgid "Arabic (Qatar)"
+msgstr ""
+
+#: picard/const/locales.py:69
+msgid "Arabic (Saudi Arabia)"
+msgstr ""
+
+#: picard/const/locales.py:70
+msgid "Arabic (Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:71
+msgid "Arabic (Somalia)"
+msgstr ""
+
+#: picard/const/locales.py:72
+msgid "Arabic (South Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:73
+msgid "Arabic (Syria)"
+msgstr ""
+
+#: picard/const/locales.py:74
+msgid "Arabic (Chad)"
+msgstr ""
+
+#: picard/const/locales.py:75
+msgid "Arabic (Tunisia)"
+msgstr ""
+
+#: picard/const/locales.py:76
+msgid "Arabic (Yemen)"
+msgstr ""
+
+#: picard/const/locales.py:77
+msgid "Mapuche"
+msgstr ""
+
+#: picard/const/locales.py:78
+msgid "Mapuche (Chile)"
+msgstr ""
+
+#: picard/const/locales.py:79
+msgid "Assamese"
+msgstr ""
+
+#: picard/const/locales.py:80
+msgid "Assamese (India)"
+msgstr ""
+
+#: picard/const/locales.py:81
+msgid "Asu"
+msgstr ""
+
+#: picard/const/locales.py:82
+msgid "Asu (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:83
+msgid "Asturian"
+msgstr ""
+
+#: picard/const/locales.py:84
+msgid "Asturian (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:85
+msgid "Azerbaijani"
+msgstr ""
+
+#: picard/const/locales.py:86
+msgid "Azerbaijani (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:87
+msgid "Azerbaijani (Arabic) (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:88
+msgid "Azerbaijani (Arabic) (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:89
+msgid "Azerbaijani (Arabic) (Türkiye)"
+msgstr ""
+
+#: picard/const/locales.py:90
+msgid "Azerbaijani (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:91
+msgid "Azerbaijani (Cyrillic) (Azerbaijan)"
+msgstr ""
+
+#: picard/const/locales.py:92
+msgid "Azerbaijani (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:93
+msgid "Azerbaijani (Latin) (Azerbaijan)"
+msgstr ""
+
+#: picard/const/locales.py:94
+msgid "Bashkir"
+msgstr ""
+
+#: picard/const/locales.py:95
+msgid "Bashkir (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:96
+msgid "Baluchi"
+msgstr ""
+
+#: picard/const/locales.py:97
+msgid "Baluchi (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:98
+msgid "Baluchi (Arabic) (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:99
+msgid "Baluchi (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:100
+msgid "Baluchi (Latin) (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:101
+msgid "Basaa"
+msgstr ""
+
+#: picard/const/locales.py:102
+msgid "Basaa (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:103
+msgid "Belarusian"
+msgstr ""
+
+#: picard/const/locales.py:104
+msgid "Belarusian (Belarus)"
+msgstr ""
+
+#: picard/const/locales.py:105
+msgid "Belarusian (Taraskievica orthography)"
+msgstr ""
+
+#: picard/const/locales.py:106
+msgid "Bemba"
+msgstr ""
+
+#: picard/const/locales.py:107
+msgid "Bemba (Zambia)"
+msgstr ""
+
+#: picard/const/locales.py:108
+msgid "Bena"
+msgstr ""
+
+#: picard/const/locales.py:109
+msgid "Bena (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:110
+msgid "Bulgarian"
+msgstr ""
+
+#: picard/const/locales.py:111
+msgid "Bulgarian (Bulgaria)"
+msgstr ""
+
+#: picard/const/locales.py:112
+msgid "Haryanvi"
+msgstr ""
+
+#: picard/const/locales.py:113
+msgid "Haryanvi (India)"
+msgstr ""
+
+#: picard/const/locales.py:114
+msgid "Western Balochi"
+msgstr ""
+
+#: picard/const/locales.py:115
+msgid "Western Balochi (United Arab Emirates)"
+msgstr ""
+
+#: picard/const/locales.py:116
+msgid "Western Balochi (Afghanistan)"
+msgstr ""
+
+#: picard/const/locales.py:117
+msgid "Western Balochi (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:118
+msgid "Western Balochi (Oman)"
+msgstr ""
+
+#: picard/const/locales.py:119
+msgid "Western Balochi (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:120
+msgid "Bhojpuri"
+msgstr ""
+
+#: picard/const/locales.py:121
+msgid "Bhojpuri (India)"
+msgstr ""
+
+#: picard/const/locales.py:122
+msgid "Tai Dam"
+msgstr ""
+
+#: picard/const/locales.py:123
+msgid "Tai Dam (Vietnam)"
+msgstr ""
+
+#: picard/const/locales.py:124
+msgid "Bambara"
+msgstr ""
+
+#: picard/const/locales.py:125
+msgid "Bambara (Mali)"
+msgstr ""
+
+#: picard/const/locales.py:126
+msgid "Bambara (N’Ko)"
+msgstr ""
+
+#: picard/const/locales.py:127
+msgid "Bambara (N’Ko) (Mali)"
+msgstr ""
+
+#: picard/const/locales.py:128
+msgid "Bangla"
+msgstr ""
+
+#: picard/const/locales.py:129
+msgid "Bangla (Bangladesh)"
+msgstr ""
+
+#: picard/const/locales.py:130
+msgid "Bangla (India)"
+msgstr ""
+
+#: picard/const/locales.py:131
+msgid "Tibetan"
+msgstr ""
+
+#: picard/const/locales.py:132
+msgid "Tibetan (China)"
+msgstr ""
+
+#: picard/const/locales.py:133
+msgid "Tibetan (India)"
+msgstr ""
+
+#: picard/const/locales.py:134
+msgid "Breton"
+msgstr ""
+
+#: picard/const/locales.py:135
+msgid "Breton (France)"
+msgstr ""
+
+#: picard/const/locales.py:136
+msgid "Bodo"
+msgstr ""
+
+#: picard/const/locales.py:137
+msgid "Bodo (India)"
+msgstr ""
+
+#: picard/const/locales.py:138
+msgid "Bosnian"
+msgstr ""
+
+#: picard/const/locales.py:139
+msgid "Bosnian (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:140
+msgid "Bosnian (Cyrillic) (Bosnia & Herzegovina)"
+msgstr ""
+
+#: picard/const/locales.py:141
+msgid "Bosnian (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:142
+msgid "Bosnian (Latin) (Bosnia & Herzegovina)"
+msgstr ""
+
+#: picard/const/locales.py:143
+msgid "Akoose"
+msgstr ""
+
+#: picard/const/locales.py:144
+msgid "Akoose (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:145
+msgid "Blin"
+msgstr ""
+
+#: picard/const/locales.py:146
+msgid "Blin (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:148
+msgid "Catalan (Andorra)"
+msgstr ""
+
+#: picard/const/locales.py:149
+msgid "Catalan (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:150
+msgid "Catalan (Spain Valencian)"
+msgstr ""
+
+#: picard/const/locales.py:151
+msgid "Catalan (France)"
+msgstr ""
+
+#: picard/const/locales.py:152
+msgid "Catalan (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:153
+msgid "Caddo"
+msgstr ""
+
+#: picard/const/locales.py:154
+msgid "Caddo (United States)"
+msgstr ""
+
+#: picard/const/locales.py:155
+msgid "Atsam"
+msgstr ""
+
+#: picard/const/locales.py:156
+msgid "Atsam (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:157
+msgid "Chakma"
+msgstr ""
+
+#: picard/const/locales.py:158
+msgid "Chakma (Bangladesh)"
+msgstr ""
+
+#: picard/const/locales.py:159
+msgid "Chakma (India)"
+msgstr ""
+
+#: picard/const/locales.py:160
+msgid "Chechen"
+msgstr ""
+
+#: picard/const/locales.py:161
+msgid "Chechen (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:162
+msgid "Cebuano"
+msgstr ""
+
+#: picard/const/locales.py:163
+msgid "Cebuano (Philippines)"
+msgstr ""
+
+#: picard/const/locales.py:164
+msgid "Chiga"
+msgstr ""
+
+#: picard/const/locales.py:165
+msgid "Chiga (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:166
+msgid "Choctaw"
+msgstr ""
+
+#: picard/const/locales.py:167
+msgid "Choctaw (United States)"
+msgstr ""
+
+#: picard/const/locales.py:168
+msgid "Cherokee"
+msgstr ""
+
+#: picard/const/locales.py:169
+msgid "Cherokee (United States)"
+msgstr ""
+
+#: picard/const/locales.py:170
+msgid "Chickasaw"
+msgstr ""
+
+#: picard/const/locales.py:171
+msgid "Chickasaw (United States)"
+msgstr ""
+
+#: picard/const/locales.py:172
+msgid "Central Kurdish"
+msgstr ""
+
+#: picard/const/locales.py:173
+msgid "Central Kurdish (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:174
+msgid "Central Kurdish (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:175
+msgid "Corsican"
+msgstr ""
+
+#: picard/const/locales.py:176
+msgid "Corsican (France)"
+msgstr ""
+
+#: picard/const/locales.py:178
+msgid "Czech (Czechia)"
+msgstr ""
+
+#: picard/const/locales.py:179
+msgid "Church Slavic"
+msgstr ""
+
+#: picard/const/locales.py:180
+msgid "Church Slavic (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:181
+msgid "Chuvash"
+msgstr ""
+
+#: picard/const/locales.py:182
+msgid "Chuvash (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:183
+msgid "Welsh"
+msgstr ""
+
+#: picard/const/locales.py:184
+msgid "Welsh (United Kingdom)"
+msgstr ""
+
+#: picard/const/locales.py:186
+msgid "Danish (Denmark)"
+msgstr ""
+
+#: picard/const/locales.py:187
+msgid "Danish (Greenland)"
+msgstr ""
+
+#: picard/const/locales.py:188
+msgid "Taita"
+msgstr ""
+
+#: picard/const/locales.py:189
+msgid "Taita (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:191
+msgid "German (Austria)"
+msgstr ""
+
+#: picard/const/locales.py:192
+msgid "German (Belgium)"
+msgstr ""
+
+#: picard/const/locales.py:194
+msgid "German (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:195
+msgid "German (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:196
+msgid "German (Liechtenstein)"
+msgstr ""
+
+#: picard/const/locales.py:197
+msgid "German (Luxembourg)"
+msgstr ""
+
+#: picard/const/locales.py:198
+msgid "Zarma"
+msgstr ""
+
+#: picard/const/locales.py:199
+msgid "Zarma (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:200
+msgid "Dogri"
+msgstr ""
+
+#: picard/const/locales.py:201
+msgid "Dogri (India)"
+msgstr ""
+
+#: picard/const/locales.py:202
+msgid "Lower Sorbian"
+msgstr ""
+
+#: picard/const/locales.py:203
+msgid "Lower Sorbian (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:204
+msgid "Duala"
+msgstr ""
+
+#: picard/const/locales.py:205
+msgid "Duala (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:206
+msgid "Divehi"
+msgstr ""
+
+#: picard/const/locales.py:207
+msgid "Divehi (Maldives)"
+msgstr ""
+
+#: picard/const/locales.py:208
+msgid "Jola-Fonyi"
+msgstr ""
+
+#: picard/const/locales.py:209
+msgid "Jola-Fonyi (Senegal)"
+msgstr ""
+
+#: picard/const/locales.py:210
+msgid "Dzongkha"
+msgstr ""
+
+#: picard/const/locales.py:211
+msgid "Dzongkha (Bhutan)"
+msgstr ""
+
+#: picard/const/locales.py:212
+msgid "Embu"
+msgstr ""
+
+#: picard/const/locales.py:213
+msgid "Embu (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:214
+msgid "Ewe"
+msgstr ""
+
+#: picard/const/locales.py:215
+msgid "Ewe (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:216
+msgid "Ewe (Togo)"
+msgstr ""
+
+#: picard/const/locales.py:218
+msgid "Greek (Cyprus)"
+msgstr ""
+
+#: picard/const/locales.py:219
+msgid "Greek (Greece)"
+msgstr ""
+
+#: picard/const/locales.py:220
+msgid "Greek (Polytonic)"
+msgstr ""
+
+#: picard/const/locales.py:222
+msgid "English (world)"
+msgstr ""
+
+#: picard/const/locales.py:223
+msgid "English (Europe)"
+msgstr ""
+
+#: picard/const/locales.py:224
+msgid "English (United Arab Emirates)"
+msgstr ""
+
+#: picard/const/locales.py:225
+msgid "English (Antigua & Barbuda)"
+msgstr ""
+
+#: picard/const/locales.py:226
+msgid "English (Anguilla)"
+msgstr ""
+
+#: picard/const/locales.py:227
+msgid "English (American Samoa)"
+msgstr ""
+
+#: picard/const/locales.py:228
+msgid "English (Austria)"
+msgstr ""
+
+#: picard/const/locales.py:230
+msgid "English (Barbados)"
+msgstr ""
+
+#: picard/const/locales.py:231
+msgid "English (Belgium)"
+msgstr ""
+
+#: picard/const/locales.py:232
+msgid "English (Burundi)"
+msgstr ""
+
+#: picard/const/locales.py:233
+msgid "English (Bermuda)"
+msgstr ""
+
+#: picard/const/locales.py:234
+msgid "English (Bahamas)"
+msgstr ""
+
+#: picard/const/locales.py:235
+msgid "English (Botswana)"
+msgstr ""
+
+#: picard/const/locales.py:236
+msgid "English (Belize)"
+msgstr ""
+
+#: picard/const/locales.py:238
+msgid "English (Cocos (Keeling) Islands)"
+msgstr ""
+
+#: picard/const/locales.py:239
+msgid "English (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:240
+msgid "English (Cook Islands)"
+msgstr ""
+
+#: picard/const/locales.py:241
+msgid "English (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:242
+msgid "English (Christmas Island)"
+msgstr ""
+
+#: picard/const/locales.py:243
+msgid "English (Cyprus)"
+msgstr ""
+
+#: picard/const/locales.py:244
+msgid "English (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:245
+msgid "English (Diego Garcia)"
+msgstr ""
+
+#: picard/const/locales.py:246
+msgid "English (Denmark)"
+msgstr ""
+
+#: picard/const/locales.py:247
+msgid "English (Dominica)"
+msgstr ""
+
+#: picard/const/locales.py:248
+msgid "English (Deseret)"
+msgstr ""
+
+#: picard/const/locales.py:249
+msgid "English (Deseret) (United States)"
+msgstr ""
+
+#: picard/const/locales.py:250
+msgid "English (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:251
+msgid "English (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:252
+msgid "English (Fiji)"
+msgstr ""
+
+#: picard/const/locales.py:253
+msgid "English (Falkland Islands)"
+msgstr ""
+
+#: picard/const/locales.py:254
+msgid "English (Micronesia)"
+msgstr ""
+
+#: picard/const/locales.py:256
+msgid "English (Grenada)"
+msgstr ""
+
+#: picard/const/locales.py:257
+msgid "English (Guernsey)"
+msgstr ""
+
+#: picard/const/locales.py:258
+msgid "English (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:259
+msgid "English (Gibraltar)"
+msgstr ""
+
+#: picard/const/locales.py:260
+msgid "English (Gambia)"
+msgstr ""
+
+#: picard/const/locales.py:261
+msgid "English (Guam)"
+msgstr ""
+
+#: picard/const/locales.py:262
+msgid "English (Guyana)"
+msgstr ""
+
+#: picard/const/locales.py:263
+msgid "English (Hong Kong)"
+msgstr ""
+
+#: picard/const/locales.py:264
+msgid "English (Ireland)"
+msgstr ""
+
+#: picard/const/locales.py:265
+msgid "English (Israel)"
+msgstr ""
+
+#: picard/const/locales.py:266
+msgid "English (Isle of Man)"
+msgstr ""
+
+#: picard/const/locales.py:267
+msgid "English (India)"
+msgstr ""
+
+#: picard/const/locales.py:268
+msgid "English (British Indian Ocean Territory)"
+msgstr ""
+
+#: picard/const/locales.py:269
+msgid "English (Jersey)"
+msgstr ""
+
+#: picard/const/locales.py:270
+msgid "English (Jamaica)"
+msgstr ""
+
+#: picard/const/locales.py:271
+msgid "English (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:272
+msgid "English (Kiribati)"
+msgstr ""
+
+#: picard/const/locales.py:273
+msgid "English (St. Kitts & Nevis)"
+msgstr ""
+
+#: picard/const/locales.py:274
+msgid "English (Cayman Islands)"
+msgstr ""
+
+#: picard/const/locales.py:275
+msgid "English (St. Lucia)"
+msgstr ""
+
+#: picard/const/locales.py:276
+msgid "English (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:277
+msgid "English (Lesotho)"
+msgstr ""
+
+#: picard/const/locales.py:278
+msgid "English (Madagascar)"
+msgstr ""
+
+#: picard/const/locales.py:279
+msgid "English (Marshall Islands)"
+msgstr ""
+
+#: picard/const/locales.py:280
+msgid "English (Macao)"
+msgstr ""
+
+#: picard/const/locales.py:281
+msgid "English (Northern Mariana Islands)"
+msgstr ""
+
+#: picard/const/locales.py:282
+msgid "English (Montserrat)"
+msgstr ""
+
+#: picard/const/locales.py:283
+msgid "English (Malta)"
+msgstr ""
+
+#: picard/const/locales.py:284
+msgid "English (Mauritius)"
+msgstr ""
+
+#: picard/const/locales.py:285
+msgid "English (Maldives)"
+msgstr ""
+
+#: picard/const/locales.py:286
+msgid "English (Malawi)"
+msgstr ""
+
+#: picard/const/locales.py:287
+msgid "English (Malaysia)"
+msgstr ""
+
+#: picard/const/locales.py:288
+msgid "English (Namibia)"
+msgstr ""
+
+#: picard/const/locales.py:289
+msgid "English (Norfolk Island)"
+msgstr ""
+
+#: picard/const/locales.py:290
+msgid "English (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:291
+msgid "English (Netherlands)"
+msgstr ""
+
+#: picard/const/locales.py:292
+msgid "English (Nauru)"
+msgstr ""
+
+#: picard/const/locales.py:293
+msgid "English (Niue)"
+msgstr ""
+
+#: picard/const/locales.py:294
+msgid "English (New Zealand)"
+msgstr ""
+
+#: picard/const/locales.py:295
+msgid "English (Papua New Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:296
+msgid "English (Philippines)"
+msgstr ""
+
+#: picard/const/locales.py:297
+msgid "English (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:298
+msgid "English (Pitcairn Islands)"
+msgstr ""
+
+#: picard/const/locales.py:299
+msgid "English (Puerto Rico)"
+msgstr ""
+
+#: picard/const/locales.py:300
+msgid "English (Palau)"
+msgstr ""
+
+#: picard/const/locales.py:301
+msgid "English (Rwanda)"
+msgstr ""
+
+#: picard/const/locales.py:302
+msgid "English (Solomon Islands)"
+msgstr ""
+
+#: picard/const/locales.py:303
+msgid "English (Seychelles)"
+msgstr ""
+
+#: picard/const/locales.py:304
+msgid "English (Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:305
+msgid "English (Sweden)"
+msgstr ""
+
+#: picard/const/locales.py:306
+msgid "English (Singapore)"
+msgstr ""
+
+#: picard/const/locales.py:307
+msgid "English (St. Helena)"
+msgstr ""
+
+#: picard/const/locales.py:308
+msgid "English (Slovenia)"
+msgstr ""
+
+#: picard/const/locales.py:309
+msgid "English (Sierra Leone)"
+msgstr ""
+
+#: picard/const/locales.py:310
+msgid "English (South Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:311
+msgid "English (Sint Maarten)"
+msgstr ""
+
+#: picard/const/locales.py:312
+msgid "English (Eswatini)"
+msgstr ""
+
+#: picard/const/locales.py:313
+msgid "English (Shavian)"
+msgstr ""
+
+#: picard/const/locales.py:314
+msgid "English (Shavian) (United Kingdom)"
+msgstr ""
+
+#: picard/const/locales.py:315
+msgid "English (Turks & Caicos Islands)"
+msgstr ""
+
+#: picard/const/locales.py:316
+msgid "English (Tokelau)"
+msgstr ""
+
+#: picard/const/locales.py:317
+msgid "English (Tonga)"
+msgstr ""
+
+#: picard/const/locales.py:318
+msgid "English (Trinidad & Tobago)"
+msgstr ""
+
+#: picard/const/locales.py:319
+msgid "English (Tuvalu)"
+msgstr ""
+
+#: picard/const/locales.py:320
+msgid "English (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:321
+msgid "English (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:322
+msgid "English (U.S. Outlying Islands)"
+msgstr ""
+
+#: picard/const/locales.py:323
+msgid "English (United States)"
+msgstr ""
+
+#: picard/const/locales.py:324
+msgid "English (St. Vincent & Grenadines)"
+msgstr ""
+
+#: picard/const/locales.py:325
+msgid "English (British Virgin Islands)"
+msgstr ""
+
+#: picard/const/locales.py:326
+msgid "English (U.S. Virgin Islands)"
+msgstr ""
+
+#: picard/const/locales.py:327
+msgid "English (Vanuatu)"
+msgstr ""
+
+#: picard/const/locales.py:328
+msgid "English (Samoa)"
+msgstr ""
+
+#: picard/const/locales.py:329
+msgid "English (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:330
+msgid "English (Zambia)"
+msgstr ""
+
+#: picard/const/locales.py:331
+msgid "English (Zimbabwe)"
+msgstr ""
+
+#: picard/const/locales.py:332
+msgid "Esperanto"
+msgstr ""
+
+#: picard/const/locales.py:333
+msgid "Esperanto (world)"
+msgstr ""
+
+#: picard/const/locales.py:335
+msgid "Spanish (Latin America)"
+msgstr ""
+
+#: picard/const/locales.py:336
+msgid "Spanish (Argentina)"
+msgstr ""
+
+#: picard/const/locales.py:337
+msgid "Spanish (Bolivia)"
+msgstr ""
+
+#: picard/const/locales.py:338
+msgid "Spanish (Brazil)"
+msgstr ""
+
+#: picard/const/locales.py:339
+msgid "Spanish (Belize)"
+msgstr ""
+
+#: picard/const/locales.py:340
+msgid "Spanish (Chile)"
+msgstr ""
+
+#: picard/const/locales.py:341
+msgid "Spanish (Colombia)"
+msgstr ""
+
+#: picard/const/locales.py:342
+msgid "Spanish (Costa Rica)"
+msgstr ""
+
+#: picard/const/locales.py:343
+msgid "Spanish (Cuba)"
+msgstr ""
+
+#: picard/const/locales.py:344
+msgid "Spanish (Dominican Republic)"
+msgstr ""
+
+#: picard/const/locales.py:345
+msgid "Spanish (Ceuta & Melilla)"
+msgstr ""
+
+#: picard/const/locales.py:346
+msgid "Spanish (Ecuador)"
+msgstr ""
+
+#: picard/const/locales.py:347
+msgid "Spanish (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:348
+msgid "Spanish (Equatorial Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:349
+msgid "Spanish (Guatemala)"
+msgstr ""
+
+#: picard/const/locales.py:350
+msgid "Spanish (Honduras)"
+msgstr ""
+
+#: picard/const/locales.py:351
+msgid "Spanish (Canary Islands)"
+msgstr ""
+
+#: picard/const/locales.py:352
+msgid "Spanish (Mexico)"
+msgstr ""
+
+#: picard/const/locales.py:353
+msgid "Spanish (Nicaragua)"
+msgstr ""
+
+#: picard/const/locales.py:354
+msgid "Spanish (Panama)"
+msgstr ""
+
+#: picard/const/locales.py:355
+msgid "Spanish (Peru)"
+msgstr ""
+
+#: picard/const/locales.py:356
+msgid "Spanish (Philippines)"
+msgstr ""
+
+#: picard/const/locales.py:357
+msgid "Spanish (Puerto Rico)"
+msgstr ""
+
+#: picard/const/locales.py:358
+msgid "Spanish (Paraguay)"
+msgstr ""
+
+#: picard/const/locales.py:359
+msgid "Spanish (El Salvador)"
+msgstr ""
+
+#: picard/const/locales.py:360
+msgid "Spanish (United States)"
+msgstr ""
+
+#: picard/const/locales.py:361
+msgid "Spanish (Uruguay)"
+msgstr ""
+
+#: picard/const/locales.py:362
+msgid "Spanish (Venezuela)"
+msgstr ""
+
+#: picard/const/locales.py:364
+msgid "Estonian (Estonia)"
+msgstr ""
+
+#: picard/const/locales.py:365
+msgid "Basque"
+msgstr ""
+
+#: picard/const/locales.py:366
+msgid "Basque (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:367
+msgid "Ewondo"
+msgstr ""
+
+#: picard/const/locales.py:368
+msgid "Ewondo (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:369
+msgid "Persian"
+msgstr ""
+
+#: picard/const/locales.py:370
+msgid "Persian (Afghanistan)"
+msgstr ""
+
+#: picard/const/locales.py:371
+msgid "Persian (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:372
+msgid "Fula"
+msgstr ""
+
+#: picard/const/locales.py:373
+msgid "Fula (Adlam)"
+msgstr ""
+
+#: picard/const/locales.py:374
+msgid "Fula (Adlam) (Burkina Faso)"
+msgstr ""
+
+#: picard/const/locales.py:375
+msgid "Fula (Adlam) (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:376
+msgid "Fula (Adlam) (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:377
+msgid "Fula (Adlam) (Gambia)"
+msgstr ""
+
+#: picard/const/locales.py:378
+msgid "Fula (Adlam) (Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:379
+msgid "Fula (Adlam) (Guinea-Bissau)"
+msgstr ""
+
+#: picard/const/locales.py:380
+msgid "Fula (Adlam) (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:381
+msgid "Fula (Adlam) (Mauritania)"
+msgstr ""
+
+#: picard/const/locales.py:382
+msgid "Fula (Adlam) (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:383
+msgid "Fula (Adlam) (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:384
+msgid "Fula (Adlam) (Sierra Leone)"
+msgstr ""
+
+#: picard/const/locales.py:385
+msgid "Fula (Adlam) (Senegal)"
+msgstr ""
+
+#: picard/const/locales.py:386
+msgid "Fula (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:387
+msgid "Fula (Latin) (Burkina Faso)"
+msgstr ""
+
+#: picard/const/locales.py:388
+msgid "Fula (Latin) (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:389
+msgid "Fula (Latin) (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:390
+msgid "Fula (Latin) (Gambia)"
+msgstr ""
+
+#: picard/const/locales.py:391
+msgid "Fula (Latin) (Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:392
+msgid "Fula (Latin) (Guinea-Bissau)"
+msgstr ""
+
+#: picard/const/locales.py:393
+msgid "Fula (Latin) (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:394
+msgid "Fula (Latin) (Mauritania)"
+msgstr ""
+
+#: picard/const/locales.py:395
+msgid "Fula (Latin) (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:396
+msgid "Fula (Latin) (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:397
+msgid "Fula (Latin) (Sierra Leone)"
+msgstr ""
+
+#: picard/const/locales.py:398
+msgid "Fula (Latin) (Senegal)"
+msgstr ""
+
+#: picard/const/locales.py:400
+msgid "Finnish (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:401
+msgid "Filipino"
+msgstr ""
+
+#: picard/const/locales.py:402
+msgid "Filipino (Philippines)"
+msgstr ""
+
+#: picard/const/locales.py:403
+msgid "Faroese"
+msgstr ""
+
+#: picard/const/locales.py:404
+msgid "Faroese (Denmark)"
+msgstr ""
+
+#: picard/const/locales.py:405
+msgid "Faroese (Faroe Islands)"
+msgstr ""
+
+#: picard/const/locales.py:407
+msgid "French (Belgium)"
+msgstr ""
+
+#: picard/const/locales.py:408
+msgid "French (Burkina Faso)"
+msgstr ""
+
+#: picard/const/locales.py:409
+msgid "French (Burundi)"
+msgstr ""
+
+#: picard/const/locales.py:410
+msgid "French (Benin)"
+msgstr ""
+
+#: picard/const/locales.py:411
+msgid "French (St. Barthélemy)"
+msgstr ""
+
+#: picard/const/locales.py:413
+msgid "French (Congo - Kinshasa)"
+msgstr ""
+
+#: picard/const/locales.py:414
+msgid "French (Central African Republic)"
+msgstr ""
+
+#: picard/const/locales.py:415
+msgid "French (Congo - Brazzaville)"
+msgstr ""
+
+#: picard/const/locales.py:416
+msgid "French (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:417
+msgid "French (Côte d’Ivoire)"
+msgstr ""
+
+#: picard/const/locales.py:418
+msgid "French (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:419
+msgid "French (Djibouti)"
+msgstr ""
+
+#: picard/const/locales.py:420
+msgid "French (Algeria)"
+msgstr ""
+
+#: picard/const/locales.py:421
+msgid "French (France)"
+msgstr ""
+
+#: picard/const/locales.py:422
+msgid "French (Gabon)"
+msgstr ""
+
+#: picard/const/locales.py:423
+msgid "French (French Guiana)"
+msgstr ""
+
+#: picard/const/locales.py:424
+msgid "French (Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:425
+msgid "French (Guadeloupe)"
+msgstr ""
+
+#: picard/const/locales.py:426
+msgid "French (Equatorial Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:427
+msgid "French (Haiti)"
+msgstr ""
+
+#: picard/const/locales.py:428
+msgid "French (Comoros)"
+msgstr ""
+
+#: picard/const/locales.py:429
+msgid "French (Luxembourg)"
+msgstr ""
+
+#: picard/const/locales.py:430
+msgid "French (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:431
+msgid "French (Monaco)"
+msgstr ""
+
+#: picard/const/locales.py:432
+msgid "French (St. Martin)"
+msgstr ""
+
+#: picard/const/locales.py:433
+msgid "French (Madagascar)"
+msgstr ""
+
+#: picard/const/locales.py:434
+msgid "French (Mali)"
+msgstr ""
+
+#: picard/const/locales.py:435
+msgid "French (Martinique)"
+msgstr ""
+
+#: picard/const/locales.py:436
+msgid "French (Mauritania)"
+msgstr ""
+
+#: picard/const/locales.py:437
+msgid "French (Mauritius)"
+msgstr ""
+
+#: picard/const/locales.py:438
+msgid "French (New Caledonia)"
+msgstr ""
+
+#: picard/const/locales.py:439
+msgid "French (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:440
+msgid "French (French Polynesia)"
+msgstr ""
+
+#: picard/const/locales.py:441
+msgid "French (St. Pierre & Miquelon)"
+msgstr ""
+
+#: picard/const/locales.py:442
+msgid "French (Réunion)"
+msgstr ""
+
+#: picard/const/locales.py:443
+msgid "French (Rwanda)"
+msgstr ""
+
+#: picard/const/locales.py:444
+msgid "French (Seychelles)"
+msgstr ""
+
+#: picard/const/locales.py:445
+msgid "French (Senegal)"
+msgstr ""
+
+#: picard/const/locales.py:446
+msgid "French (Syria)"
+msgstr ""
+
+#: picard/const/locales.py:447
+msgid "French (Chad)"
+msgstr ""
+
+#: picard/const/locales.py:448
+msgid "French (Togo)"
+msgstr ""
+
+#: picard/const/locales.py:449
+msgid "French (Tunisia)"
+msgstr ""
+
+#: picard/const/locales.py:450
+msgid "French (Vanuatu)"
+msgstr ""
+
+#: picard/const/locales.py:451
+msgid "French (Wallis & Futuna)"
+msgstr ""
+
+#: picard/const/locales.py:452
+msgid "French (Mayotte)"
+msgstr ""
+
+#: picard/const/locales.py:453
+msgid "Northern Frisian"
+msgstr ""
+
+#: picard/const/locales.py:454
+msgid "Northern Frisian (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:455
+msgid "Friulian"
+msgstr ""
+
+#: picard/const/locales.py:456
+msgid "Friulian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:457
+msgid "Western Frisian"
+msgstr ""
+
+#: picard/const/locales.py:458
+msgid "Western Frisian (Netherlands)"
+msgstr ""
+
+#: picard/const/locales.py:459
+msgid "Irish"
+msgstr ""
+
+#: picard/const/locales.py:460
+msgid "Irish (United Kingdom)"
+msgstr ""
+
+#: picard/const/locales.py:461
+msgid "Irish (Ireland)"
+msgstr ""
+
+#: picard/const/locales.py:462
+msgid "Ga"
+msgstr ""
+
+#: picard/const/locales.py:463
+msgid "Ga (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:464
+msgid "Scottish Gaelic"
+msgstr ""
+
+#: picard/const/locales.py:465
+msgid "Scottish Gaelic (United Kingdom)"
+msgstr ""
+
+#: picard/const/locales.py:466
+msgid "Geez"
+msgstr ""
+
+#: picard/const/locales.py:467
+msgid "Geez (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:468
+msgid "Geez (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:470
+msgid "Galician (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:471
+msgid "Guarani"
+msgstr ""
+
+#: picard/const/locales.py:472
+msgid "Guarani (Paraguay)"
+msgstr ""
+
+#: picard/const/locales.py:473
+msgid "Swiss German"
+msgstr ""
+
+#: picard/const/locales.py:474
+msgid "Swiss German (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:475
+msgid "Swiss German (France)"
+msgstr ""
+
+#: picard/const/locales.py:476
+msgid "Swiss German (Liechtenstein)"
+msgstr ""
+
+#: picard/const/locales.py:477
+msgid "Gujarati"
+msgstr ""
+
+#: picard/const/locales.py:478
+msgid "Gujarati (India)"
+msgstr ""
+
+#: picard/const/locales.py:479
+msgid "Gusii"
+msgstr ""
+
+#: picard/const/locales.py:480
+msgid "Gusii (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:481
+msgid "Manx"
+msgstr ""
+
+#: picard/const/locales.py:482
+msgid "Manx (Isle of Man)"
+msgstr ""
+
+#: picard/const/locales.py:483
+msgid "Hausa"
+msgstr ""
+
+#: picard/const/locales.py:484
+msgid "Hausa (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:485
+msgid "Hausa (Arabic) (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:486
+msgid "Hausa (Arabic) (Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:487
+msgid "Hausa (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:488
+msgid "Hausa (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:489
+msgid "Hausa (Latin) (Ghana)"
+msgstr ""
+
+#: picard/const/locales.py:490
+msgid "Hausa (Latin) (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:491
+msgid "Hausa (Latin) (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:492
+msgid "Hausa (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:493
+msgid "Hausa (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:494
+msgid "Hausa (Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:495
+msgid "Hawaiian"
+msgstr ""
+
+#: picard/const/locales.py:496
+msgid "Hawaiian (United States)"
+msgstr ""
+
+#: picard/const/locales.py:498
+msgid "Hebrew (Israel)"
+msgstr ""
+
+#: picard/const/locales.py:499
+msgid "Hindi"
+msgstr ""
+
+#: picard/const/locales.py:500
+msgid "Hindi (India)"
+msgstr ""
+
+#: picard/const/locales.py:501
+msgid "Hindi (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:502
+msgid "Hindi (Latin) (India)"
+msgstr ""
+
+#: picard/const/locales.py:503
+msgid "Hmong Njua"
+msgstr ""
+
+#: picard/const/locales.py:504
+msgid "Hmong Njua (Nyiakeng Puachue Hmong)"
+msgstr ""
+
+#: picard/const/locales.py:505
+msgid "Hmong Njua (Nyiakeng Puachue Hmong) (United States)"
+msgstr ""
+
+#: picard/const/locales.py:506
+msgid "Croatian"
+msgstr ""
+
+#: picard/const/locales.py:507
+msgid "Croatian (Bosnia & Herzegovina)"
+msgstr ""
+
+#: picard/const/locales.py:508
+msgid "Croatian (Croatia)"
+msgstr ""
+
+#: picard/const/locales.py:509
+msgid "Upper Sorbian"
+msgstr ""
+
+#: picard/const/locales.py:510
+msgid "Upper Sorbian (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:512
+msgid "Hungarian (Hungary)"
+msgstr ""
+
+#: picard/const/locales.py:513
+msgid "Armenian"
+msgstr ""
+
+#: picard/const/locales.py:514
+msgid "Armenian (Armenia)"
+msgstr ""
+
+#: picard/const/locales.py:515
+msgid "Armenian (Armenia) (Revised Orthography)"
+msgstr ""
+
+#: picard/const/locales.py:516
+msgid "Interlingua"
+msgstr ""
+
+#: picard/const/locales.py:517
+msgid "Interlingua (world)"
+msgstr ""
+
+#: picard/const/locales.py:518
+msgid "Indonesian"
+msgstr ""
+
+#: picard/const/locales.py:519
+msgid "Indonesian (Indonesia)"
+msgstr ""
+
+#: picard/const/locales.py:520
+msgid "Igbo"
+msgstr ""
+
+#: picard/const/locales.py:521
+msgid "Igbo (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:522
+msgid "Sichuan Yi"
+msgstr ""
+
+#: picard/const/locales.py:523
+msgid "Sichuan Yi (China)"
+msgstr ""
+
+#: picard/const/locales.py:524
+msgid "Ido"
+msgstr ""
+
+#: picard/const/locales.py:525
+msgid "Ido (world)"
+msgstr ""
+
+#: picard/const/locales.py:527
+msgid "Icelandic (Iceland)"
+msgstr ""
+
+#: picard/const/locales.py:529
+msgid "Italian (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:530
+msgid "Italian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:531
+msgid "Italian (San Marino)"
+msgstr ""
+
+#: picard/const/locales.py:532
+msgid "Italian (Vatican City)"
+msgstr ""
+
+#: picard/const/locales.py:533
+msgid "Inuktitut"
+msgstr ""
+
+#: picard/const/locales.py:534
+msgid "Inuktitut (Canada)"
+msgstr ""
+
+#: picard/const/locales.py:535
+msgid "Inuktitut (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:536
+msgid "Inuktitut (Latin) (Canada)"
+msgstr ""
+
+#: picard/const/locales.py:538
+msgid "Japanese (Japan)"
+msgstr ""
+
+#: picard/const/locales.py:539
+msgid "Lojban"
+msgstr ""
+
+#: picard/const/locales.py:540
+msgid "Lojban (world)"
+msgstr ""
+
+#: picard/const/locales.py:541
+msgid "Ngomba"
+msgstr ""
+
+#: picard/const/locales.py:542
+msgid "Ngomba (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:543
+msgid "Machame"
+msgstr ""
+
+#: picard/const/locales.py:544
+msgid "Machame (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:545
+msgid "Javanese"
+msgstr ""
+
+#: picard/const/locales.py:546
+msgid "Javanese (Indonesia)"
+msgstr ""
+
+#: picard/const/locales.py:547
+msgid "Georgian"
+msgstr ""
+
+#: picard/const/locales.py:548
+msgid "Georgian (Georgia)"
+msgstr ""
+
+#: picard/const/locales.py:549
+msgid "Kabyle"
+msgstr ""
+
+#: picard/const/locales.py:550
+msgid "Kabyle (Algeria)"
+msgstr ""
+
+#: picard/const/locales.py:551
+msgid "Jju"
+msgstr ""
+
+#: picard/const/locales.py:552
+msgid "Jju (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:553
+msgid "Kamba"
+msgstr ""
+
+#: picard/const/locales.py:554
+msgid "Kamba (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:555
+msgid "Tyap"
+msgstr ""
+
+#: picard/const/locales.py:556
+msgid "Tyap (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:557
+msgid "Makonde"
+msgstr ""
+
+#: picard/const/locales.py:558
+msgid "Makonde (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:559
+msgid "Kabuverdianu"
+msgstr ""
+
+#: picard/const/locales.py:560
+msgid "Kabuverdianu (Cape Verde)"
+msgstr ""
+
+#: picard/const/locales.py:561
+msgid "Kenyang"
+msgstr ""
+
+#: picard/const/locales.py:562
+msgid "Kenyang (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:563
+msgid "Koro"
+msgstr ""
+
+#: picard/const/locales.py:564
+msgid "Koro (Côte d’Ivoire)"
+msgstr ""
+
+#: picard/const/locales.py:565
+msgid "Kaingang"
+msgstr ""
+
+#: picard/const/locales.py:566
+msgid "Kaingang (Brazil)"
+msgstr ""
+
+#: picard/const/locales.py:567
+msgid "Koyra Chiini"
+msgstr ""
+
+#: picard/const/locales.py:568
+msgid "Koyra Chiini (Mali)"
+msgstr ""
+
+#: picard/const/locales.py:569
+msgid "Kikuyu"
+msgstr ""
+
+#: picard/const/locales.py:570
+msgid "Kikuyu (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:571
+msgid "Kazakh"
+msgstr ""
+
+#: picard/const/locales.py:572
+msgid "Kazakh (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:573
+msgid "Kazakh (Cyrillic) (Kazakhstan)"
+msgstr ""
+
+#: picard/const/locales.py:574
+msgid "Kazakh (Kazakhstan)"
+msgstr ""
+
+#: picard/const/locales.py:575
+msgid "Kako"
+msgstr ""
+
+#: picard/const/locales.py:576
+msgid "Kako (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:577
+msgid "Kalaallisut"
+msgstr ""
+
+#: picard/const/locales.py:578
+msgid "Kalaallisut (Greenland)"
+msgstr ""
+
+#: picard/const/locales.py:579
+msgid "Kalenjin"
+msgstr ""
+
+#: picard/const/locales.py:580
+msgid "Kalenjin (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:581
+msgid "Khmer"
+msgstr ""
+
+#: picard/const/locales.py:582
+msgid "Khmer (Cambodia)"
+msgstr ""
+
+#: picard/const/locales.py:583
+msgid "Kannada"
+msgstr ""
+
+#: picard/const/locales.py:584
+msgid "Kannada (India)"
+msgstr ""
+
+#: picard/const/locales.py:586
+msgid "Korean (North Korea)"
+msgstr ""
+
+#: picard/const/locales.py:587
+msgid "Korean (South Korea)"
+msgstr ""
+
+#: picard/const/locales.py:588
+msgid "Konkani"
+msgstr ""
+
+#: picard/const/locales.py:589
+msgid "Konkani (India)"
+msgstr ""
+
+#: picard/const/locales.py:590
+msgid "Kpelle"
+msgstr ""
+
+#: picard/const/locales.py:591
+msgid "Kpelle (Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:592
+msgid "Kpelle (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:593
+msgid "Kashmiri"
+msgstr ""
+
+#: picard/const/locales.py:594
+msgid "Kashmiri (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:595
+msgid "Kashmiri (Arabic) (India)"
+msgstr ""
+
+#: picard/const/locales.py:596
+msgid "Kashmiri (Devanagari)"
+msgstr ""
+
+#: picard/const/locales.py:597
+msgid "Kashmiri (Devanagari) (India)"
+msgstr ""
+
+#: picard/const/locales.py:598
+msgid "Shambala"
+msgstr ""
+
+#: picard/const/locales.py:599
+msgid "Shambala (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:600
+msgid "Bafia"
+msgstr ""
+
+#: picard/const/locales.py:601
+msgid "Bafia (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:602
+msgid "Colognian"
+msgstr ""
+
+#: picard/const/locales.py:603
+msgid "Colognian (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:604
+msgid "Kurdish"
+msgstr ""
+
+#: picard/const/locales.py:605
+msgid "Kurdish (Türkiye)"
+msgstr ""
+
+#: picard/const/locales.py:606
+msgid "Cornish"
+msgstr ""
+
+#: picard/const/locales.py:607
+msgid "Cornish (United Kingdom)"
+msgstr ""
+
+#: picard/const/locales.py:608
+msgid "Kyrgyz"
+msgstr ""
+
+#: picard/const/locales.py:609
+msgid "Kyrgyz (Kyrgyzstan)"
+msgstr ""
+
+#: picard/const/locales.py:610 picard/const/scripts.py:28
+msgid "Latin"
+msgstr ""
+
+#: picard/const/locales.py:611
+msgid "Latin (Vatican City)"
+msgstr ""
+
+#: picard/const/locales.py:612
+msgid "Langi"
+msgstr ""
+
+#: picard/const/locales.py:613
+msgid "Langi (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:614
+msgid "Luxembourgish"
+msgstr ""
+
+#: picard/const/locales.py:615
+msgid "Luxembourgish (Luxembourg)"
+msgstr ""
+
+#: picard/const/locales.py:616
+msgid "Ganda"
+msgstr ""
+
+#: picard/const/locales.py:617
+msgid "Ganda (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:618
+msgid "Ligurian"
+msgstr ""
+
+#: picard/const/locales.py:619
+msgid "Ligurian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:620
+msgid "Lakota"
+msgstr ""
+
+#: picard/const/locales.py:621
+msgid "Lakota (United States)"
+msgstr ""
+
+#: picard/const/locales.py:622
+msgid "Lombard"
+msgstr ""
+
+#: picard/const/locales.py:623
+msgid "Lombard (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:624
+msgid "Lingala"
+msgstr ""
+
+#: picard/const/locales.py:625
+msgid "Lingala (Angola)"
+msgstr ""
+
+#: picard/const/locales.py:626
+msgid "Lingala (Congo - Kinshasa)"
+msgstr ""
+
+#: picard/const/locales.py:627
+msgid "Lingala (Central African Republic)"
+msgstr ""
+
+#: picard/const/locales.py:628
+msgid "Lingala (Congo - Brazzaville)"
+msgstr ""
+
+#: picard/const/locales.py:629
+msgid "Lao"
+msgstr ""
+
+#: picard/const/locales.py:630
+msgid "Lao (Laos)"
+msgstr ""
+
+#: picard/const/locales.py:631
+msgid "Northern Luri"
+msgstr ""
+
+#: picard/const/locales.py:632
+msgid "Northern Luri (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:633
+msgid "Northern Luri (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:634
+msgid "Lithuanian"
+msgstr ""
+
+#: picard/const/locales.py:635
+msgid "Lithuanian (Lithuania)"
+msgstr ""
+
+#: picard/const/locales.py:636
+msgid "Luba-Katanga"
+msgstr ""
+
+#: picard/const/locales.py:637
+msgid "Luba-Katanga (Congo - Kinshasa)"
+msgstr ""
+
+#: picard/const/locales.py:638
+msgid "Luo"
+msgstr ""
+
+#: picard/const/locales.py:639
+msgid "Luo (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:640
+msgid "Luyia"
+msgstr ""
+
+#: picard/const/locales.py:641
+msgid "Luyia (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:642
+msgid "Latvian"
+msgstr ""
+
+#: picard/const/locales.py:643
+msgid "Latvian (Latvia)"
+msgstr ""
+
+#: picard/const/locales.py:644
+msgid "Maithili"
+msgstr ""
+
+#: picard/const/locales.py:645
+msgid "Maithili (India)"
+msgstr ""
+
+#: picard/const/locales.py:646
+msgid "Masai"
+msgstr ""
+
+#: picard/const/locales.py:647
+msgid "Masai (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:648
+msgid "Masai (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:649
+msgid "Moksha"
+msgstr ""
+
+#: picard/const/locales.py:650
+msgid "Moksha (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:651
+msgid "Meru"
+msgstr ""
+
+#: picard/const/locales.py:652
+msgid "Meru (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:653
+msgid "Morisyen"
+msgstr ""
+
+#: picard/const/locales.py:654
+msgid "Morisyen (Mauritius)"
+msgstr ""
+
+#: picard/const/locales.py:655
+msgid "Malagasy"
+msgstr ""
+
+#: picard/const/locales.py:656
+msgid "Malagasy (Madagascar)"
+msgstr ""
+
+#: picard/const/locales.py:657
+msgid "Makhuwa-Meetto"
+msgstr ""
+
+#: picard/const/locales.py:658
+msgid "Makhuwa-Meetto (Mozambique)"
+msgstr ""
+
+#: picard/const/locales.py:659
+msgid "Metaʼ"
+msgstr ""
+
+#: picard/const/locales.py:660
+msgid "Metaʼ (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:661
+msgid "Māori"
+msgstr ""
+
+#: picard/const/locales.py:662
+msgid "Māori (New Zealand)"
+msgstr ""
+
+#: picard/const/locales.py:663
+msgid "Macedonian"
+msgstr ""
+
+#: picard/const/locales.py:664
+msgid "Macedonian (North Macedonia)"
+msgstr ""
+
+#: picard/const/locales.py:665
+msgid "Malayalam"
+msgstr ""
+
+#: picard/const/locales.py:666
+msgid "Malayalam (India)"
+msgstr ""
+
+#: picard/const/locales.py:667
+msgid "Mongolian"
+msgstr ""
+
+#: picard/const/locales.py:668
+msgid "Mongolian (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:669
+msgid "Mongolian (Cyrillic) (Mongolia)"
+msgstr ""
+
+#: picard/const/locales.py:670
+msgid "Mongolian (Mongolia)"
+msgstr ""
+
+#: picard/const/locales.py:671
+msgid "Mongolian (Mongolian)"
+msgstr ""
+
+#: picard/const/locales.py:672
+msgid "Mongolian (Mongolian) (China)"
+msgstr ""
+
+#: picard/const/locales.py:673
+msgid "Mongolian (Mongolian) (Mongolia)"
+msgstr ""
+
+#: picard/const/locales.py:674
+msgid "Manipuri"
+msgstr ""
+
+#: picard/const/locales.py:675
+msgid "Manipuri (Bangla)"
+msgstr ""
+
+#: picard/const/locales.py:676
+msgid "Manipuri (Bangla) (India)"
+msgstr ""
+
+#: picard/const/locales.py:677
+msgid "Manipuri (Meitei Mayek)"
+msgstr ""
+
+#: picard/const/locales.py:678
+msgid "Manipuri (Meitei Mayek) (India)"
+msgstr ""
+
+#: picard/const/locales.py:679
+msgid "Mohawk"
+msgstr ""
+
+#: picard/const/locales.py:680
+msgid "Mohawk (Canada)"
+msgstr ""
+
+#: picard/const/locales.py:681
+msgid "Marathi"
+msgstr ""
+
+#: picard/const/locales.py:682
+msgid "Marathi (India)"
+msgstr ""
+
+#: picard/const/locales.py:683
+msgid "Malay"
+msgstr ""
+
+#: picard/const/locales.py:684
+msgid "Malay (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:685
+msgid "Malay (Arabic) (Brunei)"
+msgstr ""
+
+#: picard/const/locales.py:686
+msgid "Malay (Arabic) (Malaysia)"
+msgstr ""
+
+#: picard/const/locales.py:687
+msgid "Malay (Brunei)"
+msgstr ""
+
+#: picard/const/locales.py:688
+msgid "Malay (Indonesia)"
+msgstr ""
+
+#: picard/const/locales.py:690
+msgid "Malay (Singapore)"
+msgstr ""
+
+#: picard/const/locales.py:691
+msgid "Maltese"
+msgstr ""
+
+#: picard/const/locales.py:692
+msgid "Maltese (Malta)"
+msgstr ""
+
+#: picard/const/locales.py:693
+msgid "Mundang"
+msgstr ""
+
+#: picard/const/locales.py:694
+msgid "Mundang (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:695
+msgid "Muscogee"
+msgstr ""
+
+#: picard/const/locales.py:696
+msgid "Muscogee (United States)"
+msgstr ""
+
+#: picard/const/locales.py:697
+msgid "Burmese"
+msgstr ""
+
+#: picard/const/locales.py:698
+msgid "Burmese (Myanmar (Burma))"
+msgstr ""
+
+#: picard/const/locales.py:699
+msgid "Erzya"
+msgstr ""
+
+#: picard/const/locales.py:700
+msgid "Erzya (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:701
+msgid "Mazanderani"
+msgstr ""
+
+#: picard/const/locales.py:702
+msgid "Mazanderani (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:703
+msgid "Nama"
+msgstr ""
+
+#: picard/const/locales.py:704
+msgid "Nama (Namibia)"
+msgstr ""
+
+#: picard/const/locales.py:706
+msgid "Norwegian Bokmål (Norway)"
+msgstr ""
+
+#: picard/const/locales.py:707
+msgid "Norwegian Bokmål (Svalbard & Jan Mayen)"
+msgstr ""
+
+#: picard/const/locales.py:708
+msgid "North Ndebele"
+msgstr ""
+
+#: picard/const/locales.py:709
+msgid "North Ndebele (Zimbabwe)"
+msgstr ""
+
+#: picard/const/locales.py:710
+msgid "Low German"
+msgstr ""
+
+#: picard/const/locales.py:711
+msgid "Low German (Germany)"
+msgstr ""
+
+#: picard/const/locales.py:712
+msgid "Low German (Netherlands)"
+msgstr ""
+
+#: picard/const/locales.py:713
+msgid "Nepali"
+msgstr ""
+
+#: picard/const/locales.py:714
+msgid "Nepali (India)"
+msgstr ""
+
+#: picard/const/locales.py:715
+msgid "Nepali (Nepal)"
+msgstr ""
+
+#: picard/const/locales.py:717
+msgid "Dutch (Aruba)"
+msgstr ""
+
+#: picard/const/locales.py:718
+msgid "Dutch (Belgium)"
+msgstr ""
+
+#: picard/const/locales.py:719
+msgid "Dutch (Caribbean Netherlands)"
+msgstr ""
+
+#: picard/const/locales.py:720
+msgid "Dutch (Curaçao)"
+msgstr ""
+
+#: picard/const/locales.py:721
+msgid "Dutch (Netherlands)"
+msgstr ""
+
+#: picard/const/locales.py:722
+msgid "Dutch (Suriname)"
+msgstr ""
+
+#: picard/const/locales.py:723
+msgid "Dutch (Sint Maarten)"
+msgstr ""
+
+#: picard/const/locales.py:724
+msgid "Kwasio"
+msgstr ""
+
+#: picard/const/locales.py:725
+msgid "Kwasio (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:726
+msgid "Norwegian Nynorsk"
+msgstr ""
+
+#: picard/const/locales.py:727
+msgid "Norwegian Nynorsk (Norway)"
+msgstr ""
+
+#: picard/const/locales.py:728
+msgid "Ngiemboon"
+msgstr ""
+
+#: picard/const/locales.py:729
+msgid "Ngiemboon (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:730
+msgid "Norwegian"
+msgstr ""
+
+#: picard/const/locales.py:731
+msgid "N’Ko"
+msgstr ""
+
+#: picard/const/locales.py:732
+msgid "N’Ko (Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:733
+msgid "South Ndebele"
+msgstr ""
+
+#: picard/const/locales.py:734
+msgid "South Ndebele (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:735
+msgid "Northern Sotho"
+msgstr ""
+
+#: picard/const/locales.py:736
+msgid "Northern Sotho (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:737
+msgid "Nuer"
+msgstr ""
+
+#: picard/const/locales.py:738
+msgid "Nuer (South Sudan)"
+msgstr ""
+
+#: picard/const/locales.py:739
+msgid "Navajo"
+msgstr ""
+
+#: picard/const/locales.py:740
+msgid "Navajo (United States)"
+msgstr ""
+
+#: picard/const/locales.py:741
+msgid "Nyanja"
+msgstr ""
+
+#: picard/const/locales.py:742
+msgid "Nyanja (Malawi)"
+msgstr ""
+
+#: picard/const/locales.py:743
+msgid "Nyankole"
+msgstr ""
+
+#: picard/const/locales.py:744
+msgid "Nyankole (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:746
+msgid "Occitan (Spain)"
+msgstr ""
+
+#: picard/const/locales.py:747
+msgid "Occitan (France)"
+msgstr ""
+
+#: picard/const/locales.py:748
+msgid "Oromo"
+msgstr ""
+
+#: picard/const/locales.py:749
+msgid "Oromo (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:750
+msgid "Oromo (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:751
+msgid "Odia"
+msgstr ""
+
+#: picard/const/locales.py:752
+msgid "Odia (India)"
+msgstr ""
+
+#: picard/const/locales.py:753
+msgid "Ossetic"
+msgstr ""
+
+#: picard/const/locales.py:754
+msgid "Ossetic (Georgia)"
+msgstr ""
+
+#: picard/const/locales.py:755
+msgid "Ossetic (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:756
+msgid "Osage"
+msgstr ""
+
+#: picard/const/locales.py:757
+msgid "Osage (United States)"
+msgstr ""
+
+#: picard/const/locales.py:758
+msgid "Punjabi"
+msgstr ""
+
+#: picard/const/locales.py:759
+msgid "Punjabi (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:760
+msgid "Punjabi (Arabic) (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:761
+msgid "Punjabi (Gurmukhi)"
+msgstr ""
+
+#: picard/const/locales.py:762
+msgid "Punjabi (Gurmukhi) (India)"
+msgstr ""
+
+#: picard/const/locales.py:763
+msgid "Punjabi (India)"
+msgstr ""
+
+#: picard/const/locales.py:764
+msgid "Punjabi (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:765
+msgid "Papiamento"
+msgstr ""
+
+#: picard/const/locales.py:766
+msgid "Papiamento (Aruba)"
+msgstr ""
+
+#: picard/const/locales.py:767
+msgid "Papiamento (Curaçao)"
+msgstr ""
+
+#: picard/const/locales.py:768
+msgid "Nigerian Pidgin"
+msgstr ""
+
+#: picard/const/locales.py:769
+msgid "Nigerian Pidgin (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:770
+msgid "Pijin"
+msgstr ""
+
+#: picard/const/locales.py:771
+msgid "Pijin (Solomon Islands)"
+msgstr ""
+
+#: picard/const/locales.py:773
+msgid "Polish (Poland)"
+msgstr ""
+
+#: picard/const/locales.py:774
+msgid "Prussian"
+msgstr ""
+
+#: picard/const/locales.py:775
+msgid "Prussian (world)"
+msgstr ""
+
+#: picard/const/locales.py:776
+msgid "Pashto"
+msgstr ""
+
+#: picard/const/locales.py:777
+msgid "Pashto (Afghanistan)"
+msgstr ""
+
+#: picard/const/locales.py:778
+msgid "Pashto (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:780
+msgid "Portuguese (Angola)"
+msgstr ""
+
+#: picard/const/locales.py:782
+msgid "Portuguese (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:783
+msgid "Portuguese (Cape Verde)"
+msgstr ""
+
+#: picard/const/locales.py:784
+msgid "Portuguese (Equatorial Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:785
+msgid "Portuguese (Guinea-Bissau)"
+msgstr ""
+
+#: picard/const/locales.py:786
+msgid "Portuguese (Luxembourg)"
+msgstr ""
+
+#: picard/const/locales.py:787
+msgid "Portuguese (Macao)"
+msgstr ""
+
+#: picard/const/locales.py:788
+msgid "Portuguese (Mozambique)"
+msgstr ""
+
+#: picard/const/locales.py:789
+msgid "Portuguese (Portugal)"
+msgstr ""
+
+#: picard/const/locales.py:790
+msgid "Portuguese (São Tomé & Príncipe)"
+msgstr ""
+
+#: picard/const/locales.py:791
+msgid "Portuguese (Timor-Leste)"
+msgstr ""
+
+#: picard/const/locales.py:792
+msgid "Quechua"
+msgstr ""
+
+#: picard/const/locales.py:793
+msgid "Quechua (Bolivia)"
+msgstr ""
+
+#: picard/const/locales.py:794
+msgid "Quechua (Ecuador)"
+msgstr ""
+
+#: picard/const/locales.py:795
+msgid "Quechua (Peru)"
+msgstr ""
+
+#: picard/const/locales.py:796
+msgid "Kʼicheʼ"
+msgstr ""
+
+#: picard/const/locales.py:797
+msgid "Kʼicheʼ (Guatemala)"
+msgstr ""
+
+#: picard/const/locales.py:798
+msgid "Rajasthani"
+msgstr ""
+
+#: picard/const/locales.py:799
+msgid "Rajasthani (India)"
+msgstr ""
+
+#: picard/const/locales.py:800
+msgid "Rohingya"
+msgstr ""
+
+#: picard/const/locales.py:801
+msgid "Rohingya (Hanifi)"
+msgstr ""
+
+#: picard/const/locales.py:802
+msgid "Rohingya (Hanifi) (Bangladesh)"
+msgstr ""
+
+#: picard/const/locales.py:803
+msgid "Rohingya (Hanifi) (Myanmar (Burma))"
+msgstr ""
+
+#: picard/const/locales.py:804
+msgid "Riffian"
+msgstr ""
+
+#: picard/const/locales.py:805
+msgid "Riffian (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:806
+msgid "Romansh"
+msgstr ""
+
+#: picard/const/locales.py:807
+msgid "Romansh (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:808
+msgid "Rundi"
+msgstr ""
+
+#: picard/const/locales.py:809
+msgid "Rundi (Burundi)"
+msgstr ""
+
+#: picard/const/locales.py:811
+msgid "Romanian (Moldova)"
+msgstr ""
+
+#: picard/const/locales.py:812
+msgid "Romanian (Romania)"
+msgstr ""
+
+#: picard/const/locales.py:813
+msgid "Rombo"
+msgstr ""
+
+#: picard/const/locales.py:814
+msgid "Rombo (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:816
+msgid "Russian (Belarus)"
+msgstr ""
+
+#: picard/const/locales.py:817
+msgid "Russian (Kyrgyzstan)"
+msgstr ""
+
+#: picard/const/locales.py:818
+msgid "Russian (Kazakhstan)"
+msgstr ""
+
+#: picard/const/locales.py:819
+msgid "Russian (Moldova)"
+msgstr ""
+
+#: picard/const/locales.py:820
+msgid "Russian (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:821
+msgid "Russian (Ukraine)"
+msgstr ""
+
+#: picard/const/locales.py:822
+msgid "Kinyarwanda"
+msgstr ""
+
+#: picard/const/locales.py:823
+msgid "Kinyarwanda (Rwanda)"
+msgstr ""
+
+#: picard/const/locales.py:824
+msgid "Rwa"
+msgstr ""
+
+#: picard/const/locales.py:825
+msgid "Rwa (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:826
+msgid "Sanskrit"
+msgstr ""
+
+#: picard/const/locales.py:827
+msgid "Sanskrit (India)"
+msgstr ""
+
+#: picard/const/locales.py:828
+msgid "Yakut"
+msgstr ""
+
+#: picard/const/locales.py:829
+msgid "Yakut (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:830
+msgid "Samburu"
+msgstr ""
+
+#: picard/const/locales.py:831
+msgid "Samburu (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:832
+msgid "Santali"
+msgstr ""
+
+#: picard/const/locales.py:833
+msgid "Santali (Devanagari)"
+msgstr ""
+
+#: picard/const/locales.py:834
+msgid "Santali (Devanagari) (India)"
+msgstr ""
+
+#: picard/const/locales.py:835
+msgid "Santali (Ol Chiki)"
+msgstr ""
+
+#: picard/const/locales.py:836
+msgid "Santali (Ol Chiki) (India)"
+msgstr ""
+
+#: picard/const/locales.py:837
+msgid "Sangu"
+msgstr ""
+
+#: picard/const/locales.py:838
+msgid "Sangu (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:839
+msgid "Sardinian"
+msgstr ""
+
+#: picard/const/locales.py:840
+msgid "Sardinian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:841
+msgid "Sicilian"
+msgstr ""
+
+#: picard/const/locales.py:842
+msgid "Sicilian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:843
+msgid "Sindhi"
+msgstr ""
+
+#: picard/const/locales.py:844
+msgid "Sindhi (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:845
+msgid "Sindhi (Arabic) (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:846
+msgid "Sindhi (Devanagari)"
+msgstr ""
+
+#: picard/const/locales.py:847
+msgid "Sindhi (Devanagari) (India)"
+msgstr ""
+
+#: picard/const/locales.py:848
+msgid "Southern Kurdish"
+msgstr ""
+
+#: picard/const/locales.py:849
+msgid "Southern Kurdish (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:850
+msgid "Southern Kurdish (Iran)"
+msgstr ""
+
+#: picard/const/locales.py:851
+msgid "Northern Sami"
+msgstr ""
+
+#: picard/const/locales.py:852
+msgid "Northern Sami (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:853
+msgid "Northern Sami (Norway)"
+msgstr ""
+
+#: picard/const/locales.py:854
+msgid "Northern Sami (Sweden)"
+msgstr ""
+
+#: picard/const/locales.py:855
+msgid "Sena"
+msgstr ""
+
+#: picard/const/locales.py:856
+msgid "Sena (Mozambique)"
+msgstr ""
+
+#: picard/const/locales.py:857
+msgid "Koyraboro Senni"
+msgstr ""
+
+#: picard/const/locales.py:858
+msgid "Koyraboro Senni (Mali)"
+msgstr ""
+
+#: picard/const/locales.py:859
+msgid "Sango"
+msgstr ""
+
+#: picard/const/locales.py:860
+msgid "Sango (Central African Republic)"
+msgstr ""
+
+#: picard/const/locales.py:861
+msgid "Tachelhit"
+msgstr ""
+
+#: picard/const/locales.py:862
+msgid "Tachelhit (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:863
+msgid "Tachelhit (Latin) (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:864
+msgid "Tachelhit (Tifinagh)"
+msgstr ""
+
+#: picard/const/locales.py:865
+msgid "Tachelhit (Tifinagh) (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:866
+msgid "Shan"
+msgstr ""
+
+#: picard/const/locales.py:867
+msgid "Shan (Myanmar (Burma))"
+msgstr ""
+
+#: picard/const/locales.py:868
+msgid "Shan (Thailand)"
+msgstr ""
+
+#: picard/const/locales.py:869
+msgid "Sinhala"
+msgstr ""
+
+#: picard/const/locales.py:870
+msgid "Sinhala (Sri Lanka)"
+msgstr ""
+
+#: picard/const/locales.py:871
+msgid "Sidamo"
+msgstr ""
+
+#: picard/const/locales.py:872
+msgid "Sidamo (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:874
+msgid "Slovak (Slovakia)"
+msgstr ""
+
+#: picard/const/locales.py:876
+msgid "Slovenian (Slovenia)"
+msgstr ""
+
+#: picard/const/locales.py:877
+msgid "Southern Sami"
+msgstr ""
+
+#: picard/const/locales.py:878
+msgid "Southern Sami (Norway)"
+msgstr ""
+
+#: picard/const/locales.py:879
+msgid "Southern Sami (Sweden)"
+msgstr ""
+
+#: picard/const/locales.py:880
+msgid "Lule Sami"
+msgstr ""
+
+#: picard/const/locales.py:881
+msgid "Lule Sami (Norway)"
+msgstr ""
+
+#: picard/const/locales.py:882
+msgid "Lule Sami (Sweden)"
+msgstr ""
+
+#: picard/const/locales.py:883
+msgid "Inari Sami"
+msgstr ""
+
+#: picard/const/locales.py:884
+msgid "Inari Sami (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:885
+msgid "Skolt Sami"
+msgstr ""
+
+#: picard/const/locales.py:886
+msgid "Skolt Sami (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:887
+msgid "Shona"
+msgstr ""
+
+#: picard/const/locales.py:888
+msgid "Shona (Zimbabwe)"
+msgstr ""
+
+#: picard/const/locales.py:889
+msgid "Somali"
+msgstr ""
+
+#: picard/const/locales.py:890
+msgid "Somali (Djibouti)"
+msgstr ""
+
+#: picard/const/locales.py:891
+msgid "Somali (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:892
+msgid "Somali (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:893
+msgid "Somali (Somalia)"
+msgstr ""
+
+#: picard/const/locales.py:895
+msgid "Albanian (Albania)"
+msgstr ""
+
+#: picard/const/locales.py:896
+msgid "Albanian (North Macedonia)"
+msgstr ""
+
+#: picard/const/locales.py:897
+msgid "Albanian (Kosovo)"
+msgstr ""
+
+#: picard/const/locales.py:898
+msgid "Serbian"
+msgstr ""
+
+#: picard/const/locales.py:899
+msgid "Serbian (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:900
+msgid "Serbian (Cyrillic) (Bosnia & Herzegovina)"
+msgstr ""
+
+#: picard/const/locales.py:901
+msgid "Serbian (Cyrillic) (Montenegro)"
+msgstr ""
+
+#: picard/const/locales.py:902
+msgid "Serbian (Cyrillic) (Serbia)"
+msgstr ""
+
+#: picard/const/locales.py:903
+msgid "Serbian (Cyrillic) (Kosovo)"
+msgstr ""
+
+#: picard/const/locales.py:904
+msgid "Serbian (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:905
+msgid "Serbian (Latin) (Bosnia & Herzegovina)"
+msgstr ""
+
+#: picard/const/locales.py:906
+msgid "Serbian (Latin) (Montenegro)"
+msgstr ""
+
+#: picard/const/locales.py:907
+msgid "Serbian (Latin) (Serbia)"
+msgstr ""
+
+#: picard/const/locales.py:908
+msgid "Serbian (Latin) (Kosovo)"
+msgstr ""
+
+#: picard/const/locales.py:909
+msgid "Swati"
+msgstr ""
+
+#: picard/const/locales.py:910
+msgid "Swati (Eswatini)"
+msgstr ""
+
+#: picard/const/locales.py:911
+msgid "Swati (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:912
+msgid "Saho"
+msgstr ""
+
+#: picard/const/locales.py:913
+msgid "Saho (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:914
+msgid "Southern Sotho"
+msgstr ""
+
+#: picard/const/locales.py:915
+msgid "Southern Sotho (Lesotho)"
+msgstr ""
+
+#: picard/const/locales.py:916
+msgid "Southern Sotho (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:917
+msgid "Sundanese"
+msgstr ""
+
+#: picard/const/locales.py:918
+msgid "Sundanese (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:919
+msgid "Sundanese (Latin) (Indonesia)"
+msgstr ""
+
+#: picard/const/locales.py:921
+msgid "Swedish (Åland Islands)"
+msgstr ""
+
+#: picard/const/locales.py:922
+msgid "Swedish (Finland)"
+msgstr ""
+
+#: picard/const/locales.py:923
+msgid "Swedish (Sweden)"
+msgstr ""
+
+#: picard/const/locales.py:924
+msgid "Swahili"
+msgstr ""
+
+#: picard/const/locales.py:925
+msgid "Swahili (Congo - Kinshasa)"
+msgstr ""
+
+#: picard/const/locales.py:926
+msgid "Swahili (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:927
+msgid "Swahili (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:928
+msgid "Swahili (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:929
+msgid "Syriac"
+msgstr ""
+
+#: picard/const/locales.py:930
+msgid "Syriac (Iraq)"
+msgstr ""
+
+#: picard/const/locales.py:931
+msgid "Syriac (Syria)"
+msgstr ""
+
+#: picard/const/locales.py:932
+msgid "Silesian"
+msgstr ""
+
+#: picard/const/locales.py:933
+msgid "Silesian (Poland)"
+msgstr ""
+
+#: picard/const/locales.py:934
+msgid "Tamil"
+msgstr ""
+
+#: picard/const/locales.py:935
+msgid "Tamil (India)"
+msgstr ""
+
+#: picard/const/locales.py:936
+msgid "Tamil (Sri Lanka)"
+msgstr ""
+
+#: picard/const/locales.py:937
+msgid "Tamil (Malaysia)"
+msgstr ""
+
+#: picard/const/locales.py:938
+msgid "Tamil (Singapore)"
+msgstr ""
+
+#: picard/const/locales.py:939
+msgid "Telugu"
+msgstr ""
+
+#: picard/const/locales.py:940
+msgid "Telugu (India)"
+msgstr ""
+
+#: picard/const/locales.py:941
+msgid "Teso"
+msgstr ""
+
+#: picard/const/locales.py:942
+msgid "Teso (Kenya)"
+msgstr ""
+
+#: picard/const/locales.py:943
+msgid "Teso (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:944
+msgid "Tajik"
+msgstr ""
+
+#: picard/const/locales.py:945
+msgid "Tajik (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:946
+msgid "Tajik (Cyrillic) (Tajikistan)"
+msgstr ""
+
+#: picard/const/locales.py:947
+msgid "Tajik (Tajikistan)"
+msgstr ""
+
+#: picard/const/locales.py:948 picard/const/scripts.py:35
+msgid "Thai"
+msgstr ""
+
+#: picard/const/locales.py:949
+msgid "Thai (Thailand)"
+msgstr ""
+
+#: picard/const/locales.py:950
+msgid "Tigrinya"
+msgstr ""
+
+#: picard/const/locales.py:951
+msgid "Tigrinya (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:952
+msgid "Tigrinya (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:953
+msgid "Tigre"
+msgstr ""
+
+#: picard/const/locales.py:954
+msgid "Tigre (Eritrea)"
+msgstr ""
+
+#: picard/const/locales.py:955
+msgid "Turkmen"
+msgstr ""
+
+#: picard/const/locales.py:956
+msgid "Turkmen (Turkmenistan)"
+msgstr ""
+
+#: picard/const/locales.py:957
+msgid "Tswana"
+msgstr ""
+
+#: picard/const/locales.py:958
+msgid "Tswana (Botswana)"
+msgstr ""
+
+#: picard/const/locales.py:959
+msgid "Tswana (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:960
+msgid "Tongan"
+msgstr ""
+
+#: picard/const/locales.py:961
+msgid "Tongan (Tonga)"
+msgstr ""
+
+#: picard/const/locales.py:962
+msgid "Toki Pona"
+msgstr ""
+
+#: picard/const/locales.py:963
+msgid "Toki Pona (world)"
+msgstr ""
+
+#: picard/const/locales.py:964
+msgid "Tok Pisin"
+msgstr ""
+
+#: picard/const/locales.py:965
+msgid "Tok Pisin (Papua New Guinea)"
+msgstr ""
+
+#: picard/const/locales.py:967
+msgid "Turkish (Cyprus)"
+msgstr ""
+
+#: picard/const/locales.py:968
+msgid "Turkish (Türkiye)"
+msgstr ""
+
+#: picard/const/locales.py:969
+msgid "Taroko"
+msgstr ""
+
+#: picard/const/locales.py:970
+msgid "Taroko (Taiwan)"
+msgstr ""
+
+#: picard/const/locales.py:971
+msgid "Torwali"
+msgstr ""
+
+#: picard/const/locales.py:972
+msgid "Torwali (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:973
+msgid "Tsonga"
+msgstr ""
+
+#: picard/const/locales.py:974
+msgid "Tsonga (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:975
+msgid "Tatar"
+msgstr ""
+
+#: picard/const/locales.py:976
+msgid "Tatar (Russia)"
+msgstr ""
+
+#: picard/const/locales.py:977
+msgid "Tasawaq"
+msgstr ""
+
+#: picard/const/locales.py:978
+msgid "Tasawaq (Niger)"
+msgstr ""
+
+#: picard/const/locales.py:979
+msgid "Central Atlas Tamazight"
+msgstr ""
+
+#: picard/const/locales.py:980
+msgid "Central Atlas Tamazight (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:981
+msgid "Uyghur"
+msgstr ""
+
+#: picard/const/locales.py:982
+msgid "Uyghur (China)"
+msgstr ""
+
+#: picard/const/locales.py:984
+msgid "Ukrainian (Ukraine)"
+msgstr ""
+
+#: picard/const/locales.py:985
+msgid "Unknown language"
+msgstr ""
+
+#: picard/const/locales.py:986
+msgid "Urdu"
+msgstr ""
+
+#: picard/const/locales.py:987
+msgid "Urdu (India)"
+msgstr ""
+
+#: picard/const/locales.py:988
+msgid "Urdu (Pakistan)"
+msgstr ""
+
+#: picard/const/locales.py:989
+msgid "Uzbek"
+msgstr ""
+
+#: picard/const/locales.py:990
+msgid "Uzbek (Arabic)"
+msgstr ""
+
+#: picard/const/locales.py:991
+msgid "Uzbek (Arabic) (Afghanistan)"
+msgstr ""
+
+#: picard/const/locales.py:992
+msgid "Uzbek (Cyrillic)"
+msgstr ""
+
+#: picard/const/locales.py:993
+msgid "Uzbek (Cyrillic) (Uzbekistan)"
+msgstr ""
+
+#: picard/const/locales.py:994
+msgid "Uzbek (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:995
+msgid "Uzbek (Latin) (Uzbekistan)"
+msgstr ""
+
+#: picard/const/locales.py:996
+msgid "Vai"
+msgstr ""
+
+#: picard/const/locales.py:997
+msgid "Vai (Latin)"
+msgstr ""
+
+#: picard/const/locales.py:998
+msgid "Vai (Latin) (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:999
+msgid "Vai (Vai)"
+msgstr ""
+
+#: picard/const/locales.py:1000
+msgid "Vai (Vai) (Liberia)"
+msgstr ""
+
+#: picard/const/locales.py:1001
+msgid "Venda"
+msgstr ""
+
+#: picard/const/locales.py:1002
+msgid "Venda (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:1003
+msgid "Venetian"
+msgstr ""
+
+#: picard/const/locales.py:1004
+msgid "Venetian (Italy)"
+msgstr ""
+
+#: picard/const/locales.py:1005
+msgid "Vietnamese"
+msgstr ""
+
+#: picard/const/locales.py:1006
+msgid "Vietnamese (Vietnam)"
+msgstr ""
+
+#: picard/const/locales.py:1007
+msgid "Volapük"
+msgstr ""
+
+#: picard/const/locales.py:1008
+msgid "Volapük (world)"
+msgstr ""
+
+#: picard/const/locales.py:1009
+msgid "Vunjo"
+msgstr ""
+
+#: picard/const/locales.py:1010
+msgid "Vunjo (Tanzania)"
+msgstr ""
+
+#: picard/const/locales.py:1011
+msgid "Walloon"
+msgstr ""
+
+#: picard/const/locales.py:1012
+msgid "Walloon (Belgium)"
+msgstr ""
+
+#: picard/const/locales.py:1013
+msgid "Walser"
+msgstr ""
+
+#: picard/const/locales.py:1014
+msgid "Walser (Switzerland)"
+msgstr ""
+
+#: picard/const/locales.py:1015
+msgid "Wolaytta"
+msgstr ""
+
+#: picard/const/locales.py:1016
+msgid "Wolaytta (Ethiopia)"
+msgstr ""
+
+#: picard/const/locales.py:1017
+msgid "Warlpiri"
+msgstr ""
+
+#: picard/const/locales.py:1018
+msgid "Warlpiri (Australia)"
+msgstr ""
+
+#: picard/const/locales.py:1019
+msgid "Wolof"
+msgstr ""
+
+#: picard/const/locales.py:1020
+msgid "Wolof (Senegal)"
+msgstr ""
+
+#: picard/const/locales.py:1021
+msgid "Xhosa"
+msgstr ""
+
+#: picard/const/locales.py:1022
+msgid "Xhosa (South Africa)"
+msgstr ""
+
+#: picard/const/locales.py:1023
+msgid "Soga"
+msgstr ""
+
+#: picard/const/locales.py:1024
+msgid "Soga (Uganda)"
+msgstr ""
+
+#: picard/const/locales.py:1025
+msgid "Yangben"
+msgstr ""
+
+#: picard/const/locales.py:1026
+msgid "Yangben (Cameroon)"
+msgstr ""
+
+#: picard/const/locales.py:1027
+msgid "Yiddish"
+msgstr ""
+
+#: picard/const/locales.py:1028
+msgid "Yiddish (world)"
+msgstr ""
+
+#: picard/const/locales.py:1029
+msgid "Yoruba"
+msgstr ""
+
+#: picard/const/locales.py:1030
+msgid "Yoruba (Benin)"
+msgstr ""
+
+#: picard/const/locales.py:1031
+msgid "Yoruba (Nigeria)"
+msgstr ""
+
+#: picard/const/locales.py:1032
+msgid "Nheengatu"
+msgstr ""
+
+#: picard/const/locales.py:1033
+msgid "Nheengatu (Brazil)"
+msgstr ""
+
+#: picard/const/locales.py:1034
+msgid "Nheengatu (Colombia)"
+msgstr ""
+
+#: picard/const/locales.py:1035
+msgid "Nheengatu (Venezuela)"
+msgstr ""
+
+#: picard/const/locales.py:1036
+msgid "Cantonese"
+msgstr ""
+
+#: picard/const/locales.py:1037
+msgid "Cantonese (Simplified)"
+msgstr ""
+
+#: picard/const/locales.py:1038
+msgid "Cantonese (Simplified) (China)"
+msgstr ""
+
+#: picard/const/locales.py:1039
+msgid "Cantonese (Traditional)"
+msgstr ""
+
+#: picard/const/locales.py:1040
+msgid "Cantonese (Traditional) (Hong Kong)"
+msgstr ""
+
+#: picard/const/locales.py:1041
+msgid "Standard Moroccan Tamazight"
+msgstr ""
+
+#: picard/const/locales.py:1042
+msgid "Standard Moroccan Tamazight (Morocco)"
+msgstr ""
+
+#: picard/const/locales.py:1043 picard/const/scripts.py:31
+msgid "Chinese"
+msgstr ""
+
+#: picard/const/locales.py:1044
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: picard/const/locales.py:1045
+msgid "Chinese (Simplified) (China)"
+msgstr ""
+
+#: picard/const/locales.py:1046
+msgid "Chinese (Simplified) (Hong Kong)"
+msgstr ""
+
+#: picard/const/locales.py:1047
+msgid "Chinese (Simplified) (Macao)"
+msgstr ""
+
+#: picard/const/locales.py:1048
+msgid "Chinese (Simplified) (Singapore)"
+msgstr ""
+
+#: picard/const/locales.py:1049
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: picard/const/locales.py:1050
+msgid "Chinese (Traditional) (Hong Kong)"
+msgstr ""
+
+#: picard/const/locales.py:1051
+msgid "Chinese (Traditional) (Macao)"
+msgstr ""
+
+#: picard/const/locales.py:1052
+msgid "Chinese (Traditional) (Taiwan)"
+msgstr ""
+
+#: picard/const/locales.py:1053
+msgid "Zulu"
+msgstr ""
+
+#: picard/const/locales.py:1054
+msgid "Zulu (South Africa)"
+msgstr ""
+
+#: picard/const/scripts.py:27
+msgid "Cyrillic"
+msgstr ""
+
+#: picard/const/scripts.py:32
+msgid "Hangul"
+msgstr ""
+
+#: picard/const/scripts.py:33
+msgid "Hiragana"
+msgstr ""
+
+#: picard/const/scripts.py:34
+msgid "Katakana"
+msgstr ""
+

--- a/po/picard.pot
+++ b/po/picard.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: picard 2.9.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-08-22 17:47+0200\n"
+"POT-Creation-Date: 2023-08-23 18:23+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.12.1\n"
 
 #: picard/album.py:150
 msgid "Unmatched Files"
@@ -162,54 +162,56 @@ msgstr ""
 msgid "Picard Plugins Update"
 msgstr ""
 
-#: picard/pluginmanager.py:261
+#: picard/pluginmanager.py:263
 #, python-format
 msgid "Unable to load plugin '%s'"
 msgstr ""
 
-#: picard/pluginmanager.py:276
+#: picard/pluginmanager.py:278
 #, python-format
-msgid "Failed loading zipped plugin %r from %r"
+msgid "Failed loading zipped plugin \"%(plugin)s\" from \"%(filename)s\""
 msgstr ""
 
-#: picard/pluginmanager.py:286
+#: picard/pluginmanager.py:291
 #, python-format
-msgid "Failed loading plugin %r in %r"
+msgid "Failed loading plugin \"%(plugin)s\" in \"%(dirname)s\""
 msgstr ""
 
-#: picard/pluginmanager.py:322
+#: picard/pluginmanager.py:330
 #, python-format
-msgid "Plugin '%s' from '%s' is not compatible with this version of Picard."
+msgid ""
+"Plugin \"%(plugin)s\" from \"%(filename)s\" is not compatible with this "
+"version of Picard."
 msgstr ""
 
-#: picard/pluginmanager.py:326
+#: picard/pluginmanager.py:335
 #, python-format
-msgid "Plugin %r has an invalid API version string : %s"
+msgid "Plugin \"%(plugin)s\" has an invalid API version string : %(error)s"
 msgstr ""
 
-#: picard/pluginmanager.py:329
+#: picard/pluginmanager.py:341
 #, python-format
 msgid "Plugin %r"
 msgstr ""
 
-#: picard/pluginmanager.py:465
+#: picard/pluginmanager.py:477
 #, python-format
 msgid "Error loading plugins list: %(error)s"
 msgstr ""
 
-#: picard/pluginmanager.py:501
+#: picard/pluginmanager.py:513
 msgid "There is an update available for one of your currently installed plugins:"
 msgid_plural "There are updates available for your currently installed plugins:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: picard/pluginmanager.py:506
+#: picard/pluginmanager.py:518
 msgid "Do you want to update the plugin now?"
 msgid_plural "Do you want to update the plugins now?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: picard/pluginmanager.py:514
+#: picard/pluginmanager.py:526
 msgid "plus {extra_file_count:,d} other plugin."
 msgid_plural "plus {extra_file_count:,d} other plugins."
 msgstr[0] ""
@@ -793,8 +795,8 @@ msgid "dBpoweramp log files"
 msgstr ""
 
 #: picard/script/serializer.py:350 picard/tagger.py:1196
-#: picard/ui/coverartbox.py:610 picard/ui/mainwindow.py:1266
-#: picard/ui/options/maintenance.py:168 picard/ui/options/scripting.py:131
+#: picard/ui/coverartbox.py:610 picard/ui/mainwindow.py:1267
+#: picard/ui/options/maintenance.py:167 picard/ui/options/scripting.py:131
 msgid "All files"
 msgstr ""
 
@@ -879,4181 +881,6 @@ msgstr ""
 
 #: picard/browser/addrelease.py:166
 msgid "Add file as recording…"
-msgstr ""
-
-#: picard/const/__init__.py:169
-msgid "Stable releases only"
-msgstr ""
-
-#: picard/const/__init__.py:175
-msgid "Stable and Beta releases"
-msgstr ""
-
-#: picard/const/__init__.py:181
-msgid "Stable, Beta and Dev releases"
-msgstr ""
-
-#: picard/const/__init__.py:199
-msgid "My script"
-msgstr ""
-
-#: picard/const/__init__.py:201
-msgid "My profile"
-msgstr ""
-
-#: picard/const/__init__.py:202
-msgid "(copy)"
-msgstr ""
-
-#: picard/const/__init__.py:203
-msgid "{title} ({count})"
-msgstr ""
-
-#: picard/const/languages.py:29 picard/const/locales.py:48
-#: picard/const/scripts.py:29
-msgid "Arabic"
-msgstr ""
-
-#: picard/const/languages.py:32 picard/const/locales.py:147
-msgid "Catalan"
-msgstr ""
-
-#: picard/const/languages.py:33 picard/const/locales.py:177
-msgid "Czech"
-msgstr ""
-
-#: picard/const/languages.py:35 picard/const/locales.py:185
-msgid "Danish"
-msgstr ""
-
-#: picard/const/languages.py:36 picard/const/locales.py:190
-msgid "German"
-msgstr ""
-
-#: picard/const/languages.py:37 picard/const/locales.py:193
-msgid "German (Switzerland)"
-msgstr ""
-
-#: picard/const/languages.py:38 picard/const/locales.py:217
-#: picard/const/scripts.py:26
-msgid "Greek"
-msgstr ""
-
-#: picard/const/languages.py:39 picard/const/locales.py:221
-msgid "English"
-msgstr ""
-
-#: picard/const/languages.py:40 picard/const/locales.py:229
-msgid "English (Australia)"
-msgstr ""
-
-#: picard/const/languages.py:41 picard/const/locales.py:237
-msgid "English (Canada)"
-msgstr ""
-
-#: picard/const/languages.py:42
-msgid "English (UK)"
-msgstr ""
-
-#: picard/const/languages.py:44 picard/const/locales.py:334
-msgid "Spanish"
-msgstr ""
-
-#: picard/const/languages.py:45 picard/const/locales.py:363
-msgid "Estonian"
-msgstr ""
-
-#: picard/const/languages.py:47 picard/const/locales.py:399
-msgid "Finnish"
-msgstr ""
-
-#: picard/const/languages.py:49 picard/const/locales.py:406
-msgid "French"
-msgstr ""
-
-#: picard/const/languages.py:50 picard/const/locales.py:412
-msgid "French (Canada)"
-msgstr ""
-
-#: picard/const/languages.py:52 picard/const/locales.py:469
-msgid "Galician"
-msgstr ""
-
-#: picard/const/languages.py:53 picard/const/locales.py:497
-#: picard/const/scripts.py:30
-msgid "Hebrew"
-msgstr ""
-
-#: picard/const/languages.py:55 picard/const/locales.py:511
-msgid "Hungarian"
-msgstr ""
-
-#: picard/const/languages.py:57 picard/const/locales.py:526
-msgid "Icelandic"
-msgstr ""
-
-#: picard/const/languages.py:58 picard/const/locales.py:528
-msgid "Italian"
-msgstr ""
-
-#: picard/const/languages.py:59 picard/const/locales.py:537
-msgid "Japanese"
-msgstr ""
-
-#: picard/const/languages.py:61 picard/const/locales.py:585
-msgid "Korean"
-msgstr ""
-
-#: picard/const/languages.py:63 picard/const/locales.py:689
-msgid "Malay (Malaysia)"
-msgstr ""
-
-#: picard/const/languages.py:64 picard/const/locales.py:705
-msgid "Norwegian Bokmål"
-msgstr ""
-
-#: picard/const/languages.py:66 picard/const/locales.py:716
-msgid "Dutch"
-msgstr ""
-
-#: picard/const/languages.py:67 picard/const/locales.py:745
-msgid "Occitan"
-msgstr ""
-
-#: picard/const/languages.py:68 picard/const/locales.py:772
-msgid "Polish"
-msgstr ""
-
-#: picard/const/languages.py:69 picard/const/locales.py:779
-msgid "Portuguese"
-msgstr ""
-
-#: picard/const/languages.py:70
-msgid "Brazilian Portuguese"
-msgstr ""
-
-#: picard/const/languages.py:71 picard/const/locales.py:810
-msgid "Romanian"
-msgstr ""
-
-#: picard/const/languages.py:72 picard/const/locales.py:815
-msgid "Russian"
-msgstr ""
-
-#: picard/const/languages.py:74 picard/const/locales.py:873
-msgid "Slovak"
-msgstr ""
-
-#: picard/const/languages.py:75 picard/const/locales.py:875
-msgid "Slovenian"
-msgstr ""
-
-#: picard/const/languages.py:76 picard/const/locales.py:894
-msgid "Albanian"
-msgstr ""
-
-#: picard/const/languages.py:78 picard/const/locales.py:920
-msgid "Swedish"
-msgstr ""
-
-#: picard/const/languages.py:80 picard/const/locales.py:966
-msgid "Turkish"
-msgstr ""
-
-#: picard/const/languages.py:81 picard/const/locales.py:983
-msgid "Ukrainian"
-msgstr ""
-
-#: picard/const/languages.py:82
-msgid "Chinese (China)"
-msgstr ""
-
-#: picard/const/languages.py:83
-msgid "Chinese (Taiwan)"
-msgstr ""
-
-#: picard/const/locales.py:27
-msgid "Afar"
-msgstr ""
-
-#: picard/const/locales.py:28
-msgid "Afar (Djibouti)"
-msgstr ""
-
-#: picard/const/locales.py:29
-msgid "Afar (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:30
-msgid "Afar (Eritrea) (Saho)"
-msgstr ""
-
-#: picard/const/locales.py:31
-msgid "Afar (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:32
-msgid "Abkhazian"
-msgstr ""
-
-#: picard/const/locales.py:33
-msgid "Abkhazian (Georgia)"
-msgstr ""
-
-#: picard/const/locales.py:34
-msgid "Afrikaans"
-msgstr ""
-
-#: picard/const/locales.py:35
-msgid "Afrikaans (Namibia)"
-msgstr ""
-
-#: picard/const/locales.py:36
-msgid "Afrikaans (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:37
-msgid "Aghem"
-msgstr ""
-
-#: picard/const/locales.py:38
-msgid "Aghem (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:39
-msgid "Akan"
-msgstr ""
-
-#: picard/const/locales.py:40
-msgid "Akan (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:41
-msgid "Amharic"
-msgstr ""
-
-#: picard/const/locales.py:42
-msgid "Amharic (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:43
-msgid "Aragonese"
-msgstr ""
-
-#: picard/const/locales.py:44
-msgid "Aragonese (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:45
-msgid "Obolo"
-msgstr ""
-
-#: picard/const/locales.py:46
-msgid "Obolo (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:47
-msgid "Syria"
-msgstr ""
-
-#: picard/const/locales.py:49
-msgid "Arabic (world)"
-msgstr ""
-
-#: picard/const/locales.py:50
-msgid "Arabic (United Arab Emirates)"
-msgstr ""
-
-#: picard/const/locales.py:51
-msgid "Arabic (Bahrain)"
-msgstr ""
-
-#: picard/const/locales.py:52
-msgid "Arabic (Djibouti)"
-msgstr ""
-
-#: picard/const/locales.py:53
-msgid "Arabic (Algeria)"
-msgstr ""
-
-#: picard/const/locales.py:54
-msgid "Arabic (Egypt)"
-msgstr ""
-
-#: picard/const/locales.py:55
-msgid "Arabic (Western Sahara)"
-msgstr ""
-
-#: picard/const/locales.py:56
-msgid "Arabic (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:57
-msgid "Arabic (Israel)"
-msgstr ""
-
-#: picard/const/locales.py:58
-msgid "Arabic (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:59
-msgid "Arabic (Jordan)"
-msgstr ""
-
-#: picard/const/locales.py:60
-msgid "Arabic (Comoros)"
-msgstr ""
-
-#: picard/const/locales.py:61
-msgid "Arabic (Kuwait)"
-msgstr ""
-
-#: picard/const/locales.py:62
-msgid "Arabic (Lebanon)"
-msgstr ""
-
-#: picard/const/locales.py:63
-msgid "Arabic (Libya)"
-msgstr ""
-
-#: picard/const/locales.py:64
-msgid "Arabic (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:65
-msgid "Arabic (Mauritania)"
-msgstr ""
-
-#: picard/const/locales.py:66
-msgid "Arabic (Oman)"
-msgstr ""
-
-#: picard/const/locales.py:67
-msgid "Arabic (Palestinian Territories)"
-msgstr ""
-
-#: picard/const/locales.py:68
-msgid "Arabic (Qatar)"
-msgstr ""
-
-#: picard/const/locales.py:69
-msgid "Arabic (Saudi Arabia)"
-msgstr ""
-
-#: picard/const/locales.py:70
-msgid "Arabic (Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:71
-msgid "Arabic (Somalia)"
-msgstr ""
-
-#: picard/const/locales.py:72
-msgid "Arabic (South Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:73
-msgid "Arabic (Syria)"
-msgstr ""
-
-#: picard/const/locales.py:74
-msgid "Arabic (Chad)"
-msgstr ""
-
-#: picard/const/locales.py:75
-msgid "Arabic (Tunisia)"
-msgstr ""
-
-#: picard/const/locales.py:76
-msgid "Arabic (Yemen)"
-msgstr ""
-
-#: picard/const/locales.py:77
-msgid "Mapuche"
-msgstr ""
-
-#: picard/const/locales.py:78
-msgid "Mapuche (Chile)"
-msgstr ""
-
-#: picard/const/locales.py:79
-msgid "Assamese"
-msgstr ""
-
-#: picard/const/locales.py:80
-msgid "Assamese (India)"
-msgstr ""
-
-#: picard/const/locales.py:81
-msgid "Asu"
-msgstr ""
-
-#: picard/const/locales.py:82
-msgid "Asu (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:83
-msgid "Asturian"
-msgstr ""
-
-#: picard/const/locales.py:84
-msgid "Asturian (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:85
-msgid "Azerbaijani"
-msgstr ""
-
-#: picard/const/locales.py:86
-msgid "Azerbaijani (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:87
-msgid "Azerbaijani (Arabic) (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:88
-msgid "Azerbaijani (Arabic) (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:89
-msgid "Azerbaijani (Arabic) (Türkiye)"
-msgstr ""
-
-#: picard/const/locales.py:90
-msgid "Azerbaijani (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:91
-msgid "Azerbaijani (Cyrillic) (Azerbaijan)"
-msgstr ""
-
-#: picard/const/locales.py:92
-msgid "Azerbaijani (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:93
-msgid "Azerbaijani (Latin) (Azerbaijan)"
-msgstr ""
-
-#: picard/const/locales.py:94
-msgid "Bashkir"
-msgstr ""
-
-#: picard/const/locales.py:95
-msgid "Bashkir (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:96
-msgid "Baluchi"
-msgstr ""
-
-#: picard/const/locales.py:97
-msgid "Baluchi (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:98
-msgid "Baluchi (Arabic) (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:99
-msgid "Baluchi (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:100
-msgid "Baluchi (Latin) (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:101
-msgid "Basaa"
-msgstr ""
-
-#: picard/const/locales.py:102
-msgid "Basaa (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:103
-msgid "Belarusian"
-msgstr ""
-
-#: picard/const/locales.py:104
-msgid "Belarusian (Belarus)"
-msgstr ""
-
-#: picard/const/locales.py:105
-msgid "Belarusian (Taraskievica orthography)"
-msgstr ""
-
-#: picard/const/locales.py:106
-msgid "Bemba"
-msgstr ""
-
-#: picard/const/locales.py:107
-msgid "Bemba (Zambia)"
-msgstr ""
-
-#: picard/const/locales.py:108
-msgid "Bena"
-msgstr ""
-
-#: picard/const/locales.py:109
-msgid "Bena (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:110
-msgid "Bulgarian"
-msgstr ""
-
-#: picard/const/locales.py:111
-msgid "Bulgarian (Bulgaria)"
-msgstr ""
-
-#: picard/const/locales.py:112
-msgid "Haryanvi"
-msgstr ""
-
-#: picard/const/locales.py:113
-msgid "Haryanvi (India)"
-msgstr ""
-
-#: picard/const/locales.py:114
-msgid "Western Balochi"
-msgstr ""
-
-#: picard/const/locales.py:115
-msgid "Western Balochi (United Arab Emirates)"
-msgstr ""
-
-#: picard/const/locales.py:116
-msgid "Western Balochi (Afghanistan)"
-msgstr ""
-
-#: picard/const/locales.py:117
-msgid "Western Balochi (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:118
-msgid "Western Balochi (Oman)"
-msgstr ""
-
-#: picard/const/locales.py:119
-msgid "Western Balochi (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:120
-msgid "Bhojpuri"
-msgstr ""
-
-#: picard/const/locales.py:121
-msgid "Bhojpuri (India)"
-msgstr ""
-
-#: picard/const/locales.py:122
-msgid "Tai Dam"
-msgstr ""
-
-#: picard/const/locales.py:123
-msgid "Tai Dam (Vietnam)"
-msgstr ""
-
-#: picard/const/locales.py:124
-msgid "Bambara"
-msgstr ""
-
-#: picard/const/locales.py:125
-msgid "Bambara (Mali)"
-msgstr ""
-
-#: picard/const/locales.py:126
-msgid "Bambara (N’Ko)"
-msgstr ""
-
-#: picard/const/locales.py:127
-msgid "Bambara (N’Ko) (Mali)"
-msgstr ""
-
-#: picard/const/locales.py:128
-msgid "Bangla"
-msgstr ""
-
-#: picard/const/locales.py:129
-msgid "Bangla (Bangladesh)"
-msgstr ""
-
-#: picard/const/locales.py:130
-msgid "Bangla (India)"
-msgstr ""
-
-#: picard/const/locales.py:131
-msgid "Tibetan"
-msgstr ""
-
-#: picard/const/locales.py:132
-msgid "Tibetan (China)"
-msgstr ""
-
-#: picard/const/locales.py:133
-msgid "Tibetan (India)"
-msgstr ""
-
-#: picard/const/locales.py:134
-msgid "Breton"
-msgstr ""
-
-#: picard/const/locales.py:135
-msgid "Breton (France)"
-msgstr ""
-
-#: picard/const/locales.py:136
-msgid "Bodo"
-msgstr ""
-
-#: picard/const/locales.py:137
-msgid "Bodo (India)"
-msgstr ""
-
-#: picard/const/locales.py:138
-msgid "Bosnian"
-msgstr ""
-
-#: picard/const/locales.py:139
-msgid "Bosnian (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:140
-msgid "Bosnian (Cyrillic) (Bosnia & Herzegovina)"
-msgstr ""
-
-#: picard/const/locales.py:141
-msgid "Bosnian (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:142
-msgid "Bosnian (Latin) (Bosnia & Herzegovina)"
-msgstr ""
-
-#: picard/const/locales.py:143
-msgid "Akoose"
-msgstr ""
-
-#: picard/const/locales.py:144
-msgid "Akoose (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:145
-msgid "Blin"
-msgstr ""
-
-#: picard/const/locales.py:146
-msgid "Blin (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:148
-msgid "Catalan (Andorra)"
-msgstr ""
-
-#: picard/const/locales.py:149
-msgid "Catalan (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:150
-msgid "Catalan (Spain Valencian)"
-msgstr ""
-
-#: picard/const/locales.py:151
-msgid "Catalan (France)"
-msgstr ""
-
-#: picard/const/locales.py:152
-msgid "Catalan (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:153
-msgid "Caddo"
-msgstr ""
-
-#: picard/const/locales.py:154
-msgid "Caddo (United States)"
-msgstr ""
-
-#: picard/const/locales.py:155
-msgid "Atsam"
-msgstr ""
-
-#: picard/const/locales.py:156
-msgid "Atsam (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:157
-msgid "Chakma"
-msgstr ""
-
-#: picard/const/locales.py:158
-msgid "Chakma (Bangladesh)"
-msgstr ""
-
-#: picard/const/locales.py:159
-msgid "Chakma (India)"
-msgstr ""
-
-#: picard/const/locales.py:160
-msgid "Chechen"
-msgstr ""
-
-#: picard/const/locales.py:161
-msgid "Chechen (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:162
-msgid "Cebuano"
-msgstr ""
-
-#: picard/const/locales.py:163
-msgid "Cebuano (Philippines)"
-msgstr ""
-
-#: picard/const/locales.py:164
-msgid "Chiga"
-msgstr ""
-
-#: picard/const/locales.py:165
-msgid "Chiga (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:166
-msgid "Choctaw"
-msgstr ""
-
-#: picard/const/locales.py:167
-msgid "Choctaw (United States)"
-msgstr ""
-
-#: picard/const/locales.py:168
-msgid "Cherokee"
-msgstr ""
-
-#: picard/const/locales.py:169
-msgid "Cherokee (United States)"
-msgstr ""
-
-#: picard/const/locales.py:170
-msgid "Chickasaw"
-msgstr ""
-
-#: picard/const/locales.py:171
-msgid "Chickasaw (United States)"
-msgstr ""
-
-#: picard/const/locales.py:172
-msgid "Central Kurdish"
-msgstr ""
-
-#: picard/const/locales.py:173
-msgid "Central Kurdish (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:174
-msgid "Central Kurdish (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:175
-msgid "Corsican"
-msgstr ""
-
-#: picard/const/locales.py:176
-msgid "Corsican (France)"
-msgstr ""
-
-#: picard/const/locales.py:178
-msgid "Czech (Czechia)"
-msgstr ""
-
-#: picard/const/locales.py:179
-msgid "Church Slavic"
-msgstr ""
-
-#: picard/const/locales.py:180
-msgid "Church Slavic (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:181
-msgid "Chuvash"
-msgstr ""
-
-#: picard/const/locales.py:182
-msgid "Chuvash (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:183
-msgid "Welsh"
-msgstr ""
-
-#: picard/const/locales.py:184
-msgid "Welsh (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:186
-msgid "Danish (Denmark)"
-msgstr ""
-
-#: picard/const/locales.py:187
-msgid "Danish (Greenland)"
-msgstr ""
-
-#: picard/const/locales.py:188
-msgid "Taita"
-msgstr ""
-
-#: picard/const/locales.py:189
-msgid "Taita (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:191
-msgid "German (Austria)"
-msgstr ""
-
-#: picard/const/locales.py:192
-msgid "German (Belgium)"
-msgstr ""
-
-#: picard/const/locales.py:194
-msgid "German (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:195
-msgid "German (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:196
-msgid "German (Liechtenstein)"
-msgstr ""
-
-#: picard/const/locales.py:197
-msgid "German (Luxembourg)"
-msgstr ""
-
-#: picard/const/locales.py:198
-msgid "Zarma"
-msgstr ""
-
-#: picard/const/locales.py:199
-msgid "Zarma (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:200
-msgid "Dogri"
-msgstr ""
-
-#: picard/const/locales.py:201
-msgid "Dogri (India)"
-msgstr ""
-
-#: picard/const/locales.py:202
-msgid "Lower Sorbian"
-msgstr ""
-
-#: picard/const/locales.py:203
-msgid "Lower Sorbian (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:204
-msgid "Duala"
-msgstr ""
-
-#: picard/const/locales.py:205
-msgid "Duala (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:206
-msgid "Divehi"
-msgstr ""
-
-#: picard/const/locales.py:207
-msgid "Divehi (Maldives)"
-msgstr ""
-
-#: picard/const/locales.py:208
-msgid "Jola-Fonyi"
-msgstr ""
-
-#: picard/const/locales.py:209
-msgid "Jola-Fonyi (Senegal)"
-msgstr ""
-
-#: picard/const/locales.py:210
-msgid "Dzongkha"
-msgstr ""
-
-#: picard/const/locales.py:211
-msgid "Dzongkha (Bhutan)"
-msgstr ""
-
-#: picard/const/locales.py:212
-msgid "Embu"
-msgstr ""
-
-#: picard/const/locales.py:213
-msgid "Embu (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:214
-msgid "Ewe"
-msgstr ""
-
-#: picard/const/locales.py:215
-msgid "Ewe (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:216
-msgid "Ewe (Togo)"
-msgstr ""
-
-#: picard/const/locales.py:218
-msgid "Greek (Cyprus)"
-msgstr ""
-
-#: picard/const/locales.py:219
-msgid "Greek (Greece)"
-msgstr ""
-
-#: picard/const/locales.py:220
-msgid "Greek (Polytonic)"
-msgstr ""
-
-#: picard/const/locales.py:222
-msgid "English (world)"
-msgstr ""
-
-#: picard/const/locales.py:223
-msgid "English (Europe)"
-msgstr ""
-
-#: picard/const/locales.py:224
-msgid "English (United Arab Emirates)"
-msgstr ""
-
-#: picard/const/locales.py:225
-msgid "English (Antigua & Barbuda)"
-msgstr ""
-
-#: picard/const/locales.py:226
-msgid "English (Anguilla)"
-msgstr ""
-
-#: picard/const/locales.py:227
-msgid "English (American Samoa)"
-msgstr ""
-
-#: picard/const/locales.py:228
-msgid "English (Austria)"
-msgstr ""
-
-#: picard/const/locales.py:230
-msgid "English (Barbados)"
-msgstr ""
-
-#: picard/const/locales.py:231
-msgid "English (Belgium)"
-msgstr ""
-
-#: picard/const/locales.py:232
-msgid "English (Burundi)"
-msgstr ""
-
-#: picard/const/locales.py:233
-msgid "English (Bermuda)"
-msgstr ""
-
-#: picard/const/locales.py:234
-msgid "English (Bahamas)"
-msgstr ""
-
-#: picard/const/locales.py:235
-msgid "English (Botswana)"
-msgstr ""
-
-#: picard/const/locales.py:236
-msgid "English (Belize)"
-msgstr ""
-
-#: picard/const/locales.py:238
-msgid "English (Cocos (Keeling) Islands)"
-msgstr ""
-
-#: picard/const/locales.py:239
-msgid "English (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:240
-msgid "English (Cook Islands)"
-msgstr ""
-
-#: picard/const/locales.py:241
-msgid "English (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:242
-msgid "English (Christmas Island)"
-msgstr ""
-
-#: picard/const/locales.py:243
-msgid "English (Cyprus)"
-msgstr ""
-
-#: picard/const/locales.py:244
-msgid "English (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:245
-msgid "English (Diego Garcia)"
-msgstr ""
-
-#: picard/const/locales.py:246
-msgid "English (Denmark)"
-msgstr ""
-
-#: picard/const/locales.py:247
-msgid "English (Dominica)"
-msgstr ""
-
-#: picard/const/locales.py:248
-msgid "English (Deseret)"
-msgstr ""
-
-#: picard/const/locales.py:249
-msgid "English (Deseret) (United States)"
-msgstr ""
-
-#: picard/const/locales.py:250
-msgid "English (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:251
-msgid "English (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:252
-msgid "English (Fiji)"
-msgstr ""
-
-#: picard/const/locales.py:253
-msgid "English (Falkland Islands)"
-msgstr ""
-
-#: picard/const/locales.py:254
-msgid "English (Micronesia)"
-msgstr ""
-
-#: picard/const/locales.py:255
-msgid "English (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:256
-msgid "English (Grenada)"
-msgstr ""
-
-#: picard/const/locales.py:257
-msgid "English (Guernsey)"
-msgstr ""
-
-#: picard/const/locales.py:258
-msgid "English (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:259
-msgid "English (Gibraltar)"
-msgstr ""
-
-#: picard/const/locales.py:260
-msgid "English (Gambia)"
-msgstr ""
-
-#: picard/const/locales.py:261
-msgid "English (Guam)"
-msgstr ""
-
-#: picard/const/locales.py:262
-msgid "English (Guyana)"
-msgstr ""
-
-#: picard/const/locales.py:263
-msgid "English (Hong Kong)"
-msgstr ""
-
-#: picard/const/locales.py:264
-msgid "English (Ireland)"
-msgstr ""
-
-#: picard/const/locales.py:265
-msgid "English (Israel)"
-msgstr ""
-
-#: picard/const/locales.py:266
-msgid "English (Isle of Man)"
-msgstr ""
-
-#: picard/const/locales.py:267
-msgid "English (India)"
-msgstr ""
-
-#: picard/const/locales.py:268
-msgid "English (British Indian Ocean Territory)"
-msgstr ""
-
-#: picard/const/locales.py:269
-msgid "English (Jersey)"
-msgstr ""
-
-#: picard/const/locales.py:270
-msgid "English (Jamaica)"
-msgstr ""
-
-#: picard/const/locales.py:271
-msgid "English (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:272
-msgid "English (Kiribati)"
-msgstr ""
-
-#: picard/const/locales.py:273
-msgid "English (St. Kitts & Nevis)"
-msgstr ""
-
-#: picard/const/locales.py:274
-msgid "English (Cayman Islands)"
-msgstr ""
-
-#: picard/const/locales.py:275
-msgid "English (St. Lucia)"
-msgstr ""
-
-#: picard/const/locales.py:276
-msgid "English (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:277
-msgid "English (Lesotho)"
-msgstr ""
-
-#: picard/const/locales.py:278
-msgid "English (Madagascar)"
-msgstr ""
-
-#: picard/const/locales.py:279
-msgid "English (Marshall Islands)"
-msgstr ""
-
-#: picard/const/locales.py:280
-msgid "English (Macao)"
-msgstr ""
-
-#: picard/const/locales.py:281
-msgid "English (Northern Mariana Islands)"
-msgstr ""
-
-#: picard/const/locales.py:282
-msgid "English (Montserrat)"
-msgstr ""
-
-#: picard/const/locales.py:283
-msgid "English (Malta)"
-msgstr ""
-
-#: picard/const/locales.py:284
-msgid "English (Mauritius)"
-msgstr ""
-
-#: picard/const/locales.py:285
-msgid "English (Maldives)"
-msgstr ""
-
-#: picard/const/locales.py:286
-msgid "English (Malawi)"
-msgstr ""
-
-#: picard/const/locales.py:287
-msgid "English (Malaysia)"
-msgstr ""
-
-#: picard/const/locales.py:288
-msgid "English (Namibia)"
-msgstr ""
-
-#: picard/const/locales.py:289
-msgid "English (Norfolk Island)"
-msgstr ""
-
-#: picard/const/locales.py:290
-msgid "English (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:291
-msgid "English (Netherlands)"
-msgstr ""
-
-#: picard/const/locales.py:292
-msgid "English (Nauru)"
-msgstr ""
-
-#: picard/const/locales.py:293
-msgid "English (Niue)"
-msgstr ""
-
-#: picard/const/locales.py:294
-msgid "English (New Zealand)"
-msgstr ""
-
-#: picard/const/locales.py:295
-msgid "English (Papua New Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:296
-msgid "English (Philippines)"
-msgstr ""
-
-#: picard/const/locales.py:297
-msgid "English (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:298
-msgid "English (Pitcairn Islands)"
-msgstr ""
-
-#: picard/const/locales.py:299
-msgid "English (Puerto Rico)"
-msgstr ""
-
-#: picard/const/locales.py:300
-msgid "English (Palau)"
-msgstr ""
-
-#: picard/const/locales.py:301
-msgid "English (Rwanda)"
-msgstr ""
-
-#: picard/const/locales.py:302
-msgid "English (Solomon Islands)"
-msgstr ""
-
-#: picard/const/locales.py:303
-msgid "English (Seychelles)"
-msgstr ""
-
-#: picard/const/locales.py:304
-msgid "English (Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:305
-msgid "English (Sweden)"
-msgstr ""
-
-#: picard/const/locales.py:306
-msgid "English (Singapore)"
-msgstr ""
-
-#: picard/const/locales.py:307
-msgid "English (St. Helena)"
-msgstr ""
-
-#: picard/const/locales.py:308
-msgid "English (Slovenia)"
-msgstr ""
-
-#: picard/const/locales.py:309
-msgid "English (Sierra Leone)"
-msgstr ""
-
-#: picard/const/locales.py:310
-msgid "English (South Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:311
-msgid "English (Sint Maarten)"
-msgstr ""
-
-#: picard/const/locales.py:312
-msgid "English (Eswatini)"
-msgstr ""
-
-#: picard/const/locales.py:313
-msgid "English (Shavian)"
-msgstr ""
-
-#: picard/const/locales.py:314
-msgid "English (Shavian) (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:315
-msgid "English (Turks & Caicos Islands)"
-msgstr ""
-
-#: picard/const/locales.py:316
-msgid "English (Tokelau)"
-msgstr ""
-
-#: picard/const/locales.py:317
-msgid "English (Tonga)"
-msgstr ""
-
-#: picard/const/locales.py:318
-msgid "English (Trinidad & Tobago)"
-msgstr ""
-
-#: picard/const/locales.py:319
-msgid "English (Tuvalu)"
-msgstr ""
-
-#: picard/const/locales.py:320
-msgid "English (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:321
-msgid "English (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:322
-msgid "English (U.S. Outlying Islands)"
-msgstr ""
-
-#: picard/const/locales.py:323
-msgid "English (United States)"
-msgstr ""
-
-#: picard/const/locales.py:324
-msgid "English (St. Vincent & Grenadines)"
-msgstr ""
-
-#: picard/const/locales.py:325
-msgid "English (British Virgin Islands)"
-msgstr ""
-
-#: picard/const/locales.py:326
-msgid "English (U.S. Virgin Islands)"
-msgstr ""
-
-#: picard/const/locales.py:327
-msgid "English (Vanuatu)"
-msgstr ""
-
-#: picard/const/locales.py:328
-msgid "English (Samoa)"
-msgstr ""
-
-#: picard/const/locales.py:329
-msgid "English (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:330
-msgid "English (Zambia)"
-msgstr ""
-
-#: picard/const/locales.py:331
-msgid "English (Zimbabwe)"
-msgstr ""
-
-#: picard/const/locales.py:332
-msgid "Esperanto"
-msgstr ""
-
-#: picard/const/locales.py:333
-msgid "Esperanto (world)"
-msgstr ""
-
-#: picard/const/locales.py:335
-msgid "Spanish (Latin America)"
-msgstr ""
-
-#: picard/const/locales.py:336
-msgid "Spanish (Argentina)"
-msgstr ""
-
-#: picard/const/locales.py:337
-msgid "Spanish (Bolivia)"
-msgstr ""
-
-#: picard/const/locales.py:338
-msgid "Spanish (Brazil)"
-msgstr ""
-
-#: picard/const/locales.py:339
-msgid "Spanish (Belize)"
-msgstr ""
-
-#: picard/const/locales.py:340
-msgid "Spanish (Chile)"
-msgstr ""
-
-#: picard/const/locales.py:341
-msgid "Spanish (Colombia)"
-msgstr ""
-
-#: picard/const/locales.py:342
-msgid "Spanish (Costa Rica)"
-msgstr ""
-
-#: picard/const/locales.py:343
-msgid "Spanish (Cuba)"
-msgstr ""
-
-#: picard/const/locales.py:344
-msgid "Spanish (Dominican Republic)"
-msgstr ""
-
-#: picard/const/locales.py:345
-msgid "Spanish (Ceuta & Melilla)"
-msgstr ""
-
-#: picard/const/locales.py:346
-msgid "Spanish (Ecuador)"
-msgstr ""
-
-#: picard/const/locales.py:347
-msgid "Spanish (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:348
-msgid "Spanish (Equatorial Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:349
-msgid "Spanish (Guatemala)"
-msgstr ""
-
-#: picard/const/locales.py:350
-msgid "Spanish (Honduras)"
-msgstr ""
-
-#: picard/const/locales.py:351
-msgid "Spanish (Canary Islands)"
-msgstr ""
-
-#: picard/const/locales.py:352
-msgid "Spanish (Mexico)"
-msgstr ""
-
-#: picard/const/locales.py:353
-msgid "Spanish (Nicaragua)"
-msgstr ""
-
-#: picard/const/locales.py:354
-msgid "Spanish (Panama)"
-msgstr ""
-
-#: picard/const/locales.py:355
-msgid "Spanish (Peru)"
-msgstr ""
-
-#: picard/const/locales.py:356
-msgid "Spanish (Philippines)"
-msgstr ""
-
-#: picard/const/locales.py:357
-msgid "Spanish (Puerto Rico)"
-msgstr ""
-
-#: picard/const/locales.py:358
-msgid "Spanish (Paraguay)"
-msgstr ""
-
-#: picard/const/locales.py:359
-msgid "Spanish (El Salvador)"
-msgstr ""
-
-#: picard/const/locales.py:360
-msgid "Spanish (United States)"
-msgstr ""
-
-#: picard/const/locales.py:361
-msgid "Spanish (Uruguay)"
-msgstr ""
-
-#: picard/const/locales.py:362
-msgid "Spanish (Venezuela)"
-msgstr ""
-
-#: picard/const/locales.py:364
-msgid "Estonian (Estonia)"
-msgstr ""
-
-#: picard/const/locales.py:365
-msgid "Basque"
-msgstr ""
-
-#: picard/const/locales.py:366
-msgid "Basque (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:367
-msgid "Ewondo"
-msgstr ""
-
-#: picard/const/locales.py:368
-msgid "Ewondo (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:369
-msgid "Persian"
-msgstr ""
-
-#: picard/const/locales.py:370
-msgid "Persian (Afghanistan)"
-msgstr ""
-
-#: picard/const/locales.py:371
-msgid "Persian (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:372
-msgid "Fula"
-msgstr ""
-
-#: picard/const/locales.py:373
-msgid "Fula (Adlam)"
-msgstr ""
-
-#: picard/const/locales.py:374
-msgid "Fula (Adlam) (Burkina Faso)"
-msgstr ""
-
-#: picard/const/locales.py:375
-msgid "Fula (Adlam) (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:376
-msgid "Fula (Adlam) (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:377
-msgid "Fula (Adlam) (Gambia)"
-msgstr ""
-
-#: picard/const/locales.py:378
-msgid "Fula (Adlam) (Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:379
-msgid "Fula (Adlam) (Guinea-Bissau)"
-msgstr ""
-
-#: picard/const/locales.py:380
-msgid "Fula (Adlam) (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:381
-msgid "Fula (Adlam) (Mauritania)"
-msgstr ""
-
-#: picard/const/locales.py:382
-msgid "Fula (Adlam) (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:383
-msgid "Fula (Adlam) (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:384
-msgid "Fula (Adlam) (Sierra Leone)"
-msgstr ""
-
-#: picard/const/locales.py:385
-msgid "Fula (Adlam) (Senegal)"
-msgstr ""
-
-#: picard/const/locales.py:386
-msgid "Fula (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:387
-msgid "Fula (Latin) (Burkina Faso)"
-msgstr ""
-
-#: picard/const/locales.py:388
-msgid "Fula (Latin) (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:389
-msgid "Fula (Latin) (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:390
-msgid "Fula (Latin) (Gambia)"
-msgstr ""
-
-#: picard/const/locales.py:391
-msgid "Fula (Latin) (Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:392
-msgid "Fula (Latin) (Guinea-Bissau)"
-msgstr ""
-
-#: picard/const/locales.py:393
-msgid "Fula (Latin) (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:394
-msgid "Fula (Latin) (Mauritania)"
-msgstr ""
-
-#: picard/const/locales.py:395
-msgid "Fula (Latin) (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:396
-msgid "Fula (Latin) (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:397
-msgid "Fula (Latin) (Sierra Leone)"
-msgstr ""
-
-#: picard/const/locales.py:398
-msgid "Fula (Latin) (Senegal)"
-msgstr ""
-
-#: picard/const/locales.py:400
-msgid "Finnish (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:401
-msgid "Filipino"
-msgstr ""
-
-#: picard/const/locales.py:402
-msgid "Filipino (Philippines)"
-msgstr ""
-
-#: picard/const/locales.py:403
-msgid "Faroese"
-msgstr ""
-
-#: picard/const/locales.py:404
-msgid "Faroese (Denmark)"
-msgstr ""
-
-#: picard/const/locales.py:405
-msgid "Faroese (Faroe Islands)"
-msgstr ""
-
-#: picard/const/locales.py:407
-msgid "French (Belgium)"
-msgstr ""
-
-#: picard/const/locales.py:408
-msgid "French (Burkina Faso)"
-msgstr ""
-
-#: picard/const/locales.py:409
-msgid "French (Burundi)"
-msgstr ""
-
-#: picard/const/locales.py:410
-msgid "French (Benin)"
-msgstr ""
-
-#: picard/const/locales.py:411
-msgid "French (St. Barthélemy)"
-msgstr ""
-
-#: picard/const/locales.py:413
-msgid "French (Congo - Kinshasa)"
-msgstr ""
-
-#: picard/const/locales.py:414
-msgid "French (Central African Republic)"
-msgstr ""
-
-#: picard/const/locales.py:415
-msgid "French (Congo - Brazzaville)"
-msgstr ""
-
-#: picard/const/locales.py:416
-msgid "French (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:417
-msgid "French (Côte d’Ivoire)"
-msgstr ""
-
-#: picard/const/locales.py:418
-msgid "French (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:419
-msgid "French (Djibouti)"
-msgstr ""
-
-#: picard/const/locales.py:420
-msgid "French (Algeria)"
-msgstr ""
-
-#: picard/const/locales.py:421
-msgid "French (France)"
-msgstr ""
-
-#: picard/const/locales.py:422
-msgid "French (Gabon)"
-msgstr ""
-
-#: picard/const/locales.py:423
-msgid "French (French Guiana)"
-msgstr ""
-
-#: picard/const/locales.py:424
-msgid "French (Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:425
-msgid "French (Guadeloupe)"
-msgstr ""
-
-#: picard/const/locales.py:426
-msgid "French (Equatorial Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:427
-msgid "French (Haiti)"
-msgstr ""
-
-#: picard/const/locales.py:428
-msgid "French (Comoros)"
-msgstr ""
-
-#: picard/const/locales.py:429
-msgid "French (Luxembourg)"
-msgstr ""
-
-#: picard/const/locales.py:430
-msgid "French (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:431
-msgid "French (Monaco)"
-msgstr ""
-
-#: picard/const/locales.py:432
-msgid "French (St. Martin)"
-msgstr ""
-
-#: picard/const/locales.py:433
-msgid "French (Madagascar)"
-msgstr ""
-
-#: picard/const/locales.py:434
-msgid "French (Mali)"
-msgstr ""
-
-#: picard/const/locales.py:435
-msgid "French (Martinique)"
-msgstr ""
-
-#: picard/const/locales.py:436
-msgid "French (Mauritania)"
-msgstr ""
-
-#: picard/const/locales.py:437
-msgid "French (Mauritius)"
-msgstr ""
-
-#: picard/const/locales.py:438
-msgid "French (New Caledonia)"
-msgstr ""
-
-#: picard/const/locales.py:439
-msgid "French (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:440
-msgid "French (French Polynesia)"
-msgstr ""
-
-#: picard/const/locales.py:441
-msgid "French (St. Pierre & Miquelon)"
-msgstr ""
-
-#: picard/const/locales.py:442
-msgid "French (Réunion)"
-msgstr ""
-
-#: picard/const/locales.py:443
-msgid "French (Rwanda)"
-msgstr ""
-
-#: picard/const/locales.py:444
-msgid "French (Seychelles)"
-msgstr ""
-
-#: picard/const/locales.py:445
-msgid "French (Senegal)"
-msgstr ""
-
-#: picard/const/locales.py:446
-msgid "French (Syria)"
-msgstr ""
-
-#: picard/const/locales.py:447
-msgid "French (Chad)"
-msgstr ""
-
-#: picard/const/locales.py:448
-msgid "French (Togo)"
-msgstr ""
-
-#: picard/const/locales.py:449
-msgid "French (Tunisia)"
-msgstr ""
-
-#: picard/const/locales.py:450
-msgid "French (Vanuatu)"
-msgstr ""
-
-#: picard/const/locales.py:451
-msgid "French (Wallis & Futuna)"
-msgstr ""
-
-#: picard/const/locales.py:452
-msgid "French (Mayotte)"
-msgstr ""
-
-#: picard/const/locales.py:453
-msgid "Northern Frisian"
-msgstr ""
-
-#: picard/const/locales.py:454
-msgid "Northern Frisian (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:455
-msgid "Friulian"
-msgstr ""
-
-#: picard/const/locales.py:456
-msgid "Friulian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:457
-msgid "Western Frisian"
-msgstr ""
-
-#: picard/const/locales.py:458
-msgid "Western Frisian (Netherlands)"
-msgstr ""
-
-#: picard/const/locales.py:459
-msgid "Irish"
-msgstr ""
-
-#: picard/const/locales.py:460
-msgid "Irish (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:461
-msgid "Irish (Ireland)"
-msgstr ""
-
-#: picard/const/locales.py:462
-msgid "Ga"
-msgstr ""
-
-#: picard/const/locales.py:463
-msgid "Ga (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:464
-msgid "Scottish Gaelic"
-msgstr ""
-
-#: picard/const/locales.py:465
-msgid "Scottish Gaelic (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:466
-msgid "Geez"
-msgstr ""
-
-#: picard/const/locales.py:467
-msgid "Geez (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:468
-msgid "Geez (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:470
-msgid "Galician (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:471
-msgid "Guarani"
-msgstr ""
-
-#: picard/const/locales.py:472
-msgid "Guarani (Paraguay)"
-msgstr ""
-
-#: picard/const/locales.py:473
-msgid "Swiss German"
-msgstr ""
-
-#: picard/const/locales.py:474
-msgid "Swiss German (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:475
-msgid "Swiss German (France)"
-msgstr ""
-
-#: picard/const/locales.py:476
-msgid "Swiss German (Liechtenstein)"
-msgstr ""
-
-#: picard/const/locales.py:477
-msgid "Gujarati"
-msgstr ""
-
-#: picard/const/locales.py:478
-msgid "Gujarati (India)"
-msgstr ""
-
-#: picard/const/locales.py:479
-msgid "Gusii"
-msgstr ""
-
-#: picard/const/locales.py:480
-msgid "Gusii (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:481
-msgid "Manx"
-msgstr ""
-
-#: picard/const/locales.py:482
-msgid "Manx (Isle of Man)"
-msgstr ""
-
-#: picard/const/locales.py:483
-msgid "Hausa"
-msgstr ""
-
-#: picard/const/locales.py:484
-msgid "Hausa (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:485
-msgid "Hausa (Arabic) (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:486
-msgid "Hausa (Arabic) (Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:487
-msgid "Hausa (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:488
-msgid "Hausa (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:489
-msgid "Hausa (Latin) (Ghana)"
-msgstr ""
-
-#: picard/const/locales.py:490
-msgid "Hausa (Latin) (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:491
-msgid "Hausa (Latin) (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:492
-msgid "Hausa (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:493
-msgid "Hausa (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:494
-msgid "Hausa (Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:495
-msgid "Hawaiian"
-msgstr ""
-
-#: picard/const/locales.py:496
-msgid "Hawaiian (United States)"
-msgstr ""
-
-#: picard/const/locales.py:498
-msgid "Hebrew (Israel)"
-msgstr ""
-
-#: picard/const/locales.py:499
-msgid "Hindi"
-msgstr ""
-
-#: picard/const/locales.py:500
-msgid "Hindi (India)"
-msgstr ""
-
-#: picard/const/locales.py:501
-msgid "Hindi (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:502
-msgid "Hindi (Latin) (India)"
-msgstr ""
-
-#: picard/const/locales.py:503
-msgid "Hmong Njua"
-msgstr ""
-
-#: picard/const/locales.py:504
-msgid "Hmong Njua (Nyiakeng Puachue Hmong)"
-msgstr ""
-
-#: picard/const/locales.py:505
-msgid "Hmong Njua (Nyiakeng Puachue Hmong) (United States)"
-msgstr ""
-
-#: picard/const/locales.py:506
-msgid "Croatian"
-msgstr ""
-
-#: picard/const/locales.py:507
-msgid "Croatian (Bosnia & Herzegovina)"
-msgstr ""
-
-#: picard/const/locales.py:508
-msgid "Croatian (Croatia)"
-msgstr ""
-
-#: picard/const/locales.py:509
-msgid "Upper Sorbian"
-msgstr ""
-
-#: picard/const/locales.py:510
-msgid "Upper Sorbian (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:512
-msgid "Hungarian (Hungary)"
-msgstr ""
-
-#: picard/const/locales.py:513
-msgid "Armenian"
-msgstr ""
-
-#: picard/const/locales.py:514
-msgid "Armenian (Armenia)"
-msgstr ""
-
-#: picard/const/locales.py:515
-msgid "Armenian (Armenia) (Revised Orthography)"
-msgstr ""
-
-#: picard/const/locales.py:516
-msgid "Interlingua"
-msgstr ""
-
-#: picard/const/locales.py:517
-msgid "Interlingua (world)"
-msgstr ""
-
-#: picard/const/locales.py:518
-msgid "Indonesian"
-msgstr ""
-
-#: picard/const/locales.py:519
-msgid "Indonesian (Indonesia)"
-msgstr ""
-
-#: picard/const/locales.py:520
-msgid "Igbo"
-msgstr ""
-
-#: picard/const/locales.py:521
-msgid "Igbo (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:522
-msgid "Sichuan Yi"
-msgstr ""
-
-#: picard/const/locales.py:523
-msgid "Sichuan Yi (China)"
-msgstr ""
-
-#: picard/const/locales.py:524
-msgid "Ido"
-msgstr ""
-
-#: picard/const/locales.py:525
-msgid "Ido (world)"
-msgstr ""
-
-#: picard/const/locales.py:527
-msgid "Icelandic (Iceland)"
-msgstr ""
-
-#: picard/const/locales.py:529
-msgid "Italian (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:530
-msgid "Italian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:531
-msgid "Italian (San Marino)"
-msgstr ""
-
-#: picard/const/locales.py:532
-msgid "Italian (Vatican City)"
-msgstr ""
-
-#: picard/const/locales.py:533
-msgid "Inuktitut"
-msgstr ""
-
-#: picard/const/locales.py:534
-msgid "Inuktitut (Canada)"
-msgstr ""
-
-#: picard/const/locales.py:535
-msgid "Inuktitut (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:536
-msgid "Inuktitut (Latin) (Canada)"
-msgstr ""
-
-#: picard/const/locales.py:538
-msgid "Japanese (Japan)"
-msgstr ""
-
-#: picard/const/locales.py:539
-msgid "Lojban"
-msgstr ""
-
-#: picard/const/locales.py:540
-msgid "Lojban (world)"
-msgstr ""
-
-#: picard/const/locales.py:541
-msgid "Ngomba"
-msgstr ""
-
-#: picard/const/locales.py:542
-msgid "Ngomba (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:543
-msgid "Machame"
-msgstr ""
-
-#: picard/const/locales.py:544
-msgid "Machame (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:545
-msgid "Javanese"
-msgstr ""
-
-#: picard/const/locales.py:546
-msgid "Javanese (Indonesia)"
-msgstr ""
-
-#: picard/const/locales.py:547
-msgid "Georgian"
-msgstr ""
-
-#: picard/const/locales.py:548
-msgid "Georgian (Georgia)"
-msgstr ""
-
-#: picard/const/locales.py:549
-msgid "Kabyle"
-msgstr ""
-
-#: picard/const/locales.py:550
-msgid "Kabyle (Algeria)"
-msgstr ""
-
-#: picard/const/locales.py:551
-msgid "Jju"
-msgstr ""
-
-#: picard/const/locales.py:552
-msgid "Jju (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:553
-msgid "Kamba"
-msgstr ""
-
-#: picard/const/locales.py:554
-msgid "Kamba (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:555
-msgid "Tyap"
-msgstr ""
-
-#: picard/const/locales.py:556
-msgid "Tyap (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:557
-msgid "Makonde"
-msgstr ""
-
-#: picard/const/locales.py:558
-msgid "Makonde (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:559
-msgid "Kabuverdianu"
-msgstr ""
-
-#: picard/const/locales.py:560
-msgid "Kabuverdianu (Cape Verde)"
-msgstr ""
-
-#: picard/const/locales.py:561
-msgid "Kenyang"
-msgstr ""
-
-#: picard/const/locales.py:562
-msgid "Kenyang (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:563
-msgid "Koro"
-msgstr ""
-
-#: picard/const/locales.py:564
-msgid "Koro (Côte d’Ivoire)"
-msgstr ""
-
-#: picard/const/locales.py:565
-msgid "Kaingang"
-msgstr ""
-
-#: picard/const/locales.py:566
-msgid "Kaingang (Brazil)"
-msgstr ""
-
-#: picard/const/locales.py:567
-msgid "Koyra Chiini"
-msgstr ""
-
-#: picard/const/locales.py:568
-msgid "Koyra Chiini (Mali)"
-msgstr ""
-
-#: picard/const/locales.py:569
-msgid "Kikuyu"
-msgstr ""
-
-#: picard/const/locales.py:570
-msgid "Kikuyu (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:571
-msgid "Kazakh"
-msgstr ""
-
-#: picard/const/locales.py:572
-msgid "Kazakh (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:573
-msgid "Kazakh (Cyrillic) (Kazakhstan)"
-msgstr ""
-
-#: picard/const/locales.py:574
-msgid "Kazakh (Kazakhstan)"
-msgstr ""
-
-#: picard/const/locales.py:575
-msgid "Kako"
-msgstr ""
-
-#: picard/const/locales.py:576
-msgid "Kako (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:577
-msgid "Kalaallisut"
-msgstr ""
-
-#: picard/const/locales.py:578
-msgid "Kalaallisut (Greenland)"
-msgstr ""
-
-#: picard/const/locales.py:579
-msgid "Kalenjin"
-msgstr ""
-
-#: picard/const/locales.py:580
-msgid "Kalenjin (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:581
-msgid "Khmer"
-msgstr ""
-
-#: picard/const/locales.py:582
-msgid "Khmer (Cambodia)"
-msgstr ""
-
-#: picard/const/locales.py:583
-msgid "Kannada"
-msgstr ""
-
-#: picard/const/locales.py:584
-msgid "Kannada (India)"
-msgstr ""
-
-#: picard/const/locales.py:586
-msgid "Korean (North Korea)"
-msgstr ""
-
-#: picard/const/locales.py:587
-msgid "Korean (South Korea)"
-msgstr ""
-
-#: picard/const/locales.py:588
-msgid "Konkani"
-msgstr ""
-
-#: picard/const/locales.py:589
-msgid "Konkani (India)"
-msgstr ""
-
-#: picard/const/locales.py:590
-msgid "Kpelle"
-msgstr ""
-
-#: picard/const/locales.py:591
-msgid "Kpelle (Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:592
-msgid "Kpelle (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:593
-msgid "Kashmiri"
-msgstr ""
-
-#: picard/const/locales.py:594
-msgid "Kashmiri (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:595
-msgid "Kashmiri (Arabic) (India)"
-msgstr ""
-
-#: picard/const/locales.py:596
-msgid "Kashmiri (Devanagari)"
-msgstr ""
-
-#: picard/const/locales.py:597
-msgid "Kashmiri (Devanagari) (India)"
-msgstr ""
-
-#: picard/const/locales.py:598
-msgid "Shambala"
-msgstr ""
-
-#: picard/const/locales.py:599
-msgid "Shambala (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:600
-msgid "Bafia"
-msgstr ""
-
-#: picard/const/locales.py:601
-msgid "Bafia (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:602
-msgid "Colognian"
-msgstr ""
-
-#: picard/const/locales.py:603
-msgid "Colognian (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:604
-msgid "Kurdish"
-msgstr ""
-
-#: picard/const/locales.py:605
-msgid "Kurdish (Türkiye)"
-msgstr ""
-
-#: picard/const/locales.py:606
-msgid "Cornish"
-msgstr ""
-
-#: picard/const/locales.py:607
-msgid "Cornish (United Kingdom)"
-msgstr ""
-
-#: picard/const/locales.py:608
-msgid "Kyrgyz"
-msgstr ""
-
-#: picard/const/locales.py:609
-msgid "Kyrgyz (Kyrgyzstan)"
-msgstr ""
-
-#: picard/const/locales.py:610 picard/const/scripts.py:28
-msgid "Latin"
-msgstr ""
-
-#: picard/const/locales.py:611
-msgid "Latin (Vatican City)"
-msgstr ""
-
-#: picard/const/locales.py:612
-msgid "Langi"
-msgstr ""
-
-#: picard/const/locales.py:613
-msgid "Langi (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:614
-msgid "Luxembourgish"
-msgstr ""
-
-#: picard/const/locales.py:615
-msgid "Luxembourgish (Luxembourg)"
-msgstr ""
-
-#: picard/const/locales.py:616
-msgid "Ganda"
-msgstr ""
-
-#: picard/const/locales.py:617
-msgid "Ganda (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:618
-msgid "Ligurian"
-msgstr ""
-
-#: picard/const/locales.py:619
-msgid "Ligurian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:620
-msgid "Lakota"
-msgstr ""
-
-#: picard/const/locales.py:621
-msgid "Lakota (United States)"
-msgstr ""
-
-#: picard/const/locales.py:622
-msgid "Lombard"
-msgstr ""
-
-#: picard/const/locales.py:623
-msgid "Lombard (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:624
-msgid "Lingala"
-msgstr ""
-
-#: picard/const/locales.py:625
-msgid "Lingala (Angola)"
-msgstr ""
-
-#: picard/const/locales.py:626
-msgid "Lingala (Congo - Kinshasa)"
-msgstr ""
-
-#: picard/const/locales.py:627
-msgid "Lingala (Central African Republic)"
-msgstr ""
-
-#: picard/const/locales.py:628
-msgid "Lingala (Congo - Brazzaville)"
-msgstr ""
-
-#: picard/const/locales.py:629
-msgid "Lao"
-msgstr ""
-
-#: picard/const/locales.py:630
-msgid "Lao (Laos)"
-msgstr ""
-
-#: picard/const/locales.py:631
-msgid "Northern Luri"
-msgstr ""
-
-#: picard/const/locales.py:632
-msgid "Northern Luri (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:633
-msgid "Northern Luri (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:634
-msgid "Lithuanian"
-msgstr ""
-
-#: picard/const/locales.py:635
-msgid "Lithuanian (Lithuania)"
-msgstr ""
-
-#: picard/const/locales.py:636
-msgid "Luba-Katanga"
-msgstr ""
-
-#: picard/const/locales.py:637
-msgid "Luba-Katanga (Congo - Kinshasa)"
-msgstr ""
-
-#: picard/const/locales.py:638
-msgid "Luo"
-msgstr ""
-
-#: picard/const/locales.py:639
-msgid "Luo (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:640
-msgid "Luyia"
-msgstr ""
-
-#: picard/const/locales.py:641
-msgid "Luyia (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:642
-msgid "Latvian"
-msgstr ""
-
-#: picard/const/locales.py:643
-msgid "Latvian (Latvia)"
-msgstr ""
-
-#: picard/const/locales.py:644
-msgid "Maithili"
-msgstr ""
-
-#: picard/const/locales.py:645
-msgid "Maithili (India)"
-msgstr ""
-
-#: picard/const/locales.py:646
-msgid "Masai"
-msgstr ""
-
-#: picard/const/locales.py:647
-msgid "Masai (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:648
-msgid "Masai (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:649
-msgid "Moksha"
-msgstr ""
-
-#: picard/const/locales.py:650
-msgid "Moksha (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:651
-msgid "Meru"
-msgstr ""
-
-#: picard/const/locales.py:652
-msgid "Meru (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:653
-msgid "Morisyen"
-msgstr ""
-
-#: picard/const/locales.py:654
-msgid "Morisyen (Mauritius)"
-msgstr ""
-
-#: picard/const/locales.py:655
-msgid "Malagasy"
-msgstr ""
-
-#: picard/const/locales.py:656
-msgid "Malagasy (Madagascar)"
-msgstr ""
-
-#: picard/const/locales.py:657
-msgid "Makhuwa-Meetto"
-msgstr ""
-
-#: picard/const/locales.py:658
-msgid "Makhuwa-Meetto (Mozambique)"
-msgstr ""
-
-#: picard/const/locales.py:659
-msgid "Metaʼ"
-msgstr ""
-
-#: picard/const/locales.py:660
-msgid "Metaʼ (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:661
-msgid "Māori"
-msgstr ""
-
-#: picard/const/locales.py:662
-msgid "Māori (New Zealand)"
-msgstr ""
-
-#: picard/const/locales.py:663
-msgid "Macedonian"
-msgstr ""
-
-#: picard/const/locales.py:664
-msgid "Macedonian (North Macedonia)"
-msgstr ""
-
-#: picard/const/locales.py:665
-msgid "Malayalam"
-msgstr ""
-
-#: picard/const/locales.py:666
-msgid "Malayalam (India)"
-msgstr ""
-
-#: picard/const/locales.py:667
-msgid "Mongolian"
-msgstr ""
-
-#: picard/const/locales.py:668
-msgid "Mongolian (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:669
-msgid "Mongolian (Cyrillic) (Mongolia)"
-msgstr ""
-
-#: picard/const/locales.py:670
-msgid "Mongolian (Mongolia)"
-msgstr ""
-
-#: picard/const/locales.py:671
-msgid "Mongolian (Mongolian)"
-msgstr ""
-
-#: picard/const/locales.py:672
-msgid "Mongolian (Mongolian) (China)"
-msgstr ""
-
-#: picard/const/locales.py:673
-msgid "Mongolian (Mongolian) (Mongolia)"
-msgstr ""
-
-#: picard/const/locales.py:674
-msgid "Manipuri"
-msgstr ""
-
-#: picard/const/locales.py:675
-msgid "Manipuri (Bangla)"
-msgstr ""
-
-#: picard/const/locales.py:676
-msgid "Manipuri (Bangla) (India)"
-msgstr ""
-
-#: picard/const/locales.py:677
-msgid "Manipuri (Meitei Mayek)"
-msgstr ""
-
-#: picard/const/locales.py:678
-msgid "Manipuri (Meitei Mayek) (India)"
-msgstr ""
-
-#: picard/const/locales.py:679
-msgid "Mohawk"
-msgstr ""
-
-#: picard/const/locales.py:680
-msgid "Mohawk (Canada)"
-msgstr ""
-
-#: picard/const/locales.py:681
-msgid "Marathi"
-msgstr ""
-
-#: picard/const/locales.py:682
-msgid "Marathi (India)"
-msgstr ""
-
-#: picard/const/locales.py:683
-msgid "Malay"
-msgstr ""
-
-#: picard/const/locales.py:684
-msgid "Malay (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:685
-msgid "Malay (Arabic) (Brunei)"
-msgstr ""
-
-#: picard/const/locales.py:686
-msgid "Malay (Arabic) (Malaysia)"
-msgstr ""
-
-#: picard/const/locales.py:687
-msgid "Malay (Brunei)"
-msgstr ""
-
-#: picard/const/locales.py:688
-msgid "Malay (Indonesia)"
-msgstr ""
-
-#: picard/const/locales.py:690
-msgid "Malay (Singapore)"
-msgstr ""
-
-#: picard/const/locales.py:691
-msgid "Maltese"
-msgstr ""
-
-#: picard/const/locales.py:692
-msgid "Maltese (Malta)"
-msgstr ""
-
-#: picard/const/locales.py:693
-msgid "Mundang"
-msgstr ""
-
-#: picard/const/locales.py:694
-msgid "Mundang (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:695
-msgid "Muscogee"
-msgstr ""
-
-#: picard/const/locales.py:696
-msgid "Muscogee (United States)"
-msgstr ""
-
-#: picard/const/locales.py:697
-msgid "Burmese"
-msgstr ""
-
-#: picard/const/locales.py:698
-msgid "Burmese (Myanmar (Burma))"
-msgstr ""
-
-#: picard/const/locales.py:699
-msgid "Erzya"
-msgstr ""
-
-#: picard/const/locales.py:700
-msgid "Erzya (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:701
-msgid "Mazanderani"
-msgstr ""
-
-#: picard/const/locales.py:702
-msgid "Mazanderani (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:703
-msgid "Nama"
-msgstr ""
-
-#: picard/const/locales.py:704
-msgid "Nama (Namibia)"
-msgstr ""
-
-#: picard/const/locales.py:706
-msgid "Norwegian Bokmål (Norway)"
-msgstr ""
-
-#: picard/const/locales.py:707
-msgid "Norwegian Bokmål (Svalbard & Jan Mayen)"
-msgstr ""
-
-#: picard/const/locales.py:708
-msgid "North Ndebele"
-msgstr ""
-
-#: picard/const/locales.py:709
-msgid "North Ndebele (Zimbabwe)"
-msgstr ""
-
-#: picard/const/locales.py:710
-msgid "Low German"
-msgstr ""
-
-#: picard/const/locales.py:711
-msgid "Low German (Germany)"
-msgstr ""
-
-#: picard/const/locales.py:712
-msgid "Low German (Netherlands)"
-msgstr ""
-
-#: picard/const/locales.py:713
-msgid "Nepali"
-msgstr ""
-
-#: picard/const/locales.py:714
-msgid "Nepali (India)"
-msgstr ""
-
-#: picard/const/locales.py:715
-msgid "Nepali (Nepal)"
-msgstr ""
-
-#: picard/const/locales.py:717
-msgid "Dutch (Aruba)"
-msgstr ""
-
-#: picard/const/locales.py:718
-msgid "Dutch (Belgium)"
-msgstr ""
-
-#: picard/const/locales.py:719
-msgid "Dutch (Caribbean Netherlands)"
-msgstr ""
-
-#: picard/const/locales.py:720
-msgid "Dutch (Curaçao)"
-msgstr ""
-
-#: picard/const/locales.py:721
-msgid "Dutch (Netherlands)"
-msgstr ""
-
-#: picard/const/locales.py:722
-msgid "Dutch (Suriname)"
-msgstr ""
-
-#: picard/const/locales.py:723
-msgid "Dutch (Sint Maarten)"
-msgstr ""
-
-#: picard/const/locales.py:724
-msgid "Kwasio"
-msgstr ""
-
-#: picard/const/locales.py:725
-msgid "Kwasio (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:726
-msgid "Norwegian Nynorsk"
-msgstr ""
-
-#: picard/const/locales.py:727
-msgid "Norwegian Nynorsk (Norway)"
-msgstr ""
-
-#: picard/const/locales.py:728
-msgid "Ngiemboon"
-msgstr ""
-
-#: picard/const/locales.py:729
-msgid "Ngiemboon (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:730
-msgid "Norwegian"
-msgstr ""
-
-#: picard/const/locales.py:731
-msgid "N’Ko"
-msgstr ""
-
-#: picard/const/locales.py:732
-msgid "N’Ko (Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:733
-msgid "South Ndebele"
-msgstr ""
-
-#: picard/const/locales.py:734
-msgid "South Ndebele (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:735
-msgid "Northern Sotho"
-msgstr ""
-
-#: picard/const/locales.py:736
-msgid "Northern Sotho (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:737
-msgid "Nuer"
-msgstr ""
-
-#: picard/const/locales.py:738
-msgid "Nuer (South Sudan)"
-msgstr ""
-
-#: picard/const/locales.py:739
-msgid "Navajo"
-msgstr ""
-
-#: picard/const/locales.py:740
-msgid "Navajo (United States)"
-msgstr ""
-
-#: picard/const/locales.py:741
-msgid "Nyanja"
-msgstr ""
-
-#: picard/const/locales.py:742
-msgid "Nyanja (Malawi)"
-msgstr ""
-
-#: picard/const/locales.py:743
-msgid "Nyankole"
-msgstr ""
-
-#: picard/const/locales.py:744
-msgid "Nyankole (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:746
-msgid "Occitan (Spain)"
-msgstr ""
-
-#: picard/const/locales.py:747
-msgid "Occitan (France)"
-msgstr ""
-
-#: picard/const/locales.py:748
-msgid "Oromo"
-msgstr ""
-
-#: picard/const/locales.py:749
-msgid "Oromo (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:750
-msgid "Oromo (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:751
-msgid "Odia"
-msgstr ""
-
-#: picard/const/locales.py:752
-msgid "Odia (India)"
-msgstr ""
-
-#: picard/const/locales.py:753
-msgid "Ossetic"
-msgstr ""
-
-#: picard/const/locales.py:754
-msgid "Ossetic (Georgia)"
-msgstr ""
-
-#: picard/const/locales.py:755
-msgid "Ossetic (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:756
-msgid "Osage"
-msgstr ""
-
-#: picard/const/locales.py:757
-msgid "Osage (United States)"
-msgstr ""
-
-#: picard/const/locales.py:758
-msgid "Punjabi"
-msgstr ""
-
-#: picard/const/locales.py:759
-msgid "Punjabi (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:760
-msgid "Punjabi (Arabic) (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:761
-msgid "Punjabi (Gurmukhi)"
-msgstr ""
-
-#: picard/const/locales.py:762
-msgid "Punjabi (Gurmukhi) (India)"
-msgstr ""
-
-#: picard/const/locales.py:763
-msgid "Punjabi (India)"
-msgstr ""
-
-#: picard/const/locales.py:764
-msgid "Punjabi (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:765
-msgid "Papiamento"
-msgstr ""
-
-#: picard/const/locales.py:766
-msgid "Papiamento (Aruba)"
-msgstr ""
-
-#: picard/const/locales.py:767
-msgid "Papiamento (Curaçao)"
-msgstr ""
-
-#: picard/const/locales.py:768
-msgid "Nigerian Pidgin"
-msgstr ""
-
-#: picard/const/locales.py:769
-msgid "Nigerian Pidgin (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:770
-msgid "Pijin"
-msgstr ""
-
-#: picard/const/locales.py:771
-msgid "Pijin (Solomon Islands)"
-msgstr ""
-
-#: picard/const/locales.py:773
-msgid "Polish (Poland)"
-msgstr ""
-
-#: picard/const/locales.py:774
-msgid "Prussian"
-msgstr ""
-
-#: picard/const/locales.py:775
-msgid "Prussian (world)"
-msgstr ""
-
-#: picard/const/locales.py:776
-msgid "Pashto"
-msgstr ""
-
-#: picard/const/locales.py:777
-msgid "Pashto (Afghanistan)"
-msgstr ""
-
-#: picard/const/locales.py:778
-msgid "Pashto (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:780
-msgid "Portuguese (Angola)"
-msgstr ""
-
-#: picard/const/locales.py:781
-msgid "Portuguese (Brazil)"
-msgstr ""
-
-#: picard/const/locales.py:782
-msgid "Portuguese (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:783
-msgid "Portuguese (Cape Verde)"
-msgstr ""
-
-#: picard/const/locales.py:784
-msgid "Portuguese (Equatorial Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:785
-msgid "Portuguese (Guinea-Bissau)"
-msgstr ""
-
-#: picard/const/locales.py:786
-msgid "Portuguese (Luxembourg)"
-msgstr ""
-
-#: picard/const/locales.py:787
-msgid "Portuguese (Macao)"
-msgstr ""
-
-#: picard/const/locales.py:788
-msgid "Portuguese (Mozambique)"
-msgstr ""
-
-#: picard/const/locales.py:789
-msgid "Portuguese (Portugal)"
-msgstr ""
-
-#: picard/const/locales.py:790
-msgid "Portuguese (São Tomé & Príncipe)"
-msgstr ""
-
-#: picard/const/locales.py:791
-msgid "Portuguese (Timor-Leste)"
-msgstr ""
-
-#: picard/const/locales.py:792
-msgid "Quechua"
-msgstr ""
-
-#: picard/const/locales.py:793
-msgid "Quechua (Bolivia)"
-msgstr ""
-
-#: picard/const/locales.py:794
-msgid "Quechua (Ecuador)"
-msgstr ""
-
-#: picard/const/locales.py:795
-msgid "Quechua (Peru)"
-msgstr ""
-
-#: picard/const/locales.py:796
-msgid "Kʼicheʼ"
-msgstr ""
-
-#: picard/const/locales.py:797
-msgid "Kʼicheʼ (Guatemala)"
-msgstr ""
-
-#: picard/const/locales.py:798
-msgid "Rajasthani"
-msgstr ""
-
-#: picard/const/locales.py:799
-msgid "Rajasthani (India)"
-msgstr ""
-
-#: picard/const/locales.py:800
-msgid "Rohingya"
-msgstr ""
-
-#: picard/const/locales.py:801
-msgid "Rohingya (Hanifi)"
-msgstr ""
-
-#: picard/const/locales.py:802
-msgid "Rohingya (Hanifi) (Bangladesh)"
-msgstr ""
-
-#: picard/const/locales.py:803
-msgid "Rohingya (Hanifi) (Myanmar (Burma))"
-msgstr ""
-
-#: picard/const/locales.py:804
-msgid "Riffian"
-msgstr ""
-
-#: picard/const/locales.py:805
-msgid "Riffian (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:806
-msgid "Romansh"
-msgstr ""
-
-#: picard/const/locales.py:807
-msgid "Romansh (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:808
-msgid "Rundi"
-msgstr ""
-
-#: picard/const/locales.py:809
-msgid "Rundi (Burundi)"
-msgstr ""
-
-#: picard/const/locales.py:811
-msgid "Romanian (Moldova)"
-msgstr ""
-
-#: picard/const/locales.py:812
-msgid "Romanian (Romania)"
-msgstr ""
-
-#: picard/const/locales.py:813
-msgid "Rombo"
-msgstr ""
-
-#: picard/const/locales.py:814
-msgid "Rombo (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:816
-msgid "Russian (Belarus)"
-msgstr ""
-
-#: picard/const/locales.py:817
-msgid "Russian (Kyrgyzstan)"
-msgstr ""
-
-#: picard/const/locales.py:818
-msgid "Russian (Kazakhstan)"
-msgstr ""
-
-#: picard/const/locales.py:819
-msgid "Russian (Moldova)"
-msgstr ""
-
-#: picard/const/locales.py:820
-msgid "Russian (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:821
-msgid "Russian (Ukraine)"
-msgstr ""
-
-#: picard/const/locales.py:822
-msgid "Kinyarwanda"
-msgstr ""
-
-#: picard/const/locales.py:823
-msgid "Kinyarwanda (Rwanda)"
-msgstr ""
-
-#: picard/const/locales.py:824
-msgid "Rwa"
-msgstr ""
-
-#: picard/const/locales.py:825
-msgid "Rwa (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:826
-msgid "Sanskrit"
-msgstr ""
-
-#: picard/const/locales.py:827
-msgid "Sanskrit (India)"
-msgstr ""
-
-#: picard/const/locales.py:828
-msgid "Yakut"
-msgstr ""
-
-#: picard/const/locales.py:829
-msgid "Yakut (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:830
-msgid "Samburu"
-msgstr ""
-
-#: picard/const/locales.py:831
-msgid "Samburu (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:832
-msgid "Santali"
-msgstr ""
-
-#: picard/const/locales.py:833
-msgid "Santali (Devanagari)"
-msgstr ""
-
-#: picard/const/locales.py:834
-msgid "Santali (Devanagari) (India)"
-msgstr ""
-
-#: picard/const/locales.py:835
-msgid "Santali (Ol Chiki)"
-msgstr ""
-
-#: picard/const/locales.py:836
-msgid "Santali (Ol Chiki) (India)"
-msgstr ""
-
-#: picard/const/locales.py:837
-msgid "Sangu"
-msgstr ""
-
-#: picard/const/locales.py:838
-msgid "Sangu (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:839
-msgid "Sardinian"
-msgstr ""
-
-#: picard/const/locales.py:840
-msgid "Sardinian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:841
-msgid "Sicilian"
-msgstr ""
-
-#: picard/const/locales.py:842
-msgid "Sicilian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:843
-msgid "Sindhi"
-msgstr ""
-
-#: picard/const/locales.py:844
-msgid "Sindhi (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:845
-msgid "Sindhi (Arabic) (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:846
-msgid "Sindhi (Devanagari)"
-msgstr ""
-
-#: picard/const/locales.py:847
-msgid "Sindhi (Devanagari) (India)"
-msgstr ""
-
-#: picard/const/locales.py:848
-msgid "Southern Kurdish"
-msgstr ""
-
-#: picard/const/locales.py:849
-msgid "Southern Kurdish (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:850
-msgid "Southern Kurdish (Iran)"
-msgstr ""
-
-#: picard/const/locales.py:851
-msgid "Northern Sami"
-msgstr ""
-
-#: picard/const/locales.py:852
-msgid "Northern Sami (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:853
-msgid "Northern Sami (Norway)"
-msgstr ""
-
-#: picard/const/locales.py:854
-msgid "Northern Sami (Sweden)"
-msgstr ""
-
-#: picard/const/locales.py:855
-msgid "Sena"
-msgstr ""
-
-#: picard/const/locales.py:856
-msgid "Sena (Mozambique)"
-msgstr ""
-
-#: picard/const/locales.py:857
-msgid "Koyraboro Senni"
-msgstr ""
-
-#: picard/const/locales.py:858
-msgid "Koyraboro Senni (Mali)"
-msgstr ""
-
-#: picard/const/locales.py:859
-msgid "Sango"
-msgstr ""
-
-#: picard/const/locales.py:860
-msgid "Sango (Central African Republic)"
-msgstr ""
-
-#: picard/const/locales.py:861
-msgid "Tachelhit"
-msgstr ""
-
-#: picard/const/locales.py:862
-msgid "Tachelhit (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:863
-msgid "Tachelhit (Latin) (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:864
-msgid "Tachelhit (Tifinagh)"
-msgstr ""
-
-#: picard/const/locales.py:865
-msgid "Tachelhit (Tifinagh) (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:866
-msgid "Shan"
-msgstr ""
-
-#: picard/const/locales.py:867
-msgid "Shan (Myanmar (Burma))"
-msgstr ""
-
-#: picard/const/locales.py:868
-msgid "Shan (Thailand)"
-msgstr ""
-
-#: picard/const/locales.py:869
-msgid "Sinhala"
-msgstr ""
-
-#: picard/const/locales.py:870
-msgid "Sinhala (Sri Lanka)"
-msgstr ""
-
-#: picard/const/locales.py:871
-msgid "Sidamo"
-msgstr ""
-
-#: picard/const/locales.py:872
-msgid "Sidamo (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:874
-msgid "Slovak (Slovakia)"
-msgstr ""
-
-#: picard/const/locales.py:876
-msgid "Slovenian (Slovenia)"
-msgstr ""
-
-#: picard/const/locales.py:877
-msgid "Southern Sami"
-msgstr ""
-
-#: picard/const/locales.py:878
-msgid "Southern Sami (Norway)"
-msgstr ""
-
-#: picard/const/locales.py:879
-msgid "Southern Sami (Sweden)"
-msgstr ""
-
-#: picard/const/locales.py:880
-msgid "Lule Sami"
-msgstr ""
-
-#: picard/const/locales.py:881
-msgid "Lule Sami (Norway)"
-msgstr ""
-
-#: picard/const/locales.py:882
-msgid "Lule Sami (Sweden)"
-msgstr ""
-
-#: picard/const/locales.py:883
-msgid "Inari Sami"
-msgstr ""
-
-#: picard/const/locales.py:884
-msgid "Inari Sami (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:885
-msgid "Skolt Sami"
-msgstr ""
-
-#: picard/const/locales.py:886
-msgid "Skolt Sami (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:887
-msgid "Shona"
-msgstr ""
-
-#: picard/const/locales.py:888
-msgid "Shona (Zimbabwe)"
-msgstr ""
-
-#: picard/const/locales.py:889
-msgid "Somali"
-msgstr ""
-
-#: picard/const/locales.py:890
-msgid "Somali (Djibouti)"
-msgstr ""
-
-#: picard/const/locales.py:891
-msgid "Somali (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:892
-msgid "Somali (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:893
-msgid "Somali (Somalia)"
-msgstr ""
-
-#: picard/const/locales.py:895
-msgid "Albanian (Albania)"
-msgstr ""
-
-#: picard/const/locales.py:896
-msgid "Albanian (North Macedonia)"
-msgstr ""
-
-#: picard/const/locales.py:897
-msgid "Albanian (Kosovo)"
-msgstr ""
-
-#: picard/const/locales.py:898
-msgid "Serbian"
-msgstr ""
-
-#: picard/const/locales.py:899
-msgid "Serbian (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:900
-msgid "Serbian (Cyrillic) (Bosnia & Herzegovina)"
-msgstr ""
-
-#: picard/const/locales.py:901
-msgid "Serbian (Cyrillic) (Montenegro)"
-msgstr ""
-
-#: picard/const/locales.py:902
-msgid "Serbian (Cyrillic) (Serbia)"
-msgstr ""
-
-#: picard/const/locales.py:903
-msgid "Serbian (Cyrillic) (Kosovo)"
-msgstr ""
-
-#: picard/const/locales.py:904
-msgid "Serbian (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:905
-msgid "Serbian (Latin) (Bosnia & Herzegovina)"
-msgstr ""
-
-#: picard/const/locales.py:906
-msgid "Serbian (Latin) (Montenegro)"
-msgstr ""
-
-#: picard/const/locales.py:907
-msgid "Serbian (Latin) (Serbia)"
-msgstr ""
-
-#: picard/const/locales.py:908
-msgid "Serbian (Latin) (Kosovo)"
-msgstr ""
-
-#: picard/const/locales.py:909
-msgid "Swati"
-msgstr ""
-
-#: picard/const/locales.py:910
-msgid "Swati (Eswatini)"
-msgstr ""
-
-#: picard/const/locales.py:911
-msgid "Swati (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:912
-msgid "Saho"
-msgstr ""
-
-#: picard/const/locales.py:913
-msgid "Saho (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:914
-msgid "Southern Sotho"
-msgstr ""
-
-#: picard/const/locales.py:915
-msgid "Southern Sotho (Lesotho)"
-msgstr ""
-
-#: picard/const/locales.py:916
-msgid "Southern Sotho (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:917
-msgid "Sundanese"
-msgstr ""
-
-#: picard/const/locales.py:918
-msgid "Sundanese (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:919
-msgid "Sundanese (Latin) (Indonesia)"
-msgstr ""
-
-#: picard/const/locales.py:921
-msgid "Swedish (Åland Islands)"
-msgstr ""
-
-#: picard/const/locales.py:922
-msgid "Swedish (Finland)"
-msgstr ""
-
-#: picard/const/locales.py:923
-msgid "Swedish (Sweden)"
-msgstr ""
-
-#: picard/const/locales.py:924
-msgid "Swahili"
-msgstr ""
-
-#: picard/const/locales.py:925
-msgid "Swahili (Congo - Kinshasa)"
-msgstr ""
-
-#: picard/const/locales.py:926
-msgid "Swahili (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:927
-msgid "Swahili (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:928
-msgid "Swahili (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:929
-msgid "Syriac"
-msgstr ""
-
-#: picard/const/locales.py:930
-msgid "Syriac (Iraq)"
-msgstr ""
-
-#: picard/const/locales.py:931
-msgid "Syriac (Syria)"
-msgstr ""
-
-#: picard/const/locales.py:932
-msgid "Silesian"
-msgstr ""
-
-#: picard/const/locales.py:933
-msgid "Silesian (Poland)"
-msgstr ""
-
-#: picard/const/locales.py:934
-msgid "Tamil"
-msgstr ""
-
-#: picard/const/locales.py:935
-msgid "Tamil (India)"
-msgstr ""
-
-#: picard/const/locales.py:936
-msgid "Tamil (Sri Lanka)"
-msgstr ""
-
-#: picard/const/locales.py:937
-msgid "Tamil (Malaysia)"
-msgstr ""
-
-#: picard/const/locales.py:938
-msgid "Tamil (Singapore)"
-msgstr ""
-
-#: picard/const/locales.py:939
-msgid "Telugu"
-msgstr ""
-
-#: picard/const/locales.py:940
-msgid "Telugu (India)"
-msgstr ""
-
-#: picard/const/locales.py:941
-msgid "Teso"
-msgstr ""
-
-#: picard/const/locales.py:942
-msgid "Teso (Kenya)"
-msgstr ""
-
-#: picard/const/locales.py:943
-msgid "Teso (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:944
-msgid "Tajik"
-msgstr ""
-
-#: picard/const/locales.py:945
-msgid "Tajik (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:946
-msgid "Tajik (Cyrillic) (Tajikistan)"
-msgstr ""
-
-#: picard/const/locales.py:947
-msgid "Tajik (Tajikistan)"
-msgstr ""
-
-#: picard/const/locales.py:948 picard/const/scripts.py:35
-msgid "Thai"
-msgstr ""
-
-#: picard/const/locales.py:949
-msgid "Thai (Thailand)"
-msgstr ""
-
-#: picard/const/locales.py:950
-msgid "Tigrinya"
-msgstr ""
-
-#: picard/const/locales.py:951
-msgid "Tigrinya (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:952
-msgid "Tigrinya (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:953
-msgid "Tigre"
-msgstr ""
-
-#: picard/const/locales.py:954
-msgid "Tigre (Eritrea)"
-msgstr ""
-
-#: picard/const/locales.py:955
-msgid "Turkmen"
-msgstr ""
-
-#: picard/const/locales.py:956
-msgid "Turkmen (Turkmenistan)"
-msgstr ""
-
-#: picard/const/locales.py:957
-msgid "Tswana"
-msgstr ""
-
-#: picard/const/locales.py:958
-msgid "Tswana (Botswana)"
-msgstr ""
-
-#: picard/const/locales.py:959
-msgid "Tswana (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:960
-msgid "Tongan"
-msgstr ""
-
-#: picard/const/locales.py:961
-msgid "Tongan (Tonga)"
-msgstr ""
-
-#: picard/const/locales.py:962
-msgid "Toki Pona"
-msgstr ""
-
-#: picard/const/locales.py:963
-msgid "Toki Pona (world)"
-msgstr ""
-
-#: picard/const/locales.py:964
-msgid "Tok Pisin"
-msgstr ""
-
-#: picard/const/locales.py:965
-msgid "Tok Pisin (Papua New Guinea)"
-msgstr ""
-
-#: picard/const/locales.py:967
-msgid "Turkish (Cyprus)"
-msgstr ""
-
-#: picard/const/locales.py:968
-msgid "Turkish (Türkiye)"
-msgstr ""
-
-#: picard/const/locales.py:969
-msgid "Taroko"
-msgstr ""
-
-#: picard/const/locales.py:970
-msgid "Taroko (Taiwan)"
-msgstr ""
-
-#: picard/const/locales.py:971
-msgid "Torwali"
-msgstr ""
-
-#: picard/const/locales.py:972
-msgid "Torwali (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:973
-msgid "Tsonga"
-msgstr ""
-
-#: picard/const/locales.py:974
-msgid "Tsonga (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:975
-msgid "Tatar"
-msgstr ""
-
-#: picard/const/locales.py:976
-msgid "Tatar (Russia)"
-msgstr ""
-
-#: picard/const/locales.py:977
-msgid "Tasawaq"
-msgstr ""
-
-#: picard/const/locales.py:978
-msgid "Tasawaq (Niger)"
-msgstr ""
-
-#: picard/const/locales.py:979
-msgid "Central Atlas Tamazight"
-msgstr ""
-
-#: picard/const/locales.py:980
-msgid "Central Atlas Tamazight (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:981
-msgid "Uyghur"
-msgstr ""
-
-#: picard/const/locales.py:982
-msgid "Uyghur (China)"
-msgstr ""
-
-#: picard/const/locales.py:984
-msgid "Ukrainian (Ukraine)"
-msgstr ""
-
-#: picard/const/locales.py:985
-msgid "Unknown language"
-msgstr ""
-
-#: picard/const/locales.py:986
-msgid "Urdu"
-msgstr ""
-
-#: picard/const/locales.py:987
-msgid "Urdu (India)"
-msgstr ""
-
-#: picard/const/locales.py:988
-msgid "Urdu (Pakistan)"
-msgstr ""
-
-#: picard/const/locales.py:989
-msgid "Uzbek"
-msgstr ""
-
-#: picard/const/locales.py:990
-msgid "Uzbek (Arabic)"
-msgstr ""
-
-#: picard/const/locales.py:991
-msgid "Uzbek (Arabic) (Afghanistan)"
-msgstr ""
-
-#: picard/const/locales.py:992
-msgid "Uzbek (Cyrillic)"
-msgstr ""
-
-#: picard/const/locales.py:993
-msgid "Uzbek (Cyrillic) (Uzbekistan)"
-msgstr ""
-
-#: picard/const/locales.py:994
-msgid "Uzbek (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:995
-msgid "Uzbek (Latin) (Uzbekistan)"
-msgstr ""
-
-#: picard/const/locales.py:996
-msgid "Vai"
-msgstr ""
-
-#: picard/const/locales.py:997
-msgid "Vai (Latin)"
-msgstr ""
-
-#: picard/const/locales.py:998
-msgid "Vai (Latin) (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:999
-msgid "Vai (Vai)"
-msgstr ""
-
-#: picard/const/locales.py:1000
-msgid "Vai (Vai) (Liberia)"
-msgstr ""
-
-#: picard/const/locales.py:1001
-msgid "Venda"
-msgstr ""
-
-#: picard/const/locales.py:1002
-msgid "Venda (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:1003
-msgid "Venetian"
-msgstr ""
-
-#: picard/const/locales.py:1004
-msgid "Venetian (Italy)"
-msgstr ""
-
-#: picard/const/locales.py:1005
-msgid "Vietnamese"
-msgstr ""
-
-#: picard/const/locales.py:1006
-msgid "Vietnamese (Vietnam)"
-msgstr ""
-
-#: picard/const/locales.py:1007
-msgid "Volapük"
-msgstr ""
-
-#: picard/const/locales.py:1008
-msgid "Volapük (world)"
-msgstr ""
-
-#: picard/const/locales.py:1009
-msgid "Vunjo"
-msgstr ""
-
-#: picard/const/locales.py:1010
-msgid "Vunjo (Tanzania)"
-msgstr ""
-
-#: picard/const/locales.py:1011
-msgid "Walloon"
-msgstr ""
-
-#: picard/const/locales.py:1012
-msgid "Walloon (Belgium)"
-msgstr ""
-
-#: picard/const/locales.py:1013
-msgid "Walser"
-msgstr ""
-
-#: picard/const/locales.py:1014
-msgid "Walser (Switzerland)"
-msgstr ""
-
-#: picard/const/locales.py:1015
-msgid "Wolaytta"
-msgstr ""
-
-#: picard/const/locales.py:1016
-msgid "Wolaytta (Ethiopia)"
-msgstr ""
-
-#: picard/const/locales.py:1017
-msgid "Warlpiri"
-msgstr ""
-
-#: picard/const/locales.py:1018
-msgid "Warlpiri (Australia)"
-msgstr ""
-
-#: picard/const/locales.py:1019
-msgid "Wolof"
-msgstr ""
-
-#: picard/const/locales.py:1020
-msgid "Wolof (Senegal)"
-msgstr ""
-
-#: picard/const/locales.py:1021
-msgid "Xhosa"
-msgstr ""
-
-#: picard/const/locales.py:1022
-msgid "Xhosa (South Africa)"
-msgstr ""
-
-#: picard/const/locales.py:1023
-msgid "Soga"
-msgstr ""
-
-#: picard/const/locales.py:1024
-msgid "Soga (Uganda)"
-msgstr ""
-
-#: picard/const/locales.py:1025
-msgid "Yangben"
-msgstr ""
-
-#: picard/const/locales.py:1026
-msgid "Yangben (Cameroon)"
-msgstr ""
-
-#: picard/const/locales.py:1027
-msgid "Yiddish"
-msgstr ""
-
-#: picard/const/locales.py:1028
-msgid "Yiddish (world)"
-msgstr ""
-
-#: picard/const/locales.py:1029
-msgid "Yoruba"
-msgstr ""
-
-#: picard/const/locales.py:1030
-msgid "Yoruba (Benin)"
-msgstr ""
-
-#: picard/const/locales.py:1031
-msgid "Yoruba (Nigeria)"
-msgstr ""
-
-#: picard/const/locales.py:1032
-msgid "Nheengatu"
-msgstr ""
-
-#: picard/const/locales.py:1033
-msgid "Nheengatu (Brazil)"
-msgstr ""
-
-#: picard/const/locales.py:1034
-msgid "Nheengatu (Colombia)"
-msgstr ""
-
-#: picard/const/locales.py:1035
-msgid "Nheengatu (Venezuela)"
-msgstr ""
-
-#: picard/const/locales.py:1036
-msgid "Cantonese"
-msgstr ""
-
-#: picard/const/locales.py:1037
-msgid "Cantonese (Simplified)"
-msgstr ""
-
-#: picard/const/locales.py:1038
-msgid "Cantonese (Simplified) (China)"
-msgstr ""
-
-#: picard/const/locales.py:1039
-msgid "Cantonese (Traditional)"
-msgstr ""
-
-#: picard/const/locales.py:1040
-msgid "Cantonese (Traditional) (Hong Kong)"
-msgstr ""
-
-#: picard/const/locales.py:1041
-msgid "Standard Moroccan Tamazight"
-msgstr ""
-
-#: picard/const/locales.py:1042
-msgid "Standard Moroccan Tamazight (Morocco)"
-msgstr ""
-
-#: picard/const/locales.py:1043 picard/const/scripts.py:31
-msgid "Chinese"
-msgstr ""
-
-#: picard/const/locales.py:1044
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: picard/const/locales.py:1045
-msgid "Chinese (Simplified) (China)"
-msgstr ""
-
-#: picard/const/locales.py:1046
-msgid "Chinese (Simplified) (Hong Kong)"
-msgstr ""
-
-#: picard/const/locales.py:1047
-msgid "Chinese (Simplified) (Macao)"
-msgstr ""
-
-#: picard/const/locales.py:1048
-msgid "Chinese (Simplified) (Singapore)"
-msgstr ""
-
-#: picard/const/locales.py:1049
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: picard/const/locales.py:1050
-msgid "Chinese (Traditional) (Hong Kong)"
-msgstr ""
-
-#: picard/const/locales.py:1051
-msgid "Chinese (Traditional) (Macao)"
-msgstr ""
-
-#: picard/const/locales.py:1052
-msgid "Chinese (Traditional) (Taiwan)"
-msgstr ""
-
-#: picard/const/locales.py:1053
-msgid "Zulu"
-msgstr ""
-
-#: picard/const/locales.py:1054
-msgid "Zulu (South Africa)"
-msgstr ""
-
-#: picard/const/scripts.py:27
-msgid "Cyrillic"
-msgstr ""
-
-#: picard/const/scripts.py:32
-msgid "Hangul"
-msgstr ""
-
-#: picard/const/scripts.py:33
-msgid "Hiragana"
-msgstr ""
-
-#: picard/const/scripts.py:34
-msgid "Katakana"
 msgstr ""
 
 #: picard/coverart/__init__.py:103
@@ -5159,18 +986,18 @@ msgstr ""
 
 #: picard/script/__init__.py:145
 #, python-format
-msgid "Preset %d: %s"
+msgid "Preset %(number)d: %(title)s"
 msgstr ""
 
-#: picard/script/__init__.py:149
+#: picard/script/__init__.py:152
 msgid "Default file naming script"
 msgstr ""
 
-#: picard/script/__init__.py:161
+#: picard/script/__init__.py:164
 msgid "[album artist]/[album]/[track #]. [title]"
 msgstr ""
 
-#: picard/script/__init__.py:175
+#: picard/script/__init__.py:178
 msgid "[album artist]/[album]/[disc and track #] [artist] - [title]"
 msgstr ""
 
@@ -6183,7 +2010,7 @@ msgstr ""
 
 #: picard/script/serializer.py:202
 #, python-format
-msgid "Error exporting file \"%s\". %s."
+msgid "Error exporting file \"%(filename)s\": %(error)s."
 msgstr ""
 
 #: picard/script/serializer.py:209
@@ -6201,12 +2028,12 @@ msgstr ""
 
 #: picard/script/serializer.py:243
 #, python-format
-msgid "Error importing \"%s\". %s."
+msgid "Error importing \"%(filename)s\": %(error)s."
 msgstr ""
 
 #: picard/script/serializer.py:244
 #, python-format
-msgid "Error decoding \"%s\". %s."
+msgid "Error decoding \"%(filename)s\": %(error)s."
 msgstr ""
 
 #: picard/script/serializer.py:246
@@ -6239,7 +2066,7 @@ msgstr ""
 msgid "File content not a dictionary"
 msgstr ""
 
-#: picard/script/serializer.py:340 picard/ui/options/scripting.py:188
+#: picard/script/serializer.py:340 picard/ui/options/scripting.py:191
 msgid "Unnamed Script"
 msgstr ""
 
@@ -6311,12 +2138,12 @@ msgid "Official website"
 msgstr ""
 
 #: picard/ui/cdlookup.py:72 picard/ui/itemviews.py:166
-#: picard/ui/mainwindow.py:1150 picard/util/tags.py:40
+#: picard/ui/mainwindow.py:1151 picard/util/tags.py:40
 msgid "Album"
 msgstr ""
 
 #: picard/ui/cdlookup.py:72 picard/ui/itemviews.py:163
-#: picard/ui/mainwindow.py:1151 picard/ui/searchdialog/album.py:153
+#: picard/ui/mainwindow.py:1152 picard/ui/searchdialog/album.py:153
 #: picard/ui/searchdialog/track.py:71 picard/util/tags.py:43
 msgid "Artist"
 msgstr ""
@@ -6350,8 +2177,8 @@ msgstr ""
 
 #: picard/ui/collectionmenu.py:173
 #, python-format
-msgid "%s (%i release)"
-msgid_plural "%s (%i releases)"
+msgid "%(name)s (%(count)i release)"
+msgid_plural "%(name)s (%(count)i releases)"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6486,7 +2313,7 @@ msgstr ""
 msgid "Cover"
 msgstr ""
 
-#: picard/ui/infodialog.py:154 picard/ui/infodialog.py:359
+#: picard/ui/infodialog.py:154 picard/ui/infodialog.py:365
 #: picard/ui/options/interface_toolbar.py:95
 msgid "Info"
 msgstr ""
@@ -6495,95 +2322,95 @@ msgstr ""
 #, python-format
 msgid ""
 "Double-click to open in external viewer\n"
-"Temporary file: %s\n"
-"Source: %s"
+"Temporary file: %(tempfile)s\n"
+"Source: %(sourcefile)s"
 msgstr ""
 
-#: picard/ui/infodialog.py:216
+#: picard/ui/infodialog.py:219
 #, python-format
 msgid ""
-"Missing temporary file: %s\n"
-"Source: %s"
-msgstr ""
-
-#: picard/ui/infodialog.py:280
-msgid "Filename:"
-msgstr ""
-
-#: picard/ui/infodialog.py:282
-msgid "Format:"
+"Missing temporary file: %(tempfile)s\n"
+"Source: %(sourcefile)s"
 msgstr ""
 
 #: picard/ui/infodialog.py:286
-msgid "Size:"
+msgid "Filename:"
 msgstr ""
 
-#: picard/ui/infodialog.py:290
-msgid "Length:"
+#: picard/ui/infodialog.py:288
+msgid "Format:"
 msgstr ""
 
 #: picard/ui/infodialog.py:292
-msgid "Bitrate:"
-msgstr ""
-
-#: picard/ui/infodialog.py:294
-msgid "Sample rate:"
+msgid "Size:"
 msgstr ""
 
 #: picard/ui/infodialog.py:296
-msgid "Bits per sample:"
+msgid "Length:"
+msgstr ""
+
+#: picard/ui/infodialog.py:298
+msgid "Bitrate:"
 msgstr ""
 
 #: picard/ui/infodialog.py:300
-msgid "Mono"
+msgid "Sample rate:"
 msgstr ""
 
 #: picard/ui/infodialog.py:302
+msgid "Bits per sample:"
+msgstr ""
+
+#: picard/ui/infodialog.py:306
+msgid "Mono"
+msgstr ""
+
+#: picard/ui/infodialog.py:308
 msgid "Stereo"
 msgstr ""
 
-#: picard/ui/infodialog.py:303
+#: picard/ui/infodialog.py:309
 msgid "Channels:"
 msgstr ""
 
-#: picard/ui/infodialog.py:310
+#: picard/ui/infodialog.py:316
 msgid "Album:"
 msgstr ""
 
-#: picard/ui/infodialog.py:311
+#: picard/ui/infodialog.py:317
 msgid "Artist:"
 msgstr ""
 
-#: picard/ui/infodialog.py:341
+#: picard/ui/infodialog.py:347
 #, python-format
 msgid "Disc %d"
 msgstr ""
 
-#: picard/ui/infodialog.py:343
+#: picard/ui/infodialog.py:349
 msgid "Tracklist:"
 msgstr ""
 
-#: picard/ui/infodialog.py:371
+#: picard/ui/infodialog.py:377
 msgid "Album Info"
 msgstr ""
 
-#: picard/ui/infodialog.py:385
+#: picard/ui/infodialog.py:391
 msgid "Track Info"
 msgstr ""
 
-#: picard/ui/infodialog.py:393 picard/ui/infodialog.py:397
-#: picard/ui/infodialog.py:415 picard/ui/ui_infodialog.py:81
+#: picard/ui/infodialog.py:399 picard/ui/infodialog.py:403
+#: picard/ui/infodialog.py:421 picard/ui/ui_infodialog.py:81
 msgid "&Info"
 msgstr ""
 
-#: picard/ui/infodialog.py:398
+#: picard/ui/infodialog.py:404
 #, python-format
 msgid "%i file in this track"
 msgid_plural "%i files in this track"
 msgstr[0] ""
 msgstr[1] ""
 
-#: picard/ui/infodialog.py:409
+#: picard/ui/infodialog.py:415
 msgid "Cluster Info"
 msgstr ""
 
@@ -6591,7 +2418,7 @@ msgstr ""
 msgid "Estimated Time"
 msgstr ""
 
-#: picard/ui/infostatus.py:71 picard/ui/options/plugins.py:612
+#: picard/ui/infostatus.py:71 picard/ui/options/plugins.py:617
 msgid "Files"
 msgstr ""
 
@@ -6901,524 +2728,519 @@ msgstr ""
 msgid "Ready"
 msgstr ""
 
-#: picard/ui/mainwindow.py:398
+#: picard/ui/mainwindow.py:399
 msgid ""
 "Picard listens on this port to integrate with your browser. When you "
 "\"Search\" or \"Open in Browser\" from Picard, clicking the \"Tagger\" "
 "button on the web page loads the release into Picard."
 msgstr ""
 
-#: picard/ui/mainwindow.py:424
-#, python-format
-msgid "Listening on port %(port)d"
-msgstr ""
-
-#: picard/ui/mainwindow.py:483
+#: picard/ui/mainwindow.py:484
 msgid "AcoustID submission not configured"
 msgstr ""
 
-#: picard/ui/mainwindow.py:484
+#: picard/ui/mainwindow.py:485
 msgid ""
 "You need to configure your AcoustID API key before you can submit "
 "fingerprints."
 msgstr ""
 
-#: picard/ui/mainwindow.py:487
+#: picard/ui/mainwindow.py:488
 msgid "Open AcoustID options"
 msgstr ""
 
-#: picard/ui/mainwindow.py:498
+#: picard/ui/mainwindow.py:499
 msgid "&Options…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:505
+#: picard/ui/mainwindow.py:506
 msgid "Open &file naming script editor…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:506
+#: picard/ui/mainwindow.py:507
 msgid "Ctrl+Shift+S"
 msgstr ""
 
-#: picard/ui/mainwindow.py:512
+#: picard/ui/mainwindow.py:513
 msgid "&Cut"
 msgstr ""
 
-#: picard/ui/mainwindow.py:520 picard/ui/metadatabox.py:443
+#: picard/ui/mainwindow.py:521 picard/ui/metadatabox.py:443
 msgid "&Paste"
 msgstr ""
 
-#: picard/ui/mainwindow.py:528 picard/ui/scripteditor.py:617
+#: picard/ui/mainwindow.py:529 picard/ui/scripteditor.py:617
 msgid "&Help…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:535
+#: picard/ui/mainwindow.py:536
 msgid "&About…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:542
+#: picard/ui/mainwindow.py:543
 msgid "&Donate…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:548
+#: picard/ui/mainwindow.py:549
 msgid "&Report a Bug…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:554
+#: picard/ui/mainwindow.py:555
 msgid "&Support Forum…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:560
+#: picard/ui/mainwindow.py:561
 msgid "&Add Files…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:561
+#: picard/ui/mainwindow.py:562
 msgid "Add files to the tagger"
 msgstr ""
 
-#: picard/ui/mainwindow.py:569
+#: picard/ui/mainwindow.py:570
 msgid "Add Fold&er…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:570
+#: picard/ui/mainwindow.py:571
 msgid "Add a folder to the tagger"
 msgstr ""
 
-#: picard/ui/mainwindow.py:572
+#: picard/ui/mainwindow.py:573
 msgid "Ctrl+E"
 msgstr ""
 
-#: picard/ui/mainwindow.py:579
+#: picard/ui/mainwindow.py:580
 msgid "Close Window"
 msgstr ""
 
-#: picard/ui/mainwindow.py:580
+#: picard/ui/mainwindow.py:581
 msgid "Ctrl+W"
 msgstr ""
 
-#: picard/ui/mainwindow.py:588
+#: picard/ui/mainwindow.py:589
 msgid "&Save"
 msgstr ""
 
-#: picard/ui/mainwindow.py:589
+#: picard/ui/mainwindow.py:590
 msgid "Save selected files"
 msgstr ""
 
-#: picard/ui/mainwindow.py:598
+#: picard/ui/mainwindow.py:599
 msgid "S&ubmit AcoustIDs"
 msgstr ""
 
-#: picard/ui/mainwindow.py:599
+#: picard/ui/mainwindow.py:600
 msgid "Submit acoustic fingerprints"
 msgstr ""
 
-#: picard/ui/mainwindow.py:606
+#: picard/ui/mainwindow.py:607
 msgid "E&xit"
 msgstr ""
 
-#: picard/ui/mainwindow.py:609
+#: picard/ui/mainwindow.py:610
 msgid "Ctrl+Q"
 msgstr ""
 
-#: picard/ui/mainwindow.py:615
+#: picard/ui/mainwindow.py:616
 msgid "&Remove"
 msgstr ""
 
-#: picard/ui/mainwindow.py:616
+#: picard/ui/mainwindow.py:617
 msgid "Remove selected files/albums"
 msgstr ""
 
-#: picard/ui/mainwindow.py:623 picard/ui/metadatabox.py:400
+#: picard/ui/mainwindow.py:624 picard/ui/metadatabox.py:400
 msgid "Lookup in &Browser"
 msgstr ""
 
-#: picard/ui/mainwindow.py:624
+#: picard/ui/mainwindow.py:625
 msgid "Lookup selected item on MusicBrainz website"
 msgstr ""
 
-#: picard/ui/mainwindow.py:627
+#: picard/ui/mainwindow.py:628
 msgid "Ctrl+Shift+L"
 msgstr ""
 
-#: picard/ui/mainwindow.py:634
+#: picard/ui/mainwindow.py:635
 msgid "Submit cluster as release…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:635
+#: picard/ui/mainwindow.py:636
 msgid "Submit cluster as a new release to MusicBrainz"
 msgstr ""
 
-#: picard/ui/mainwindow.py:645
+#: picard/ui/mainwindow.py:646
 msgid "Submit file as standalone recording…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:646
+#: picard/ui/mainwindow.py:647
 msgid "Submit file as a new recording to MusicBrainz"
 msgstr ""
 
-#: picard/ui/mainwindow.py:656
+#: picard/ui/mainwindow.py:657
 msgid "Submit file as release…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:657
+#: picard/ui/mainwindow.py:658
 msgid "Submit file as a new release to MusicBrainz"
 msgstr ""
 
-#: picard/ui/mainwindow.py:666
+#: picard/ui/mainwindow.py:667
 msgid "Search for similar items…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:667 picard/ui/options/interface_toolbar.py:123
+#: picard/ui/mainwindow.py:668 picard/ui/options/interface_toolbar.py:123
 msgid "Similar items"
 msgstr ""
 
-#: picard/ui/mainwindow.py:668
+#: picard/ui/mainwindow.py:669
 msgid "View similar releases or recordings and optionally choose a different one"
 msgstr ""
 
-#: picard/ui/mainwindow.py:670 picard/ui/mainwindow.py:679
-#: picard/ui/mainwindow.py:688
+#: picard/ui/mainwindow.py:671 picard/ui/mainwindow.py:680
+#: picard/ui/mainwindow.py:689
 msgid "Ctrl+T"
 msgstr ""
 
-#: picard/ui/mainwindow.py:676
+#: picard/ui/mainwindow.py:677
 msgid "Search for similar albums…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:677
+#: picard/ui/mainwindow.py:678
 msgid "View similar releases and optionally choose a different release"
 msgstr ""
 
-#: picard/ui/mainwindow.py:685
+#: picard/ui/mainwindow.py:686
 msgid "Search for similar tracks…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:686
+#: picard/ui/mainwindow.py:687
 msgid "View similar tracks and optionally choose a different release"
 msgstr ""
 
-#: picard/ui/mainwindow.py:694
+#: picard/ui/mainwindow.py:695
 msgid "Show &other album versions…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:695
+#: picard/ui/mainwindow.py:696
 msgid "Ctrl+Shift+O"
 msgstr ""
 
-#: picard/ui/mainwindow.py:702
+#: picard/ui/mainwindow.py:703
 msgid "File &Browser"
 msgstr ""
 
-#: picard/ui/mainwindow.py:706
+#: picard/ui/mainwindow.py:707
 msgid "Ctrl+B"
 msgstr ""
 
-#: picard/ui/mainwindow.py:713
+#: picard/ui/mainwindow.py:714
 msgid "&Metadata"
 msgstr ""
 
-#: picard/ui/mainwindow.py:717
+#: picard/ui/mainwindow.py:718
 msgid "Ctrl+Shift+M"
 msgstr ""
 
-#: picard/ui/mainwindow.py:724
+#: picard/ui/mainwindow.py:725
 msgid "&Cover Art"
 msgstr ""
 
-#: picard/ui/mainwindow.py:735
+#: picard/ui/mainwindow.py:736
 msgid "&Actions"
 msgstr ""
 
-#: picard/ui/mainwindow.py:744 picard/ui/mainwindow.py:1139
+#: picard/ui/mainwindow.py:745 picard/ui/mainwindow.py:1140
 #: picard/ui/searchdialog/__init__.py:48
 msgid "Search"
 msgstr ""
 
-#: picard/ui/mainwindow.py:751 picard/ui/mainwindow.py:758
+#: picard/ui/mainwindow.py:752 picard/ui/mainwindow.py:759
 msgid "Lookup &CD…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:752
+#: picard/ui/mainwindow.py:753
 msgid "Lookup the details of the CD in your drive"
 msgstr ""
 
-#: picard/ui/mainwindow.py:754
+#: picard/ui/mainwindow.py:755
 msgid "Ctrl+K"
 msgstr ""
 
-#: picard/ui/mainwindow.py:771
+#: picard/ui/mainwindow.py:772
 msgid "&Scan"
 msgstr ""
 
-#: picard/ui/mainwindow.py:772
+#: picard/ui/mainwindow.py:773
 msgid ""
 "Use AcoustID audio fingerprint to identify the files by the actual music,"
 " even if they have no metadata"
 msgstr ""
 
-#: picard/ui/mainwindow.py:774
+#: picard/ui/mainwindow.py:775
 msgid "Identify the file using its AcoustID audio fingerprint"
 msgstr ""
 
-#: picard/ui/mainwindow.py:776
+#: picard/ui/mainwindow.py:777
 msgid "Ctrl+Y"
 msgstr ""
 
-#: picard/ui/mainwindow.py:782
+#: picard/ui/mainwindow.py:783
 msgid "&Generate AcoustID Fingerprints"
 msgstr ""
 
-#: picard/ui/mainwindow.py:783 picard/ui/options/interface_toolbar.py:107
+#: picard/ui/mainwindow.py:784 picard/ui/options/interface_toolbar.py:107
 msgid "Generate Fingerprints"
 msgstr ""
 
-#: picard/ui/mainwindow.py:784
+#: picard/ui/mainwindow.py:785
 msgid ""
 "Generate the AcoustID audio fingerprints for the selected files without "
 "doing a lookup"
 msgstr ""
 
-#: picard/ui/mainwindow.py:786
+#: picard/ui/mainwindow.py:787
 msgid "Generate the AcoustID audio fingerprints for the selected files"
 msgstr ""
 
-#: picard/ui/mainwindow.py:787
+#: picard/ui/mainwindow.py:788
 msgid "Ctrl+Shift+Y"
 msgstr ""
 
-#: picard/ui/mainwindow.py:793
+#: picard/ui/mainwindow.py:794
 msgid "Cl&uster"
 msgstr ""
 
-#: picard/ui/mainwindow.py:794
+#: picard/ui/mainwindow.py:795
 msgid "Cluster files into album clusters"
 msgstr ""
 
-#: picard/ui/mainwindow.py:797
+#: picard/ui/mainwindow.py:798
 msgid "Ctrl+U"
 msgstr ""
 
-#: picard/ui/mainwindow.py:803
+#: picard/ui/mainwindow.py:804
 msgid "&Lookup"
 msgstr ""
 
-#: picard/ui/mainwindow.py:804
+#: picard/ui/mainwindow.py:805
 msgid "Lookup selected items in MusicBrainz"
 msgstr ""
 
-#: picard/ui/mainwindow.py:809
+#: picard/ui/mainwindow.py:810
 msgid "Ctrl+L"
 msgstr ""
 
-#: picard/ui/mainwindow.py:815
+#: picard/ui/mainwindow.py:816
 msgid "&Info…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:818
+#: picard/ui/mainwindow.py:819
 msgid "Ctrl+I"
 msgstr ""
 
-#: picard/ui/mainwindow.py:824
+#: picard/ui/mainwindow.py:825
 msgid "&Refresh"
 msgstr ""
 
-#: picard/ui/mainwindow.py:825
+#: picard/ui/mainwindow.py:826
 msgid "Ctrl+R"
 msgstr ""
 
-#: picard/ui/mainwindow.py:832
+#: picard/ui/mainwindow.py:833
 msgid "&Rename Files"
 msgstr ""
 
-#: picard/ui/mainwindow.py:841
+#: picard/ui/mainwindow.py:842
 msgid "&Move Files"
 msgstr ""
 
-#: picard/ui/mainwindow.py:850
+#: picard/ui/mainwindow.py:851
 msgid "Save &Tags"
 msgstr ""
 
-#: picard/ui/mainwindow.py:858
+#: picard/ui/mainwindow.py:859
 msgid "Tags From &File Names…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:859 picard/ui/options/interface_toolbar.py:119
+#: picard/ui/mainwindow.py:860 picard/ui/options/interface_toolbar.py:119
 msgid "Parse File Names…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:860
+#: picard/ui/mainwindow.py:861
 msgid "Set tags based on the file names"
 msgstr ""
 
-#: picard/ui/mainwindow.py:861 picard/ui/widgets/scripttextedit.py:341
+#: picard/ui/mainwindow.py:862 picard/ui/widgets/scripttextedit.py:341
 msgid "Ctrl+Shift+T"
 msgstr ""
 
-#: picard/ui/mainwindow.py:869
+#: picard/ui/mainwindow.py:870
 msgid "&Open My Collections in Browser"
 msgstr ""
 
-#: picard/ui/mainwindow.py:876
+#: picard/ui/mainwindow.py:877
 msgid "View &Error/Debug Log"
 msgstr ""
 
-#: picard/ui/mainwindow.py:878
+#: picard/ui/mainwindow.py:879
 msgid "Ctrl+G"
 msgstr ""
 
-#: picard/ui/mainwindow.py:884
+#: picard/ui/mainwindow.py:885
 msgid "View Activity &History"
 msgstr ""
 
-#: picard/ui/mainwindow.py:887
+#: picard/ui/mainwindow.py:888
 msgid "Ctrl+Shift+H"
 msgstr ""
 
-#: picard/ui/mainwindow.py:887 picard/ui/scripteditor.py:608
+#: picard/ui/mainwindow.py:888 picard/ui/scripteditor.py:608
 msgid "Ctrl+H"
 msgstr ""
 
-#: picard/ui/mainwindow.py:893
+#: picard/ui/mainwindow.py:894
 msgid "Open in &Player"
 msgstr ""
 
-#: picard/ui/mainwindow.py:894
+#: picard/ui/mainwindow.py:895
 msgid "Play the file in your default media player"
 msgstr ""
 
-#: picard/ui/mainwindow.py:901
+#: picard/ui/mainwindow.py:902
 msgid "Open Containing &Folder"
 msgstr ""
 
-#: picard/ui/mainwindow.py:902
+#: picard/ui/mainwindow.py:903
 msgid "Open the containing folder in your file explorer"
 msgstr ""
 
-#: picard/ui/mainwindow.py:910
+#: picard/ui/mainwindow.py:911
 msgid "&Check for Update…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:949
+#: picard/ui/mainwindow.py:950
 msgid "From CD ripper &log file…"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1002 picard/ui/scripteditor.py:533
+#: picard/ui/mainwindow.py:1003 picard/ui/scripteditor.py:533
 msgid "&File"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1015
+#: picard/ui/mainwindow.py:1016
 msgid "&Edit"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1021 picard/ui/scripteditor.py:593
+#: picard/ui/mainwindow.py:1022 picard/ui/scripteditor.py:593
 msgid "&View"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1030
+#: picard/ui/mainwindow.py:1031
 msgid "&Options"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1036
+#: picard/ui/mainwindow.py:1037
 msgid "&Select file naming script"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1044
+#: picard/ui/mainwindow.py:1045
 msgid "&Enable/disable profiles"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1051
+#: picard/ui/mainwindow.py:1052
 msgid "&Tools"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1065 picard/ui/scripteditor.py:614
+#: picard/ui/mainwindow.py:1066 picard/ui/scripteditor.py:614
 #: picard/ui/util.py:51
 msgid "&Help"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1100 picard/ui/ui_options_plugins.py:134
+#: picard/ui/mainwindow.py:1101 picard/ui/ui_options_plugins.py:134
 msgid "Actions"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1152
+#: picard/ui/mainwindow.py:1153
 msgid "Track"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1169
+#: picard/ui/mainwindow.py:1170
 msgid "&Advanced search"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1170
+#: picard/ui/mainwindow.py:1171
 msgid "&Builtin search"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1265
+#: picard/ui/mainwindow.py:1266
 msgid "All supported formats"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1294
+#: picard/ui/mainwindow.py:1295
 #, python-format
 msgid "Adding multiple directories from '%(directory)s' …"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1299
+#: picard/ui/mainwindow.py:1300
 #, python-format
 msgid "Adding directory: '%(directory)s' …"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1411
+#: picard/ui/mainwindow.py:1412
 msgid "Configuration Required"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1412
+#: picard/ui/mainwindow.py:1413
 msgid ""
 "Audio fingerprinting is not yet configured. Would you like to configure "
 "it now?"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1525
+#: picard/ui/mainwindow.py:1526
 msgid "Browser integration not enabled"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1526
+#: picard/ui/mainwindow.py:1527
 msgid ""
 "Submitting releases to MusicBrainz requires the browser integration to be"
 " enabled. Do you want to enable the browser integration now?"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1637
+#: picard/ui/mainwindow.py:1638
 #, python-format
 msgid "%(filename)s (error: %(error)s)"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1643
+#: picard/ui/mainwindow.py:1644
 #, python-format
 msgid "%(filename)s"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1652
+#: picard/ui/mainwindow.py:1653
 #, python-format
 msgid "%(filename)s (%(similarity)d%%) (error: %(error)s)"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1659
+#: picard/ui/mainwindow.py:1660
 #, python-format
 msgid "%(filename)s (%(similarity)d%%)"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1722
+#: picard/ui/mainwindow.py:1723
 msgid "Authentication Required"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1723
+#: picard/ui/mainwindow.py:1724
 msgid ""
 "Picard needs authorization to access your personal data on the "
 "MusicBrainz server. Would you like to log in now?"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1738
+#: picard/ui/mainwindow.py:1739
 msgid "Authentication failed"
 msgstr ""
 
-#: picard/ui/mainwindow.py:1739 picard/ui/options/general.py:156
+#: picard/ui/mainwindow.py:1740 picard/ui/options/general.py:156
 #, python-format
 msgid "Login failed: %s"
 msgstr ""
@@ -7551,52 +3373,52 @@ msgstr ""
 
 #: picard/ui/playertoolbar.py:179
 #, python-format
-msgid "Internal player: error, code=%d, msg=%s"
+msgid "Internal player: error, code=%(code)d, msg=%(message)s"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:185
+#: picard/ui/playertoolbar.py:188
 msgid "Player"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:193
+#: picard/ui/playertoolbar.py:196
 msgid "Play"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:194
+#: picard/ui/playertoolbar.py:197
 msgid "Play selected files"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:200
+#: picard/ui/playertoolbar.py:203
 msgid "Pause"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:201
+#: picard/ui/playertoolbar.py:204
 msgid "Pause or resume current playback"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:339
+#: picard/ui/playertoolbar.py:342
 #, python-format
 msgid "%1.1f ×"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:345
+#: picard/ui/playertoolbar.py:348
 msgid "Change playback speed"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:352
+#: picard/ui/playertoolbar.py:355
 msgid "Playback speed"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:395
+#: picard/ui/playertoolbar.py:398
 #, python-format
 msgid "%d%%"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:401
+#: picard/ui/playertoolbar.py:404
 msgid "Change audio volume"
 msgstr ""
 
-#: picard/ui/playertoolbar.py:407
+#: picard/ui/playertoolbar.py:410
 msgid "Audio volume"
 msgstr ""
 
@@ -7838,7 +3660,7 @@ msgstr ""
 msgid "Are you sure that you want to delete the script?"
 msgstr ""
 
-#: picard/ui/options/scripting.py:161 picard/ui/scripteditor.py:1208
+#: picard/ui/options/scripting.py:164 picard/ui/scripteditor.py:1208
 msgid "File Error"
 msgstr ""
 
@@ -8389,7 +4211,7 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
-#: picard/ui/options/plugins.py:609 picard/ui/searchdialog/album.py:152
+#: picard/ui/options/plugins.py:614 picard/ui/searchdialog/album.py:152
 #: picard/ui/searchdialog/artist.py:54 picard/ui/searchdialog/track.py:69
 #: picard/ui/ui_options_plugins.py:132
 msgid "Name"
@@ -8960,7 +4782,7 @@ msgstr ""
 
 #: picard/ui/options/genres.py:156
 #, python-format
-msgid "Error line %d: %s"
+msgid "Error line %(lineno)d: %(error)s"
 msgstr ""
 
 #: picard/ui/options/interface.py:94
@@ -9121,34 +4943,34 @@ msgstr ""
 #: picard/ui/options/maintenance.py:127
 #, python-format
 msgid ""
-"The configuration file currently contains %d option settings, %d which "
-"are unused."
+"The configuration file currently contains %(totalcount)d option settings,"
+" %(unusedcount)d which are unused."
 msgstr ""
 
-#: picard/ui/options/maintenance.py:167
+#: picard/ui/options/maintenance.py:166
 msgid "Configuration files"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:184 picard/ui/options/maintenance.py:201
+#: picard/ui/options/maintenance.py:183 picard/ui/options/maintenance.py:200
 msgid "Backup Configuration File"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:188
+#: picard/ui/options/maintenance.py:187
 msgid ""
 "There was a problem backing up the configuration file. Please see the "
 "logs for more details."
 msgstr ""
 
-#: picard/ui/options/maintenance.py:216
+#: picard/ui/options/maintenance.py:215
 #, python-format
 msgid "Configuration successfully backed up to %s"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:225
+#: picard/ui/options/maintenance.py:224
 msgid "Load Backup Configuration File"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:229
+#: picard/ui/options/maintenance.py:228
 msgid ""
 "Loading a backup configuration file will replace the current "
 "configuration settings. A backup copy of the current file will be saved "
@@ -9157,24 +4979,24 @@ msgid ""
 "Do you want to continue?"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:261
+#: picard/ui/options/maintenance.py:260
 #, python-format
 msgid "Configuration successfully loaded from %s"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:269
+#: picard/ui/options/maintenance.py:268
 msgid ""
 "There was a problem restoring the configuration file. Please see the logs"
 " for more details."
 msgstr ""
 
-#: picard/ui/options/maintenance.py:295
+#: picard/ui/options/maintenance.py:294
 #: picard/ui/widgets/profilelistwidget.py:84
 #: picard/ui/widgets/scriptlistwidget.py:90
 msgid "Confirm Remove"
 msgstr ""
 
-#: picard/ui/options/maintenance.py:296
+#: picard/ui/options/maintenance.py:295
 msgid "Are you sure you want to remove the selected option settings?"
 msgstr ""
 
@@ -9228,66 +5050,68 @@ msgstr ""
 msgid "Reloading list of available plugins…"
 msgstr ""
 
-#: picard/ui/options/plugins.py:416 picard/ui/options/plugins.py:425
-#: picard/ui/options/plugins.py:446
+#: picard/ui/options/plugins.py:416 picard/ui/options/plugins.py:428
+#: picard/ui/options/plugins.py:449
 #, python-format
-msgid "Plugin '%s'"
+msgid "Plugin \"%(plugin)s\""
 msgstr ""
 
 #: picard/ui/options/plugins.py:417
 #, python-format
 msgid ""
-"An error occurred while loading the plugin '%s':\n"
+"An error occurred while loading the plugin \"%(plugin)s\":\n"
 "\n"
-"%s"
+"%(error)s"
 msgstr ""
 
-#: picard/ui/options/plugins.py:426
+#: picard/ui/options/plugins.py:429
 #, python-format
-msgid "The plugin '%s' is not compatible with this version of Picard."
+msgid "The plugin \"%(plugin)s\" is not compatible with this version of Picard."
 msgstr ""
 
-#: picard/ui/options/plugins.py:447
+#: picard/ui/options/plugins.py:450
 #, python-format
-msgid "The plugin '%s' will be upgraded to version %s on next run of Picard."
+msgid ""
+"The plugin \"%(plugin)s\" will be upgraded to version %(version)s on next"
+" run of Picard."
 msgstr ""
 
-#: picard/ui/options/plugins.py:468
+#: picard/ui/options/plugins.py:473
 #, python-format
-msgid "Uninstall plugin '%s'?"
+msgid "Uninstall plugin \"%(plugin)s\"?"
 msgstr ""
 
-#: picard/ui/options/plugins.py:469
+#: picard/ui/options/plugins.py:474
 #, python-format
-msgid "Do you really want to uninstall the plugin '%s' ?"
+msgid "Do you really want to uninstall the plugin \"%(plugin)s\"?"
 msgstr ""
 
-#: picard/ui/options/plugins.py:601
+#: picard/ui/options/plugins.py:606
 msgid "Restart Picard to upgrade to new version"
 msgstr ""
 
-#: picard/ui/options/plugins.py:603
+#: picard/ui/options/plugins.py:608
 msgid "New version available"
 msgstr ""
 
-#: picard/ui/options/plugins.py:610
+#: picard/ui/options/plugins.py:615
 msgid "Authors"
 msgstr ""
 
-#: picard/ui/options/plugins.py:611 picard/util/tags.py:73
+#: picard/ui/options/plugins.py:616 picard/util/tags.py:73
 msgid "License"
 msgstr ""
 
-#: picard/ui/options/plugins.py:613
+#: picard/ui/options/plugins.py:618
 msgid "User Guide"
 msgstr ""
 
-#: picard/ui/options/plugins.py:678
+#: picard/ui/options/plugins.py:684
 #, python-format
-msgid "The plugin '%s' could not be downloaded."
+msgid "The plugin \"%(plugin)s\" could not be downloaded."
 msgstr ""
 
-#: picard/ui/options/plugins.py:679
+#: picard/ui/options/plugins.py:685
 msgid "Please try again later."
 msgstr ""
 
@@ -9398,12 +5222,12 @@ msgstr ""
 msgid "Picard tagging script package"
 msgstr ""
 
-#: picard/ui/options/scripting.py:173
+#: picard/ui/options/scripting.py:176
 #, python-format
 msgid "%s (imported)"
 msgstr ""
 
-#: picard/ui/options/scripting.py:240
+#: picard/ui/options/scripting.py:243
 msgid "Script Error"
 msgstr ""
 
@@ -9437,15 +5261,15 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: picard/ui/searchdialog/__init__.py:252
+#: picard/ui/searchdialog/__init__.py:259
 #, python-format
 msgid ""
 "<strong>Following error occurred while fetching "
-"results:<br><br></strong>Network request error for %s:<br>%s (QT code %d,"
-" HTTP code %s)<br>"
+"results:<br><br></strong>Network request error for %(url)s:<br>%(error)s "
+"(QT code %(qtcode)d, HTTP code %(statuscode)r)<br>"
 msgstr ""
 
-#: picard/ui/searchdialog/__init__.py:263
+#: picard/ui/searchdialog/__init__.py:264
 msgid "<strong>No results found. Please try a different search query.</strong>"
 msgstr ""
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,3 +1,3 @@
-Babel==2.9.1
+Babel>=2.10.0
 PyInstaller==5.12.0
 setuptools>=62.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 # E501: line too long (xx > 79 characters)
 # W503: line break occurred before a binary operator
 ignore = E127,E128,E129,E226,E241,E501,W503
-builtins = _,N_,ngettext,gettext_attributes,pgettext_attributes,gettext_countries
+builtins = _,N_,ngettext,gettext_attributes,pgettext_attributes,gettext_constants,gettext_countries
 exclude = ui_*.py,picard/resources.py
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -683,13 +683,13 @@ def cflags_to_include_dirs(cflags):
 
 def _picard_get_locale_files():
     locales = []
-    path_domain = {
-        'po': 'picard',
-        os.path.join('po', 'attributes'): 'picard-attributes',
-        os.path.join('po', 'constants'): 'picard-constants',
-        os.path.join('po', 'countries'): 'picard-countries',
+    domain_path = {
+        'picard': 'po',
+        'picard-attributes': os.path.join('po', 'attributes'),
+        'picard-constants': os.path.join('po', 'constants'),
+        'picard-countries': os.path.join('po', 'countries'),
     }
-    for path, domain in path_domain.items():
+    for domain, path in domain_path.items():
         for filepath in glob.glob(os.path.join(path, '*.po')):
             filename = os.path.basename(filepath)
             locale = os.path.splitext(filename)[0]

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -53,8 +53,9 @@ class TestI18n(PicardTestCase):
         self.assertEqual('Country', N_('Country'))
         self.assertEqual('%i image', ngettext('%i image', '%i images', 1))
         self.assertEqual('%i images', ngettext('%i image', '%i images', 2))
-        self.assertEqual('France', gettext_countries('France'))
         self.assertEqual('Cassette', pgettext_attributes('medium_format', 'Cassette'))
+        self.assertEqual('French', gettext_constants('French'))
+        self.assertEqual('France', gettext_countries('France'))
 
     @unittest.skipUnless(os.path.exists(os.path.join(localedir, 'de')),
         'Test requires locales to be built with "python setup.py build_locales -i"')
@@ -73,8 +74,9 @@ class TestI18n(PicardTestCase):
         self.assertEqual('Country', N_('Country'))
         self.assertEqual('%i Bild', ngettext('%i image', '%i images', 1))
         self.assertEqual('%i Bilder', ngettext('%i image', '%i images', 2))
-        self.assertEqual('Frankreich', gettext_countries('France'))
         self.assertEqual('Kassette', pgettext_attributes('medium_format', 'Cassette'))
+        # self.assertEqual('Französisch', gettext_constants('French'))
+        self.assertEqual('Frankreich', gettext_countries('France'))
 
 
 @patch('locale.getpreferredencoding', autospec=True)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2690
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The `picard.const` module contains longs lists, most specifically for locales and written scripts.

This makes translating much harder, as half the strings to translate are from these lists, but they are essentially only used for very few UI elements.

Also it makes it difficult to assess how complete a translation of Picard is. A translations that translates all the UI texts except for the locale list has a low completion percentage on Weblate, but actually it is a very complete translation. Likewise a translation that solely translates the locales list shows with the same or higher completion, but actually the application can hardly be described as being localized.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Move translations of the strings in `picard.const` into a separate gettext message domain "picard-constants".

I originally planned to move only the locales there, but with Babel it is easier to handle it by excluding a folder. And actually I think that fits well, as it also includes the scripts. Likewise I think it is no mistake to include the values in `picard/const/__init__.py` as well.

There is a new setup command `picard_regen_constants_pot_file`. We could also include a single meta command to update both, but for now I wanted to keep it separate (see below).


# Action

Of course we should keep existing translations. My plan was as follows:

- Once this has been merged I set up the Weblate component for it
- We leverage Weblate's capability to automatically translate strings from other components to fill the translations again
- Afterwards we can regenerate the main `picard.pot` (removing the strings from it)
- I'll also update the translation docs and unify generating both `picard.pot`  and `constants/constants.pot` with a single command