### PR TITLE
PICARD-2736: Fix Windows system wide libssl conflicting with bundled libssl

### DIFF
--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -36,8 +36,4 @@ Function FinalizePackage {
   CodeSignBinary (Join-Path $Path picard.exe)
   CodeSignBinary (Join-Path $Path fpcalc.exe)
   CodeSignBinary (Join-Path $Path discid.dll)
-
-  # Delete unused files
-  Remove-Item -Path (Join-Path $Path libcrypto-1_1.dll)
-  Remove-Item -Path (Join-Path $Path libssl-1_1.dll)
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2736
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
Removed an old workaround that no longer applies for current PyQt5 and/or PyInstaller. The OpenSSL DLLs should be kept in the main install folder in order to be prioritized over system libs.