### PR TITLE
PICARD-2749: Avoid deprecated importlib APIs in log module

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -48,7 +48,7 @@ from picard.const.sys import (
 if IS_FROZEN:
     picard_module_path = Path(FROZEN_TEMP_PATH).joinpath('picard').resolve()
 else:
-    picard_module_path = Path(PathFinder().find_module('picard').get_filename()).resolve()
+    picard_module_path = Path(PathFinder().find_spec('picard').origin).resolve()
 
 _MAX_TAIL_LEN = 10**6
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2749
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

With Python 3.12 the `find_module` method gets removed from importlib.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Update the `picard.log` module to use `find_spec instead.

**Note:** This does not provide full Python 3.12 compatibility as for now. We need to solve [PICARD-2354](https://tickets.metabrainz.org/browse/PICARD-2354) and [PICARD-2355](https://tickets.metabrainz.org/browse/PICARD-2355)) for this as well. See #2134