### PR TITLE
PICARD-2724: Move all Qt5 DLLs into main directory on Windows

### DIFF
--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -33,16 +33,16 @@ Function FinalizePackage {
     $Path
   )
 
-  CodeSignBinary (Join-Path $Path picard.exe)
-  CodeSignBinary (Join-Path $Path fpcalc.exe)
-  CodeSignBinary (Join-Path $Path discid.dll)
+  CodeSignBinary (Join-Path -Path $Path -ChildPath picard.exe)
+  CodeSignBinary (Join-Path -Path $Path -ChildPath fpcalc.exe)
+  CodeSignBinary (Join-Path -Path $Path -ChildPath discid.dll)
 
   # Move all Qt5 DLLs into the main folder to avoid conflicts with system wide
   # versions of those dependencies. Since some version PyInstaller tries to
   # maintain the file hierarchy of imported modules, but this easily breaks
   # DLL loading on Windows.
   # Workaround for https://tickets.metabrainz.org/browse/PICARD-2736
-  $Qt5BinDir = (Join-Path $Path PyQt5 Qt5 bin)
-  Move-Item (Join-Path $Qt5BinDir *.dll) $Path -Force
-  Remove-Item $Qt5BinDir
+  $Qt5BinDir = (Join-Path -Path $Path -ChildPath PyQt5\Qt5\bin)
+  Move-Item -Path (Join-Path -Path $Qt5BinDir -ChildPath *.dll) -Destination $Path -Force
+  Remove-Item -Path $Qt5BinDir
 }

--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -36,4 +36,13 @@ Function FinalizePackage {
   CodeSignBinary (Join-Path $Path picard.exe)
   CodeSignBinary (Join-Path $Path fpcalc.exe)
   CodeSignBinary (Join-Path $Path discid.dll)
+
+  # Move all Qt5 DLLs into the main folder to avoid conflicts with system wide
+  # versions of those dependencies. Since some version PyInstaller tries to
+  # maintain the file hierarchy of imported modules, but this easily breaks
+  # DLL loading on Windows.
+  # Workaround for https://tickets.metabrainz.org/browse/PICARD-2736
+  $Qt5BinDir = (Join-Path $Path PyQt5 Qt5 bin)
+  Move-Item (Join-Path $Qt5BinDir *.dll) $Path -Force
+  Remove-Item $Qt5BinDir
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2736
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Copy all Qt5 DLLs to the main installation folder next to `picard.exe`.
Avoids import errors if a system wide, incompatible Qt5 installation is present on the system.
