### PR TITLE
PICARD-2751: Avoid deprecated importlib APIs, full Python 3.12 compatibility

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.1']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.1']
         include:
         - os: macos-11
           python-version: '3.7'

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -598,17 +598,17 @@ class PluginMetaPathFinder(MetaPathFinder):
         if not fullname.startswith(_PLUGIN_MODULE_PREFIX):
             return None
         plugin_name = fullname[len(_PLUGIN_MODULE_PREFIX):]
-        for plugin_dir in _plugin_dirs:
-            spec = None
-            if hasattr(zipimport.zipimporter, 'find_spec'):  # Python >= 3.10
+        spec = None
+        if hasattr(zipimport.zipimporter, 'find_spec'):  # Python >= 3.10
+            for plugin_dir in _plugin_dirs:
                 zipfilename = os.path.join(plugin_dir, plugin_name + '.zip')
                 zip_importer = zip_import(zipfilename)
                 if zip_importer:
                     spec = zip_importer.find_spec(fullname)
-            if not spec:
-                spec = importlib.machinery.PathFinder().find_spec(fullname, [plugin_dir])
-            if spec and spec.loader:
-                return spec
+                    break
+        if not spec:
+            spec = importlib.machinery.PathFinder().find_spec(fullname, _plugin_dirs)
+        return spec if spec and spec.loader else None
 
 
 sys.meta_path.append(PluginMetaPathFinder())

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -270,7 +270,6 @@ class PluginManager(QtCore.QObject):
         return (None, None)
 
     def _load_plugin_from_directory(self, name, plugindir):
-        module_file = None
         info = None
         zipfilename = os.path.join(plugindir, name + '.zip')
         (zip_importer, module_name, manifest_data) = zip_import(zipfilename)
@@ -321,6 +320,8 @@ class PluginManager(QtCore.QObject):
                 plugin_module = zip_importer.load_module(full_module_name)
             else:
                 plugin_module = importlib.util.module_from_spec(info)
+                info.loader.exec_module(plugin_module)
+
             plugin = PluginWrapper(plugin_module, plugindir,
                                    file=module_pathname, manifest_data=manifest_data)
             compatible_versions = _compatible_api_versions(plugin.api_versions)

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -353,6 +353,12 @@ class PluginManager(QtCore.QObject):
                 plugin_module = zip_importer.load_module(full_module_name)
             else:
                 plugin_module = importlib.util.module_from_spec(spec)
+                # This is kind of a hack. The module will be in sys.modules
+                # after exec_module has run. But if inside of the loaded plugin
+                # there are relative imports it would load the same plugin
+                # module twice. This executes the plugins code twice and leads
+                # to potential side effects.
+                sys.modules[full_module_name] = plugin_module
                 spec.loader.exec_module(plugin_module)
 
             plugin = PluginWrapper(plugin_module, plugindir,

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -215,8 +215,11 @@ def register_plugin_dir(path):
 
 def plugin_dir_for_path(path):
     for plugin_dir in plugin_dirs():
-        if path.startswith(plugin_dir):
-            return plugin_dir
+        try:
+            if os.path.commonpath((path, plugin_dir)) == plugin_dir:
+                return plugin_dir
+        except ValueError:
+            pass
     return path
 
 
@@ -338,7 +341,7 @@ class PluginManager(QtCore.QObject):
             module_pathname = spec.origin
             if isinstance(spec.loader, zipimport.zipimporter):
                 manifest_data = load_zip_manifest(spec.loader.archive)
-            if module_pathname.endswith("__init__.py"):
+            if os.path.basename(module_pathname) == '__init__.py':
                 module_pathname = os.path.dirname(module_pathname)
             plugin_dir = plugin_dir_for_path(module_pathname)
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -94,12 +94,8 @@ from picard.config import (
     setup_config,
 )
 from picard.config_upgrade import upgrade_config
-from picard.const import (
-    USER_DIR,
-    USER_PLUGIN_DIR,
-)
+from picard.const import USER_DIR
 from picard.const.sys import (
-    IS_FROZEN,
     IS_HAIKU,
     IS_MACOS,
     IS_WIN,
@@ -114,7 +110,10 @@ from picard.disc import (
 from picard.file import File
 from picard.formats import open_ as open_file
 from picard.i18n import setup_gettext
-from picard.pluginmanager import PluginManager
+from picard.pluginmanager import (
+    PluginManager,
+    plugin_dirs,
+)
 from picard.releasegroup import ReleaseGroup
 from picard.track import (
     NonAlbumTrack,
@@ -173,21 +172,6 @@ def _patched_shutil_copystat(src, dst, *, follow_symlinks=True):
 
 _orig_shutil_copystat = shutil.copystat
 shutil.copystat = _patched_shutil_copystat
-
-
-def plugin_dirs():
-    if IS_FROZEN:
-        toppath = sys.argv[0]
-    else:
-        toppath = os.path.abspath(__file__)
-
-    topdir = os.path.dirname(toppath)
-    plugin_dir = os.path.join(topdir, "plugins")
-    yield plugin_dir
-
-    if not os.path.exists(USER_PLUGIN_DIR):
-        os.makedirs(USER_PLUGIN_DIR)
-    yield USER_PLUGIN_DIR
 
 
 class ParseItemsToLoad:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2751, PICARD-2354, PICARD-2355
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard's plugin loading system must be updated to avoid long deprecated and inf Python 3.12 finally removed APIs of the importlib and zipimport modules.

This PR replaces #2134

# Solution

At the core the change is to use `find_spec` in combination with `exec_module` to load the modules. A large benefit is that both the normal module loading via importlib as well as the zipimporter can now use the exactly same API.

Unfortunately for zipimporter we need to maintain the legacy loading code with `find_module` + `load_module` for compatibility with Python < 3.10.

This PR maintains full compatibility with the existing plugin systems. Overall there is likely a lot that we could further refactor and trim down, but that is something to be reserved for Picard 3.0.

To properly test the result this PR also enables CI testing with Python 3.12.0rc1