### PR TITLE
PICARD-2751: Restore the ability to load compiled .pyc plugins

### DIFF
--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -639,10 +639,13 @@ class PluginMetaPathFinder(MetaPathFinder):
 
     @staticmethod
     def _plugin_file_paths(plugin_dir, plugin_name):
-        yield os.path.join(plugin_dir, plugin_name, '__init__.py')
-        yield os.path.join(plugin_dir, plugin_name + '.py')
-        if hasattr(zipimport.zipimporter, 'find_spec'):  # Python >= 3.10
-            yield os.path.join(plugin_dir, plugin_name + '.zip')
+        for entry in _PACKAGE_ENTRIES:
+            yield os.path.join(plugin_dir, plugin_name, entry)
+        for ext in _FILEEXTS:
+            # On Python < 3.10 ZIP file loading is handled in PluginManager._load_plugin
+            if ext == '.zip' and not hasattr(zipimport.zipimporter, 'find_spec'):
+                continue
+            yield os.path.join(plugin_dir, plugin_name + ext)
 
 
 sys.meta_path.append(PluginMetaPathFinder())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2751
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

With the changes in #2307 the plugin system's ability to load plugins that only exist as compiled bytecode (`.pyc`) files got lost.



# Solution

Consider all possible file extensions again when trying to load the spec.