### PR TITLE
PICARD-2756: Windows long path support for UNC paths

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -267,8 +267,16 @@ def normpath(path):
 
 
 def win_prefix_longpath(path):
+    """
+    For paths longer then WIN_MAX_FILEPATH_LEN enable long path support by prefixing with WIN_LONGPATH_PREFIX.
+
+    See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    """
     if len(path) > WIN_MAX_FILEPATH_LEN and not path.startswith(WIN_LONGPATH_PREFIX):
-        path = WIN_LONGPATH_PREFIX + path
+        if path.startswith('\\\\'):  # UNC path
+            path = WIN_LONGPATH_PREFIX + 'UNC' + path[1:]
+        else:
+            path = WIN_LONGPATH_PREFIX + path
     return path
 
 

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -273,7 +273,7 @@ def win_prefix_longpath(path):
     See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
     """
     if len(path) > WIN_MAX_FILEPATH_LEN and not path.startswith(WIN_LONGPATH_PREFIX):
-        if path.startswith('\\\\'):  # UNC path
+        if path.startswith(r'\\'):  # UNC path
             path = WIN_LONGPATH_PREFIX + 'UNC' + path[1:]
         else:
             path = WIN_LONGPATH_PREFIX + path

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -809,6 +809,10 @@ class WinPrefixLongpathTest(PicardTestCase):
         path = 'C:\\foo\\' + (252 * 'a')
         self.assertEqual(path, win_prefix_longpath(path))
 
+    def test_win_prefix_longpath_unc(self):
+        path = '\\\\server\\' + (251 * 'a')
+        self.assertEqual('\\\\?\\UNC' + path[1:], win_prefix_longpath(path))
+
 
 class StrxfrmTest(PicardTestCase):
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -786,32 +786,32 @@ class NormpathTest(PicardTestCase):
 
     @unittest.skipUnless(IS_WIN, "windows test")
     def test_normpath_windows(self):
-        self.assertEqual('C:\\Foo\\Bar.baz', normpath('C:/Foo/Bar.baz'))
-        self.assertEqual('C:\\Bar.baz', normpath('C:/Foo/../Bar.baz'))
+        self.assertEqual(r'C:\Foo\Bar.baz', normpath('C:/Foo/Bar.baz'))
+        self.assertEqual(r'C:\Bar.baz', normpath('C:/Foo/../Bar.baz'))
 
     @unittest.skipUnless(IS_WIN, "windows test")
     @patch.object(util, 'system_supports_long_paths')
     def test_normpath_windows_longpath(self, mock_system_supports_long_paths):
         mock_system_supports_long_paths.return_value = False
-        path = 'C:\\foo\\' + (252 * 'a')
+        path = rf'C:\foo\{252 * "a"}'
         self.assertEqual(path, normpath(path))
         path += 'a'
-        self.assertEqual('\\\\?\\' + path, normpath(path))
+        self.assertEqual(rf'\\?\{path}', normpath(path))
 
 
 class WinPrefixLongpathTest(PicardTestCase):
 
     def test_win_prefix_longpath_is_long(self):
-        path = 'C:\\foo\\' + (253 * 'a')
-        self.assertEqual('\\\\?\\' + path, win_prefix_longpath(path))
+        path = rf'C:\foo\{253 * "a"}'
+        self.assertEqual(rf'\\?\{path}', win_prefix_longpath(path))
 
     def test_win_prefix_longpath_is_short(self):
-        path = 'C:\\foo\\' + (252 * 'a')
+        path = rf'C:\foo\{252 * "a"}'
         self.assertEqual(path, win_prefix_longpath(path))
 
     def test_win_prefix_longpath_unc(self):
-        path = '\\\\server\\' + (251 * 'a')
-        self.assertEqual('\\\\?\\UNC' + path[1:], win_prefix_longpath(path))
+        path = rf'\\server\{251 * "a"}'
+        self.assertEqual(rf'\\?\UNC{path[1:]}', win_prefix_longpath(path))
 
 
 class StrxfrmTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2756
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

For Windows UNC paths (e.g. for network shares) the long path support did not work and lead to invalid paths.

While for local paths the file path needs to be preficed with `\\?\`, e.g. `\\?\C:\somelongpath...`, for UNC paths in the form of `\\servername\path` the long path must be defined as `\\?\UNC\servername\somelongpath...`.

See also:

- https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
- https://en.wikipedia.org/wiki/Path_(computing)#Universal_Naming_Convention

# Solution

Extend `picard.util.win_prefix_longpath`  to handle UNC paths.