### PR TITLE
Replace hashlib.md5() with hashlib.blake2b()

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -28,7 +28,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from hashlib import md5
+from hashlib import blake2b
 import os
 import shutil
 import tempfile
@@ -77,9 +77,7 @@ class DataHash:
         self._filename = None
         _datafile_mutex.lock()
         try:
-            m = md5()  # nosec
-            m.update(data)
-            self._hash = m.hexdigest()
+            self._hash = blake2b(data).hexdigest()
             if self._hash not in _datafiles:
                 (fd, self._filename) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
                 QObject.tagger.register_cleanup(self.delete_file)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -47,7 +47,7 @@
 
 import argparse
 from functools import partial
-from hashlib import md5
+from hashlib import blake2b
 import logging
 import os
 import platform
@@ -1532,8 +1532,12 @@ def main(localedir=None, autoupdate=True):
     if picard_args.stand_alone_instance:
         identifier = uuid4().hex
     else:
-        identifier = md5(picard_args.config_file.encode('utf8')).hexdigest() if picard_args.config_file else 'main'  # nosec: B303
-        identifier += '_NP' if picard_args.no_plugins else ''
+        if picard_args.config_file:
+            identifier = blake2b(picard_args.config_file.encode('utf8'), digest_size=16).hexdigest()
+        else:
+            identifier = 'main'
+        if picard_args.no_plugins:
+            identifier += '_NP'
 
     if picard_args.processable:
         log.info("Sending messages to main instance: %r", picard_args.processable)


### PR DESCRIPTION
It is faster, and more secure.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`hashlib.md5()` is now quite old, and it raises few warnings (even though our use isn't risky).
Since a while `hashlib.blake2b()` is a good alternative, it is even slightly faster than `md5()`


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
