### PR TITLE
PICARD-2760: Timestamp the Windows binaries when codesigning

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -188,8 +188,10 @@ jobs:
     - name: Build Windows 10 signed app package
       if: matrix.type == 'signed-app' && env.CODESIGN == '1'
       run: |
-        $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
-        & .\scripts\package\win-package-appx.ps1 -BuildNumber $Env:BUILD_NUMBER -CertificateFile .\codesign.pfx -CertificatePassword $CertPassword
+        $CertificateFile = ".\codesign.pfx"
+        $CertificatePassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
+        & .\scripts\package\win-package-appx.ps1 -BuildNumber $Env:BUILD_NUMBER `
+          -CertificateFile $CertificateFile -CertificatePassword $CertificatePassword
         Move-Item .\dist\*.msix .\artifacts
       env:
         CODESIGN_P12_PASSWORD: ${{ secrets.CODESIGN_P12_PASSWORD }}
@@ -198,12 +200,14 @@ jobs:
       run: |
         # choco install nsis
         If ($Env:CODESIGN -eq "1") {
-          $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
-          $Certificate = Get-PfxCertificate -FilePath .\codesign.pfx -Password $CertPassword
+          $CertificateFile = ".\codesign.pfx"
+          $CertificatePassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
         } Else {
-          $Certificate = $null
+          $CertificateFile = $null
+          $CertificatePassword = $null
         }
-        & .\scripts\package\win-package-installer.ps1 -BuildNumber $Env:BUILD_NUMBER -Certificate $Certificate
+        & .\scripts\package\win-package-installer.ps1 -BuildNumber $Env:BUILD_NUMBER `
+          -CertificateFile $CertificateFile -CertificatePassword $CertificatePassword
         Move-Item .\installer\*.exe .\artifacts
         dist\picard\fpcalc -version
       env:
@@ -212,12 +216,14 @@ jobs:
       if: matrix.type == 'portable'
       run: |
         If ($Env:CODESIGN -eq "1") {
-          $CertPassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
-          $Certificate = Get-PfxCertificate -FilePath .\codesign.pfx -Password $CertPassword
+          $CertificateFile = ".\codesign.pfx"
+          $CertificatePassword = ConvertTo-SecureString -String $Env:CODESIGN_P12_PASSWORD -Force -AsPlainText
         } Else {
-          $Certificate = $null
+          $CertificateFile = $null
+          $CertificatePassword = $null
         }
-        & .\scripts\package\win-package-portable.ps1 -BuildNumber $Env:BUILD_NUMBER -Certificate $Certificate
+        & .\scripts\package\win-package-portable.ps1 -BuildNumber $Env:BUILD_NUMBER `
+          -CertificateFile $CertificateFile -CertificatePassword $CertificatePassword
         Move-Item .\dist\*.exe .\artifacts
       env:
         CODESIGN_P12_PASSWORD: ${{ secrets.CODESIGN_P12_PASSWORD }}

--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -5,6 +5,9 @@ Param(
   $Certificate
 )
 
+# RFC 3161 timestamp server for code signing
+$TimeStampServer = 'http://ts.ssl.com'
+
 Function CodeSignBinary {
   Param(
     [ValidateScript({Test-Path $_ -PathType Leaf})]
@@ -13,7 +16,7 @@ Function CodeSignBinary {
   )
   If ($Certificate) {
     Set-AuthenticodeSignature -FilePath $BinaryPath -Certificate $Certificate `
-      -ErrorAction Stop
+      -TimestampServer $TimeStampServer -ErrorAction Stop
   } Else {
     Write-Output "Skip signing $BinaryPath"
   }

--- a/scripts/package/win-package-appx.ps1
+++ b/scripts/package/win-package-appx.ps1
@@ -12,6 +12,9 @@ Param(
   $BuildNumber
 )
 
+# RFC 3161 timestamp server for code signing
+$TimeStampServer = 'http://ts.ssl.com'
+
 # Errors are handled explicitly. Otherwise any output to stderr when
 # calling classic Windows exes causes a script error.
 $ErrorActionPreference = 'Continue'
@@ -72,9 +75,9 @@ ThrowOnExeError "MakeAppx failed"
 
 # Sign package
 If ($CertificateFile) {
-  SignTool sign /fd SHA256 /f "$CertificateFile" /p (ConvertFrom-SecureString -AsPlainText $CertificatePassword) $PackageFile
+  SignTool sign /v /fd SHA256 /tr "$TimeStampServer" /td sha256 /f "$CertificateFile" /p (ConvertFrom-SecureString -AsPlainText $CertificatePassword) $PackageFile
   ThrowOnExeError "SignTool failed"
 } ElseIf ($Certificate) {
-  SignTool sign /fd SHA256 /sha1 $Certificate.Thumbprint $PackageFile
+  SignTool sign /v /fd SHA256 /tr "$TimeStampServer" /td sha256 /sha1 $Certificate.Thumbprint $PackageFile
   ThrowOnExeError "SignTool failed"
 }

--- a/scripts/package/win-package-installer.ps1
+++ b/scripts/package/win-package-installer.ps1
@@ -1,8 +1,11 @@
 # Build a Windows installer
 
 Param(
-  [System.Security.Cryptography.X509Certificates.X509Certificate]
-  $Certificate,
+  [ValidateScript({ (Test-Path $_ -PathType Leaf) -or (-not $_) })]
+  [String]
+  $CertificateFile,
+  [SecureString]
+  $CertificatePassword,
   [Int]
   $BuildNumber
 )
@@ -16,7 +19,7 @@ If (-Not $BuildNumber) {
 }
 
 $ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
-. $ScriptDirectory\win-common.ps1 -Certificate $Certificate
+. $ScriptDirectory\win-common.ps1 -CertificateFile $CertificateFile -CertificatePassword $CertificatePassword
 
 Write-Output "Building Windows installer..."
 

--- a/scripts/package/win-package-portable.ps1
+++ b/scripts/package/win-package-portable.ps1
@@ -1,8 +1,11 @@
 # Build a portable app
 
 Param(
-  [System.Security.Cryptography.X509Certificates.X509Certificate]
-  $Certificate,
+  [ValidateScript({ (Test-Path $_ -PathType Leaf) -or (-not $_) })]
+  [String]
+  $CertificateFile,
+  [SecureString]
+  $CertificatePassword,
   [Int]
   $BuildNumber
 )
@@ -16,7 +19,7 @@ If (-Not $BuildNumber) {
 }
 
 $ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
-. $ScriptDirectory\win-common.ps1 -Certificate $Certificate
+. $ScriptDirectory\win-common.ps1 -CertificateFile $CertificateFile -CertificatePassword $CertificatePassword
 
 Write-Output "Building portable exe..."
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2760
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Enable timestamping when code signing for Windows. Signed binaries with a timestamp will remain valid even after the certificates have expired as long as they get signed before expiration of the certificates.

For details see:

- https://learn.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures
- https://www.ssl.com/how-to/using-your-code-signing-certificate/#ftoc-heading-10

# Solution

Use the timestamp server provided by ssl.com with SignTool