### PR TITLE
PICARD-2748: Add check for missing profile_id keys

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -173,9 +173,11 @@ class SettingConfigSection(ConfigSection):
 
     def _get_profile_settings(self, profile_id):
         if self.settings_override is None:
-            profile_settings = self.__qt_config.profiles[self.SETTINGS_KEY][profile_id]
+            # Set to None if profile_id not in profile settings
+            profile_settings = self.__qt_config.profiles[self.SETTINGS_KEY][profile_id] if profile_id in self.__qt_config.profiles[self.SETTINGS_KEY] else None
         else:
-            profile_settings = self.settings_override[profile_id]
+            # Set to None if profile_id not in settings_override
+            profile_settings = self.settings_override[profile_id] if profile_id in self.settings_override else None
         if profile_settings is None:
             log.error("Unable to find settings for user profile '%s'", profile_id)
             return {}

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -291,6 +291,22 @@ class TestUserProfiles(TestPicardProfilesCommon):
         self.assertEqual(self.config.setting[self.test_setting_1], False)
         self.assertEqual(self.config.setting[self.test_setting_2], 99)
 
+        # Re-enable profile overrides and check that the saved settings still exist
+        # with invalid profile id in profile list
+        profiles = [
+            {
+                "position": 4,
+                "title": "Test Profile 4",
+                "enabled": True,
+                "id": "test_key_4",
+            }
+        ]
+        profiles.extend(self.get_profiles(enabled=True))
+        self.config.setting.set_profiles_override(profiles)
+        self.assertEqual(self.config.setting[self.test_setting_0], "def")
+        self.assertEqual(self.config.setting[self.test_setting_1], False)
+        self.assertEqual(self.config.setting[self.test_setting_2], 99)
+
     def test_config_option_rename(self):
         from picard.config_upgrade import rename_option
         self.config.setting[self.test_setting_0] = "abc"


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add test for invalid `profile_id` keys

# Problem

* JIRA ticket (_optional_): PICARD-2748

See the discussion in PICARD-2748.

# Solution

Add checks for invalid keys.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
