### PR TITLE
PICARD-2764: Attached profiles dialog does not display on option sub-pages

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -225,11 +225,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             message_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
             return message_box.exec_()
 
+        option_group = page.PARENT if page.PARENT in UserProfileGroups.SETTINGS_GROUPS else page.NAME
         override_profiles = self.profile_page._clean_and_get_all_profiles()
         override_settings = self.profile_page.profile_settings
         profile_dialog = AttachedProfilesDialog(
             parent=self,
-            option_group=page.NAME,
+            option_group=option_group,
             override_profiles=override_profiles,
             override_settings=override_settings
         )


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add mapping from option setting pages to the controlling option profile category

# Problem

When you try to display the "Attached Profiles" dialog from an option settings sub-page Picard prints a "KeyError" exception to the terminal but does not record the exception in the log.

Steps to reproduce:

1. Open "Options..."
2. Select the "Option Profiles" options page.
3. Create a new profile and enable the "Advanced" settings for the profile.
4. Select the "Advanced" > "Network" options page.
5. Click the "Attached Profiles" button.  The dialog is not displayed and the exception is written to the terminal.

* JIRA ticket (_optional_): PICARD-2764

# Solution

Get the option group from the parent option page if applicable.

# Action

None.
