### PR TITLE
Highlight associated labels for items not showing highlight

### DIFF
--- a/picard/profile.py
+++ b/picard/profile.py
@@ -185,8 +185,8 @@ class UserProfileGroups():
             # Main User Interface Page
             SettingDesc('toolbar_show_labels', N_("Show text labels under icons"), ['toolbar_show_labels']),
             SettingDesc('show_menu_icons', N_("Show icons in menus"), ['show_menu_icons']),
-            SettingDesc('ui_language', N_("User interface language"), ['ui_language']),
-            SettingDesc('ui_theme', N_("User interface color theme"), ['ui_theme']),
+            SettingDesc('ui_language', N_("User interface language"), ['ui_language', 'label']),
+            SettingDesc('ui_theme', N_("User interface color theme"), ['ui_theme', 'label_theme']),
             SettingDesc('toolbar_multiselect', N_("Allow selection of multiple directories"), ['toolbar_multiselect']),
             SettingDesc('builtin_search', N_("Use builtin search rather than looking in browser"), ['builtin_search']),
             SettingDesc('use_adv_search_syntax', N_("Use advanced search syntax"), ['use_adv_search_syntax']),


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**: Add highlight to label for options not properly displaying the highlight.

# Problem

Some settings in the option settings pages do not properly display highlighted when associated with an option profile.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Add highlight to label for options not properly displaying the highlight.

# Action

None.
