### PR TITLE
Drop unused imports

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -120,10 +120,6 @@ for k, v in MB_ATTRIBUTES.items():
     elif k.startswith('DB:release_status/name:'):
         RELEASE_STATUS[v] = v
 
-# List of alias locales
-from picard.const.locales import (  # noqa: F401,E402 # pylint: disable=unused-import
-    ALIAS_LOCALES,
-)
 # List of available charsets
 from picard.const.scripts import (  # noqa: F401,E402 # pylint: disable=unused-import
     SCRIPTS,

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -120,10 +120,6 @@ for k, v in MB_ATTRIBUTES.items():
     elif k.startswith('DB:release_status/name:'):
         RELEASE_STATUS[v] = v
 
-# List of available user interface languages
-from picard.const.languages import (  # noqa: F401,E402 # pylint: disable=unused-import
-    UI_LANGUAGES,
-)
 # List of alias locales
 from picard.const.locales import (  # noqa: F401,E402 # pylint: disable=unused-import
     ALIAS_LOCALES,

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -120,10 +120,6 @@ for k, v in MB_ATTRIBUTES.items():
     elif k.startswith('DB:release_status/name:'):
         RELEASE_STATUS[v] = v
 
-# Release countries
-from picard.const.countries import (  # noqa: F401,E402 # pylint: disable=unused-import
-    RELEASE_COUNTRIES,
-)
 # List of available user interface languages
 from picard.const.languages import (  # noqa: F401,E402 # pylint: disable=unused-import
     UI_LANGUAGES,

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -120,12 +120,6 @@ for k, v in MB_ATTRIBUTES.items():
     elif k.startswith('DB:release_status/name:'):
         RELEASE_STATUS[v] = v
 
-# List of available charsets
-from picard.const.scripts import (  # noqa: F401,E402 # pylint: disable=unused-import
-    SCRIPTS,
-)
-
-
 # List of official musicbrainz servers - must support SSL for mblogin requests (such as collections).
 MUSICBRAINZ_SERVERS = [
     'musicbrainz.org',

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -33,12 +33,12 @@ from PyQt5 import (
 )
 
 from picard.const import (
-    RELEASE_COUNTRIES,
     RELEASE_FORMATS,
     RELEASE_PRIMARY_GROUPS,
     RELEASE_SECONDARY_GROUPS,
     RELEASE_STATUS,
 )
+from picard.const.countries import RELEASE_COUNTRIES
 from picard.util.tags import TAG_NAMES
 
 from picard.ui import PicardDialog

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -42,7 +42,7 @@ from picard.config import (
     TextOption,
     get_config,
 )
-from picard.const import UI_LANGUAGES
+from picard.const.languages import UI_LANGUAGES
 from picard.const.sys import IS_MACOS
 from picard.util import strxfrm
 

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -38,9 +38,11 @@ from picard.config import (
     TextOption,
     get_config,
 )
-from picard.const import SCRIPTS
 from picard.const.locales import ALIAS_LOCALES
-from picard.const.scripts import scripts_sorted_by_localized_name
+from picard.const.scripts import (
+    SCRIPTS,
+    scripts_sorted_by_localized_name,
+)
 
 from picard.ui import PicardDialog
 from picard.ui.moveable_list_view import MoveableListView

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -38,10 +38,8 @@ from picard.config import (
     TextOption,
     get_config,
 )
-from picard.const import (
-    ALIAS_LOCALES,
-    SCRIPTS,
-)
+from picard.const import SCRIPTS
+from picard.const.locales import ALIAS_LOCALES
 from picard.const.scripts import scripts_sorted_by_localized_name
 
 from picard.ui import PicardDialog

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -37,11 +37,11 @@ from picard.config import (
     get_config,
 )
 from picard.const import (
-    RELEASE_COUNTRIES,
     RELEASE_FORMATS,
     RELEASE_PRIMARY_GROUPS,
     RELEASE_SECONDARY_GROUPS,
 )
+from picard.const.countries import RELEASE_COUNTRIES
 from picard.const.sys import IS_WIN
 from picard.util import strxfrm
 


### PR DESCRIPTION
I think it may break some plugins expecting those constants in `picard.const`.

