### PR TITLE
In debug mode, log QT_* env vars

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -321,6 +321,9 @@ class Tagger(QtWidgets.QApplication):
         log.debug("User directory: %r", os.path.abspath(USER_DIR))
         log.debug("System long path support: %r", system_supports_long_paths())
 
+        # log interesting environment variables
+        log.debug("Qt Env.: %s", " ".join("%s=%r" % (k, v) for k, v in os.environ.items() if k.startswith('QT_')))
+
         # for compatibility with pre-1.3 plugins
         QtCore.QObject.tagger = self
         QtCore.QObject.config = config


### PR DESCRIPTION
It might be useful as many QT_ env vars modify the behavior of Qt and therefore Picard's behavior.


Example of output:

```
D: 16:50:10,035 tagger.__init__:325: Qt Environment: QT_ACCESSIBILITY='1' QT_QPA_PLATFORMTHEME='qt5ct'
```

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
