### PR TITLE
PICARD-2769: Show a file's original metadata in the panes for unset tags

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -816,7 +816,10 @@ class File(QtCore.QObject, Item):
             return self.base_filename
         elif column == 'covercount':
             return self.cover_art_description()
-        return m[column]
+        value = m[column]
+        if not value and not get_config().setting['clear_existing_tags']:
+            value = self.orig_metadata[column]
+        return value
 
     def _lookup_finished(self, lookuptype, document, http, error):
         self.lookup_task = None


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2769
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If a tag is unset then the metadata for this is shown empty on the main panes' columns.

At least for the case where there is a file and the option "clear existing tags" is not set the original value for the file should be shown to better reflect what is being saved.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
In case a tag has been unset and "clear existing tags" is not enabled display a file's original value in the pane columns.
