### PR TITLE
Fix track metadata compare ignoring video check if there is no release

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -369,6 +369,12 @@ class Metadata(MutableMapping):
                 score = self.length_score(a, b)
                 parts.append((score, weights["length"]))
 
+            if 'isvideo' in weights:
+                metadata_is_video = self['~video'] == '1'
+                track_is_video = track.get('video', False)
+                score = 1 if metadata_is_video == track_is_video else 0
+                parts.append((score, weights['isvideo']))
+
             if "releases" in track:
                 releases = track['releases']
 
@@ -376,12 +382,6 @@ class Metadata(MutableMapping):
             if not releases:
                 sim = linear_combination_of_weights(parts) * search_score
                 return SimMatchTrack(similarity=sim, releasegroup=None, release=None, track=track)
-
-            if 'isvideo' in weights:
-                metadata_is_video = self['~video'] == '1'
-                track_is_video = track.get('video', False)
-                score = 1 if metadata_is_video == track_is_video else 0
-                parts.append((score, weights['isvideo']))
 
         result = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
         for release in releases:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
In metadata track comparison the video flag check was not performed if no releases where set.




# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Perform the video flag check earlier