### PR TITLE
PICARD-2774: Do not fail loading files with invalid ID3 image types

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -170,13 +170,17 @@ class CoverArtImage:
         self.can_be_saved_to_tags = True
         self.can_be_saved_to_disk = True
         self.can_be_saved_to_metadata = True
-        self.id3_type = id3_type
         if support_types is not None:
             self.support_types = support_types
         if support_multi_types is not None:
             self.support_multi_types = support_multi_types
         if data is not None:
             self.set_data(data)
+        try:
+            self.id3_type = id3_type
+        except ValueError:
+            log.warning("Invalid ID3 image type %r in %r", type, self)
+            self.id3_type = Id3ImageType.OTHER
 
     @property
     def source(self):

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -148,6 +148,10 @@ class CoverArtImageTest(PicardTestCase):
             with self.assertRaises(ValueError):
                 image.id3_type = invalid_value
 
+    def test_init_invalid_id3_type(self):
+        image = CoverArtImage(id3_type=255)
+        self.assertEqual(image.id3_type, Id3ImageType.OTHER)
+
     def test_compare_without_type(self):
         image1 = create_image(b'a', types=["front"])
         image2 = create_image(b'a', types=["back"])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2774
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Files containing embedded cover art with invalid ID3 image type fail to load.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Load files even with invalid type. Assume type "other" in this case.