### PR TITLE
PICARD-2775; Disable Qt WebP plugin for Windows and macOS binary builds

### DIFF
--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -204,8 +204,10 @@ class CoverArtThumbnail(ActiveLabel):
             if len(self.data) == 1:
                 pixmap = QtGui.QPixmap()
                 try:
-                    pixmap.loadFromData(self.data[0].data)
-                    pixmap = self.decorate_cover(pixmap)
+                    if pixmap.loadFromData(self.data[0].data):
+                        pixmap = self.decorate_cover(pixmap)
+                    else:
+                        pixmap = self.file_missing_pixmap
                 except CoverArtImageIOError:
                     pixmap = self.file_missing_pixmap
             else:
@@ -280,7 +282,8 @@ class CoverArtThumbnail(ActiveLabel):
             else:
                 thumb = QtGui.QPixmap()
                 try:
-                    thumb.loadFromData(image.data)
+                    if not thumb.loadFromData(image.data):
+                        thumb = self.file_missing_pixmap
                 except CoverArtImageIOError:
                     thumb = self.file_missing_pixmap
             thumb = self.decorate_cover(thumb)

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -69,6 +69,10 @@ pushd "$APP_BUNDLE/Contents/MacOS/PyQt5/$QT5_DIR/"
 ln -s "../../../Resources/$QT5_DIR/translations" .
 popd
 
+# Mitigate libwebp vulnerability allowing for arbitrary code execution (CVE-2023-4863).
+# Disable the Qt webp imageformat plugin.
+rm "$APP_BUNDLE/Contents/MacOS/PyQt5/$QT5_DIR/plugins/imageformats/libqwebp.dylib"
+
 if [ "$CODESIGN" = '1' ]; then
     # Enable hardened runtime if app will get notarized
     if [ "$NOTARIZE" = "1" ]; then

--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -53,4 +53,8 @@ Function FinalizePackage {
   $Qt5BinDir = (Join-Path -Path $Path -ChildPath PyQt5\Qt5\bin)
   Move-Item -Path (Join-Path -Path $Qt5BinDir -ChildPath *.dll) -Destination $Path -Force
   Remove-Item -Path $Qt5BinDir
+
+  # Mitigate libwebp vulnerability allowing for arbitrary code execution (CVE-2023-4863).
+  # Disable the Qt webp imageformat plugin.
+  Remove-Item -Path (Join-Path -Path $Path -ChildPath PyQt5\Qt5\plugins\imageformats\qwebp.dll)
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Security 
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
A libwebp vulnerability allows arbitrary code execution when loading a manipulated image. CVE-2023-4863

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Disable the Qt webp imageformat plugin for binary builds for macOS and Windows for now. WebP images still can be loaded and saved, but they will not be displayed.