### PR TITLE
PICARD-2795: display log view verbosity

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -64,10 +64,10 @@ def get_effective_level():
 _feat = namedtuple('_feat', ['name', 'prefix', 'color_key'])
 
 levels_features = OrderedDict([
-    (logging.ERROR,   _feat('Error',   'E', 'log_error')),
-    (logging.WARNING, _feat('Warning', 'W', 'log_warning')),
-    (logging.INFO,    _feat('Info',    'I', 'log_info')),
-    (logging.DEBUG,   _feat('Debug',   'D', 'log_debug')),
+    (logging.ERROR,   _feat(N_('Error'),   'E', 'log_error')),
+    (logging.WARNING, _feat(N_('Warning'), 'W', 'log_warning')),
+    (logging.INFO,    _feat(N_('Info'),    'I', 'log_info')),
+    (logging.DEBUG,   _feat(N_('Debug'),   'D', 'log_debug')),
 ])
 
 

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -176,11 +176,12 @@ class LogView(LogViewCommon):
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
-        self.verbosity_menu_button = QtWidgets.QPushButton(_("Verbosity"))
+        self.verbosity_menu_button = QtWidgets.QPushButton()
+        self.verbosity_menu_button.setAccessibleName(_("Verbosity"))
         self.hbox.addWidget(self.verbosity_menu_button)
 
         self.verbosity_menu = VerbosityMenu()
-        self.verbosity_menu.set_verbosity(self.verbosity)
+        self._set_verbosity(self.verbosity)
         self.verbosity_menu.verbosity_changed.connect(self._verbosity_changed)
         self.verbosity_menu_button.setMenu(self.verbosity_menu)
 
@@ -315,14 +316,21 @@ class LogView(LogViewCommon):
     def _set_verbosity(self, level):
         self.verbosity = level
         self.verbosity_menu.set_verbosity(self.verbosity)
+        self._update_verbosity_label()
 
     def _verbosity_changed(self, level):
         if level != self.verbosity:
             config = get_config()
             config.setting['log_verbosity'] = level
-            QtCore.QObject.tagger.set_log_level(level)
             self.verbosity = level
+            self._update_verbosity_label()
+            QtCore.QObject.tagger.set_log_level(level)
             self.display(clear=True)
+
+    def _update_verbosity_label(self):
+        feat = log.levels_features.get(self.verbosity)
+        label = _(feat.name) if feat else _("Verbosity")
+        self.verbosity_menu_button.setText(label)
 
 
 class HistoryView(LogViewCommon):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2795
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
The log view's verbosity selection just shows the static string "Verbosity" instead of the actually selected level.

Also the level names where not extracted for translation.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Set the displayed label to the selected level.

![grafik](https://github.com/metabrainz/picard/assets/29852/a14f39aa-8e9d-435d-a43e-1ca1f57a0e67)