### PR TITLE
PICARD-2792: fix matching for AcoustID results without metadata and standalone-recordings

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2017-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018-2021 Laurent Monin
-# Copyright (C) 2018-2022 Philipp Wolfer
+# Copyright (C) 2018-2023 Philipp Wolfer
 # Copyright (C) 2023 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
@@ -34,7 +34,10 @@ import json
 from PyQt6 import QtCore
 
 from picard import log
-from picard.acoustid.json_helpers import parse_recording
+from picard.acoustid.json_helpers import (
+    max_source_count,
+    parse_recording,
+)
 from picard.config import get_config
 from picard.const import (
     DEFAULT_FPCALC_THREADS,
@@ -113,14 +116,14 @@ class AcoustIDClient(QtCore.QObject):
                     results = document.get('results') or []
                     for result in results:
                         recordings = result.get('recordings') or []
-                        max_sources = max([r.get('sources', 1) for r in recordings] + [1])
+                        max_sources = max_source_count(recordings)
                         result_score = get_score(result)
                         for recording in recordings:
                             parsed_recording = parse_recording(recording)
                             if parsed_recording is not None:
                                 # Calculate a score based on result score and sources for this
                                 # recording relative to other recordings in this result
-                                score = recording.get('sources', 1) / max_sources * 100
+                                score = min(recording.get('sources', 1) / max_sources, 1.0) * 100
                                 parsed_recording['score'] = score * result_score
                                 parsed_recording['acoustid'] = result['id']
                                 recording_list.append(parsed_recording)

--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2017 Sambhav Kothari
-# Copyright (C) 2018-2020 Philipp Wolfer
+# Copyright (C) 2018-2020, 2023 Philipp Wolfer
 # Copyright (C) 2020 Ray Bouchard
 # Copyright (C) 2020-2021 Laurent Monin
 #
@@ -142,3 +142,15 @@ def parse_recording(recording):
         recording_mb['sources'] = recording['sources']
 
     return recording_mb
+
+
+def max_source_count(recordings):
+    """Given a list of recordings return the highest number of sources.
+    This ignores recordings without metadata.
+    """
+    sources = [
+        r.get('sources', 1)
+        for r in recordings
+        if r.get('title')
+    ]
+    return max(sources + [1])

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -382,6 +382,9 @@ class Metadata(MutableMapping):
 
             search_score = get_score(track)
             if not releases:
+                config = get_config()
+                score = dict(config.setting['release_type_scores']).get('Other', 0.5)
+                parts.append((score, _get_total_release_weight(weights)))
                 sim = linear_combination_of_weights(parts) * search_score
                 return SimMatchTrack(similarity=sim, releasegroup=None, release=None, track=track)
 
@@ -661,6 +664,12 @@ class MultiMetadataProxy:
 
     def __repr__(self):
         return self.__read('__repr__')
+
+
+def _get_total_release_weight(weights):
+    release_weights = ('album', 'totaltracks', 'totalalbumtracks', 'releasetype',
+                       'releasecountry', 'format', 'date')
+    return sum(weights[w] for w in release_weights if w in weights)
 
 
 _album_metadata_processors = PluginFunctions(label='album_metadata_processors')

--- a/test/data/ws_data/acoustid_no_metadata.json
+++ b/test/data/ws_data/acoustid_no_metadata.json
@@ -1,0 +1,1522 @@
+{
+  "results": [
+    {
+      "id": "38338eff-b530-498c-a2ef-07e01d642187",
+      "recordings": [
+        {
+          "artists": [
+            {
+              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+              "name": "Focus"
+            }
+          ],
+          "duration": 200,
+          "id": "308d6e5a-52ff-41ca-aae8-7881e92472be",
+          "releasegroups": [
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "71b5e81c-e951-45a0-9554-8599ad1b52e9",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 2008
+                  },
+                  "id": "f0b647ce-8db2-4682-ac34-50d0cfd390fd",
+                  "medium_count": 15,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "title": "\u201971",
+                      "track_count": 20,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "1147bf65-bb79-39dd-bcfa-e16569ee8fa3",
+                          "position": 11
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 2008
+                      }
+                    }
+                  ],
+                  "track_count": 301
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Testament van de Seventies",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "97c03161-7b75-4108-9797-bf95f873e7dc",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1989
+                  },
+                  "id": "ed3c7767-ea90-4070-8c47-cbe47780130d",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 20,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "0f26f8ed-b746-3c99-8888-2158817c05a4",
+                          "position": 7
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1989
+                      }
+                    }
+                  ],
+                  "track_count": 40
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "25 jaar Top 40 Hits, deel 2: \u201969\u2013\u201972",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "2a2b8925-d819-476c-bcf8-8e9a523f3d38",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1996
+                  },
+                  "id": "4aadc99c-a165-4f25-9426-71c41087326f",
+                  "medium_count": 4,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 3,
+                      "track_count": 20,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "e555d7c6-bcdf-4910-905f-5d4b86853cbd",
+                          "position": 3
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1996
+                      }
+                    }
+                  ],
+                  "track_count": 80
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Classic Pop Songs",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "b7a5ba18-0f62-47e2-a4f2-760cfddbe6fa",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1995
+                  },
+                  "id": "ba58ab3a-2bc7-49eb-b187-df4229cf9b21",
+                  "medium_count": 3,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 19,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "d76a3e60-cdda-4b50-9808-352ac8f45ca2",
+                          "position": 16
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1995
+                      }
+                    }
+                  ],
+                  "track_count": 57
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Greatest Hits Of The '70's - The Definitive Singles Collection 1970-1979",
+              "type": "Album"
+            }
+          ],
+          "sources": 1,
+          "title": "Hocus Pocus"
+        },
+        {
+          "id": "8855169b-b148-4896-9ed3-a1065dc60cf4",
+          "sources": 94
+        },
+        {
+          "artists": [
+            {
+              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+              "name": "Focus"
+            }
+          ],
+          "duration": 204,
+          "id": "af578913-c456-4d27-bb69-612c8cea0799",
+          "releasegroups": [
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "3e0fa0db-d167-4b37-8567-2df76035cec9",
+              "releases": [
+                {
+                  "country": "GB",
+                  "date": {
+                    "year": 2010
+                  },
+                  "id": "6d754580-0c14-433e-9256-463f211ad9f3",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 17,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "13e8e402-25a4-4fbd-894e-68a5c004d583",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "GB",
+                      "date": {
+                        "year": 2010
+                      }
+                    }
+                  ],
+                  "track_count": 34
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Wondrous Stories: 34 Artists That Shaped the Prog Rock Era",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "a57fe353-7abe-47d6-8f9d-e90d16d9fda3",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 2015
+                  },
+                  "id": "a3f5396e-7059-42f0-9085-d81d7eb8d028",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 9,
+                      "tracks": [
+                        {
+                          "id": "24e3e837-3fab-49da-83b7-d711047022f0",
+                          "position": 9,
+                          "title": "Hocus Pocus U.S. Version"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 2015
+                      }
+                    }
+                  ],
+                  "track_count": 30
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "The Golden Years of Dutch Pop Music (A&B Sides and More)",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "4ee2ab34-692f-4e34-b5f9-a1d5854fc9b3",
+              "releases": [
+                {
+                  "date": {
+                    "month": 7,
+                    "year": 2017
+                  },
+                  "id": "a7ef6356-0b43-4986-978e-887b26f33445",
+                  "medium_count": 13,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 7,
+                      "title": "Ship of Memories",
+                      "track_count": 10,
+                      "tracks": [
+                        {
+                          "id": "998c87d0-4b33-40d0-b487-b787cbdab64d",
+                          "position": 10,
+                          "title": "Hocus Pocus (US single version)"
+                        }
+                      ]
+                    },
+                    {
+                      "format": "CD",
+                      "position": 13,
+                      "title": "The Best of Focus: Hocus Pocus",
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "id": "b636e3b9-d916-4204-816a-6c5468b84134",
+                          "position": 16,
+                          "title": "Hocus Pocus (U.S. single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "date": {
+                        "month": 7,
+                        "year": 2017
+                      }
+                    }
+                  ],
+                  "track_count": 124
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Hocus Pocus Box",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "e36f6749-cf76-469e-9dd9-f9195c326928",
+                  "name": "Jan Akkerman"
+                }
+              ],
+              "id": "1994d1b8-6b5e-411e-90fc-c44674dfcbc5",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "day": 7,
+                    "month": 4,
+                    "year": 2017
+                  },
+                  "id": "a8ecc767-e239-480d-bb68-11c43fca90d9",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 23,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "eedba674-c22f-4a7c-b6c2-696be1bd4516",
+                          "position": 10,
+                          "title": "Hocus Pocus (Us single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "day": 7,
+                        "month": 4,
+                        "year": 2017
+                      }
+                    }
+                  ],
+                  "track_count": 42
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "The Golden Years of Dutch Pop Music - Solo & Groups",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "4b90822a-2e4b-4985-b0ff-693bf9e3ced8",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1976
+                  },
+                  "id": "6a8a03db-4c08-4aa0-9a50-9727f9e96fb0",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "12\" Vinyl",
+                      "position": 1,
+                      "track_count": 9,
+                      "tracks": [
+                        {
+                          "id": "a29a8c7d-6f07-4a8b-8fc1-76d02efd5d68",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1976
+                      }
+                    }
+                  ],
+                  "track_count": 9
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "House of the King",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "bc0ae552-897d-3db6-a667-b1b90334063d",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1993
+                  },
+                  "id": "13afa320-030e-44f8-a258-9df1466056ac",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "id": "2fe521d1-0f31-3b35-8296-597020e360d1",
+                          "position": 16,
+                          "title": "Hocus Pocus (U.S. Single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1993
+                      }
+                    }
+                  ],
+                  "track_count": 16
+                },
+                {
+                  "country": "XE",
+                  "date": {
+                    "year": 2001
+                  },
+                  "id": "e8857505-db03-4296-8ae3-86b008d552cc",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "id": "f3c4b647-1646-4438-80e8-3e5dca84d619",
+                          "position": 16,
+                          "title": "Hocus Pocus (U.S. single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "XE",
+                      "date": {
+                        "year": 2001
+                      }
+                    }
+                  ],
+                  "track_count": 16
+                },
+                {
+                  "country": "US",
+                  "date": {
+                    "year": 1993
+                  },
+                  "id": "90e6c726-4886-4e59-b3fd-5e4aab873188",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "id": "7031bb86-4575-491b-b27e-b0ff2ab1002e",
+                          "position": 16,
+                          "title": "Hocus Pocus (U.S. Single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "US",
+                      "date": {
+                        "year": 1993
+                      }
+                    }
+                  ],
+                  "track_count": 16
+                },
+                {
+                  "country": "XE",
+                  "date": {
+                    "year": 2020
+                  },
+                  "id": "382e13e0-ef4c-4290-8519-a3dc2f80efe7",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "id": "84e7cd4a-dd07-4c1d-952b-11595fd6863d",
+                          "position": 16,
+                          "title": "Hocus Pocus (U.S. single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "XE",
+                      "date": {
+                        "year": 2020
+                      }
+                    }
+                  ],
+                  "track_count": 16
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "The Best of Focus: Hocus Pocus",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "e3a473b9-140f-4328-a417-dae0ae90331d",
+              "releases": [
+                {
+                  "country": "US",
+                  "date": {
+                    "day": 27,
+                    "month": 10,
+                    "year": 2017
+                  },
+                  "id": "5eb13c9e-d613-45ae-9566-e80a394016fe",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 21,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "4192f56a-a563-4897-b91a-e6e6f45f9a8d",
+                          "position": 3
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "US",
+                      "date": {
+                        "day": 27,
+                        "month": 10,
+                        "year": 2017
+                      }
+                    }
+                  ],
+                  "track_count": 21
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Hard to Find 45s on CD, Volume 18: 70s Essentials",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "b9aa5125-0703-4186-afa5-cb51eaeff29d",
+              "releases": [
+                {
+                  "country": "AU",
+                  "date": {
+                    "year": 1997
+                  },
+                  "id": "89b14dc9-5665-4257-8ad8-f9707c28f7ac",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 17,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "d9f8cd02-d0d0-4cf7-b081-947ce1f718c7",
+                          "position": 16
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "AU",
+                      "date": {
+                        "year": 1997
+                      }
+                    }
+                  ],
+                  "track_count": 34
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Retro Rarities of the 70's & 80's",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "af2140b4-aea3-3bcb-a1ea-a3a80e6c4298",
+              "releases": [
+                {
+                  "country": "US",
+                  "date": {
+                    "day": 26,
+                    "month": 3,
+                    "year": 1996
+                  },
+                  "id": "38e96797-941e-4062-88ed-27f1422718b7",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 12,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "43722609-9f1f-3726-9f8a-5f08a07997e3",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "US",
+                      "date": {
+                        "day": 26,
+                        "month": 3,
+                        "year": 1996
+                      }
+                    }
+                  ],
+                  "track_count": 12
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Super Hits of the '70s: Have a Nice Day, Vol. 23",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "9491ee85-cb53-3537-b1a1-0396b90ea974",
+              "releases": [
+                {
+                  "id": "8e432b18-b9cb-46e1-a0d0-1653cf3d4fcc",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "position": 1,
+                      "track_count": 14,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "c4d7bf4c-b2cd-334d-8071-8dd2152acc96",
+                          "position": 12
+                        }
+                      ]
+                    }
+                  ],
+                  "track_count": 14
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Power Chords, Volume 1",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "819b26b4-019b-4157-93aa-96a3311262fb",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "month": 7,
+                    "year": 1971
+                  },
+                  "id": "f92d6ea1-e412-403c-be03-953715ef872c",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "7\" Vinyl",
+                      "position": 1,
+                      "track_count": 2,
+                      "tracks": [
+                        {
+                          "id": "2e426de4-398d-4b3f-bb44-1dd07dbbe4f4",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "month": 7,
+                        "year": 1971
+                      }
+                    }
+                  ],
+                  "track_count": 2
+                }
+              ],
+              "title": "Hocus Pocus / Janis",
+              "type": "Single"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "fb49f2e7-3390-3eac-9040-69feb4e81be4",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1983
+                  },
+                  "id": "0959de0b-e633-4be0-bee4-eae66af3a375",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 14,
+                      "tracks": [
+                        {
+                          "id": "bc13e5f9-e5c5-3f09-966d-3293274e16da",
+                          "position": 11
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1983
+                      }
+                    }
+                  ],
+                  "track_count": 14
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Best Of",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "037994ae-21c9-328e-82f7-dfe6a2ca7e33",
+              "releases": [
+                {
+                  "country": "GB",
+                  "date": {
+                    "year": 1988
+                  },
+                  "id": "ae2f755f-a667-449c-a6c7-922b26eff633",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "Cassette",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "d853c93b-3300-4e32-93ed-17229fdf1949",
+                          "position": 4
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "GB",
+                      "date": {
+                        "year": 1988
+                      }
+                    }
+                  ],
+                  "track_count": 32
+                },
+                {
+                  "country": "GB",
+                  "date": {
+                    "year": 1988
+                  },
+                  "id": "33d52b29-443e-42d9-90e5-a0b04ffc6d5d",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "12\" Vinyl",
+                      "position": 1,
+                      "track_count": 16,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "2e2dc6aa-c00f-4453-9bc1-7b3803124ed5",
+                          "position": 4
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "GB",
+                      "date": {
+                        "year": 1988
+                      }
+                    }
+                  ],
+                  "track_count": 32
+                },
+                {
+                  "country": "GB",
+                  "date": {
+                    "year": 1988
+                  },
+                  "id": "b3af7981-21d1-4b23-b189-b9c5411e5775",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 18,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "5351ffac-6834-36b7-8fde-8223ed0e99e5",
+                          "position": 6
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "GB",
+                      "date": {
+                        "year": 1988
+                      }
+                    }
+                  ],
+                  "track_count": 18
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Back on the Road",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "ff3e27e8-4655-48e4-ba9b-d3d631a1c2b0",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 2008
+                  },
+                  "id": "3a31b1d3-3b62-45b4-8e04-b4daff8aa5db",
+                  "medium_count": 5,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "title": "70's",
+                      "track_count": 22,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "232ae1d3-71e9-3df8-9b77-3ee20d915aac",
+                          "position": 4
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 2008
+                      }
+                    }
+                  ],
+                  "track_count": 103
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "50 jaar nederpop",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "daa32df7-56af-490f-9ae7-1306a9be9802",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1996
+                  },
+                  "id": "4454dbe2-745a-4148-91d5-8db7043e1e37",
+                  "medium_count": 3,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 25,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "570ff779-58f7-3808-a46c-1e32a602ed28",
+                          "position": 12
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1996
+                      }
+                    }
+                  ],
+                  "track_count": 75
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "De 75 Beste Nederpop Hits",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "f0d011be-94e2-3313-a973-9cb42bdb8021",
+              "releases": [
+                {
+                  "country": "US",
+                  "date": {
+                    "year": 1988
+                  },
+                  "id": "50c893a8-b4d3-451a-8ded-554be7b98977",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 12,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "aec0ae14-0ff1-3293-b7d3-220fe7616ca9",
+                          "position": 12
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "US",
+                      "date": {
+                        "year": 1988
+                      }
+                    }
+                  ],
+                  "track_count": 12
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Electric Seventies",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "54ad8a66-18c6-3977-a833-3eac08fa0892",
+              "releases": [
+                {
+                  "id": "75f2c2b1-201c-4055-a554-ebee5a2cab8b",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "position": 1,
+                      "track_count": 20,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "549c7c0b-42a1-3390-aea8-5418f5e93458",
+                          "position": 18
+                        }
+                      ]
+                    }
+                  ],
+                  "track_count": 20
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Millennium Classic Rock Party",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "d80b61c0-d4ea-3632-a5fc-0ef85389eabe",
+              "releases": [
+                {
+                  "country": "GB",
+                  "date": {
+                    "day": 6,
+                    "month": 6,
+                    "year": 2005
+                  },
+                  "id": "10832769-0788-4d6e-859b-5931e4767554",
+                  "medium_count": 2,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 2,
+                      "track_count": 19,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "7018de94-4633-3453-879d-c1bd993abfe0",
+                          "position": 11
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "GB",
+                      "date": {
+                        "day": 6,
+                        "month": 6,
+                        "year": 2005
+                      }
+                    }
+                  ],
+                  "track_count": 37
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Driving Rock: 37 Classic Anthems for the Open Road",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "89ad4ac3-39f7-470e-963a-56509c546377",
+                  "name": "Various Artists"
+                }
+              ],
+              "id": "ba8afc07-2a75-4d89-9880-48e9482b9550",
+              "releases": [
+                {
+                  "country": "BE",
+                  "date": {
+                    "year": 2013
+                  },
+                  "id": "f7cf6c60-054e-4c76-9876-37bfe4ea8d51",
+                  "medium_count": 5,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 4,
+                      "track_count": 20,
+                      "tracks": [
+                        {
+                          "artists": [
+                            {
+                              "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                              "name": "Focus"
+                            }
+                          ],
+                          "id": "d0f7dd20-2b88-4dfb-960b-daf456c6fab9",
+                          "position": 6
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "BE",
+                      "date": {
+                        "year": 2013
+                      }
+                    }
+                  ],
+                  "track_count": 100
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "De topcollectie: Rock klassiekers",
+              "type": "Album"
+            },
+            {
+              "artists": [
+                {
+                  "id": "821e11d6-cfec-44a7-9615-06a4e631c975",
+                  "name": "Focus"
+                }
+              ],
+              "id": "4a9fc107-02b4-3bb6-9206-4e1d74db4357",
+              "releases": [
+                {
+                  "country": "NL",
+                  "date": {
+                    "year": 1988
+                  },
+                  "id": "2dc17dca-01ca-4148-be56-cb3bf1ba1616",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 10,
+                      "tracks": [
+                        {
+                          "id": "139ccd0b-b19f-4535-91a1-dc671bbd9e46",
+                          "position": 10,
+                          "title": "Hocus Pocus (US single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "NL",
+                      "date": {
+                        "year": 1988
+                      }
+                    }
+                  ],
+                  "track_count": 10
+                },
+                {
+                  "country": "JP",
+                  "date": {
+                    "year": 2006
+                  },
+                  "id": "968b0d26-9603-48b0-86da-c4f3cc4de821",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "CD",
+                      "position": 1,
+                      "track_count": 10,
+                      "tracks": [
+                        {
+                          "id": "914758b6-c8cf-32c0-b14d-22a7cd528c6c",
+                          "position": 10,
+                          "title": "Hocus Pocus (US single version)"
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "JP",
+                      "date": {
+                        "year": 2006
+                      }
+                    }
+                  ],
+                  "track_count": 10
+                }
+              ],
+              "title": "Ship of Memories",
+              "type": "Album"
+            },
+            {
+              "id": "060a1a33-532d-479c-9c06-42868000c49b",
+              "releases": [
+                {
+                  "country": "CL",
+                  "date": {
+                    "year": 2013
+                  },
+                  "id": "00617296-b431-4d0c-91cf-75099c858ac3",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "position": 1,
+                      "track_count": 11,
+                      "tracks": [
+                        {
+                          "id": "72fdb429-fbfd-40e3-a9ed-89d9e0e30500",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "CL",
+                      "date": {
+                        "year": 2013
+                      }
+                    }
+                  ],
+                  "track_count": 11
+                },
+                {
+                  "country": "AR",
+                  "date": {
+                    "year": 1983
+                  },
+                  "id": "5441fe4e-1bd8-49ee-bba3-638ca4748925",
+                  "medium_count": 1,
+                  "mediums": [
+                    {
+                      "format": "12\" Vinyl",
+                      "position": 1,
+                      "track_count": 11,
+                      "tracks": [
+                        {
+                          "id": "8955c75f-2583-46c3-981a-c41bbcde201f",
+                          "position": 1
+                        }
+                      ]
+                    }
+                  ],
+                  "releaseevents": [
+                    {
+                      "country": "AR",
+                      "date": {
+                        "year": 1983
+                      }
+                    }
+                  ],
+                  "title": "Grandes exitos",
+                  "track_count": 11
+                }
+              ],
+              "secondarytypes": [
+                "Compilation"
+              ],
+              "title": "Grandes \u00e9xitos",
+              "type": "Album"
+            }
+          ],
+          "sources": 13,
+          "title": "Hocus Pocus"
+        }
+      ],
+      "score": 0.946796
+    }
+  ],
+  "status": "ok"
+}

--- a/test/test_acoustid.py
+++ b/test/test_acoustid.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2019-2020 Philipp Wolfer
+# Copyright (C) 2019-2020, 2023 Philipp Wolfer
 # Copyright (C) 2020 Ray Bouchard
 # Copyright (C) 2020-2021 Laurent Monin
 # Copyright (C) 2021 Bob Swift
@@ -30,7 +30,10 @@ import os
 
 from test.picardtestcase import PicardTestCase
 
-from picard.acoustid.json_helpers import parse_recording
+from picard.acoustid.json_helpers import (
+    max_source_count,
+    parse_recording,
+)
 from picard.mbjson import recording_to_metadata
 from picard.metadata import Metadata
 from picard.track import Track
@@ -95,3 +98,19 @@ class NullRecordingTest(AcoustIDTest):
         parsed_recording = parse_recording(self.json_doc)
         recording_to_metadata(parsed_recording, m, t)
         self.assertEqual(m, {})
+
+
+class MaxSourceCountTest(AcoustIDTest):
+    filename = 'acoustid_no_metadata.json'
+
+    def test_max_source_count(self):
+        c = max_source_count(self.json_doc['results'][0]['recordings'])
+        self.assertEqual(13, c)
+
+    def test_max_source_count_no_recordings(self):
+        c = max_source_count([])
+        self.assertEqual(1, c)
+
+    def test_max_source_count_no_value(self):
+        c = max_source_count([{'title': 'foo', 'sources': 42}, {'title': 'foo'}])
+        self.assertEqual(42, c)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2792
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

In PICARD-2792 and the forum discussions at https://community.metabrainz.org/t/worse-results-in-picard-2-10/663668/34 two issues with the metadata matching were identified:

1. For AcoustID recordings without metadata a high submission score led to disproportional high scoring. This happens for example if recordings get merged without the AcoustID server having applied this merge yet.

2. Generally matching recordings without any releases (standalone-recordings) scored higher on average. This is because as soon as release data gets compared it usually leads to lower score (as a 100% score is seldom).


# Solution
For 1) ignore AcoustID recordings without additional metadata when determining the submission count score. This intentionally does not drop those recordings completely, as they in some cases are the only result and still useful for standalone-recording matches. Also during metadata comparison those recordings naturally score lower due to missing data.

For 2) apply a weighted score in case there are no releases for the recording. The weight is based on the total weight of release specific weights, the score uses the "Other" release type by default.