### PR TITLE
Prevent QObject::connect nullptr warning on startup

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1521,6 +1521,7 @@ def main(localedir=None, autoupdate=True):
     picard_args = process_picard_args()
 
     if picard_args.long_version:
+        _ = QtCore.QCoreApplication(sys.argv)
         print_message_and_exit(versions.as_string())
     if picard_args.version:
         print_message_and_exit(f"{PICARD_ORG_NAME} {PICARD_APP_NAME} {PICARD_FANCY_VERSION_STR}")

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2006-2014 Lukáš Lalinský
 # Copyright (C) 2014-2015, 2017-2018, 2020-2021 Laurent Monin
 # Copyright (C) 2016 Sambhav Kothari
-# Copyright (C) 2018-2019, 2021 Philipp Wolfer
+# Copyright (C) 2018-2019, 2021, 2023 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -38,16 +38,7 @@ from picard.disc import discid_version
 from picard.util.astrcmp import astrcmp_implementation
 
 
-_versions = OrderedDict([
-    ('version', PICARD_FANCY_VERSION_STR),
-    ('python-version', python_version()),
-    ('pyqt-version', pyqt_version),
-    ('qt-version', qVersion()),
-    ('mutagen-version', mutagen_version),
-    ('discid-version', discid_version),
-    ('astrcmp', astrcmp_implementation),
-    ('ssl-version', QSslSocket.sslLibraryVersionString())
-])
+_versions = None
 
 _names = {
     'version': "Picard",
@@ -59,6 +50,20 @@ _names = {
     'astrcmp': "astrcmp",
     'ssl-version': "SSL",
 }
+
+
+def _load_versions():
+    global _versions
+    _versions = OrderedDict((
+        ('version', PICARD_FANCY_VERSION_STR),
+        ('python-version', python_version()),
+        ('pyqt-version', pyqt_version),
+        ('qt-version', qVersion()),
+        ('mutagen-version', mutagen_version),
+        ('discid-version', discid_version),
+        ('astrcmp', astrcmp_implementation),
+        ('ssl-version', QSslSocket.sslLibraryVersionString())
+    ))
 
 
 def _value_as_text(value, i18n=False):
@@ -74,6 +79,8 @@ def version_name(key):
 
 
 def as_dict(i18n=False):
+    if not _versions:
+        _load_versions()
     return OrderedDict((key, _value_as_text(value, i18n))
                         for key, value in _versions.items())
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On startup the following error message is printed:

```
qt.core.qobject.connect: QObject::connect(QObject, Unknown): invalid nullptr parameter
```

This is caused by the call to `QSslSocket.sslLibraryVersionString()` in `picard.util.version`, which expects an initialized Qt application but was called before this exists.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Fill the version list on demand.
- When running with "-V" CLI flag initialize a QCoreApplication.

