### PR TITLE
PICARD-2584: Load recording if AcoustId metadata is missing

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -91,7 +91,6 @@ class AcoustIDClient(QtCore.QObject):
         return config.setting['fpcalc_threads'] or DEFAULT_FPCALC_THREADS
 
     def _on_lookup_finished(self, task, document, http, error):
-        doc = {}
         if error:
             mparms = {
                 'error': http.errorString(),
@@ -106,7 +105,7 @@ class AcoustIDClient(QtCore.QObject):
                 mparms,
                 echo=None
             )
-            task.next_func(doc, http, error)
+            task.next_func({}, http, error)
         else:
             try:
                 status = document['status']
@@ -129,13 +128,13 @@ class AcoustIDClient(QtCore.QObject):
                         mparms,
                         echo=None
                     )
-                    task.next_func(doc, http, error)
+                    task.next_func({}, http, error)
             except (AttributeError, KeyError, TypeError) as e:
                 log.error("AcoustID: Error reading response", exc_info=True)
-                task.next_func(doc, http, e)
+                task.next_func({}, http, e)
 
     def _on_recording_resolve_finish(self, task, document, http, result=None, error=None):
-        document['recordings'] = recording_list = result
+        recording_list = result
         if not recording_list:
             results = document.get('results')
             if results:
@@ -154,7 +153,7 @@ class AcoustIDClient(QtCore.QObject):
                 task.file.filename,
                 len(recording_list)
             )
-        task.next_func(document, http, error)
+        task.next_func({'recordings': recording_list}, http, error)
 
     def _lookup_fingerprint(self, task, result=None, error=None):
         if task.file.state == File.REMOVED:

--- a/picard/acoustid/json_helpers.py
+++ b/picard/acoustid/json_helpers.py
@@ -144,13 +144,5 @@ def parse_recording(recording):
     return recording_mb
 
 
-def max_source_count(recordings):
-    """Given a list of recordings return the highest number of sources.
-    This ignores recordings without metadata.
-    """
-    sources = [
-        r.get('sources', 1)
-        for r in recordings
-        if r.get('title')
-    ]
-    return max(sources + [1])
+def recording_has_metadata(recording):
+    return 'id' in recording and recording.get('title') is not None

--- a/picard/acoustid/recordings.py
+++ b/picard/acoustid/recordings.py
@@ -111,7 +111,7 @@ class RecordingResolver:
             self._mbapi.get_track_by_id(
                 self._missing_metadata[0].mbid,
                 self._recording_request_finished,
-                inc=['release-groups', 'releases'],
+                inc=('artists', 'release-groups', 'releases', 'media'),
             )
 
     def _recording_request_finished(self, mb_recording, http, error):

--- a/picard/acoustid/recordings.py
+++ b/picard/acoustid/recordings.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2023 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.acoustid.json_helpers import (
+    max_source_count,
+    parse_recording,
+)
+from picard.webservice import WebService
+from picard.webservice.api_helpers import MBAPIHelper
+
+
+class RecordingResolver:
+
+    def __init__(self, ws: WebService) -> None:
+        self.mbapi = MBAPIHelper(ws)
+
+    def resolve(self, doc: dict, callback: callable) -> None:
+        recording_map = {}
+        results = doc.get('results') or []
+        for result in results:
+            recordings = result.get('recordings') or []
+            max_sources = max_source_count(recordings)
+            result_score = get_score(result)
+            for recording in recordings:
+                parsed_recording = parse_recording(recording)
+                if parsed_recording is not None:
+                    # Calculate a score based on result score and sources for this
+                    # recording relative to other recordings in this result
+                    score = min(recording.get('sources', 1) / max_sources, 1.0) * 100
+                    parsed_recording['score'] = score * result_score
+                    parsed_recording['acoustid'] = result.get('id')
+                    recording_map[parsed_recording['id']] = parsed_recording
+
+        # TODO: Load recording details for recordings without metadata
+        callback(recording_map.values())
+
+
+def get_score(node):
+    try:
+        return float(node.get('score', 1.0))
+    except (TypeError, ValueError):
+        return 1.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2584
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

AcoustID can sometimes contain no MB metadata for linked recordings. This happens if:

1. recordings have been merged and this merge was not yet handled by the AcoustID server
2. recordings have been deleted and the AcoustID server has not yet cleaned up

AFAIK both should be handled by AcoustID, but currently this does not seem to work correctly (e.g. https://github.com/acoustid/acoustid-server/issues/114). There can always be some time frame where this has not been done as there is some delay in AcoustID database synchronizing., though

In case of 1) this can lead to recording data not being available and files getting matched to standalone recordings instead. It also messes with submission counts.

Examples:

- https://acoustid.org/track/d10da0d8-8b13-4453-9ac5-b179958d01ca

In case of 2) this can lead to files being matched to a standalone-recording that does not load.

Examples:

- https://acoustid.org/track/cb127606-8e3d-4dcf-9902-69c7a9b59bc9
- https://acoustid.org/track/aed07515-2856-4265-afce-247c09e2b12a
- https://acoustid.org/track/47e0f233-9494-4197-b5ab-aa943ab54ee7
- https://acoustid.org/track/85c71305-a4e5-43cf-8a0f-1749cf10edde


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
If AcoustID provides no MB metadata but only MB recording ID load the recording data from the MB web service. This is done by the new `RecordingResolver` in the picard.acoustid package.

If metadata is provided, the recording is used directly. If not a MB web service call to load the recording is initiated.

If the recording no longer exist (404) then the result is ignored. If it exists and was redirected to another recording MBID that is also linked to the same AcoustID, the submission counts get combined.