### PR TITLE
Bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -76,7 +76,7 @@ jobs:
         APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         CODESIGN_MACOS_P12_PASSWORD: ${{ secrets.CODESIGN_MACOS_P12_PASSWORD }}
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: macos-app-${{ matrix.setup.macos-deployment-version }}
         path: artifacts/

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         rm -rf "$HOME/.gnupg"
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: picard-sdist
         path: dist/*
@@ -117,9 +117,9 @@ jobs:
       run: |
         python setup.py clean bdist_wheel
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: picard-bdist-${{ runner.os }}
+        name: picard-bdist-${{ runner.os }}-${{ matrix.python-version }}
         path: dist/*.whl
     - name: Publish Python distribution to PyPI
       if: startsWith(github.ref, 'refs/tags/') && env.TWINE_PASSWORD

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -121,7 +121,7 @@ jobs:
       if: env.CODESIGN == '1'
       run: Remove-Item .\codesign.pfx
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: matrix.type != 'signed-app' || env.CODESIGN == '1'
       with:
         name: windows-${{ matrix.type }}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Replaces #2355 . There is a backward incompatible change where it is no longer possible to upload to the same file multiple times to update the uploaded archive file. That means the Python bdist packages now are separated by Python version.

For details see https://github.com/actions/upload-artifact/tree/v4/#v4---whats-new

