### PR TITLE
PICARD-2813: Ignore fpcalc errors if there was still a result.

### DIFF
--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -28,6 +28,7 @@ from collections import (
     deque,
     namedtuple,
 )
+from enum import IntEnum
 from functools import partial
 import json
 
@@ -47,6 +48,13 @@ from picard.util import (
     win_prefix_longpath,
 )
 from picard.webservice.api_helpers import AcoustIdAPIHelper
+
+
+class FpcalcExit(IntEnum):
+    # fpcalc returned successfully
+    NOERROR = 0
+    # fpcalc encountered errors during decoding, but could still generate a fingerprint
+    DECODING_ERROR = 3
 
 
 def get_score(node):
@@ -205,7 +213,7 @@ class AcoustIDClient(QtCore.QObject):
             self._run_next_task()
             # fpcalc returns the exit code 3 in case of decoding errors that
             # still allowed it to calculate a result.
-            if exit_code in {0, 3} and exit_status == QtCore.QProcess.ExitStatus.NormalExit:
+            if exit_code in {FpcalcExit.NOERROR, FpcalcExit.DECODING_ERROR} and exit_status == QtCore.QProcess.ExitStatus.NormalExit:
                 output = bytes(process.readAllStandardOutput()).decode()
                 jsondata = json.loads(output)
                 # Use only integer part of duration, floats are not allowed in lookup
@@ -227,7 +235,7 @@ class AcoustIDClient(QtCore.QObject):
                 # Only set the fingerprint if it was calculated without
                 # decoding errors. Otherwise fingerprints for broken files
                 # might get submitted.
-                if exit_code == 0:
+                if exit_code == FpcalcExit.NOERROR:
                     task.file.set_acoustid_fingerprint(fingerprint, length)
             task.next_func(result)
 

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -214,6 +214,9 @@ class AcoustIDClient(QtCore.QObject):
             # fpcalc returns the exit code 3 in case of decoding errors that
             # still allowed it to calculate a result.
             if exit_code in {FpcalcExit.NOERROR, FpcalcExit.DECODING_ERROR} and exit_status == QtCore.QProcess.ExitStatus.NormalExit:
+                if exit_code == FpcalcExit.DECODING_ERROR:
+                    error = bytes(process.readAllStandardError()).decode()
+                    log.warning("fpcalc non-critical decoding errors for %s: %s", task.file, error)
                 output = bytes(process.readAllStandardOutput()).decode()
                 jsondata = json.loads(output)
                 # Use only integer part of duration, floats are not allowed in lookup

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2017-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018-2021 Laurent Monin
-# Copyright (C) 2018-2023 Philipp Wolfer
+# Copyright (C) 2018-2024 Philipp Wolfer
 # Copyright (C) 2023 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
@@ -203,7 +203,9 @@ class AcoustIDClient(QtCore.QObject):
         try:
             self._running -= 1
             self._run_next_task()
-            if exit_code == 0 and exit_status == QtCore.QProcess.ExitStatus.NormalExit:
+            # fpcalc returns the exit code 3 in case of decoding errors that
+            # still allowed it to calculate a result.
+            if exit_code in {0, 3} and exit_status == QtCore.QProcess.ExitStatus.NormalExit:
                 output = bytes(process.readAllStandardOutput()).decode()
                 jsondata = json.loads(output)
                 # Use only integer part of duration, floats are not allowed in lookup
@@ -222,7 +224,11 @@ class AcoustIDClient(QtCore.QObject):
         finally:
             if result and result[0] == 'fingerprint':
                 fp_type, fingerprint, length = result
-                task.file.set_acoustid_fingerprint(fingerprint, length)
+                # Only set the fingerprint if it was calculated without
+                # decoding errors. Otherwise fingerprints for broken files
+                # might get submitted.
+                if exit_code == 0:
+                    task.file.set_acoustid_fingerprint(fingerprint, length)
             task.next_func(result)
 
     def _on_fpcalc_error(self, task, error):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2813
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If fpcalc encounters a decoding error for which it still was able to generate a result it will return the special return code 3. Continue receiving results if this code was returned. See https://github.com/acoustid/chromaprint/blob/master/src/cmd/fpcalc.cpp#L403-L408 and https://github.com/acoustid/chromaprint/commit/3f07ceef8438058d14a1d479009cb66779cf3594

Example for such a call:

```
% fpcalc "/home/phw/Musik/Library/Deep Purple/The Platinum Collection/01-12 Flight of the Rat.mp3" -json              
ERROR: Error reading from the audio source (Invalid data found when processing input)
{"duration": 471.75, "fingerprint": "AQABRU5CaQ2DfsO--qi1oFQ0-D16oruQ7ikSMiiVBj8VoZeFKXnw4zr-I5xZiPWD8MqB_5iowDquHzkT8NDy5PiGlDvxJY9w0UL6Dh-OB00U7QLzreiuwxZ-mMKD68Fh_EZ19EdN9EGz41ty3JmD52giiihozvjROxx0wnNQ7cMT6OiP-kd_hJmEh_jxB838DTnOFycugw-uwtfRH8e5I8-D73ivwyfe5TiOH8ytIOE6C7nzguRk-EV7zPgVhKlyQXNaIr-NaxLuIL2y4RGEXeCDJyh_XNlAdcN56GOOLs2HHz-eRDhltHvgoeeE4w2OW-rRHw5T6DhE7vjRxBeeZMfO4zk0VkfD4wtwH_vBH_0e6HhqPFzhI3xw48d3PDnuw-dB3sgvCDmzoDk-Dc3z4IsyXD5-5OGN5vESaM9sPD9yLceXJB6uJ_A7HOePH_zUIH-ORNGTwM0Oa0dP4HkC_1KQWMmRS8QT9E_QnBP4E_dx5ogO7TSiPQquLHCFFnmO59ByWkFIxccjZXh28A58Ai8y-riiQ8uRxmDEaMd3nETzHeE_6AnyaJZxPTj2C010hFcS6JM4I9hz8KjGveguZI8OzR2MsIzwB-_w6MEnnEcYMkaX94F-4gSfC0-OP8YHKWODH-mDE-1x7fh0nD9uo_kx8TnyI8mP53gO5hW6iwquKCX4RMqF40d7pKeYI5l3XCHO44wco1GlTEHP4wWPH2GKhFtzXNmOUwd_9MIlOIwuIXeD5CVOwwt3XM-HLziPjN-EEvnx4McPfyLOwXSJPB60nIg__MGPhs_RJ9Fx8cjHHNpF4UIuXKidNOjx50glB-qKWscdAAsEEAIIYIyRjBgDICAEAWCAAAQjhQQhCDjEhADKIlEAGUYqAoBhQDgCAQGAC6QEcAwwAQRowhEgAFGMGWEYMgQIRBDIzighAGCCCCMkcZpLBwgDAgimkEIEEVfMAMYQiogwiAjDiABOGKMIIwAi47CjDimEGBNEEiawJUAQYwhgQCADhDGAAUcAYcYQgABRghEgjHFECKIYIMQLQYBjBgDjEBMGMYGZYEYII5whTCDgiDDGCwCMBQQZQQwBChBiJKPAAZCYQ4QoZABARihlAGeQIgYQAHBwBgQyCBGhHHYKCEgEUlYEQ5kDAiBlAIJUKSoEAkAiRSQgQAABjALGWACQoAA"}
% echo $? 
3
```

The fingerprint otherwise will still produce a lookup result, despite the error. So by ignoring these results we also ignore possible positive lookup results.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
On fpcalc exit code 3 continue the lookup.

But do not store the received fingerprint for submission. In case the decoding error causes a fingerprint to be really off it is better to not submit it. 