### PR TITLE
PICARD-2814: Fix exception on loading embedded cover with invalid ID3 type

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2007 Oliver Charles
 # Copyright (C) 2007, 2010-2011 Lukáš Lalinský
-# Copyright (C) 2007-2011, 2014, 2018-2023 Philipp Wolfer
+# Copyright (C) 2007-2011, 2014, 2018-2024 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012, 2015 Wieland Hoffmann
 # Copyright (C) 2013-2015, 2018-2022 Laurent Monin
@@ -461,9 +461,9 @@ class TagCoverArtImage(CoverArtImage):
     def __init__(self, file, tag=None, types=None, is_front=None,
                  support_types=False, comment='', data=None,
                  support_multi_types=False, id3_type=None):
-        super().__init__(url=None, types=types, comment=comment, data=data, id3_type=id3_type)
         self.sourcefile = file
         self.tag = tag
+        super().__init__(url=None, types=types, comment=comment, data=data, id3_type=id3_type)
         self.support_types = support_types
         self.support_multi_types = support_multi_types
         if is_front is not None:

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019, 2021-2022 Philipp Wolfer
+# Copyright (C) 2019, 2021-2024 Philipp Wolfer
 # Copyright (C) 2019-2021 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
@@ -41,6 +41,7 @@ from picard.coverart.utils import (
     Id3ImageType,
     types_from_id3,
 )
+from picard.file import File
 from picard.metadata import Metadata
 from picard.util import encode_filename
 from picard.util.filenaming import WinPathTooLong
@@ -149,8 +150,13 @@ class CoverArtImageTest(PicardTestCase):
                 image.id3_type = invalid_value
 
     def test_init_invalid_id3_type(self):
-        image = CoverArtImage(id3_type=255)
-        self.assertEqual(image.id3_type, Id3ImageType.OTHER)
+        cases = (
+            (CoverArtImage, []),
+            (TagCoverArtImage, [File('test.mp3')]),
+        )
+        for image_class, args in cases:
+            image = image_class(*args, id3_type=255)
+            self.assertEqual(image.id3_type, Id3ImageType.OTHER)
 
     def test_compare_without_type(self):
         image1 = create_image(b'a', types=["front"])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2814
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is a follow up to the fix for PICARD-2774 (#2336). While the type fix in general was correct an exception was thrown when doing the logging in https://github.com/phw/picard/blob/c612116a6342b0aab0e7a4af1862eb2b6fbe01e2/picard/coverart/image.py#L182 as the implementation of `TagCoverArtImage._repr` did access variables not yet initialized at this point.


# Solution

Set `self.sourcefile` and `self.tag` for `TagCoverArtImage` before calling the parent constructor. Both are needed for `_repr()`  and `_str()` working as expected.

Added additional test case to capture this specific issue.