### PR TITLE
Do PyPI deployment with Trusted Publisher Management

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODESIGN: 0
+    environment:
+      name: pypi
+      url: https://pypi.org/p/picard
+    permissions:
+      id-token: write  # required for PyPI upload
 
     steps:
     - uses: actions/checkout@v4
@@ -71,14 +76,9 @@ jobs:
       with:
         name: picard-sdist
         path: dist/*
-    - name: Publish Python distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags/') && env.TWINE_PASSWORD
-      run: |
-        pip install --upgrade twine
-        twine upload --non-interactive dist/*.tar.gz
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags/')
 
   pypi-bdist:
     runs-on: ${{ matrix.os }}
@@ -87,6 +87,11 @@ jobs:
       matrix:
         os: [macos-11, windows-2019]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    environment:
+      name: pypi
+      url: https://pypi.org/p/picard
+    permissions:
+      id-token: write  # required for PyPI upload
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -121,11 +126,6 @@ jobs:
       with:
         name: picard-bdist-${{ runner.os }}-${{ matrix.python-version }}
         path: dist/*.whl
-    - name: Publish Python distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags/') && env.TWINE_PASSWORD
-      run: |
-        pip install --upgrade twine>=3.0
-        twine upload --non-interactive dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -12,12 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CODESIGN: 0
-    environment:
-      name: pypi
-      url: https://pypi.org/p/picard
-    permissions:
-      id-token: write  # required for PyPI upload
-
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -76,9 +70,6 @@ jobs:
       with:
         name: picard-sdist
         path: dist/*
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      if: startsWith(github.ref, 'refs/tags/')
 
   pypi-bdist:
     runs-on: ${{ matrix.os }}
@@ -87,11 +78,6 @@ jobs:
       matrix:
         os: [macos-11, windows-2019]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-    environment:
-      name: pypi
-      url: https://pypi.org/p/picard
-    permissions:
-      id-token: write  # required for PyPI upload
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -126,6 +112,26 @@ jobs:
       with:
         name: picard-bdist-${{ runner.os }}-${{ matrix.python-version }}
         path: dist/*.whl
+
+  pypi-release:
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-bdist
+      - pypi-sdist
+    environment:
+      name: pypi
+      url: https://pypi.org/p/picard
+    permissions:
+      id-token: write  # required for PyPI upload
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: picard-?dist*
+        path: dist/
+        merge-multiple: true
+    - name: Verify distributions
+      run: |
+        ls -l dist/
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -115,6 +115,7 @@ jobs:
 
   pypi-release:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - pypi-bdist
       - pypi-sdist
@@ -134,4 +135,3 @@ jobs:
         ls -l dist/
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,6 +42,8 @@ jobs:
     strategy:
       fail-fast: false
     secrets: inherit
+    permissions:
+      id-token: write
 
   github-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This eliminates the need to provide permanent access tokens for PyPI in the CI and instead uses temporary tokens issued by OpenID Connect (OIDC)

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The metabrainz/picard repository has been setup as a trusted publisher on the PyPI picard project. The Github action now uses pypa/gh-action-pypi-publish@release/v1 instead of unvoking twine.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Once this has been merged (including the 2.10.x branch) we could remove PYPI_UPLOAD_TOKEN from the Github Actions environment.

Generally this is difficult to test as we need to perform our first release with this to see how it goes. But the risk is low. If everything fails twine can be run locally.
