### PR TITLE
PICARD-1685 : Add ~filesize variable

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -83,13 +83,13 @@ from picard.util import (
     any_exception_isinstance,
     decode_filename,
     emptydir,
+    encode_filename,
     find_best_match,
     format_time,
     is_absolute_path,
     normpath,
     thread,
     tracknum_and_title_from_filename,
-    encode_filename,
 )
 from picard.util.filenaming import (
     get_available_filename,

--- a/picard/file.py
+++ b/picard/file.py
@@ -762,7 +762,7 @@ class File(QtCore.QObject, Item):
 
     def _info(self, metadata, file):
         try:
-            metadata['~filesize'] = os.path.getsize(encode_filename(self.filename))
+            metadata['~filesize'] = os.path.getsize(encode_filename(file.filename))
         except BaseException:
             pass
         if hasattr(file.info, 'length'):

--- a/picard/file.py
+++ b/picard/file.py
@@ -762,8 +762,7 @@ class File(QtCore.QObject, Item):
 
     def _info(self, metadata, file):
         try:
-            size = os.path.getsize(encode_filename(self.filename))
-            metadata['~filesize'] = size
+            metadata['~filesize'] = os.path.getsize(encode_filename(self.filename))
         except BaseException:
             pass
         if hasattr(file.info, 'length'):

--- a/picard/file.py
+++ b/picard/file.py
@@ -89,6 +89,7 @@ from picard.util import (
     normpath,
     thread,
     tracknum_and_title_from_filename,
+    encode_filename,
 )
 from picard.util.filenaming import (
     get_available_filename,
@@ -132,7 +133,7 @@ class File(QtCore.QObject, Item):
 
     EXTENSIONS = []
 
-    FILE_INFO_TAGS = ('~bitrate', '~sample_rate', '~channels', '~bits_per_sample', '~format')
+    FILE_INFO_TAGS = ('~bitrate', '~sample_rate', '~channels', '~bits_per_sample', '~format', '~filesize')
 
     comparison_weights = {
         'title': 13,
@@ -760,6 +761,11 @@ class File(QtCore.QObject, Item):
         return True
 
     def _info(self, metadata, file):
+        try:
+            size = os.path.getsize(encode_filename(self.filename))
+            metadata['~filesize'] = size
+        except BaseException:
+            pass
         if hasattr(file.info, 'length'):
             metadata.length = int(file.info.length * 1000)
         if hasattr(file.info, 'bitrate') and file.info.bitrate:

--- a/picard/file.py
+++ b/picard/file.py
@@ -763,8 +763,8 @@ class File(QtCore.QObject, Item):
     def _info(self, metadata, file):
         try:
             metadata['~filesize'] = os.path.getsize(encode_filename(file.filename))
-        except BaseException:
-            pass
+        except BaseException as e:
+            log.error(e)
         if hasattr(file.info, 'length'):
             metadata.length = int(file.info.length * 1000)
         if hasattr(file.info, 'bitrate') and file.info.bitrate:

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -237,7 +237,7 @@ except ImportError:
             metadata['~sample_rate'] = f.getframerate()
             metadata.length = 1000 * f.getnframes() // f.getframerate()
             metadata['~format'] = self.NAME
-            metadata['~filesize'] = os.path.getsize(encode_filename(self.filename))
+            metadata['~filesize'] = os.path.getsize(encode_filename(filename))
             self._add_path_to_metadata(metadata)
             return metadata
 

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -25,6 +25,7 @@
 
 
 from collections.abc import MutableMapping
+import os
 
 import mutagen
 
@@ -33,6 +34,7 @@ from picard.config import get_config
 from picard.file import File
 from picard.formats.id3 import NonCompatID3File
 from picard.metadata import Metadata
+from picard.util import encode_filename
 
 
 try:
@@ -235,6 +237,7 @@ except ImportError:
             metadata['~sample_rate'] = f.getframerate()
             metadata.length = 1000 * f.getnframes() // f.getframerate()
             metadata['~format'] = self.NAME
+            metadata['~filesize'] = os.path.getsize(encode_filename(self.filename))
             self._add_path_to_metadata(metadata)
             return metadata
 

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -286,12 +286,10 @@ def format_file_info(file_):
     info.append((_("Filename:"), file_.filename))
     if '~format' in file_.orig_metadata:
         info.append((_("Format:"), file_.orig_metadata['~format']))
-    try:
-        size = os.path.getsize(encode_filename(file_.filename))
+    if '~filesize' in file_.orig_metadata:
+        size = file_.orig_metadata['~filesize']
         sizestr = "%s (%s)" % (bytes2human.decimal(size), bytes2human.binary(size))
         info.append((_("Size:"), sizestr))
-    except BaseException:
-        pass
     if file_.orig_metadata.length:
         info.append((_("Length:"), format_time(file_.orig_metadata.length)))
     if '~bitrate' in file_.orig_metadata:

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -33,7 +33,6 @@ from collections import (
     namedtuple,
 )
 from html import escape
-import os.path
 import re
 import traceback
 

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -49,7 +49,6 @@ from picard.file import File
 from picard.track import Track
 from picard.util import (
     bytes2human,
-    encode_filename,
     format_time,
     open_local_path,
     union_sorted_lists,

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -170,6 +170,7 @@ class MainPanel(QtWidgets.QSplitter):
         (N_("Catalog No."), 'catalognumber'),
         (N_("Barcode"), 'barcode'),
         (N_("Media"), 'media'),
+        (N_("Size"), '~filesize'),
         (N_("Genre"), 'genre'),
         (N_("Fingerprint status"), '~fingerprint'),
         (N_("Date"), 'date'),

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@
 # Maurits Meulenbelt, 2012
 # Maurits Meulenbelt, 2012
 # Maurits Meulenbelt, 2012-2023
-# Philipp Wolfer <ph.wolfer@gmail.com>, 2019-2021,2023
+# Philipp Wolfer <ph.wolfer@gmail.com>, 2019-2021,2023, 2024.
 # mfmeulenbelt <mfmeulenbelt@gmail.com>, 2023.
 # RandomMushroom128 <RandomMushroom128@users.noreply.translations.metabrainz.org>, 2023.
 # mfmeulenbelt <mfmeulenbelt@users.noreply.translations.metabrainz.org>, 2024.
@@ -18,9 +18,8 @@ msgstr ""
 "Project-Id-Version: MusicBrainz\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2023-12-15 17:44+0100\n"
-"PO-Revision-Date: 2024-01-07 12:28+0000\n"
-"Last-Translator: mfmeulenbelt <mfmeulenbelt@users.noreply.translations."
-"metabrainz.org>\n"
+"PO-Revision-Date: 2024-01-09 07:28+0000\n"
+"Last-Translator: Philipp Wolfer <ph.wolfer@gmail.com>\n"
 "Language-Team: Dutch <https://translations.metabrainz.org/projects/picard/3/"
 "app/nl/>\n"
 "Language: nl\n"
@@ -2153,7 +2152,7 @@ msgstr ""
 "\n"
 "Voorbeeld:\n"
 "\n"
-" $map(First:A; Second:B,$upper(%_loop_count%=%_loop_value%))\n"
+"    $map(First:A; Second:B,$upper(%_loop_count%=%_loop_value%))\n"
 "\n"
 "Resultaat: 1=FIRST:A; 2=SECOND:B\n"
 

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -235,7 +235,7 @@ class CommonTests:
         def test_info(self):
             if not self.expected_info:
                 raise unittest.SkipTest("Ratings not supported for %s" % self.format.NAME)
-            metadata = save_and_load_metadata(self.filename, Metadata())
+            metadata = load_metadata(self.filename)
             for key, expected_value in self.expected_info.items():
                 value = metadata.length if key == 'length' else metadata[key]
                 self.assertEqual(expected_value, value, '%s: %r != %r' % (key, expected_value, value))

--- a/test/formats/test_aac.py
+++ b/test/formats/test_aac.py
@@ -41,6 +41,7 @@ class AACTest(CommonTests.SimpleFormatsTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '123.824',
+        '~filesize': '1896',
     }
     unexpected_info = ['~video']
 
@@ -53,6 +54,7 @@ class AACWithAPETest(CommonApeTests.ApeTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '123.824',
+        '~filesize': '1974',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_ac3.py
+++ b/test/formats/test_ac3.py
@@ -40,11 +40,11 @@ class AC3WithAPETest(CommonApeTests.ApeTestCase):
     testfile = 'test.ac3'
     supports_ratings = False
     expected_info = {
-        'length': 106,
+        'length': 104,
         '~bitrate': '192.0',
         '~sample_rate': '44100',
         '~channels': '2',
-        '~filesize': '2570',
+        '~filesize': '2506',
     }
     unexpected_info = ['~video']
 
@@ -107,10 +107,10 @@ class EAC3Test(CommonTests.SimpleFormatsTestCase):
     testfile = 'test.eac3'
     expected_info = {
         '~format': 'Enhanced AC-3',
-        'length': 107,
+        'length': 104,
         '~sample_rate': '44100',
         '~channels': '2',
-        '~filesize': '2570',
+        '~filesize': '2506',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_ac3.py
+++ b/test/formats/test_ac3.py
@@ -44,6 +44,7 @@ class AC3WithAPETest(CommonApeTests.ApeTestCase):
         '~bitrate': '192.0',
         '~sample_rate': '44100',
         '~channels': '2',
+        '~filesize': '2570',
     }
     unexpected_info = ['~video']
 
@@ -109,6 +110,7 @@ class EAC3Test(CommonTests.SimpleFormatsTestCase):
         'length': 107,
         '~sample_rate': '44100',
         '~channels': '2',
+        '~filesize': '2570',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -172,6 +172,7 @@ class MonkeysAudioTest(CommonApeTests.ApeTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bits_per_sample': '16',
+        '~filesize': '2496',
     }
     unexpected_info = ['~video']
 
@@ -183,6 +184,7 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         'length': 82,
         '~channels': '2',
         '~sample_rate': '44100',
+        '~filesize': '2542',
     }
     unexpected_info = ['~video']
 
@@ -247,6 +249,7 @@ class MusepackSV7Test(CommonApeTests.ApeTestCase):
         'length': 91,
         '~channels': '2',
         '~sample_rate': '44100',
+        '~filesize': '1605',
     }
     unexpected_info = ['~video']
 
@@ -258,6 +261,7 @@ class MusepackSV8Test(CommonApeTests.ApeTestCase):
         'length': 82,
         '~channels': '2',
         '~sample_rate': '44100',
+        '~filesize': '1633',
     }
     unexpected_info = ['~video']
 
@@ -274,7 +278,8 @@ class TAKTest(CommonApeTests.ApeTestCase):
                 'length': 82,
                 '~channels': '2',
                 '~sample_rate': '44100',
-                '~bits_per_sample': '16'
+                '~bits_per_sample': '16',
+                '~filesize': '2144',
             }
 
 
@@ -285,6 +290,7 @@ class OptimFROGLosslessTest(CommonApeTests.ApeTestCase):
         'length': 0,
         '~channels': '2',
         '~sample_rate': '48000',
+        '~filesize': '181',
     }
     unexpected_info = ['~video']
 
@@ -300,6 +306,7 @@ class OptimFROGDUalStreamTest(CommonApeTests.ApeTestCase):
         'length': 0,
         '~channels': '2',
         '~sample_rate': '48000',
+        '~filesize': '181',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_apev2.py
+++ b/test/formats/test_apev2.py
@@ -172,7 +172,7 @@ class MonkeysAudioTest(CommonApeTests.ApeTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bits_per_sample': '16',
-        '~filesize': '2496',
+        '~filesize': '2432',
     }
     unexpected_info = ['~video']
 
@@ -184,7 +184,7 @@ class WavPackTest(CommonApeTests.ApeTestCase):
         'length': 82,
         '~channels': '2',
         '~sample_rate': '44100',
-        '~filesize': '2542',
+        '~filesize': '2478',
     }
     unexpected_info = ['~video']
 
@@ -261,7 +261,7 @@ class MusepackSV8Test(CommonApeTests.ApeTestCase):
         'length': 82,
         '~channels': '2',
         '~sample_rate': '44100',
-        '~filesize': '1633',
+        '~filesize': '1569',
     }
     unexpected_info = ['~video']
 
@@ -279,7 +279,7 @@ class TAKTest(CommonApeTests.ApeTestCase):
                 '~channels': '2',
                 '~sample_rate': '44100',
                 '~bits_per_sample': '16',
-                '~filesize': '2144',
+                '~filesize': '2080',
             }
 
 
@@ -290,7 +290,7 @@ class OptimFROGLosslessTest(CommonApeTests.ApeTestCase):
         'length': 0,
         '~channels': '2',
         '~sample_rate': '48000',
-        '~filesize': '181',
+        '~filesize': '117',
     }
     unexpected_info = ['~video']
 
@@ -306,7 +306,7 @@ class OptimFROGDUalStreamTest(CommonApeTests.ApeTestCase):
         'length': 0,
         '~channels': '2',
         '~sample_rate': '48000',
-        '~filesize': '181',
+        '~filesize': '117',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -105,6 +105,7 @@ class ASFTest(CommonAsfTests.AsfTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '128.0',
+        '~filesize': '4881',
     }
 
 
@@ -116,6 +117,7 @@ class WMATest(CommonAsfTests.AsfTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '64.0',
+        '~filesize': '8164',
     }
     unexpected_info = ['~video']
 
@@ -129,6 +131,7 @@ class WMVTest(CommonAsfTests.AsfTestCase):
         '~sample_rate': '44100',
         '~bitrate': '128.0',
         '~video': '1',
+        '~filesize': '8453',
     }
 
 

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -105,7 +105,7 @@ class ASFTest(CommonAsfTests.AsfTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '128.0',
-        '~filesize': '4881',
+        '~filesize': '3744',
     }
 
 
@@ -131,7 +131,7 @@ class WMVTest(CommonAsfTests.AsfTestCase):
         '~sample_rate': '44100',
         '~bitrate': '128.0',
         '~video': '1',
-        '~filesize': '8453',
+        '~filesize': '7373',
     }
 
 

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -610,6 +610,7 @@ class MP3Test(CommonId3Tests.Id3TestCase):
         'length': 156,
         '~channels': '2',
         '~sample_rate': '44100',
+        '~filesize': '2888',
     }
     unexpected_info = ['~video']
 
@@ -641,6 +642,7 @@ class TTATest(CommonId3Tests.Id3TestCase):
     expected_info = {
         'length': 82,
         '~sample_rate': '44100',
+        '~filesize': '3464',
     }
     unexpected_info = ['~video']
 
@@ -654,6 +656,7 @@ class DSFTest(CommonId3Tests.Id3TestCase):
         '~sample_rate': '5644800',
         '~bitrate': '11289.6',
         '~bits_per_sample': '1',
+        '~filesize': '114022',
     }
     unexpected_info = ['~video']
 
@@ -668,6 +671,7 @@ if id3.DSDIFFFile:
             '~sample_rate': '5644800',
             '~bitrate': '11289.6',
             '~bits_per_sample': '1',
+            '~filesize': '15288',
         }
         unexpected_info = ['~video']
 
@@ -679,6 +683,7 @@ if id3.DSDIFFFile:
             '~channels': '2',
             '~sample_rate': '5644800',
             '~bits_per_sample': '1',
+            '~filesize': '2214',
         }
         unexpected_info = ['~video']
 
@@ -691,6 +696,7 @@ class AIFFTest(CommonId3Tests.Id3TestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '1411.2',
+        '~filesize': '15704',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -610,7 +610,7 @@ class MP3Test(CommonId3Tests.Id3TestCase):
         'length': 156,
         '~channels': '2',
         '~sample_rate': '44100',
-        '~filesize': '2888',
+        '~filesize': '2760',
     }
     unexpected_info = ['~video']
 
@@ -642,7 +642,7 @@ class TTATest(CommonId3Tests.Id3TestCase):
     expected_info = {
         'length': 82,
         '~sample_rate': '44100',
-        '~filesize': '3464',
+        '~filesize': '2300',
     }
     unexpected_info = ['~video']
 
@@ -656,7 +656,7 @@ class DSFTest(CommonId3Tests.Id3TestCase):
         '~sample_rate': '5644800',
         '~bitrate': '11289.6',
         '~bits_per_sample': '1',
-        '~filesize': '114022',
+        '~filesize': '112988',
     }
     unexpected_info = ['~video']
 
@@ -671,7 +671,7 @@ if id3.DSDIFFFile:
             '~sample_rate': '5644800',
             '~bitrate': '11289.6',
             '~bits_per_sample': '1',
-            '~filesize': '15288',
+            '~filesize': '14242',
         }
         unexpected_info = ['~video']
 
@@ -696,7 +696,7 @@ class AIFFTest(CommonId3Tests.Id3TestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~bitrate': '1411.2',
-        '~filesize': '15704',
+        '~filesize': '14662',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_midi.py
+++ b/test/formats/test_midi.py
@@ -32,7 +32,8 @@ class MIDITest(CommonTests.SimpleFormatsTestCase):
     testfile = 'test.mid'
     expected_info = {
         'length': 127997,
-        '~format': 'Standard MIDI File'
+        '~format': 'Standard MIDI File',
+        '~filesize': '8444',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -146,6 +146,7 @@ class M4ATest(CommonMP4Tests.MP4TestCase):
         '~sample_rate': '44100',
         '~bitrate': '14.376',
         '~bits_per_sample': '16',
+        '~filesize': '3591',
     }
     unexpected_info = ['~video']
 
@@ -168,6 +169,7 @@ class M4VTest(CommonMP4Tests.MP4TestCase):
         '~bitrate': '108.043',
         '~bits_per_sample': '16',
         '~video': '1',
+        '~filesize': '5097',
     }
 
 

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -146,7 +146,7 @@ class M4ATest(CommonMP4Tests.MP4TestCase):
         '~sample_rate': '44100',
         '~bitrate': '14.376',
         '~bits_per_sample': '16',
-        '~filesize': '3591',
+        '~filesize': '2559',
     }
     unexpected_info = ['~video']
 
@@ -169,7 +169,7 @@ class M4VTest(CommonMP4Tests.MP4TestCase):
         '~bitrate': '108.043',
         '~bits_per_sample': '16',
         '~video': '1',
-        '~filesize': '5097',
+        '~filesize': '4065',
     }
 
 

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -208,7 +208,7 @@ class FLACTest(CommonVorbisTests.VorbisTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~format': 'FLAC',
-        '~filesize':'6546'
+        '~filesize': '6546',
     }
     unexpected_info = ['~video']
 
@@ -302,6 +302,7 @@ class OggVorbisTest(CommonVorbisTests.VorbisTestCase):
         'length': 82,
         '~channels': '2',
         '~sample_rate': '44100',
+        '~filesize': '5221',
     }
 
 
@@ -312,6 +313,7 @@ class OggSpxTest(CommonVorbisTests.VorbisTestCase):
         'length': 89,
         '~channels': '2',
         '~bitrate': '29.6',
+        '~filesize': '608',
     }
     unexpected_info = ['~video']
 
@@ -322,6 +324,7 @@ class OggOpusTest(CommonVorbisTests.VorbisTestCase):
     expected_info = {
         'length': 82,
         '~channels': '2',
+        '~filesize': '1637',
     }
     unexpected_info = ['~video']
 
@@ -341,6 +344,7 @@ class OggTheoraTest(CommonVorbisTests.VorbisTestCase):
         'length': 520,
         '~bitrate': '200.0',
         '~video': '1',
+        '~filesize': '5298',
     }
 
 
@@ -350,6 +354,7 @@ class OggFlacTest(CommonVorbisTests.VorbisTestCase):
     expected_info = {
         'length': 82,
         '~channels': '2',
+        '~filesize': '2573',
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -208,6 +208,7 @@ class FLACTest(CommonVorbisTests.VorbisTestCase):
         '~channels': '2',
         '~sample_rate': '44100',
         '~format': 'FLAC',
+        '~filesize':'6546'
     }
     unexpected_info = ['~video']
 

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -41,6 +41,7 @@ expected_info = {
     '~channels': '2',
     '~sample_rate': '44100',
     '~bits_per_sample': '16',
+    '~filesize': '15706',
 }
 
 if WAVFile.supports_tag('artist'):

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -41,6 +41,7 @@ expected_info = {
     '~channels': '2',
     '~sample_rate': '44100',
     '~bits_per_sample': '16',
+    '~filesize': '14652',
 }
 
 if WAVFile.supports_tag('artist'):

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -41,7 +41,6 @@ expected_info = {
     '~channels': '2',
     '~sample_rate': '44100',
     '~bits_per_sample': '16',
-    '~filesize': '15706',
 }
 
 if WAVFile.supports_tag('artist'):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Add ~filesize variable
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
Provide the file size in bytes as a hidden file variable ~filesize (similar to the existing file variables like e.g. ~bitrate and ~length). 
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-1685
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

I have added the "~filename" variable which stores the size of the file in bytes using "os.path.getsize" and passing the "self.filename" in it. also I have used this variable in infodialog.py to show Size. Modified test cases for '~filsize'. Add '~filesize' to metadata in wav.py since it doesn't uses mutagen. 

# Action
I don't know if you want to also add size option in itemviews.py (since it was mention in the old discussion "https://community.metabrainz.org/t/current-file-size/453338/5"). If yes, then please specifiy how to add it in UI, sicne the size is in bytes and in itemviews.py values are directly added from the list ("columns").
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
