### PR TITLE
PICARD-2826: Update ~filesize after saving file

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -787,10 +787,7 @@ class File(QtCore.QObject, Item):
         filename_encoded = encode_filename(self.filename)
         try:
             metadata['~filesize'] = os.path.getsize(filename_encoded)
-        except OSError as ex:
-            log.error(f"File Size Error: {ex}")
 
-        try:
             created = os.path.getctime(filename_encoded)
             created_timestamp = time.strftime(DEFAULT_TIME_FORMAT, time.localtime(created))
             metadata['~file_created_timestamp'] = created_timestamp
@@ -799,7 +796,7 @@ class File(QtCore.QObject, Item):
             modified_timestamp = time.strftime(DEFAULT_TIME_FORMAT, time.localtime(modified))
             metadata['~file_modified_timestamp'] = modified_timestamp
         except OSError as ex:
-            log.error(f"File Timestamps Error: {ex}")
+            log.error(f"File access error: {ex}")
 
     @property
     def state(self):

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -26,7 +26,6 @@
 
 
 from collections.abc import MutableMapping
-import os
 
 import mutagen
 
@@ -35,7 +34,6 @@ from picard.config import get_config
 from picard.file import File
 from picard.formats.id3 import NonCompatID3File
 from picard.metadata import Metadata
-from picard.util import encode_filename
 
 
 try:
@@ -238,8 +236,7 @@ except ImportError:
             metadata['~sample_rate'] = f.getframerate()
             metadata.length = 1000 * f.getnframes() // f.getframerate()
             metadata['~format'] = self.NAME
-            metadata['~filesize'] = os.path.getsize(encode_filename(filename))
-            self._add_path_to_metadata(metadata)
+            self._update_filesystem_metadata(metadata)
             return metadata
 
         def _save(self, filename, metadata):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2826
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
The `~filesize` variable added in #2361 does not update after saving.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Move the filesize update into `File._add_path_to_metadata`, which is specifically called after file save. Also rename this to `File._update_filesystem_metadata` due to changed scope.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
PICARD-2826 is broader. We have other info metadata that is not being updated properly. I think it is only about `~format`, but e.g. for ID3 this cane change from v2.3 to v2.4 (or vice versa). And for e.g. AC3 it indicates whether APE tags are present or not, which can also change after save.

Fixing this is more difficult, especially if we want to avoid re-reading the entire file (which would be a straightforward solution). I'll look into this separately.