### PR TITLE
PICARD-2832: Add warning when select multiple directories option is enabled

### DIFF
--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -11,7 +11,7 @@
 # Copyright (C) 2016 Rahul Raturi
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017 Antonio Larrosa
-# Copyright (C) 2018, 2023 Bob Swift
+# Copyright (C) 2018, 2023-2024 Bob Swift
 # Copyright (C) 2021 Gabriel Ferreira
 #
 # This program is free software; you can redistribute it and/or
@@ -143,6 +143,8 @@ class InterfaceOptionsPage(OptionsPage):
         if not OS_SUPPORTS_THEMES:
             self.ui.ui_theme_container.hide()
 
+        self.ui.toolbar_multiselect.clicked.connect(self.multi_selection_warning)
+
     def load(self):
         config = get_config()
         self.ui.toolbar_show_labels.setChecked(config.setting['toolbar_show_labels'])
@@ -207,6 +209,20 @@ class InterfaceOptionsPage(OptionsPage):
         if path:
             path = os.path.normpath(path)
             item.setText(path)
+
+    def multi_selection_warning(self):
+        if self.ui.toolbar_multiselect.isChecked():
+            dialog = QtWidgets.QMessageBox(
+                QtWidgets.QMessageBox.Icon.Warning,
+                _('Option Setting Warning'),
+                _(
+                    'Enabling the multiple directories option setting may result in external drives not being recognized by Picard.\n\n'
+                    'Are you sure that you want to enable this setting?'
+                ),
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+                self)
+            if dialog.exec() == QtWidgets.QMessageBox.StandardButton.No:
+                self.ui.toolbar_multiselect.setChecked(False)
 
 
 register_options_page(InterfaceOptionsPage)


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds a warning dialog when the "Select multiple directories" configuration option is enabled.

# Problem

As discussed in https://tickets.metabrainz.org/browse/PICARD-2829 it is possible for Picard to not recognize external drives when the "Allow selection of multiple directories" option setting is enabled.  This is unexpected behavior for the user.

* JIRA ticket (_optional_): PICARD-2832

# Solution

This PR adds a warning dialog that is presented to the user to inform them of the potential consequence (external drives not being recognized by Picard) when the "Allow selection of multiple directories" option setting is enabled.

This should be considered an interim measure until the issue is resolved in the Qt library.

# Action

If this is acceptable, it might be appropriate to cherry pick the commit into the `2.x` branch in case a future release is required at some point. 