### PR TITLE
PICARD-2829: make volumes available in MultiDirsSelectDialog sidebar

### DIFF
--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -103,15 +103,12 @@ class MultiDirsSelectDialog(QtWidgets.QFileDialog):
                 else:
                     if not IS_LINUX or (path.startswith("/media/") or path.startswith("/mnt/")):
                         volume_paths.append(path)
-        sidebar_urls = [
-            QtCore.QUrl.fromLocalFile(root_volume),
-            QtCore.QUrl.fromLocalFile(QtCore.QDir.homePath()),
-            QtCore.QUrl.fromLocalFile(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.MusicLocation))
+        paths = [
+            root_volume,
+            QtCore.QDir.homePath(),
+            QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.MusicLocation),
         ]
-
-        for path in sorted(volume_paths):
-            sidebar_urls.append(QtCore.QUrl.fromLocalFile(path))
-        self.setSidebarUrls(sidebar_urls)
+        self.setSidebarUrls(QtCore.QUrl.fromLocalFile(p) for p in paths + sorted(volume_paths) if p)
 
 
 def qlistwidget_items(qlistwidget):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2829
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

As discovered in PICARD-2829 when using the "multi dir" directory selection dialog on macOS the user cannot select mounted volumes other than the main volume. That's because by default the dialog only shows the root volume and macOS hides the `/Volumes/` folder.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Customize the sidebar of the Qt file dialog to list all mounted volumes. As this is generic and also improves the dialog on other platforms the implementation is not macOS specific. By default on all platforms there were only two entries in the sidebar: "Computer" and the user's home directory.

Extend this to always include:

- Root volume
- User's home
- Primary "Music" folder
- All additionally mounted volumes (on Linux this get filtered to include only those under `/media` or `/mnt`, otherwise all kinds of virtual filesystem end up there).

Here is how this looks on Windows and Linux (sorry, not macOS screenshot today, but essentially the same):

![grafik](https://github.com/metabrainz/picard/assets/29852/0d42b770-be0c-49f7-a846-ad344b1ee2b9)

![grafik](https://github.com/metabrainz/picard/assets/29852/9022d4b2-d774-4d44-8ff6-a885270dd9b5)

There is one caveat: By default the sidebar of Qt's file dialog shows an entry "Computer" which on Linux and macOS gives only access to the main volume, on Windows lists all drives.

I found not way to make this specific location show up in the sidebar if the sidebar gets customized. But it is still accessible via the path dropdown at the top, as can be seen in the screenshots. Also I believe on none of the platforms it was actually very useful and having the volumes in the sidebar is more convenient.