### PR TITLE
Handle exceptions if ~filesize is not numeric

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -826,7 +826,10 @@ class File(QtCore.QObject, Item):
         if not value and not get_config().setting['clear_existing_tags']:
             value = self.orig_metadata[column]
         if column == '~filesize':
-            value = bytes2human.binary(value)
+            try:
+                value = bytes2human.binary(value)
+            except ValueError:
+                pass
         return value
 
     def _lookup_finished(self, lookuptype, document, http, error):

--- a/picard/ui/infodialog.py
+++ b/picard/ui/infodialog.py
@@ -287,7 +287,10 @@ def format_file_info(file_):
         info.append((_("Format:"), file_.orig_metadata['~format']))
     if '~filesize' in file_.orig_metadata:
         size = file_.orig_metadata['~filesize']
-        sizestr = "%s (%s)" % (bytes2human.decimal(size), bytes2human.binary(size))
+        try:
+            sizestr = "%s (%s)" % (bytes2human.decimal(size), bytes2human.binary(size))
+        except ValueError:
+            sizestr = _("unknown")
         info.append((_("Size:"), sizestr))
     if file_.orig_metadata.length:
         info.append((_("Length:"), format_time(file_.orig_metadata.length)))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
This is a bit of an edge case, but should `~filesize` be non-numeric `bytes2human` would throw a `ValueError`. This makes sure Picard keeps functioning.