### PR TITLE
Fix Sliders in PyQt 6.6

### DIFF
--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -94,7 +94,16 @@ class TipSlider(ClickableSlider):
     def show_tip(self, value):
         self.round_value(value)
         self.initStyleOption(self.opt)
-        rectHandle = self.style.subControlRect(self.style.CC_Slider, self.opt, self.style.SC_SliderHandle)
+        try:
+            cc_slider = self.style.CC_Slider
+        except AttributeError:
+            cc_slider = self.style.ComplexControl.CC_Slider
+
+        try:
+            sc_slider_handle = self.style.SC_SliderHandle
+        except AttributeError:
+            sc_slider_handle = self.style.SubControl.SC_ScrollBarSlider
+        rectHandle = self.style.subControlRect(cc_slider, self.opt, sc_slider_handle)
 
         offset = self._offset * self.tagger.primaryScreen().devicePixelRatio()
         pos_local = rectHandle.topLeft() + offset

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -94,15 +94,8 @@ class TipSlider(ClickableSlider):
     def show_tip(self, value):
         self.round_value(value)
         self.initStyleOption(self.opt)
-        try:
-            cc_slider = self.style.CC_Slider
-        except AttributeError:
-            cc_slider = self.style.ComplexControl.CC_Slider
-
-        try:
-            sc_slider_handle = self.style.SC_SliderHandle
-        except AttributeError:
-            sc_slider_handle = self.style.SubControl.SC_ScrollBarSlider
+        cc_slider = self.style.ComplexControl.CC_Slider
+        sc_slider_handle = self.style.SubControl.SC_ScrollBarSlider
         rectHandle = self.style.subControlRect(cc_slider, self.opt, sc_slider_handle)
 
         offset = self._offset * self.tagger.primaryScreen().devicePixelRatio()


### PR DESCRIPTION

# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Using a source code install (i.e. `pip install .`) I ran into this exception when modifying the release preference sliders: 

```
Traceback (most recent call last):
  File "/home/joncrall/.pyenv/versions/3.11.2/envs/pyenv3.11.2/lib/python3.11/site-packages/picard/ui/options/releases.py", line 97, in show_tip
    rectHandle = self.style.subControlRect(self.style.CC_Slider, self.opt, self.style.SC_SliderHandle)
                                           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'QCommonStyle' object has no attribute 'CC_Slider'
```

I was able to determine what the correct values should be and I modifed them (while still allowing old values to work in case this is a PyQt 6.6 thing versus a 6.5 thing)

# Problem

The slider breaks in my Python environment (not sure if it would work if I had PyQt 6.5). 

# Solution

Because I don't know if the new values will work with the official dev requirements, I wrapped the change in an exception so it will try the old way, and if it fails it will fallback to the new way. 
