### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Install dependencies (Linux)
       if: runner.os == 'linux'
       run: |
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2019]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
         - os: macos-11
-          python-version: '3.8'
+          python-version: '3.9'
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8']
+        python-version: ['3.9']
         dependencies: [
           "PyQt6==6.2.3 mutagen==1.37",
         ]
@@ -110,7 +110,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Before installing Picard from source, you need to check you have the following d
 
 Required:
 
-* [Python 3.8 or newer](https://python.org/download)
+* [Python 3.9 or newer](https://python.org/download)
 * [PyQt 6.5 or newer](https://riverbankcomputing.com/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -180,13 +180,7 @@ def setup_gettext(localedir, ui_language=None, logger=None):
     builtins.__dict__['gettext_attributes'] = trans_attributes.gettext
     builtins.__dict__['gettext_constants'] = trans_constants.gettext
     builtins.__dict__['gettext_countries'] = trans_countries.gettext
-
-    if hasattr(trans_attributes, 'pgettext'):
-        builtins.__dict__['pgettext_attributes'] = trans_attributes.pgettext
-    else:
-        def pgettext(context, message):
-            return gettext_ctxt(trans_attributes.gettext, message, context)
-        builtins.__dict__['pgettext_attributes'] = pgettext
+    builtins.__dict__['pgettext_attributes'] = trans_attributes.pgettext
 
     _logger("_ = %r", _)
     _logger("N_ = %r", N_)
@@ -194,23 +188,3 @@ def setup_gettext(localedir, ui_language=None, logger=None):
     _logger("gettext_countries = %r", gettext_countries)
     _logger("gettext_attributes = %r", gettext_attributes)
     _logger("pgettext_attributes = %r", pgettext_attributes)
-
-
-# Workaround for po files with msgctxt which isn't supported by Python < 3.8
-# gettext
-# msgctxt are used within attributes.po, and gettext is failing to translate
-# strings due to that
-# This workaround is a hack until we get proper msgctxt support
-_CONTEXT_SEPARATOR = "\x04"
-
-
-def gettext_ctxt(gettext_, message, context=None):
-    if context is None:
-        return gettext_(message)
-
-    msg_with_ctxt = "%s%s%s" % (context, _CONTEXT_SEPARATOR, message)
-    translated = gettext_(msg_with_ctxt)
-    if _CONTEXT_SEPARATOR in translated:
-        # no translation found, return original message
-        return message
-    return translated

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ from picard import (
 )
 
 
-if sys.version_info < (3, 8):
-    sys.exit("ERROR: You need Python 3.8 or higher to use Picard.")
+if sys.version_info < (3, 9):
+    sys.exit("ERROR: You need Python 3.9 or higher to use Picard.")
 
 PACKAGE_NAME = "picard"
 APPDATA_FILE = PICARD_APP_ID + '.appdata.xml'
@@ -792,7 +792,7 @@ args = {
     },
     'scripts': ['scripts/' + PACKAGE_NAME],
     'install_requires': _get_requirements(),
-    'python_requires': '~=3.8',
+    'python_requires': '~=3.9',
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Development Status :: 5 - Production/Stable',
@@ -801,7 +801,6 @@ args = {
         'Environment :: X11 Applications :: Qt',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

By the time Picard 3 will be released official support for Python 3.8 will be already or nearly at its end. Also pygit2 dropped support for Python 3.8, and we might want to use that for the new plugin system.

This PR also removes some gettext workaround for missing pgettext in Python 3.7 and lower.