### PR TITLE
PICARD-2468: Properly handle unspecified languages in ID3v2 comments

### DIFF
--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -177,13 +177,22 @@ def parse_comment_tag(name):  # noqa: E302
     If language is not set ("comment:desc") "eng" is assumed as default.
     Returns a (lang, desc) tuple.
     """
-    try:
-        desc = name.split(':', 1)[1]
-    except IndexError:
-        desc = ''
     lang = 'eng'
+    desc = ''
+
+    split = name.split(':', 1)
+    if len(split) > 1:
+        desc = split[1]
+
     match = RE_COMMENT_LANG.match(desc)
     if match:
         lang = match.group(1)
         desc = desc[4:]
-    return (lang, desc)
+        return lang, desc
+
+    # Special case for unspecified language + empty description
+    if desc == 'XXX':
+        lang = 'XXX'
+        desc = ''
+
+    return lang, desc

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -37,4 +37,5 @@ class UtilTagsTest(PicardTestCase):
     def test_parse_comment_tag(self):
         self.assertEqual(('XXX', 'foo'), parse_comment_tag('comment:XXX:foo'))
         self.assertEqual(('eng', 'foo'), parse_comment_tag('comment:foo'))
+        self.assertEqual(('XXX', ''), parse_comment_tag('comment:XXX'))
         self.assertEqual(('eng', ''), parse_comment_tag('comment'))


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Picard no longer creates a duplicate `COMM` frame with the incorrect language when using `lang='XXX' + desc=''`.
# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Previously, a `COMM` frame with `lang='XXX' desc=''` would be saved as a separate frame with `lang='eng' desc='XXX'`. This is due to Picard supporting both `comment:desc` and `comment:lang:desc` syntax for comment tags.

* JIRA ticket (_optional_): PICARD-2468
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

A special case was added for `lang='XXX', desc=''`. I could not think of a better solution for the problem, as Picard normalizes all metadata keys. It would be more elegant if trailing colons were preserved.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Possibly explore storing these comments as `comment:XXX:`, leaving the trailing colon as a marker for an empty description. This solution is not perfect. In the event that someone has `comment:eng:XXX`, all `eng` comments are simply stored as `comment:desc`. With this change, their language would be overwritten with `XXX`.