### PR TITLE
CI: Install gettext for Windows

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -90,6 +90,16 @@ jobs:
         brew install gettext
         brew link gettext --force
         echo "/usr/local/opt/gettext/bin" >> $GITHUB_PATH
+    - name: Install gettext (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        & .\scripts\package\win-setup-gettext.ps1 `
+          -GettextVersion $Env:GETTEXT_VERSION -GettextSha256Sum $Env:GETTEXT_SHA256SUM
+        Add-Content $env:GITHUB_PATH (Join-Path -Path (Resolve-Path .) -ChildPath gettext\bin)
+      shell: pwsh
+      env:
+        GETTEXT_VERSION: 0.22.4
+        GETTEXT_SHA256SUM: 220068ac0b9e7aedda03534a3088e584640ac1e639800b3a0baa9410aa6d012a
     - name: Install dependencies (Linux)
       if: runner.os == 'linux'
       run: |

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -41,6 +41,14 @@ jobs:
         DISCID_SHA256SUM: 330199495d71f71251e91eb0b4e3103b6c663fea09ffc9fd3e5108d48e0452c8
         FPCALC_VERSION: 1.5.1
         FPCALC_SHA256SUM: 36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc
+    - name: Install gettext
+      run: |
+        & .\scripts\package\win-setup-gettext.ps1 `
+          -GettextVersion $Env:GETTEXT_VERSION -GettextSha256Sum $Env:GETTEXT_SHA256SUM
+        Add-Content $env:GITHUB_PATH (Join-Path -Path (Resolve-Path .) -ChildPath gettext\bin)
+      env:
+        GETTEXT_VERSION: 0.22.4
+        GETTEXT_SHA256SUM: 220068ac0b9e7aedda03534a3088e584640ac1e639800b3a0baa9410aa6d012a
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -129,6 +129,15 @@ jobs:
         brew install gettext
         brew link gettext --force
         echo "/usr/local/opt/gettext/bin" >> $GITHUB_PATH
+    - name: Install gettext (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        & .\scripts\package\win-setup-gettext.ps1 `
+          -GettextVersion $Env:GETTEXT_VERSION -GettextSha256Sum $Env:GETTEXT_SHA256SUM
+        Add-Content $env:GITHUB_PATH (Join-Path -Path (Resolve-Path .) -ChildPath gettext\bin)
+      env:
+        GETTEXT_VERSION: 0.22.4
+        GETTEXT_SHA256SUM: 220068ac0b9e7aedda03534a3088e584640ac1e639800b3a0baa9410aa6d012a
     - name: Run pip install .
       run: |
         python -m pip install --upgrade pip

--- a/scripts/package/win-common.ps1
+++ b/scripts/package/win-common.ps1
@@ -56,3 +56,30 @@ Function FinalizePackage {
   Move-Item -Path (Join-Path -Path $Qt6Dir -ChildPath bin\*.dll) -Destination $Path -Force
   Remove-Item -Path (Join-Path -Path $Qt6Dir -ChildPath bin)
 }
+
+Function DownloadFile {
+  Param(
+    [Parameter(Mandatory = $true)]
+    [String]
+    $FileName,
+    [Parameter(Mandatory = $true)]
+    [String]
+    $Url
+  )
+  $OutputPath = (Join-Path (Resolve-Path .) $FileName)
+  (New-Object System.Net.WebClient).DownloadFile($Url, "$OutputPath")
+}
+
+Function VerifyHash {
+  Param(
+    [Parameter(Mandatory = $true)]
+    [String]
+    $FileName,
+    [Parameter(Mandatory = $true)]
+    [String]
+    $Sha256Sum
+  )
+  If ((Get-FileHash "$FileName").hash -ne "$Sha256Sum") {
+    Throw "Invalid SHA256 hash for $FileName"
+  }
+}

--- a/scripts/package/win-setup-gettext.ps1
+++ b/scripts/package/win-setup-gettext.ps1
@@ -1,0 +1,20 @@
+Param(
+  [Parameter(Mandatory = $true)]
+  [String]
+  $GettextVersion,
+  [Parameter(Mandatory = $true)]
+  [String]
+  $GettextSha256Sum
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+. $ScriptDirectory\win-common.ps1
+
+$ArchiveFile = ".\gettext-tools-windows.zip"
+Write-Output "Downloading gettext-tools-windows $GettextVersion to $ArchiveFile..."
+DownloadFile -Url "https://github.com/vslavik/gettext-tools-windows/releases/download/v$GettextVersion/gettext-tools-windows-$GettextVersion.zip" `
+  -FileName $ArchiveFile
+VerifyHash -FileName $ArchiveFile -Sha256Sum $GettextSha256Sum
+Expand-Archive -Path $ArchiveFile -DestinationPath .\gettext -Force

--- a/scripts/package/win-setup.ps1
+++ b/scripts/package/win-setup.ps1
@@ -15,32 +15,8 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-Function DownloadFile {
-  Param(
-    [Parameter(Mandatory=$true)]
-    [String]
-    $FileName,
-    [Parameter(Mandatory=$true)]
-    [String]
-    $Url
-  )
-  $OutputPath = (Join-Path (Resolve-Path .) $FileName)
-  (New-Object System.Net.WebClient).DownloadFile($Url, "$OutputPath")
-}
-
-Function VerifyHash {
-  Param(
-    [Parameter(Mandatory = $true)]
-    [String]
-    $FileName,
-    [Parameter(Mandatory = $true)]
-    [String]
-    $Sha256Sum
-  )
-  If ((Get-FileHash "$FileName").hash -ne "$Sha256Sum") {
-    Throw "Invalid SHA256 hash for $FileName"
-  }
-}
+$ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+. $ScriptDirectory\win-common.ps1
 
 New-Item -Name .\build -ItemType Directory -ErrorAction Ignore
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

On Github action the provided gettext tools (in particular `msgfmt` where gettext commands shipping with git for Window. Since git 2.44.0 these are no longer bundled and hence the builds started failing.

Fix this by explicitly downloading and installing gettext for Windows.

Unfortunalety there are no official binary packages and many binary packages offered online are outdated. In particular there are no recent gettext packages available for automatic installation via Win-Get or chocolatey.

But https://github.com/vslavik/gettext-tools-windows is maintained by the Poedit author and provides up-to-date packages. Hence this PR downloads the latest release from there and unzips it locally.