### PR TITLE
Make `Version.from_string()` stricter, matching from start of string

### DIFF
--- a/picard/version.py
+++ b/picard/version.py
@@ -29,7 +29,7 @@ class VersionError(Exception):
 
 
 class Version(namedtuple('VersionBase', 'major minor patch identifier revision')):
-    _version_re = re.compile(r"(\d+)(?:[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?)?$")
+    _version_re = re.compile(r"^(\d+)(?:[._](\d+)(?:[._](\d+)[._]?(?:(dev|a|alpha|b|beta|rc|final)[._]?(\d+))?)?)?$")
 
     _identifiers = {
         'dev': 0,

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -74,18 +74,22 @@ class VersionsTest(PicardTestCase):
         l, s = (1, 1, 0, 'dev', 0), '1_1_0_dev_0'
         self.assertEqual(l, Version.from_string(s))
 
-    def test_version_from_string_prefixed(self):
-        l, s = (1, 1, 0, 'dev', 0), 'anything_28_1_1_0_dev_0'
-        self.assertEqual(l, Version.from_string(s))
+    def test_version_from_string_prefixed_with_num(self):
+        self.assertRaises(VersionError, Version.from_string, '8_1_1_0_dev_0')
+
+    def test_version_from_string_suffixed_with_num(self):
+        self.assertRaises(VersionError, Version.from_string, '1_1_0_dev_0_8')
+
+    def test_version_from_string_prefixed_with_alpha(self):
+        self.assertRaises(VersionError, Version.from_string, 'a_1_1_0_dev_0')
+
+    def test_version_from_string_suffixed_with_alpha(self):
+        self.assertRaises(VersionError, Version.from_string, '1_1_0_dev_0_a')
 
     def test_version_single_digit(self):
         l, s = (2, 0, 0, 'final', 0), '2'
         self.assertEqual(l, Version.from_string(s))
         self.assertEqual(l, Version(2))
-
-    def test_version_from_string_prefixed_final(self):
-        l, s = (1, 1, 0, 'final', 0), 'anything_28_1_1_0'
-        self.assertEqual(l, Version.from_string(s))
 
     def test_from_string_invalid_identifier(self):
         self.assertRaises(VersionError, Version.from_string, '1.1.0dev')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem


Old code leads to unexpected results with strings like `1.1.1xxx2`, as it matches only from end of string, it would consider this as a valid version, equivalent to ... `2.0.0final0`.

AFAIK, this "feature" isn't used anywhere anyway.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution


Be stricter, and match the full string.

With this change, `1.1.1xxx2` will raise a `VersionError`.
Tests were updated accordingly.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
