### PR TITLE
Move cluster & file comparison weights at module level

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -67,6 +67,18 @@ from picard.ui.item import (
 )
 
 
+# Weights for different elements when comparing a cluster to a release
+CLUSTER_COMPARISON_WEIGHTS = {
+    'album': 17,
+    'albumartist': 6,
+    'date': 4,
+    'format': 2,
+    'releasecountry': 2,
+    'releasetype': 10,
+    'totalalbumtracks': 5,
+}
+
+
 class FileList(QtCore.QObject, FileListItem):
 
     metadata_images_changed = QtCore.pyqtSignal()
@@ -93,17 +105,6 @@ class FileList(QtCore.QObject, FileListItem):
 
 
 class Cluster(FileList):
-
-    # Weights for different elements when comparing a cluster to a release
-    comparison_weights = {
-        'album': 17,
-        'albumartist': 6,
-        'totalalbumtracks': 5,
-        'releasetype': 10,
-        'releasecountry': 2,
-        'format': 2,
-        'date': 4,
-    }
 
     def __init__(self, name, artist="", special=False, related_album=None, hide_if_empty=False):
         super().__init__()
@@ -265,7 +266,7 @@ class Cluster(FileList):
         # multiple matches -- calculate similarities to each of them
         def candidates():
             for release in releases:
-                match = self.metadata.compare_to_release(release, Cluster.comparison_weights)
+                match = self.metadata.compare_to_release(release, CLUSTER_COMPARISON_WEIGHTS)
                 if match.similarity >= threshold:
                     yield match
 

--- a/picard/file.py
+++ b/picard/file.py
@@ -110,6 +110,20 @@ from picard.util.tags import (
 from picard.ui.item import Item
 
 
+FILE_COMPARISON_WEIGHTS = {
+    'album': 5,
+    'artist': 4,
+    'date': 4,
+    'format': 2,
+    'isvideo': 2,
+    'length': 10,
+    'releasecountry': 2,
+    'releasetype': 14,
+    'title': 13,
+    'totaltracks': 4,
+}
+
+
 class FileErrorType(Enum):
 
     UNKNOWN = auto()
@@ -135,19 +149,6 @@ class File(QtCore.QObject, Item):
     LOOKUP_ACOUSTID = 2
 
     EXTENSIONS = []
-
-    comparison_weights = {
-        'title': 13,
-        'artist': 4,
-        'album': 5,
-        'length': 10,
-        'totaltracks': 4,
-        'releasetype': 14,
-        'releasecountry': 2,
-        'format': 2,
-        'isvideo': 2,
-        'date': 4,
-    }
 
     class PreserveTimesStatError(Exception):
         pass
@@ -881,7 +882,7 @@ class File(QtCore.QObject, Item):
     def _match_to_track(self, tracks, threshold=0):
         # multiple matches -- calculate similarities to each of them
         candidates = (
-            self.metadata.compare_to_track(track, self.comparison_weights)
+            self.metadata.compare_to_track(track, FILE_COMPARISON_WEIGHTS)
             for track in tracks
         )
         no_match = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -28,7 +28,7 @@ from picard.config import (
     Option,
     get_config,
 )
-from picard.file import File
+from picard.file import FILE_COMPARISON_WEIGHTS
 from picard.mbjson import (
     countries_from_node,
     recording_to_metadata,
@@ -128,7 +128,7 @@ class TrackSearchDialog(SearchDialog):
         if self.file_:
             metadata = self.file_.orig_metadata
             candidates = (
-                metadata.compare_to_track(track, File.comparison_weights)
+                metadata.compare_to_track(track, FILE_COMPARISON_WEIGHTS)
                 for track in tracks
             )
             tracks = (result.track for result in sort_by_similarity(candidates))

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -33,9 +33,9 @@ from test.test_coverart_image import create_image
 from picard.acoustid.json_helpers import (
     parse_recording as acoustid_parse_recording,
 )
-from picard.cluster import Cluster
+from picard.cluster import CLUSTER_COMPARISON_WEIGHTS
 from picard.coverart.image import CoverArtImage
-from picard.file import File
+from picard.file import FILE_COMPARISON_WEIGHTS
 from picard.mbjson import (
     release_to_metadata,
     track_to_metadata,
@@ -567,7 +567,7 @@ class CommonTests:
             release = load_test_json('release.json')
             metadata = Metadata()
             release_to_metadata(release, metadata)
-            match = metadata.compare_to_release(release, Cluster.comparison_weights)
+            match = metadata.compare_to_release(release, CLUSTER_COMPARISON_WEIGHTS)
             self.assertEqual(1.0, match.similarity)
             self.assertEqual(release, match.release)
 
@@ -577,7 +577,7 @@ class CommonTests:
             release_to_metadata(release, metadata)
             for score, sim in ((42, 0.42), ('42', 0.42), ('foo', 1.0), (None, 1.0)):
                 release['score'] = score
-                match = metadata.compare_to_release(release, Cluster.comparison_weights)
+                match = metadata.compare_to_release(release, CLUSTER_COMPARISON_WEIGHTS)
                 self.assertEqual(sim, match.similarity)
 
         def test_compare_to_release_parts_totaltracks(self):
@@ -667,7 +667,7 @@ class CommonTests:
             track_json = load_test_json('track.json')
             track = Track(track_json['id'])
             track_to_metadata(track_json, track)
-            match = track.metadata.compare_to_track(track_json, File.comparison_weights)
+            match = track.metadata.compare_to_track(track_json, FILE_COMPARISON_WEIGHTS)
             self.assertEqual(1.0, match.similarity)
             self.assertEqual(track_json, match.track)
 
@@ -677,7 +677,7 @@ class CommonTests:
             track_to_metadata(track_json, track)
             for score, sim in ((42, 0.42), ('42', 0.42), ('foo', 1.0), (None, 1.0)):
                 track_json['score'] = score
-                match = track.metadata.compare_to_track(track_json, File.comparison_weights)
+                match = track.metadata.compare_to_track(track_json, FILE_COMPARISON_WEIGHTS)
                 self.assertEqual(sim, match.similarity)
 
         def test_compare_to_track_is_video(self):
@@ -703,7 +703,7 @@ class CommonTests:
                 'albumartist': 'Tim Green',
                 'tracknumber': '4',
             })
-            match = m.compare_to_track(recording, File.comparison_weights)
+            match = m.compare_to_track(recording, FILE_COMPARISON_WEIGHTS)
             self.assertGreaterEqual(match.similarity, 0.8)
             self.assertEqual(recording, match.track)
             self.assertEqual(recording['releases'][0], match.release)
@@ -720,9 +720,9 @@ class CommonTests:
                 'title': 'Nina',
             })
             track.metadata.length = 225000
-            m1 = track.metadata.compare_to_track(track_json, File.comparison_weights)
+            m1 = track.metadata.compare_to_track(track_json, FILE_COMPARISON_WEIGHTS)
             del track_json['releases']
-            m2 = track.metadata.compare_to_track(track_json, File.comparison_weights)
+            m2 = track.metadata.compare_to_track(track_json, FILE_COMPARISON_WEIGHTS)
             self.assertGreater(m1.similarity, m2.similarity,
                                'Matching score for release with recordings must be higher then for release without')
 


### PR DESCRIPTION
- it reduces the size of Cluster and File objects
- those are constant

It doesn't seem any plugin uses this.