### PR TITLE
Refactor ReleaseGroup._parse_versions()

### DIFF
--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -45,6 +45,17 @@ from picard.util import (
 
 
 VERSIONS_MAX_TRACKS = 10
+VERSIONS_NAME_KEYS = ('tracks', 'year', 'country', 'format', 'label', 'catnum')
+VERSIONS_HEADINGS = {
+    'tracks':   N_("Tracks"),
+    'year':     N_("Year"),
+    'country':  N_("Country"),
+    'format':   N_("Format"),
+    'label':    N_("Label"),
+    'catnum':   N_("Cat No"),
+}
+# additional keys displayed only for disambiguation
+VERSIONS_EXTRA_KEYS = ('packaging', 'barcode', 'disambiguation')
 
 
 def prepare_releases_for_versions(releases):
@@ -81,19 +92,6 @@ def prepare_releases_for_versions(releases):
             'countries': countries,
             'formats': formats,
         }
-
-
-VERSIONS_NAME_KEYS = ('tracks', 'year', 'country', 'format', 'label', 'catnum')
-VERSIONS_HEADINGS = {
-    'tracks':   N_("Tracks"),
-    'year':     N_("Year"),
-    'country':  N_("Country"),
-    'format':   N_("Format"),
-    'label':    N_("Label"),
-    'catnum':   N_("Cat No"),
-}
-# additional keys displayed only for disambiguation
-VERSIONS_EXTRA_KEYS = ('packaging', 'barcode', 'disambiguation')
 
 
 class ReleaseGroup(DataObject):

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -116,7 +116,7 @@ class ReleaseGroup(DataObject):
         try:
             releases = document['releases']
         except (TypeError, KeyError):
-            releases = []
+            return
 
         versions = defaultdict(list)
 

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -101,7 +101,7 @@ class ReleaseGroup(DataObject):
         self.metadata = Metadata()
         self.loaded = False
         self.versions = []
-        self.version_headings = ''
+        self.version_headings = " / ".join(_(VERSIONS_HEADINGS[k]) for k in VERSIONS_NAME_KEYS)
         self.loaded_albums = set()
         self.refcount = 0
 
@@ -149,7 +149,6 @@ class ReleaseGroup(DataObject):
                     'formats': release['formats'],
                 }
                 self.versions.append(version)
-        self.version_headings = " / ".join(_(VERSIONS_HEADINGS[k]) for k in VERSIONS_NAME_KEYS)
 
     def _request_finished(self, callback, document, http, error):
         try:

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -44,7 +44,7 @@ from picard.util import (
 )
 
 
-def releases_to_versions(releases):
+def prepare_releases_for_versions(releases):
     max_tracks = 10
     for node in releases:
         labels, catnums = label_info_from_node(node['label-info'])
@@ -120,7 +120,7 @@ class ReleaseGroup(DataObject):
         versions = defaultdict(list)
 
         # Group versions by same display name
-        for release in releases_to_versions(releases):
+        for release in prepare_releases_for_versions(releases):
             name = " / ".join(release[k] for k in namekeys)
             if name == release['tracks']:
                 name = "%s / %s" % (_('[no release info]'), name)

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -81,6 +81,19 @@ def prepare_releases_for_versions(releases):
         }
 
 
+VERSIONS_NAME_KEYS = ('tracks', 'year', 'country', 'format', 'label', 'catnum')
+VERSIONS_HEADINGS = {
+    'tracks':   N_("Tracks"),
+    'year':     N_("Year"),
+    'country':  N_("Country"),
+    'format':   N_("Format"),
+    'label':    N_("Label"),
+    'catnum':   N_("Cat No"),
+}
+# additional keys displayed only for disambiguation
+VERSIONS_EXTRA_KEYS = ('packaging', 'barcode', 'disambiguation')
+
+
 class ReleaseGroup(DataObject):
 
     def __init__(self, rg_id):
@@ -100,18 +113,6 @@ class ReleaseGroup(DataObject):
         """Parse document and return a list of releases"""
         del self.versions[:]
 
-        namekeys = ('tracks', 'year', 'country', 'format', 'label', 'catnum')
-        headings = {
-            'tracks':   N_("Tracks"),
-            'year':     N_("Year"),
-            'country':  N_("Country"),
-            'format':   N_("Format"),
-            'label':    N_("Label"),
-            'catnum':   N_("Cat No"),
-        }
-        # additional keys displayed only for disambiguation
-        extrakeys = ('packaging', 'barcode', 'disambiguation')
-
         try:
             releases = document['releases']
         except (TypeError, KeyError):
@@ -121,7 +122,7 @@ class ReleaseGroup(DataObject):
 
         # Group versions by same display name
         for release in prepare_releases_for_versions(releases):
-            name = " / ".join(release[k] for k in namekeys)
+            name = " / ".join(release[k] for k in VERSIONS_NAME_KEYS)
             if name == release['tracks']:
                 name = "%s / %s" % (_('[no release info]'), name)
             versions[name].append(release)
@@ -129,7 +130,7 @@ class ReleaseGroup(DataObject):
         # de-duplicate names if possible
         for name, releases in versions.items():
             for a, b in combinations(releases, 2):
-                for key in extrakeys:
+                for key in VERSIONS_EXTRA_KEYS:
                     (value1, value2) = (a[key], b[key])
                     if value1 != value2:
                         a['_disambiguate_name'].append(value1)
@@ -148,7 +149,7 @@ class ReleaseGroup(DataObject):
                     'formats': release['formats'],
                 }
                 self.versions.append(version)
-        self.version_headings = " / ".join(_(headings[k]) for k in namekeys)
+        self.version_headings = " / ".join(_(VERSIONS_HEADINGS[k]) for k in VERSIONS_NAME_KEYS)
 
     def _request_finished(self, callback, document, http, error):
         try:

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -128,8 +128,8 @@ class ReleaseGroup(DataObject):
             versions[name].append(release)
 
         # de-duplicate names if possible
-        for name, releases in versions.items():
-            for a, b in combinations(releases, 2):
+        for name in versions:
+            for a, b in combinations(versions[name], 2):
                 for key in VERSIONS_EXTRA_KEYS:
                     (value1, value2) = (a[key], b[key])
                     if value1 != value2:
@@ -137,8 +137,8 @@ class ReleaseGroup(DataObject):
                         b['_disambiguate_name'].append(value2)
 
         # build the final list of versions, using the disambiguation if needed
-        for name, releases in versions.items():
-            for release in releases:
+        for name in versions:
+            for release in versions[name]:
                 dis = " / ".join(filter(None, uniqify(release['_disambiguate_name'])))
                 disname = name if not dis else name + ' / ' + dis
                 version = {

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -44,8 +44,10 @@ from picard.util import (
 )
 
 
+VERSIONS_MAX_TRACKS = 10
+
+
 def prepare_releases_for_versions(releases):
-    max_tracks = 10
     for node in releases:
         labels, catnums = label_info_from_node(node['label-info'])
 
@@ -55,8 +57,8 @@ def prepare_releases_for_versions(releases):
         else:
             country_label = node.get('country', '') or '??'
 
-        if len(node['media']) > max_tracks:
-            tracks = "+".join(str(m['track-count']) for m in node['media'][:max_tracks]) + '+…'
+        if len(node['media']) > VERSIONS_MAX_TRACKS:
+            tracks = "+".join(str(m['track-count']) for m in node['media'][:VERSIONS_MAX_TRACKS]) + '+…'
         else:
             tracks = "+".join(str(m['track-count']) for m in node['media'])
         formats = []

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -45,7 +45,6 @@ from picard.util import (
 
 
 def releases_to_versions(releases):
-    data = []
     max_tracks = 10
     for node in releases:
         labels, catnums = label_info_from_node(node['label-info'])
@@ -64,7 +63,7 @@ def releases_to_versions(releases):
         for medium in node['media']:
             if 'format' in medium:
                 formats.append(medium['format'])
-        release = {
+        yield {
             'id':      node['id'],
             'year':    node['date'][:4] if 'date' in node else '????',
             'country': country_label,
@@ -80,8 +79,6 @@ def releases_to_versions(releases):
             'countries': countries,
             'formats': formats,
         }
-        data.append(release)
-    return data
 
 
 class ReleaseGroup(DataObject):

--- a/test/data/ws_data/release_group_5.json
+++ b/test/data/ws_data/release_group_5.json
@@ -1,0 +1,46 @@
+{
+    "release-offset": 0,
+    "releases": [
+        {
+            "id": "789",
+            "title": "Foox",
+            "status": "Official",
+            "country": "FR",
+            "date": "2009-08-07",
+            "barcode": "0123456789",
+            "text-representation": {
+                "language": "eng",
+                "script": "Latn"
+            },
+            "media": [
+                {
+                    "track-count": 2,
+                    "position": 1,
+                    "format": "CD",
+                    "title": ""
+                },
+                {
+                    "track-count": 3,
+                    "position": 2,
+                    "format": "CD",
+                    "title": ""
+                },
+                {
+                    "track-count": 4,
+                    "position": 3,
+                    "format": "CD",
+                    "title": ""
+                }
+            ],
+            "label-info": [
+                {
+                    "label": {
+                        "name": "label A"
+                    },
+                    "catalog-number": "cat 123"
+                }
+            ]
+        }
+    ],
+    "release-count": 1
+}

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -23,13 +23,17 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from unittest.mock import patch
 
 from test.picardtestcase import (
     PicardTestCase,
     load_test_json,
 )
 
-from picard.releasegroup import ReleaseGroup
+from picard.releasegroup import (
+    ReleaseGroup,
+    prepare_releases_for_versions,
+)
 
 
 settings = {
@@ -45,6 +49,13 @@ class ReleaseTest(PicardTestCase):
     def test_1(self):
         self.set_config_values(settings)
         rlist = load_test_json('release_group_2.json')
+        releases = list(prepare_releases_for_versions(rlist['releases']))
+        expected = [
+            {'id': '123', 'year': '2009', 'country': 'GB', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': 'Jewel Case', 'disambiguation': 'special', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+            {'id': '456', 'year': '2009', 'country': 'GB', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': 'Digipak', 'disambiguation': 'special', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+            {'id': '789', 'year': '2009', 'country': 'GB', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': 'Digipak', 'disambiguation': 'specialx', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+        ]
+        self.assertEqual(releases, expected)
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],
@@ -57,6 +68,12 @@ class ReleaseTest(PicardTestCase):
     def test_2(self):
         self.set_config_values(settings)
         rlist = load_test_json('release_group_3.json')
+        releases = list(prepare_releases_for_versions(rlist['releases']))
+        expected = [
+            {'id': '789', 'year': '2011', 'country': 'FR', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': '??', 'disambiguation': 'special A', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+            {'id': '789', 'year': '2011', 'country': 'FR', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': '??', 'disambiguation': '', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+        ]
+        self.assertEqual(releases, expected)
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],
@@ -67,9 +84,35 @@ class ReleaseTest(PicardTestCase):
     def test_3(self):
         self.set_config_values(settings)
         rlist = load_test_json('release_group_4.json')
+        releases = list(prepare_releases_for_versions(rlist['releases']))
+        expected = [
+            {'id': '789', 'year': '2009', 'country': 'FR', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '0123456789', 'packaging': '??', 'disambiguation': '', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+            {'id': '789', 'year': '2009', 'country': 'FR', 'format': 'CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '5', 'barcode': '[no barcode]', 'packaging': '??', 'disambiguation': '', '_disambiguate_name': [], 'totaltracks': 5, 'countries': [], 'formats': ['CD']},
+        ]
+        self.assertEqual(releases, expected)
         r = ReleaseGroup(1)
         r._parse_versions(rlist)
         self.assertEqual(r.versions[0]['name'],
                          '5 / 2009 / FR / CD / label A / cat 123 / 0123456789')
         self.assertEqual(r.versions[1]['name'],
                          '5 / 2009 / FR / CD / label A / cat 123 / [no barcode]')
+
+    @patch('picard.releasegroup.VERSIONS_MAX_TRACKS', 2)
+    def test_4(self):
+        self.set_config_values(settings)
+        rlist = load_test_json('release_group_5.json')
+        releases = list(prepare_releases_for_versions(rlist['releases']))
+        expected = [
+            {'id': '789', 'year': '2009', 'country': 'FR', 'format': '3×CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '2+3+…', 'barcode': '0123456789', 'packaging': '??', 'disambiguation': '', '_disambiguate_name': [], 'totaltracks': 9, 'countries': [], 'formats': ['CD', 'CD', 'CD']},
+        ]
+        self.assertEqual(releases, expected)
+
+    @patch('picard.releasegroup.VERSIONS_MAX_TRACKS', 3)
+    def test_5(self):
+        self.set_config_values(settings)
+        rlist = load_test_json('release_group_5.json')
+        releases = list(prepare_releases_for_versions(rlist['releases']))
+        expected = [
+            {'id': '789', 'year': '2009', 'country': 'FR', 'format': '3×CD', 'label': 'label A', 'catnum': 'cat 123', 'tracks': '2+3+4', 'barcode': '0123456789', 'packaging': '??', 'disambiguation': '', '_disambiguate_name': [], 'totaltracks': 9, 'countries': [], 'formats': ['CD', 'CD', 'CD']},
+        ]
+        self.assertEqual(releases, expected)


### PR DESCRIPTION
- reduce size of the method, moving part of the code outside the class
- use constants at module level
- code cleanup