### PR TITLE
Configure cache size from environ

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -34,6 +34,7 @@
 
 import builtins
 from collections import OrderedDict
+import os
 
 from picard import PICARD_VERSION
 from picard.const import appdirs
@@ -49,7 +50,11 @@ USER_DIR = appdirs.config_folder()
 USER_PLUGIN_DIR = appdirs.plugin_folder()
 
 # Network Cache default settings
-CACHE_SIZE_IN_BYTES = 100*1000*1000
+CACHE_SIZE_IN_BYTES = os.environ.get('PICARD_CACHE_SIZE', '').strip()
+if CACHE_SIZE_IN_BYTES.isdigit():
+    CACHE_SIZE_IN_BYTES = int(CACHE_SIZE_IN_BYTES)
+else:
+    CACHE_SIZE_IN_BYTES = 100*1000*1000
 
 # AcoustID client API key
 ACOUSTID_KEY = 'v8pQ6oyB'


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Configure network cache size from env.

# Problem

When tagging large libraries, 100M cache is not enough. After tagging 25K files, cache size was about 8GB. In addition I suspect that after cache overflow picard silently crashes, so you can't just leave library lookup for a night and have tagged songs in the morning.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Environmental variable `PICARD_CACHE_SIZE` to configure cache size, defaults to stock `100M`.

# Action

Check if it is a good approach to use env when also using env for cache location