### PR TITLE
Fix inconsistency in picard_module_path

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -53,6 +53,9 @@ if IS_FROZEN:
 else:
     picard_module_path = Path(PathFinder().find_spec('picard').origin).resolve()
 
+if not picard_module_path.is_dir():
+    picard_module_path = picard_module_path.parent
+
 _MAX_TAIL_LEN = 10**6
 
 
@@ -170,7 +173,7 @@ def name_filter(record):
     # to avoid the exception handling.
     if path.is_absolute():
         try:
-            path = path.resolve().relative_to(picard_module_path.parent)
+            path = path.resolve().relative_to(picard_module_path)
         except ValueError:
             pass
     parts = list(path.parts)

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -139,17 +139,17 @@ class NameFilterTestRel(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='/path1/path2/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module/file')
+        self.assertEqual(record.name, 'module/file')
 
     def test_2(self):
         record = FakeRecord(name=None, pathname='/path1/path2/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module')
+        self.assertEqual(record.name, 'module')
 
     def test_3(self):
         record = FakeRecord(name=None, pathname='/path1/path2/module/subpath/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module/subpath/file')
+        self.assertEqual(record.name, 'module/subpath/file')
 
     def test_4(self):
         record = FakeRecord(name=None, pathname='')
@@ -159,7 +159,7 @@ class NameFilterTestRel(PicardTestCase):
     def test_5(self):
         record = FakeRecord(name=None, pathname='/path1/path2/__init__/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/__init__/module')
+        self.assertEqual(record.name, '__init__/module')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -204,17 +204,17 @@ class NameFilterTestRelWin(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='C:/path1/path2/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module/file')
+        self.assertEqual(record.name, 'module/file')
 
     def test_2(self):
         record = FakeRecord(name=None, pathname='C:/path1/path2/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module')
+        self.assertEqual(record.name, 'module')
 
     def test_3(self):
         record = FakeRecord(name=None, pathname='C:/path1/path2/module/subpath/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/module/subpath/file')
+        self.assertEqual(record.name, 'module/subpath/file')
 
     def test_4(self):
         record = FakeRecord(name=None, pathname='')
@@ -224,7 +224,7 @@ class NameFilterTestRelWin(PicardTestCase):
     def test_5(self):
         record = FakeRecord(name=None, pathname='C:/path1/path2/__init__/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/__init__/module')
+        self.assertEqual(record.name, '__init__/module')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")


### PR DESCRIPTION
`picard_module_path` can be a file path or a dir path. When it's a frozen package, that's always a directory, and when running from source it is always a file path.

Ensure it is always a directory (that is the parent of the file path if it happens)

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
