### PR TITLE
Update plugin path shortening logic

### DIFF
--- a/picard/log.py
+++ b/picard/log.py
@@ -184,6 +184,7 @@ def name_filter(record):
         try:
             path = path.resolve().relative_to(USER_PLUGIN_DIR)
             parts = list(p for p in path.parts if not p.endswith('.zip'))
+            parts.insert(0, 'plugins')
             path = Path(*parts)
         except ValueError:
             pass

--- a/picard/log.py
+++ b/picard/log.py
@@ -10,6 +10,7 @@
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2021 Gabriel Ferreira
+# Copyright (C) 2024 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -41,6 +42,7 @@ from threading import Lock
 
 from PyQt6 import QtCore
 
+from picard.const import USER_PLUGIN_DIR
 from picard.const.sys import (
     FROZEN_TEMP_PATH,
     IS_FROZEN,
@@ -177,11 +179,15 @@ def name_filter(record):
             path = path.resolve().relative_to(picard_module_path)
         except ValueError:
             pass
-        else:
-            if not DebugOpt.PLUGIN_FULLPATH.enabled and 'plugins' in path.parts:
-                parts = list(reversed(path.parts))
-                parts = parts[:parts.index('plugins') + 1]
-                path = Path(*reversed(parts))
+
+    if path.is_absolute() and not DebugOpt.PLUGIN_FULLPATH.enabled:
+        try:
+            path = path.resolve().relative_to(USER_PLUGIN_DIR)
+            parts = list(p for p in path.parts if not p.endswith('.zip'))
+            parts.insert(0, 'plugins')
+            path = Path(*parts)
+        except ValueError:
+            pass
 
     parts = list(path.parts)
     if parts[-1] == '__init__':

--- a/picard/log.py
+++ b/picard/log.py
@@ -183,7 +183,7 @@ def name_filter(record):
     if path.is_absolute() and not DebugOpt.PLUGIN_FULLPATH.enabled:
         try:
             path = path.resolve().relative_to(USER_PLUGIN_DIR)
-            parts = list(p for p in path.parts if not p.endswith('.zip'))
+            parts = list(path.parts)
             parts.insert(0, 'plugins')
             path = Path(*parts)
         except ValueError:
@@ -194,6 +194,11 @@ def name_filter(record):
         del parts[-1]
     if parts[0] == path.anchor:
         parts[0] = '/'
+    # Remove the plugin module file if the file name is the same as
+    # the immediately preceeding plugin zip file name, similar to the
+    # way that the final `__init__.py` file is removed.
+    if len(parts) > 1 and parts[-1] + '.zip' == parts[-2]:
+        del parts[-1]
     record.name = str(PurePosixPath(*parts))
     return True
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -184,7 +184,6 @@ def name_filter(record):
         try:
             path = path.resolve().relative_to(USER_PLUGIN_DIR)
             parts = list(p for p in path.parts if not p.endswith('.zip'))
-            parts.insert(0, 'plugins')
             path = Path(*parts)
         except ValueError:
             pass
@@ -193,7 +192,7 @@ def name_filter(record):
     if parts[-1] == '__init__':
         del parts[-1]
     if parts[0] == path.anchor:
-        del parts[0]
+        parts[0] = '/'
     record.name = str(PurePosixPath(*parts))
     return True
 

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -168,25 +168,25 @@ class NameFilterTestRel(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
         record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/plugin.zip/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/plugin.zip/xxx')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/plugin')
+        self.assertEqual(record.name, 'plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/plugin')
+        self.assertEqual(record.name, 'xxx')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -197,17 +197,17 @@ class NameFilterTestAbs(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='/path/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module/file')
+        self.assertEqual(record.name, '/path/module/file')
 
     def test_2(self):
         record = FakeRecord(name=None, pathname='/path/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module')
+        self.assertEqual(record.name, '/path/module')
 
     def test_3(self):
         record = FakeRecord(name=None, pathname='/path/module/subpath/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module/subpath/file')
+        self.assertEqual(record.name, '/path/module/subpath/file')
 
     def test_4(self):
         record = FakeRecord(name=None, pathname='')
@@ -218,25 +218,25 @@ class NameFilterTestAbs(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
         record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin.zip/xxx')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'path2/plugins/xxx')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -247,7 +247,7 @@ class NameFilterTestEndingSlash(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='/path3/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path3/module/file')
+        self.assertEqual(record.name, '/path3/module/file')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
@@ -284,25 +284,25 @@ class NameFilterTestRelWin(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path3/plugins/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path3/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path3/plugins/plugin.zip/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path3/plugins/plugin.zip/xxx')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
+        self.assertEqual(record.name, 'path3/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
+        self.assertEqual(record.name, 'path3/plugins/xxx')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
@@ -313,17 +313,17 @@ class NameFilterTestAbsWin(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='C:/path/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module/file')
+        self.assertEqual(record.name, '/path/module/file')
 
     def test_2(self):
         record = FakeRecord(name=None, pathname='C:/path/module/__init__.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module')
+        self.assertEqual(record.name, '/path/module')
 
     def test_3(self):
         record = FakeRecord(name=None, pathname='C:/path/module/subpath/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path/module/subpath/file')
+        self.assertEqual(record.name, '/path/module/subpath/file')
 
     def test_4(self):
         record = FakeRecord(name=None, pathname='')
@@ -334,25 +334,25 @@ class NameFilterTestAbsWin(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin.zip/xxx')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'path2/plugins/xxx')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
@@ -363,4 +363,4 @@ class NameFilterTestEndingSlashWin(PicardTestCase):
     def test_1(self):
         record = FakeRecord(name=None, pathname='C:/path3/module/file.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path3/module/file')
+        self.assertEqual(record.name, '/path3/module/file')

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -180,13 +180,13 @@ class NameFilterTestRel(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugin')
+        self.assertEqual(record.name, 'plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'xxx')
+        self.assertEqual(record.name, 'plugins/xxx')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -230,13 +230,13 @@ class NameFilterTestAbs(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/plugins/plugin')
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/plugins/xxx')
+        self.assertEqual(record.name, 'plugins/path2/plugins/xxx')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -296,13 +296,13 @@ class NameFilterTestRelWin(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path3/plugins/plugin')
+        self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path3/plugins/xxx')
+        self.assertEqual(record.name, 'plugins/path3/plugins/xxx')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
@@ -346,13 +346,13 @@ class NameFilterTestAbsWin(PicardTestCase):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/plugins/plugin')
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
         record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/xxx')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path2/plugins/xxx')
+        self.assertEqual(record.name, 'plugins/path2/plugins/xxx')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -3,8 +3,9 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2021 Gabriel Ferreira
-# Copyright (C) 2021 Laurent Monin
+# Copyright (C) 2021, 2024 Laurent Monin
 # Copyright (C) 2021 Philipp Wolfer
+# Copyright (C) 2024 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -135,6 +136,7 @@ class FakeRecord:
 
 @unittest.skipIf(IS_WIN, "Posix test")
 @patch('picard.log.picard_module_path', PurePosixPath('/path1/path2'))
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('/user/picard/plugins'))
 class NameFilterTestRel(PicardTestCase):
 
     def test_1(self):
@@ -162,21 +164,34 @@ class NameFilterTestRel(PicardTestCase):
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, '__init__/module')
 
-    def test_plugin_path_long(self):
+    def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/path1/path2/plugins/path3/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
+        self.assertEqual(record.name, 'user/picard/plugins/plugin')
 
-    def test_plugin_path_short(self):
+    def test_plugin_path_long_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = True
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/plugin')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'user/picard/plugins/plugin.zip/plugin')
+
+    def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/path1/path2/plugins/path3/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/plugin')
+
+    def test_plugin_path_short_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/plugin')
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, 'plugins/plugin')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
 @patch('picard.log.picard_module_path', PurePosixPath('/picard'))
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('/user/picard/plugins/'))
 class NameFilterTestAbs(PicardTestCase):
 
     def test_1(self):
@@ -199,21 +214,34 @@ class NameFilterTestAbs(PicardTestCase):
         with self.assertRaises(ValueError):
             name_filter(record)
 
-    def test_plugin_path_long(self):
+    def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/path1/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path1/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin')
 
-    def test_plugin_path_short(self):
-        DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/path1/plugins/path2/plugins/plugin.zip')
+    def test_plugin_path_long_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = True
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/plugin')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path1/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin.zip/plugin')
+
+    def test_plugin_path_short_1(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+
+    def test_plugin_path_short_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
 @patch('picard.log.picard_module_path', PurePosixPath('/path1/path2/'))  # incorrect, but testing anyway
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('/user/picard/plugins'))
 class NameFilterTestEndingSlash(PicardTestCase):
 
     def test_1(self):
@@ -223,7 +251,8 @@ class NameFilterTestEndingSlash(PicardTestCase):
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
-@patch('picard.log.picard_module_path', PureWindowsPath('C:/path1/path2'))
+@patch('picard.log.picard_module_path', PureWindowsPath('C:\\path1\\path2'))
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('C:\\user\\picard\\plugins'))
 class NameFilterTestRelWin(PicardTestCase):
 
     def test_1(self):
@@ -251,21 +280,34 @@ class NameFilterTestRelWin(PicardTestCase):
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, '__init__/module')
 
-    def test_plugin_path_long(self):
+    def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/path3/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'user/picard/plugins/path3/plugins/plugin')
+
+    def test_plugin_path_long_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = True
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/plugin')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'user/picard/plugins/path3/plugins/plugin.zip/plugin')
+
+    def test_plugin_path_short_1(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
 
-    def test_plugin_path_short(self):
+    def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/path3/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/plugin')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/plugin')
+        self.assertEqual(record.name, 'plugins/path3/plugins/plugin')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
-@patch('picard.log.picard_module_path', PureWindowsPath('C:/picard'))
+@patch('picard.log.picard_module_path', PureWindowsPath('C:\\picard'))
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('C:\\user\\picard/plugins'))
 class NameFilterTestAbsWin(PicardTestCase):
 
     def test_1(self):
@@ -288,21 +330,34 @@ class NameFilterTestAbsWin(PicardTestCase):
         with self.assertRaises(ValueError):
             name_filter(record)
 
-    def test_plugin_path_long(self):
+    def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/path1/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path1/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin')
 
-    def test_plugin_path_short(self):
-        DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/path1/plugins/path2/plugins/plugin.zip')
+    def test_plugin_path_long_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = True
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/plugin')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'path1/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, 'user/picard/plugins/path2/plugins/plugin.zip/plugin')
+
+    def test_plugin_path_short_1(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+
+    def test_plugin_path_short_2(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/plugin')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
-@patch('picard.log.picard_module_path', PureWindowsPath('C:/path1/path2/'))  # incorrect, but testing anyway
+@patch('picard.log.picard_module_path', PureWindowsPath('C:\\path1\\path2\\'))  # incorrect, but testing anyway
+@patch('picard.log.USER_PLUGIN_DIR', PurePosixPath('C:\\user\\picard\\plugins'))
 class NameFilterTestEndingSlashWin(PicardTestCase):
 
     def test_1(self):

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -172,7 +172,7 @@ class NameFilterTestRel(PicardTestCase):
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, '/user/picard/plugins/plugin.zip/xxx')
 
@@ -184,9 +184,21 @@ class NameFilterTestRel(PicardTestCase):
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/xxx')
+        self.assertEqual(record.name, 'plugins/plugin.zip/xxx')
+
+    def test_plugin_path_short_3(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/myplugin.zip/myplugin.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/myplugin.zip')
+
+    def test_plugin_path_short_4(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/user/picard/plugins/myplugin.zip/__init__.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/myplugin.zip')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -216,27 +228,45 @@ class NameFilterTestAbs(PicardTestCase):
 
     def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin.zip/xxx')
+
+    def test_plugin_path_long_3(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = True
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/plugin.zip/__init__.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin.zip')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/xxx')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin.zip/xxx')
+
+    def test_plugin_path_short_3(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/myplugin.zip/myplugin.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, '/path1/path2/plugins/myplugin.zip')
+
+    def test_plugin_path_short_4(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='/path1/path2/plugins/myplugin.zip/__init__.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, '/path1/path2/plugins/myplugin.zip')
 
 
 @unittest.skipIf(IS_WIN, "Posix test")
@@ -288,7 +318,7 @@ class NameFilterTestRelWin(PicardTestCase):
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, '/user/picard/plugins/path3/plugins/plugin.zip/xxx')
 
@@ -300,9 +330,21 @@ class NameFilterTestRelWin(PicardTestCase):
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path3/plugins/xxx')
+        self.assertEqual(record.name, 'plugins/path3/plugins/plugin.zip/xxx')
+
+    def test_plugin_path_short_3(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/myplugin.zip/myplugin.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path3/plugins/myplugin.zip')
+
+    def test_plugin_path_short_4(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path3/plugins/myplugin.zip/__init__.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, 'plugins/path3/plugins/myplugin.zip')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")
@@ -332,27 +374,39 @@ class NameFilterTestAbsWin(PicardTestCase):
 
     def test_plugin_path_long_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin')
 
     def test_plugin_path_long_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = True
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, '/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin.zip/xxx')
 
     def test_plugin_path_short_1(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip')
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/plugin.zip')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/plugin')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin')
 
     def test_plugin_path_short_2(self):
         DebugOpt.PLUGIN_FULLPATH.enabled = False
-        record = FakeRecord(name=None, pathname='C:/user/picard/plugins/path2/plugins/plugin.zip/xxx')
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/plugin.zip/xxx.py')
         self.assertTrue(name_filter(record))
-        self.assertEqual(record.name, 'plugins/path2/plugins/xxx')
+        self.assertEqual(record.name, '/path1/path2/plugins/plugin.zip/xxx')
+
+    def test_plugin_path_short_3(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/myplugin.zip/myplugin.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, '/path1/path2/plugins/myplugin.zip')
+
+    def test_plugin_path_short_4(self):
+        DebugOpt.PLUGIN_FULLPATH.enabled = False
+        record = FakeRecord(name=None, pathname='C:/path1/path2/plugins/myplugin.zip/__init__.py')
+        self.assertTrue(name_filter(record))
+        self.assertEqual(record.name, '/path1/path2/plugins/myplugin.zip')
 
 
 @unittest.skipUnless(IS_WIN, "Windows test")


### PR DESCRIPTION

# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Further to the discussion in https://github.com/metabrainz/picard/pull/2397 this PR modifies the way that plugin paths are displayed in the logs.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Shorten the path by making it relative to the path stored in the `picard.const.USER_PLUGIN_DIR` variable if possible.

# Action

None.