### PR TITLE
Build SETTINGS_GROUPS from Options pages

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -187,6 +187,8 @@ class SettingConfigSection(ConfigSection):
         opt = Option.get(self.__name, name)
         if opt is None:
             return None
+        if opt.title is not None and name not in UserProfileGroups.ALL_SETTINGS:
+            log.debug("Option %s has a title (%s), but it isn't in UserProfileGroups", opt.name, opt.title)
         return self.value(name, opt, opt.default)
 
     def __setitem__(self, name, value):
@@ -384,6 +386,12 @@ class Option(QtCore.QObject):
         self.registry[key] = self
 
     @classmethod
+    def getall(cls, section=None):
+        for opt in cls.registry.values():
+            if section is None or opt.section == section:
+                yield opt
+
+    @classmethod
     def get(cls, section, name):
         return cls.registry.get((section, name))
 
@@ -461,7 +469,7 @@ def setup_config(app, filename=None):
     setting = config.setting
     persist = config.persist
     profiles = config.profiles
-    UserProfileGroups.initialize()
+    UserProfileGroups.initialize(config)
 
 
 def get_config():

--- a/picard/config.py
+++ b/picard/config.py
@@ -41,7 +41,10 @@ from picard import (
     PICARD_VERSION,
     log,
 )
-from picard.profile import UserProfileGroups
+from picard.profile import (
+    UserProfileGroups,
+    init_settings_groups,
+)
 from picard.version import Version
 
 
@@ -461,6 +464,7 @@ def setup_config(app, filename=None):
     setting = config.setting
     persist = config.persist
     profiles = config.profiles
+    init_settings_groups()
 
 
 def get_config():

--- a/picard/config.py
+++ b/picard/config.py
@@ -41,10 +41,7 @@ from picard import (
     PICARD_VERSION,
     log,
 )
-from picard.profile import (
-    UserProfileGroups,
-    init_settings_groups,
-)
+from picard.profile import UserProfileGroups
 from picard.version import Version
 
 
@@ -464,7 +461,7 @@ def setup_config(app, filename=None):
     setting = config.setting
     persist = config.persist
     profiles = config.profiles
-    init_settings_groups()
+    UserProfileGroups.initialize()
 
 
 def get_config():

--- a/picard/config.py
+++ b/picard/config.py
@@ -371,7 +371,7 @@ class Option(QtCore.QObject):
     registry = {}
     qtype = None
 
-    def __init__(self, section, name, default, title=None):
+    def __init__(self, section, name, default, title=None, highlight=None):
         key = (section, name)
         if key in self.registry:
             raise OptionError("Already declared", section, name)
@@ -379,6 +379,7 @@ class Option(QtCore.QObject):
         self.section = section
         self.name = name
         self.default = default
+        self.highlight = highlight
         self.title = title
         self.registry[key] = self
 

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -52,28 +52,28 @@ class UserProfileGroups():
         """
         yield from cls.SETTINGS_GROUPS
 
+    @classmethod
+    def initialize(cls):
+        from picard.ui.options import _pages as page_classes
 
-def init_settings_groups():
-    from picard.ui.options import _pages as page_classes
+        def _all_pages(parent=None):
+            pages = [p for p in page_classes if p.PARENT == parent]
+            for page in sorted(pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
+                yield page
+                yield from _all_pages(page.NAME)
 
-    def _all_pages(parent=None):
-        pages = [p for p in page_classes if p.PARENT == parent]
-        for page in sorted(pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
-            yield page
-            yield from _all_pages(page.NAME)
+        for page in _all_pages():
+            settings = []
+            for opt in page.options:
+                if opt.title is not None:
+                    settings.append(SettingDesc(opt.name, opt.highlight))
+            if settings:
+                cls.SETTINGS_GROUPS[page.NAME] = {
+                    'title': page.TITLE,
+                    'settings': settings,
+                }
 
-    for page in _all_pages():
-        settings = []
-        for opt in page.options:
-            if opt.title is not None:
-                settings.append(SettingDesc(opt.name, opt.highlight))
-        if settings:
-            UserProfileGroups.SETTINGS_GROUPS[page.NAME] = {
-                'title': page.TITLE,
-                'settings': settings,
-            }
-
-    UserProfileGroups.ALL_SETTINGS = set(
-        s.name for group in UserProfileGroups.SETTINGS_GROUPS.values()
-        for s in group['settings']
-    )
+        cls.ALL_SETTINGS = set(
+            s.name for group in cls.SETTINGS_GROUPS.values()
+            for s in group['settings']
+        )

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -41,223 +41,7 @@ class UserProfileGroups():
     """
     SETTINGS_GROUPS = OrderedDict()  # Add groups in the order they should be displayed
 
-    # Each item in "settings" is a tuple of the setting key, the display title, and a list of the names of the widgets to highlight
-    SETTINGS_GROUPS['general'] = {
-        'title': N_("General"),
-        'settings': [
-            SettingDesc('server_host', ['server_host']),
-            SettingDesc('server_port', ['server_port']),
-            SettingDesc('analyze_new_files', ['analyze_new_files']),
-            SettingDesc('cluster_new_files', ['cluster_new_files']),
-            SettingDesc('ignore_file_mbids', ['ignore_file_mbids']),
-            SettingDesc('check_for_plugin_updates', ['check_for_plugin_updates']),
-            SettingDesc('check_for_updates', ['check_for_updates']),
-            SettingDesc('update_check_days', ['update_check_days']),
-            SettingDesc('update_level', ['update_level']),
-        ],
-    }
-
-    SETTINGS_GROUPS['metadata'] = {
-        'title': N_("Metadata"),
-        'settings': [
-            # Main Metadata Page
-            SettingDesc('translate_artist_names', ['translate_artist_names']),
-            SettingDesc('artist_locales', ['selected_locales']),
-            SettingDesc('translate_artist_names_script_exception', ['translate_artist_names_script_exception']),
-            SettingDesc('script_exceptions', ['selected_scripts']),
-            SettingDesc('standardize_artists', ['standardize_artists']),
-            SettingDesc('standardize_instruments', ['standardize_instruments']),
-            SettingDesc('convert_punctuation', ['convert_punctuation']),
-            SettingDesc('release_ars', ['release_ars']),
-            SettingDesc('track_ars', ['track_ars']),
-            SettingDesc('guess_tracknumber_and_title', ['guess_tracknumber_and_title']),
-            SettingDesc('va_name', ['va_name']),
-            SettingDesc('nat_name', ['nat_name']),
-
-            # Preferred Releases Page
-            SettingDesc('release_type_scores', ['type_group']),
-            SettingDesc('preferred_release_countries', ['country_group']),
-            SettingDesc('preferred_release_formats', ['format_group']),
-
-            # Genres Page
-            SettingDesc('use_genres', []),  # No highlight specified because the 'use_genres'
-                                            # object is a QGroupBox and it highlights all sub
-                                            # options, even if the sub options are not selected.
-            SettingDesc('only_my_genres', ['only_my_genres']),
-            SettingDesc('artists_genres', ['artists_genres']),
-            SettingDesc('folksonomy_tags', ['folksonomy_tags']),
-            SettingDesc('min_genre_usage', ['min_genre_usage']),
-            SettingDesc('max_genres', ['max_genres']),
-            SettingDesc('join_genres', ['join_genres']),
-            SettingDesc('genres_filter', ['genres_filter']),
-
-            # Ratings Page
-            SettingDesc('enable_ratings', []),  # No highlight specified because the 'enable_ratings'
-                                                # object is a QGroupBox and it highlights all sub options,
-                                                # even if the sub options are not selected.
-            SettingDesc('rating_user_email', ['rating_user_email']),
-            SettingDesc('submit_ratings', ['submit_ratings']),
-        ],
-    }
-
-    SETTINGS_GROUPS['tags'] = {
-        'title': N_("Tags"),
-        'settings': [
-            # Main Tags Page
-            SettingDesc('dont_write_tags', ['write_tags']),
-            SettingDesc('preserve_timestamps', ['preserve_timestamps']),
-            SettingDesc('clear_existing_tags', ['clear_existing_tags']),
-            SettingDesc('preserve_images', ['preserve_images']),
-            SettingDesc('remove_id3_from_flac', ['remove_id3_from_flac']),
-            SettingDesc('remove_ape_from_mp3', ['remove_ape_from_mp3']),
-            SettingDesc('fix_missing_seekpoints_flac', ['fix_missing_seekpoints_flac']),
-            SettingDesc('preserved_tags', ['preserved_tags']),
-
-            # ID3 Tags Page
-            SettingDesc('write_id3v23', ['write_id3v23', 'write_id3v24']),
-            SettingDesc('id3v2_encoding', ['enc_utf8', 'enc_utf16', 'enc_iso88591']),
-            SettingDesc('id3v23_join_with', ['id3v23_join_with']),
-            SettingDesc('itunes_compatible_grouping', ['itunes_compatible_grouping']),
-            SettingDesc('write_id3v1', ['write_id3v1']),
-
-            # AAC Tags Page
-            SettingDesc('aac_save_ape', ['aac_save_ape', 'aac_no_tags']),
-            SettingDesc('remove_ape_from_aac', ['remove_ape_from_aac']),
-
-            # AC3 Tags Page
-            SettingDesc('ac3_save_ape', ['ac3_save_ape', 'ac3_no_tags']),
-            SettingDesc('remove_ape_from_ac3', ['remove_ape_from_ac3']),
-
-            # WAVE Tags Page
-            SettingDesc('write_wave_riff_info', ['write_wave_riff_info']),
-            SettingDesc('remove_wave_riff_info', ['remove_wave_riff_info']),
-            SettingDesc('wave_riff_info_encoding', ['wave_riff_info_enc_cp1252', 'wave_riff_info_enc_utf8']),
-        ],
-    }
-
-    SETTINGS_GROUPS['cover'] = {
-        'title': N_("Cover Art"),
-        'settings': [
-            SettingDesc('save_images_to_tags', ['save_images_to_tags']),
-            SettingDesc('embed_only_one_front_image', ['cb_embed_front_only']),
-            SettingDesc('save_images_to_files', ['save_images_to_files']),
-            SettingDesc('cover_image_filename', ['cover_image_filename']),
-            SettingDesc('save_images_overwrite', ['save_images_overwrite']),
-            SettingDesc('save_only_one_front_image', ['save_only_one_front_image']),
-            SettingDesc('image_type_as_filename', ['image_type_as_filename']),
-            SettingDesc('ca_providers', ['ca_providers_list']),
-        ],
-    }
-
-    SETTINGS_GROUPS['filerenaming'] = {
-        'title': N_("File Naming"),
-        'settings': [
-            # Main File Naming Page
-            SettingDesc('move_files', ['move_files']),
-            SettingDesc('move_files_to', ['move_files_to']),
-            SettingDesc('move_additional_files', ['move_additional_files']),
-            SettingDesc('move_additional_files_pattern', ['move_additional_files_pattern']),
-            SettingDesc('delete_empty_dirs', ['delete_empty_dirs']),
-            SettingDesc('rename_files', ['rename_files']),
-            SettingDesc('selected_file_naming_script_id', ['naming_script_selector']),
-
-            # File Naming Compatibility Page
-            SettingDesc('ascii_filenames', ['ascii_filenames']),
-            SettingDesc('windows_compatibility', ['windows_compatibility']),
-            SettingDesc('win_compat_replacements', ['win_compat_replacements']),
-            SettingDesc('windows_long_paths', ['windows_long_paths']),
-            SettingDesc('replace_spaces_with_underscores', ['replace_spaces_with_underscores']),
-            SettingDesc('replace_dir_separator', ['replace_dir_separator']),
-        ],
-    }
-
-    SETTINGS_GROUPS['scripting'] = {
-        'title': N_("Scripting"),
-        'settings': [
-            SettingDesc('enable_tagger_scripts', ['enable_tagger_scripts']),
-            SettingDesc('list_of_scripts', ['script_list']),
-        ],
-    }
-
-    SETTINGS_GROUPS['interface'] = {
-        'title': N_("User Interface"),
-        'settings': [
-            # Main User Interface Page
-            SettingDesc('toolbar_show_labels', ['toolbar_show_labels']),
-            SettingDesc('show_menu_icons', ['show_menu_icons']),
-            SettingDesc('ui_language', ['ui_language', 'label']),
-            SettingDesc('ui_theme', ['ui_theme', 'label_theme']),
-            SettingDesc('allow_multi_dirs_selection', ['allow_multi_dirs_selection']),
-            SettingDesc('builtin_search', ['builtin_search']),
-            SettingDesc('use_adv_search_syntax', ['use_adv_search_syntax']),
-            SettingDesc('show_new_user_dialog', ['new_user_dialog']),
-            SettingDesc('quit_confirmation', ['quit_confirmation']),
-            SettingDesc('file_save_warning', ['file_save_warning']),
-            SettingDesc('filebrowser_horizontal_autoscroll', ['filebrowser_horizontal_autoscroll']),
-            SettingDesc('starting_directory', ['starting_directory']),
-            SettingDesc('starting_directory_path', ['starting_directory_path']),
-
-            # User Interface Colors Page
-            SettingDesc('interface_colors', ['colors']),
-            SettingDesc('interface_colors_dark', ['colors']),
-
-            # User Interface Top Tags Page
-            SettingDesc('metadatabox_top_tags', ['top_tags_groupBox']),
-
-            # User Interface Action Toolbar Page
-            SettingDesc('toolbar_layout', ['toolbar_layout_list']),
-        ],
-    }
-
-    SETTINGS_GROUPS['advanced'] = {
-        'title': N_("Advanced"),
-        'settings': [
-            # Main Advanced Options Page
-            SettingDesc('ignore_regex', ['ignore_regex']),
-            SettingDesc('ignore_hidden_files', ['ignore_hidden_files']),
-            SettingDesc('recursively_add_files', ['recursively_add_files']),
-            SettingDesc(
-                'ignore_track_duration_difference_under',
-                ['ignore_track_duration_difference_under', 'label_track_duration_diff']
-            ),
-            SettingDesc(
-                'query_limit',
-                ['query_limit', 'label_query_limit']
-            ),
-            SettingDesc('completeness_ignore_videos', ['completeness_ignore_videos']),
-            SettingDesc('completeness_ignore_pregap', ['completeness_ignore_pregap']),
-            SettingDesc('completeness_ignore_data', ['completeness_ignore_data']),
-            SettingDesc('completeness_ignore_silence', ['completeness_ignore_silence']),
-            SettingDesc('compare_ignore_tags', ['groupBox_ignore_tags']),
-
-            # Network Options Page
-            SettingDesc('use_proxy', []),   # No highlight specified because the 'use_proxy'
-                                            # object is a QGroupBox and it highlights all sub
-                                            # options, even if the sub options are not selected.
-            SettingDesc('proxy_type', ['proxy_type_socks', 'proxy_type_http']),
-            SettingDesc('proxy_server_host', ['server_host']),
-            SettingDesc('proxy_server_port', ['server_port']),
-            SettingDesc('proxy_username', ['username']),
-            SettingDesc('proxy_password', ['password']),
-            SettingDesc('network_transfer_timeout_seconds', ['transfer_timeout']),
-            SettingDesc('network_cache_size_bytes', ['network_cache_size']),
-            SettingDesc('browser_integration', []),  # No highlight specified because the 'browser_integration'
-                                                     # object is a QGroupBox and it highlights all sub options,
-                                                     # even if the sub options are not selected.
-            SettingDesc('browser_integration_port', ['browser_integration_port']),
-            SettingDesc('browser_integration_localhost_only', ['browser_integration_localhost_only']),
-
-            # Matching Options Page
-            SettingDesc('file_lookup_threshold', ['file_lookup_threshold']),
-            SettingDesc('cluster_lookup_threshold', ['cluster_lookup_threshold']),
-            SettingDesc('track_matching_threshold', ['track_matching_threshold']),
-        ],
-    }
-
-    ALL_SETTINGS = set(
-        s.name for group in SETTINGS_GROUPS.values()
-        for s in group['settings']
-    )
+    ALL_SETTINGS = set()
 
     @classmethod
     def get_setting_groups_list(cls):
@@ -267,3 +51,29 @@ class UserProfileGroups():
             str: Key
         """
         yield from cls.SETTINGS_GROUPS
+
+
+def init_settings_groups():
+    from picard.ui.options import _pages as page_classes
+
+    def _all_pages(parent=None):
+        pages = [p for p in page_classes if p.PARENT == parent]
+        for page in sorted(pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
+            yield page
+            yield from _all_pages(page.NAME)
+
+    for page in _all_pages():
+        settings = []
+        for opt in page.options:
+            if opt.title is not None:
+                settings.append(SettingDesc(opt.name, opt.highlight))
+        if settings:
+            UserProfileGroups.SETTINGS_GROUPS[page.NAME] = {
+                'title': page.TITLE,
+                'settings': settings,
+            }
+
+    UserProfileGroups.ALL_SETTINGS = set(
+        s.name for group in UserProfileGroups.SETTINGS_GROUPS.values()
+        for s in group['settings']
+    )

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -115,6 +115,7 @@ from picard.pluginmanager import (
     PluginManager,
     plugin_dirs,
 )
+from picard.profile import init_settings_groups
 from picard.releasegroup import ReleaseGroup
 from picard.track import (
     NonAlbumTrack,
@@ -244,6 +245,7 @@ class Tagger(QtWidgets.QApplication):
         self.__class__.__instance = self
         setup_config(self, picard_args.config_file)
         config = get_config()
+        init_settings_groups()
         theme.setup(self)
 
         self._to_load = picard_args.processable

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -115,7 +115,6 @@ from picard.pluginmanager import (
     PluginManager,
     plugin_dirs,
 )
-from picard.profile import init_settings_groups
 from picard.releasegroup import ReleaseGroup
 from picard.track import (
     NonAlbumTrack,
@@ -245,7 +244,6 @@ class Tagger(QtWidgets.QApplication):
         self.__class__.__instance = self
         setup_config(self, picard_args.config_file)
         config = get_config()
-        init_settings_groups()
         theme.setup(self)
 
         self._to_load = picard_args.processable

--- a/picard/ui/options/advanced.py
+++ b/picard/ui/options/advanced.py
@@ -48,16 +48,16 @@ class AdvancedOptionsPage(OptionsPage):
     HELP_URL = "/config/options_advanced.html"
 
     options = [
-        TextOption('setting', 'ignore_regex', '', title=N_("Ignore file paths matching a regular expression")),
-        BoolOption('setting', 'ignore_hidden_files', False, title=N_("Ignore hidden files")),
-        BoolOption('setting', 'recursively_add_files', True, title=N_("Include sub-folders when adding files from folder")),
-        IntOption('setting', 'ignore_track_duration_difference_under', 2, title=N_("Ignore track duration difference under x seconds")),
-        IntOption('setting', 'query_limit', QUERY_LIMIT, title=N_("Maximum number of entities to return per MusicBrainz query")),
-        BoolOption('setting', 'completeness_ignore_videos', False, title=N_("Completeness check ignore: Video tracks")),
-        BoolOption('setting', 'completeness_ignore_pregap', False, title=N_("Completeness check ignore: Pregap tracks")),
-        BoolOption('setting', 'completeness_ignore_data', False, title=N_("Completeness check ignore: Data tracks")),
-        BoolOption('setting', 'completeness_ignore_silence', False, title=N_("Completeness check ignore: Silent tracks")),
-        ListOption('setting', 'compare_ignore_tags', [], title=N_("Tags to ignore for comparison")),
+        TextOption('setting', 'ignore_regex', '', title=N_("Ignore file paths matching a regular expression"), highlight=['ignore_regex']),
+        BoolOption('setting', 'ignore_hidden_files', False, title=N_("Ignore hidden files"), highlight=['ignore_hidden_files']),
+        BoolOption('setting', 'recursively_add_files', True, title=N_("Include sub-folders when adding files from folder"), highlight=['recursively_add_files']),
+        IntOption('setting', 'ignore_track_duration_difference_under', 2, title=N_("Ignore track duration difference under x seconds"), highlight=['ignore_track_duration_difference_under', 'label_track_duration_diff']),
+        IntOption('setting', 'query_limit', QUERY_LIMIT, title=N_("Maximum number of entities to return per MusicBrainz query"), highlight=['query_limit', 'label_query_limit']),
+        BoolOption('setting', 'completeness_ignore_videos', False, title=N_("Completeness check ignore: Video tracks"), highlight=['completeness_ignore_videos']),
+        BoolOption('setting', 'completeness_ignore_pregap', False, title=N_("Completeness check ignore: Pregap tracks"), highlight=['completeness_ignore_pregap']),
+        BoolOption('setting', 'completeness_ignore_data', False, title=N_("Completeness check ignore: Data tracks"), highlight=['completeness_ignore_data']),
+        BoolOption('setting', 'completeness_ignore_silence', False, title=N_("Completeness check ignore: Silent tracks"), highlight=['completeness_ignore_silence']),
+        ListOption('setting', 'compare_ignore_tags', [], title=N_("Tags to ignore for comparison"), highlight=['groupBox_ignore_tags']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -64,14 +64,14 @@ class CoverOptionsPage(OptionsPage):
     HELP_URL = "/config/options_cover.html"
 
     options = [
-        BoolOption('setting', 'save_images_to_tags', True, title=N_("Embed cover images into tags")),
-        BoolOption('setting', 'embed_only_one_front_image', True, title=N_("Embed only a single front image")),
-        BoolOption('setting', 'save_images_to_files', False, title=N_("Save cover images as separate files")),
-        TextOption('setting', 'cover_image_filename', DEFAULT_COVER_IMAGE_FILENAME, title=N_("File name for images")),
-        BoolOption('setting', 'save_images_overwrite', False, title=N_("Overwrite existing image files")),
-        BoolOption('setting', 'save_only_one_front_image', False, title=N_("Save only a single front image as separate file")),
-        BoolOption('setting', 'image_type_as_filename', False, title=N_("Always use the primary image type as the file name for non-front images")),
-        ListOption('setting', 'ca_providers', DEFAULT_CA_PROVIDERS, title=N_("Cover art providers")),
+        BoolOption('setting', 'save_images_to_tags', True, title=N_("Embed cover images into tags"), highlight=['save_images_to_tags']),
+        BoolOption('setting', 'embed_only_one_front_image', True, title=N_("Embed only a single front image"), highlight=['cb_embed_front_only']),
+        BoolOption('setting', 'save_images_to_files', False, title=N_("Save cover images as separate files"), highlight=['save_images_to_files']),
+        TextOption('setting', 'cover_image_filename', DEFAULT_COVER_IMAGE_FILENAME, title=N_("File name for images"), highlight=['cover_image_filename']),
+        BoolOption('setting', 'save_images_overwrite', False, title=N_("Overwrite existing image files"), highlight=['save_images_overwrite']),
+        BoolOption('setting', 'save_only_one_front_image', False, title=N_("Save only a single front image as separate file"), highlight=['save_only_one_front_image']),
+        BoolOption('setting', 'image_type_as_filename', False, title=N_("Always use the primary image type as the file name for non-front images"), highlight=['image_type_as_filename']),
+        ListOption('setting', 'ca_providers', DEFAULT_CA_PROVIDERS, title=N_("Cover art providers"), highlight=['ca_providers_list']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -269,19 +269,22 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         else:
             option_colors = HighlightColors('#000000', '#F9F906')
 
+        settings_groups = UserProfileGroups.SETTINGS_GROUPS
         for page in self.pages:
-            page_name = page.PARENT if page.PARENT in UserProfileGroups.SETTINGS_GROUPS else page.NAME
-            if page_name in UserProfileGroups.SETTINGS_GROUPS:
-                if load_settings:
-                    page.load()
-                for opt in UserProfileGroups.SETTINGS_GROUPS[page_name]['settings']:
-                    for opt_field in opt.fields:
-                        style = HIGHLIGHT_FMT % (opt_field, option_colors.fg, option_colors.bg)
-                        try:
-                            obj = getattr(page.ui, opt_field)
-                        except AttributeError:
-                            continue
-                        self._check_and_highlight_option(obj, opt.name, working_profiles, working_settings, style)
+            if page.NAME not in settings_groups:
+                continue
+            if 'settings' not in settings_groups[page.NAME]:
+                continue
+            if load_settings:
+                page.load()
+            for opt in settings_groups[page.NAME]['settings']:
+                for opt_field in opt.fields:
+                    style = HIGHLIGHT_FMT % (opt_field, option_colors.fg, option_colors.bg)
+                    try:
+                        obj = getattr(page.ui, opt_field)
+                    except AttributeError:
+                        continue
+                    self._check_and_highlight_option(obj, opt.name, working_profiles, working_settings, style)
 
     def _check_and_highlight_option(self, obj, option_name, working_profiles, working_settings, style):
         obj.setStyleSheet(None)

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -60,22 +60,22 @@ class GeneralOptionsPage(OptionsPage):
     HELP_URL = "/config/options_general.html"
 
     options = [
-        TextOption('setting', 'server_host', MUSICBRAINZ_SERVERS[0], title=N_("Server address")),
-        IntOption('setting', 'server_port', 443, title=N_("Port")),
+        TextOption('setting', 'server_host', MUSICBRAINZ_SERVERS[0], title=N_("Server address"), highlight=['server_host']),
+        IntOption('setting', 'server_port', 443, title=N_("Port"), highlight=['server_port']),
         BoolOption('setting', 'use_server_for_submission', False),
-        BoolOption('setting', 'analyze_new_files', False, title=N_("Automatically scan all new files")),
-        BoolOption('setting', 'cluster_new_files', False, title=N_("Automatically cluster all new files")),
-        BoolOption('setting', 'ignore_file_mbids', False, title=N_("Ignore MBIDs when loading new files")),
+        BoolOption('setting', 'analyze_new_files', False, title=N_("Automatically scan all new files"), highlight=['analyze_new_files']),
+        BoolOption('setting', 'cluster_new_files', False, title=N_("Automatically cluster all new files"), highlight=['cluster_new_files']),
+        BoolOption('setting', 'ignore_file_mbids', False, title=N_("Ignore MBIDs when loading new files"), highlight=['ignore_file_mbids']),
         TextOption('persist', 'oauth_refresh_token', ''),
         TextOption('persist', 'oauth_refresh_token_scopes', ''),
         TextOption('persist', 'oauth_access_token', ''),
         IntOption('persist', 'oauth_access_token_expires', 0),
         TextOption('persist', 'oauth_username', ''),
-        BoolOption('setting', 'check_for_updates', True, title=N_("Check for program updates during startup")),
-        IntOption('setting', 'update_check_days', 7, title=N_("Days between update checks")),
-        IntOption('setting', 'update_level', DEFAULT_PROGRAM_UPDATE_LEVEL, title=N_("Updates to check")),
+        BoolOption('setting', 'check_for_updates', True, title=N_("Check for program updates during startup"), highlight=['check_for_updates']),
+        IntOption('setting', 'update_check_days', 7, title=N_("Days between update checks"), highlight=['update_check_days']),
+        IntOption('setting', 'update_level', DEFAULT_PROGRAM_UPDATE_LEVEL, title=N_("Updates to check"), highlight=['update_level']),
         IntOption('persist', 'last_update_check', 0),
-        BoolOption('setting', 'check_for_plugin_updates', False, title=N_("Check for plugin updates during startup")),
+        BoolOption('setting', 'check_for_plugin_updates', False, title=N_("Check for plugin updates during startup"), highlight=['check_for_plugin_updates']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -91,14 +91,14 @@ class GenresOptionsPage(OptionsPage):
     HELP_URL = "/config/options_genres.html"
 
     options = [
-        BoolOption('setting', 'use_genres', False, title=N_("Use genres from MusicBrainz")),
-        IntOption('setting', 'max_genres', 5, title=N_("Maximum number of genres")),
-        IntOption('setting', 'min_genre_usage', 90, title=N_("Minimal genre usage")),
-        TextOption('setting', 'genres_filter', '-seen live\n-favorites\n-fixme\n-owned', title=N_("Genres to include or exclude")),
-        TextOption('setting', 'join_genres', '', title=N_("Join multiple genres with")),
-        BoolOption('setting', 'only_my_genres', False, title=N_("Use only my genres")),
-        BoolOption('setting', 'artists_genres', False, title=N_("Use album artist genres")),
-        BoolOption('setting', 'folksonomy_tags', False, title=N_("Use folksonomy tags as genre")),
+        BoolOption('setting', 'use_genres', False, title=N_("Use genres from MusicBrainz"), highlight=[]),
+        IntOption('setting', 'max_genres', 5, title=N_("Maximum number of genres"), highlight=['max_genres']),
+        IntOption('setting', 'min_genre_usage', 90, title=N_("Minimal genre usage"), highlight=['min_genre_usage']),
+        TextOption('setting', 'genres_filter', '-seen live\n-favorites\n-fixme\n-owned', title=N_("Genres to include or exclude"), highlight=['genres_filter']),
+        TextOption('setting', 'join_genres', '', title=N_("Join multiple genres with"), highlight=['join_genres']),
+        BoolOption('setting', 'only_my_genres', False, title=N_("Use only my genres"), highlight=['only_my_genres']),
+        BoolOption('setting', 'artists_genres', False, title=N_("Use album artist genres"), highlight=['artists_genres']),
+        BoolOption('setting', 'folksonomy_tags', False, title=N_("Use folksonomy tags as genre"), highlight=['folksonomy_tags']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -75,19 +75,19 @@ class InterfaceOptionsPage(OptionsPage):
     HELP_URL = "/config/options_interface.html"
 
     options = [
-        BoolOption('setting', 'toolbar_show_labels', True, title=N_("Show text labels under icons")),
-        BoolOption('setting', 'allow_multi_dirs_selection', False, title=N_("Allow selection of multiple directories")),
-        BoolOption('setting', 'show_menu_icons', DEFAULT_SHOW_MENU_ICONS, title=N_("Show icons in menus")),
-        BoolOption('setting', 'builtin_search', True, title=N_("Use builtin search rather than looking in browser")),
-        BoolOption('setting', 'use_adv_search_syntax', False, title=N_("Use advanced search syntax")),
-        BoolOption('setting', 'show_new_user_dialog', True, title=N_("Show a usage warning dialog when Picard starts")),
-        BoolOption('setting', 'quit_confirmation', True, title=N_("Show a quit confirmation dialog for unsaved changes")),
-        BoolOption('setting', 'file_save_warning', True, title=N_("Show a confirmation dialog when saving files")),
-        TextOption('setting', 'ui_language', '', title=N_("User interface language")),
-        TextOption('setting', 'ui_theme', str(UiTheme.DEFAULT), title=N_("User interface color theme")),
-        BoolOption('setting', 'filebrowser_horizontal_autoscroll', True, title=N_("Adjust horizontal position in file browser automatically")),
-        BoolOption('setting', 'starting_directory', False, title=N_("Begin browsing in a specific directory")),
-        TextOption('setting', 'starting_directory_path', _default_starting_dir, title=N_("Directory to begin browsing")),
+        BoolOption('setting', 'toolbar_show_labels', True, title=N_("Show text labels under icons"), highlight=['toolbar_show_labels']),
+        BoolOption('setting', 'allow_multi_dirs_selection', False, title=N_("Allow selection of multiple directories"), highlight=['allow_multi_dirs_selection']),
+        BoolOption('setting', 'show_menu_icons', DEFAULT_SHOW_MENU_ICONS, title=N_("Show icons in menus"), highlight=['show_menu_icons']),
+        BoolOption('setting', 'builtin_search', True, title=N_("Use builtin search rather than looking in browser"), highlight=['builtin_search']),
+        BoolOption('setting', 'use_adv_search_syntax', False, title=N_("Use advanced search syntax"), highlight=['use_adv_search_syntax']),
+        BoolOption('setting', 'show_new_user_dialog', True, title=N_("Show a usage warning dialog when Picard starts"), highlight=['new_user_dialog']),
+        BoolOption('setting', 'quit_confirmation', True, title=N_("Show a quit confirmation dialog for unsaved changes"), highlight=['quit_confirmation']),
+        BoolOption('setting', 'file_save_warning', True, title=N_("Show a confirmation dialog when saving files"), highlight=['file_save_warning']),
+        TextOption('setting', 'ui_language', '', title=N_("User interface language"), highlight=['ui_language', 'label']),
+        TextOption('setting', 'ui_theme', str(UiTheme.DEFAULT), title=N_("User interface color theme"), highlight=['ui_theme', 'label_theme']),
+        BoolOption('setting', 'filebrowser_horizontal_autoscroll', True, title=N_("Adjust horizontal position in file browser automatically"), highlight=['filebrowser_horizontal_autoscroll']),
+        BoolOption('setting', 'starting_directory', False, title=N_("Begin browsing in a specific directory"), highlight=['starting_directory']),
+        TextOption('setting', 'starting_directory_path', _default_starting_dir, title=N_("Directory to begin browsing"), highlight=['starting_directory_path']),
         TextOption('setting', 'load_image_behavior', 'append'),
     ]
 

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -97,8 +97,8 @@ class InterfaceColorsOptionsPage(OptionsPage):
     HELP_URL = "/config/options_interface_colors.html"
 
     options = [
-        Option('setting', 'interface_colors', InterfaceColors(dark_theme=False).get_colors(), title=N_("Colors to use for light theme")),
-        Option('setting', 'interface_colors_dark', InterfaceColors(dark_theme=True).get_colors(), title=N_("Colors to use for dark theme")),
+        Option('setting', 'interface_colors', InterfaceColors(dark_theme=False).get_colors(), title=N_("Colors to use for light theme"), highlight=['colors']),
+        Option('setting', 'interface_colors_dark', InterfaceColors(dark_theme=True).get_colors(), title=N_("Colors to use for dark theme"), highlight=['colors']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -147,7 +147,7 @@ class InterfaceToolbarOptionsPage(OptionsPage):
     }
     ACTION_NAMES = set(TOOLBAR_BUTTONS.keys())
     options = [
-        ListOption('setting', 'toolbar_layout', DEFAULT_TOOLBAR_LAYOUT, title=N_("Layout of the tool bar")),
+        ListOption('setting', 'toolbar_layout', DEFAULT_TOOLBAR_LAYOUT, title=N_("Layout of the tool bar"), highlight=['toolbar_layout_list']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/interface_top_tags.py
+++ b/picard/ui/options/interface_top_tags.py
@@ -54,7 +54,7 @@ class InterfaceTopTagsOptionsPage(OptionsPage):
     HELP_URL = "/config/options_interface_top_tags.html"
 
     options = [
-        ListOption('setting', 'metadatabox_top_tags', DEFAULT_TOP_TAGS, title=N_("Tags to show at the top")),
+        ListOption('setting', 'metadatabox_top_tags', DEFAULT_TOP_TAGS, title=N_("Tags to show at the top"), highlight=['top_tags_groupBox']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -44,9 +44,9 @@ class MatchingOptionsPage(OptionsPage):
     HELP_URL = "/config/options_matching.html"
 
     options = [
-        FloatOption('setting', 'file_lookup_threshold', 0.7, title=N_("Minimal similarity for file lookups")),
-        FloatOption('setting', 'cluster_lookup_threshold', 0.7, title=N_("Minimal similarity for cluster lookups")),
-        FloatOption('setting', 'track_matching_threshold', 0.4, title=N_("Minimal similarity for matching files to tracks")),
+        FloatOption('setting', 'file_lookup_threshold', 0.7, title=N_("Minimal similarity for file lookups"), highlight=['file_lookup_threshold']),
+        FloatOption('setting', 'cluster_lookup_threshold', 0.7, title=N_("Minimal similarity for cluster lookups"), highlight=['cluster_lookup_threshold']),
+        FloatOption('setting', 'track_matching_threshold', 0.4, title=N_("Minimal similarity for matching files to tracks"), highlight=['track_matching_threshold']),
     ]
 
     _release_type_sliders = {}

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -84,18 +84,18 @@ class MetadataOptionsPage(OptionsPage):
     HELP_URL = "/config/options_metadata.html"
 
     options = [
-        TextOption('setting', 'va_name', "Various Artists", title=N_("Various Artists name")),
-        TextOption('setting', 'nat_name', '[standalone recordings]', title=N_("Standalone recordings name")),
-        ListOption('setting', 'artist_locales', ['en'], title=N_("Translation locales")),
-        BoolOption('setting', 'translate_artist_names', False, title=N_("Translate artist names")),
-        BoolOption('setting', 'translate_artist_names_script_exception', False, title=N_("Translate artist names exception")),
-        ListOption('setting', 'script_exceptions', [], title=N_("Translation script exceptions")),
-        BoolOption('setting', 'release_ars', True, title=N_("Use release relationships")),
-        BoolOption('setting', 'track_ars', False, title=N_("Use track and release relationships")),
-        BoolOption('setting', 'convert_punctuation', False, title=N_("Convert Unicode punctuation characters to ASCII")),
-        BoolOption('setting', 'standardize_artists', False, title=N_("Use standardized artist names")),
-        BoolOption('setting', 'standardize_instruments', True, title=N_("Use standardized instrument and vocal credits")),
-        BoolOption('setting', 'guess_tracknumber_and_title', True, title=N_("Guess track number and title from filename if empty")),
+        TextOption('setting', 'va_name', "Various Artists", title=N_("Various Artists name"), highlight=['va_name']),
+        TextOption('setting', 'nat_name', '[standalone recordings]', title=N_("Standalone recordings name"), highlight=['nat_name']),
+        ListOption('setting', 'artist_locales', ['en'], title=N_("Translation locales"), highlight=['selected_locales']),
+        BoolOption('setting', 'translate_artist_names', False, title=N_("Translate artist names"), highlight=['translate_artist_names']),
+        BoolOption('setting', 'translate_artist_names_script_exception', False, title=N_("Translate artist names exception"), highlight=['translate_artist_names_script_exception']),
+        ListOption('setting', 'script_exceptions', [], title=N_("Translation script exceptions"), highlight=['selected_scripts']),
+        BoolOption('setting', 'release_ars', True, title=N_("Use release relationships"), highlight=['release_ars']),
+        BoolOption('setting', 'track_ars', False, title=N_("Use track and release relationships"), highlight=['track_ars']),
+        BoolOption('setting', 'convert_punctuation', False, title=N_("Convert Unicode punctuation characters to ASCII"), highlight=['convert_punctuation']),
+        BoolOption('setting', 'standardize_artists', False, title=N_("Use standardized artist names"), highlight=['standardize_artists']),
+        BoolOption('setting', 'standardize_instruments', True, title=N_("Use standardized instrument and vocal credits"), highlight=['standardize_instruments']),
+        BoolOption('setting', 'guess_tracknumber_and_title', True, title=N_("Guess track number and title from filename if empty"), highlight=['guess_tracknumber_and_title']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -50,17 +50,17 @@ class NetworkOptionsPage(OptionsPage):
     HELP_URL = "/config/options_network.html"
 
     options = [
-        BoolOption('setting', 'use_proxy', False, title=N_("Use a web proxy server")),
-        TextOption('setting', 'proxy_type', 'http', title=N_("Type of proxy server")),
-        TextOption('setting', 'proxy_server_host', '', title=N_("Proxy server address")),
-        IntOption('setting', 'proxy_server_port', 80, title=N_("Proxy server port")),
-        TextOption('setting', 'proxy_username', '', title=N_("Proxy username")),
-        TextOption('setting', 'proxy_password', '', title=N_("Proxy password")),
-        BoolOption('setting', 'browser_integration', True, title=N_("Browser integration")),
-        IntOption('setting', 'browser_integration_port', 8000, title=N_("Default listening port")),
-        BoolOption('setting', 'browser_integration_localhost_only', True, title=N_("Listen only on localhost")),
-        IntOption('setting', 'network_transfer_timeout_seconds', 30, title=N_("Request timeout in seconds")),
-        IntOption('setting', 'network_cache_size_bytes', CACHE_SIZE_IN_BYTES, title=N_("Network cache size in bytes")),
+        BoolOption('setting', 'use_proxy', False, title=N_("Use a web proxy server"), highlight=[]),
+        TextOption('setting', 'proxy_type', 'http', title=N_("Type of proxy server"), highlight=['proxy_type_socks', 'proxy_type_http']),
+        TextOption('setting', 'proxy_server_host', '', title=N_("Proxy server address"), highlight=['server_host']),
+        IntOption('setting', 'proxy_server_port', 80, title=N_("Proxy server port"), highlight=['server_port']),
+        TextOption('setting', 'proxy_username', '', title=N_("Proxy username"), highlight=['username']),
+        TextOption('setting', 'proxy_password', '', title=N_("Proxy password"), highlight=['password']),
+        BoolOption('setting', 'browser_integration', True, title=N_("Browser integration"), highlight=[]),
+        IntOption('setting', 'browser_integration_port', 8000, title=N_("Default listening port"), highlight=['browser_integration_port']),
+        BoolOption('setting', 'browser_integration_localhost_only', True, title=N_("Listen only on localhost"), highlight=['browser_integration_localhost_only']),
+        IntOption('setting', 'network_transfer_timeout_seconds', 30, title=N_("Request timeout in seconds"), highlight=['transfer_timeout']),
+        IntOption('setting', 'network_cache_size_bytes', CACHE_SIZE_IN_BYTES, title=N_("Network cache size in bytes"), highlight=['network_cache_size']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -223,7 +223,7 @@ class ProfilesOptionsPage(OptionsPage):
             return
         self.building_tree = True
         for group in UserProfileGroups.SETTINGS_GROUPS.values():
-            title = group['title']
+            title = _(group['title'])
             group_settings = group['settings']
             widget_item = QtWidgets.QTreeWidgetItem([title])
             widget_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsAutoTristate)

--- a/picard/ui/options/ratings.py
+++ b/picard/ui/options/ratings.py
@@ -45,9 +45,9 @@ class RatingsOptionsPage(OptionsPage):
     HELP_URL = "/config/options_ratings.html"
 
     options = [
-        BoolOption('setting', 'enable_ratings', False, title=N_("Enable track ratings")),
-        TextOption('setting', 'rating_user_email', 'users@musicbrainz.org', title=N_("Email to use when saving ratings")),
-        BoolOption('setting', 'submit_ratings', True, title=N_("Submit ratings to MusicBrainz")),
+        BoolOption('setting', 'enable_ratings', False, title=N_("Enable track ratings"), highlight=[]),
+        TextOption('setting', 'rating_user_email', 'users@musicbrainz.org', title=N_("Email to use when saving ratings"), highlight=['rating_user_email']),
+        BoolOption('setting', 'submit_ratings', True, title=N_("Submit ratings to MusicBrainz"), highlight=['submit_ratings']),
         IntOption('setting', 'rating_steps', 6),
     ]
 

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -164,9 +164,9 @@ class ReleasesOptionsPage(OptionsPage):
     HELP_URL = "/config/options_releases.html"
 
     options = [
-        ListOption('setting', 'release_type_scores', _release_type_scores, title=N_("Preferred release types")),
-        ListOption('setting', 'preferred_release_countries', [], title=N_("Preferred release countries")),
-        ListOption('setting', 'preferred_release_formats', [], title=N_("Preferred medium formats")),
+        ListOption('setting', 'release_type_scores', _release_type_scores, title=N_("Preferred release types"), highlight=['type_group']),
+        ListOption('setting', 'preferred_release_countries', [], title=N_("Preferred release countries"), highlight=['country_group']),
+        ListOption('setting', 'preferred_release_formats', [], title=N_("Preferred medium formats"), highlight=['format_group']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -77,12 +77,12 @@ class RenamingOptionsPage(OptionsPage):
     HELP_URL = "/config/options_filerenaming.html"
 
     options = [
-        BoolOption('setting', 'rename_files', False, title=N_("Rename files")),
-        BoolOption('setting', 'move_files', False, title=N_("Move files")),
-        TextOption('setting', 'move_files_to', _default_music_dir, title=N_("Destination directory")),
-        BoolOption('setting', 'move_additional_files', False, title=N_("Move additional files")),
-        TextOption('setting', 'move_additional_files_pattern', "*.jpg *.png", title=N_("Additional file patterns")),
-        BoolOption('setting', 'delete_empty_dirs', True, title=N_("Delete empty directories")),
+        BoolOption('setting', 'rename_files', False, title=N_("Rename files"), highlight=['rename_files']),
+        BoolOption('setting', 'move_files', False, title=N_("Move files"), highlight=['move_files']),
+        TextOption('setting', 'move_files_to', _default_music_dir, title=N_("Destination directory"), highlight=['move_files_to']),
+        BoolOption('setting', 'move_additional_files', False, title=N_("Move additional files"), highlight=['move_additional_files']),
+        TextOption('setting', 'move_additional_files_pattern', "*.jpg *.png", title=N_("Additional file patterns"), highlight=['move_additional_files_pattern']),
+        BoolOption('setting', 'delete_empty_dirs', True, title=N_("Delete empty directories"), highlight=['delete_empty_dirs']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/renaming_compat.py
+++ b/picard/ui/options/renaming_compat.py
@@ -80,12 +80,12 @@ class RenamingCompatOptionsPage(OptionsPage):
     HELP_URL = "/config/options_filerenaming_compat.html"
 
     options = [
-        BoolOption('setting', 'windows_compatibility', True, title=N_("Windows compatibility")),
-        BoolOption('setting', 'windows_long_paths', system_supports_long_paths() if IS_WIN else False, title=N_("Windows long path support")),
-        BoolOption('setting', 'ascii_filenames', False, title=N_("Replace non-ASCII characters")),
-        BoolOption('setting', 'replace_spaces_with_underscores', False, title=N_("Replace spaces with underscores")),
-        TextOption('setting', 'replace_dir_separator', DEFAULT_REPLACEMENT, title=N_("Replacement character to use for directory separators")),
-        Option('setting', 'win_compat_replacements', DEFAULT_WIN_COMPAT_REPLACEMENTS, title=N_("Replacement characters used for Windows compatibility"))
+        BoolOption('setting', 'windows_compatibility', True, title=N_("Windows compatibility"), highlight=['windows_compatibility']),
+        BoolOption('setting', 'windows_long_paths', system_supports_long_paths() if IS_WIN else False, title=N_("Windows long path support"), highlight=['windows_long_paths']),
+        BoolOption('setting', 'ascii_filenames', False, title=N_("Replace non-ASCII characters"), highlight=['ascii_filenames']),
+        BoolOption('setting', 'replace_spaces_with_underscores', False, title=N_("Replace spaces with underscores"), highlight=['replace_spaces_with_underscores']),
+        TextOption('setting', 'replace_dir_separator', DEFAULT_REPLACEMENT, title=N_("Replacement character to use for directory separators"), highlight=['replace_dir_separator']),
+        Option('setting', 'win_compat_replacements', DEFAULT_WIN_COMPAT_REPLACEMENTS, title=N_("Replacement characters used for Windows compatibility"), highlight=['win_compat_replacements']),
     ]
 
     options_changed = QtCore.pyqtSignal(dict)

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -104,8 +104,8 @@ class ScriptingOptionsPage(OptionsPage):
     HELP_URL = "/config/options_scripting.html"
 
     options = [
-        BoolOption('setting', 'enable_tagger_scripts', False, title=N_("Enable tagger scripts")),
-        ListOption('setting', 'list_of_scripts', [], title=N_("Tagger scripts")),
+        BoolOption('setting', 'enable_tagger_scripts', False, title=N_("Enable tagger scripts"), highlight=['enable_tagger_scripts']),
+        ListOption('setting', 'list_of_scripts', [], title=N_("Tagger scripts"), highlight=['script_list']),
         IntOption('persist', 'last_selected_script_pos', 0),
     ]
 

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -51,14 +51,14 @@ class TagsOptionsPage(OptionsPage):
     HELP_URL = "/config/options_tags.html"
 
     options = [
-        BoolOption('setting', 'dont_write_tags', False, title=N_("Don't write tags")),
-        BoolOption('setting', 'preserve_timestamps', False, title=N_("Preserve timestamps of tagged files")),
-        BoolOption('setting', 'clear_existing_tags', False, title=N_("Clear existing tags")),
-        BoolOption('setting', 'preserve_images', False, title=N_("Keep embedded images when clearing tags")),
-        BoolOption('setting', 'remove_id3_from_flac', False, title=N_("Remove ID3 tags from FLAC files")),
-        BoolOption('setting', 'remove_ape_from_mp3', False, title=N_("Remove APEv2 tags from MP3 files")),
-        BoolOption('setting', 'fix_missing_seekpoints_flac', False, title=N_("Fix missing seekpoints for FLAC files")),
-        ListOption('setting', 'preserved_tags', [], title=N_("Preserved tags list")),
+        BoolOption('setting', 'dont_write_tags', False, title=N_("Don't write tags"), highlight=['write_tags']),
+        BoolOption('setting', 'preserve_timestamps', False, title=N_("Preserve timestamps of tagged files"), highlight=['preserve_timestamps']),
+        BoolOption('setting', 'clear_existing_tags', False, title=N_("Clear existing tags"), highlight=['clear_existing_tags']),
+        BoolOption('setting', 'preserve_images', False, title=N_("Keep embedded images when clearing tags"), highlight=['preserve_images']),
+        BoolOption('setting', 'remove_id3_from_flac', False, title=N_("Remove ID3 tags from FLAC files"), highlight=['remove_id3_from_flac']),
+        BoolOption('setting', 'remove_ape_from_mp3', False, title=N_("Remove APEv2 tags from MP3 files"), highlight=['remove_ape_from_mp3']),
+        BoolOption('setting', 'fix_missing_seekpoints_flac', False, title=N_("Fix missing seekpoints for FLAC files"), highlight=['fix_missing_seekpoints_flac']),
+        ListOption('setting', 'preserved_tags', [], title=N_("Preserved tags list"), highlight=['preserved_tags']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/tags_compatibility_aac.py
+++ b/picard/ui/options/tags_compatibility_aac.py
@@ -45,8 +45,8 @@ class TagsCompatibilityAACOptionsPage(OptionsPage):
     HELP_URL = "/config/options_tags_compatibility_aac.html"
 
     options = [
-        BoolOption('setting', 'aac_save_ape', True, title=N_("Save APEv2 tags to AAC")),
-        BoolOption('setting', 'remove_ape_from_aac', False, title=N_("Remove APEv2 tags from AAC files")),
+        BoolOption('setting', 'aac_save_ape', True, title=N_("Save APEv2 tags to AAC"), highlight=['aac_save_ape', 'aac_no_tags']),
+        BoolOption('setting', 'remove_ape_from_aac', False, title=N_("Remove APEv2 tags from AAC files"), highlight=['remove_ape_from_aac']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/tags_compatibility_ac3.py
+++ b/picard/ui/options/tags_compatibility_ac3.py
@@ -45,8 +45,8 @@ class TagsCompatibilityAC3OptionsPage(OptionsPage):
     HELP_URL = "/config/options_tags_compatibility_ac3.html"
 
     options = [
-        BoolOption('setting', 'ac3_save_ape', True, title=N_("Save APEv2 tags to AC3")),
-        BoolOption('setting', 'remove_ape_from_ac3', False, title=N_("Remove APEv2 tags from AC3 files")),
+        BoolOption('setting', 'ac3_save_ape', True, title=N_("Save APEv2 tags to AC3"), highlight=['ac3_save_ape', 'ac3_no_tags']),
+        BoolOption('setting', 'remove_ape_from_ac3', False, title=N_("Remove APEv2 tags from AC3 files"), highlight=['remove_ape_from_ac3']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/tags_compatibility_id3.py
+++ b/picard/ui/options/tags_compatibility_id3.py
@@ -48,11 +48,11 @@ class TagsCompatibilityID3OptionsPage(OptionsPage):
     HELP_URL = "/config/options_tags_compatibility_id3.html"
 
     options = [
-        BoolOption('setting', 'write_id3v1', True, title=N_("Write ID3v1 tags")),
-        BoolOption('setting', 'write_id3v23', False, title=N_("ID3v2 version to write")),
-        TextOption('setting', 'id3v2_encoding', 'utf-8', title=N_("ID3v2 text encoding")),
-        TextOption('setting', 'id3v23_join_with', '/', title=N_("ID3v2.3 join character")),
-        BoolOption('setting', 'itunes_compatible_grouping', False, title=N_("Save iTunes compatible grouping and work")),
+        BoolOption('setting', 'write_id3v1', True, title=N_("Write ID3v1 tags"), highlight=['write_id3v1']),
+        BoolOption('setting', 'write_id3v23', False, title=N_("ID3v2 version to write"), highlight=['write_id3v23', 'write_id3v24']),
+        TextOption('setting', 'id3v2_encoding', 'utf-8', title=N_("ID3v2 text encoding"), highlight=['enc_utf8', 'enc_utf16', 'enc_iso88591']),
+        TextOption('setting', 'id3v23_join_with', '/', title=N_("ID3v2.3 join character"), highlight=['id3v23_join_with']),
+        BoolOption('setting', 'itunes_compatible_grouping', False, title=N_("Save iTunes compatible grouping and work"), highlight=['itunes_compatible_grouping']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/options/tags_compatibility_wave.py
+++ b/picard/ui/options/tags_compatibility_wave.py
@@ -47,9 +47,9 @@ class TagsCompatibilityWaveOptionsPage(OptionsPage):
     HELP_URL = "/config/options_tags_compatibility_wave.html"
 
     options = [
-        BoolOption('setting', 'write_wave_riff_info', True, title=N_("Write RIFF INFO tags to WAVE files")),
-        BoolOption('setting', 'remove_wave_riff_info', False, title=N_("Remove existing RIFF INFO tags from WAVE files")),
-        TextOption('setting', 'wave_riff_info_encoding', 'windows-1252', title=N_("RIFF INFO text encoding")),
+        BoolOption('setting', 'write_wave_riff_info', True, title=N_("Write RIFF INFO tags to WAVE files"), highlight=['write_wave_riff_info']),
+        BoolOption('setting', 'remove_wave_riff_info', False, title=N_("Remove existing RIFF INFO tags from WAVE files"), highlight=['remove_wave_riff_info']),
+        TextOption('setting', 'wave_riff_info_encoding', 'windows-1252', title=N_("RIFF INFO text encoding"), highlight=['wave_riff_info_enc_cp1252', 'wave_riff_info_enc_utf8']),
     ]
 
     def __init__(self, parent=None):

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -434,7 +434,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
     options = [
         BoolOption('persist', 'script_editor_show_documentation', False),
         Option('setting', 'file_renaming_scripts', {}),
-        TextOption('setting', 'selected_file_naming_script_id', '', title=N_("Selected file naming script")),
+        TextOption('setting', 'selected_file_naming_script_id', '', title=N_("Selected file naming script"), highlight=['naming_script_selector']),
     ]
 
     signal_save = QtCore.pyqtSignal()


### PR DESCRIPTION
Not perfect yet, but that's the idea.

I think:
- we can get rid of `UserProfileGroups` totally
- we need a multilevel tree for Profiles (like the one for option pages)
- we could reduce the need of highlight with option name = widget name and defaulting to that if not provided
- tests are broken, because not initialized in tests

@rdswift give it a try, and see if you can improve this