### PR TITLE
Add documentation note to PR template as reminder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,6 +51,10 @@
 
 # Action
 
+Additional actions required:
+* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
+* [ ] Other (please specify below)
+
 <!--
     Other than merging your change, do you want / need us to do anything else
     with your change? This could include reviewing a specific part of your PR.


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:  Adds a checkbox reminder to update the documentation

# Problem

Often changes are made that should result in an update to the Picard documentation.  Currently it is up to the reviewers to remember and point this out.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Add a checkbox to the PR template to serve as a reminder / notification as to whether or not the documentation also needs to be updated.

# Action

None
