### PR TITLE
PICARD-2869: Register a global exception handler

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -83,8 +83,11 @@ def crash_handler(exc: Exception = None):
     from tempfile import NamedTemporaryFile
     import traceback
     if exc:
-        # Since Python 3.10 calling only traceback.format_exception(exc) is possible
-        trace = "\n".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        if sys.version_info < (3, 10):
+            trace_list = traceback.format_exception(None, exc, exc.__traceback__)
+        else:
+            trace_list = traceback.format_exception(exc)  # pylint: disable=no-value-for-parameter
+        trace = "".join(trace_list)
     else:
         trace = traceback.format_exc()
     logfile = None

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2008, 2011-2014 Lukáš Lalinský
-# Copyright (C) 2009, 2018-2023 Philipp Wolfer
+# Copyright (C) 2009, 2018-2024 Philipp Wolfer
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2012-2013 Michael Wiencek
 # Copyright (C) 2013-2024 Laurent Monin
@@ -31,6 +31,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import sys
 
 from picard.version import Version
 
@@ -67,14 +68,12 @@ api_versions = [
 api_versions_tuple = [Version.from_string(v) for v in api_versions]
 
 
-def crash_handler():
+def crash_handler(exc: Exception = None):
     """Implements minimal handling of an exception crashing the application.
     This function tries to log the exception to a log file and display
     a minimal crash dialog to the user.
     This function is supposed to be called from inside an except blog.
     """
-    import sys
-
     # Allow disabling the graphical crash handler for debugging and CI purposes.
     if set(sys.argv) & {'--no-crash-dialog', '-v', '--version', '-V', '--long-version', '-h', '--help'}:
         return
@@ -83,7 +82,11 @@ def crash_handler():
     # with minimum chance to fail.
     from tempfile import NamedTemporaryFile
     import traceback
-    trace = traceback.format_exc()
+    if exc:
+        # Since Python 3.10 calling only traceback.format_exception(exc) is possible
+        trace = "\n".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    else:
+        trace = traceback.format_exc()
     logfile = None
     try:
         with NamedTemporaryFile(suffix='.log', prefix='picard-crash-', delete=False) as f:
@@ -124,3 +127,12 @@ def crash_handler():
     msgbox.setDefaultButton(QMessageBox.StandardButton.Close)
     msgbox.exec()
     app.quit()
+
+
+def _global_exception_handler(exctype, value, traceback):
+    from picard import crash_handler
+    crash_handler(exc=value)
+    sys.__excepthook__(exctype, value, traceback)
+
+
+sys.excepthook = _global_exception_handler


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2869
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Register a handler on sys.excepthook and have it call the global crash_handler(). This allows to show the exception dialog in otherwise unhandled exceptions, e.g. has happened in PICARD-2868

![grafik](https://github.com/metabrainz/picard/assets/29852/967cdc35-1061-4ddd-a3e4-b4c8a0879bcc)

