### PR TITLE
PICARD-2192: Build macOS universal2 binaries with ARM64 (Apple Silicon) support

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         setup:
         - macos-deployment-version: 11
-          python-version: 3.12.1-macos11
-          python-sha256sum: 6178e42679eb83196240fc58b1438f481c32c2b0557f28ccf43aa7b1b80b7c4a
+          python-version: 3.12.3-macos11
+          python-sha256sum: 70a701542ff297760ac5e20f81d0e610aaaa1aba016e411788aa80029e571c5e
     env:
       DISCID_VERSION: 0.6.4
       DISCID_SHA256SUM: 829133dd38acbdaa2b989de59e256c8d139ac34cb4dd4b8fd3c9d55a97c824f3

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install -r requirements-build.txt
-        pip3 install -r requirements-macos-${MACOSX_DEPLOYMENT_TARGET}.txt
+        pip3 install --no-binary "charset-normalizer,PyYAML" -r requirements-macos-${MACOSX_DEPLOYMENT_TARGET}.txt
       env:
         PYINSTALLER_COMPILE_BOOTLOADER: "1"
     - name: Run tests

--- a/picard.spec
+++ b/picard.spec
@@ -106,6 +106,7 @@ else:
     exe = EXE(pyz,
               a.scripts,
               exclude_binaries=True,
+              target_arch='universal2' if os_name == 'Darwin' else None,
               # Avoid name clash between picard executable and picard module folder
               name='picard' if os_name == 'Windows' else 'picard-run',
               debug=False,

--- a/scripts/package/macos-setup.sh
+++ b/scripts/package/macos-setup.sh
@@ -20,7 +20,7 @@ if [ -n "$DISCID_VERSION" ]; then
   wget "ftp://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/$DISCID_FILENAME"
   echo "$DISCID_SHA256SUM  $DISCID_FILENAME" | shasum --algorithm 256 --check --status
   unzip "$DISCID_FILENAME"
-  cp "libdiscid-$DISCID_VERSION-mac/x86_64/libdiscid.0.dylib" .
+  cp "libdiscid-$DISCID_VERSION-mac/universal2/libdiscid.0.dylib" .
 fi
 
 # Install fpcalc


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2192
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This updates the build for macOS to produce universal2 fat binaries, that combine the code for Intel and ARM64 CPUs.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Specify "universal" as architecture in PyInstaller spec. Use universal2 binaries  libdiscid and compile PIP packages PyYAML and charset-normalizer.

TODO:

- The Qt6 binaries are single arch only. We need some solution for this. One option will be to download both the arm64 and x86_64 variants of the PyQt6_Qt6 package from PyPI and combine the binaries locally.
- Qt6 should generally be upgraded to 6.6, as there are some runtime issues with the currently used 6.5 (e.g. global menu does not open). But this is handled in #2420, but unfortunately there are some CI issues to solve.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Testing on macOS with both Intel and ARM chips

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
