### PR TITLE
Fixed calls to QFileDialog options

### DIFF
--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -212,8 +212,7 @@ class PicardScript():
 
         dialog_title = _("Export Script File")
         dialog_file_types = self._get_dialog_filetypes()
-        options = QtWidgets.QFileDialog.Options()
-        filename, file_type = QtWidgets.QFileDialog.getSaveFileName(parent, dialog_title, default_path, dialog_file_types, options=options)
+        filename, file_type = QtWidgets.QFileDialog.getSaveFileName(parent, dialog_title, default_path, dialog_file_types)
         if not filename:
             return False
         # Fix issue where Qt may set the extension twice
@@ -250,8 +249,7 @@ class PicardScript():
         dialog_title = _("Import Script File")
         dialog_file_types = cls._get_dialog_filetypes()
         default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
-        options = QtWidgets.QFileDialog.Options()
-        filename, file_type = QtWidgets.QFileDialog.getOpenFileName(parent, dialog_title, default_script_directory, dialog_file_types, options=options)
+        filename, file_type = QtWidgets.QFileDialog.getOpenFileName(parent, dialog_title, default_script_directory, dialog_file_types)
         if not filename:
             return None
         log.debug("Importing script file: %s", filename)

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -204,8 +204,7 @@ class MaintenanceOptionsPage(OptionsPage):
 
         dialog_title = _("Backup Configuration File")
         dialog_file_types = self._get_dialog_filetypes(ext)
-        options = QtWidgets.QFileDialog.Options()
-        filename, file_type = QtWidgets.QFileDialog.getSaveFileName(self, dialog_title, default_path, dialog_file_types, options=options)
+        filename, file_type = QtWidgets.QFileDialog.getSaveFileName(self, dialog_title, default_path, dialog_file_types)
         if not filename:
             return
         # Fix issue where Qt may set the extension twice
@@ -249,8 +248,7 @@ class MaintenanceOptionsPage(OptionsPage):
         ext = path.splitext(filename)[1]
         dialog_file_types = self._get_dialog_filetypes(ext)
         directory = path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
-        options = QtWidgets.QFileDialog.Options()
-        filename, file_type = QtWidgets.QFileDialog.getOpenFileName(self, dialog_title, directory, dialog_file_types, options=options)
+        filename, file_type = QtWidgets.QFileDialog.getOpenFileName(self, dialog_title, directory, dialog_file_types)
         if not filename:
             return
         log.warning("Loading configuration from %s", filename)


### PR DESCRIPTION
The code is invalid in PyQt6 and also just was supposed to set the standard options being set anyway.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Invalid call to get default QFileDialog options. This is unneeded anyway, as the dialog will use the default options regardless.
