### PR TITLE
metainfo: fix recommended display length definition

### DIFF
--- a/org.musicbrainz.Picard.appdata.xml.in
+++ b/org.musicbrainz.Picard.appdata.xml.in
@@ -76,7 +76,7 @@
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>
-    <display_length compare="ge">medium</display_length>
+    <display_length compare="ge">768</display_length>
     <internet>always</internet>
   </recommends>
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Currently, flathub's build are failing as they don't allow releasing builds with invalid appdata (even if it's just a warning). Running `appstreamcli validate` do raise this warning: `W: org.musicbrainz.Picard:318: relation-display-length-value-invalid medium` currently.

According to https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-display_length, display length's value must be an integer value corresponding to logical pixels.

# Solution

I took `768`px as value because it corresponds to the recommended referenced size for laptops and tablets, which should match imho the previous incorrect `medium` value.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
