### PR TITLE
PICARD-2873: Fetch Search dialog cover art images after it was resized

### DIFF
--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -168,6 +168,7 @@ class AlbumSearchDialog(SearchDialog):
         self.cover_cells = []
         self.fetching = False
         self.scrolled.connect(self.fetch_coverarts)
+        self.resized.connect(self.fetch_coverarts)
 
     @staticmethod
     def show_releasegroup_search(releasegroup_id, existing_album=None):

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -52,6 +52,7 @@ class ResultTable(QtWidgets.QTableWidget):
 
     def __init__(self, parent):
         super().__init__(parent)
+        self._parent_dialog = parent
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
         self.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
@@ -73,6 +74,14 @@ class ResultTable(QtWidgets.QTableWidget):
         self.setRowCount(0)
         self.setSortingEnabled(False)
 
+    @throttle(1000)  # only emit resized signal once per second
+    def emit_resized(self):
+        self._parent_dialog.resized.emit()
+
+    def resizeEvent(self, event):
+        self.emit_resized()
+        super().resizeEvent(event)
+
 
 class SortableTableWidgetItem(QtWidgets.QTableWidgetItem):
 
@@ -88,6 +97,7 @@ class TableBasedDialog(PicardDialog):
 
     defaultsize = QtCore.QSize(720, 360)
     scrolled = pyqtSignal()
+    resized = pyqtSignal()
 
     def __init__(self, parent):
         super().__init__(parent)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

In Album Search Dialog, scrolling table causes missing cover art images to be fetched, but it doesn't work if the dialog is resized and those cells made visible.
No signal is associated with this event, and therefore no code leading to fetching missing images is executed when it happens

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2873

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- create a new `resized` signal emitted every second
- call `AlbumSearchDialog.fetch_coverarts()` when it happens

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
