### PR TITLE
Fix upgrade hooks re-declaring options

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -34,10 +34,7 @@ from inspect import (
 import re
 import sys
 
-from PyQt6 import (
-    QtCore,
-    QtWidgets,
-)
+from PyQt6 import QtWidgets
 
 from picard import (
     PICARD_VERSION,
@@ -393,7 +390,7 @@ def upgrade_to_v2_7_0dev2(config):
         splitter_dict = {}
         for (old_splitter_key, new_splitter_key) in key_map:
             if old_splitter_key in _p:
-                if v := _p.raw_value(old_splitter_key, qtype=QtCore.QByteArray):
+                if v := _p.raw_value(old_splitter_key):
                     splitter_dict[new_splitter_key] = v
                 _p.remove(old_splitter_key)
         _p[new_persist_key] = splitter_dict


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Options must only be registered once. This includes upgrade hooks, which must only access declared options or for removed options access their raw value.

# Solution

Rewrite upgrade hooks to not declare Option instances during runtime. Added tests.

Tested with old configuration backups for various development and final versions of 2.5, 2.6 and 2.7.