### PR TITLE
PICARD-2869: Avoid double crash dialog

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -73,7 +73,6 @@ from picard import (
     PICARD_ORG_NAME,
     acoustid,
     log,
-    register_excepthook,
 )
 from picard.acoustid.manager import AcoustIDManager
 from picard.album import (
@@ -1508,8 +1507,6 @@ If a new instance will not be spawned files/directories will be passed to the ex
 
 
 def main(localedir=None, autoupdate=True):
-    register_excepthook()
-
     # Some libs (ie. Phonon) require those to be set
     QtWidgets.QApplication.setApplicationName(PICARD_APP_NAME)
     QtWidgets.QApplication.setOrganizationName(PICARD_ORG_NAME)

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 
-try:
-    from picard.tagger import main
-    main('%(localedir)s', %(autoupdate)s)
-except SystemExit:
-    raise  # Just continue with a normal application exit
-except:  # noqa: E722,F722 # pylint: disable=bare-except
-    from picard import crash_handler
-    crash_handler()
-    raise
+from picard import register_excepthook
+register_excepthook()
+
+from picard.tagger import main
+main('%(localedir)s', %(autoupdate)s)

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -12,12 +12,8 @@ if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
 else:
     basedir = os.path.dirname(os.path.abspath(__file__))
 
-try:
-    from picard.tagger import main
-    main(os.path.join(basedir, 'locale'), %(autoupdate)s)
-except SystemExit:
-    raise  # Just continue with a normal application exit
-except:  # noqa: E722,F722 # pylint: disable=bare-except
-    from picard import crash_handler
-    crash_handler()
-    raise
+from picard import register_excepthook
+register_excepthook()
+
+from picard.tagger import main
+main(os.path.join(basedir, 'locale'), %(autoupdate)s)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2869
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

For some exceptions the crash dialog got shown twice. This happens because we already catch exceptions around the call of ` main` in the startup scripts. Exceptions catched there would show the crash dialog. Then the exception got re-raised (intentionally, to trigger normal exception handling, including logging and final exit) and catched by the new excepthook introduced in #2436

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Run register_excepthook early, don't separately catch exceptions around main.

This prevents the crash dialog to be shown twice for exceptions which are catched by the exception handler already. Early registration is required so that errors early during startup (e.g. import errors) are being catched.