### PR TITLE
PICARD-2879: macOS: Extend all paths in filebrowser with /Volumes/

### DIFF
--- a/picard/const/defaults.py
+++ b/picard/const/defaults.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2007, 2014, 2016 Lukáš Lalinský
-# Copyright (C) 2014, 2019-2022 Philipp Wolfer
+# Copyright (C) 2014, 2019-2022, 2024 Philipp Wolfer
 # Copyright (C) 2014-2016, 2018-2021, 2024 Laurent Monin
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2016 Rahul Raturi
@@ -77,9 +77,6 @@ DEFAULT_LOCAL_COVER_ART_REGEX = r'^(?:cover|folder|albumart)(.*)\.(?:jpe?g|png|g
 
 
 DEFAULT_CURRENT_BROWSER_PATH = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.HomeLocation)
-if IS_MACOS:
-    from picard.util.macos import extend_root_volume_path
-    DEFAULT_CURRENT_BROWSER_PATH = extend_root_volume_path(DEFAULT_CURRENT_BROWSER_PATH)
 
 # Default query limit
 DEFAULT_QUERY_LIMIT = 50

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008 Lukáš Lalinský
 # Copyright (C) 2008 Hendrik van Antwerpen
-# Copyright (C) 2008-2009, 2019-2022 Philipp Wolfer
+# Copyright (C) 2008-2009, 2019-2022, 2024 Philipp Wolfer
 # Copyright (C) 2011 Andrew Barnert
 # Copyright (C) 2012-2013 Michael Wiencek
 # Copyright (C) 2013 Wieland Hoffmann
@@ -42,6 +42,10 @@ from picard.const.sys import IS_MACOS
 from picard.formats import supported_formats
 from picard.i18n import gettext as _
 from picard.util import find_existing_path
+from picard.util.macos import (
+    extend_root_volume_path,
+    strip_root_volume_path,
+)
 
 
 class FileBrowser(QtWidgets.QTreeView):
@@ -176,6 +180,8 @@ class FileBrowser(QtWidgets.QTreeView):
             path = config.persist['current_browser_path']
             scrolltype = QtWidgets.QAbstractItemView.ScrollHint.PositionAtCenter
         if path:
+            if IS_MACOS:
+                path = extend_root_volume_path(path)
             index = self.model().index(find_existing_path(path))
             self.setCurrentIndex(index)
             self.expand(index)
@@ -185,6 +191,8 @@ class FileBrowser(QtWidgets.QTreeView):
         destination = os.path.normpath(path)
         if not os.path.isdir(destination):
             destination = os.path.dirname(destination)
+        if IS_MACOS:
+            destination = strip_root_volume_path(destination)
         return destination
 
     def load_file_for_item(self, index):

--- a/picard/util/macos.py
+++ b/picard/util/macos.py
@@ -41,3 +41,14 @@ def extend_root_volume_path(path):
                 path = path[1:]
             path = os.path.join(root_volume, path)
     return path
+
+
+def strip_root_volume_path(path):
+    if not path.startswith("/Volumes/"):
+        return path
+    root_volume = _find_root_volume()
+    if root_volume:
+        norm_path = os.path.normpath(path)
+        if norm_path.startswith(root_volume):
+            path = os.path.join('/', norm_path[len(root_volume):])
+    return path

--- a/test/test_util_macos.py
+++ b/test/test_util_macos.py
@@ -24,7 +24,10 @@ from unittest.mock import patch
 from test.picardtestcase import PicardTestCase
 
 from picard.const.sys import IS_MACOS
-from picard.util.macos import extend_root_volume_path
+from picard.util.macos import (
+    extend_root_volume_path,
+    strip_root_volume_path,
+)
 
 
 def fake_os_scandir(path):
@@ -58,3 +61,24 @@ class UtilMacosExtendRootVolumeTest(PicardTestCase):
             result = extend_root_volume_path(path)
             self.assertEqual(result, path)
             self.assertTrue(mock.called)
+
+
+@unittest.skipUnless(IS_MACOS, "macOS test")
+class UtilMacosStripRootVolumeTest(PicardTestCase):
+
+    def test_path_starts_not_with_volumes(self):
+        path = '/Users/sandra'
+        result = strip_root_volume_path(path)
+        self.assertEqual(result, path)
+
+    @patch('picard.util.macos._find_root_volume', lambda: '/Volumes/root_volume')
+    def test_path_starts_not_with_root_volume(self):
+        path = '/Volumes/other_volume/foo/bar'
+        result = strip_root_volume_path(path)
+        self.assertEqual(result, path)
+
+    @patch('picard.util.macos._find_root_volume', lambda: '/Volumes/root_volume')
+    def test_path_starts_with_root_volume(self):
+        path = '/Volumes/root_volume/foo/bar'
+        result = strip_root_volume_path(path)
+        self.assertEqual(result, '/foo/bar')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2879
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If the user has selected a starting directory in Opions > User interface that is not under the /Volumes/ path, this starting directory is not being used in the file browser on startup.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Extend all paths in filebrowser with /Volumes/

This ensures that selected starting directory gets resolved correctly, as the filebrowser only supports paths under /Volumes/, not directly under /. On saving drop the /Volumes/ prefix for paths on the root volume. This gives the nicer shorter paths the user is more familiar with (e.g. `/Users/phw/Music`  instead of the long `/Volumes/System/Users/phw/Music`).
