### PR TITLE
Always detect_file_encoding ASCII as UTF-8, fix tests with chardet

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1208,6 +1208,11 @@ def detect_file_encoding(path, max_bytes_to_read=1024*256):
         result = detect(f.read(max_bytes_to_read))
         if result['encoding'] is None:
             log.warning("Couldn't detect encoding for file %r", path)
-            result['encoding'] = 'UTF-8'
+            encoding = 'utf-8'
+        elif result['encoding'].lower() == 'ascii':
+            # Treat ASCII as UTF-8 (an ASCII document is also valid UTF-8)
+            encoding = 'utf-8'
+        else:
+            encoding = result['encoding'].lower()
 
-        return result['encoding'].lower()
+        return encoding

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -941,6 +941,7 @@ class IgnoreUpdatesContextTest(PicardTestCase):
 
 class DetectUnicodeEncodingTest(PicardTestCase):
 
+    @unittest.skipUnless(charset_detect, "test requires charset_normalizer or chardet package")
     def test_detect_file_encoding_bom(self):
         boms = {
             b'\xff\xfe': 'utf-16-le',
@@ -950,6 +951,7 @@ class DetectUnicodeEncodingTest(PicardTestCase):
             b'\xef\xbb\xbf': 'utf-8-sig',
             b'': 'utf-8',
             b'\00': 'utf-8',
+            b'no BOM, only ASCII': 'utf-8',
         }
         for bom, expected_encoding in boms.items():
             try:
@@ -973,7 +975,7 @@ class DetectUnicodeEncodingTest(PicardTestCase):
         file_path = get_test_data_path('eac-utf32le.log')
         self.assertEqual(expected_encoding, detect_file_encoding(file_path))
 
-    @unittest.skipUnless(charset_detect, "test requires charset-normalizer or chardet package")
+    @unittest.skipUnless(charset_detect, "test requires charset_normalizer or chardet package")
     def test_detect_file_encoding_eac_windows_1251(self):
         expected_encoding = 'windows-1251'
         file_path = get_test_data_path('eac-windows1251.log')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This is something up for discussion. At its core this PR addresses the issue that running the DetectUnicodeEncodingTest tests failed if chardet is installed instead of charset_normalizer. This is because chardet detects `b'\00'` as ASCII, but charset_normalizer as `UTF-8`.

```
test/test_utils.py F...                                                                                                                                         [100%]

============================================================================== FAILURES ===============================================================================
_______________________________________________________ DetectUnicodeEncodingTest.test_detect_file_encoding_bom _______________________________________________________

self = <test.test_utils.DetectUnicodeEncodingTest testMethod=test_detect_file_encoding_bom>

    def test_detect_file_encoding_bom(self):
        boms = {
            b'\xff\xfe': 'utf-16-le',
            b'\xfe\xff': 'utf-16-be',
            b'\xff\xfe\x00\x00': 'utf-32-le',
            b'\x00\x00\xfe\xff': 'utf-32-be',
            b'\xef\xbb\xbf': 'utf-8-sig',
            b'': 'utf-8',
            b'\00': 'utf-8',
        }
        for bom, expected_encoding in boms.items():
            try:
                f = NamedTemporaryFile(delete=False)
                f.write(bom)
                f.close()
                encoding = detect_file_encoding(f.name)
>               self.assertEqual(expected_encoding, encoding,
                                 f'BOM {bom!r} detected as {encoding}, expected {expected_encoding}')
E                                AssertionError: 'utf-8' != 'ascii'
E                                - utf-8
E                                + ascii
E                                 : BOM b'\x00' detected as ascii, expected utf-8

test/test_utils.py:960: AssertionError
------------------------------------------------------------------------ Captured stderr call -------------------------------------------------------------------------
W: 08:27:15,405 util.detect_file_encoding:1210: Couldn't detect encoding for file '/tmp/tmpmpo4gps0'
======================================================================= short test summary info =======================================================================
FAILED test/test_utils.py::DetectUnicodeEncodingTest::test_detect_file_encoding_bom - AssertionError: 'utf-8' != 'ascii'
```

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The fix always returns UTF-8 if the library detected ASCII. The idea behind this is that because any ASCII document is also valid UTF-8 (the encodings up to code point 127 are identical) and the detected encoding is used to parse, the parser will also work with UTF-8.

This ensures also that partially analyzed documents that are detected as ASCII but contain UTF-8 encodings later in the file still get loaded.

As a side effect this standardizes charset detection between chardet and charset_normalizers for this case, which previously differed on the \00 test case.