### PR TITLE
Run tests with specific combination of required packages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,16 +55,6 @@ jobs:
         python setup.py build_locales -i
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose --cov=picard --cov-report xml:coverage.xml test
-    - name: Test python-libdiscid (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libdiscid-dev
-        python -c "from picard.disc import discid_version; print(discid_version)"
-        pytest --verbose test/test_disc.py
-        pip install python-libdiscid
-        python -c "from picard.disc import discid_version; print(discid_version)"
-        pytest --verbose test/test_disc.py
     - name: Submit code coverage to Codacy
       if: env.CODACY_PROJECT_TOKEN
       run: |
@@ -78,7 +68,11 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.9']
         dependencies: [
-          "PyQt6==6.2.3 mutagen==1.37",
+          "PyQt6==6.5.3 PyQt6-Qt6==6.5.3 mutagen==1.37 python-dateutil==2.7 PyYAML==5.1",  # minimal versions, minimum dependencies
+          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 discid==1.0",
+          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 python-libdiscid",
+          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 charset-normalizer==2.0.6",
+          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 chardet==3.0.4",
         ]
 
     steps:
@@ -91,12 +85,11 @@ jobs:
       if: runner.os == 'linux'
       run: |
         sudo apt-get update
-        sudo apt-get install libegl1
+        sudo apt-get install libdiscid-dev libegl1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install $DEPENDENCIES
-        pip install -r requirements.txt
       env:
         DEPENDENCIES: ${{ matrix.dependencies }}
     - name: Test with pytest

--- a/test/test_disc_eaclog.py
+++ b/test/test_disc_eaclog.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2022 Laurent Monin
-# Copyright (C) 2022 Philipp Wolfer
+# Copyright (C) 2022, 2024 Philipp Wolfer
 # Copyright (C) 2022 Jeffrey Bosboom
 #
 # This program is free software; you can redistribute it and/or
@@ -22,6 +22,7 @@
 
 
 from typing import Iterator
+import unittest
 
 from test.picardtestcase import (
     PicardTestCase,
@@ -36,6 +37,7 @@ from picard.disc.utils import (
     NotSupportedTOCError,
     TocEntry,
 )
+from picard.util import detect as charset_detect
 
 
 test_log = (
@@ -72,6 +74,7 @@ class TestTocFromFile(PicardTestCase):
         toc = toc_from_file(test_log)
         self.assertEqual((1, 8, 149323, 150, 25064, 43611, 60890, 83090, 100000, 115057, 135558), toc)
 
+    @unittest.skipUnless(charset_detect, "test requires charset_normalizer or chardet package")
     def test_toc_from_file_eac_windows1251(self):
         self._test_toc_from_file('eac-windows1251.log')
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Some of Picard's dependencies are optional or have alternatives (e.g. discid|python-libdiscid or charset-normalizer|chardet). CI testing currently only insufficiently tests for these scenarios.



# Solution

Run tests with specific combination of required packages

This tests for tests passing with optional packages and alternative packages.