### PR TITLE
PICARD-2880: Ensure ratecontrol.set_minimum_delay stores the delay as int

### DIFF
--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018, 2020-2021, 2023-2024 Laurent Monin
-# Copyright (C) 2019, 2022 Philipp Wolfer
+# Copyright (C) 2019, 2022, 2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -83,7 +83,7 @@ def set_minimum_delay(hostkey, delay_ms):
             hostkey is an unique key, for example (host, port)
             delay_ms is the delay in milliseconds
     """
-    REQUEST_DELAY_MINIMUM[hostkey] = delay_ms
+    REQUEST_DELAY_MINIMUM[hostkey] = int(delay_ms)
 
 
 def set_minimum_delay_for_url(url, delay_ms):

--- a/test/test_ratecontrol.py
+++ b/test/test_ratecontrol.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from collections import defaultdict
+
+from test.picardtestcase import PicardTestCase
+
+from picard.webservice import ratecontrol
+
+
+class RateControlTest(PicardTestCase):
+
+    def setUp(self):
+        super().setUp()
+        ratecontrol.REQUEST_DELAY_MINIMUM = defaultdict(lambda: 1000)
+
+    def test_set_minimum_delay(self):
+        hostkey = ('example.com', 80)
+        ratecontrol.set_minimum_delay(hostkey, 200)
+        self.assertEqual(200, ratecontrol.REQUEST_DELAY_MINIMUM[hostkey])
+
+    def test_set_minimum_delay_with_float(self):
+        hostkey = ('example.com', 80)
+        ratecontrol.set_minimum_delay(hostkey, 33.8)
+        self.assertEqual(33, ratecontrol.REQUEST_DELAY_MINIMUM[hostkey])
+
+    def test_set_minimum_delay_for_url(self):
+        hostkey = ('example.com', 443)
+        ratecontrol.set_minimum_delay_for_url('https://example.com', 300)
+        self.assertEqual(300, ratecontrol.REQUEST_DELAY_MINIMUM[hostkey])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:


# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2880
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If a rate limit delay is set via ratecontrol.set_minimum_delay to a float value Picard crashes during networking. See also the comment on [PICARD-2742](https://tickets.metabrainz.org/browse/PICARD-2742).


# Solution
Ensure `ratecontrol.set_minimum_delay` stores the delay as int. Added some initial tests for the ratecontrol module.