### PR TITLE
PICARD-2882: Support OAuth2 PKCE

### DIFF
--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -302,10 +302,37 @@ class OAuthManager(object):
             return _("Unexpected request error (HTTP code %s)") % self._http_code(http)
 
 
-def s256_encode(token):
-    return base64url_encode(sha256(token).digest())
+def s256_encode(input: bytes) -> bytes:
+    """Implements the S256 code challenge encoding as defined for PKCE in RFC 7636.
+
+    The input data gets hashed by SHA256 and Base64url encoded.
+
+    See also https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+
+    Args:
+        input (bytes): Input bytes to encode. Is expected to consist only of ASCII characters.
+
+    Returns:
+        bytes: encoded data
+    """
+    return base64url_encode(sha256(input).digest())
 
 
-def base64url_encode(s):
-    # see https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
-    return urlsafe_b64encode(s).rstrip(b'=')
+def base64url_encode(input: bytes) -> bytes:
+    """Implements the Base64url Encoding as defined for PKCE in RFC 7636.
+
+    Base64 encoding using the URL- and filename-safe character set
+    defined in Section 5 of [RFC4648], with all trailing '='
+    characters omitted (as permitted by Section 3.2 of [RFC4648]) and
+    without the inclusion of any line breaks, whitespace, or other
+    additional characters.
+
+    See also https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
+
+    Args:
+        s (bytes): Input bytes to encode.
+
+    Returns:
+        bytes: Base64url encoded data
+    """
+    return urlsafe_b64encode(input).rstrip(b'=')

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -3,6 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2022 Laurent Monin
+# Copyright (C) 2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,7 +22,11 @@
 
 from test.picardtestcase import PicardTestCase
 
-from picard.oauth import OAuthManager
+from picard.oauth import (
+    OAuthManager,
+    base64url_encode,
+    s256_encode,
+)
 
 
 class OAuthManagerTest(PicardTestCase):
@@ -35,3 +40,15 @@ class OAuthManagerTest(PicardTestCase):
         }
         data = OAuthManager._query_data(params)
         self.assertEqual(data, "a%26b=a+b&c+d=c%26d&e%3Df=e%3Df")
+
+    def test_s256_encode(self):
+        code_verifier = b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+        code_challenge = s256_encode(code_verifier)
+        self.assertEqual(b'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM', code_challenge)
+
+    def test_base64url_encode(self):
+        b = bytes([116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
+            187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
+            132, 141, 121])
+        encoded = base64url_encode(b)
+        self.assertEqual(b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', encoded)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2882
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The existing MusicBrainz OAuth2 implementation implements PKCE (Proof Key for Code Exchange) and "strongly recommends" using it, see https://musicbrainz.org/doc/Development/OAuth2

This is also useful for but independent from supporting the upcoming MetaBrainz OAuth endpoints.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Implement PKCE according to https://datatracker.ietf.org/doc/html/rfc7636#section-4.1

The examples for the tests of the `s256_encode` and `base64url_encode`  helper functions are taken directly from the examples at https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
