### PR TITLE
PICARD-2884: Show tooltips for more file / track icon types

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1088,8 +1088,8 @@ class TrackItem(TreeItem):
             file.item = self
             color = TrackItem.track_colors[file.state]
             bgcolor = get_match_color(file.similarity, TreeItem.base_color)
-            icon = FileItem.decide_file_icon(file)
-            self.setToolTip(MainPanel.TITLE_COLUMN, _(FileItem.decide_file_icon_info(file)))
+            icon, icon_tooltip = FileItem.decide_file_icon_info(file)
+            self.setToolTip(MainPanel.TITLE_COLUMN, icon_tooltip)
             self.takeChildren()
             self.setExpanded(False)
             fingerprint_icon, fingerprint_tooltip = FileItem.decide_fingerprint_icon_info(file)
@@ -1150,8 +1150,9 @@ class FileItem(TreeItem):
 
     def update(self, update_track=True, update_selection=True):
         file = self.obj
-        self.setIcon(MainPanel.TITLE_COLUMN, FileItem.decide_file_icon(file))
-        self.setToolTip(MainPanel.TITLE_COLUMN, _(FileItem.decide_file_icon_info(file)))
+        icon, icon_tooltip = FileItem.decide_file_icon_info(file)
+        self.setIcon(MainPanel.TITLE_COLUMN, icon)
+        self.setToolTip(MainPanel.TITLE_COLUMN, icon_tooltip)
         fingerprint_icon, fingerprint_tooltip = FileItem.decide_fingerprint_icon_info(file)
         self.setToolTip(MainPanel.FINGERPRINT_COLUMN, fingerprint_tooltip)
         self.setIcon(MainPanel.FINGERPRINT_COLUMN, fingerprint_icon)
@@ -1170,38 +1171,31 @@ class FileItem(TreeItem):
             parent.update(update_files=False, update_selection=update_selection)
 
     @staticmethod
-    def decide_file_icon(file):
+    def decide_file_icon_info(file):
+        tooltip = ""
         if file.state == File.ERROR:
             if file.error_type == FileErrorType.NOTFOUND:
-                return FileItem.icon_error_not_found
+                icon = FileItem.icon_error_not_found
             elif file.error_type == FileErrorType.NOACCESS:
-                return FileItem.icon_error_no_access
+                icon = FileItem.icon_error_no_access
             else:
-                return FileItem.icon_error
+                icon = FileItem.icon_error
         elif isinstance(file.parent, Track):
             if file.state == File.NORMAL:
-                return FileItem.icon_saved
+                icon = FileItem.icon_saved
+                tooltip = N_("Track saved")
             elif file.state == File.PENDING:
-                return FileItem.match_pending_icons[int(file.similarity * 5 + 0.5)]
+                icon = FileItem.match_pending_icons[int(file.similarity * 5 + 0.5)]
+                tooltip = N_("Pending")
             else:
-                return FileItem.match_icons[int(file.similarity * 5 + 0.5)]
+                icon = FileItem.match_icons[int(file.similarity * 5 + 0.5)]
+                tooltip = FileItem.match_icons_info[int(file.similarity * 5 + 0.5)]
         elif file.state == File.PENDING:
-            return FileItem.icon_file_pending
+            icon = FileItem.icon_file_pending
+            tooltip = N_("Pending")
         else:
-            return FileItem.icon_file
-
-    @staticmethod
-    def decide_file_icon_info(file):
-        # Note error state info is already handled
-        if isinstance(file.parent, Track):
-            if file.state == File.NORMAL:
-                return N_("Track saved")
-            elif file.state == File.PENDING:   # unsure how to use int(file.similarity * 5 + 0.5)
-                return N_("Pending")
-            else:   # returns description of the match ranging from bad to excellent
-                return FileItem.match_icons_info[int(file.similarity * 5 + 0.5)]
-        elif file.state == File.PENDING:
-            return N_("Pending")
+            icon = FileItem.icon_file
+        return (icon, _(tooltip))
 
     @staticmethod
     def decide_fingerprint_icon_info(file):

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1151,6 +1151,7 @@ class FileItem(TreeItem):
     def update(self, update_track=True, update_selection=True):
         file = self.obj
         self.setIcon(MainPanel.TITLE_COLUMN, FileItem.decide_file_icon(file))
+        self.setToolTip(MainPanel.TITLE_COLUMN, _(FileItem.decide_file_icon_info(file)))
         fingerprint_icon, fingerprint_tooltip = FileItem.decide_fingerprint_icon_info(file)
         self.setToolTip(MainPanel.FINGERPRINT_COLUMN, fingerprint_tooltip)
         self.setIcon(MainPanel.FINGERPRINT_COLUMN, fingerprint_icon)

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1192,17 +1192,22 @@ class FileItem(TreeItem):
                 icon = FileItem.icon_saved
                 tooltip = _("Track saved")
             elif file.state == File.PENDING:
-                icon = FileItem.match_pending_icons[int(file.similarity * 5 + 0.5)]
+                index = FileItem._match_icon_index(file.similarity)
+                icon = FileItem.match_pending_icons[index]
                 tooltip = _("Pending")
             else:
-                icon = FileItem.match_icons[int(file.similarity * 5 + 0.5)]
-                tooltip = _(FileItem.match_icons_info[int(file.similarity * 5 + 0.5)])
+                index = FileItem._match_icon_index(file.similarity)
+                icon = FileItem.match_icons[index]
+                tooltip = _(FileItem.match_icons_info[index])
         elif file.state == File.PENDING:
             icon = FileItem.icon_file_pending
             tooltip = _("Pending")
         else:
             icon = FileItem.icon_file
         return (icon, tooltip)
+
+    def _match_icon_index(similarity):
+        return int(similarity * 5 + 0.5)
 
     @staticmethod
     def decide_fingerprint_icon_info(file):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2883, PICARD-2884
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This enhances the tooltips for file / track icons:

- Show match status icon tooltips also for files, not only for tracks. Fixes PICARD-2883
- Show tooltips for more icons, specifically for unmatched tracks, tracks matched to multiple files and file errors (PICARD-2884)


# Solution

Refactor determining icon and tooltip for file items by combining both in the same function (similar to how the icon / tooltip for the fingerprint column is implemented).

Add additional tooltips.

