### PR TITLE
PICARD-2885: Fix file permission and not found error icons not being shown

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -219,13 +219,13 @@ class File(QtCore.QObject, Item):
 
     def _set_error(self, error):
         self.state = File.ERROR
-        if any_exception_isinstance(error, MutagenError):
-            self.error_type = FileErrorType.PARSER
-            self.error_append(_("The file failed to parse, either the file is damaged or has an unsupported file format."))
-        elif any_exception_isinstance(error, FileNotFoundError):
+        if any_exception_isinstance(error, FileNotFoundError):
             self.error_type = FileErrorType.NOTFOUND
         elif any_exception_isinstance(error, PermissionError):
             self.error_type = FileErrorType.NOACCESS
+        elif any_exception_isinstance(error, MutagenError):
+            self.error_type = FileErrorType.PARSER
+            self.error_append(_("The file failed to parse, either the file is damaged or has an unsupported file format."))
         else:
             self.error_type = FileErrorType.UNKNOWN
         self.error_append(str(error))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2885
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When PICARD-2662 got implemented it broke showing the specific file icons for permission and file not found errors.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Majority of file errors happen inside mutagen and are wrapped into a MutagenError. This hid the handling of the specific error conditions for permission and file not found errors.

Handle the specific errors before the more general MutagenError.