### PR TITLE
PICARD-2886: OAuth2 token revocation

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2009, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 amckinle
-# Copyright (C) 2008-2010, 2014-2015, 2018-2023 Philipp Wolfer
+# Copyright (C) 2008-2010, 2014-2015, 2018-2024 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2010 Andrew Barnert
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -674,15 +674,20 @@ class Tagger(QtWidgets.QApplication):
         else:
             callback(False, error_msg)
 
-    @classmethod
     def on_mb_login_finished(self, callback, successful, error_msg):
         if successful:
             load_user_collections()
         callback(successful, error_msg)
 
-    def mb_logout(self):
-        self.webservice.oauth_manager.revoke_tokens()
-        load_user_collections()
+    def mb_logout(self, callback):
+        self.webservice.oauth_manager.revoke_tokens(
+            partial(self.on_mb_logout_finished, callback)
+        )
+
+    def on_mb_logout_finished(self, callback, successful, error_msg):
+        if successful:
+            load_user_collections()
+        callback(successful, error_msg)
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007, 2014 Lukáš Lalinský
-# Copyright (C) 2008, 2018-2023 Philipp Wolfer
+# Copyright (C) 2008, 2018-2024 Philipp Wolfer
 # Copyright (C) 2011, 2013 Michael Wiencek
 # Copyright (C) 2011, 2019 Wieland Hoffmann
 # Copyright (C) 2013-2014 Sophist-UK
@@ -158,16 +158,18 @@ class GeneralOptionsPage(OptionsPage):
     def login(self):
         self.tagger.mb_login(self.on_login_finished, self)
 
-    def restore_defaults(self):
-        super().restore_defaults()
-        self.logout()
-
     def on_login_finished(self, successful, error_msg=None):
         self.update_login_logout(error_msg)
 
     def logout(self):
-        self.tagger.mb_logout()
-        self.update_login_logout()
+        self.tagger.mb_logout(self.on_logout_finished)
+
+    def on_logout_finished(self, successful, error_msg=None):
+        self.update_login_logout(error_msg)
+
+    def restore_defaults(self):
+        super().restore_defaults()
+        self.logout()
 
     def _update_analyze_new_files(self, cluster_new_files):
         if cluster_new_files:

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -28,7 +28,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt6 import QtCore
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
 
 from picard.config import get_config
 from picard.const import (
@@ -165,7 +168,27 @@ class GeneralOptionsPage(OptionsPage):
         self.tagger.mb_logout(self.on_logout_finished)
 
     def on_logout_finished(self, successful, error_msg=None):
-        self.update_login_logout(error_msg)
+        if not successful:
+            msg = QtWidgets.QMessageBox(self)
+            msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+            msg.setWindowTitle(_("Logout error"))
+            msg.setText(_(
+                "A server error occurred while revoking access to the MusicBrainz server: %s\n"
+                "\n"
+                "Remove locally stored credentials anyway?"
+            ) % error_msg)
+            msg.setStandardButtons(
+                QtWidgets.QMessageBox.StandardButton.Yes
+                | QtWidgets.QMessageBox.StandardButton.No
+                | QtWidgets.QMessageBox.StandardButton.Retry)
+            result = msg.exec()
+            if result == QtWidgets.QMessageBox.StandardButton.Yes:
+                oauth_manager = self.tagger.webservice.oauth_manager
+                oauth_manager.forget_access_token()
+                oauth_manager.forget_refresh_token()
+            elif result == QtWidgets.QMessageBox.StandardButton.Retry:
+                self.logout()
+        self.update_login_logout()
 
     def restore_defaults(self):
         super().restore_defaults()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2886
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When logging out Picard so far was only removing the locally stored OAuth2 tokens (access and refresh tokens). This removed the tokens from the local system, but the tokens themselves were still present on the MB server and could potentially be used.

MB's OAuth2 implementation supports token revocation, see https://musicbrainz.org/doc/Development/OAuth2#Revoking_a_token. This PR makes use of this to revoke the tokens on the server.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Implement support for calling `POST /oauth2/revoke` in `OAuthManager.revoke_tokens`. Refactor this method to work asynchronously with a callback similar to  the login process.

In Options > General implement a dialog that is shown in case of an error during logout. As there can be network errors other technical issues the user could theoretically be stuck with invalid local credentials without the possibility to logout and login again. The dialog allows the user to cancel, retry or just removing the local credentials without revoking access on the server (this is identical to Picard's old behavior).

![image](https://github.com/metabrainz/picard/assets/29852/62a4a535-6c0f-459e-aba7-bcec3dfb42ca)



# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

Please test carefully. After login the "MusicBrainz Picard" application should be visible in your MB profile on https://musicbrainz.org/account/applications . After logout with this patch this entry should be removed again, if no error occurred. With older versions of Picard the entry will stay.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
