### PR TITLE
PICARD-736: OAuth2 login with local callback URL

### DIFF
--- a/picard/browser/browser.py
+++ b/picard/browser/browser.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2006-2007, 2011 Lukáš Lalinský
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
-# Copyright (C) 2012-2013, 2018, 2021-2022 Philipp Wolfer
+# Copyright (C) 2012-2013, 2018, 2021-2022, 2024 Philipp Wolfer
 # Copyright (C) 2013, 2018, 2020-2021, 2024 Laurent Monin
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
@@ -24,7 +24,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-
 
 from http.server import (
     BaseHTTPRequestHandler,
@@ -47,6 +46,7 @@ from picard import (
 )
 from picard.browser import addrelease
 from picard.config import get_config
+from picard.oauth import OAuthInvalidStateError
 from picard.util import mbid_validate
 from picard.util.thread import to_main
 
@@ -184,6 +184,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._load_mbid('nat', args)
         elif action == '/add' and addrelease.is_available():
             self._add_release(args)
+        elif action == '/auth':
+            self._auth(args)
         else:
             self._response(404, 'Unknown action.')
 
@@ -210,6 +212,26 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._response(400, 'Invalid token')
         else:
             self._response(400, 'Missing parameter "token".')
+
+    def _auth(self, args):
+        if 'code' in args and args['code']:
+            tagger = QtCore.QCoreApplication.instance()
+            oauth_manager = tagger.webservice.oauth_manager
+            try:
+                state = args.get('state', [''])[0]
+                callback = oauth_manager.verify_state(state)
+            except OAuthInvalidStateError:
+                self._response(400, 'Invalid "state" parameter.')
+                return
+            to_main(
+                oauth_manager.exchange_authorization_code,
+                authorization_code=args['code'][0],
+                scopes='profile tag rating collection submit_isrc submit_barcode',
+                callback=callback,
+            )
+            self._response(200, "Authentication successful, you can close this window now.", 'text/html')
+        else:
+            self._response(400, 'Missing parameter "code".')
 
     def _response(self, code, content='', content_type='text/plain'):
         self.server_version = SERVER_VERSION

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2014 Lukáš Lalinský
 # Copyright (C) 2015 Sophist-UK
 # Copyright (C) 2015 Wieland Hoffmann
-# Copyright (C) 2015, 2018, 2021, 2024 Philipp Wolfer
+# Copyright (C) 2015, 2018, 2021-2022, 2024 Philipp Wolfer
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
 # Copyright (C) 2018-2024 Laurent Monin
@@ -45,10 +45,21 @@ from picard.util import (
 )
 
 
+class OAuthInvalidStateError(Exception):
+    pass
+
+
 class OAuthManager(object):
 
     def __init__(self, webservice):
         self.webservice = webservice
+        # Associates state tokens with callbacks
+        self.__states = {}
+
+    @property
+    def redirect_uri(self):
+        # return "urn:ietf:wg:oauth:2.0:oob"
+        return "http://localhost:8000/auth"
 
     @property
     def setting(self):
@@ -205,14 +216,35 @@ class OAuthManager(object):
         code_challenge = s256_encode(code_verifier)  # code_challenge_method=S256
         return code_challenge.decode('ASCII')
 
-    def get_authorization_url(self, scopes):
+    def _create_auth_state(self, callback):
+        state = secrets.token_urlsafe(16)
+        self.__states[state] = callback
+        return state
+
+    def verify_state(self, state):
+        """Verifies a state variable used in an authorization URL.
+
+        On success returns a callback associated with this state.
+        If the state is invalid raises OAuthInvalidStateError. Can only be
+        called once on a state, the state itself will be revoked afterwards.
+        """
+        try:
+            callback = self.__states[state]
+            del self.__states[state]
+            return callback
+        except KeyError:
+            raise OAuthInvalidStateError
+
+    def get_authorization_url(self, scopes, callback: callable):
         params = {
             'response_type': 'code',
             'client_id': MUSICBRAINZ_OAUTH_CLIENT_ID,
-            'redirect_uri': "urn:ietf:wg:oauth:2.0:oob",
+            'redirect_uri': self.redirect_uri,
             'code_challenge_method': 'S256',
             'code_challenge': self._create_code_challenge(),
             'scope': scopes,
+            'state': self._create_auth_state(callback),
+            'access_type': 'offline',
         }
         return bytes(self.url(path="/oauth2/authorize", params=params).toEncoded()).decode()
 
@@ -272,7 +304,7 @@ class OAuthManager(object):
             'code': authorization_code,
             'client_id': MUSICBRAINZ_OAUTH_CLIENT_ID,
             'client_secret': MUSICBRAINZ_OAUTH_CLIENT_SECRET,
-            'redirect_uri': "urn:ietf:wg:oauth:2.0:oob",
+            'redirect_uri': self.redirect_uri,
             'code_verifier': self.__code_verifier,
         }
         self.webservice.post_url(

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -45,6 +45,9 @@ from picard.util import (
 )
 
 
+OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+
+
 class OAuthInvalidStateError(Exception):
     pass
 
@@ -55,11 +58,22 @@ class OAuthManager(object):
         self.webservice = webservice
         # Associates state tokens with callbacks
         self.__states = {}
+        self._redirect_uri = OOB_URI
 
     @property
     def redirect_uri(self):
-        # return "urn:ietf:wg:oauth:2.0:oob"
-        return "http://localhost:8000/auth"
+        return self._redirect_uri
+
+    @redirect_uri.setter
+    def redirect_uri(self, redirect_uri):
+        if not redirect_uri:
+            self._redirect_uri = OOB_URI
+        else:
+            self._redirect_uri = redirect_uri
+
+    @property
+    def is_oob(self):
+        return self.redirect_uri == OOB_URI
 
     @property
     def setting(self):
@@ -243,9 +257,10 @@ class OAuthManager(object):
             'code_challenge_method': 'S256',
             'code_challenge': self._create_code_challenge(),
             'scope': scopes,
-            'state': self._create_auth_state(callback),
             'access_type': 'offline',
         }
+        if not self.is_oob:
+            params['state'] = self._create_auth_state(callback)
         return bytes(self.url(path="/oauth2/authorize", params=params).toEncoded()).decode()
 
     def set_refresh_token(self, refresh_token, scopes):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -657,15 +657,16 @@ class Tagger(QtWidgets.QApplication):
 
     def mb_login(self, callback, parent=None):
         scopes = 'profile tag rating collection submit_isrc submit_barcode'
-        authorization_url = self.webservice.oauth_manager.get_authorization_url(scopes)
+        authorization_url = self.webservice.oauth_manager.get_authorization_url(
+            scopes, partial(self.on_mb_authorization_finished, callback))
         webbrowser2.open(authorization_url)
-        authorization_code = self._mb_login_dialog(parent)
-        if authorization_code is not None:
-            self.webservice.oauth_manager.exchange_authorization_code(
-                authorization_code, scopes,
-                partial(self.on_mb_authorization_finished, callback))
-        else:
-            callback(False, None)
+        # authorization_code = self._mb_login_dialog(parent)
+        # if authorization_code is not None:
+        #     self.webservice.oauth_manager.exchange_authorization_code(
+        #         authorization_code, scopes,
+        #         partial(self.on_mb_authorization_finished, callback))
+        # else:
+        #     callback(False, None)
 
     def on_mb_authorization_finished(self, callback, successful=False, error_msg=None):
         if successful:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -361,7 +361,7 @@ class Tagger(QtWidgets.QApplication):
                 self.pluginmanager.load_plugins_from_directory(plugin_dir)
 
         self.browser_integration = BrowserIntegration()
-        self.browser_integration.listen_port_changed.connect(self.listen_port_changed)
+        self.browser_integration.listen_port_changed.connect(self.on_listen_port_changed)
 
         self._pending_files_count = 0
         self.files = {}
@@ -642,6 +642,10 @@ class Tagger(QtWidgets.QApplication):
         self._debug = level == logging.DEBUG
         log.set_level(level)
 
+    def on_listen_port_changed(self, port):
+        self.webservice.oauth_manager.redirect_uri = self._mb_login_redirect_uri()
+        self.listen_port_changed.emit(port)
+
     def _mb_login_dialog(self, parent):
         if not parent:
             parent = self.window
@@ -655,18 +659,28 @@ class Tagger(QtWidgets.QApplication):
         else:
             return None
 
+    def _mb_login_redirect_uri(self):
+        if self.browser_integration and self.browser_integration.is_running:
+            return f'http://localhost:{self.browser_integration.port}/auth'
+        else:
+            # If browser integration is disabled or not running on the standard
+            # port use out-of-band flow (with manual copying of the token).
+            return None
+
     def mb_login(self, callback, parent=None):
+        oauth_manager = self.webservice.oauth_manager
         scopes = 'profile tag rating collection submit_isrc submit_barcode'
-        authorization_url = self.webservice.oauth_manager.get_authorization_url(
+        authorization_url = oauth_manager.get_authorization_url(
             scopes, partial(self.on_mb_authorization_finished, callback))
         webbrowser2.open(authorization_url)
-        # authorization_code = self._mb_login_dialog(parent)
-        # if authorization_code is not None:
-        #     self.webservice.oauth_manager.exchange_authorization_code(
-        #         authorization_code, scopes,
-        #         partial(self.on_mb_authorization_finished, callback))
-        # else:
-        #     callback(False, None)
+        if oauth_manager.is_oob:
+            authorization_code = self._mb_login_dialog(parent)
+            if authorization_code is not None:
+                self.webservice.oauth_manager.exchange_authorization_code(
+                    authorization_code, scopes,
+                    partial(self.on_mb_authorization_finished, callback))
+            else:
+                callback(False, None)
 
     def on_mb_authorization_finished(self, callback, successful=False, error_msg=None):
         if successful:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-736
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

So far Picard supported the OAuth2 login to MusicBrainz only via the out-of-band flow for token exchange, which requires the user to manually copy the code used to exchange the access token.

This PR updates the implementation to use a callback URL on localhost, making use of Picard's built-in web server.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The built-in webserver provides a new `/auth` endpoint to be used as a callback URL. If the built-in webserver is running, this is used on localhost as the redirect URI for the OAuth2 authorization URL, and the auth endpoint handles exchanging the provided code for the access token.

The old OOB workflow is used as a fallback in case the browser integration is turned off.

Note: This will also ease transition to the future central MeB OAuth endpoint, but this will need further changes, some of them still up for discussion.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
