### PR TITLE
PICARD-2889, PICARD-2890: Fix set focus calls

### DIFF
--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -274,7 +274,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             else:
                 self.remove()
         elif event.matches(QtGui.QKeySequence.StandardKey.Find):
-            self.search_edit.setFocus(True)
+            self.search_edit.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
         else:
             super().keyPressEvent(event)
 

--- a/picard/ui/widgets/editablelistview.py
+++ b/picard/ui/widgets/editablelistview.py
@@ -84,7 +84,7 @@ class EditableListView(QtWidgets.QListView):
 
     def add_empty_row(self):
         # Setting the focus causes any open editor to getting closed
-        self.setFocus(True)
+        self.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
         index = self.add_item()
         self.setCurrentIndex(index)
         self.edit(index)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Calling `setFocus(True)` is incorrect

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2889, PICARD-2890
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Call `setFocus()` with proper Qt.FocusReason
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
