### PR TITLE
QMouseEvent.globalPos() is deprecated -> replace with globalPosition(…

### DIFF
--- a/picard/ui/widgets/tristatesortheaderview.py
+++ b/picard/ui/widgets/tristatesortheaderview.py
@@ -56,7 +56,7 @@ class TristateSortHeaderView(QtWidgets.QHeaderView):
             tooltip = _(
                 "The table is locked. To enable sorting and column resizing\n"
                 "unlock the table in the table header's context menu.")
-            QtWidgets.QToolTip.showText(event.globalPos(), tooltip, self)
+            QtWidgets.QToolTip.showText(event.globalPosition().toPoint(), tooltip, self)
             return
 
         if event.button() == QtCore.Qt.MouseButton.LeftButton:


### PR DESCRIPTION
…).toPoint()

It's deprecated since 6.0 and doesn't work at all with 6.6 See https://doc.qt.io/qt-6/qmouseevent-obsolete.html

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
