### PR TITLE
Remove deprecated Track.linked_files

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -151,11 +151,6 @@ class Track(DataObject, FileListItem):
     def __repr__(self):
         return '<Track %s %r>' % (self.id, self.metadata["title"])
 
-    @property
-    def linked_files(self):
-        """For backward compatibility with old code in plugins"""
-        return self.files
-
     def add_file(self, file, new_album=True):
         track_will_expand = False
         if file not in self.files:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This was only retained for some plugin compatibility. Track.files should be used instead.
