### PR TITLE
Turn item capability methods into properties

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -739,27 +739,35 @@ class Album(DataObject, Item):
                 for file in list(files):
                     file.move(self.unmatched_files)
 
+    @property
     def can_save(self):
         return self._files_count > 0
 
+    @property
     def can_remove(self):
         return True
 
+    @property
     def can_edit_tags(self):
         return True
 
+    @property
     def can_analyze(self):
         return False
 
+    @property
     def can_autotag(self):
         return False
 
+    @property
     def can_refresh(self):
         return True
 
+    @property
     def can_view_info(self):
         return self.loaded or bool(self.errors)
 
+    @property
     def is_album_like(self):
         return True
 
@@ -888,12 +896,15 @@ class NatAlbum(Album):
     def _finalize_loading(self, error):
         self.update()
 
+    @property
     def can_refresh(self):
         return False
 
+    @property
     def can_browser_lookup(self):
         return False
 
+    @property
     def can_view_info(self):
         return False
 

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -191,37 +191,47 @@ class Cluster(FileList):
     def get_num_files(self):
         return len(self.files)
 
+    @property
     def can_save(self):
         """Return if this object can be saved."""
         return bool(self.files)
 
+    @property
     def can_remove(self):
         """Return if this object can be removed."""
         return not self.special
 
+    @property
     def can_edit_tags(self):
         """Return if this object supports tag editing."""
         return True
 
+    @property
     def can_analyze(self):
         """Return if this object can be fingerprinted."""
-        return any(_file.can_analyze() for _file in self.files)
+        return any(_file.can_analyze for _file in self.files)
 
+    @property
     def can_autotag(self):
         return True
 
+    @property
     def can_refresh(self):
         return False
 
+    @property
     def can_browser_lookup(self):
         return not self.special
 
+    @property
     def can_view_info(self):
         return bool(self.files)
 
+    @property
     def can_submit(self):
         return not self.special and bool(self.files)
 
+    @property
     def is_album_like(self):
         return True
 
@@ -347,15 +357,19 @@ class UnclusteredFiles(Cluster):
     def lookup_metadata(self):
         self.tagger.autotag(self.files)
 
+    @property
     def can_edit_tags(self):
         return False
 
+    @property
     def can_autotag(self):
         return bool(self.files)
 
+    @property
     def can_view_info(self):
         return False
 
+    @property
     def can_remove(self):
         return bool(self.files)
 
@@ -383,18 +397,23 @@ class ClusterList(list, Item):
         for cluster in self:
             yield from cluster.iterfiles(save)
 
+    @property
     def can_save(self):
         return len(self) > 0
 
+    @property
     def can_analyze(self):
-        return any(cluster.can_analyze() for cluster in self)
+        return any(cluster.can_analyze for cluster in self)
 
+    @property
     def can_autotag(self):
         return len(self) > 0
 
+    @property
     def can_browser_lookup(self):
         return False
 
+    @property
     def lookup_metadata(self):
         for cluster in self:
             cluster.lookup_metadata()

--- a/picard/file.py
+++ b/picard/file.py
@@ -742,28 +742,35 @@ class File(QtCore.QObject, Item):
             log.debug("Updating file %r", self)
             self.update_item()
 
+    @property
     def can_save(self):
         """Return if this object can be saved."""
         return True
 
+    @property
     def can_remove(self):
         """Return if this object can be removed."""
         return True
 
+    @property
     def can_edit_tags(self):
         """Return if this object supports tag editing."""
         return True
 
+    @property
     def can_analyze(self):
         """Return if this object can be fingerprinted."""
         return True
 
+    @property
     def can_autotag(self):
         return True
 
+    @property
     def can_refresh(self):
         return False
 
+    @property
     def can_view_info(self):
         return True
 

--- a/picard/formats/midi.py
+++ b/picard/formats/midi.py
@@ -56,5 +56,6 @@ class MIDIFile(File):
     def supports_tag(cls, name):
         return False
 
+    @property
     def can_analyze(self):
         return False

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -848,7 +848,7 @@ class Tagger(QtWidgets.QApplication):
             unmatched_files.append(file)
 
         # fallback on analyze if nothing else worked
-        if not file_moved and config.setting['analyze_new_files'] and file.can_analyze():
+        if not file_moved and config.setting['analyze_new_files'] and file.can_analyze:
             log.debug("Trying to analyze %r …", file)
             self.analyze([file])
 
@@ -1030,11 +1030,11 @@ class Tagger(QtWidgets.QApplication):
                 lookup.album_lookup(itemid)
         else:
             lookup.tag_lookup(
-                metadata['albumartist'] if item.is_album_like() else metadata['artist'],
+                metadata['albumartist'] if item.is_album_like else metadata['artist'],
                 metadata['album'],
                 metadata['title'],
                 metadata['tracknumber'],
-                '' if item.is_album_like() else str(metadata.length),
+                '' if item.is_album_like else str(metadata.length),
                 item.filename if isinstance(item, File) else '')
 
     def get_files_from_objects(self, objects, save=False):
@@ -1249,7 +1249,7 @@ class Tagger(QtWidgets.QApplication):
         if not self.use_acoustid:
             return
         for file in iter_files_from_objects(objs):
-            if file.can_analyze():
+            if file.can_analyze:
                 file.set_pending()
                 self._acoustid.analyze(file, partial(file._lookup_finished, File.LOOKUP_ACOUSTID))
 
@@ -1271,7 +1271,7 @@ class Tagger(QtWidgets.QApplication):
 
     def autotag(self, objects):
         for obj in objects:
-            if obj.can_autotag():
+            if obj.can_autotag:
                 obj.lookup_metadata()
 
     # =======================================================================
@@ -1334,7 +1334,7 @@ class Tagger(QtWidgets.QApplication):
 
     def refresh(self, objs):
         for obj in objs:
-            if obj.can_refresh():
+            if obj.can_refresh:
                 obj.load(priority=True, refresh=True)
 
     def bring_tagger_front(self):

--- a/picard/track.py
+++ b/picard/track.py
@@ -230,18 +230,22 @@ class Track(DataObject, FileListItem):
     def is_linked(self):
         return self.num_linked_files > 0
 
+    @property
     def can_save(self):
         """Return if this object can be saved."""
-        return any(file.can_save() for file in self.files)
+        return any(file.can_save for file in self.files)
 
+    @property
     def can_remove(self):
         """Return if this object can be removed."""
-        return any(file.can_remove() for file in self.files)
+        return any(file.can_remove for file in self.files)
 
+    @property
     def can_edit_tags(self):
         """Return if this object supports tag editing."""
         return True
 
+    @property
     def can_view_info(self):
         return self.num_linked_files == 1 or bool(self.metadata.images)
 
@@ -381,6 +385,7 @@ class NonAlbumTrack(Track):
         self.loaded = False
         self.status = None
 
+    @property
     def can_refresh(self):
         return True
 
@@ -428,6 +433,7 @@ class NonAlbumTrack(Track):
             refresh=refresh
         )
 
+    @property
     def can_remove(self):
         return True
 

--- a/picard/ui/coverartbox.py
+++ b/picard/ui/coverartbox.py
@@ -424,7 +424,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         # We want to show the 2 coverarts only if they are different
         # and orig_cover_art data is set and not the default cd shadow
         if self.orig_cover_art.data is None or self.cover_art == self.orig_cover_art:
-            self.show_details_button.setVisible(bool(self.item and self.item.can_view_info()))
+            self.show_details_button.setVisible(bool(self.item and self.item.can_view_info))
             self.orig_cover_art.setVisible(False)
             self.cover_art_label.setText('')
             self.orig_cover_art_label.setText('')

--- a/picard/ui/item.py
+++ b/picard/ui/item.py
@@ -32,33 +32,41 @@ from picard.util.imagelist import update_metadata_images
 
 class Item(object):
 
+    @property
     def can_save(self):
         """Return if this object can be saved."""
         return False
 
+    @property
     def can_remove(self):
         """Return if this object can be removed."""
         return False
 
+    @property
     def can_edit_tags(self):
         """Return if this object supports tag editing."""
         return False
 
+    @property
     def can_analyze(self):
         """Return if this object can be fingerprinted."""
         return False
 
+    @property
     def can_autotag(self):
         """Return if this object can be autotagged."""
         return False
 
+    @property
     def can_refresh(self):
         """Return if this object can be refreshed."""
         return False
 
+    @property
     def can_view_info(self):
         return False
 
+    @property
     def can_submit(self):
         """Return True if this object can be submitted to MusicBrainz.org."""
         return False
@@ -66,11 +74,13 @@ class Item(object):
     @property
     def can_show_coverart(self):
         """Return if this object supports cover art."""
-        return self.can_edit_tags()
+        return self.can_edit_tags
 
+    @property
     def can_browser_lookup(self):
         return True
 
+    @property
     def is_album_like(self):
         return False
 

--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -843,7 +843,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         obj = self.itemFromIndex(index).obj
         # Double-clicking albums or clusters should expand them. The album info can be
         # viewed by using the toolbar button.
-        if not isinstance(obj, (Album, Cluster)) and obj.can_view_info():
+        if not isinstance(obj, (Album, Cluster)) and obj.can_view_info:
             self.window.view_info()
 
     def add_cluster(self, cluster, parent_item=None):

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1129,8 +1129,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         can_autotag = False
         can_submit = False
         single = self.selected_objects[0] if len(self.selected_objects) == 1 else None
-        can_view_info = bool(single and single.can_view_info())
-        can_browser_lookup = bool(single and single.can_browser_lookup())
+        can_view_info = bool(single and single.can_view_info)
+        can_browser_lookup = bool(single and single.can_browser_lookup)
         is_file = bool(single and isinstance(single, (File, Track)))
         is_album = bool(single and isinstance(single, Album))
         is_cluster = bool(single and isinstance(single, Cluster) and not single.special)
@@ -1149,12 +1149,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                     continue
                 # using x = x or obj.x() form prevents calling function
                 # if x is already True
-                can_analyze = can_analyze or obj.can_analyze()
-                can_autotag = can_autotag or obj.can_autotag()
-                can_refresh = can_refresh or obj.can_refresh()
-                can_remove = can_remove or obj.can_remove()
-                can_save = can_save or obj.can_save()
-                can_submit = can_submit or obj.can_submit()
+                can_analyze = can_analyze or obj.can_analyze
+                can_autotag = can_autotag or obj.can_autotag
+                can_refresh = can_refresh or obj.can_refresh
+                can_remove = can_remove or obj.can_remove
+                can_save = can_save or obj.can_save
+                can_submit = can_submit or obj.can_submit
                 # Skip further loops if all values now True.
                 if (
                     can_analyze

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -515,7 +515,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             elif isinstance(obj, Track):
                 tracks.add(obj)
                 files.update(obj.files)
-            elif isinstance(obj, Cluster) and obj.can_edit_tags():
+            elif isinstance(obj, Cluster) and obj.can_edit_tags:
                 objects.add(obj)
                 files.update(obj.files)
             elif isinstance(obj, Album):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Newer ones, like `can_link_fingerprint` or `can_show_coverart` already got defined as properties. This changes make it consistent for older ones as well.
