### PR TITLE
PICARD-2891: When clustering files attached to a Track use orig_metadata

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2008, 2011 Lukáš Lalinský
 # Copyright (C) 2008 Hendrik van Antwerpen
 # Copyright (C) 2008 Will
-# Copyright (C) 2010-2011, 2014, 2018-2023 Philipp Wolfer
+# Copyright (C) 2010-2011, 2014, 2018-2024 Philipp Wolfer
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
 # Copyright (C) 2012 Wieland Hoffmann
@@ -54,6 +54,7 @@ from picard.metadata import (
     Metadata,
     SimMatchRelease,
 )
+from picard.track import Track
 from picard.util import (
     album_artist_from_path,
     find_best_match,
@@ -315,8 +316,15 @@ class Cluster(FileList):
 
         cluster_list = defaultdict(FileCluster)
         for file in files:
-            artist = file.metadata['albumartist'] or file.metadata['artist']
-            album = file.metadata['album']
+            # If the file is attached to a track we should use the original
+            # metadata for clustering. This is often used by users when moving
+            # mismatched files back from the right pane to the left.
+            if isinstance(file.parent, Track):
+                metadata = file.orig_metadata
+            else:
+                metadata = file.metadata
+            artist = metadata['albumartist'] or metadata['artist']
+            album = metadata['album']
 
             # Improve clustering from directory structure if no existing tags
             # Only used for grouping and to provide cluster title / artist - not added to file tags.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2891
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When dragging files already matched to tracks on the right pane directly back to the left pane "Clusters" item the files get clustered by the new metadata from the matches releases. This is confusing, as the user likely wants to drag mismatched files back and retry with new clustering.

After clustering the files get their metadata reset to original anyway (because this happens when moving away a file from a track), which makes the cluster result even less understandable. 

Note that using the new metadata is actually wanted when clustering files already on the left pane.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
During clustering check the parent of the file. If it is a track, then use the original metadata for clustering.
