### PR TITLE
Removed deprecated webservice methods

### DIFF
--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -61,7 +61,6 @@ from picard.const.defaults import DEFAULT_CACHE_SIZE_IN_BYTES
 from picard.debug_opts import DebugOpt
 from picard.oauth import OAuthManager
 from picard.util import (
-    build_qurl,
     bytes2human,
     encoded_queryargs,
     parse_json,
@@ -579,83 +578,6 @@ class WebService(QtCore.QObject):
         finally:
             reply.close()
             reply.deleteLater()
-
-    def get(self, host, port, path, handler, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
-            priority=False, important=False, mblogin=False, cacheloadcontrol=None, refresh=False,
-            queryargs=None):
-        log.warning("This method is deprecated, use WebService.get_url() instead")
-        request = WSRequest(
-            method='GET',
-            url=build_qurl(host, port, path=path, queryargs=queryargs),
-            handler=handler,
-            parse_response_type=parse_response_type,
-            priority=priority,
-            important=important,
-            mblogin=mblogin,
-            cacheloadcontrol=cacheloadcontrol,
-            refresh=refresh,
-        )
-        return self.add_request(request)
-
-    def post(self, host, port, path, data, handler, parse_response_type=DEFAULT_RESPONSE_PARSER_TYPE,
-             priority=False, important=False, mblogin=True, queryargs=None, request_mimetype=None):
-        log.warning("This method is deprecated, use WebService.post_url() instead")
-        request = WSRequest(
-            method='POST',
-            url=build_qurl(host, port, path=path, queryargs=queryargs),
-            handler=handler,
-            parse_response_type=parse_response_type,
-            priority=priority,
-            important=important,
-            mblogin=mblogin,
-            data=data,
-            request_mimetype=request_mimetype,
-        )
-        log.debug("POST-DATA %r", data)
-        return self.add_request(request)
-
-    def put(self, host, port, path, data, handler, priority=True, important=False, mblogin=True,
-            queryargs=None, request_mimetype=None):
-        log.warning("This method is deprecated, use WebService.put_url() instead")
-        request = WSRequest(
-            method='PUT',
-            url=build_qurl(host, port, path=path, queryargs=queryargs),
-            handler=handler,
-            priority=priority,
-            important=important,
-            mblogin=mblogin,
-            data=data,
-            request_mimetype=request_mimetype,
-        )
-        return self.add_request(request)
-
-    def delete(self, host, port, path, handler, priority=True, important=False, mblogin=True,
-               queryargs=None):
-        log.warning("This method is deprecated, use WebService.delete_url() instead")
-        request = WSRequest(
-            method='DELETE',
-            url=build_qurl(host, port, path=path, queryargs=queryargs),
-            handler=handler,
-            priority=priority,
-            important=important,
-            mblogin=mblogin,
-        )
-        return self.add_request(request)
-
-    def download(self, host, port, path, handler, priority=False,
-                 important=False, cacheloadcontrol=None, refresh=False,
-                 queryargs=None):
-        log.warning("This method is deprecated, use WebService.download_url() instead")
-        request = WSRequest(
-            method='GET',
-            url=build_qurl(host, port, path=path, queryargs=queryargs),
-            handler=handler,
-            priority=priority,
-            important=important,
-            cacheloadcontrol=cacheloadcontrol,
-            refresh=refresh,
-        )
-        return self.add_request(request)
 
     def get_url(self, **kwargs):
         kwargs['method'] = 'GET'

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -82,32 +82,6 @@ class WebServiceTest(PicardTestCase):
         self.ws = WebService()
 
     @patch.object(WebService, 'add_task')
-    def test_webservice_method_calls(self, mock_add_task):
-        host = "abc.xyz"
-        port = 80
-        path = ""
-        handler = dummy_handler
-        data = None
-
-        def get_wsreq(mock_add_task):
-            return mock_add_task.call_args[0][1]
-
-        self.ws.get(host, port, path, handler)
-        self.assertEqual(1, mock_add_task.call_count)
-        self.assertEqual(host, get_wsreq(mock_add_task).host)
-        self.assertEqual(port, get_wsreq(mock_add_task).port)
-        self.assertIn("GET", get_wsreq(mock_add_task).method)
-        self.ws.post(host, port, path, data, handler)
-        self.assertIn("POST", get_wsreq(mock_add_task).method)
-        self.ws.put(host, port, path, data, handler)
-        self.assertIn("PUT", get_wsreq(mock_add_task).method)
-        self.ws.delete(host, port, path, handler)
-        self.assertIn("DELETE", get_wsreq(mock_add_task).method)
-        self.ws.download(host, port, path, handler)
-        self.assertIn("GET", get_wsreq(mock_add_task).method)
-        self.assertEqual(5, mock_add_task.call_count)
-
-    @patch.object(WebService, 'add_task')
     def test_webservice_url_method_calls(self, mock_add_task):
         url = "http://abc.xyz"
         handler = dummy_handler


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

We can remove the deprecated request methods in favor of the newer *_url methods. The old ones are not in use in the codebase anymore and we just kept them around for plugin compatibility.