### PR TITLE
PICARD-2895: Web service requests must set Authorization header only when required

### DIFF
--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2007 Lukáš Lalinský
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2017 Sambhav Kothari
-# Copyright (C) 2018-2022 Philipp Wolfer
+# Copyright (C) 2018-2022, 2024 Philipp Wolfer
 # Copyright (C) 2018-2023 Laurent Monin
 # Copyright (C) 2021 Tche333
 #
@@ -220,8 +220,9 @@ class WSRequest(QNetworkRequest):
         return self.mblogin and self.access_token
 
     def _update_authorization_header(self):
-        auth = 'Bearer ' + self.access_token if self.has_auth else ''
-        self.setRawHeader(b'Authorization', auth.encode('utf-8'))
+        if self.has_auth:
+            auth = 'Bearer ' + self.access_token
+            self.setRawHeader(b'Authorization', auth.encode('utf-8'))
 
     @property
     def host(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2895
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Setting an empty authorization header can lead to request errors if the server tries to validate the header if present. In the reported ticket this is the case with the Deezer API, which expects a valid token in case the authorization header is present.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Only set the authorization header, if login has been set.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
