### PR TITLE
PICARD-2897: Load supported file formats with unknown / uncommon extension

### DIFF
--- a/picard/extension_points/formats.py
+++ b/picard/extension_points/formats.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008, 2012 Lukáš Lalinský
 # Copyright (C) 2008 Will
-# Copyright (C) 2010, 2014, 2018-2020, 2023 Philipp Wolfer
+# Copyright (C) 2010, 2014, 2018-2020, 2023-2024 Philipp Wolfer
 # Copyright (C) 2013 Michael Wiencek
 # Copyright (C) 2013, 2017-2024 Laurent Monin
 # Copyright (C) 2016-2018 Sambhav Kothari
@@ -36,8 +36,8 @@ _formats_extensions = {}
 def register_format(file_format):
     ext_point_formats.register(file_format.__module__, file_format)
     for ext in file_format.EXTENSIONS:
-        _formats_extensions[ext[1:]] = file_format
+        _formats_extensions[ext.lower()] = file_format
 
 
 def ext_to_format(ext):
-    return _formats_extensions.get(ext, None)
+    return _formats_extensions.get(ext.lower(), None)

--- a/picard/formats/util.py
+++ b/picard/formats/util.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008, 2012 Lukáš Lalinský
 # Copyright (C) 2008 Will
-# Copyright (C) 2010, 2014, 2018-2020, 2023 Philipp Wolfer
+# Copyright (C) 2010, 2014, 2018-2020, 2023-2024 Philipp Wolfer
 # Copyright (C) 2013 Michael Wiencek
 # Copyright (C) 2013, 2017-2019, 2021, 2023-2024 Laurent Monin
 # Copyright (C) 2016-2018 Sambhav Kothari
@@ -25,6 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import os.path
 
 from picard import log
 from picard.extension_points.formats import (
@@ -72,23 +73,12 @@ def open_(filename):
     """Open the specified file and return a File instance with the appropriate format handler, or None."""
     try:
         # Use extension based opening as default
-        i = filename.rfind(".")
-        if i >= 0:
-            ext = filename[i+1:].lower()
-            file_format = ext_to_format(ext)
-            if file_format is None:
-                audio_file = guess_format(filename)
-            else:
-                audio_file = file_format(filename)
-        else:
-            # If there is no extension, try to guess the format based on file headers
-            audio_file = guess_format(filename)
-        if not audio_file:
-            return None
-        return audio_file
-    except KeyError:
-        # None is returned if both the methods fail
-        return None
+        _name, ext = os.path.splitext(filename)
+        if ext:
+            if file_format := ext_to_format(ext):
+                return file_format(filename)
+        # If detection by extension failed, try to guess the format based on file headers
+        return guess_format(filename)
     except Exception as error:
         log.error("Error occurred:\n%s", error)
         return None

--- a/picard/formats/util.py
+++ b/picard/formats/util.py
@@ -77,8 +77,9 @@ def open_(filename):
             ext = filename[i+1:].lower()
             file_format = ext_to_format(ext)
             if file_format is None:
-                return None
-            audio_file = file_format(filename)
+                audio_file = guess_format(filename)
+            else:
+                audio_file = file_format(filename)
         else:
             # If there is no extension, try to guess the format based on file headers
             audio_file = guess_format(filename)

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -216,7 +216,7 @@ class CommonTests:
                 self.testfile_path = os.path.join('test', 'data', self.testfile)
                 self.testfile_ext = os.path.splitext(self.testfile)[1]
                 self.filename = self.copy_of_original_testfile()
-                self.format = ext_to_format(self.testfile_ext[1:])
+                self.format = ext_to_format(self.testfile_ext)
 
         def copy_of_original_testfile(self):
             return self.copy_file_tmp(self.testfile_path, self.testfile_ext)

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -49,7 +49,7 @@ class CommonAsfTests:
     class AsfTestCase(CommonTests.TagFormatsTestCase):
 
         def test_supports_tag(self):
-            fmt = ext_to_format(self.testfile_ext[1:])
+            fmt = ext_to_format(self.testfile_ext)
             self.assertTrue(fmt.supports_tag('copyright'))
             self.assertTrue(fmt.supports_tag('compilation'))
             self.assertTrue(fmt.supports_tag('bpm'))

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -44,7 +44,7 @@ class CommonMP4Tests:
 
     class MP4TestCase(CommonTests.TagFormatsTestCase):
         def test_supports_tag(self):
-            fmt = ext_to_format(self.testfile_ext[1:])
+            fmt = ext_to_format(self.testfile_ext)
             self.assertTrue(fmt.supports_tag('copyright'))
             self.assertTrue(fmt.supports_tag('compilation'))
             self.assertTrue(fmt.supports_tag('bpm'))

--- a/test/formats/test_util.py
+++ b/test/formats/test_util.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import os.path
+
+from test.picardtestcase import PicardTestCase
+
+from picard.formats import util
+from picard.formats.id3 import MP3File
+
+
+class FormatsOpenTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({'enabled_plugins': []})
+
+    def test_open(self):
+        file_path = os.path.join('test', 'data', 'test.mp3')
+        filename = self.copy_file_tmp(file_path, '.mp3')
+        filetype = util.open_(filename)
+        self.assertIsInstance(filetype, MP3File)
+
+    def test_open_no_extension(self):
+        file_path = os.path.join('test', 'data', 'test.mp3')
+        filename = self.copy_file_tmp(file_path, '')
+        filetype = util.open_(filename)
+        self.assertIsInstance(filetype, MP3File)
+
+    def test_open_unknown_extension(self):
+        file_path = os.path.join('test', 'data', 'test.mp3')
+        filename = self.copy_file_tmp(file_path, '.fake')
+        filetype = util.open_(filename)
+        self.assertIsInstance(filetype, MP3File)
+
+    def test_open_unknown_type(self):
+        file_path = os.path.join('test', 'data', 'mb.png')
+        filename = self.copy_file_tmp(file_path, '.ogg')
+        filetype = util.open_(filename)
+        self.assertIsNone(filetype)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2897
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
Picard currently tries load files based on the file extension. Only if the file has no extension or if loading causes an error it falls back to guess format by file content.

Picard should also guess format by file content if the extension was unknown.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- If detection of file format by extension fails, try guessing by content instead of returning `None`
- Added tests for `format.open_`
- Refactor `format.open_` to simplify the code. This also changes `extension_points.formats.ext_to_format`, which now expects the extension with leading dot. This avoid the need to remove the dot in every place where `ext_to_format` got called.

