### PR TITLE
Fixed CheckboxListItem hiding QListWidgetItem.data()

### DIFF
--- a/picard/ui/checkbox_list_item.py
+++ b/picard/ui/checkbox_list_item.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2018 Sambhav Kothari
 # Copyright (C) 2018, 2020-2024 Laurent Monin
-# Copyright (C) 2022 Philipp Wolfer
+# Copyright (C) 2022, 2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -27,12 +27,10 @@ from PyQt6.QtWidgets import QListWidgetItem
 
 class CheckboxListItem(QListWidgetItem):
 
-    def __init__(self, text='', checked=False, data=None):
-        super().__init__()
-        self.setText(text)
+    def __init__(self, text='', checked=False):
+        super().__init__(text)
         self.setFlags(self.flags() | Qt.ItemFlag.ItemIsUserCheckable)
         self.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
-        self.data = data
 
     @property
     def checked(self):

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2010, 2018-2021 Philipp Wolfer
+# Copyright (C) 2010, 2018-2021, 2024 Philipp Wolfer
 # Copyright (C) 2012, 2014 Wieland Hoffmann
 # Copyright (C) 2012-2014 Michael Wiencek
 # Copyright (C) 2013-2015, 2018-2021, 2023-2024 Laurent Monin
@@ -25,6 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from PyQt6.QtCore import Qt
 
 from picard.config import (
     Option,
@@ -83,7 +84,8 @@ class CoverOptionsPage(OptionsPage):
         """
         self.ui.ca_providers_list.clear()
         for p in cover_art_providers():
-            item = CheckboxListItem(_(p.title), checked=p.enabled, data=p.name)
+            item = CheckboxListItem(_(p.title), checked=p.enabled)
+            item.setData(Qt.ItemDataRole.UserRole, p.name)
             self.ui.ca_providers_list.addItem(item)
 
     def load(self):
@@ -101,7 +103,7 @@ class CoverOptionsPage(OptionsPage):
 
     def _ca_providers(self):
         for item in qlistwidget_items(self.ui.ca_providers_list):
-            yield (item.data, item.checked)
+            yield (item.data(Qt.ItemDataRole.UserRole), item.checked)
 
     def save(self):
         config = get_config()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This is something I came across while debugging my PySide branch: The current implementation of `CheckboxListItem` does replace the `QListWidgetItem.data()` method with a string. This can lead to unintended side effects, as Qt might expect a function there.

Also Qt already provides data handling with  `QListWidgetItem.setData()` and `QListWidgetItem.data()`, so use this instead of the custom implementation. Have `CheckboxListItem` focus on checkbox handling.