### PR TITLE
Fixed callback for click signal in CAATypesSelectorDialog

### DIFF
--- a/picard/ui/caa_types_selector.py
+++ b/picard/ui/caa_types_selector.py
@@ -325,7 +325,7 @@ class CAATypesSelectorDialog(PicardDialog):
     def excluded(self):
         return list(self.list_exclude.all_items_data()) or ['none']
 
-    def clear_focus(self, lists):
+    def clear_focus(self, lists, *args):
         for temp_list in lists:
             temp_list.clearSelection()
         self.set_buttons_enabled_state()

--- a/picard/ui/caa_types_selector.py
+++ b/picard/ui/caa_types_selector.py
@@ -190,9 +190,9 @@ class CAATypesSelectorDialog(PicardDialog):
         self.fill_lists(types_include, types_exclude)
 
         # Set triggers when the lists receive the current focus
-        self.list_include.clicked.connect(partial(self.clear_focus, [self.list_ignore, self.list_exclude]))
-        self.list_exclude.clicked.connect(partial(self.clear_focus, [self.list_ignore, self.list_include]))
-        self.list_ignore.clicked.connect(partial(self.clear_focus, [self.list_include, self.list_exclude]))
+        self.list_include.clicked.connect(partial(self._on_list_clicked, (self.list_ignore, self.list_exclude)))
+        self.list_exclude.clicked.connect(partial(self._on_list_clicked, (self.list_ignore, self.list_include)))
+        self.list_ignore.clicked.connect(partial(self._on_list_clicked, (self.list_include, self.list_exclude)))
 
         # Add instructions to the dialog box
         instructions = QtWidgets.QLabel()
@@ -325,7 +325,7 @@ class CAATypesSelectorDialog(PicardDialog):
     def excluded(self):
         return list(self.list_exclude.all_items_data()) or ['none']
 
-    def clear_focus(self, lists, *args):
+    def _on_list_clicked(self, lists, index):
         for temp_list in lists:
             temp_list.clearSelection()
         self.set_buttons_enabled_state()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The `QListWidget.Clicked` signal expects a slot which accepts a single index parameter. In `CAATypesSelectorDialog` the signal gets connected to a function without parameters. See https://doc.qt.io/qt-6/qabstractitemview.html#clicked

While PyQt does handle this, we should still provide callbacks following the expected signature. I came across this while testing with PySide (which is less forgiving).

I chose to set the parameter to `*argc`  here, as we don't care about the actually passed parameter.