### PR TITLE
PICARD-2926: Add option to filter out images below a given size

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -108,7 +108,9 @@ class CoverArt:
                 },
                 echo=None
             )
-            filters_result = run_image_filters(data)
+            filters_result = True
+            if coverartimage.can_be_filtered:
+                filters_result = run_image_filters(data)
             if filters_result:
                 try:
                     self._set_metadata(coverartimage, data)

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -36,6 +36,7 @@ from picard.coverart.image import (
     CoverArtImageIdentificationError,
     CoverArtImageIOError,
 )
+from picard.coverart.processing import run_image_filters
 from picard.coverart.providers import (
     CoverArtProvider,
     cover_art_providers,
@@ -107,12 +108,14 @@ class CoverArt:
                 },
                 echo=None
             )
-            try:
-                self._set_metadata(coverartimage, data)
-            except CoverArtImageIOError:
-                # It doesn't make sense to store/download more images if we can't
-                # save them in the temporary folder, abort.
-                return
+            filters_result = run_image_filters(data)
+            if filters_result:
+                try:
+                    self._set_metadata(coverartimage, data)
+                except CoverArtImageIOError:
+                    # It doesn't make sense to store/download more images if we can't
+                    # save them in the temporary folder, abort.
+                    return
 
         self.next_in_queue()
 

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -175,6 +175,7 @@ class CoverArtImage:
         self.can_be_saved_to_tags = True
         self.can_be_saved_to_disk = True
         self.can_be_saved_to_metadata = True
+        self.can_be_filtered = True
         if support_types is not None:
             self.support_types = support_types
         if support_multi_types is not None:
@@ -486,6 +487,7 @@ class CaaThumbnailCoverArtImage(CaaCoverArtImage):
         self.can_be_saved_to_disk = False
         self.can_be_saved_to_tags = False
         self.can_be_saved_to_metadata = False
+        self.can_be_filtered = False
 
 
 class TagCoverArtImage(CoverArtImage):

--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.coverart.processing import (  # noqa: F401 # pylint: disable=unused-import
+    filters,
+)
+from picard.extension_points.cover_art_filters import (
+    ext_point_cover_art_filters,
+)
+
+
+def run_image_filters(data):
+    for f in ext_point_cover_art_filters:
+        if not f(data):
+            return False
+    return True
+
+
+# def run_image_processors(data):
+#     pass

--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -23,12 +23,20 @@ from picard.coverart.processing import (  # noqa: F401 # pylint: disable=unused-
 )
 from picard.extension_points.cover_art_filters import (
     ext_point_cover_art_filters,
+    ext_point_cover_art_metadata_filters,
 )
 
 
 def run_image_filters(data):
     for f in ext_point_cover_art_filters:
         if not f(data):
+            return False
+    return True
+
+
+def run_image_metadata_filters(metadata):
+    for f in ext_point_cover_art_metadata_filters:
+        if not f(metadata):
             return False
     return True
 

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from PyQt6.QtGui import QImage
+
+from picard import log
+from picard.config import get_config
+from picard.extension_points.cover_art_filters import register_cover_art_filter
+
+
+def size_filter(data):
+    config = get_config()
+    if not config.setting['filter_cover_by_size']:
+        return True
+    image = QImage.fromData(data)
+    width = config.setting['cover_width_threshold']
+    height = config.setting['cover_height_threshold']
+    if not (image.width() >= width and image.height() >= height):
+        log.debug(
+            "Discarding cover art due to size. Image size: %d x %d. Minimum: %d x %d",
+            image.width(),
+            image.height(),
+            width,
+            height
+        )
+        return False
+    return True
+
+
+register_cover_art_filter(size_filter)

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -28,42 +28,33 @@ from picard.extension_points.cover_art_filters import (
 )
 
 
-def size_filter(data):
+def _check_threshold_size(width, height):
     config = get_config()
     if not config.setting['filter_cover_by_size']:
         return True
-    image = QImage.fromData(data)
-    width = config.setting['cover_width_threshold']
-    height = config.setting['cover_height_threshold']
-    if not (image.width() >= width and image.height() >= height):
+    min_width = config.setting['cover_width_threshold']
+    min_height = config.setting['cover_height_threshold']
+    if width < min_width or height < min_height:
         log.debug(
             "Discarding cover art due to size. Image size: %d x %d. Minimum: %d x %d",
-            image.width(),
-            image.height(),
             width,
-            height
+            height,
+            min_width,
+            min_height
         )
         return False
     return True
+
+
+def size_filter(data):
+    image = QImage.fromData(data)
+    return _check_threshold_size(image.width(), image.height())
 
 
 def size_metadata_filter(metadata):
-    config = get_config()
-    if (not config.setting['filter_cover_by_size']
-            or 'width' not in metadata or 'height' not in metadata):
+    if 'width' not in metadata or 'height' not in metadata:
         return True
-    width = config.setting['cover_width_threshold']
-    height = config.setting['cover_height_threshold']
-    if not (metadata['width'] >= width and metadata['height'] >= height):
-        log.debug(
-            "Avoiding download of cover art due to size. Image size: %d x %d. Minimum: %d x %d",
-            metadata['width'],
-            metadata['height'],
-            width,
-            height
-        )
-        return False
-    return True
+    return _check_threshold_size(metadata['width'], metadata['height'])
 
 
 register_cover_art_filter(size_filter)

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -22,7 +22,10 @@ from PyQt6.QtGui import QImage
 
 from picard import log
 from picard.config import get_config
-from picard.extension_points.cover_art_filters import register_cover_art_filter
+from picard.extension_points.cover_art_filters import (
+    register_cover_art_filter,
+    register_cover_art_metadata_filter,
+)
 
 
 def size_filter(data):
@@ -44,4 +47,24 @@ def size_filter(data):
     return True
 
 
+def size_metadata_filter(metadata):
+    config = get_config()
+    if (not config.setting['filter_cover_by_size']
+            or 'width' not in metadata or 'height' not in metadata):
+        return True
+    width = config.setting['cover_width_threshold']
+    height = config.setting['cover_height_threshold']
+    if not (metadata['width'] >= width and metadata['height'] >= height):
+        log.debug(
+            "Avoiding download of cover art due to size. Image size: %d x %d. Minimum: %d x %d",
+            metadata['width'],
+            metadata['height'],
+            width,
+            height
+        )
+        return False
+    return True
+
+
 register_cover_art_filter(size_filter)
+register_cover_art_metadata_filter(size_metadata_filter)

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -32,8 +32,9 @@ def _check_threshold_size(width, height):
     config = get_config()
     if not config.setting['filter_cover_by_size']:
         return True
-    min_width = config.setting['cover_width_threshold']
-    min_height = config.setting['cover_height_threshold']
+    # If the given width or height is -1, that dimension is not considered
+    min_width = config.setting['cover_width_threshold'] if width != -1 else -1
+    min_height = config.setting['cover_height_threshold'] if height != -1 else -1
     if width < min_width or height < min_height:
         log.debug(
             "Discarding cover art due to size. Image size: %d x %d. Minimum: %d x %d",

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -33,8 +33,8 @@ def _check_threshold_size(width, height):
     if not config.setting['filter_cover_by_size']:
         return True
     # If the given width or height is -1, that dimension is not considered
-    min_width = config.setting['cover_width_threshold'] if width != -1 else -1
-    min_height = config.setting['cover_height_threshold'] if height != -1 else -1
+    min_width = config.setting['cover_minimum_width'] if width != -1 else -1
+    min_height = config.setting['cover_minimum_height'] if height != -1 else -1
     if width < min_width or height < min_height:
         log.debug(
             "Discarding cover art due to size. Image size: %d x %d. Minimum: %d x %d",

--- a/picard/extension_points/cover_art_filters.py
+++ b/picard/extension_points/cover_art_filters.py
@@ -22,7 +22,12 @@ from picard.plugin import ExtensionPoint
 
 
 ext_point_cover_art_filters = ExtensionPoint(label='cover_art_filters')
+ext_point_cover_art_metadata_filters = ExtensionPoint(label='cover_art_metadata_filters')
 
 
 def register_cover_art_filter(cover_art_filter):
     ext_point_cover_art_filters.register(cover_art_filter.__module__, cover_art_filter)
+
+
+def register_cover_art_metadata_filter(cover_art_metadata_filter):
+    ext_point_cover_art_metadata_filters.register(cover_art_metadata_filter.__module__, cover_art_metadata_filter)

--- a/picard/extension_points/cover_art_filters.py
+++ b/picard/extension_points/cover_art_filters.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.plugin import ExtensionPoint
+
+
+ext_point_cover_art_filters = ExtensionPoint(label='cover_art_filters')
+
+
+def register_cover_art_filter(cover_art_filter):
+    ext_point_cover_art_filters.register(cover_art_filter.__module__, cover_art_filter)

--- a/picard/options.py
+++ b/picard/options.py
@@ -168,6 +168,12 @@ BoolOption('setting', 'save_images_to_files', False, title=N_("Save cover images
 BoolOption('setting', 'save_images_to_tags', True, title=N_("Embed cover images into tags"))
 BoolOption('setting', 'save_only_one_front_image', False, title=N_("Save only a single front image as separate file"))
 
+# picard/ui/options/cover_processing.py
+# Cover Art Image Processing
+BoolOption('setting', 'filter_cover_by_size', False)
+IntOption('setting', 'cover_width_threshold', 250)
+IntOption('setting', 'cover_height_threshold', 250)
+
 # picard/ui/options/dialog.py
 # Attached Profiles
 TextOption('persist', 'options_last_active_page', '')

--- a/picard/options.py
+++ b/picard/options.py
@@ -171,8 +171,8 @@ BoolOption('setting', 'save_only_one_front_image', False, title=N_("Save only a 
 # picard/ui/options/cover_processing.py
 # Cover Art Image Processing
 BoolOption('setting', 'filter_cover_by_size', False)
-IntOption('setting', 'cover_width_threshold', 250)
-IntOption('setting', 'cover_height_threshold', 250)
+IntOption('setting', 'cover_minimum_width', 250)
+IntOption('setting', 'cover_minimum_height', 250)
 
 # picard/ui/options/dialog.py
 # Attached Profiles

--- a/picard/ui/forms/ui_options_cover_processing.py
+++ b/picard/ui/forms/ui_options_cover_processing.py
@@ -1,0 +1,96 @@
+# Form implementation generated from reading ui file 'ui/options_cover_processing.ui'
+#
+# Created by: PyQt6 UI code generator 6.6.1
+#
+# Automatically generated - do not edit.
+# Use `python setup.py build_ui` to update it.
+
+from PyQt6 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+
+from picard.i18n import gettext as _
+
+
+class Ui_CoverProcessingOptionsPage(object):
+    def setupUi(self, CoverProcessingOptionsPage):
+        CoverProcessingOptionsPage.setObjectName("CoverProcessingOptionsPage")
+        CoverProcessingOptionsPage.resize(400, 300)
+        self.verticalLayout = QtWidgets.QVBoxLayout(CoverProcessingOptionsPage)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.filtering = QtWidgets.QGroupBox(parent=CoverProcessingOptionsPage)
+        self.filtering.setCheckable(True)
+        self.filtering.setChecked(False)
+        self.filtering.setObjectName("filtering")
+        self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.filtering)
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
+        self.width_widget = QtWidgets.QWidget(parent=self.filtering)
+        self.width_widget.setObjectName("width_widget")
+        self.horizontalLayout = QtWidgets.QHBoxLayout(self.width_widget)
+        self.horizontalLayout.setContentsMargins(0, 0, 0, 0)
+        self.horizontalLayout.setObjectName("horizontalLayout")
+        self.width_label = QtWidgets.QLabel(parent=self.width_widget)
+        self.width_label.setObjectName("width_label")
+        self.horizontalLayout.addWidget(self.width_label)
+        self.width_value = QtWidgets.QSpinBox(parent=self.width_widget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.width_value.sizePolicy().hasHeightForWidth())
+        self.width_value.setSizePolicy(sizePolicy)
+        self.width_value.setMaximum(1000)
+        self.width_value.setProperty("value", 250)
+        self.width_value.setObjectName("width_value")
+        self.horizontalLayout.addWidget(self.width_value)
+        self.px_label2 = QtWidgets.QLabel(parent=self.width_widget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.px_label2.sizePolicy().hasHeightForWidth())
+        self.px_label2.setSizePolicy(sizePolicy)
+        self.px_label2.setObjectName("px_label2")
+        self.horizontalLayout.addWidget(self.px_label2)
+        self.verticalLayout_2.addWidget(self.width_widget)
+        self.height_widget = QtWidgets.QWidget(parent=self.filtering)
+        self.height_widget.setObjectName("height_widget")
+        self.horizontalLayout_2 = QtWidgets.QHBoxLayout(self.height_widget)
+        self.horizontalLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
+        self.height_label = QtWidgets.QLabel(parent=self.height_widget)
+        self.height_label.setObjectName("height_label")
+        self.horizontalLayout_2.addWidget(self.height_label)
+        self.height_value = QtWidgets.QSpinBox(parent=self.height_widget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.height_value.sizePolicy().hasHeightForWidth())
+        self.height_value.setSizePolicy(sizePolicy)
+        self.height_value.setMaximum(1000)
+        self.height_value.setProperty("value", 250)
+        self.height_value.setObjectName("height_value")
+        self.horizontalLayout_2.addWidget(self.height_value)
+        self.px_label1 = QtWidgets.QLabel(parent=self.height_widget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Maximum, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.px_label1.sizePolicy().hasHeightForWidth())
+        self.px_label1.setSizePolicy(sizePolicy)
+        self.px_label1.setObjectName("px_label1")
+        self.horizontalLayout_2.addWidget(self.px_label1)
+        self.verticalLayout_2.addWidget(self.height_widget)
+        self.verticalLayout.addWidget(self.filtering)
+        spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+
+        self.retranslateUi(CoverProcessingOptionsPage)
+        QtCore.QMetaObject.connectSlotsByName(CoverProcessingOptionsPage)
+
+    def retranslateUi(self, CoverProcessingOptionsPage):
+        CoverProcessingOptionsPage.setWindowTitle(_("Form"))
+        self.filtering.setTitle(_("Discard images if below the given size"))
+        self.width_label.setText(_("Width:"))
+        self.px_label2.setText(_("px"))
+        self.height_label.setText(_("Height:"))
+        self.px_label1.setText(_("px"))

--- a/picard/ui/forms/ui_provider_options_caa.py
+++ b/picard/ui/forms/ui_provider_options_caa.py
@@ -74,5 +74,5 @@ class Ui_CaaOptions(object):
         CaaOptions.setWindowTitle(_("Form"))
         self.restrict_images_types.setText(_("Download only cover art images matching selected types"))
         self.select_caa_types.setText(_("Select types…"))
-        self.label.setText(_("Only use images of the following size:"))
+        self.label.setText(_("Only use images of at most the following size:"))
         self.cb_approved_only.setText(_("Download only approved images"))

--- a/picard/ui/options/cover_processing.py
+++ b/picard/ui/options/cover_processing.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from picard.config import get_config
+from picard.extension_points.options_pages import register_options_page
+from picard.i18n import N_
+
+from picard.ui.forms.ui_options_cover_processing import (
+    Ui_CoverProcessingOptionsPage,
+)
+from picard.ui.options import OptionsPage
+
+
+class CoverProcessingOptionsPage(OptionsPage):
+
+    NAME = 'cover_processing'
+    TITLE = N_("Processing")
+    PARENT = 'cover'
+    SORT_ORDER = 0
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_CoverProcessingOptionsPage()
+        self.ui.setupUi(self)
+        self.register_setting('filter_cover_by_size')
+        self.register_setting('cover_width_threshold')
+        self.register_setting('cover_height_threshold')
+
+    def load(self):
+        config = get_config()
+        self.ui.filtering.setChecked(config.setting['filter_cover_by_size'])
+        self.ui.width_value.setValue(config.setting['cover_width_threshold'])
+        self.ui.height_value.setValue(config.setting['cover_height_threshold'])
+
+    def save(self):
+        config = get_config()
+        config.setting['filter_cover_by_size'] = self.ui.filtering.isChecked()
+        config.setting['cover_width_threshold'] = self.ui.width_value.value()
+        config.setting['cover_height_threshold'] = self.ui.height_value.value()
+
+
+register_options_page(CoverProcessingOptionsPage)

--- a/picard/ui/options/cover_processing.py
+++ b/picard/ui/options/cover_processing.py
@@ -40,20 +40,20 @@ class CoverProcessingOptionsPage(OptionsPage):
         self.ui = Ui_CoverProcessingOptionsPage()
         self.ui.setupUi(self)
         self.register_setting('filter_cover_by_size')
-        self.register_setting('cover_width_threshold')
-        self.register_setting('cover_height_threshold')
+        self.register_setting('cover_minimum_width')
+        self.register_setting('cover_minimum_height')
 
     def load(self):
         config = get_config()
         self.ui.filtering.setChecked(config.setting['filter_cover_by_size'])
-        self.ui.width_value.setValue(config.setting['cover_width_threshold'])
-        self.ui.height_value.setValue(config.setting['cover_height_threshold'])
+        self.ui.width_value.setValue(config.setting['cover_minimum_width'])
+        self.ui.height_value.setValue(config.setting['cover_minimum_height'])
 
     def save(self):
         config = get_config()
         config.setting['filter_cover_by_size'] = self.ui.filtering.isChecked()
-        config.setting['cover_width_threshold'] = self.ui.width_value.value()
-        config.setting['cover_height_threshold'] = self.ui.height_value.value()
+        config.setting['cover_minimum_width'] = self.ui.width_value.value()
+        config.setting['cover_minimum_height'] = self.ui.height_value.value()
 
 
 register_options_page(CoverProcessingOptionsPage)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -70,6 +70,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     advanced,
     cdlookup,
     cover,
+    cover_processing,
     fingerprinting,
     general,
     genres,

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -41,8 +41,8 @@ class ImageFiltersTest(PicardTestCase):
     def test_filter_by_size(self):
         settings = {
             'filter_cover_by_size': True,
-            'cover_width_threshold': 500,
-            'cover_height_threshold': 500
+            'cover_minimum_width': 500,
+            'cover_minimum_height': 500
         }
         self.set_config_values(settings)
         image1 = create_fake_image(400, 600, "png")
@@ -55,8 +55,8 @@ class ImageFiltersTest(PicardTestCase):
     def test_filter_by_size_metadata(self):
         settings = {
             'filter_cover_by_size': True,
-            'cover_width_threshold': 500,
-            'cover_height_threshold': 500
+            'cover_minimum_width': 500,
+            'cover_minimum_height': 500
         }
         self.set_config_values(settings)
         image_metadata1 = {'width': 400, 'height': 600}

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -23,7 +23,10 @@ from PyQt6.QtGui import QImage
 
 from test.picardtestcase import PicardTestCase
 
-from picard.coverart.processing.filters import size_filter
+from picard.coverart.processing.filters import (
+    size_filter,
+    size_metadata_filter,
+)
 
 
 def create_fake_image(width, height, image_format):
@@ -48,6 +51,20 @@ class ImageFiltersTest(PicardTestCase):
         self.assertFalse(size_filter(image1))
         self.assertTrue(size_filter(image2))
         self.assertTrue(size_filter(image3))
+
+    def test_filter_by_size_metadata(self):
+        settings = {
+            'filter_cover_by_size': True,
+            'cover_width_threshold': 500,
+            'cover_height_threshold': 500
+        }
+        self.set_config_values(settings)
+        image_metadata1 = {'width': 400, 'height': 600}
+        image_metadata2 = {'width': 500, 'height': 500}
+        image_metadata3 = {'width': 600, 'height': 600}
+        self.assertFalse(size_metadata_filter(image_metadata1))
+        self.assertTrue(size_metadata_filter(image_metadata2))
+        self.assertTrue(size_metadata_filter(image_metadata3))
 
 
 # class ImageProcessorsTest(PicardTestCase):

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from PyQt6.QtCore import QBuffer
+from PyQt6.QtGui import QImage
+
+from test.picardtestcase import PicardTestCase
+
+from picard.coverart.processing.filters import size_filter
+
+
+def create_fake_image(width, height, image_format):
+    buffer = QBuffer()
+    image = QImage(width, height, QImage.Format.Format_ARGB32)
+    image.save(buffer, image_format)
+    buffer.close()
+    return buffer.data()
+
+
+class ImageFiltersTest(PicardTestCase):
+    def test_filter_by_size(self):
+        settings = {
+            'filter_cover_by_size': True,
+            'cover_width_threshold': 500,
+            'cover_height_threshold': 500
+        }
+        self.set_config_values(settings)
+        image1 = create_fake_image(400, 600, "png")
+        image2 = create_fake_image(500, 500, "jpeg")
+        image3 = create_fake_image(600, 600, "bmp")
+        self.assertFalse(size_filter(image1))
+        self.assertTrue(size_filter(image2))
+        self.assertTrue(size_filter(image3))
+
+
+# class ImageProcessorsTest(PicardTestCase):
+#     pass

--- a/test/test_coverartprovider_caa.py
+++ b/test/test_coverartprovider_caa.py
@@ -32,7 +32,7 @@ class CoverArtImageProviderCaaTest(PicardTestCase):
             thumbnails = {size: "url %s" % size for size in sizes}
             msgfmt = "for size %s, with sizes %r, got %r, expected %r"
             for size, expect in expectations.items():
-                result, width = caa_url_fallback_list(size, thumbnails)
+                result = [thumbnail.url for thumbnail in caa_url_fallback_list(size, thumbnails)]
                 self.assertEqual(result, expect, msg=msgfmt % (size, sizes, result, expect))
 
         # For historical reasons, caa web service returns 2 identical urls,

--- a/test/test_coverartprovider_caa.py
+++ b/test/test_coverartprovider_caa.py
@@ -32,7 +32,7 @@ class CoverArtImageProviderCaaTest(PicardTestCase):
             thumbnails = {size: "url %s" % size for size in sizes}
             msgfmt = "for size %s, with sizes %r, got %r, expected %r"
             for size, expect in expectations.items():
-                result = caa_url_fallback_list(size, thumbnails)
+                result, width = caa_url_fallback_list(size, thumbnails)
                 self.assertEqual(result, expect, msg=msgfmt % (size, sizes, result, expect))
 
         # For historical reasons, caa web service returns 2 identical urls,

--- a/ui/options_cover_processing.ui
+++ b/ui/options_cover_processing.ui
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CoverProcessingOptionsPage</class>
+ <widget class="QWidget" name="CoverProcessingOptionsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="filtering">
+     <property name="title">
+      <string>Discard images if below the given size</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QWidget" name="width_widget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="width_label">
+           <property name="text">
+            <string>Width:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="width_value">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>250</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="px_label2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>px</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="height_widget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="height_label">
+           <property name="text">
+            <string>Height:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="height_value">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="value">
+            <number>250</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="px_label1">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>px</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/provider_options_caa.ui
+++ b/ui/provider_options_caa.ui
@@ -65,7 +65,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Only use images of the following size:</string>
+        <string>Only use images of at most the following size:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Adds a setting to discard downloaded cover art images if they are below a given width and height.
# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2926
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The options page looks like this:
![image](https://github.com/metabrainz/picard/assets/119691774/0a6a4432-3501-4e12-903f-7d51744bc1e5)
I plan to add settings for resizing and converting formats also to this page.



I created an extension point for adding image filters. I'm aware this is bound to change for Picard 3, but I was thinking that I can use this for now, until the new plugin apis are defined, and change it later in the last couple of weeks of gsoc.



I'm still working on adding another extension point for filtering functions that use the image metadata, since outsidecontext suggested I should add a way for providers to filter images before actually downloading them, if they can.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
