### PR TITLE
Add new column for external images to artwork infodialog

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -322,7 +322,7 @@ class CoverArtImage:
             raise CoverArtImageIOError(e)
 
     def set_external_file_data(self, data):
-        self.external_file_coverart = CoverArtImage(data=data)
+        self.external_file_coverart = CoverArtImage(data=data, url=self.url)
 
     @property
     def maintype(self):

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -115,7 +115,9 @@ class ImageProcessorsTest(PicardTestCase):
             'cover_tags_maximum_height': 500,
             'resize_images_saved_to_file': True,
             'cover_file_maximum_width': 750,
-            'cover_file_maximum_height': 750
+            'cover_file_maximum_height': 750,
+            'save_images_to_tags': True,
+            'save_images_to_files': True,
         }
         self.set_config_values(settings)
         sizes = [

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -18,6 +18,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from copy import copy
+import itertools
+
 from PyQt6.QtCore import QBuffer
 from PyQt6.QtGui import QImage
 
@@ -46,13 +49,15 @@ def create_fake_image(width, height, image_format):
 
 
 class ImageFiltersTest(PicardTestCase):
-    def test_filter_by_size(self):
+    def setUp(self):
         settings = {
             'filter_cover_by_size': True,
             'cover_minimum_width': 500,
             'cover_minimum_height': 500
         }
         self.set_config_values(settings)
+
+    def test_filter_by_size(self):
         image1 = create_fake_image(400, 600, "png")
         image2 = create_fake_image(500, 500, "jpeg")
         image3 = create_fake_image(600, 600, "bmp")
@@ -61,12 +66,6 @@ class ImageFiltersTest(PicardTestCase):
         self.assertTrue(size_filter(image3))
 
     def test_filter_by_size_metadata(self):
-        settings = {
-            'filter_cover_by_size': True,
-            'cover_minimum_width': 500,
-            'cover_minimum_height': 500
-        }
-        self.set_config_values(settings)
         image_metadata1 = {'width': 400, 'height': 600}
         image_metadata2 = {'width': 500, 'height': 500}
         image_metadata3 = {'width': 600, 'height': 600}
@@ -76,14 +75,21 @@ class ImageFiltersTest(PicardTestCase):
 
 
 class ImageProcessorsTest(PicardTestCase):
-    def test_resize(self):
-        processor = ResizeImage()
-        settings = {
+    def setUp(self):
+        self.settings = {
+            'enabled_plugins': [],
             'resize_images_saved_to_tags': True,
             'cover_tags_maximum_width': 500,
-            'cover_tags_maximum_height': 500
+            'cover_tags_maximum_height': 500,
+            'resize_images_saved_to_file': True,
+            'cover_file_maximum_width': 750,
+            'cover_file_maximum_height': 750,
+            'save_images_to_tags': True,
+            'save_images_to_files': True,
         }
-        self.set_config_values(settings)
+        self.set_config_values(self.settings)
+
+    def test_resize(self):
         sizes = [
             (500, 500),
             (1000, 500),
@@ -98,6 +104,7 @@ class ImageProcessorsTest(PicardTestCase):
             (500, 500),
             (400, 400)
         ]
+        processor = ResizeImage()
         for size, expected_size in zip(sizes, expected_sizes):
             image = ProcessingImage(create_fake_image(size[0], size[1], "jpg"))
             processor.run(image, ProcessingTarget.TAGS)
@@ -108,18 +115,6 @@ class ImageProcessorsTest(PicardTestCase):
             self.assertEqual(new_size, (image.info.width, image.info.height))
 
     def test_image_processors(self):
-        settings = {
-            'enabled_plugins': [],
-            'resize_images_saved_to_tags': True,
-            'cover_tags_maximum_width': 500,
-            'cover_tags_maximum_height': 500,
-            'resize_images_saved_to_file': True,
-            'cover_file_maximum_width': 750,
-            'cover_file_maximum_height': 750,
-            'save_images_to_tags': True,
-            'save_images_to_files': True,
-        }
-        self.set_config_values(settings)
         sizes = [
             (1000, 1000),
             (1000, 500),
@@ -130,16 +125,28 @@ class ImageProcessorsTest(PicardTestCase):
             ((500, 250), (750, 375)),
             ((500, 500), (600, 600)),
         ]
-        for size, expected_size in zip(sizes, expected_sizes):
-            coverartimage = CoverArtImage()
-            image = create_fake_image(size[0], size[1], "jpg")
-            run_image_processors(image, coverartimage)
-            tags_size = (coverartimage.width, coverartimage.height)
-            file_size = (coverartimage.external_file_coverart.width, coverartimage.external_file_coverart.height)
-            extension = coverartimage.extension[1:]
-            self.assertEqual(tags_size, expected_size[0])
-            self.assertEqual(file_size, expected_size[1])
-            self.assertEqual(extension, "jpg")
+        settings = copy(self.settings)
+        self.target_combinations = itertools.product([True, False], repeat=2)
+        for save_to_tags, save_to_file in self.target_combinations:
+            settings['save_images_to_tags'] = save_to_tags
+            settings['save_images_to_files'] = save_to_file
+            self.set_config_values(settings)
+            for size, expected_size in zip(sizes, expected_sizes):
+                coverartimage = CoverArtImage()
+                image = create_fake_image(size[0], size[1], "jpg")
+                run_image_processors(image, coverartimage)
+                tags_size = (coverartimage.width, coverartimage.height)
+                expected_size_tags = expected_size[0] if save_to_tags else size
+                self.assertEqual(tags_size, expected_size_tags)
+                if save_to_file:
+                    external_cover = coverartimage.external_file_coverart
+                    file_size = (external_cover.width, external_cover.height)
+                    self.assertEqual(file_size, expected_size[1])
+                else:
+                    self.assertIsNone(coverartimage.external_file_coverart)
+                extension = coverartimage.extension[1:]
+                self.assertEqual(extension, "jpg")
+        self.set_config_values(self.settings)
 
     def test_identification_error(self):
         image = create_fake_image(0, 0, "jpg")


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Now the table looks like this:

(Both embedding images to tags and saving to external file)
![existing_external](https://github.com/metabrainz/picard/assets/119691774/019e701b-d2cb-4d47-b02d-a535fad412b0)

(Same as above but with no pre-existing cover art)
![both_new](https://github.com/metabrainz/picard/assets/119691774/e59e8aa4-9d1b-47e7-a8e8-a324452990d8)

(Saving only to an external file, not embedding to tags)
![only_external](https://github.com/metabrainz/picard/assets/119691774/0f28bc8d-c48b-4c53-874f-d1e690e8a5c2)

I modified the `run_image_processors` function so that the tags and file queues run only if their result is actually used to either embed into tags or save to external file.

Also now the external `CoverArtImage` object is created only if the option to save to an external file is selected. This way it's not shown in the `infodialog`, so the resulting table in this case is the same as before.

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
