### PR TITLE
PICARD-2935: apply genre filters and threshold before selecting minimal usage

### DIFF
--- a/test/test_taggenrefilter.py
+++ b/test/test_taggenrefilter.py
@@ -20,6 +20,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import Counter
 
 from test.picardtestcase import PicardTestCase
 
@@ -168,5 +169,12 @@ class TagGenreFilterTest(PicardTestCase):
 
     def test_filter_method(self):
         tag_filter = TagGenreFilter("-a*")
-        result = list(tag_filter.filter([("ax", 1), ("bx", 2), ("ay", 3), ("by", 4)]))
-        self.assertEqual([('bx', 2), ('by', 4)], result)
+        genres = Counter(ax=1, bx=2, ay=3, by=4)
+        result = tag_filter.filter(genres)
+        self.assertEqual([('bx', 2), ('by', 4)], list(result.items()))
+
+    def test_filter_method_minusage(self):
+        tag_filter = TagGenreFilter("-a*")
+        genres = Counter(ax=4, bx=5, ay=20, by=10, bz=4)
+        result = tag_filter.filter(genres, minusage=50)
+        self.assertEqual([('bx', 5), ('by', 10)], list(result.items()))

--- a/test/test_track.py
+++ b/test/test_track.py
@@ -62,6 +62,12 @@ class TrackGenres2MetadataTest(PicardTestCase):
         ret = Track._genres_to_metadata(genres, limit=0)
         self.assertEqual(ret, [])
 
+    def test_limit_after_filter(self):
+        genres = Counter(rock=5, blues=7, pop=1, psychedelic=3)
+        filters = '-rock'
+        ret = Track._genres_to_metadata(genres, limit=3, filters=filters)
+        self.assertEqual(ret, ['Blues', 'Pop', 'Psychedelic'])
+
     def test_minusage(self):
         genres = Counter(pop=6, rock=7, blues=2)
         ret = Track._genres_to_metadata(genres, minusage=10)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2935
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The genre filter options can give unexpected results, where less genres are used then the maximum number of genres configured, even though more genres are available that would match the criteria. There are two distinct issues:

1. The genre list is reduced to the maximum allowed number of items before filters are applied.
2. The max. count (used to filter out genres by minusage threshold) is taken over the entire list. It better should ignore filtered out genres.

**Examples case 1:**

You have the following tags with counts:<br>
Pop: 5, Blues: 7, Rock: 5, Psychedelic: 4
You have a filter "-pop"<br>
Number of genres is limited to max. 3.

Picard takes the first most used tags (Blues, Pop, Rock), then applies the filters.

Result: *Blues, Rock*

Better would be to ignore the filtered genre and use: *Blues, Rock, Psychedelic*

 
**Example case 2**

You have the following tags with counts:<br>
Pop: 5, Blues: 11, Rock: 20, Psychedelic: 9
You have a filter "-rock"<br>
The threshold is set to 50%.

Picard takes the first most used tags (Rock, Blues, Pop), then applies the filters and the threshold. For the threshold the most used genre (Rock=20) is used as the reference max. count, even if it gets removed.

Result:  *Blues*

Better would be to ignore the filtered genre. Then the max. count would be Blues=11 and the result be: *Blues, Psychedelic*


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Apply the filters first, then the minusage threshold on the filtered result. Take max. no. of genres from the resulting list.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
