### PR TITLE
PICARD-2918: avoid exception if hash isn't found in _datafiles on exit (2.x)

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -79,15 +79,15 @@ class DataHash:
         try:
             self._hash = blake2b(data).hexdigest()
             if self._hash not in _datafiles:
-                (fd, self._filename) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+                # store tmp file path in  _datafiles[self._hash] ASAP
+                (fd, _datafiles[self._hash]) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+                filepath = _datafiles[self._hash]
                 QObject.tagger.register_cleanup(self.delete_file)
+                periodictouch.register_file(filepath)
                 with os.fdopen(fd, 'wb') as imagefile:
                     imagefile.write(data)
-                _datafiles[self._hash] = self._filename
-                periodictouch.register_file(self._filename)
-                log.debug("Saving image data %s to %r", self._hash, self._filename)
-            else:
-                self._filename = _datafiles[self._hash]
+                log.debug("Saving image data %s to %r", self._hash[:16], filepath)
+            self._filename = _datafiles[self._hash]
         finally:
             _datafile_mutex.unlock()
 
@@ -98,20 +98,25 @@ class DataHash:
         return self._hash
 
     def delete_file(self):
-        if self._filename:
+        if not self._hash or self._hash not in _datafiles:
+            return
+
+        _datafile_mutex.lock()
+        try:
+            filepath = _datafiles[self._hash]
             try:
-                os.unlink(self._filename)
-                periodictouch.unregister_file(self._filename)
-            except BaseException:
-                pass
-            else:
-                _datafile_mutex.lock()
-                try:
-                    self._filename = None
-                    del _datafiles[self._hash]
-                    self._hash = None
-                finally:
-                    _datafile_mutex.unlock()
+                os.unlink(filepath)
+                periodictouch.unregister_file(filepath)
+            except BaseException as e:
+                log.debug("Failed to delete file %r: %s",  filepath, e)
+
+            del _datafiles[self._hash]
+        except KeyError:
+            log.error("Hash %s not found in cache for file: %r", self._hash[:16], self._filename)
+        finally:
+            self._hash = None
+            self._filename = None
+            _datafile_mutex.unlock()
 
     @property
     def data(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2918
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This backports the fix from #2505 to the Picard 2.x branch.