### PR TITLE
Update caa types selector to allow replacement instructions text

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -11,7 +11,7 @@
 # Copyright (C) 2015-2016 Rahul Raturi
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
-# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018, 2024 Bob Swift
 # Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
@@ -169,6 +169,8 @@ class ProviderOptionsCaa(ProviderOptions):
             types_include=self.caa_image_types,
             types_exclude=self.caa_image_types_to_omit,
             parent=self,
+            instructions_top=None,
+            instructions_bottom=None,
         )
         if ok:
             self.caa_image_types = types

--- a/picard/ui/caa_types_selector.py
+++ b/picard/ui/caa_types_selector.py
@@ -11,7 +11,7 @@
 # Copyright (C) 2015-2016 Rahul Raturi
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
-# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018, 2024 Bob Swift
 # Copyright (C) 2018 Vishal Choudhary
 #
 # This program is free software; you can redistribute it and/or
@@ -164,6 +164,8 @@ class CAATypesSelectorDialog(PicardDialog):
         types_include {[string]} -- List of CAA image types to include (default: {None})
         types_exclude {[string]} -- List of CAA image types to exclude (default: {None})
         parent {[type]} -- Parent of the QDialog object being created (default: {None})
+        instructions_top {string} -- Replacement for the default instruction text to display above the list boxes (default: {None})
+        instructions_bottom {string} -- Replacement for the instruction text to display between the list boxes and the button bar (default: {None})
     """
 
     help_url = 'doc_cover_art_types'
@@ -173,6 +175,8 @@ class CAATypesSelectorDialog(PicardDialog):
         types_include=None,
         types_exclude=None,
         parent=None,
+        instructions_top=None,
+        instructions_bottom=None,
     ):
         super().__init__(parent=parent)
         types_include = set(types_include or ())
@@ -201,7 +205,10 @@ class CAATypesSelectorDialog(PicardDialog):
 
         # Add instructions to the dialog box
         instructions = QtWidgets.QLabel()
-        instructions.setText(_("Please select the contents of the image type 'Include' and 'Exclude' lists."))
+        if instructions_top:
+            instructions.setText(_(instructions_top))
+        else:
+            instructions.setText(_("Please select the contents of the image type 'Include' and 'Exclude' lists."))
         instructions.setWordWrap(True)
         instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)
@@ -244,13 +251,16 @@ class CAATypesSelectorDialog(PicardDialog):
 
         # Add usage explanation to the dialog box
         instructions = QtWidgets.QLabel()
-        instructions.setText(_(
-            "CAA images with an image type found in the 'Include' list will be downloaded and used "
-            "UNLESS they also have an image type found in the 'Exclude' list. Images with types "
-            "found in the 'Exclude' list will NEVER be used. Image types not appearing in the 'Include' "
-            "or 'Exclude' lists will not be considered when determining whether or not to download and "
-            "use a CAA image.\n")
-        )
+        if instructions_bottom:
+            instructions.setText(_(instructions_bottom))
+        else:
+            instructions.setText(_(
+                "CAA images with an image type found in the 'Include' list will be downloaded and used "
+                "UNLESS they also have an image type found in the 'Exclude' list. Images with types "
+                "found in the 'Exclude' list will NEVER be used. Image types not appearing in the 'Include' "
+                "or 'Exclude' lists will not be considered when determining whether or not to download and "
+                "use a CAA image.\n")
+            )
         instructions.setWordWrap(True)
         instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)
@@ -366,11 +376,15 @@ class CAATypesSelectorDialog(PicardDialog):
         types_include=None,
         types_exclude=None,
         parent=None,
+        instructions_top=None,
+        instructions_bottom=None,
     ):
         dialog = cls(
             types_include=types_include,
             types_exclude=types_exclude,
             parent=parent,
+            instructions_top=instructions_top,
+            instructions_bottom=instructions_bottom,
         )
         result = dialog.exec()
         return (dialog.included, dialog.excluded, result == QtWidgets.QDialog.DialogCode.Accepted)

--- a/picard/ui/caa_types_selector.py
+++ b/picard/ui/caa_types_selector.py
@@ -205,10 +205,9 @@ class CAATypesSelectorDialog(PicardDialog):
 
         # Add instructions to the dialog box
         instructions = QtWidgets.QLabel()
-        if instructions_top:
-            instructions.setText(_(instructions_top))
-        else:
-            instructions.setText(_("Please select the contents of the image type 'Include' and 'Exclude' lists."))
+        if instructions_top is None:
+            instructions_top = N_("Please select the contents of the image type 'Include' and 'Exclude' lists.")
+        instructions.setText(_(instructions_top))
         instructions.setWordWrap(True)
         instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)
@@ -251,16 +250,15 @@ class CAATypesSelectorDialog(PicardDialog):
 
         # Add usage explanation to the dialog box
         instructions = QtWidgets.QLabel()
-        if instructions_bottom:
-            instructions.setText(_(instructions_bottom))
-        else:
-            instructions.setText(_(
+        if instructions_bottom is None:
+            instructions_bottom = N_(
                 "CAA images with an image type found in the 'Include' list will be downloaded and used "
                 "UNLESS they also have an image type found in the 'Exclude' list. Images with types "
                 "found in the 'Exclude' list will NEVER be used. Image types not appearing in the 'Include' "
                 "or 'Exclude' lists will not be considered when determining whether or not to download and "
-                "use a CAA image.\n")
+                "use a CAA image.\n"
             )
+        instructions.setText(_(instructions_bottom))
         instructions.setWordWrap(True)
         instructions.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.layout.addWidget(instructions)


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: This change allows the default instructions text to be overridden in the CAA Types Selector dialog.  This allows the dialog to be used in other cases such as the new cover art processing settings.

# Problem

The original CAA Types Selector dialog has fixed instructions, and as such cannot be reused for other (similar) cases.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

This change allows the default instructions text to be overridden in the CAA Types Selector dialog.  This allows the dialog to be used in other cases such as the new cover art processing settings.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
