### PR TITLE
PICARD-2939: Fix exception when genre filtering results in empty genre list

### DIFF
--- a/picard/track.py
+++ b/picard/track.py
@@ -115,6 +115,8 @@ class TagGenreFilter:
         for name, count in counter.items():
             if not self.skip(name):
                 result[name] = count
+        if not result:
+            return result
         topcount = result.most_common(1)[0][1]
         for name, count in counter.items():
             percent = 100 * count // topcount

--- a/test/test_taggenrefilter.py
+++ b/test/test_taggenrefilter.py
@@ -178,3 +178,15 @@ class TagGenreFilterTest(PicardTestCase):
         genres = Counter(ax=4, bx=5, ay=20, by=10, bz=4)
         result = tag_filter.filter(genres, minusage=50)
         self.assertEqual([('bx', 5), ('by', 10)], list(result.items()))
+
+    def test_filter_method_empty_input(self):
+        tag_filter = TagGenreFilter("")
+        genres = Counter()
+        result = tag_filter.filter(genres)
+        self.assertEqual([], list(result.items()))
+
+    def test_filter_method_empty_result(self):
+        tag_filter = TagGenreFilter("-*")
+        genres = Counter(ax=1, bx=2, ay=3, by=4)
+        result = tag_filter.filter(genres)
+        self.assertEqual([], list(result.items()))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2939
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`TagGenreFilter.filter` raises an exception if the filtering leads to an empty genre list.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Return an empty result if the filtered list is empty.