### PR TITLE
PICARD-2940: Fix prematurely releasing lock in `Metadata.__iter__`

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -542,7 +542,7 @@ class Metadata(MutableMapping):
 
     def __iter__(self):
         with self._lock.lock_for_read():
-            return iter(self._store)
+            yield from self._store
 
     def items(self):
         with self._lock.lock_for_read():


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Change `Metadata.__iter__` implementation in `metadata.py` to acquire and hold the lock for the full lifetime of the iterator (until it is exhausted or falls out of scope).

# Problem

Previously the lock was being acquired and then released immediately when the iterator was returned. This meant that when the iterator was being iterated by the consumer, the lock was not held.

* JIRA ticket (_optional_): PICARD-2940


# Solution

This change ensures that the lock is held until the iterator is exhausted or goes out of scope.
This change makes the behavior equivalent to the iterator returned by the `Metadata.items` method.
See PICARD-2940 for further info.
