### PR TITLE
PICARD-2122: Display cover dimensions in an optional column

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -813,6 +813,8 @@ class Album(MetadataItem):
             return self.metadata['totaldiscs']
         elif column == 'covercount':
             return self.cover_art_description()
+        elif column == 'coverdimensions':
+            return self.cover_art_dimensions()
         else:
             return self.metadata[column]
 

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -231,6 +231,8 @@ class Cluster(FileList):
             return self.metadata['totaldiscs']
         elif column == 'covercount':
             return self.cover_art_description()
+        elif column == 'coverdimensions':
+            return self.cover_art_dimensions()
         return self.metadata[column]
 
     def _lookup_finished(self, document, http, error):

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -229,6 +229,11 @@ class CoverArtImage:
                                                                 self.datalength,
                                                                 self.tempfile_filename)
 
+    def dimensions_as_string(self):
+        if self.datahash is None:
+            return ""
+        return f"{self.width}x{self.height}"
+
     def _repr(self):
         if self.url is not None:
             yield "url=%r" % self.url.toString()

--- a/picard/file.py
+++ b/picard/file.py
@@ -821,6 +821,8 @@ class File(MetadataItem):
             return self.base_filename
         elif column == 'covercount':
             return self.cover_art_description()
+        elif column == 'coverdimensions':
+            return self.cover_art_dimensions()
         value = m[column]
         if not value and not get_config().setting['clear_existing_tags']:
             value = self.orig_metadata[column]

--- a/picard/item.py
+++ b/picard/item.py
@@ -164,6 +164,12 @@ class Item:
             return ngettext("%i image not in all tracks", "%i different images among tracks",
                             number_of_images) % number_of_images
 
+    def cover_art_dimensions(self):
+        front_image = self.metadata.images.get_front_image()
+        if front_image:
+            return front_image.dimensions_as_string()
+        return ''
+
 
 class ImageListState:
     def __init__(self):

--- a/picard/track.py
+++ b/picard/track.py
@@ -257,6 +257,8 @@ class Track(FileListItem):
             return "%s%s  %s" % (prefix, m['tracknumber'].zfill(2), m['title'])
         elif column == 'covercount':
             return self.cover_art_description()
+        elif column == 'coverdimensions':
+            return self.cover_art_dimensions()
         elif column in m:
             return m[column]
         elif self.num_linked_files == 1:

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -220,6 +220,7 @@ DEFAULT_COLUMNS = Columns((
     Column(N_("Original Release Date"), 'originaldate'),
     Column(N_("Release Date"), 'releasedate'),
     Column(N_("Cover"), 'covercount'),
+    Column(N_("Cover Dimensions"), 'coverdimensions')
 ))
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Adds a column to display front image dimension to the basetreeview
# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2122
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

I liked the reporter's idea to add an optional column, instead of showing the dimensions under the cover art box. This is what it looks like:

![image](https://github.com/user-attachments/assets/eba9cfe1-2b98-4256-ba78-ae9eee3f77df)

These are the tags front image dimensions.

I think this can be useful for people who are resizing cover art to check everything went right, rather than clicking "show more info" on each album individually.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
