### PR TITLE
PICARD-2914: Workaround for segfaults on macOS with Spanish locale

### DIFF
--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -24,7 +24,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from functools import partial
+from functools import (
+    cmp_to_key,
+    partial,
+)
+from locale import strcoll
 
 from PyQt6 import (
     QtCore,
@@ -47,7 +51,6 @@ from picard.i18n import (
     gettext_countries,
     pgettext_attributes,
 )
-from picard.util import strxfrm
 
 from picard.ui.forms.ui_options_releases import Ui_ReleasesOptionsPage
 from picard.ui.options import OptionsPage
@@ -281,7 +284,8 @@ class ReleasesOptionsPage(OptionsPage):
             translate_func = _
 
         def fcmp(x):
-            return strxfrm(x[1])
+            # Workaround for PICARD-2914 to avoid segfaults on macOS with strxfrm.
+            return cmp_to_key(strcoll)(x[1])
 
         source_list = [(c[0], translate_func(c[1])) for c in source.items()]
         source_list.sort(key=fcmp)

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -8,7 +8,7 @@
 # Copyright (C) 2013-2015, 2018-2024 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Suhas
-# Copyright (C) 2018-2022 Philipp Wolfer
+# Copyright (C) 2018-2022, 2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -24,8 +24,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
-from operator import itemgetter
+from functools import partial
 
 from PyQt6 import (
     QtCore,
@@ -275,31 +274,27 @@ class ReleasesOptionsPage(OptionsPage):
 
     def _load_list_items(self, setting, source, list1, list2):
         if setting == 'preferred_release_countries':
-            source_list = [(c[0], gettext_countries(c[1])) for c in
-                           source.items()]
+            translate_func = gettext_countries
         elif setting == 'preferred_release_formats':
-            source_list = [(c[0], pgettext_attributes('medium_format', c[1])) for c
-                           in source.items()]
+            translate_func = partial(pgettext_attributes, 'medium_format')
         else:
-            source_list = [(c[0], _(c[1])) for c in source.items()]
+            translate_func = _
 
         def fcmp(x):
             return strxfrm(x[1])
+
+        source_list = [(c[0], translate_func(c[1])) for c in source.items()]
         source_list.sort(key=fcmp)
         config = get_config()
         saved_data = config.setting[setting]
-        move = []
         for data, name in source_list:
             item = QtWidgets.QListWidgetItem(name)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, data)
             try:
-                i = saved_data.index(data)
-                move.append((i, item))
-            except BaseException:
+                saved_data.index(data)
+                list2.addItem(item)
+            except ValueError:
                 list1.addItem(item)
-        move.sort(key=itemgetter(0))
-        for i, item in move:
-            list2.addItem(item)
 
     def _save_list_items(self, setting, list1):
         data = [


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2914
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard on macOS segfaults semi-randomly when sorting the release countries / formats locale aware in the preferred releases options. The segfault happens when the key-function used for sorting is calling `strxfrm`.

I could not narrow it down to any specific value. When reducing the number of items sorted often the crash could be avoided. Calling strxfrm on all individual values on itself is fine. With some luck the segfault did not happen at all.

I could not reproduce the crash with other locales like en, fr or de, but I haven't tested all.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

As a workaround avoid calling strxfrm and use strcoll for locale aware sorting. In my testing this never triggered the segfault. But this should be confirmed by others.

The PR also applies some refactoring in 4af20ad4af40b35cd057fb999e2b05b67485e48b to simplify the code.