### PR TITLE
PICARD-2953: Use strxfrm for sorting on Windows again

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -229,11 +229,6 @@ def gettext_constants(message: str) -> str:
     return _translation['constants'].gettext(message)
 
 
-def _digit_replace(matchobj):
-    s = matchobj.group(0)
-    return str(int(s)) if s.isdigit() else s
-
-
 def sort_key(string, numeric=False):
     """Transforms a string to one that can be used in locale-aware comparisons.
 
@@ -243,13 +238,44 @@ def sort_key(string, numeric=False):
 
     Returns: An object that can be compared locale-aware
     """
+    # QCollator.sortKey is broken, see https://bugreports.qt.io/browse/QTBUG-128170
+    if IS_WIN:
+        return _sort_key_strxfrm(string, numeric)
+    else:
+        return _sort_key_qt(string, numeric)
+
+
+RE_NUMBER = re.compile(r'(\d+)')
+
+
+def _digits_replace(matchobj):
+    s = matchobj.group(0)
+    return str(int(s)) if s.isdecimal() else s
+
+
+def _sort_key_qt(string, numeric=False):
     collator = _qcollator_numeric if numeric else _qcollator
     # On macOS / Windows the numeric sorting does not work reliable with non-latin
     # scripts. Replace numbers in the sort string with their latin equivalent.
     if numeric and (IS_MACOS or IS_WIN):
-        string = re.sub(r'\d', _digit_replace, string)
+        string = RE_NUMBER.sub(_digits_replace, string)
 
     # On macOS numeric sorting of strings entirely consisting of numeric characters fails
-    # and always sorts alphabetically (002 < 1). Always prefix with an alphabeticcharacter
+    # and always sorts alphabetically (002 < 1). Always prefix with an alphabetic character
     # to work around that.
     return collator.sortKey('a' + string.replace('\0', ''))
+
+
+def _sort_key_strxfrm(string, numeric=False):
+    if numeric:
+        return [int(s) if s.isdecimal() else _strxfrm(s)
+            for s in RE_NUMBER.split(str(string).replace('\0', ''))]
+    else:
+        return _strxfrm(string)
+
+
+def _strxfrm(string):
+    try:
+        return locale.strxfrm(string)
+    except (OSError, ValueError):
+        return string.lower()

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -90,10 +90,12 @@ class TestI18n(PicardTestCase):
         self.assertTrue(sort_key('äb') < sort_key('ac'))
         self.assertTrue(sort_key('foo002') < sort_key('foo1'))
         self.assertTrue(sort_key('002 foo') < sort_key('1 foo'))
+        self.assertTrue(sort_key('1') < sort_key('C'))
         self.assertTrue(sort_key('foo1', numeric=True) < sort_key('foo002', numeric=True))
         self.assertTrue(sort_key('004', numeric=True) < sort_key('5', numeric=True))
         self.assertTrue(sort_key('0042', numeric=True) < sort_key('50', numeric=True))
         self.assertTrue(sort_key('5', numeric=True) < sort_key('0042', numeric=True))
+        self.assertTrue(sort_key('99', numeric=True) < sort_key('100', numeric=True))
 
     def test_sort_key_numbers_different_scripts(self):
         setup_gettext(localedir, 'en')


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2953, PICARD-2955
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On Windows `QCollator.sortKey` is broken and results of wrong ordering of numbers, both in numeric and normal alphabetic mode.

This results in both the below conditions failing unexpectedly:

```python
assert(i18n.sort_key("1") < i18n.sort_key("C"))
assert(i18n.sort_key("99", numeric=True) < i18n.sort_key("100", numeric=True))
```

See also [QTBUG-128170](https://bugreports.qt.io/browse/QTBUG-128170).

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Use `locale.strxfrm` for sorting on Windows again. We replaced this with `QCollator` in PICARD-2914 due to `strxfrm` segfaulting on macOS frequently. But since we did not get the crashes on Windows it seems safe to move back to strxfrm for Windows again.

