### PR TITLE
PICARD-2466: Lookup function by using Catalog Number and other identifying info

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -297,6 +297,9 @@ class Cluster(FileList):
             artist=self.metadata['albumartist'],
             release=self.metadata['album'],
             tracks=str(len(self.files)),
+            catno=self.metadata['catalognumber'],
+            barcode=self.metadata['barcode'],
+            asin=self.metadata['asin'],
             limit=config.setting['query_limit'])
 
     def clear_lookup_task(self):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -166,6 +166,17 @@ class Cluster(FileList):
 
     def update(self, signal=True):
         self.metadata['~totalalbumtracks'] = self.metadata['totaltracks'] = len(self.files)
+        metadata_counters = {}
+        tags_to_update = ['catalognumber', 'barcode', 'asin', 'genre']
+        for file in self.files:
+            for tag in tags_to_update:
+                if tag in file.metadata:
+                    value = file.metadata[tag]
+                    if tag not in metadata_counters:
+                        metadata_counters[tag] = Counter()
+                    metadata_counters[tag][value] += 1
+        for tag in metadata_counters:
+            self.metadata[tag] = metadata_counters[tag].most_common(1)[0][0]
         if signal and self.ui_item:
             self.ui_item.update()
 

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -72,6 +72,9 @@ CLUSTER_COMPARISON_WEIGHTS = {
     'releasecountry': 2,
     'releasetype': 10,
     'totalalbumtracks': 5,
+    'catalognumber': 60,
+    'asin': 65,
+    'barcode': 68,
 }
 
 

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -163,6 +163,9 @@ class Metadata(MutableMapping):
         ('totaltracks', 5),
         ('discnumber', 5),
         ('totaldiscs', 4),
+        ('catalognumber', 30),
+        ('barcode', 33),
+        ('asin', 32),
     ]
 
     __date_match_factors = {
@@ -232,6 +235,8 @@ class Metadata(MutableMapping):
                             ia = a
                             ib = b
                         score = 1.0 - (int(ia != ib))
+                    elif name in {'catalognumber', 'barcode', 'asin'}:
+                        score = 1.0 if a == b else 0.0
                     else:
                         score = similarity2(a, b)
                     parts.append((score, weight))
@@ -288,6 +293,26 @@ class Metadata(MutableMapping):
                     parts.append((score, weights['totalalbumtracks']))
                 except (ValueError, KeyError):
                     pass
+
+            if 'catalognumber' in self and 'catalognumber' in weights:
+                try:
+                    found = 0.0
+                    for _ in release['label-info']:
+                        if self['catalognumber'] == _['catalog-number']:
+                            print(_['catalog-number'])
+                            found += 1.0
+                            break
+                    parts.append((found, weights['catalognumber']))
+                except (KeyError, IndexError):
+                    pass
+
+            if 'barcode' in self and 'barcode' in weights:
+                score = 1.0 if self['barcode'] == release['barcode'] else 0.0
+                parts.append((score, weights['barcode']))
+
+            if 'asin' in self and 'asin' in weights:
+                score = 1.0 if self['asin'] == release['asin'] else 0.0
+                parts.append((score, weights['asin']))
 
             # Date Logic
             date_match_factor = 0.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Try to match by catalog number, barcode and asin when using the Lookup function on clusters.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
When using the Lookup (Ctrl+L) function on clusters, Picard won't try to match using available release identifiers (like catalogue number or barcode), this PR aims to fix this.
The problem still applies to unclustered files (I haven't checked to them yet).

I searched online but couldn't find anything similar to this (except for the mentioned JIRA tickets) so I apologize if there already is something similar.

* JIRA ticket (_optional_): PICARD-2466, PICARD-2793
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Make a dictionary containing a `Counter` for each tag, iterating through it and using `most_common()` gives us the most common value in all files in the cluster for each tag specified in `tags_to_update` (Method shamelessly copied from `FileCluster`'s `artist` and `title`). This way we can populate the cluster's metadata with additional useful info.
This PR also adds those identifiers to `Metadata.compare()` and `Metadata.compare_to_release_parts()` (using their respective weights defined in `CLUSTER_COMPARISON_WEIGHTS`)


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->