### PR TITLE
PICARD-2958: Fix PO file header showing up as file tooltip

### DIFF
--- a/picard/ui/itemviews.py
+++ b/picard/ui/itemviews.py
@@ -1169,19 +1169,19 @@ class FileItem(TreeItem):
         elif isinstance(file.parent, Track):
             if file.state == File.NORMAL:
                 icon = FileItem.icon_saved
-                tooltip = N_("Track saved")
+                tooltip = _("Track saved")
             elif file.state == File.PENDING:
                 icon = FileItem.match_pending_icons[int(file.similarity * 5 + 0.5)]
-                tooltip = N_("Pending")
+                tooltip = _("Pending")
             else:
                 icon = FileItem.match_icons[int(file.similarity * 5 + 0.5)]
-                tooltip = FileItem.match_icons_info[int(file.similarity * 5 + 0.5)]
+                tooltip = _(FileItem.match_icons_info[int(file.similarity * 5 + 0.5)])
         elif file.state == File.PENDING:
             icon = FileItem.icon_file_pending
-            tooltip = N_("Pending")
+            tooltip = _("Pending")
         else:
             icon = FileItem.icon_file
-        return (icon, _(tooltip))
+        return (icon, tooltip)
 
     @staticmethod
     def decide_fingerprint_icon_info(file):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2958
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Calling _("") causes gettext to show the header of the PO file for the current locale. This causes the tooltip for unmatched files to show this header.

Only affects the 2.x branch, master is fine.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Call `_()`  explicitly for each item. This code is similar to what is currently in the master branch