### PR TITLE
PICARD-2958: Handle gettext being called with empty string

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -196,6 +196,10 @@ def setup_gettext(localedir, ui_language=None, logger=None):
 
 def gettext(message: str) -> str:
     """Translate the messsage using the current translator."""
+    # Calling gettext("") by default returns the header of the PO file for the
+    # current locale. This is unexpected. Return an empty string instead.
+    if message == "":
+        return message
     return _translation['main'].gettext(message)
 
 

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -85,6 +85,10 @@ class TestI18n(PicardTestCase):
         # self.assertEqual('Französisch', gettext_constants('French'))
         self.assertEqual('Frankreich', gettext_countries('France'))
 
+    def test_gettext_handles_empty_string(self):
+        setup_gettext(localedir, 'fr')
+        self.assertEqual('', _(''))
+
     def test_sort_key(self):
         setup_gettext(localedir, 'de')
         self.assertTrue(sort_key('äb') < sort_key('ac'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2958
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Calling gettext("") by default returns the header of the PO file for the current locale. This is unexpected. Return an empty string instead.

While PICARD-2958 effectively only happens on the 2.x branch due to recent refactorings of itemviews, the behavior of gettext itself is unexpected and can easily cause similar issues.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


Update the gettext wrapper to return an empty string if the input was an empty string.