### PR TITLE
PICARD-2960: Prevent dir separator replacement being set to dir separator (2.x backport)

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -40,7 +40,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(2, 12, 2, 'final', 0)
+PICARD_VERSION = Version(2, 12, 3, 'dev', 1)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -26,7 +26,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
+import os
 import re
 
 from PyQt5 import QtWidgets
@@ -45,6 +45,8 @@ from picard.const import (
 )
 from picard.const.sys import IS_FROZEN
 from picard.util import unique_numbered_title
+
+from picard.ui.options.renaming_compat import DEFAULT_REPLACEMENT
 
 
 # TO ADD AN UPGRADE HOOK:
@@ -478,6 +480,15 @@ def upgrade_to_v2_10_1_dev_2(config):
     config.persist['splitters_OptionsDialog'] = b''
 
 
+def upgrade_to_v2_12_3_dev_1(config):
+    """Ensure "replace_dir_separator" contains no directory separator"""
+    replace_dir_separator = config.setting['replace_dir_separator']
+    replace_dir_separator = replace_dir_separator.replace(os.sep, DEFAULT_REPLACEMENT)
+    if os.altsep:
+        replace_dir_separator = replace_dir_separator.replace(os.altsep, DEFAULT_REPLACEMENT)
+    config.setting['replace_dir_separator'] = replace_dir_separator
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:
@@ -524,4 +535,5 @@ def upgrade_config(config):
     cfg.register_upgrade_hook(upgrade_to_v2_8_0_dev_2)
     cfg.register_upgrade_hook(upgrade_to_v2_9_0_alpha_2)
     cfg.register_upgrade_hook(upgrade_to_v2_10_1_dev_2)
+    cfg.register_upgrade_hook(upgrade_to_v2_12_3_dev_1)
     cfg.run_upgrade_hooks(log.debug)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -21,6 +21,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import os
 
 from PyQt5.QtCore import QByteArray
 
@@ -58,12 +59,15 @@ from picard.config_upgrade import (
     upgrade_to_v2_6_0_beta_3,
     upgrade_to_v2_6_0_dev_1,
     upgrade_to_v2_8_0_dev_2,
+    upgrade_to_v2_12_3_dev_1,
 )
 from picard.const import (
     DEFAULT_FILE_NAMING_FORMAT,
     DEFAULT_SCRIPT_NAME,
 )
 from picard.util import unique_numbered_title
+
+from picard.ui.options.renaming_compat import DEFAULT_REPLACEMENT
 
 
 class TestPicardConfigUpgrades(TestPicardConfigCommon):
@@ -364,3 +368,14 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual(expected, self.config.setting['toolbar_layout'])
         upgrade_to_v2_8_0_dev_2(self.config)
         self.assertEqual(expected, self.config.setting['toolbar_layout'])
+
+    def test_upgrade_to_v2_12_3_dev_1(self):
+        TextOption('setting', 'replace_dir_separator', DEFAULT_REPLACEMENT)
+        self.config.setting['replace_dir_separator'] = os.sep
+        upgrade_to_v2_12_3_dev_1(self.config)
+        self.assertEqual(DEFAULT_REPLACEMENT, self.config.setting['replace_dir_separator'])
+
+        if os.altsep:
+            self.config.setting['replace_dir_separator'] = os.altsep
+            upgrade_to_v2_12_3_dev_1(self.config)
+            self.assertEqual(DEFAULT_REPLACEMENT, self.config.setting['replace_dir_separator'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2960
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Same as https://github.com/metabrainz/picard/pull/2541 , but backported to 2.x branch.