### PR TITLE
PICARD-2989: fix settings override recursion

### DIFF
--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -184,7 +184,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 self.player.error.connect(self._on_player_error)
 
         self.script_editor_dialog = None
-        self.examples = None
 
         self.tagger.pluginmanager.updates_available.connect(self.show_plugin_update_dialog)
 
@@ -1485,8 +1484,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def open_file_naming_script_editor(self):
         """Open the file naming script editor / manager in a new window.
         """
-        self.examples = ScriptEditorExamples(tagger=self.tagger)
-        self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=self.examples)
+        examples = ScriptEditorExamples(tagger=self.tagger)
+        self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=examples)
         self.script_editor_dialog.signal_save.connect(self._script_editor_save)
         self.script_editor_dialog.signal_selection_changed.connect(self._update_selector_from_script_editor)
         self.script_editor_dialog.signal_index_changed.connect(self._script_editor_index_changed)
@@ -1516,22 +1515,23 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _update_script_editor_example_files(self):
         """Update the list of example files for the file naming script editor.
         """
-        if self.examples:
-            self.examples.update_sample_example_files()
+        script_editor_dialog = self.script_editor_dialog
+        if script_editor_dialog and script_editor_dialog.isVisible():
+            script_editor_dialog.examples.update_sample_example_files()
             self._update_script_editor_examples()
 
     def _update_script_editor_examples(self):
         """Update the examples for the file naming script editor, using current settings.
         """
-        if self.examples:
+        script_editor_dialog = self.script_editor_dialog
+        if script_editor_dialog and script_editor_dialog.isVisible():
             config = get_config()
             override = {
                 "rename_files": config.setting["rename_files"],
                 "move_files": config.setting["move_files"],
             }
-            self.examples.update_examples(override=override)
-            if self.script_editor_dialog:
-                self.script_editor_dialog.display_examples()
+            script_editor_dialog.examples.update_examples(override=override)
+            script_editor_dialog.display_examples()
 
     def _script_editor_index_changed(self):
         """Process "signal_index_changed" signal from the script editor.

--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -136,7 +136,8 @@ class ScriptEditorExamples():
             script_text (str, optional): Text of the file naming script to use. Defaults to None.
         """
         if override and isinstance(override, dict):
-            self.settings = SettingsOverride(self.settings, override)
+            config = get_config()
+            self.settings = SettingsOverride(config.setting, override)
         if script_text and isinstance(script_text, str):
             self.script_text = script_text
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2989
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The `ScriptEditorDialog` uses `SettingsOverride` for locally changed settings. On repeated example file updates the `SettingsOverride` would recursively reference itself. As there are many example updates on selection change this could lead to a deep recursion depth until max recursion would trigger an error. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Fix SettingsOverride always referencing base settings only.

Also avoid example update calls if the script editor dialog is not visible. The edittor will update anyway once it becomes visible or gains focus.