### PR TITLE
PICARD-2607: Add a “_genre” variable

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -856,6 +856,10 @@ class Album(MetadataItem):
             yield from track.files
         yield from self.unmatched_files.files
 
+    def delete_genres_from_tags(self):
+        for genre in self.genres:
+            del self.folksonomy_tags[genre]
+
 
 class NatAlbum(Album):
 

--- a/picard/item.py
+++ b/picard/item.py
@@ -200,6 +200,7 @@ class MetadataItem(QtCore.QObject, Item):
         self.iter_children_items_metadata_ignore_attrs = {}
         self.suspend_metadata_images_update = IgnoreUpdatesContext()
         self._genres = Counter()
+        self._folksonomy_tags = Counter()
 
     @property
     def tagger(self):
@@ -314,13 +315,20 @@ class MetadataItem(QtCore.QObject, Item):
         require_authentication = False
         config = config or get_config()
         if config.setting['use_genres']:
-            use_folksonomy = config.setting['folksonomy_tags']
             if config.setting['only_my_genres']:
                 require_authentication = True
-                inc |= {'user-tags'} if use_folksonomy else {'user-genres'}
+                inc |= {'user-tags', 'user-genres'}
             else:
-                inc |= {'tags'} if use_folksonomy else {'genres'}
+                inc |= {'tags', 'genres'}
         return require_authentication
+
+    @property
+    def folksonomy_tags(self):
+        return self._folksonomy_tags
+
+    def add_folksonomy_tag(self, name, count):
+        if name:
+            self._folksonomy_tags[name] += count
 
 
 class FileListItem(MetadataItem):

--- a/picard/item.py
+++ b/picard/item.py
@@ -310,6 +310,14 @@ class MetadataItem(QtCore.QObject, Item):
         if name:
             self._genres[name] += count
 
+    @property
+    def folksonomy_tags(self):
+        return self._folksonomy_tags
+
+    def add_folksonomy_tag(self, name, count):
+        if name:
+            self._folksonomy_tags[name] += count
+
     @staticmethod
     def set_genre_inc_params(inc, config=None):
         require_authentication = False
@@ -321,14 +329,6 @@ class MetadataItem(QtCore.QObject, Item):
             else:
                 inc |= {'tags', 'genres'}
         return require_authentication
-
-    @property
-    def folksonomy_tags(self):
-        return self._folksonomy_tags
-
-    def add_folksonomy_tag(self, name, count):
-        if name:
-            self._folksonomy_tags[name] += count
 
 
 class FileListItem(MetadataItem):

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -636,16 +636,14 @@ def add_secondary_release_types(node, m):
 def add_genres_from_node(node, obj):
     if obj is None:
         return
-    config = get_config()
-    if config.setting['use_genres']:
-        if 'tags' in node:
-            add_tags(node['tags'], obj)
-        if 'user-tags' in node:
-            add_user_tags(node['user-tags'], obj)
-        if 'genres' in node:
-            add_genres(node['genres'], obj)
-        if 'user-genres' in node:
-            add_user_genres(node['user-genres'], obj)
+    if 'tags' in node:
+        add_tags(node['tags'], obj)
+    if 'user-tags' in node:
+        add_user_tags(node['user-tags'], obj)
+    if 'genres' in node:
+        add_genres(node['genres'], obj)
+    if 'user-genres' in node:
+        add_user_genres(node['user-genres'], obj)
 
 
 def add_genres(node, obj):

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -636,14 +636,16 @@ def add_secondary_release_types(node, m):
 def add_genres_from_node(node, obj):
     if obj is None:
         return
-    if 'genres' in node:
-        add_genres(node['genres'], obj)
-    if 'tags' in node:
-        add_genres(node['tags'], obj)
-    if 'user-genres' in node:
-        add_user_genres(node['user-genres'], obj)
-    if 'user-tags' in node:
-        add_user_genres(node['user-tags'], obj)
+    config = get_config()
+    if config.setting['use_genres']:
+        if 'tags' in node:
+            add_tags(node['tags'], obj)
+        if 'user-tags' in node:
+            add_user_tags(node['user-tags'], obj)
+        if 'genres' in node:
+            add_genres(node['genres'], obj)
+        if 'user-genres' in node:
+            add_user_genres(node['user-genres'], obj)
 
 
 def add_genres(node, obj):
@@ -654,6 +656,16 @@ def add_genres(node, obj):
 def add_user_genres(node, obj):
     for tag in node:
         obj.add_genre(tag['name'], 1)
+
+
+def add_tags(node, obj):
+    for tag in node:
+        obj.add_folksonomy_tag(tag['name'], tag['count'])
+
+
+def add_user_tags(node, obj):
+    for tag in node:
+        obj.add_folksonomy_tag(tag['name'], 1)
 
 
 def add_isrcs_to_metadata(node, metadata):

--- a/picard/track.py
+++ b/picard/track.py
@@ -313,6 +313,8 @@ class Track(FileListItem):
             tm['~silence'] = '1'
 
         if config.setting['use_genres']:
+            self.add_folksonomy_tags()
+            self.add_genres()
             self._convert_folksonomy_tags_to_genre()
 
         # Convert Unicode punctuation
@@ -367,6 +369,18 @@ class Track(FileListItem):
             filters=config.setting['genres_filter'],
             join_with=config.setting['join_genres']
         )
+
+    def add_folksonomy_tags(self):
+        config = get_config()
+        tags = Counter(self._folksonomy_tags)
+        tags += self.album._folksonomy_tags
+        self.metadata['_folksonomy_tags'] = self._genres_to_metadata(tags, join_with=config.setting['join_genres'])
+
+    def add_genres(self):
+        config = get_config()
+        _genres = Counter(self._genres)
+        _genres += self.album._genres
+        self.metadata['_genres'] = self._genres_to_metadata(_genres, join_with=config.setting['join_genres'])
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -314,7 +314,7 @@ class Track(FileListItem):
 
         if config.setting['use_genres']:
             self._convert_folksonomy_tags_to_genre()
-            self._delete_genres_from_tags()
+            self.album.delete_genres_from_tags()
             self._add_folksonomy_tags()
             self._add_genres()
 
@@ -387,10 +387,6 @@ class Track(FileListItem):
         genre = Counter(self.genres)
         genre += self.album.genres
         self._add_tags(genre, '_genres')
-
-    def _delete_genres_from_tags(self):
-        for genre in self.album.genres:
-            del self.album.folksonomy_tags[genre]
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -313,9 +313,8 @@ class Track(FileListItem):
             tm['~silence'] = '1'
 
         if config.setting['use_genres']:
-            config = get_config()
-            self._add_folksonomy_tags(config)
-            self._add_genres(config)
+            self._add_folksonomy_tags()
+            self._add_genres()
             self._convert_folksonomy_tags_to_genre()
 
         # Convert Unicode punctuation
@@ -375,19 +374,18 @@ class Track(FileListItem):
             join_with=config.setting['join_genres']
         )
 
-    def _add_tags(self, tags, name, config=None):
-        config = config or get_config()
+    def _add_tags(self, tags, name):
         self.metadata[name] = tags.keys()
 
-    def _add_folksonomy_tags(self, config=None):
+    def _add_folksonomy_tags(self):
         tags = Counter(self._folksonomy_tags)
         tags += self.album._folksonomy_tags
-        self._add_tags(tags, '_folksonomy_tags', config)
+        self._add_tags(tags, '_folksonomy_tags')
 
-    def _add_genres(self, config=None):
+    def _add_genres(self):
         genre = Counter(self._genres)
         genre += self.album._genres
-        self._add_tags(genre, '_genres', config)
+        self._add_tags(genre, '_genres')
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -389,8 +389,8 @@ class Track(FileListItem):
         self._add_tags(genre, '_genres')
 
     def _delete_genres_from_tags(self):
-        for genres in self.album.genres:
-            del self.album._folksonomy_tags[genres]
+        for genre in self.album.genres:
+            del self.album._folksonomy_tags[genre]
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -352,9 +352,9 @@ class Track(FileListItem):
         genres = Counter(self.genres)
         use_folksonomy = config.setting['folksonomy_tags']
         if use_folksonomy:
-            genres += self.album._folksonomy_tags
+            genres += self.album.folksonomy_tags
         else:
-            genres += self.album._genres
+            genres += self.album.genres
         # Combine release and track genres
         if self.album.release_group:
             genres += self.album.release_group.genres
@@ -379,18 +379,18 @@ class Track(FileListItem):
         self.metadata[name] = tags.keys()
 
     def _add_folksonomy_tags(self):
-        tags = Counter(self._folksonomy_tags)
-        tags += self.album._folksonomy_tags
+        tags = Counter(self.folksonomy_tags)
+        tags += self.album.folksonomy_tags
         self._add_tags(tags, '_folksonomy_tags')
 
     def _add_genres(self):
-        genre = Counter(self._genres)
-        genre += self.album._genres
+        genre = Counter(self.genres)
+        genre += self.album.genres
         self._add_tags(genre, '_genres')
 
     def _delete_genres_from_tags(self):
         for genre in self.album.genres:
-            del self.album._folksonomy_tags[genre]
+            del self.album.folksonomy_tags[genre]
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -313,9 +313,10 @@ class Track(FileListItem):
             tm['~silence'] = '1'
 
         if config.setting['use_genres']:
+            self._convert_folksonomy_tags_to_genre()
+            self._delete_genres_from_tags()
             self._add_folksonomy_tags()
             self._add_genres()
-            self._convert_folksonomy_tags_to_genre()
 
         # Convert Unicode punctuation
         if config.setting['convert_punctuation']:
@@ -386,6 +387,10 @@ class Track(FileListItem):
         genre = Counter(self._genres)
         genre += self.album._genres
         self._add_tags(genre, '_genres')
+
+    def _delete_genres_from_tags(self):
+        for genres in self.album.genres:
+            del self.album._folksonomy_tags[genres]
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -313,8 +313,9 @@ class Track(FileListItem):
             tm['~silence'] = '1'
 
         if config.setting['use_genres']:
-            self.add_folksonomy_tags()
-            self.add_genres()
+            config = get_config()
+            self._add_folksonomy_tags(config)
+            self._add_genres(config)
             self._convert_folksonomy_tags_to_genre()
 
         # Convert Unicode punctuation
@@ -374,17 +375,19 @@ class Track(FileListItem):
             join_with=config.setting['join_genres']
         )
 
-    def add_folksonomy_tags(self):
-        config = get_config()
+    def _add_tags(self, tags, name, config=None):
+        config = config or get_config()
+        self.metadata[name] = tags.keys()
+
+    def _add_folksonomy_tags(self, config=None):
         tags = Counter(self._folksonomy_tags)
         tags += self.album._folksonomy_tags
-        self.metadata['_folksonomy_tags'] = self._genres_to_metadata(tags, join_with=config.setting['join_genres'])
+        self._add_tags(tags, '_folksonomy_tags', config)
 
-    def add_genres(self):
-        config = get_config()
-        _genres = Counter(self._genres)
-        _genres += self.album._genres
-        self.metadata['_genres'] = self._genres_to_metadata(_genres, join_with=config.setting['join_genres'])
+    def _add_genres(self, config=None):
+        genre = Counter(self._genres)
+        genre += self.album._genres
+        self._add_tags(genre, '_genres', config)
 
 
 class NonAlbumTrack(Track):

--- a/picard/track.py
+++ b/picard/track.py
@@ -348,9 +348,13 @@ class Track(FileListItem):
 
     def _convert_folksonomy_tags_to_genre(self):
         config = get_config()
-        # Combine release and track genres
         genres = Counter(self.genres)
-        genres += self.album.genres
+        use_folksonomy = config.setting['folksonomy_tags']
+        if use_folksonomy:
+            genres += self.album._folksonomy_tags
+        else:
+            genres += self.album._genres
+        # Combine release and track genres
         if self.album.release_group:
             genres += self.album.release_group.genres
         if not genres and config.setting['artists_genres']:

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -169,14 +169,14 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
         self.assertEqual(m['~releaselanguage'], 'eng')
         self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
-        self.assertEqual(a._genres, {
+        self.assertEqual(a.genres, {
             'genre1': 6, 'genre2': 3
         })
-        self.assertEqual(a._folksonomy_tags, {
+        self.assertEqual(a.folksonomy_tags, {
             'tag1': 6, 'tag2': 3
         })
         for artist in a._album_artists:
-            self.assertEqual(artist._folksonomy_tags, {
+            self.assertEqual(artist.folksonomy_tags, {
                 'british': 2,
                 'progressive rock': 10})
 
@@ -299,11 +299,11 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~video'], '')
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
-        self.assertEqual(t._folksonomy_tags, {
+        self.assertEqual(t.folksonomy_tags, {
             'blue-eyed soul': 1,
             'pop': 3})
         for artist in t._track_artists:
-            self.assertEqual(artist._folksonomy_tags, {
+            self.assertEqual(artist.folksonomy_tags, {
                 'dance-pop': 1,
                 'guitarist': 0})
 
@@ -776,7 +776,7 @@ class ReleaseGroupTest(MBJSONTest):
         self.assertEqual(m['releasetype'], 'album')
         self.assertEqual(m['~primaryreleasetype'], 'album')
         self.assertEqual(m['~releasegroup'], 'The Dark Side of the Moon')
-        self.assertEqual(r._folksonomy_tags, {'test2': 3, 'test': 6})
+        self.assertEqual(r.folksonomy_tags, {'test2': 3, 'test': 6})
 
 
 class NullReleaseGroupTest(MBJSONTest):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -135,11 +135,14 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~release_seriesid'], '7421b602-a413-4151-bcf4-d831debc3f27')
         self.assertEqual(m['~release_seriescomment'], 'Pink Floyed special editions')
         self.assertEqual(m['~release_seriesnumber'], '')
-        self.assertEqual(a.genres, {
-            'genre1': 6, 'genre2': 3,
-            'tag1': 6, 'tag2': 3})
+        self.assertEqual(a._genres, {
+            'genre1': 6, 'genre2': 3
+        })
+        self.assertEqual(a._folksonomy_tags, {
+            'tag1': 6, 'tag2': 3
+        })
         for artist in a._album_artists:
-            self.assertEqual(artist.genres, {
+            self.assertEqual(artist._folksonomy_tags, {
                 'british': 2,
                 'progressive rock': 10})
 
@@ -166,11 +169,14 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
         self.assertEqual(m['~releaselanguage'], 'eng')
         self.assertEqual(m.getall('~releasecountries'), ['GB', 'NZ'])
-        self.assertEqual(a.genres, {
-            'genre1': 6, 'genre2': 3,
-            'tag1': 6, 'tag2': 3})
+        self.assertEqual(a._genres, {
+            'genre1': 6, 'genre2': 3
+        })
+        self.assertEqual(a._folksonomy_tags, {
+            'tag1': 6, 'tag2': 3
+        })
         for artist in a._album_artists:
-            self.assertEqual(artist.genres, {
+            self.assertEqual(artist._folksonomy_tags, {
                 'british': 2,
                 'progressive rock': 10})
 
@@ -293,11 +299,11 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~video'], '')
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
-        self.assertEqual(t.genres, {
+        self.assertEqual(t._folksonomy_tags, {
             'blue-eyed soul': 1,
             'pop': 3})
         for artist in t._track_artists:
-            self.assertEqual(artist.genres, {
+            self.assertEqual(artist._folksonomy_tags, {
                 'dance-pop': 1,
                 'guitarist': 0})
 
@@ -770,7 +776,7 @@ class ReleaseGroupTest(MBJSONTest):
         self.assertEqual(m['releasetype'], 'album')
         self.assertEqual(m['~primaryreleasetype'], 'album')
         self.assertEqual(m['~releasegroup'], 'The Dark Side of the Moon')
-        self.assertEqual(r.genres, {'test2': 3, 'test': 6})
+        self.assertEqual(r._folksonomy_tags, {'test2': 3, 'test': 6})
 
 
 class NullReleaseGroupTest(MBJSONTest):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Adds a custom field for folksonomy tags and genre.
# Problem
There was no custom field for folksonomy tags. User was forced to either set all genre as genre tags or all folksonomy tags as Genre. 
This PR aims to resolve it by introducing two new tags _folksonomy_tag and _genre.  
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2607
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
To get both _genres and _folksonomy tags from the MusicBrainz server, I removed the 'use_folksonomy` check in picard/items.py and stored the tags in respective variables. Then for writing the metadata, I added two new functions in picard/track.py that would update the metadata with _genre and _folksonomy_tag. And before writing genre into the file, check whether genre should be set to _folksonomy_tag or _genre itself.   

Check for 'Use only my genre' option is still done in picard/items.py
# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
