### PR TITLE
Add missing unittest setup calls

### DIFF
--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -83,7 +83,9 @@ class FakeTagger(QtCore.QObject):
 
 
 class PicardTestCase(unittest.TestCase):
+
     def setUp(self):
+        super().setUp()
         log.set_level(logging.DEBUG)
         setup_gettext(None, 'C')
         self.tagger = FakeTagger()

--- a/test/test_debug_opt.py
+++ b/test/test_debug_opt.py
@@ -30,6 +30,7 @@ class DebugOptTestCase(DebugOptEnum):
 
 class TestDebugOpt(PicardTestCase):
     def setUp(self):
+        super().setUp()
         DebugOptTestCase.set_registry(set())
 
     def test_enabled(self):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -664,6 +664,7 @@ class ArtistTranslationArabicExceptionsTest(MBJSONTest):
 class TestAliasesLocales(PicardTestCase):
 
     def setUp(self):
+        super().setUp()
         self.maxDiff = None
 
         self.aliases = [

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -102,9 +102,6 @@ class CommonTests:
         def get_metadata_object():
             pass
 
-        def tearDown(self):
-            pass
-
         def test_metadata_setitem(self):
             self.assertEqual(["single1-value"], self.metadata.getraw("single1"))
             self.assertEqual(["single2-value"], self.metadata.getraw("single2"))

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -105,9 +105,6 @@ class TestPicardPluginsCommon(PicardTestCase):
         super().setUp()
         logging.disable(logging.ERROR)
 
-    def tearDown(self):
-        pass
-
 
 class TestPicardPluginsCommonTmpDir(TestPicardPluginsCommon):
 


### PR DESCRIPTION
I reviewed the code and checked all `setUp()` and `tearDown()` definitions, some were missing parent method call, and some were useless.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Related to https://github.com/metabrainz/picard/pull/2547