### PR TITLE
CI: Replace deprecated macos-12 image with macos-13 (2.13)

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, windows-2019]
+        os: [macos-13, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,7 +26,7 @@ permissions: {}
 
 jobs:
   package-macos:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         setup:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest, windows-2019]
+        os: [macos-13, ubuntu-latest, windows-2019]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-        - os: macos-12
+        - os: macos-13
           python-version: '3.7'
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest, windows-latest]
+        os: [macos-13, ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.11']
 
     steps:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
Github deprectaed the macos-12 package since 2024-10-07 and will fully remove it on 2024-12-03. Use macos-13 instead.

This is for the 2.x branch.