### PR TITLE
PICARD-2991: Handle statvfs errors on file rename

### DIFF
--- a/picard/ui/scripteditor.py
+++ b/picard/ui/scripteditor.py
@@ -173,7 +173,7 @@ class ScriptEditorExamples():
             if not self.settings['move_files']:
                 return os.path.basename(filename_before), os.path.basename(filename_after)
             return filename_before, filename_after
-        except (ScriptError, TypeError, WinPathTooLong):
+        except (FileNotFoundError, PermissionError, ScriptError, TypeError, WinPathTooLong):
             return "", ""
 
     def update_example_listboxes(self, before_listbox, after_listbox):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2991
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`make_short_filename` runs `_get_filename_limit` on the basedir, which in turn tries to get filename limits by calling `statvfs`. `statvfs` can fail with `FileNotFoundError` or `PermissionError`.

To reproduce:

- In Options > File naming set the target dir to something on which `os.statvfs` fails. On my Linux system this is e.g. `/run/user/1000/doc`
- Save options and reopen the options dialog

=> File naming failed to load, exception is logged

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. If in `_get_filename_limit` the call to `os.statvfs` fails, retry on the parent path
2. Do not fail to load the options dialog on `FileNotFoundError` or `PermissionError` when updating the examples