### PR TITLE
PICARD-3008: Handle OverflowError in extract_year_from_date

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -946,7 +946,7 @@ def extract_year_from_date(dt):
             return int(dt.get('year'))
         else:
             return parse(dt).year
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -172,6 +172,7 @@ class ExtractYearTest(PicardTestCase):
         self.assertEqual(extract_year_from_date('2020-02-28'), 2020)
         self.assertEqual(extract_year_from_date('2015.02'), 2015)
         self.assertEqual(extract_year_from_date('2015; 2015'), None)
+        self.assertEqual(extract_year_from_date('20190303201903032019030320190303'), None)
         # test for the format as supported by ID3 (https://id3.org/id3v2.4.0-structure): yyyy-MM-ddTHH:mm:ss
         self.assertEqual(extract_year_from_date('2020-07-21T13:00:00'), 2020)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3008
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard can crash when loading a release that contains a huge number as the `date` tag. This is caused by an OverflowError when parsing the date for metadata comparison.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Handle `OverflowError` from `dateutil.parser.parse` in `picard.util.extract_year_from_date`.