### PR TITLE
2.x OAuth improvements

### DIFF
--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -301,10 +301,37 @@ class OAuthManager(object):
             return _("Unexpected request error (HTTP code %s)") % self._http_code(http)
 
 
-def s256_encode(token):
-    return base64url_encode(sha256(token).digest())
+def s256_encode(input: bytes) -> bytes:
+    """Implements the S256 code challenge encoding as defined for PKCE in RFC 7636.
+
+    The input data gets hashed by SHA256 and Base64url encoded.
+
+    See also https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+
+    Args:
+        input (bytes): Input bytes to encode. Is expected to consist only of ASCII characters.
+
+    Returns:
+        bytes: encoded data
+    """
+    return base64url_encode(sha256(input).digest())
 
 
-def base64url_encode(s):
-    # see https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
-    return urlsafe_b64encode(s).rstrip(b'=')
+def base64url_encode(input: bytes) -> bytes:
+    """Implements the Base64url Encoding as defined for PKCE in RFC 7636.
+
+    Base64 encoding using the URL- and filename-safe character set
+    defined in Section 5 of [RFC4648], with all trailing '='
+    characters omitted (as permitted by Section 3.2 of [RFC4648]) and
+    without the inclusion of any line breaks, whitespace, or other
+    additional characters.
+
+    See also https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
+
+    Args:
+        s (bytes): Input bytes to encode.
+
+    Returns:
+        bytes: Base64url encoded data
+    """
+    return urlsafe_b64encode(input).rstrip(b'=')

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -154,10 +154,48 @@ class OAuthManager(object):
     def is_logged_in(self):
         return self.is_authorized() and bool(self.username)
 
-    def revoke_tokens(self):
-        # TODO actually revoke the tokens on MB (I think it's not implemented there)
-        self.forget_refresh_token()
-        self.forget_access_token()
+    def revoke_tokens(self, callback):
+        # Actually revoke the tokens on MB.
+        # From https://musicbrainz.org/doc/Development/OAuth2#Revoking_a_token :
+        # "If your application is installed or offline and token is a
+        # refresh token, we'll revoke the entire authorization grant associated
+        # with that token."
+        log.debug("OAuth: Revoking authorization grant")
+        self._revoke_token(self.refresh_token, callback)
+
+    def _revoke_token(self, token, callback):
+        params = {
+            'token': token,
+            'client_id': MUSICBRAINZ_OAUTH_CLIENT_ID,
+            'client_secret': MUSICBRAINZ_OAUTH_CLIENT_SECRET,
+        }
+        self.webservice.post_url(
+            url=self.url(path="/oauth2/revoke"),
+            data=self._query_data(params),
+            handler=partial(self._on_revoke_token_finished, callback),
+            mblogin=True,
+            priority=True,
+            important=True,
+            request_mimetype='application/x-www-form-urlencoded',
+            parse_response_type=False,
+        )
+
+    def _on_revoke_token_finished(self, callback, data, http, error):
+        successful = False
+        error_msg = None
+        try:
+            if error:
+                log.error("OAuth: revoking token failed: %s", error)
+                error_msg = self._extract_error_description(http, data)
+            else:
+                self.forget_refresh_token()
+                self.forget_access_token()
+                successful = True
+        except Exception as e:
+            log.error("OAuth: Unexpected error handling token revocation response: %r", e)
+            error_msg = _("Unexpected token revocation error")
+        finally:
+            callback(successful=successful, error_msg=error_msg)
 
     def forget_refresh_token(self):
         del self.refresh_token

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2014 Lukáš Lalinský
 # Copyright (C) 2015 Sophist-UK
 # Copyright (C) 2015 Wieland Hoffmann
-# Copyright (C) 2015, 2018, 2021 Philipp Wolfer
+# Copyright (C) 2015, 2018, 2021, 2024 Philipp Wolfer
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
 # Copyright (C) 2018-2022 Laurent Monin
@@ -24,9 +24,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
+from base64 import urlsafe_b64encode
 from functools import partial
+from hashlib import sha256
 from json.decoder import JSONDecodeError
+import secrets
 import time
 import urllib.parse
 
@@ -128,7 +130,7 @@ class OAuthManager(object):
         return self.is_authorized() and bool(self.username)
 
     def revoke_tokens(self):
-        # TODO actually revoke the tokens on MB (I think it's not implementented there)
+        # TODO actually revoke the tokens on MB (I think it's not implemented there)
         self.forget_refresh_token()
         self.forget_access_token()
 
@@ -156,11 +158,21 @@ class OAuthManager(object):
             queryargs=params
         )
 
+    def _create_code_challenge(self):
+        # see https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
+        # and https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
+        code_verifier = base64url_encode(secrets.token_bytes(32))
+        self.__code_verifier = code_verifier.decode('ASCII')
+        code_challenge = s256_encode(code_verifier)  # code_challenge_method=S256
+        return code_challenge.decode('ASCII')
+
     def get_authorization_url(self, scopes):
         params = {
             'response_type': 'code',
             'client_id': MUSICBRAINZ_OAUTH_CLIENT_ID,
             'redirect_uri': "urn:ietf:wg:oauth:2.0:oob",
+            'code_challenge_method': 'S256',
+            'code_challenge': self._create_code_challenge(),
             'scope': scopes,
         }
         return bytes(self.url(path="/oauth2/authorize", params=params).toEncoded()).decode()
@@ -222,6 +234,7 @@ class OAuthManager(object):
             'client_id': MUSICBRAINZ_OAUTH_CLIENT_ID,
             'client_secret': MUSICBRAINZ_OAUTH_CLIENT_SECRET,
             'redirect_uri': "urn:ietf:wg:oauth:2.0:oob",
+            'code_verifier': self.__code_verifier,
         }
         self.webservice.post_url(
             url=self.url(path="/oauth2/token"),
@@ -286,3 +299,12 @@ class OAuthManager(object):
             return response['error_description']
         except (JSONDecodeError, KeyError, TypeError):
             return _("Unexpected request error (HTTP code %s)") % self._http_code(http)
+
+
+def s256_encode(token):
+    return base64url_encode(sha256(token).digest())
+
+
+def base64url_encode(s):
+    # see https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
+    return urlsafe_b64encode(s).rstrip(b'=')

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -653,15 +653,16 @@ class Tagger(QtWidgets.QApplication):
 
     def mb_login(self, callback, parent=None):
         scopes = 'profile tag rating collection submit_isrc submit_barcode'
-        authorization_url = self.webservice.oauth_manager.get_authorization_url(scopes)
+        authorization_url = self.webservice.oauth_manager.get_authorization_url(
+            scopes, partial(self.on_mb_authorization_finished, callback))
         webbrowser2.open(authorization_url)
-        authorization_code = self._mb_login_dialog(parent)
-        if authorization_code is not None:
-            self.webservice.oauth_manager.exchange_authorization_code(
-                authorization_code, scopes,
-                partial(self.on_mb_authorization_finished, callback))
-        else:
-            callback(False, None)
+        # authorization_code = self._mb_login_dialog(parent)
+        # if authorization_code is not None:
+        #     self.webservice.oauth_manager.exchange_authorization_code(
+        #         authorization_code, scopes,
+        #         partial(self.on_mb_authorization_finished, callback))
+        # else:
+        #     callback(False, None)
 
     def on_mb_authorization_finished(self, callback, successful=False, error_msg=None):
         if successful:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2009, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 amckinle
-# Copyright (C) 2008-2010, 2014-2015, 2018-2023 Philipp Wolfer
+# Copyright (C) 2008-2010, 2014-2015, 2018-2024 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2010 Andrew Barnert
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -685,15 +685,20 @@ class Tagger(QtWidgets.QApplication):
         else:
             callback(False, error_msg)
 
-    @classmethod
     def on_mb_login_finished(self, callback, successful, error_msg):
         if successful:
             load_user_collections()
         callback(successful, error_msg)
 
-    def mb_logout(self):
-        self.webservice.oauth_manager.revoke_tokens()
-        load_user_collections()
+    def mb_logout(self, callback):
+        self.webservice.oauth_manager.revoke_tokens(
+            partial(self.on_mb_logout_finished, callback)
+        )
+
+    def on_mb_logout_finished(self, callback, successful, error_msg):
+        if successful:
+            load_user_collections()
+        callback(successful, error_msg)
 
     def move_files_to_album(self, files, albumid=None, album=None):
         """Move `files` to tracks on album `albumid`."""

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007, 2014 Lukáš Lalinský
-# Copyright (C) 2008, 2018-2022 Philipp Wolfer
+# Copyright (C) 2008, 2018-2024 Philipp Wolfer
 # Copyright (C) 2011, 2013 Michael Wiencek
 # Copyright (C) 2011, 2019 Wieland Hoffmann
 # Copyright (C) 2013-2014 Sophist-UK
@@ -166,16 +166,18 @@ class GeneralOptionsPage(OptionsPage):
     def login(self):
         self.tagger.mb_login(self.on_login_finished, self)
 
-    def restore_defaults(self):
-        super().restore_defaults()
-        self.logout()
-
     def on_login_finished(self, successful, error_msg=None):
         self.update_login_logout(error_msg)
 
     def logout(self):
-        self.tagger.mb_logout()
-        self.update_login_logout()
+        self.tagger.mb_logout(self.on_logout_finished)
+
+    def on_logout_finished(self, successful, error_msg=None):
+        self.update_login_logout(error_msg)
+
+    def restore_defaults(self):
+        super().restore_defaults()
+        self.logout()
 
     def _update_analyze_new_files(self, cluster_new_files):
         if cluster_new_files:

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -3,6 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2022 Laurent Monin
+# Copyright (C) 2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,7 +22,11 @@
 
 from test.picardtestcase import PicardTestCase
 
-from picard.oauth import OAuthManager
+from picard.oauth import (
+    OAuthManager,
+    base64url_encode,
+    s256_encode,
+)
 
 
 class OAuthManagerTest(PicardTestCase):
@@ -35,3 +40,15 @@ class OAuthManagerTest(PicardTestCase):
         }
         data = OAuthManager._query_data(params)
         self.assertEqual(data, "a%26b=a+b&c+d=c%26d&e%3Df=e%3Df")
+
+    def test_s256_encode(self):
+        code_verifier = b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+        code_challenge = s256_encode(code_verifier)
+        self.assertEqual(b'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM', code_challenge)
+
+    def test_base64url_encode(self):
+        b = bytes([116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
+            187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
+            132, 141, 121])
+        encoded = base64url_encode(b)
+        self.assertEqual(b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', encoded)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2882, PICARD-736, PICARD-2886
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

This PR backports the OAuth improvements from the master branch to 2.x:

- PICARD-2882: Support OAuth2 PKCE (#2446)
- PICARD-736: OAuth2 login with local callback URL (#2451)
- PICARD-2886: OAuth2 token revocation (#2449)

This is in preparation of finishing the work to support the new MetaBrainz OAuth, which I will provide next and also backport to 2.x. The goal is to be able to make a 2.15 release to offer a release without deprecated MB login.