### PR TITLE
Mark Python 3.13 as supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-"""Picard, the next-generation MusicBrainz tagger"""
-
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
 # Copyright (C) 2006-2008, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2007 Santiago M. Mola
 # Copyright (C) 2008 Robert Kaye

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
-# Picard, the next-generation MusicBrainz tagger
-#
+"""Picard, the next-generation MusicBrainz tagger"""
+
 # Copyright (C) 2006-2008, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2007 Santiago M. Mola
 # Copyright (C) 2008 Robert Kaye
@@ -824,6 +822,7 @@ args = {
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
~~Dropped utf-8 compat line for Python 2.~~

Added 3.13 Python as explicitly supported.

~~Converted the file description to an appropriate docstring.~~

---

PR irrelevant side note - It would be nice if there could be a new release, as the lack of [this change](https://github.com/metabrainz/picard/commit/cbbf53dee4c7e0de201daddc096941a4c822d5fc) breaks installation for us.