### PR TITLE
PICARD-3013: Fix case-only renaming on case-insensitive filesystems

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -545,7 +545,7 @@ class File(MetadataItem):
             new_filename = self._format_filename(new_dirname, new_filename, metadata, settings, naming_format)
 
         new_path = os.path.join(new_dirname, new_filename)
-        return normpath(new_path)
+        return normpath(new_path, realpath=False)
 
     def _rename(self, old_filename, metadata, settings=None):
         new_filename = self.make_filename(old_filename, metadata, settings)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2004 Robert Kaye
 # Copyright (C) 2006-2009, 2011-2012, 2014 Lukáš Lalinský
-# Copyright (C) 2008-2011, 2014, 2018-2023 Philipp Wolfer
+# Copyright (C) 2008-2011, 2014, 2018-2024 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2009 david
 # Copyright (C) 2010 fatih
@@ -232,15 +232,16 @@ def system_supports_long_paths():
         return False
 
 
-def normpath(path):
+def normpath(path, realpath=True):
     path = os.path.normpath(path)
-    try:
-        path = os.path.realpath(path)
-    except OSError as why:
-        # realpath can fail if path does not exist or is not accessible
-        # or on Windows if drives are mounted without mount manager
-        # (see https://tickets.metabrainz.org/browse/PICARD-2425).
-        log.warning("Failed getting realpath for `%s`: %s", path, why)
+    if realpath:
+        try:
+            path = os.path.realpath(path)
+        except OSError as why:
+            # realpath can fail if path does not exist or is not accessible
+            # or on Windows if drives are mounted without mount manager
+            # (see https://tickets.metabrainz.org/browse/PICARD-2425).
+            log.warning("Failed getting realpath for `%s`: %s", path, why)
     # If the path is longer than 259 characters on Windows, prepend the \\?\
     # prefix. This enables access to long paths using the Windows API. See
     # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2018-2022 Philipp Wolfer
+# Copyright (C) 2018-2022, 2024 Philipp Wolfer
 # Copyright (C) 2019-2022 Laurent Monin
 # Copyright (C) 2021 Bob Swift
 # Copyright (C) 2021 Sophist-UK
@@ -228,18 +228,18 @@ class FileNamingTest(PicardTestCase):
 
     def test_make_filename_no_move_and_rename(self):
         filename = self.file.make_filename(self.file.filename, self.metadata)
-        self.assertEqual(os.path.realpath(self.file.filename), filename)
+        self.assertEqual(os.path.normpath(self.file.filename), filename)
 
     def test_make_filename_rename_only(self):
         config.setting['rename_files'] = True
         filename = self.file.make_filename(self.file.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/somepath/sometitle.mp3'), filename)
+        self.assertEqual(os.path.normpath('/somepath/sometitle.mp3'), filename)
 
     def test_make_filename_move_only(self):
         config.setting['move_files'] = True
         filename = self.file.make_filename(self.file.filename, self.metadata)
         self.assertEqual(
-            os.path.realpath('/media/music/somealbum/somefile.mp3'),
+            os.path.normpath('/media/music/somealbum/somefile.mp3'),
             filename)
 
     def test_make_filename_move_and_rename(self):
@@ -247,7 +247,7 @@ class FileNamingTest(PicardTestCase):
         config.setting['move_files'] = True
         filename = self.file.make_filename(self.file.filename, self.metadata)
         self.assertEqual(
-            os.path.realpath('/media/music/somealbum/sometitle.mp3'),
+            os.path.normpath('/media/music/somealbum/sometitle.mp3'),
             filename)
 
     def test_make_filename_move_relative_path(self):
@@ -255,39 +255,39 @@ class FileNamingTest(PicardTestCase):
         config.setting['move_files_to'] = 'subdir'
         filename = self.file.make_filename(self.file.filename, self.metadata)
         self.assertEqual(
-            os.path.realpath('/somepath/subdir/somealbum/somefile.mp3'),
+            os.path.normpath('/somepath/subdir/somealbum/somefile.mp3'),
             filename)
 
     def test_make_filename_empty_script(self):
         config.setting['rename_files'] = True
         config.setting['file_renaming_scripts'] = {'test_id': {'script': '$noop()'}}
         filename = self.file.make_filename(self.file.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/somepath/somefile.mp3'), filename)
+        self.assertEqual(os.path.normpath('/somepath/somefile.mp3'), filename)
 
     def test_make_filename_empty_basename(self):
         config.setting['move_files'] = True
         config.setting['rename_files'] = True
         config.setting['file_renaming_scripts'] = {'test_id': {'script': '/somedir/$noop()'}}
         filename = self.file.make_filename(self.file.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/media/music/somedir/somefile.mp3'), filename)
+        self.assertEqual(os.path.normpath('/media/music/somedir/somefile.mp3'), filename)
 
     def test_make_filename_no_extension(self):
         config.setting['rename_files'] = True
         file_ = FakeMp3File('/somepath/_')
         filename = file_.make_filename(file_.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/somepath/sometitle.mp3'), filename)
+        self.assertEqual(os.path.normpath('/somepath/sometitle.mp3'), filename)
 
     def test_make_filename_lowercase_extension(self):
         config.setting['rename_files'] = True
         file_ = FakeMp3File('/somepath/somefile.MP3')
         filename = file_.make_filename(file_.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/somepath/sometitle.mp3'), filename)
+        self.assertEqual(os.path.normpath('/somepath/sometitle.mp3'), filename)
 
     def test_make_filename_scripted_extension(self):
         config.setting['rename_files'] = True
         config.setting['file_renaming_scripts'] = {'test_id': {'script': '$set(_extension,.foo)%title%'}}
         filename = self.file.make_filename(self.file.filename, self.metadata)
-        self.assertEqual(os.path.realpath('/somepath/sometitle.foo'), filename)
+        self.assertEqual(os.path.normpath('/somepath/sometitle.foo'), filename)
 
     def test_make_filename_replace_trailing_dots(self):
         config.setting['rename_files'] = True
@@ -299,7 +299,7 @@ class FileNamingTest(PicardTestCase):
         })
         filename = self.file.make_filename(self.file.filename, metadata)
         self.assertEqual(
-            os.path.realpath('/media/music/somealbum_/sometitle.mp3'),
+            os.path.normpath('/media/music/somealbum_/sometitle.mp3'),
             filename)
 
     @unittest.skipUnless(not IS_WIN, "non-windows test")
@@ -313,7 +313,7 @@ class FileNamingTest(PicardTestCase):
         })
         filename = self.file.make_filename(self.file.filename, metadata)
         self.assertEqual(
-            os.path.realpath('/media/music/somealbum./sometitle.mp3'),
+            os.path.normpath('/media/music/somealbum./sometitle.mp3'),
             filename)
 
     def test_make_filename_replace_leading_dots(self):
@@ -326,7 +326,7 @@ class FileNamingTest(PicardTestCase):
         })
         filename = self.file.make_filename(self.file.filename, metadata)
         self.assertEqual(
-            os.path.realpath('/media/music/_somealbum/_sometitle.mp3'),
+            os.path.normpath('/media/music/_somealbum/_sometitle.mp3'),
             filename)
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3013
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Fix case-only renaming on case-insensitive filesystems. This broke when fixing PICARD-2076 (allow long filenames) in commit https://github.com/metabrainz/picard/commit/5037ce993551d739689095fbea323bcc4ac6c3f0#diff-8e9e6145ecc7e912b2d643f5064e6f196d3668bd010ffa6037775232c2aba236L520 .

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make calling `os.path.realpath` optional in `normpath`. It is not needed here if we assume the new filename does not exist and we want to move a file to a new name.

Generally keep calling of `os.path.realpath` enabled as standard, as in many cases we call `normpath` on existing paths


