### PR TITLE
2.x drop python 3.7

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest, windows-2019]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        include:
-        - os: macos-13
-          python-version: '3.7'
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -71,12 +68,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7']
+        python-version: ['3.8']
         dependencies: [
+          "PyQt5==5.15.11",
           "PyQt5==5.14.2",
           "PyQt5==5.13.2",
           "PyQt5==5.12.3",
-          "PyQt5==5.11.3 sip==4.19.8 mutagen==1.37",
+          "PyQt5==5.11.3 mutagen==1.37",
         ]
 
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Before installing Picard from source, you need to check you have the following d
 
 Required:
 
-* [Python 3.7 or newer](https://python.org/download)
+* [Python 3.8 or newer](https://python.org/download)
 * [PyQt 5.11 or newer](https://riverbankcomputing.com/software/pyqt/download)
 * [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -29,12 +29,10 @@
 It handles and displays errors in PyQt and also adds a utility function for opening Picard URLS.
 """
 
-from sys import version_info
 import webbrowser
 
 from PyQt5 import QtWidgets
 
-from picard import log
 from picard.const import PICARD_URLS
 
 
@@ -45,12 +43,3 @@ def open(url):
         webbrowser.open(url)
     except webbrowser.Error as e:
         QtWidgets.QMessageBox.critical(None, _("Web Browser Error"), _("Error while launching a web browser:\n\n%s") % (e,))
-    except TypeError:
-        if version_info.major == 3 and version_info.minor == 7 and version_info.micro == 0:
-            # See https://bugs.python.org/issue31014, webbrowser.open doesn't
-            # work on 3.7.0 the first time it's called. The initialization code
-            # in it will be skipped after the first call, making it possibly to
-            # use it, although it might not accurately identify the users
-            # preferred browser.
-            log.info("Working around https://bugs.python.org/issue31014 - URLs might not be opened in the correct browser")
-            webbrowser.open(url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ mutagen~=1.37
 PyJWT~=2.0
 pyobjc-core>=6.2, <10; sys_platform == 'darwin'
 pyobjc-framework-Cocoa>=6.2, <10; sys_platform == 'darwin'
-PyQt5-sip<=12.9.1; python_version < '3.7'
 PyQt5-sip<=12.15.0; python_version < '3.9'
 PyQt5~=5.11
 python-dateutil~=2.7

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ except ImportError:
 # required for PEP 517
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
-from picard import (
+from picard import (  # noqa: E402
     PICARD_APP_ID,
     PICARD_APP_NAME,
     PICARD_DESKTOP_NAME,
@@ -75,8 +75,8 @@ from picard import (
 )
 
 
-if sys.version_info < (3, 7):
-    sys.exit("ERROR: You need Python 3.7 or higher to use Picard.")
+if sys.version_info < (3, 8):
+    sys.exit("ERROR: You need Python 3.8 or higher to use Picard.")
 
 PACKAGE_NAME = "picard"
 APPDATA_FILE = PICARD_APP_ID + '.appdata.xml'
@@ -792,7 +792,7 @@ args = {
     },
     'scripts': ['scripts/' + PACKAGE_NAME],
     'install_requires': _get_requirements(),
-    'python_requires': '~=3.7',
+    'python_requires': '~=3.8',
     'classifiers': [
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Development Status :: 5 - Production/Stable',
@@ -801,7 +801,6 @@ args = {
         'Environment :: X11 Applications :: Qt',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Python 3.7 is no longer supported on our build pipeline. Given that 3.8 has reached EOL it makes sense to at least drop 3.7 support now also on the 2.x branch.