### PR TITLE
PICARD-2025: Add file path to metadatabox

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -624,6 +624,8 @@ class MetadataBox(QtWidgets.QTableWidget):
 
             tag_diff.add('~length', str(orig_metadata.length), str(new_metadata.length),
                          removable=False, readonly=True)
+            if (len(files) == 1) and (settings['rename_files'] or settings['move_files']):
+                tag_diff.add('Path', [file.filename], [file.make_filename(file.filename, orig_metadata)], removable=False, readonly=True)
 
         for track in tracks:
             if track.num_linked_files == 0:

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -282,8 +282,21 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.ignore_updates = IgnoreUpdatesContext(on_exit=self.update)
         self.tagger.clipboard().dataChanged.connect(self._update_clipboard)
 
-    def _on_setting_changed(self, key, old_value, new_value):
-        if key in ('rename_files', 'move_files'):
+    def _on_setting_changed(self, name, old_value, new_value):
+        settings_to_watch = {
+            "enabled_plugins",
+            "move_files",
+            "move_files_to",
+            "rename_files",
+            "standardize_artists",
+            "va_name",
+            "windows_compatibility",
+            "selected_file_naming_script_id",
+            "file_naming_scripts",
+            "user_profiles",
+            "user_profile_settings"
+        }
+        if name in settings_to_watch:
             self.update(drop_album_caches=False)
 
     def _get_file_lookup(self):

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -624,8 +624,12 @@ class MetadataBox(QtWidgets.QTableWidget):
 
             tag_diff.add('~length', str(orig_metadata.length), str(new_metadata.length),
                          removable=False, readonly=True)
-            if len(files) == 1 and (settings['rename_files'] or settings['move_files']):
-                tag_diff.add('~filepath', [file.filename], [file.make_filename(file.filename, orig_metadata)], removable=False, readonly=True)
+            if len(files) == 1:
+                if settings['rename_files'] or settings['move_files']:
+                    new_filename = file.make_filename(file.filename, new_metadata)
+                else:
+                    new_filename = file.filename
+                tag_diff.add('~filepath', [file.filename], [new_filename], removable=False, readonly=True)
 
         for track in tracks:
             if track.num_linked_files == 0:

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -238,6 +238,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         super().__init__(parent=parent)
         self.tagger = QtCore.QCoreApplication.instance()
         config = get_config()
+        config.setting.setting_changed_signal.connect(self._on_setting_changed)
         self.setAccessibleName(_("metadata view"))
         self.setAccessibleDescription(_("Displays original and new tags for the selected files"))
         self.setColumnCount(3)
@@ -280,6 +281,10 @@ class MetadataBox(QtWidgets.QTableWidget):
         self._single_track_album = False
         self.ignore_updates = IgnoreUpdatesContext(on_exit=self.update)
         self.tagger.clipboard().dataChanged.connect(self._update_clipboard)
+
+    def _on_setting_changed(self, key, old_value, new_value):
+        if key in ('rename_files', 'move_files'):
+            self.update(drop_album_caches=False)
 
     def _get_file_lookup(self):
         """Return a FileLookup object."""

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -149,6 +149,9 @@ class TagDiff:
         else:
             return orig != new
 
+    def is_readonly(self, tag):
+        return bool(self.status[tag] & TagStatus.READONLY)
+
     def add(self, tag, orig_values, new_values, removable, removed=False, readonly=False, top_tags=None):
         if orig_values:
             self.orig.add(tag, orig_values)
@@ -714,7 +717,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             if not new_item:
                 new_item = QtWidgets.QTableWidgetItem()
                 new_item.setTextAlignment(alignment)
-                if tag == '~length':
+                if self.tag_diff.is_readonly(tag):
                     new_item.setFlags(orig_flags)
                 else:
                     new_item.setFlags(new_flags)

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -624,8 +624,8 @@ class MetadataBox(QtWidgets.QTableWidget):
 
             tag_diff.add('~length', str(orig_metadata.length), str(new_metadata.length),
                          removable=False, readonly=True)
-            if (len(files) == 1) and (settings['rename_files'] or settings['move_files']):
-                tag_diff.add('Path', [file.filename], [file.make_filename(file.filename, orig_metadata)], removable=False, readonly=True)
+            if len(files) == 1 and (settings['rename_files'] or settings['move_files']):
+                tag_diff.add('~filepath', [file.filename], [file.make_filename(file.filename, orig_metadata)], removable=False, readonly=True)
 
         for track in tracks:
             if track.num_linked_files == 0:

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -67,6 +67,7 @@ TAG_NAMES = {
     'encodedby': N_('Encoded By'),
     'encodersettings': N_('Encoder Settings'),
     'engineer': N_('Engineer'),
+    '~filepath': N_('File Path'),
     'gapless': N_('Gapless Playback'),
     'genre': N_('Genre'),
     'grouping': N_('Grouping'),


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

# Problem

Adding File Path to metadata view

* JIRA ticket (_optional_): PICARD-2025
* JIRA ticket to update documentation: PICARD-3017



# Solution

Add a Path tag in the metadatabox for a single file (for efficiency reasons) with original value from `file.filename`, new value from `file.make_filename` only when `move_files` or `rename_files` is enabled.
