### PR TITLE
Fix run scripts manually

### DIFF
--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -23,7 +23,10 @@
 
 from functools import partial
 
-from PyQt6 import QtWidgets
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
 
 from picard import log
 from picard.album import Album
@@ -44,6 +47,7 @@ class ScriptsMenu(QtWidgets.QMenu):
 
     def __init__(self, scripts, title, parent=None):
         super().__init__(title, parent=parent)
+        self.tagger = QtCore.QCoreApplication.instance()
 
         for script in scripts:
             action = self.addAction(script.name)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

When manually running scripts by right-clicking on a file and choosing "Run Scripts", Picard crashes. I could not find a JIRA ticket.


# Solution

Initialised the `tagger` field in the `ScriptsMenu` class.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
