### PR TITLE
Support more LRC timestamps

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -245,9 +245,11 @@ class ID3File(File):
         'MVIN': re.compile(r'^(?P<movementnumber>\d+)(?:/(?P<movementtotal>\d+))?$')
     }
 
-    __lrc_line_re_parse = re.compile(r'(\[\d\d:\d\d\.\d\d\d\])')
-    __lrc_syllable_re_parse = re.compile(r'(<\d\d:\d\d\.\d\d\d>)')
-    __lrc_both_re_parse = re.compile(r'(\[\d\d:\d\d\.\d\d\d\]|<\d\d:\d\d\.\d\d\d>)')
+
+    __lrc_time_format_re = r'\d+:\d{1,2}(?:.\d+)?'
+    __lrc_line_re_parse = re.compile(r'(\[' + __lrc_time_format_re + r'\])')
+    __lrc_syllable_re_parse = re.compile(r'(<' + __lrc_time_format_re + r'>)')
+    __lrc_both_re_parse = re.compile(r'(\[' + __lrc_time_format_re + r'\]|<' + __lrc_time_format_re + r'>)')
 
     def __init__(self, filename):
         super().__init__(filename)
@@ -765,8 +767,8 @@ class ID3File(File):
 
         timestamp_and_lyrics = batched(self.__lrc_both_re_parse.split(text)[1:], 2)
         for timestamp, lyrics in timestamp_and_lyrics:
-            minutes, seconds, ms = timestamp[1:-1].replace(".", ":").split(':')
-            milliseconds = int(minutes) * 60 * 1000 + int(float('%s.%s' % (seconds, ms)) * 1000)
+            minutes, seconds = timestamp[1:-1].split(':')
+            milliseconds = int(minutes) * 60 * 1000 + int(float(seconds) * 1000)
             sylt_lyrics.append((lyrics, milliseconds))
 
         # Remove frames with no lyrics and a repeating timestamp

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -245,7 +245,6 @@ class ID3File(File):
         'MVIN': re.compile(r'^(?P<movementnumber>\d+)(?:/(?P<movementtotal>\d+))?$')
     }
 
-
     __lrc_time_format_re = r'\d+:\d{1,2}(?:.\d+)?'
     __lrc_line_re_parse = re.compile(r'(\[' + __lrc_time_format_re + r'\])')
     __lrc_syllable_re_parse = re.compile(r'(<' + __lrc_time_format_re + r'>)')

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -799,6 +799,10 @@ class ID3FileTest(PicardTestCase):
             "[00:00.000]Test lyrics with\n[01:00.000]only line time stamps",
             "<00:00.000>Test lyrics with<01:00.000>only syllable time stamps",
             "[00:00.000]<00:00.000>Test extra\n<00:00.750>[00:00.750]<00:00.750>timestamp<00:01.500>",
+            "[00:01.00]<00:01.00>Test lyrics with two\n[00:01.75]<00:01.75>digit ms",
+            "[01:01.0]<01:01.000>Test lyrics with different\n[01:01.8]<01:01.7506>digit ms",
+            "[2:1.0]<2:1.0>Test lyrics with single digits\n[2:2]<2:2>or no ms",
+            "[300:1.000]<300:1.000>Test lyrics with long minutes",
             "Test invalid[00:00.000]input\nTest invalid[00:01.000]input",
             "Test lyrics with no timestamps")
         correct_sylt = (
@@ -806,6 +810,10 @@ class ID3FileTest(PicardTestCase):
             [("Test lyrics with\n", 0), ("only line time stamps", 60 * 1000)],
             [("Test lyrics with", 0), ("only syllable time stamps", 60 * 1000)],
             [("Test extra\n", 0), ("timestamp", 750), ("", 1500)],
+            [("Test lyrics with two\n", 1000), ("digit ms", 1750)],
+            [("Test lyrics with different\n", 61000), ("digit ms", 61750)],
+            [("Test lyrics with single digits\n", 121000), ("or no ms", 122000)],
+            [("Test lyrics with long minutes", (300*60+1)*1000)],
             [("input\nTest invalid", 0), ("input", 1000)],
             [])
         for lrc, correct_sylt in zip(lrc, correct_sylt):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

When saving an ID3 file with LRC synced lyrics, it only accepted a very narrow definition of timestamps (two-digit minutes, two-digit seconds, and three-digit milliseconds). While this is fine for preserving the field (as in PICARD-1092), some plugins may import or download LRCs with different timestamps, and people can edit the field manually and change as well.

No JIRA ticket was open for this problem, and there was no LRC support at all in the previous release.


# Solution

I changed the regular expressions that are used for LRC decoding (`ID3File.__lrc_*_re_parse`), and the corresponding timestamp parsing at `ID3File._parse_lrc_text`. I also added new test cases for the new timestamps.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
