### PR TITLE
Add signal when file naming related settings are changed

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -136,6 +136,22 @@ class SettingConfigSection(ConfigSection):
     PROFILES_KEY = 'user_profiles'
     SETTINGS_KEY = 'user_profile_settings'
 
+    # Set containing settings that can impact the result of file renaming (path or filename)
+    FILE_NAMING_SETTINGS = {
+        'enabled_plugins',
+        'move_files',
+        'move_files_to',
+        'rename_files',
+        'standardize_artists',
+        'va_name',
+        'windows_compatibility',
+        'selected_file_naming_script_id',
+        'file_naming_scripts',
+        'user_profiles',
+        'user_profile_settings',
+    }
+    naming_settings_changed_signal = QtCore.pyqtSignal(str)
+
     @classmethod
     def init_profile_options(cls):
         ListOption.add_if_missing('profiles', cls.PROFILES_KEY, [])
@@ -195,10 +211,16 @@ class SettingConfigSection(ConfigSection):
             for profile_id, settings in self._get_active_profile_settings():
                 if name in settings:
                     self._save_profile_setting(profile_id, name, value)
+                    self._send_file_naming_signal(name)
                     return
         key = self.key(name)
         self.__qt_config.setValue(key, value)
         self._memoization[key].dirty = True
+        self._send_file_naming_signal(name)
+
+    def _send_file_naming_signal(self, name: str):
+        if name in self.FILE_NAMING_SETTINGS:
+            self.naming_settings_changed_signal.emit(name)
 
     def _save_profile_setting(self, profile_id, name, value):
         profile_settings = self.__qt_config.profiles[self.SETTINGS_KEY]

--- a/picard/config.py
+++ b/picard/config.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2017 Sophist-UK
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2020-2021 Gabriel Ferreira
-# Copyright (C) 2021-2023 Bob Swift
+# Copyright (C) 2021-2024 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -137,7 +137,7 @@ class SettingConfigSection(ConfigSection):
     SETTINGS_KEY = 'user_profile_settings'
 
     # Signal emitted when the value of a setting has changed.
-    setting_changed_signal = QtCore.pyqtSignal(str)
+    setting_changed_signal = QtCore.pyqtSignal(str, object, object)
 
     @classmethod
     def init_profile_options(cls):
@@ -200,13 +200,13 @@ class SettingConfigSection(ConfigSection):
                 if name in settings:
                     self._save_profile_setting(profile_id, name, value)
                     if value != old_value:
-                        self.setting_changed_signal.emit(name)
+                        self.setting_changed_signal.emit(name, old_value, value)
                     return
         key = self.key(name)
         self.__qt_config.setValue(key, value)
         self._memoization[key].dirty = True
         if value != old_value:
-            self.setting_changed_signal.emit(name)
+            self.setting_changed_signal.emit(name, old_value, value)
 
     def _save_profile_setting(self, profile_id, name, value):
         profile_settings = self.__qt_config.profiles[self.SETTINGS_KEY]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -454,15 +454,19 @@ class TestPicardConfigSignals(TestPicardConfigCommon):
         self.setting_name = name
 
     def test_file_naming_signal(self):
-        TextOption('setting', 'selected_file_naming_script_id', 'abc')
-        TextOption('setting', 'unrelated_file_naming_setting', 'abc')
+        TextOption('setting', 'option_1', 'abc')
+        TextOption('setting', 'option_2', 'abc')
 
-        self.config.setting.naming_settings_changed_signal.connect(self._set_signal_value)
-
-        self.setting_name = ''
-        self.config.setting['selected_file_naming_script_id'] = 'def'
-        self.assertEqual(self.setting_name, 'selected_file_naming_script_id')
+        self.config.setting.setting_changed_signal.connect(self._set_signal_value)
 
         self.setting_name = ''
-        self.config.setting['unrelated_file_naming_setting'] = 'def'
+        self.config.setting['option_1'] = 'def'
+        self.assertEqual(self.setting_name, 'option_1')
+
+        self.setting_name = ''
+        self.config.setting['option_1'] = 'def'
+        self.assertEqual(self.setting_name, '')
+
+        self.setting_name = ''
+        self.config.setting['option_2'] = 'abc'
         self.assertEqual(self.setting_name, '')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -450,23 +450,90 @@ class TestPicardConfigVarOption(TestPicardConfigCommon):
 
 class TestPicardConfigSignals(TestPicardConfigCommon):
 
-    def _set_signal_value(self, name: str):
+    def _set_signal_value(self, name: str, old_value: object, new_value: object):
         self.setting_name = name
+        self.setting_old_value = old_value
+        self.setting_new_value = new_value
 
     def test_file_naming_signal(self):
-        TextOption('setting', 'option_1', 'abc')
-        TextOption('setting', 'option_2', 'abc')
+        TextOption('setting', 'option_text', 'abc')
+        BoolOption('setting', 'option_bool', False)
+        IntOption('setting', 'option_int', 1)
+        FloatOption('setting', 'option_float', 1.0)
+        ListOption('setting', 'option_list', [1, 2, 3])
+        Option('setting', 'option_set', {1, 2, 3})
+        Option('setting', 'option_dict', {'a': 1, 'b': 2, 'c': 3})
 
         self.config.setting.setting_changed_signal.connect(self._set_signal_value)
 
+        # Test text option
         self.setting_name = ''
-        self.config.setting['option_1'] = 'def'
-        self.assertEqual(self.setting_name, 'option_1')
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_text'] = 'def'
+        self.assertEqual(self.setting_name, 'option_text')
+        self.assertEqual(self.setting_old_value, 'abc')
+        self.assertEqual(self.setting_new_value, 'def')
 
+        # Test no signal if set to same value
         self.setting_name = ''
-        self.config.setting['option_1'] = 'def'
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_text'] = 'def'
         self.assertEqual(self.setting_name, '')
+        self.assertEqual(self.setting_old_value, '')
+        self.assertEqual(self.setting_new_value, '')
 
+        # Test bool option
         self.setting_name = ''
-        self.config.setting['option_2'] = 'abc'
-        self.assertEqual(self.setting_name, '')
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_bool'] = True
+        self.assertEqual(self.setting_name, 'option_bool')
+        self.assertEqual(self.setting_old_value, False)
+        self.assertEqual(self.setting_new_value, True)
+
+        # Test int option
+        self.setting_name = ''
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_int'] = 2
+        self.assertEqual(self.setting_name, 'option_int')
+        self.assertEqual(self.setting_old_value, 1)
+        self.assertEqual(self.setting_new_value, 2)
+
+        # Test float option
+        self.setting_name = ''
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_float'] = 2.5
+        self.assertEqual(self.setting_name, 'option_float')
+        self.assertEqual(self.setting_old_value, 1.0)
+        self.assertEqual(self.setting_new_value, 2.5)
+
+        # Test list option
+        self.setting_name = ''
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_list'] = [3, 2, 1]
+        self.assertEqual(self.setting_name, 'option_list')
+        self.assertEqual(self.setting_old_value, [1, 2, 3])
+        self.assertEqual(self.setting_new_value, [3, 2, 1])
+
+        # Test option (set)
+        self.setting_name = ''
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_set'] = {4, 5, 6}
+        self.assertEqual(self.setting_name, 'option_set')
+        self.assertEqual(self.setting_old_value, {1, 2, 3})
+        self.assertEqual(self.setting_new_value, {4, 5, 6})
+
+        # Test option (dict)
+        self.setting_name = ''
+        self.setting_old_value = ''
+        self.setting_new_value = ''
+        self.config.setting['option_dict'] = {'a': 3, 'b': 2, 'c': 1}
+        self.assertEqual(self.setting_name, 'option_dict')
+        self.assertEqual(self.setting_old_value, {'a': 1, 'b': 2, 'c': 3})
+        self.assertEqual(self.setting_new_value, {'a': 3, 'b': 2, 'c': 1})

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -446,3 +446,23 @@ class TestPicardConfigVarOption(TestPicardConfigCommon):
         # store invalid value in config file directly
         self.config.setValue('setting/var_option', object)
         self.assertEqual(self.config.setting["var_option"], {"a", "b"})
+
+
+class TestPicardConfigSignals(TestPicardConfigCommon):
+
+    def _set_signal_value(self, name: str):
+        self.setting_name = name
+
+    def test_file_naming_signal(self):
+        TextOption('setting', 'selected_file_naming_script_id', 'abc')
+        TextOption('setting', 'unrelated_file_naming_setting', 'abc')
+
+        self.config.setting.naming_settings_changed_signal.connect(self._set_signal_value)
+
+        self.setting_name = ''
+        self.config.setting['selected_file_naming_script_id'] = 'def'
+        self.assertEqual(self.setting_name, 'selected_file_naming_script_id')
+
+        self.setting_name = ''
+        self.config.setting['unrelated_file_naming_setting'] = 'def'
+        self.assertEqual(self.setting_name, '')


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds a signal when file naming related settings are changed

# Problem

File naming related settings can be changed in a number of places, and there is no consolidated way to capture whether a setting has been changed.  Something like this is required for https://github.com/metabrainz/picard/pull/2563

* JIRA ticket (_optional_): PICARD-XXX


# Solution

This PR adds a signal to the config settings class to determine when a file naming related setting has been updated.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
