### PR TITLE
PICARD-3014: Fix macOS not sorting empty values before other entries

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -259,15 +259,25 @@ def _digits_replace(matchobj):
 
 def _sort_key_qt(string, numeric=False):
     collator = _qcollator_numeric if numeric else _qcollator
+
+    # Null bytes can cause crashes in OS collation functions.
+    string = string.replace('\0', '')
+
     # On macOS / Windows the numeric sorting does not work reliable with non-latin
     # scripts. Replace numbers in the sort string with their latin equivalent.
     if numeric and (IS_MACOS or IS_WIN):
         string = RE_NUMBER.sub(_digits_replace, string)
 
-    # On macOS numeric sorting of strings entirely consisting of numeric characters fails
-    # and always sorts alphabetically (002 < 1). Always prefix with an alphabetic character
-    # to work around that.
-    return collator.sortKey('a' + string.replace('\0', ''))
+    if IS_MACOS:
+        # macOS does not sort the empty string before other values correctly
+        if not string:
+            string = ' '
+        # On macOS numeric sorting of strings entirely consisting of numeric
+        # characters fails and always sorts alphabetically (002 < 1). Always
+        # prefix with an alphabetic character to work around that.
+        string = 'a' + string
+
+    return collator.sortKey(string)
 
 
 def _sort_key_strxfrm(string, numeric=False):

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -91,25 +91,28 @@ class TestI18n(PicardTestCase):
 
     def test_sort_key(self):
         setup_gettext(localedir, 'de')
-        self.assertTrue(sort_key('äb') < sort_key('ac'))
-        self.assertTrue(sort_key('foo002') < sort_key('foo1'))
-        self.assertTrue(sort_key('002 foo') < sort_key('1 foo'))
-        self.assertTrue(sort_key('1') < sort_key('C'))
-        self.assertTrue(sort_key('foo1', numeric=True) < sort_key('foo002', numeric=True))
-        self.assertTrue(sort_key('004', numeric=True) < sort_key('5', numeric=True))
-        self.assertTrue(sort_key('0042', numeric=True) < sort_key('50', numeric=True))
-        self.assertTrue(sort_key('5', numeric=True) < sort_key('0042', numeric=True))
-        self.assertTrue(sort_key('99', numeric=True) < sort_key('100', numeric=True))
+        self.assertLess(sort_key('äb'), sort_key('ac'))
+        self.assertLess(sort_key('foo002'), sort_key('foo1'))
+        self.assertLess(sort_key('002 foo'), sort_key('1 foo'))
+        self.assertLess(sort_key('1'), sort_key('C'))
+        self.assertLess(sort_key(''), sort_key('0'))
+        self.assertLess(sort_key('\0'), sort_key('0'))
+        self.assertLess(sort_key('0'), sort_key('00'))
+        self.assertLess(sort_key('foo1', numeric=True), sort_key('foo002', numeric=True))
+        self.assertLess(sort_key('004', numeric=True), sort_key('5', numeric=True))
+        self.assertLess(sort_key('0042', numeric=True), sort_key('50', numeric=True))
+        self.assertLess(sort_key('5', numeric=True), sort_key('0042', numeric=True))
+        self.assertLess(sort_key('99', numeric=True), sort_key('100', numeric=True))
 
     def test_sort_key_numbers_different_scripts(self):
         setup_gettext(localedir, 'en')
         for four in ('4', '𝟜', '٤', '๔'):
-            self.assertTrue(
-                sort_key('3', numeric=True) < sort_key(four, numeric=True),
+            self.assertLess(
+                sort_key('3', numeric=True), sort_key(four, numeric=True),
                 msg=f'3 < {four}'
             )
-            self.assertTrue(
-                sort_key(four, numeric=True) < sort_key('5', numeric=True),
+            self.assertLess(
+                sort_key(four, numeric=True), sort_key('5', numeric=True),
                 msg=f'{four} < 5'
             )
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3014
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Sorting on macOS is failing to sort empty string properly. This issue was introduced by PICARD-2914, but PICARD-2914 specifically was addressing macOS crashes with collation functions and hence cannot be reverted.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
 This applies the workaround of treating empty string as a single space.