### PR TITLE
Use settings changed signal to update file move / rename toggles

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -137,7 +137,7 @@ class SettingConfigSection(ConfigSection):
     SETTINGS_KEY = 'user_profile_settings'
 
     # Signal emitted when the value of a setting has changed.
-    setting_changed_signal = QtCore.pyqtSignal(str, object, object)
+    setting_changed = QtCore.pyqtSignal(str, object, object)
 
     @classmethod
     def init_profile_options(cls):
@@ -200,13 +200,13 @@ class SettingConfigSection(ConfigSection):
                 if name in settings:
                     self._save_profile_setting(profile_id, name, value)
                     if value != old_value:
-                        self.setting_changed_signal.emit(name, old_value, value)
+                        self.setting_changed.emit(name, old_value, value)
                     return
         key = self.key(name)
         self.__qt_config.setValue(key, value)
         self._memoization[key].dirty = True
         if value != old_value:
-            self.setting_changed_signal.emit(name, old_value, value)
+            self.setting_changed.emit(name, old_value, value)
 
     def _save_profile_setting(self, profile_id, name, value):
         profile_settings = self.__qt_config.profiles[self.SETTINGS_KEY]

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -264,8 +264,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.actions[MainAction.ENABLE_MOVING].setChecked(new_value)
         elif name == 'dont_write_tags':
             self.actions[MainAction.ENABLE_TAG_SAVING].setChecked(not new_value)
-        elif name == 'clear_existing_tags':
-            self.metadata_box.update()
         elif name in {'file_renaming_scripts', 'selected_file_naming_script_id'}:
             self._make_script_selector_menu()
 

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -238,7 +238,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         super().__init__(parent=parent)
         self.tagger = QtCore.QCoreApplication.instance()
         config = get_config()
-        config.setting.setting_changed_signal.connect(self._on_setting_changed)
+        config.setting.setting_changed.connect(self._on_setting_changed)
         self.setAccessibleName(_("metadata view"))
         self.setAccessibleDescription(_("Displays original and new tags for the selected files"))
         self.setColumnCount(3)

--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -285,16 +285,17 @@ class MetadataBox(QtWidgets.QTableWidget):
     def _on_setting_changed(self, name, old_value, new_value):
         settings_to_watch = {
             "enabled_plugins",
-            "move_files",
+            "clear_existing_tags",
+            "file_naming_scripts",
             "move_files_to",
+            "move_files",
             "rename_files",
+            "selected_file_naming_script_id",
             "standardize_artists",
+            "user_profile_settings"
+            "user_profiles",
             "va_name",
             "windows_compatibility",
-            "selected_file_naming_script_id",
-            "file_naming_scripts",
-            "user_profiles",
-            "user_profile_settings"
         }
         if name in settings_to_watch:
             self.update(drop_album_caches=False)

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008, 2011 Lukáš Lalinský
 # Copyright (C) 2008-2009 Nikolai Prokoschenko
-# Copyright (C) 2009-2010, 2014-2015, 2018-2022 Philipp Wolfer
+# Copyright (C) 2009-2010, 2014-2015, 2018-2022, 2024 Philipp Wolfer
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2011-2013 Wieland Hoffmann
 # Copyright (C) 2013 Calvin Walton
@@ -45,7 +45,6 @@ from picard.i18n import (
 )
 from picard.script import ScriptParser
 
-from picard.ui.enums import MainAction
 from picard.ui.forms.ui_options_renaming import Ui_RenamingOptionsPage
 from picard.ui.options import (
     OptionsCheckError,
@@ -270,9 +269,6 @@ class RenamingOptionsPage(OptionsPage):
         config.setting['move_additional_files_pattern'] = self.ui.move_additional_files_pattern.text()
         config.setting['delete_empty_dirs'] = self.ui.delete_empty_dirs.isChecked()
         config.setting['selected_file_naming_script_id'] = self.selected_naming_script_id
-        self.tagger.window.actions[MainAction.ENABLE_RENAMING].setChecked(config.setting['rename_files'])
-        self.tagger.window.actions[MainAction.ENABLE_MOVING].setChecked(config.setting['move_files'])
-        self.tagger.window.make_script_selector_menu()
 
     def display_error(self, error):
         # Ignore scripting errors, those are handled inline

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007, 2011 Lukáš Lalinský
 # Copyright (C) 2009 Nikolai Prokoschenko
-# Copyright (C) 2009-2010, 2018-2021 Philipp Wolfer
+# Copyright (C) 2009-2010, 2018-2021, 2024 Philipp Wolfer
 # Copyright (C) 2012 Erik Wasser
 # Copyright (C) 2012 Johannes Weißl
 # Copyright (C) 2012-2013 Michael Wiencek
@@ -32,7 +32,6 @@ from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
 
-from picard.ui.enums import MainAction
 from picard.ui.forms.ui_options_tags import Ui_TagsOptionsPage
 from picard.ui.options import OptionsPage
 
@@ -76,16 +75,12 @@ class TagsOptionsPage(OptionsPage):
         config = get_config()
         config.setting['dont_write_tags'] = not self.ui.write_tags.isChecked()
         config.setting['preserve_timestamps'] = self.ui.preserve_timestamps.isChecked()
-        clear_existing_tags = self.ui.clear_existing_tags.isChecked()
-        if clear_existing_tags != config.setting['clear_existing_tags']:
-            config.setting['clear_existing_tags'] = clear_existing_tags
-            self.tagger.window.metadata_box.update()
+        config.setting['clear_existing_tags'] = self.ui.clear_existing_tags.isChecked()
         config.setting['preserve_images'] = self.ui.preserve_images.isChecked()
         config.setting['remove_ape_from_mp3'] = self.ui.remove_ape_from_mp3.isChecked()
         config.setting['remove_id3_from_flac'] = self.ui.remove_id3_from_flac.isChecked()
         config.setting['fix_missing_seekpoints_flac'] = self.ui.fix_missing_seekpoints_flac.isChecked()
         config.setting['preserved_tags'] = list(self.ui.preserved_tags.tags)
-        self.tagger.window.actions[MainAction.ENABLE_TAG_SAVING].setChecked(not config.setting['dont_write_tags'])
 
 
 register_options_page(TagsOptionsPage)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -464,7 +464,7 @@ class TestPicardConfigSignals(TestPicardConfigCommon):
         Option('setting', 'option_set', {1, 2, 3})
         Option('setting', 'option_dict', {'a': 1, 'b': 2, 'c': 3})
 
-        self.config.setting.setting_changed_signal.connect(self._set_signal_value)
+        self.config.setting.setting_changed.connect(self._set_signal_value)
 
         # Test text option
         self.setting_name = ''


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This makes use of @rdswift's recent settings changed signal (#2567) to handle updating the filenaming toggles in Options menu

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

There are additionally issues with the profiles. When switching profiles via menu the toggles don't update accordingly. This issue is also present on the current 2.x release.

I started looking into this, but encountered additional profile issues on the master branch:

1. Profile specific settings are not available directly after startup, hence the toggles don't show the settings properly. The profile groups are only properly initialized after the option dialog has been opened the first time. This is due to #2433 moving the initialization of profile groups to the option pages constructors.
2. When opening the option dialog multiple times the settings in the profile configuration tree view duplicate each time.

I'll look into this in more detail in the new year. Because this is more complex I would like to keep this out of this more simple PR.