### PR TITLE
Fix option profiles

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -59,6 +59,9 @@ class ConfigSection(QtCore.QObject):
 
     """Configuration section."""
 
+    # Signal emitted when the value of a setting has changed.
+    setting_changed = QtCore.pyqtSignal(str, object, object)
+
     def __init__(self, config, name):
         super().__init__()
         self.__qt_config = config
@@ -76,9 +79,12 @@ class ConfigSection(QtCore.QObject):
         return self.value(name, opt, opt.default)
 
     def __setitem__(self, name, value):
+        old_value = self.__getitem__(name)
         key = self.key(name)
         self.__qt_config.setValue(key, value)
         self._memoization[key].dirty = True
+        if value != old_value:
+            self.setting_changed.emit(name, old_value, value)
 
     def __contains__(self, name):
         return self.__qt_config.contains(self.key(name))
@@ -135,9 +141,6 @@ class SettingConfigSection(ConfigSection):
     """
     PROFILES_KEY = 'user_profiles'
     SETTINGS_KEY = 'user_profile_settings'
-
-    # Signal emitted when the value of a setting has changed.
-    setting_changed = QtCore.pyqtSignal(str, object, object)
 
     @classmethod
     def init_profile_options(cls):

--- a/picard/extension_points/options_pages.py
+++ b/picard/extension_points/options_pages.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
 # Copyright (C) 2009 Nikolai Prokoschenko
-# Copyright (C) 2009, 2019-2022 Philipp Wolfer
+# Copyright (C) 2009, 2019-2022, 2025 Philipp Wolfer
 # Copyright (C) 2013, 2015, 2018-2024 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 #
@@ -30,3 +30,5 @@ ext_point_options_pages = ExtensionPoint(label='options_pages')
 
 def register_options_page(page_class):
     ext_point_options_pages.register(page_class.__module__, page_class)
+    for opt_name, opt_highlights in page_class.OPTIONS:
+        page_class.register_setting(opt_name, opt_highlights)

--- a/picard/options.py
+++ b/picard/options.py
@@ -80,16 +80,14 @@ from picard.ui.colors import InterfaceColors
 #      The translated title will be displayed in Profiles option page.
 #
 #   2. If the option is a 'setting' which is edited in one of the option pages,
-#      then the option can be registered in the `__init__()` method of the
-#      matching `OptionPage` declaration with a call to the page's
-#      `register_setting()` method.
+#      then the option must be added to the OPTIONS tuple in the class. The
+#      first parameter is the option name, the second is a list of UI elements
+#      to highlight if the option is part of an option profile. If the setting
+#      can be overridden in profiles, the `highlights` has to be a list of
+#      widget names associated with the option.
 #
 #      Registering a setting allows it to be reset to the default when the user
 #      asks for it on the corresponding option page.
-#
-#      If the setting can be overriden in profiles, the `highlights` parameter
-#      has to be set a list of widget names associated with the option.
-#
 #
 # Please, try to keep options ordered by section and name in their own group.
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
 # Copyright (C) 2009 Nikolai Prokoschenko
-# Copyright (C) 2009, 2019-2022 Philipp Wolfer
+# Copyright (C) 2009, 2019-2022, 2025 Philipp Wolfer
 # Copyright (C) 2013, 2015, 2018-2024 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 #
@@ -53,7 +53,9 @@ class OptionsPage(QtWidgets.QWidget):
     HELP_URL = None
     STYLESHEET_ERROR = "QWidget { background-color: #f55; color: white; font-weight:bold; padding: 2px; }"
     STYLESHEET = "QLabel { qproperty-wordWrap: true; }"
+    OPTIONS = ()
 
+    _registered_settings = []
     initialized = False
     loaded = False
 
@@ -71,8 +73,6 @@ class OptionsPage(QtWidgets.QWidget):
         def on_destroyed(obj=None):
             self.deleted = True
         self.destroyed.connect(on_destroyed)
-
-        self._registered_settings = []
 
     def set_dialog(self, dialog):
         self.dialog = dialog
@@ -131,12 +131,13 @@ class OptionsPage(QtWidgets.QWidget):
 
         regex_edit.textChanged.connect(live_checker)
 
-    def register_setting(self, name, highlights=None):
+    @classmethod
+    def register_setting(cls, name, highlights=None):
         """Register a setting edited in the page, used to restore defaults
            and to highlight when profiles are used"""
         option = Option.get('setting', name)
         if option is None:
             raise Exception(f"Cannot register setting for non-existing option {name}")
-        self._registered_settings.append(option)
+        OptionsPage._registered_settings.append(option)
         if highlights is not None:
-            profile_groups_add_setting(self.NAME, name, tuple(highlights), title=self.TITLE)
+            profile_groups_add_setting(cls.NAME, name, tuple(highlights), title=cls.TITLE)

--- a/picard/ui/options/advanced.py
+++ b/picard/ui/options/advanced.py
@@ -39,22 +39,24 @@ class AdvancedOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_advanced.html"
 
+    OPTIONS = (
+        ('ignore_regex', ['ignore_regex']),
+        ('ignore_hidden_files', ['ignore_hidden_files']),
+        ('recursively_add_files', ['recursively_add_files']),
+        ('ignore_track_duration_difference_under', ['ignore_track_duration_difference_under', 'label_track_duration_diff']),
+        ('query_limit', ['query_limit', 'label_query_limit']),
+        ('completeness_ignore_videos', ['completeness_ignore_videos']),
+        ('completeness_ignore_pregap', ['completeness_ignore_pregap']),
+        ('completeness_ignore_data', ['completeness_ignore_data']),
+        ('completeness_ignore_silence', ['completeness_ignore_silence']),
+        ('compare_ignore_tags', ['groupBox_ignore_tags']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_AdvancedOptionsPage()
         self.ui.setupUi(self)
         self.init_regex_checker(self.ui.ignore_regex, self.ui.regex_error)
-
-        self.register_setting('ignore_regex', ['ignore_regex'])
-        self.register_setting('ignore_hidden_files', ['ignore_hidden_files'])
-        self.register_setting('recursively_add_files', ['recursively_add_files'])
-        self.register_setting('ignore_track_duration_difference_under', ['ignore_track_duration_difference_under', 'label_track_duration_diff'])
-        self.register_setting('query_limit', ['query_limit', 'label_query_limit'])
-        self.register_setting('completeness_ignore_videos', ['completeness_ignore_videos'])
-        self.register_setting('completeness_ignore_pregap', ['completeness_ignore_pregap'])
-        self.register_setting('completeness_ignore_data', ['completeness_ignore_data'])
-        self.register_setting('completeness_ignore_silence', ['completeness_ignore_silence'])
-        self.register_setting('compare_ignore_tags', ['groupBox_ignore_tags'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/cdlookup.py
+++ b/picard/ui/options/cdlookup.py
@@ -52,6 +52,10 @@ class CDLookupOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_cdlookup.html"
 
+    OPTIONS = (
+        ('cd_lookup_device', None),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_CDLookupOptionsPage()
@@ -59,8 +63,6 @@ class CDLookupOptionsPage(OptionsPage):
         if AUTO_DETECT_DRIVES:
             self._device_list = get_cdrom_drives()
             self.ui.cd_lookup_device.addItems(self._device_list)
-
-        self.register_setting('cd_lookup_device')
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -59,6 +59,21 @@ class CoverOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_cover.html"
 
+    OPTIONS = (
+        ('save_images_to_tags', ['save_images_to_tags']),
+        ('embed_only_one_front_image', ['cb_embed_front_only']),
+        ('dont_replace_with_smaller_cover', ['cb_dont_replace_with_smaller']),
+        ('dont_replace_cover_of_types', ['cb_never_replace_types']),
+        ('dont_replace_included_types', ['dont_replace_included_types']),
+        ('dont_replace_excluded_types', ['dont_replace_excluded_types']),
+        ('save_images_to_files', ['save_images_to_files']),
+        ('cover_image_filename', ['cover_image_filename']),
+        ('save_images_overwrite', ['save_images_overwrite']),
+        ('save_only_one_front_image', ['save_only_one_front_image']),
+        ('image_type_as_filename', ['image_type_as_filename']),
+        ('ca_providers', ['ca_providers_list']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_CoverOptionsPage()
@@ -71,19 +86,6 @@ class CoverOptionsPage(OptionsPage):
         self.ui.select_types_button.clicked.connect(self.select_never_replace_image_types)
         self.move_view = MoveableListView(self.ui.ca_providers_list, self.ui.up_button,
                                           self.ui.down_button)
-
-        self.register_setting('save_images_to_tags', ['save_images_to_tags'])
-        self.register_setting('embed_only_one_front_image', ['cb_embed_front_only'])
-        self.register_setting('dont_replace_with_smaller_cover', ['dont_replace_with_smaller_cover'])
-        self.register_setting('dont_replace_cover_of_types', ['dont_replace_cover_of_types'])
-        self.register_setting('dont_replace_included_types', ['dont_replace_included_types'])
-        self.register_setting('dont_replace_excluded_types', ['dont_replace_excluded_types'])
-        self.register_setting('save_images_to_files', ['save_images_to_files'])
-        self.register_setting('cover_image_filename', ['cover_image_filename'])
-        self.register_setting('save_images_overwrite', ['save_images_overwrite'])
-        self.register_setting('save_only_one_front_image', ['save_only_one_front_image'])
-        self.register_setting('image_type_as_filename', ['image_type_as_filename'])
-        self.register_setting('ca_providers', ['ca_providers_list'])
 
     def restore_defaults(self):
         # Remove previous entries

--- a/picard/ui/options/cover_processing.py
+++ b/picard/ui/options/cover_processing.py
@@ -49,27 +49,30 @@ class CoverProcessingOptionsPage(OptionsPage):
     PARENT = 'cover'
     SORT_ORDER = 0
 
+    OPTIONS = (
+        ('filter_cover_by_size', None),
+        ('cover_minimum_width', None),
+        ('cover_minimum_height', None),
+        ('cover_tags_enlarge', None),
+        ('cover_tags_resize', None),
+        ('cover_tags_resize_target_width', None),
+        ('cover_tags_resize_target_height', None),
+        ('cover_tags_resize_mode', None),
+        ('cover_tags_convert_images', None),
+        ('cover_tags_convert_to_format', None),
+        ('cover_file_enlarge', None),
+        ('cover_file_resize', None),
+        ('cover_file_resize_target_width', None),
+        ('cover_file_resize_target_height', None),
+        ('cover_file_resize_mode', None),
+        ('cover_file_convert_images', None),
+        ('cover_file_convert_to_format', None),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.ui = Ui_CoverProcessingOptionsPage()
         self.ui.setupUi(self)
-        self.register_setting('filter_cover_by_size')
-        self.register_setting('cover_minimum_width')
-        self.register_setting('cover_minimum_height')
-        self.register_setting('cover_tags_enlarge')
-        self.register_setting('cover_tags_resize')
-        self.register_setting('cover_tags_resize_target_width')
-        self.register_setting('cover_tags_resize_target_height')
-        self.register_setting('cover_tags_resize_mode')
-        self.register_setting('cover_tags_convert_images')
-        self.register_setting('cover_tags_convert_to_format')
-        self.register_setting('cover_file_enlarge')
-        self.register_setting('cover_file_resize')
-        self.register_setting('cover_file_resize_target_width')
-        self.register_setting('cover_file_resize_target_height')
-        self.register_setting('cover_file_resize_mode')
-        self.register_setting('cover_file_convert_images')
-        self.register_setting('cover_file_convert_to_format')
 
         for resize_mode in COVER_RESIZE_MODES:
             self.ui.tags_resize_mode.addItem(resize_mode.title, resize_mode.mode.value)

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -66,6 +66,15 @@ class FingerprintingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_fingerprinting.html"
 
+    OPTIONS = (
+        ('fingerprinting_system', None),
+        ('acoustid_fpcalc', None),
+        ('acoustid_apikey', None),
+        ('ignore_existing_acoustid_fingerprints', None),
+        ('save_acoustid_fingerprints', None),
+        ('fpcalc_threads', None),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self._fpcalc_valid = True
@@ -78,13 +87,6 @@ class FingerprintingOptionsPage(OptionsPage):
         self.ui.acoustid_fpcalc_download.clicked.connect(self.acoustid_fpcalc_download)
         self.ui.acoustid_apikey_get.clicked.connect(self.acoustid_apikey_get)
         self.ui.acoustid_apikey.setValidator(ApiKeyValidator())
-
-        self.register_setting('fingerprinting_system')
-        self.register_setting('acoustid_fpcalc')
-        self.register_setting('acoustid_apikey')
-        self.register_setting('ignore_existing_acoustid_fingerprints')
-        self.register_setting('save_acoustid_fingerprints')
-        self.register_setting('fpcalc_threads')
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -60,6 +60,19 @@ class GeneralOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_general.html"
 
+    OPTIONS = (
+        ('server_host', ['server_host']),
+        ('server_port', ['server_port']),
+        ('analyze_new_files', ['analyze_new_files']),
+        ('cluster_new_files', ['cluster_new_files']),
+        ('ignore_file_mbids', ['ignore_file_mbids']),
+        ('check_for_plugin_updates', ['check_for_plugin_updates']),
+        ('check_for_updates', ['check_for_updates']),
+        ('update_check_days', ['update_check_days']),
+        ('update_level', ['update_level']),
+        ('use_server_for_submission', ['use_server_for_submission']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_GeneralOptionsPage()
@@ -73,17 +86,6 @@ class GeneralOptionsPage(OptionsPage):
         self.ui.login_error.setStyleSheet(self.STYLESHEET_ERROR)
         self.ui.login_error.hide()
         self.update_login_logout()
-
-        self.register_setting('server_host', ['server_host'])
-        self.register_setting('server_port', ['server_port'])
-        self.register_setting('analyze_new_files', ['analyze_new_files'])
-        self.register_setting('cluster_new_files', ['cluster_new_files'])
-        self.register_setting('ignore_file_mbids', ['ignore_file_mbids'])
-        self.register_setting('check_for_plugin_updates', ['check_for_plugin_updates'])
-        self.register_setting('check_for_updates', ['check_for_updates'])
-        self.register_setting('update_check_days', ['update_check_days'])
-        self.register_setting('update_level', ['update_level'])
-        self.register_setting('use_server_for_submission')
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -87,6 +87,17 @@ class GenresOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_genres.html"
 
+    OPTIONS = (
+        ('use_genres', None),
+        ('only_my_genres', ['only_my_genres']),
+        ('artists_genres', ['artists_genres']),
+        ('folksonomy_tags', ['folksonomy_tags']),
+        ('min_genre_usage', ['min_genre_usage']),
+        ('max_genres', ['max_genres']),
+        ('join_genres', ['join_genres']),
+        ('genres_filter', ['genres_filter']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_GenresOptionsPage()
@@ -107,15 +118,6 @@ class GenresOptionsPage(OptionsPage):
 
         self.fmt_clear = QTextBlockFormat()
         self.fmt_clear.clearBackground()
-
-        self.register_setting('use_genres', [])
-        self.register_setting('only_my_genres', ['only_my_genres'])
-        self.register_setting('artists_genres', ['artists_genres'])
-        self.register_setting('folksonomy_tags', ['folksonomy_tags'])
-        self.register_setting('min_genre_usage', ['min_genre_usage'])
-        self.register_setting('max_genres', ['max_genres'])
-        self.register_setting('join_genres', ['join_genres'])
-        self.register_setting('genres_filter', ['genres_filter'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -68,6 +68,22 @@ class InterfaceOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface.html"
 
+    OPTIONS = (
+        ('toolbar_show_labels', ['toolbar_show_labels']),
+        ('show_menu_icons', ['show_menu_icons']),
+        ('ui_language', ['ui_language']),
+        ('ui_theme', ['ui_theme']),
+        ('allow_multi_dirs_selection', ['allow_multi_dirs_selection']),
+        ('builtin_search', ['builtin_search']),
+        ('use_adv_search_syntax', ['use_adv_search_syntax']),
+        ('show_new_user_dialog', ['new_user_dialog']),
+        ('quit_confirmation', ['quit_confirmation']),
+        ('file_save_warning', ['file_save_warning']),
+        ('filebrowser_horizontal_autoscroll', ['filebrowser_horizontal_autoscroll']),
+        ('starting_directory', ['starting_directory']),
+        ('starting_directory_path', ['starting_directory_path']),
+    )
+
     # Those are labels for theme display
     _UI_THEME_LABELS = {
         UiTheme.DEFAULT: {
@@ -125,20 +141,6 @@ class InterfaceOptionsPage(OptionsPage):
             self.ui.ui_theme_container.hide()
 
         self.ui.allow_multi_dirs_selection.stateChanged.connect(self.multi_selection_warning)
-
-        self.register_setting('toolbar_show_labels', ['toolbar_show_labels'])
-        self.register_setting('show_menu_icons', ['show_menu_icons'])
-        self.register_setting('ui_language', ['ui_language', 'label'])
-        self.register_setting('ui_theme', ['ui_theme', 'label_theme'])
-        self.register_setting('allow_multi_dirs_selection', ['allow_multi_dirs_selection'])
-        self.register_setting('builtin_search', ['builtin_search'])
-        self.register_setting('use_adv_search_syntax', ['use_adv_search_syntax'])
-        self.register_setting('show_new_user_dialog', ['new_user_dialog'])
-        self.register_setting('quit_confirmation', ['quit_confirmation'])
-        self.register_setting('file_save_warning', ['file_save_warning'])
-        self.register_setting('filebrowser_horizontal_autoscroll', ['filebrowser_horizontal_autoscroll'])
-        self.register_setting('starting_directory', ['starting_directory'])
-        self.register_setting('starting_directory_path', ['starting_directory_path'])
 
     def load(self):
         # Don't display the multi-selection warning when loading values.

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -100,6 +100,11 @@ class InterfaceColorsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_colors.html"
 
+    OPTIONS = (
+        ('interface_colors', ['colors']),
+        ('interface_colors_dark', ['colors']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_InterfaceColorsOptionsPage()
@@ -107,9 +112,6 @@ class InterfaceColorsOptionsPage(OptionsPage):
         self.new_colors = {}
         self.colors_list = QtWidgets.QVBoxLayout()
         self.ui.colors.setLayout(self.colors_list)
-
-        self.register_setting('interface_colors', ['colors'])
-        self.register_setting('interface_colors_dark', ['colors'])
 
     def update_color_selectors(self):
         if self.colors_list:

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -72,6 +72,11 @@ class InterfaceToolbarOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_toolbar.html"
     SEPARATOR = '—' * 5
+
+    OPTIONS = (
+        ('toolbar_layout', ['toolbar_layout_list']),
+    )
+
     TOOLBAR_BUTTONS = {
         MainAction.ADD_DIRECTORY: ToolbarButtonDesc(
             N_("Add Folder"),
@@ -147,8 +152,6 @@ class InterfaceToolbarOptionsPage(OptionsPage):
         self.move_view = MoveableListView(self.ui.toolbar_layout_list, self.ui.up_button,
                                           self.ui.down_button, self.update_action_buttons)
         self.update_buttons = self.move_view.update_buttons
-
-        self.register_setting('toolbar_layout', ['toolbar_layout_list'])
 
     def load(self):
         self.populate_action_list()

--- a/picard/ui/options/interface_top_tags.py
+++ b/picard/ui/options/interface_top_tags.py
@@ -39,12 +39,14 @@ class InterfaceTopTagsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_top_tags.html"
 
+    OPTIONS = (
+        ('metadatabox_top_tags', ['top_tags_groupBox']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_InterfaceTopTagsOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('metadatabox_top_tags', ['top_tags_groupBox'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -77,6 +77,10 @@ class MaintenanceOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_maintenance.html"
 
+    OPTIONS = (
+        ('autobackup_directory', ['autobackup_dir']),
+    )
+
     signal_reload = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
@@ -112,8 +116,6 @@ class MaintenanceOptionsPage(OptionsPage):
         palette_readonly.setColor(QtGui.QPalette.ColorRole.Base, disabled_color)
         self.ui.config_file.setPalette(palette_readonly)
         self.last_valid_path = _safe_autobackup_dir('')
-
-        self.register_setting('autobackup_directory', ['autobackup_dir'])
 
     def get_current_autobackup_dir(self):
         return _safe_autobackup_dir(self.ui.autobackup_dir.text())

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -39,16 +39,18 @@ class MatchingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_matching.html"
 
+    OPTIONS = (
+        ('file_lookup_threshold', ['file_lookup_threshold']),
+        ('cluster_lookup_threshold', ['cluster_lookup_threshold']),
+        ('track_matching_threshold', ['track_matching_threshold']),
+    )
+
     _release_type_sliders = {}
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_MatchingOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('file_lookup_threshold', ['file_lookup_threshold'])
-        self.register_setting('cluster_lookup_threshold', ['cluster_lookup_threshold'])
-        self.register_setting('track_matching_threshold', ['track_matching_threshold'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -85,6 +85,21 @@ class MetadataOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_metadata.html"
 
+    OPTIONS = (
+        ('translate_artist_names', ['translate_artist_names']),
+        ('artist_locales', ['selected_locales']),
+        ('translate_artist_names_script_exception', ['translate_artist_names_script_exception']),
+        ('script_exceptions', ['selected_scripts']),
+        ('standardize_artists', ['standardize_artists']),
+        ('standardize_instruments', ['standardize_instruments']),
+        ('convert_punctuation', ['convert_punctuation']),
+        ('release_ars', ['release_ars']),
+        ('track_ars', ['track_ars']),
+        ('guess_tracknumber_and_title', ['guess_tracknumber_and_title']),
+        ('va_name', ['va_name']),
+        ('nat_name', ['nat_name']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_MetadataOptionsPage()
@@ -95,19 +110,6 @@ class MetadataOptionsPage(OptionsPage):
         self.ui.select_scripts.clicked.connect(self.open_script_selector)
         self.ui.translate_artist_names.stateChanged.connect(self.set_enabled_states)
         self.ui.translate_artist_names_script_exception.stateChanged.connect(self.set_enabled_states)
-
-        self.register_setting('translate_artist_names', ['translate_artist_names'])
-        self.register_setting('artist_locales', ['selected_locales'])
-        self.register_setting('translate_artist_names_script_exception', ['translate_artist_names_script_exception'])
-        self.register_setting('script_exceptions', ['selected_scripts'])
-        self.register_setting('standardize_artists', ['standardize_artists'])
-        self.register_setting('standardize_instruments', ['standardize_instruments'])
-        self.register_setting('convert_punctuation', ['convert_punctuation'])
-        self.register_setting('release_ars', ['release_ars'])
-        self.register_setting('track_ars', ['track_ars'])
-        self.register_setting('guess_tracknumber_and_title', ['guess_tracknumber_and_title'])
-        self.register_setting('va_name', ['va_name'])
-        self.register_setting('nat_name', ['nat_name'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -40,22 +40,24 @@ class NetworkOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_network.html"
 
+    OPTIONS = (
+        ('use_proxy', ['web_proxy']),
+        ('proxy_type', ['proxy_type_socks', 'proxy_type_http']),
+        ('proxy_server_host', ['server_host']),
+        ('proxy_server_port', ['server_port']),
+        ('proxy_username', ['username']),
+        ('proxy_password', ['password']),
+        ('network_transfer_timeout_seconds', ['transfer_timeout']),
+        ('network_cache_size_bytes', ['network_cache_size']),
+        ('browser_integration', ['browser_integration']),
+        ('browser_integration_port', ['browser_integration_port']),
+        ('browser_integration_localhost_only', ['browser_integration_localhost_only']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_NetworkOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('use_proxy', [])
-        self.register_setting('proxy_type', ['proxy_type_socks', 'proxy_type_http'])
-        self.register_setting('proxy_server_host', ['server_host'])
-        self.register_setting('proxy_server_port', ['server_port'])
-        self.register_setting('proxy_username', ['username'])
-        self.register_setting('proxy_password', ['password'])
-        self.register_setting('network_transfer_timeout_seconds', ['transfer_timeout'])
-        self.register_setting('network_cache_size_bytes', ['network_cache_size'])
-        self.register_setting('browser_integration', [])
-        self.register_setting('browser_integration_port', ['browser_integration_port'])
-        self.register_setting('browser_integration_localhost_only', ['browser_integration_localhost_only'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/ratings.py
+++ b/picard/ui/options/ratings.py
@@ -38,14 +38,16 @@ class RatingsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_ratings.html"
 
+    OPTIONS = (
+        ('enable_ratings', ['enable_ratings']),
+        ('rating_user_email', ['rating_user_email']),
+        ('submit_ratings', ['submit_ratings']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_RatingsOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('enable_ratings', [])
-        self.register_setting('rating_user_email', ['rating_user_email'])
-        self.register_setting('submit_ratings', ['submit_ratings'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -161,6 +161,12 @@ class ReleasesOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_releases.html"
 
+    OPTIONS = (
+        ('release_type_scores', ['type_group']),
+        ('preferred_release_countries', ['country_group']),
+        ('preferred_release_formats', ['format_group']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_ReleasesOptionsPage()
@@ -213,10 +219,6 @@ class ReleasesOptionsPage(OptionsPage):
         self.ui.preferred_country_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.ui.format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.ui.preferred_format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
-
-        self.register_setting('release_type_scores', ['type_group'])
-        self.register_setting('preferred_release_countries', ['country_group'])
-        self.register_setting('preferred_release_formats', ['format_group'])
 
     def restore_defaults(self):
         # Clear lists

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -72,6 +72,16 @@ class RenamingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_filerenaming.html"
 
+    OPTIONS = (
+        ('move_files', ['move_files']),
+        ('move_files_to', ['move_files_to']),
+        ('move_additional_files', ['move_additional_files']),
+        ('move_additional_files_pattern', ['move_additional_files_pattern']),
+        ('delete_empty_dirs', ['delete_empty_dirs']),
+        ('rename_files', ['rename_files']),
+        ('selected_file_naming_script_id', ['naming_script_selector']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.script_text = ""
@@ -113,14 +123,6 @@ class RenamingOptionsPage(OptionsPage):
         synchronize_vertical_scrollbars((self.ui.example_filename_before, self.ui.example_filename_after))
 
         self.current_row = -1
-
-        self.register_setting('move_files', ['move_files'])
-        self.register_setting('move_files_to', ['move_files_to'])
-        self.register_setting('move_additional_files', ['move_additional_files'])
-        self.register_setting('move_additional_files_pattern', ['move_additional_files_pattern'])
-        self.register_setting('delete_empty_dirs', ['delete_empty_dirs'])
-        self.register_setting('rename_files', ['rename_files'])
-        self.register_setting('selected_file_naming_script_id', ['naming_script_selector'])
 
     def update_selector_from_editor(self):
         """Update the script selector combo box from the script editor page.

--- a/picard/ui/options/renaming_compat.py
+++ b/picard/ui/options/renaming_compat.py
@@ -70,6 +70,15 @@ class RenamingCompatOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_filerenaming_compat.html"
 
+    OPTIONS = (
+        ('ascii_filenames', ['ascii_filenames']),
+        ('windows_compatibility', ['windows_compatibility']),
+        ('win_compat_replacements', ['win_compat_replacements']),
+        ('windows_long_paths', ['windows_long_paths']),
+        ('replace_spaces_with_underscores', ['replace_spaces_with_underscores']),
+        ('replace_dir_separator', ['replace_dir_separator']),
+    )
+
     options_changed = QtCore.pyqtSignal(dict)
 
     def __init__(self, parent=None):
@@ -85,13 +94,6 @@ class RenamingCompatOptionsPage(OptionsPage):
         self.ui.replace_dir_separator.textChanged.connect(self.on_options_changed)
         self.ui.replace_dir_separator.setValidator(NoDirectorySeparatorValidator())
         self.ui.btn_windows_compatibility_change.clicked.connect(self.open_win_compat_dialog)
-
-        self.register_setting('ascii_filenames', ['ascii_filenames'])
-        self.register_setting('windows_compatibility', ['windows_compatibility'])
-        self.register_setting('win_compat_replacements', ['win_compat_replacements'])
-        self.register_setting('windows_long_paths', ['windows_long_paths'])
-        self.register_setting('replace_spaces_with_underscores', ['replace_spaces_with_underscores'])
-        self.register_setting('replace_dir_separator', ['replace_dir_separator'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -106,6 +106,11 @@ class ScriptingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_scripting.html"
 
+    OPTIONS = (
+        ('enable_tagger_scripts', ['enable_tagger_scripts']),
+        ('list_of_scripts', ['script_list']),
+    )
+
     default_script_directory = os.path.normpath(QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.StandardLocation.DocumentsLocation))
     default_script_extension = "ptsp"
 
@@ -131,9 +136,6 @@ class ScriptingOptionsPage(OptionsPage):
         self.FILE_TYPE_PACKAGE = _("Picard tagging script package") + " (*.ptsp *.yaml)"
 
         self.ui.script_list.signal_reset_selected_item.connect(self.reset_selected_item)
-
-        self.register_setting('enable_tagger_scripts', ['enable_tagger_scripts'])
-        self.register_setting('list_of_scripts', ['script_list'])
 
     def show_scripting_documentation(self):
         ScriptingDocumentationDialog.show_instance(parent=self)

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -45,19 +45,21 @@ class TagsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags.html"
 
+    OPTIONS = (
+        ('dont_write_tags', ['write_tags']),
+        ('preserve_timestamps', ['preserve_timestamps']),
+        ('clear_existing_tags', ['clear_existing_tags']),
+        ('preserve_images', ['preserve_images']),
+        ('remove_id3_from_flac', ['remove_id3_from_flac']),
+        ('remove_ape_from_mp3', ['remove_ape_from_mp3']),
+        ('fix_missing_seekpoints_flac', ['fix_missing_seekpoints_flac']),
+        ('preserved_tags', ['preserved_tags']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_TagsOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('dont_write_tags', ['write_tags'])
-        self.register_setting('preserve_timestamps', ['preserve_timestamps'])
-        self.register_setting('clear_existing_tags', ['clear_existing_tags'])
-        self.register_setting('preserve_images', ['preserve_images'])
-        self.register_setting('remove_id3_from_flac', ['remove_id3_from_flac'])
-        self.register_setting('remove_ape_from_mp3', ['remove_ape_from_mp3'])
-        self.register_setting('fix_missing_seekpoints_flac', ['fix_missing_seekpoints_flac'])
-        self.register_setting('preserved_tags', ['preserved_tags'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/tags_compatibility_aac.py
+++ b/picard/ui/options/tags_compatibility_aac.py
@@ -40,14 +40,16 @@ class TagsCompatibilityAACOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_aac.html"
 
+    OPTIONS = (
+        ('aac_save_ape', ['aac_save_ape', 'aac_no_tags']),
+        ('remove_ape_from_aac', ['remove_ape_from_aac']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_TagsCompatibilityOptionsPage()
         self.ui.setupUi(self)
         self.ui.aac_no_tags.toggled.connect(self.ui.remove_ape_from_aac.setEnabled)
-
-        self.register_setting('aac_save_ape', ['aac_save_ape', 'aac_no_tags'])
-        self.register_setting('remove_ape_from_aac', ['remove_ape_from_aac'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/tags_compatibility_ac3.py
+++ b/picard/ui/options/tags_compatibility_ac3.py
@@ -40,14 +40,16 @@ class TagsCompatibilityAC3OptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_ac3.html"
 
+    OPTIONS = (
+        ('ac3_save_ape', ['ac3_save_ape', 'ac3_no_tags']),
+        ('remove_ape_from_ac3', ['remove_ape_from_ac3']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_TagsCompatibilityOptionsPage()
         self.ui.setupUi(self)
         self.ui.ac3_no_tags.toggled.connect(self.ui.remove_ape_from_ac3.setEnabled)
-
-        self.register_setting('ac3_save_ape', ['ac3_save_ape', 'ac3_no_tags'])
-        self.register_setting('remove_ape_from_ac3', ['remove_ape_from_ac3'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/tags_compatibility_id3.py
+++ b/picard/ui/options/tags_compatibility_id3.py
@@ -42,18 +42,20 @@ class TagsCompatibilityID3OptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_id3.html"
 
+    OPTIONS = (
+        ('write_id3v23', ['write_id3v23', 'write_id3v24']),
+        ('id3v2_encoding', ['enc_utf8', 'enc_utf16', 'enc_iso88591']),
+        ('id3v23_join_with', ['id3v23_join_with']),
+        ('itunes_compatible_grouping', ['itunes_compatible_grouping']),
+        ('write_id3v1', ['write_id3v1']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_TagsCompatibilityOptionsPage()
         self.ui.setupUi(self)
         self.ui.write_id3v23.clicked.connect(self.update_encodings)
         self.ui.write_id3v24.clicked.connect(partial(self.update_encodings, force_utf8=True))
-
-        self.register_setting('write_id3v23', ['write_id3v23', 'write_id3v24'])
-        self.register_setting('id3v2_encoding', ['enc_utf8', 'enc_utf16', 'enc_iso88591'])
-        self.register_setting('id3v23_join_with', ['id3v23_join_with'])
-        self.register_setting('itunes_compatible_grouping', ['itunes_compatible_grouping'])
-        self.register_setting('write_id3v1', ['write_id3v1'])
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/tags_compatibility_wave.py
+++ b/picard/ui/options/tags_compatibility_wave.py
@@ -41,14 +41,16 @@ class TagsCompatibilityWaveOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_wave.html"
 
+    OPTIONS = (
+        ('write_wave_riff_info', ['write_wave_riff_info']),
+        ('remove_wave_riff_info', ['remove_wave_riff_info']),
+        ('wave_riff_info_encoding', ['wave_riff_info_enc_cp1252', 'wave_riff_info_enc_utf8']),
+    )
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.ui = Ui_TagsCompatibilityOptionsPage()
         self.ui.setupUi(self)
-
-        self.register_setting('write_wave_riff_info', ['write_wave_riff_info'])
-        self.register_setting('remove_wave_riff_info', ['remove_wave_riff_info'])
-        self.register_setting('wave_riff_info_encoding', ['wave_riff_info_enc_cp1252', 'wave_riff_info_enc_utf8'])
 
     def load(self):
         config = get_config()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3019
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This addresses several issues with option profiles.

1. PICARD-3019: Changing profile using the menu is not persisted and does not update the other quick setting toggles in the Option menu. This issue is also present in the current release version 2.13.3.
2. Option profiles are not initialized properly on startup until the Options dialog got opened the first time, as settings being part of profiles are registered late in the profile page constructors since https://github.com/metabrainz/picard/pull/2433

See also comment in https://github.com/metabrainz/picard/pull/2569

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. The first issue is addressed by generalizing the the new `setting_changed` signal and using it to listen to profile changes. If profiles are changed rebuild the full option menu and the CD lookup config.
2. For fixing the option profile registration move the registration back to initialization by making `register_setting` static and have each option page define an `OPTIONS` tuple again. It's a bit similar to old 2.x code, but the OPTIONS tuple is simplified and just consists of the name and the highlights.

