### PR TITLE
PICARD-3021: Context menu action to merge original and new metadata values

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -465,6 +465,9 @@ class MetadataBox(QtWidgets.QTableWidget):
                     use_orig_value_action = QtGui.QAction(name, self)
                     use_orig_value_action.triggered.connect(partial(self._apply_update_funcs, useorigs))
                     menu.addAction(use_orig_value_action)
+                    merge_tags_action = QtGui.QAction(_("Merge Original Values"), self)
+                    merge_tags_action.triggered.connect(partial(self._merge_tags, selected_tag))
+                    menu.addAction(merge_tags_action)
                     menu.addSeparator()
                 if single_tag:
                     menu.addSeparator()
@@ -490,6 +493,16 @@ class MetadataBox(QtWidgets.QTableWidget):
             for f in funcs:
                 f()
         self.tagger.window.update_selection(new_selection=False, drop_album_caches=True)
+
+    def _merge_tags(self, tag):
+        with self.tagger.window.ignore_selection_changes:
+            for obj in self.objects:
+                values = list(obj.orig_metadata.getall(tag))
+                for new_value in obj.metadata.getall(tag):
+                    if new_value not in values:
+                        values.append(new_value)
+                obj.metadata[tag] = values
+                obj.update()
 
     def _edit_tag(self, tag):
         if self.tag_diff is not None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3021
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Add the ability to merge new and old values of a tag in the metadatabox.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add a context menu entry "Merge Original Values" that will combine the original and new values of selected tags into a single list. No duplicates are added.

![grafik](https://github.com/user-attachments/assets/79e62dbc-da44-4ec8-949e-7c3109968eae)

