### PR TITLE
PICARD-3030: Fix crash when merging original values for multiple tags

### DIFF
--- a/picard/ui/metadatabox.py
+++ b/picard/ui/metadatabox.py
@@ -495,20 +495,14 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def _use_orig_tags(self, obj, tag, extra_objects=None):
         orig_values = list(obj.orig_metadata.getall(tag)) or [""]
-        objects = [obj]
-        if extra_objects:
-            objects.extend(extra_objects)
-        self._set_tag_values(tag, orig_values, objects)
+        self._set_tag_values_extra(tag, orig_values, obj, extra_objects)
 
     def _merge_orig_tags(self, obj, tag, extra_objects=None):
         values = list(obj.orig_metadata.getall(tag))
         for new_value in obj.metadata.getall(tag):
             if new_value not in values:
                 values.append(new_value)
-        objects = [obj]
-        if extra_objects:
-            objects.extend(extra_objects)
-        self._set_tag_values(tag, values, objects)
+        self._set_tag_values_extra(tag, values, obj, extra_objects)
 
     def _edit_tag(self, tag):
         if self.tag_diff is not None:
@@ -523,6 +517,12 @@ class MetadataBox(QtWidgets.QTableWidget):
         config = get_config()
         config.persist['show_changes_first'] = checked
         self.update()
+
+    def _set_tag_values_extra(self, tag, values, obj, extra_objects):
+        objects = [obj]
+        if extra_objects:
+            objects.extend(extra_objects)
+        self._set_tag_values(tag, values, objects=objects)
 
     def _set_tag_values(self, tag, values, objects=None):
         if objects is None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3030
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This refactors the change from PICARD-3021 to address a crash when selecting more then one changed tag in the metadatabox and then open the context menu.

# Solution

Avoid the crash by implementing merge originals similar to the existing use originals.

Also refactor use original values a bit to reduce code duplication and harmonize the implementation of both merge and use originals.
