### PR TITLE
PICARD-3034: Fix win-build-fixes.ps1 not being called

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -75,6 +75,7 @@ jobs:
         python setup.py build_ext
         pyinstaller --noconfirm --clean picard.spec
         If ($env:PICARD_BUILD_PORTABLE -ne "1") {
+          & .\scripts\package\win-build-fixes.ps1 dist\picard
           dist\picard\fpcalc -version
         }
       env:

--- a/scripts/package/win-build-fixes.ps1
+++ b/scripts/package/win-build-fixes.ps1
@@ -14,5 +14,6 @@ $ErrorActionPreference = 'Stop'
 # DLL loading on Windows.
 # Workaround for https://tickets.metabrainz.org/browse/PICARD-2736
 $Qt5BinDir = (Join-Path -Path $Path -ChildPath PyQt5\Qt5\bin)
-Move-Item -Path (Join-Path -Path $Qt5BinDir -ChildPath *.dll) -Destination $Path -Force
+Write-Output "Moving DLLs from $Qt5BinDir to package root..."
+Move-Item -Path (Join-Path -Path $Qt5BinDir -ChildPath *.dll) -Destination $Path -Verbose -Force
 Remove-Item -Path $Qt5BinDir


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3034
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This fixes packaging issues on Windows, where system wide Qt and libssl related libraries would be loaded over the bundled ones.

This was originally fixed in PICARD-2736. But the change in PICARD-3002 moved the cleanup code to a separate helper script `win-build-fixes.ps1`, which was forgotten to be called.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Call `win-build-fixes.ps1`