### PR TITLE
PICARD-2192: For macOS build separate x86_64 and arm64 packages

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -11,6 +11,11 @@ jobs:
       matrix:
         setup:
         - macos-deployment-version: '11.0'
+          target-arch: 'x86_64'
+          python-version: 3.13.1-macos11
+          python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b
+        - macos-deployment-version: '11.0'
+          target-arch: 'arm64'
           python-version: 3.13.1-macos11
           python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b
     env:
@@ -21,6 +26,7 @@ jobs:
       PYTHON_VERSION: ${{ matrix.setup.python-version }}
       PYTHON_SHA256SUM: ${{ matrix.setup.python-sha256sum }}
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.setup.macos-deployment-version }}
+      TARGET_ARCH: ${{ matrix.setup.target-arch }}
       CODESIGN: 0
     steps:
     - uses: actions/checkout@v4
@@ -45,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip3 install -r requirements-build.txt
-        pip3 install -r requirements-macos-${MACOSX_DEPLOYMENT_TARGET}.txt
+        pip3 install --no-binary "charset-normalizer,PyYAML" -r requirements-macos-${MACOSX_DEPLOYMENT_TARGET}.txt
       env:
         PYINSTALLER_COMPILE_BOOTLOADER: "1"
     - name: Run tests
@@ -77,5 +83,5 @@ jobs:
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: macos-app-${{ matrix.setup.macos-deployment-version }}
+        name: macos-app-${{ matrix.setup.macos-deployment-version }}-${{ matrix.setup.target-arch }}
         path: artifacts/

--- a/picard.spec
+++ b/picard.spec
@@ -5,6 +5,7 @@ import os
 import platform
 import sys
 
+
 sys.path.insert(0, '.')
 from picard import (
     PICARD_APP_ID,
@@ -106,6 +107,7 @@ else:
     exe = EXE(pyz,
               a.scripts,
               exclude_binaries=True,
+              target_arch=os.environ.get('TARGET_ARCH', None),
               # Avoid name clash between picard executable and picard module folder
               name='picard' if os_name == 'Windows' else 'picard-run',
               debug=False,

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -73,7 +73,7 @@ if [ "$CODESIGN" = '1' ]; then
 fi
 
 # Only test the app if it was codesigned, otherwise execution likely fails
-if [ "$CODESIGN" = '1' ]; then
+if [ "$CODESIGN" = '1' ] && [ "$TARGET_ARCH" = 'x86_64' ]; then
   "$APP_BUNDLE/Contents/MacOS/picard-run" --long-version --no-crash-dialog || echo "Failed running picard-run"
   VERSIONS=$("$APP_BUNDLE/Contents/MacOS/picard-run" --long-version --no-crash-dialog)
   echo "$VERSIONS"
@@ -85,11 +85,7 @@ if [ "$CODESIGN" = '1' ]; then
 fi
 
 echo "Package app bundle into DMG image..."
-if [ -n "$MACOSX_DEPLOYMENT_TARGET" ]; then
-  DMG="MusicBrainz-Picard-${VERSION}-macOS-${MACOSX_DEPLOYMENT_TARGET}.dmg"
-else
-  DMG="MusicBrainz-Picard-${VERSION}.dmg"
-fi
+DMG="MusicBrainz-Picard${VERSION:+-$VERSION}${MACOSX_DEPLOYMENT_TARGET:+-macOS-$MACOSX_DEPLOYMENT_TARGET}${TARGET_ARCH:+-$TARGET_ARCH}.dmg"
 mkdir staging
 mv "$APP_BUNDLE" staging/
 # Offer a link to /Applications for easy installation

--- a/scripts/package/macos-setup.sh
+++ b/scripts/package/macos-setup.sh
@@ -20,7 +20,7 @@ if [ -n "$DISCID_VERSION" ]; then
   wget "ftp://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/$DISCID_FILENAME"
   echo "$DISCID_SHA256SUM  $DISCID_FILENAME" | shasum --algorithm 256 --check --status
   unzip "$DISCID_FILENAME"
-  cp "libdiscid-$DISCID_VERSION-mac/x86_64/libdiscid.0.dylib" .
+  cp "libdiscid-$DISCID_VERSION-mac/universal2/libdiscid.0.dylib" .
 fi
 
 # Install fpcalc


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2192
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is an alternative attempt to provide ARM64 packages for macOS. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Instead of building a single universal2, as attempted in #2423, this builds two separate packages for the x86_64 and arm64 architectures.

The reason for now is that the PyQt6-Qt6 package is only available as separate packages as well. 

While it would be nicer to have a single package, this approach will solve PICARD-2192 as well. If we want to provide a combined package in the future there would be two approaches:

- Download the separate binary packages of PyQt6-Qt6 and have the individual dynamic libraries from each package combined in a single universal2 one by a script.
- Build Qt6 ourselves as part of the build pipeline.