### PR TITLE
PICARD-2909: Do not write image width / height for Opus files

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008, 2012 Lukáš Lalinský
 # Copyright (C) 2008 Hendrik van Antwerpen
-# Copyright (C) 2008-2010, 2014-2015, 2018-2024 Philipp Wolfer
+# Copyright (C) 2008-2010, 2014-2015, 2018-2025 Philipp Wolfer
 # Copyright (C) 2012-2013 Michael Wiencek
 # Copyright (C) 2012-2014 Wieland Hoffmann
 # Copyright (C) 2013 Calvin Walton
@@ -243,6 +243,7 @@ class VCommentFile(File):
         log.debug("Saving file %r", filename)
         config = get_config()
         is_flac = self._File == mutagen.flac.FLAC
+        is_opus = self._File == mutagen.oggopus.OggOpus
         file = self._File(encode_filename(filename))
         if file.tags is None:
             file.add_tags()
@@ -304,9 +305,15 @@ class VCommentFile(File):
             picture.data = image.data
             picture.mime = image.mimetype
             picture.desc = image.comment
-            picture.width = image.width
-            picture.height = image.height
             picture.type = image.id3_type
+
+            # libopus expects width, height and depth to be either all zero
+            # or all non-zero. As depth is not easily available, do not set
+            # width and height either. See PICARD-2909.
+            if not is_opus:
+                picture.width = image.width
+                picture.height = image.height
+
             if is_flac:
                 # See https://xiph.org/flac/format.html#metadata_block_picture
                 expected_block_size = (8 * 4 + len(picture.data)

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2024 Philipp Wolfer
+# Copyright (C) 2019-2025 Philipp Wolfer
 # Copyright (C) 2020 Laurent Monin
 # Copyright (C) 2024 Suryansh Shakya
 #
@@ -336,6 +336,16 @@ class OggOpusTest(CommonVorbisTests.VorbisTestCase):
             'r128_track_gain': '-2857',
         }
         self._test_supported_tags(tags)
+
+    def test_leave_picture_dimensions_empty(self):
+        cover = CoverArtImage(data=load_coverart_file('mb.jpg'))
+        file_save_image(self.filename, cover)
+        raw_metadata = load_raw(self.filename)
+        data = raw_metadata['metadata_block_picture'][0]
+        image = Picture(base64.standard_b64decode(data))
+        self.assertEqual(0, image.width)
+        self.assertEqual(0, image.height)
+        self.assertEqual(0, image.depth)
 
 
 class OggTheoraTest(CommonVorbisTests.VorbisTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:



# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
libopus expects width, height and depth to all be zero or all be non-zero


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
As depth is not easily available, do not set width and height either