### PR TITLE
Use pytest and PEP 517 build

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools pytest
+        python -m pip install --upgrade build pytest
         pip install --upgrade -r requirements.txt
     - name: Run tests
       timeout-minutes: 30
@@ -35,7 +35,7 @@ jobs:
     - name: Build Python source distribution
       run: |
         git clean -dfx
-        python setup.py clean sdist --formats=gztar,zip
+        python -m build --sdist
     - name: Prepare GPG signing key
       run: |
         if [ -n "$CODESIGN_GPG_URL" ] && [ -n "$AWS_ACCESS_KEY_ID" ]; then
@@ -57,7 +57,7 @@ jobs:
     - name: Sign source archives
       if: env.CODESIGN == '1'
       run: |
-        for f in dist/*.{zip,tar.gz}; do
+        for f in dist/*.tar.gz; do
           gpg --armor --local-user "$CODESIGN_GPG_IDENTITY" --output "${f}.asc" --detach-sig "$f"
         done
       env:
@@ -110,7 +110,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools pytest wheel
+        python -m pip install --upgrade build pytest
         pip install --upgrade -r requirements.txt
     - name: Run tests
       timeout-minutes: 30
@@ -118,7 +118,7 @@ jobs:
         pytest
     - name: Build Python binary distribution
       run: |
-        python setup.py clean bdist_wheel
+        python -m build --wheel
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -26,12 +26,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
+        python -m pip install --upgrade setuptools pytest
         pip install --upgrade -r requirements.txt
     - name: Run tests
       timeout-minutes: 30
       run: |
-        python setup.py test
+        pytest
     - name: Build Python source distribution
       run: |
         git clean -dfx
@@ -110,12 +110,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
+        python -m pip install --upgrade setuptools pytest wheel
         pip install --upgrade -r requirements.txt
     - name: Run tests
       timeout-minutes: 30
       run: |
-        python setup.py test
+        pytest
     - name: Build Python binary distribution
       run: |
         python setup.py clean bdist_wheel

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -140,6 +140,5 @@ jobs:
       if: runner.os != 'Windows'
       timeout-minutes: 30
       run: |
-        pip install --upgrade setuptools
-        pip install pytest
+        pip install build pytest
         scripts/package/run-sdist-test.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,9 +162,9 @@ Running the Test Suite
 ----------------------
 
 To run the included tests, follow the instructions for "Running From
-the Source Tree".  Afterward you can run the tests using setup.py:
+the Source Tree". Afterward you can run the tests using setup.py:
 
-    python3 setup.py test
+    pytest
 
 
 Packaging

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,7 +66,7 @@ Edit `picard/__init__.py` and set new version tuple
 Run tests:
 
 ```bash
-python setup.py test
+pytest
 ```
 
 Commit changes!
@@ -88,7 +88,7 @@ Edit `picard/__init__.py` and set new dev version tuple.
 Run tests:
 
 ```bash
-python setup.py test
+pytest
 ```
 
 Commit changes!

--- a/scripts/package/run-sdist-test.sh
+++ b/scripts/package/run-sdist-test.sh
@@ -5,7 +5,7 @@
 set -e
 
 rm -rf dist
-python3 setup.py sdist
+python -m build --sdist
 cd dist
 SDIST_ARCHIVE=$(echo picard-*.tar.gz)
 tar xvf "$SDIST_ARCHIVE"

--- a/setup.py
+++ b/setup.py
@@ -103,43 +103,6 @@ def newer(source, target):
     return os.path.getmtime(source) > os.path.getmtime(target)
 
 
-class picard_test(Command):
-    description = "run automated tests"
-    user_options = [
-        ("tests=", None, "list of tests to run (default all)"),
-        ("verbosity=", "v", "verbosity"),
-    ]
-
-    def initialize_options(self):
-        self.tests = []
-        self.verbosity = 1
-
-    def finalize_options(self):
-        if self.tests:
-            self.tests = self.tests.split(",")
-        # In case the verbosity flag is used, verbosity is None
-        if not self.verbosity:
-            self.verbosity = 2
-        # Convert to appropriate verbosity if passed by --verbosity option
-        self.verbosity = int(self.verbosity)
-
-    def run(self):
-        import unittest
-
-        names = []
-        for filename in glob.glob("test/**/test_*.py", recursive=True):
-            modules = os.path.splitext(filename)[0].split(os.sep)
-            name = '.'.join(modules[1:])
-            if not self.tests or name in self.tests:
-                names.append('test.' + name)
-
-        tests = unittest.defaultTestLoader.loadTestsFromNames(names)
-        t = unittest.TextTestRunner(verbosity=self.verbosity)
-        testresult = t.run(tests)
-        if not testresult.wasSuccessful():
-            sys.exit("At least one test failed.")
-
-
 class picard_build_locales(Command):
     description = 'build locale files'
     user_options = [
@@ -794,7 +757,6 @@ args = {
     'ext_modules': ext_modules,
     'data_files': [],
     'cmdclass': {
-        'test': picard_test,
         'build': picard_build,
         'build_locales': picard_build_locales,
         'build_ui': picard_build_ui,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Attempt to reduce the direct calls to `setup.py`.


# Solution

Remove `setup.py test` completely and replace the calls with `pytest`.

Build sdist / bdist packages with `python -m build`.

**Note:** As a side effect this removes the source builds in zip format, as PEP 517 only specifies .tar.gz as format. Do we need the zip source distribution? I think with public availability of the source in git and wide availability of extraction tools for .tar.gz even on Windows this is not really needed.

If we want to provide it we could add a CI step to also create a zip file.