### PR TITLE
Pyproject metadata

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Run pip install .
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install --verbose .
     - name: Test running installed package
       if: runner.os != 'Windows'
       run: picard --long-version --no-crash-dialog

--- a/org.musicbrainz.Picard.appdata.xml.in
+++ b/org.musicbrainz.Picard.appdata.xml.in
@@ -4,7 +4,9 @@
   <project_license>GPL-2.0-or-later</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>MusicBrainz Picard</name>
-  <summary>MusicBrainz's music tagger</summary>
+  <summary>
+    Picard is a cross-platform music tagger powered by the MusicBrainz database
+  </summary>
 
   <description>
     <p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,18 @@ Repository = "https://github.com/metabrainz/picard.git"
 Issues = "https://tickets.metabrainz.org/projects/PICARD/issues/"
 Changelog = "https://picard.musicbrainz.org/changelog/"
 
+[tool.setuptools]
+ext-modules = [
+    {name = "picard.util._astrcmp", sources = ["picard/util/_astrcmp.c"]},
+]
+
 [tool.setuptools.dynamic]
 version = {attr = "picard.PICARD_VERSION_STR_SHORT"}
 readme = {file = ["README.md"], content-type = "text/markdown"}
 dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.packages.find]
+include = ["picard*"]
 
 [tool.isort]
 sections = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,47 @@
-#[project]
-#requires-python = ">=3.9"
-
 [build-system]
-requires = ["setuptools>=62.4.0"]
+requires = ["setuptools>=66.1.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "picard"
+description = "MusicBrainz Picard audio tagger"
+authors = [{name = "The MusicBrainz Team"}]
+license = {text = "GPL-2.0-or-later"}
+keywords = ["musicbrainz", "tagging", "audio"]
+requires-python = ">=3.9"
+classifiers = [
+    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: MacOS X",
+    "Environment :: Win32 (MS Windows)",
+    "Environment :: X11 Applications :: Qt",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Multimedia :: Sound/Audio :: Analysis",
+    "Intended Audience :: End Users/Desktop",
+]
+dynamic = ["version", "readme", "dependencies"]
+
+[project.urls]
+Homepage = "https://picard.musicbrainz.org/"
+Documentation = "https://picard-docs.musicbrainz.org/"
+Repository = "https://github.com/metabrainz/picard.git"
+Issues = "https://tickets.metabrainz.org/projects/PICARD/issues/"
+Changelog = "https://picard.musicbrainz.org/changelog/"
+
+[tool.setuptools.dynamic]
+version = {attr = "picard.PICARD_VERSION_STR_SHORT"}
+readme = {file = ["README.md"], content-type = "text/markdown"}
+dependencies = {file = ["requirements.txt"]}
 
 [tool.isort]
 sections = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "picard"
-description = "MusicBrainz Picard audio tagger"
+description = "Picard is a cross-platform music tagger powered by the MusicBrainz database"
 authors = [{name = "The MusicBrainz Team"}]
 license = {text = "GPL-2.0-or-later"}
 keywords = ["musicbrainz", "tagging", "audio"]

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ from picard import (  # noqa: E402
     PICARD_DESKTOP_NAME,
     PICARD_DISPLAY_NAME,
     PICARD_VERSION,
-    PICARD_VERSION_STR_SHORT,
 )
 
 
@@ -733,24 +732,7 @@ def _picard_packages():
 this_directory = os.path.abspath(os.path.dirname(__file__))
 
 
-def _get_description():
-    with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-        return f.read()
-
-
-def _get_requirements():
-    with open(os.path.join(this_directory, 'requirements.txt'), encoding='utf-8') as f:
-        return f.readlines()
-
-
 args = {
-    'name': PACKAGE_NAME,
-    'version': PICARD_VERSION_STR_SHORT,
-    'description': 'The next generation MusicBrainz tagger',
-    'keywords': 'MusicBrainz metadata tagger picard',
-    'long_description': _get_description(),
-    'long_description_content_type': 'text/markdown',
-    'url': 'https://picard.musicbrainz.org/',
     'package_dir': {'picard': 'picard'},
     'packages': _picard_packages(),
     'locales': _picard_get_locale_files(),
@@ -772,28 +754,6 @@ args = {
         'patch_version': picard_patch_version,
     },
     'scripts': ['scripts/' + PACKAGE_NAME],
-    'install_requires': _get_requirements(),
-    'python_requires': '~=3.9',
-    'classifiers': [
-        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: MacOS X',
-        'Environment :: Win32 (MS Windows)',
-        'Environment :: X11 Applications :: Qt',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Operating System :: MacOS',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX :: Linux',
-        'Topic :: Multimedia :: Sound/Audio',
-        'Topic :: Multimedia :: Sound/Audio :: Analysis',
-        'Intended Audience :: End Users/Desktop',
-    ]
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2008, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2007 Santiago M. Mola
 # Copyright (C) 2008 Robert Kaye
-# Copyright (C) 2008-2009, 2018-2024 Philipp Wolfer
+# Copyright (C) 2008-2009, 2018-2025 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2011-2012, 2014, 2016-2018 Wieland Hoffmann
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -53,14 +53,10 @@ from setuptools import (
     Extension,
     setup,
 )
+from setuptools.command.build import build
 from setuptools.command.install import install
 from setuptools.dist import Distribution
 
-
-try:
-    from setuptools.command.build import build
-except ImportError:
-    from distutils.command.build import build
 
 # required for PEP 517
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
@@ -685,15 +681,6 @@ class picard_patch_version(Command):
             f.truncate()
 
 
-def cflags_to_include_dirs(cflags):
-    cflags = cflags.split()
-    include_dirs = []
-    for cflag in cflags:
-        if cflag.startswith('-I'):
-            include_dirs.append(cflag[2:])
-    return include_dirs
-
-
 def _picard_get_locale_files():
     locales = []
     domain_path = {
@@ -766,13 +753,6 @@ def generate_file(infilename, outfilename, variables):
 
 def make_executable(filename):
     os.chmod(filename, os.stat(filename).st_mode | stat.S_IEXEC)
-
-
-def find_file_in_path(filename):
-    for include_path in sys.path:
-        file_path = os.path.join(include_path, filename)
-        if os.path.exists(file_path):
-            return file_path
 
 
 if sys.platform not in {'darwin', 'haiku1', 'win32'}:

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ class picard_build(build):
         make_executable('tagger.py')
         generate_file('scripts/picard.in', 'scripts/' + PACKAGE_NAME, params)
         if sys.platform == 'win32':
+            common_args = self._metadata()
             file_version = PICARD_VERSION[0:3] + (self.build_number,)
             file_version_str = '.'.join(str(v) for v in file_version)
 
@@ -245,7 +246,7 @@ class picard_build(build):
                 'file-version': file_version_str,
             }
             if os.path.isfile('installer/picard-setup.nsi.in'):
-                generate_file('installer/picard-setup.nsi.in', 'installer/picard-setup.nsi', {**args, **installer_args})
+                generate_file('installer/picard-setup.nsi.in', 'installer/picard-setup.nsi', {**common_args, **installer_args})
                 log.info('generating NSIS translation files')
                 self.spawn(['python', 'installer/i18n/json2nsh.py'])
 
@@ -253,7 +254,7 @@ class picard_build(build):
                 'filevers': str(file_version),
                 'prodvers': str(file_version),
             }
-            generate_file('win-version-info.txt.in', 'win-version-info.txt', {**args, **version_args})
+            generate_file('win-version-info.txt.in', 'win-version-info.txt', {**common_args, **version_args})
 
             default_publisher = 'CN=Metabrainz Foundation Inc., O=Metabrainz Foundation Inc., L=San Luis Obispo, S=California, C=US'
             # Combine patch version with build number. As Windows store apps require continuously
@@ -271,6 +272,15 @@ class picard_build(build):
             self.run_command('build_appdata')
             self.run_command('build_desktop_file')
         super().run()
+
+    def _metadata(self):
+        metadata = self.distribution.metadata
+        return {
+            'name': metadata.name,
+            'description': metadata.description,
+            'version': metadata.version,
+            'url': metadata.url,
+        }
 
 
 def py_from_ui(uifile):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ import tempfile
 
 from setuptools import (
     Command,
-    Extension,
     setup,
 )
 from setuptools.command.build import build
@@ -79,10 +78,6 @@ APPDATA_FILE = PICARD_APP_ID + '.appdata.xml'
 APPDATA_FILE_TEMPLATE = APPDATA_FILE + '.in'
 DESKTOP_FILE = PICARD_APP_ID + '.desktop'
 DESKTOP_FILE_TEMPLATE = DESKTOP_FILE + '.in'
-
-ext_modules = [
-    Extension('picard.util._astrcmp', sources=['picard/util/_astrcmp.c']),
-]
 
 
 def newer(source, target):
@@ -697,33 +692,8 @@ def _picard_get_locale_files():
     return locales
 
 
-def _explode_path(path):
-    """Return a list of components of the path (ie. "/a/b" -> ["a", "b"])"""
-    components = []
-    while True:
-        (path, tail) = os.path.split(path)
-        if tail == "":
-            components.reverse()
-            return components
-        components.append(tail)
-
-
-def _picard_packages():
-    """Build a tuple containing each module under picard/"""
-    packages = []
-    for subdir, _dirs, _files in os.walk("picard"):
-        packages.append(".".join(_explode_path(subdir)))
-    return tuple(sorted(packages))
-
-
-this_directory = os.path.abspath(os.path.dirname(__file__))
-
-
 args = {
-    'package_dir': {'picard': 'picard'},
-    'packages': _picard_packages(),
     'locales': _picard_get_locale_files(),
-    'ext_modules': ext_modules,
     'data_files': [],
     'cmdclass': {
         'build': picard_build,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This is one step in the goal to nove package metadata into `pyproject.toml` and reduce code in `setup.py`.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Define `[project]` section in `pyproject.toml` and declare package metadata there. Remove the corresponding data from `setup.py`
- Remove obsolete code from `setup.py`
- Define setuptools package and extension in `pyproject.toml` and remove custom code from `setup.py`
- Unified the short app description to be the same in Python package metadata and appstream metadata.

Not handled here:

- Requirements are still defined in `requirements.txt` and read from there. This can be changed once we move to e.g. ruff
- Entry points: This is currently highly system dependent and for now handled dynamically by `setup.py`.
- Data files: Handling of locale translation files will be changed and done in a separate PR. The additional handling for system wide assets (which are not directly loaded by the application) on Unix systems (.desktop file, app icon, appstream metadata) will most likely stay in `setup.py` as part of the packaging process.
- Custom commands in `setup.py`: In he future those could be moved to a separate task handler, at least the ones that are not invoked during build. Custom commands that are invoked during build likely better stay in `setup.py` to avoid additional build-time dependencies.

