### PR TITLE
PICARD-2003: Include locales as package data inside the main package.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
       if: always()
       timeout-minutes: 30
       run: |
-        python setup.py build_locales -i
+        python setup.py build_locales
         pip install pytest pytest-randomly pytest-cov
         pytest --verbose --cov=picard --cov-report xml:coverage.xml test
     - name: Submit code coverage to Codacy

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ coverage.xml
 dist/
 installer/picard-setup.nsi
 installer/i18n/out/*.nsh
-locale/
+picard/locale/
 org.musicbrainz.Picard.appdata.xml
 org.musicbrainz.Picard.desktop
 picard.egg-info

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -147,7 +147,6 @@ Then you can build Picard dependencies:
 
     python3 setup.py build
     python3 setup.py build_ext -i
-    python3 setup.py build_locales -i
 
 And to start Picard use:
 

--- a/picard.spec
+++ b/picard.spec
@@ -37,7 +37,7 @@ def get_locale_messages():
     data_files = []
     for locale in _picard_get_locale_files():
         data_files.append(
-            (os.path.join("build", "locale", locale[1], "LC_MESSAGES", locale[0] + ".mo"),
+            (os.path.join("picard", "locale", locale[1], "LC_MESSAGES", locale[0] + ".mo"),
              os.path.join("locale", locale[1], "LC_MESSAGES")))
     return data_files
 

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2006-2009, 2011-2014, 2017 Lukáš Lalinský
 # Copyright (C) 2008 Gary van der Merwe
 # Copyright (C) 2008 amckinle
-# Copyright (C) 2008-2010, 2014-2015, 2018-2024 Philipp Wolfer
+# Copyright (C) 2008-2010, 2014-2015, 2018-2025 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2010 Andrew Barnert
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -96,6 +96,8 @@ from picard.config import (
 from picard.config_upgrade import upgrade_config
 from picard.const import USER_DIR
 from picard.const.sys import (
+    FROZEN_TEMP_PATH,
+    IS_FROZEN,
     IS_HAIKU,
     IS_MACOS,
     IS_WIN,
@@ -336,8 +338,12 @@ class Tagger(QtWidgets.QApplication):
 
         check_io_encoding()
 
-        # Must be before config upgrade because upgrade dialogs need to be
-        # translated
+        if not localedir:
+            # Unfortunately we cannot use importlib.resources to access the data
+            # files, as gettext expects a path to a directory for localedir.
+            basedir = FROZEN_TEMP_PATH if IS_FROZEN else os.path.dirname(__file__)
+            localedir = os.path.join(basedir, 'locale')
+        # Must be before config upgrade because upgrade dialogs need to be translated.
         setup_gettext(localedir, config.setting['ui_language'], log.debug)
 
         upgrade_config(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dependencies = {file = ["requirements.txt"]}
 [tool.setuptools.packages.find]
 include = ["picard*"]
 
+[tool.setuptools.package-data]
+"*" = ["*.mo"]
+
 [tool.isort]
 sections = [
     "FUTURE", "STDLIB", "FIRSTPARTY", "THIRDPARTY", "QT", "TEST", "PICARD", "LOCALFOLDER",

--- a/scripts/picard.in
+++ b/scripts/picard.in
@@ -4,4 +4,4 @@ from picard import register_excepthook
 register_excepthook()
 
 from picard.tagger import main
-main('%(localedir)s', %(autoupdate)s)
+main(autoupdate=%(autoupdate)s)

--- a/tagger.py.in
+++ b/tagger.py.in
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
 
-import os
 import sys
 
 
 sys.path.insert(0, '.')
 
-# This is needed to find resources when using pyinstaller
-if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-    basedir = getattr(sys, '_MEIPASS', '')
-else:
-    basedir = os.path.dirname(os.path.abspath(__file__))
-
 from picard import register_excepthook
 register_excepthook()
 
 from picard.tagger import main
-main(os.path.join(basedir, 'locale'), %(autoupdate)s)
+main(autoupdate=%(autoupdate)s)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -70,7 +70,7 @@ class TestI18n(PicardTestCase):
         self.assertEqual('France', gettext_countries('France'))
 
     @unittest.skipUnless(os.path.exists(os.path.join(localedir, 'de')),
-        'Test requires locales to be built with "python setup.py build_locales -i"')
+        'Test requires locales to be built with "python setup.py build_locales"')
     def test_existing_locales(self):
         locale_de = os.path.join(localedir, 'de', 'LC_MESSAGES', 'picard.mo')
         self.assertTrue(os.path.exists(locale_de), 'expected file %s' % locale_de)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2003
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If picard got installed by `pip install picard` the translations where unavailable. That is because the locale files got included as a data files outside the package folder, and there is no default way to get this data folder.

This PR ensures locales are available also in pip installs by moving the locale as data files into the picard package.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Move the locale directory holding the *.mo files into the picard package and include them as data files in the source package and wheel. Adjust the loading to use this locale dir by default.

This simplifies the code to build the locales, as there are no longer separate build target directories. This also removes the need to run `setup.py build_locales -i` after `setup.py build` for local development.

Separate handling is needed for pyinstaller "frozen" install. Oherwise the location of the locales is now always the same.

See also https://setuptools.pypa.io/en/latest/userguide/datafiles.html#interplay-between-these-keywords