### PR TITLE
PICARD-3003: Disable autoupdate during build with PICARD_DISABLE_AUTOUPDATE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,10 @@ class picard_build(build):
         except ValueError:
             self.build_number = 0
         if self.disable_autoupdate is None:
-            self.disable_autoupdate = False
+            # Support setting this option with an environment variable as
+            # a workaround for https://tickets.metabrainz.org/browse/PICARD-3003
+            env_autoupdate = os.environ.get('PICARD_DISABLE_AUTOUPDATE')
+            self.disable_autoupdate = bool(env_autoupdate and env_autoupdate != '0')
         self.sub_commands.append(('build_locales', None))
 
     def run(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3003
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When building Picard via PEP 517, e.g. by calling "python -m build", it is currently not possible to pass custom build parameters like `--disable-autoupdate`. This is due to setuptools not passing on `config_settings` to the build backend (otherwise something like `python -m build --wheel -C--disable-autoupdate` could work).

See also https://github.com/pypa/setuptools/issues/2491


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

As specifically `--disable-autoupdate` is an important option for distributions, allow setting this value via the environment variable `PICARD_DISABLE_AUTOUPDATE`. This will work now:

```
PICARD_DISABLE_AUTOUPDATE=1 python -m build
```

This is also something recommended in https://github.com/pypa/setuptools/discussions/3969

Alternatives: Pillow implemented a custom build backend, see https://github.com/python-pillow/Pillow/pull/7171 . But this seems like a lot of overhead for a rather simple use case.

We could also generalize the environment variable approach more to support other custom options. But I'd rather keep it simple for now to handle the requested use case. The hope is still that setuptools will make PEP 517 `config_settings` available to the build commands in a future update.