### PR TITLE
Packaging fixes

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -71,8 +71,9 @@ jobs:
         python setup.py clean
     - name: Build
       run: |
-        python setup.py build --build-number=$BuildNumber
-        python setup.py build_ext
+        python setup.py build --build-number=$BuildNumber --disable-locales
+        python setup.py build_locales
+        python setup.py build_ext -i
         pyinstaller --noconfirm --clean picard.spec
         If ($env:PICARD_BUILD_PORTABLE -ne "1") {
           dist\picard\_internal\fpcalc -version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Analysis",
     "Intended Audience :: End Users/Desktop",
 ]
-dynamic = ["version", "readme", "dependencies"]
+dynamic = ["version", "readme", "dependencies", "gui-scripts"]
 
 [project.urls]
 Homepage = "https://picard.musicbrainz.org/"

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -15,7 +15,8 @@ MACOS_VERSION_MINOR=${MACOS_VERSION_MINOR%.*}
 echo "Building Picard..."
 rm -rf dist build locale
 python3 setup.py clean
-python3 setup.py build
+python3 setup.py build --disable-locales
+python3 setup.py build_locales
 python3 setup.py build_ext -i
 pyinstaller --noconfirm --clean picard.spec
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class picard_build_locales(Command):
 
     def run(self):
         # build_lib is only set when run as part of the "build" command.
-        # When "buil_locales" is run standalone this will not be set and
+        # When "build_locales" is run standalone this will not be set and
         # locales will be compiled in the local directory.
         build_lib = self.distribution.get_command_obj('build').build_lib
 
@@ -141,12 +141,14 @@ class picard_build(build):
     user_options = build.user_options + [
         ('disable-autoupdate', None, 'disable update checking and hide settings for it'),
         ('build-number=', None, 'build number (integer)'),
+        ('disable-locales', None, ''),
     ]
 
     def initialize_options(self):
         super().initialize_options()
         self.build_number = 0
         self.disable_autoupdate = None
+        self.disable_locales = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -159,7 +161,8 @@ class picard_build(build):
             # a workaround for https://tickets.metabrainz.org/browse/PICARD-3003
             env_autoupdate = os.environ.get('PICARD_DISABLE_AUTOUPDATE')
             self.disable_autoupdate = bool(env_autoupdate and env_autoupdate != '0')
-        self.sub_commands.append(('build_locales', None))
+        if not self.disable_locales:
+            self.sub_commands.append(('build_locales', None))
 
     def run(self):
         params = {'autoupdate': not self.disable_autoupdate}

--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,16 @@ class picard_build_locales(Command):
         pass
 
     def run(self):
+        # build_lib is only set when run as part of the "build" command.
+        # When "buil_locales" is run standalone this will not be set and
+        # locales will be compiled in the local directory.
+        build_lib = self.distribution.get_command_obj('build').build_lib
+
         for domain, locale, po in _picard_get_locale_files():
             path = os.path.join('picard', 'locale', locale, 'LC_MESSAGES')
-            mo = os.path.join(path, '%s.mo' % domain)
+            if build_lib:
+                path = os.path.join(build_lib, path)
+            mo = os.path.join(path, f'{domain}.mo')
             self.mkpath(path)
             self.spawn(['msgfmt', '-o', mo, po])
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

This fixes two issues in the PyPI packages recently introduced with #2588

1. Locales where not included in the wheel if building with e.g. "python -m build". As this is building in a clean environment the locales did not end up in the local source tree and where not used. Locales need to be put into the build-lib dir. For local source builds running `python setup.py build_locales` still works and writes the locales to `picard/locale` as expected.
2. On Windows setuptools complained that "gui-scripts" in pyproject.toml needs to be dynamic. As gui-scripts currently is only used on Windows this was not obvious during testing.