### PR TITLE
PICARD-3040: Register a custom protocol handler for browser integration

### DIFF
--- a/appxmanifest.xml.in
+++ b/appxmanifest.xml.in
@@ -108,6 +108,12 @@
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="%(protocol)s">
+            <uap:Logo>Square44x44Logo.targetsize-44_altform-unplated.png</uap:Logo>
+            <uap:DisplayName>%(display-name)s</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/installer/picard-setup.nsi.in
+++ b/installer/picard-setup.nsi.in
@@ -8,6 +8,7 @@
 !define PRODUCT_DESCRIPTION "%(description)s"
 !define PRODUCT_URL "%(url)s"
 !define PRODUCT_HELP_URL "https://picard-docs.musicbrainz.org/"
+!define PRODUCT_CUSTOM_PROTOCOL "%(protocol)s"
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
 
@@ -142,6 +143,11 @@ Section "!$(SectionRequired)" required
     ; Write the installation path into the registry
     WriteRegStr HKLM "Software\${PRODUCT_PUBLISHER}\${PRODUCT_NAME}" "InstallDir" "$INSTDIR"
 
+    ; Register a custom protocol handler
+    WriteRegStr HKCR "${PRODUCT_CUSTOM_PROTOCOL}" "URL Protocol" ""
+    WriteRegStr HKCR "${PRODUCT_CUSTOM_PROTOCOL}\DefaultIcon" "" "$INSTDIR\picard.exe,1"
+    WriteRegStr HKCR "${PRODUCT_CUSTOM_PROTOCOL}\shell\open\command" "" "$INSTDIR\picard.exe %%1"
+
     ; Create uninstaller
     WriteUninstaller "$INSTDIR\uninst.exe"
     WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayName" "${PRODUCT_NAME}"
@@ -199,6 +205,7 @@ Section Uninstall
 
   DeleteRegKey ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}"
   DeleteRegKey HKLM "Software\${PRODUCT_PUBLISHER}\${PRODUCT_NAME}"
+  DeleteRegKey HKCR "${PRODUCT_CUSTOM_PROTOCOL}"
 
   !insertmacro INSTALLOPTIONS_READ $R0 "removeSettings.ini" "Field 1" "State"
   StrCmp $R0 "1" 0 +2

--- a/org.musicbrainz.Picard.desktop.in
+++ b/org.musicbrainz.Picard.desktop.in
@@ -1,16 +1,16 @@
 [Desktop Entry]
 Name=MusicBrainz Picard
 Comment=Tag your music with the next generation MusicBrainz tagger
-Exec=picard %F
+Exec=picard %U
 Terminal=false
 Type=Application
 StartupNotify=true
 StartupWMClass=Picard
 Icon=org.musicbrainz.Picard
 Categories=AudioVideo;Audio;AudioVideoEditing;
-MimeType=application/ogg;application/x-flac;audio/aac;audio/ac3;audio/aiff;audio/ape;audio/dsf;audio/flac;audio/midi;audio/mp4;audio/mpeg;audio/mpeg4;audio/mpg;audio/ogg;audio/vorbis;audio/x-aac;audio/x-aiff;audio/x-ape;audio/x-flac;audio/x-flac+ogg;audio/x-m4a;audio/x-midi;audio/x-mp3;audio/x-mpc;audio/x-mpeg;audio/x-ms-wma;audio/x-ms-wmv;audio/x-musepack;audio/x-oggflac;audio/x-speex;audio/x-speex+ogg;audio/x-tak;audio/x-tta;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-wma;video/x-ms-asf;video/x-theora;video/x-wmv;
+MimeType=x-scheme-handler/org.musicbrainz.picard;application/ogg;application/x-flac;audio/aac;audio/ac3;audio/aiff;audio/ape;audio/dsf;audio/flac;audio/midi;audio/mp4;audio/mpeg;audio/mpeg4;audio/mpg;audio/ogg;audio/vorbis;audio/x-aac;audio/x-aiff;audio/x-ape;audio/x-flac;audio/x-flac+ogg;audio/x-m4a;audio/x-midi;audio/x-mp3;audio/x-mpc;audio/x-mpeg;audio/x-ms-wma;audio/x-ms-wmv;audio/x-musepack;audio/x-oggflac;audio/x-speex;audio/x-speex+ogg;audio/x-tak;audio/x-tta;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-wma;video/x-ms-asf;video/x-theora;video/x-wmv;
 Actions=new-window;
 
 [Desktop Action new-window]
 Name=New Window
-Exec=picard --stand-alone-instance %F
+Exec=picard --stand-alone-instance %U

--- a/picard.spec
+++ b/picard.spec
@@ -13,6 +13,7 @@ from picard import (
     PICARD_APP_NAME,
     PICARD_DISPLAY_NAME,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION,
     __version__,
 )
@@ -228,6 +229,13 @@ else:
                         'public.mpeg-4-audio',
                     ],
                     'CFBundleTypeRole': 'Editor',
+                }
+            ],
+            'CFBundleURLTypes': [
+                {
+                    'CFBundleURLName': PICARD_APP_ID,
+                    'CFBundleURLSchemes': [PICARD_PROTOCOL_SCHEME],
+                    'CFBundleURLIconFile': 'picard',
                 }
             ],
         }

--- a/picard.spec
+++ b/picard.spec
@@ -21,6 +21,7 @@ from picard import (
     PICARD_APP_NAME,
     PICARD_DISPLAY_NAME,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION,
     __version__,
 )
@@ -228,6 +229,13 @@ else:
                         'public.mpeg-4-audio',
                     ],
                     'CFBundleTypeRole': 'Editor',
+                }
+            ],
+            'CFBundleURLTypes': [
+                {
+                    'CFBundleURLName': PICARD_APP_ID,
+                    'CFBundleURLSchemes': [PICARD_PROTOCOL_SCHEME],
+                    'CFBundleURLIconFile': 'picard',
                 }
             ],
         }

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -44,7 +44,6 @@ PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
 PICARD_VERSION = Version(3, 0, 0, 'beta', 2)
 
-
 PICARD_VERSION_STR = str(PICARD_VERSION)
 __version__ = PICARD_VERSION.short_str()
 PICARD_FANCY_VERSION_STR = __version__
@@ -56,6 +55,9 @@ PICARD_BUILD_VERSION_STR = ""
 if PICARD_BUILD_VERSION_STR:
     __version__ = f"{__version__}+{PICARD_BUILD_VERSION_STR}"
     PICARD_FANCY_VERSION_STR = f"{PICARD_FANCY_VERSION_STR} ({PICARD_BUILD_VERSION_STR})"
+
+# Custom protocol for browser integration
+PICARD_PROTOCOL_SCHEME = 'org.musicbrainz.picard'
 
 # Keep those ordered
 api_versions = [

--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -50,7 +50,6 @@ PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
 PICARD_VERSION = Version(3, 0, 0, 'beta', 9)
 COPYRIGHT_YEARS = "2004-2026"
 
-
 PICARD_VERSION_STR = str(PICARD_VERSION)
 __version__ = PICARD_VERSION.short_str()
 PICARD_FANCY_VERSION_STR = __version__
@@ -62,6 +61,9 @@ PICARD_BUILD_VERSION_STR = ""
 if PICARD_BUILD_VERSION_STR:
     __version__ = f"{__version__}+{PICARD_BUILD_VERSION_STR}"
     PICARD_FANCY_VERSION_STR = f"{PICARD_FANCY_VERSION_STR} ({PICARD_BUILD_VERSION_STR})"
+
+# Custom protocol for browser integration
+PICARD_PROTOCOL_SCHEME = 'org.musicbrainz.picard'
 
 # Keep those ordered
 api_versions = ("3.0",)

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -39,10 +39,12 @@ from urllib.parse import (
 )
 
 from PyQt6 import QtCore
+from PyQt6.QtGui import QDesktopServices
 
 from picard import (
     PICARD_APP_NAME,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION_STR,
     log,
 )
@@ -79,6 +81,8 @@ class BrowserIntegration(QtCore.QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.server = None
+        self._action_handler = RequestActionHandler()
+        QDesktopServices.setUrlHandler(PICARD_PROTOCOL_SCHEME, self.url_handler)
 
     @property
     def host_address(self):
@@ -98,7 +102,7 @@ class BrowserIntegration(QtCore.QObject):
 
     def start(self):
         if self.server:
-            self.stop()
+            self.stop(stop_url_handler=False)
 
         config = get_config()
 
@@ -133,7 +137,7 @@ class BrowserIntegration(QtCore.QObject):
         except Exception:
             log.error("%s: Failed to start listening on %s", LOG_PREFIX, host_address, exc_info=True)
 
-    def stop(self):
+    def stop(self, stop_url_handler=True):
         if self.server:
             try:
                 log.info("%s: Stopping", LOG_PREFIX)
@@ -145,6 +149,19 @@ class BrowserIntegration(QtCore.QObject):
                 log.error("%s: Failed to stop", LOG_PREFIX, exc_info=True)
         else:
             log.debug("%s: inactive, no need to stop", LOG_PREFIX)
+
+        if stop_url_handler:
+            QDesktopServices.unsetUrlHandler(PICARD_PROTOCOL_SCHEME)
+
+    def url_handler(self, url: QtCore.QUrl):
+        """URL handler used for custom protocol handling."""
+        log.debug("Received custom URL: %s", url.toString())
+
+        if url.scheme() != PICARD_PROTOCOL_SCHEME:
+            log.error("Invalid URL scheme: %s", url.scheme())
+            return
+
+        self._action_handler.handle_get(url.toString())
 
 
 # From https://github.com/python/cpython/blob/f474264b1e3cd225b45cf2c0a91226d2a9d3ee9b/Lib/http/server.py#L570C1-L573C43
@@ -158,6 +175,10 @@ def safe_message(message):
 
 
 class RequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        self._action_handler = RequestActionHandler(self._response)
+        super().__init__(*args, **kwargs)
+
     def do_OPTIONS(self):
         origin = self.headers['origin']
         if _is_valid_origin(origin):
@@ -183,7 +204,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            self._handle_get()
+            self._action_handler.handle_get(self.path)
         except Exception:
             log.error('%s: failed handling request', LOG_PREFIX, exc_info=True)
             self._response(500, 'Unexpected request error')
@@ -202,10 +223,33 @@ class RequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         self._log(log.info, format, args)
 
-    def _handle_get(self):
-        parsed = urlparse(self.path)
+    def _response(self, code, content='', content_type='text/plain'):
+        self.server_version = SERVER_VERSION
+        self.send_response(code)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Cache-Control', 'max-age=0')
+        origin = self.headers['origin']
+        if _is_valid_origin(origin):
+            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
+            self.send_header('Vary', 'Origin')
+        self.end_headers()
+        self.wfile.write(content.encode())
+
+
+class RequestActionHandler:
+    """
+    Handles URL requests by executing the appropriate action based on URL path.
+    """
+
+    def __init__(self, response_handler=None):
+        self._response_handler = response_handler
+
+    def handle_get(self, path):
+        parsed = urlparse(path)
         args = parse_qs(parsed.query)
         action = parsed.path
+        if not action.startswith('/'):
+            action = '/' + action
 
         if action == '/':
             self._response(200, SERVER_VERSION)
@@ -218,6 +262,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         elif action == '/auth':
             self._auth(args)
         else:
+            log.error('Unknown browser action: %s', action)
             self._response(404, 'Unknown action.')
 
     def _load_mbid(self, type, args):
@@ -265,16 +310,11 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._response(400, 'Missing parameter "code".')
 
     def _response(self, code, content='', content_type='text/plain'):
-        self.server_version = SERVER_VERSION
-        self.send_response(code)
-        self.send_header('Content-Type', content_type)
-        self.send_header('Cache-Control', 'max-age=0')
-        origin = self.headers['origin']
-        if _is_valid_origin(origin):
-            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
-            self.send_header('Vary', 'Origin')
-        self.end_headers()
-        self.wfile.write(content.encode())
+        if not self._response_handler:
+            log.debug(f'Finished custom request with code {code}')
+            return
+
+        self._response_handler(code, content, content_type)
 
 
 def clean_header(header):

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -36,10 +36,12 @@ from urllib.parse import (
 )
 
 from PyQt6 import QtCore
+from PyQt6.QtGui import QDesktopServices
 
 from picard import (
     PICARD_APP_NAME,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION_STR,
     log,
     tagger_instance,
@@ -80,6 +82,8 @@ class BrowserIntegration(QtCore.QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.server = None
+        self._action_handler = RequestActionHandler()
+        QDesktopServices.setUrlHandler(PICARD_PROTOCOL_SCHEME, self.url_handler)
 
     @property
     def host_address(self):
@@ -99,7 +103,7 @@ class BrowserIntegration(QtCore.QObject):
 
     def start(self):
         if self.server:
-            self.stop()
+            self.stop(stop_url_handler=False)
 
         config = get_config()
 
@@ -134,7 +138,7 @@ class BrowserIntegration(QtCore.QObject):
         except Exception:
             log.error("%s: Failed to start listening on %s", LOG_PREFIX, host_address, exc_info=True)
 
-    def stop(self):
+    def stop(self, stop_url_handler=True):
         if self.server:
             try:
                 log.info("%s: Stopping", LOG_PREFIX)
@@ -146,6 +150,19 @@ class BrowserIntegration(QtCore.QObject):
                 log.error("%s: Failed to stop", LOG_PREFIX, exc_info=True)
         else:
             log.debug("%s: inactive, no need to stop", LOG_PREFIX)
+
+        if stop_url_handler:
+            QDesktopServices.unsetUrlHandler(PICARD_PROTOCOL_SCHEME)
+
+    def url_handler(self, url: QtCore.QUrl):
+        """URL handler used for custom protocol handling."""
+        log.debug("Received custom URL: %s", url.toString())
+
+        if url.scheme() != PICARD_PROTOCOL_SCHEME:
+            log.error("Invalid URL scheme: %s", url.scheme())
+            return
+
+        self._action_handler.handle_get(url.toString())
 
 
 # From https://github.com/python/cpython/blob/f474264b1e3cd225b45cf2c0a91226d2a9d3ee9b/Lib/http/server.py#L570C1-L573C43
@@ -159,6 +176,10 @@ def safe_message(message):
 
 
 class RequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        self._action_handler = RequestActionHandler(self._response)
+        super().__init__(*args, **kwargs)
+
     def do_OPTIONS(self):
         origin = self.headers['origin']
         if _is_valid_origin(origin):
@@ -184,7 +205,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            self._handle_get()
+            self._action_handler.handle_get(self.path)
         except Exception:
             log.error('%s: failed handling request', LOG_PREFIX, exc_info=True)
             self._response(500, 'Unexpected request error')
@@ -203,10 +224,33 @@ class RequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         self._log(log.info, format, args)
 
-    def _handle_get(self):
-        parsed = urlparse(self.path)
+    def _response(self, code, content='', content_type='text/plain'):
+        self.server_version = SERVER_VERSION
+        self.send_response(code)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Cache-Control', 'max-age=0')
+        origin = self.headers['origin']
+        if _is_valid_origin(origin):
+            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
+            self.send_header('Vary', 'Origin')
+        self.end_headers()
+        self.wfile.write(content.encode())
+
+
+class RequestActionHandler:
+    """
+    Handles URL requests by executing the appropriate action based on URL path.
+    """
+
+    def __init__(self, response_handler=None):
+        self._response_handler = response_handler
+
+    def handle_get(self, path):
+        parsed = urlparse(path)
         args = parse_qs(parsed.query)
         action = parsed.path
+        if not action.startswith('/'):
+            action = '/' + action
 
         if action == '/':
             self._response(200, SERVER_VERSION)
@@ -219,6 +263,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         elif action == '/auth':
             self._auth(args)
         else:
+            log.error('Unknown browser action: %s', action)
             self._response(404, 'Unknown action.')
 
     def _load_mbid(self, type, args):
@@ -266,16 +311,11 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._response(400, 'Missing parameter "code".')
 
     def _response(self, code, content='', content_type='text/plain'):
-        self.server_version = SERVER_VERSION
-        self.send_response(code)
-        self.send_header('Content-Type', content_type)
-        self.send_header('Cache-Control', 'max-age=0')
-        origin = self.headers['origin']
-        if _is_valid_origin(origin):
-            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
-            self.send_header('Vary', 'Origin')
-        self.end_headers()
-        self.wfile.write(content.encode())
+        if not self._response_handler:
+            log.debug(f'Finished custom request with code {code}')
+            return
+
+        self._response_handler(code, content, content_type)
 
 
 def clean_header(header):

--- a/picard/remotecommands/handlers.py
+++ b/picard/remotecommands/handlers.py
@@ -52,7 +52,10 @@ from urllib.parse import urlparse
 
 from PyQt6 import QtCore
 
-from picard import log
+from picard import (
+    PICARD_PROTOCOL_SCHEME,
+    log,
+)
 from picard.const.sys import IS_WIN
 from picard.file import File
 from picard.util import thread
@@ -73,6 +76,7 @@ class ParseItemsToLoad:
         self.files = set()
         self.mbids = set()
         self.urls = set()
+        self.custom_urls = set()
 
         for item in items:
             parsed = urlparse(item)
@@ -87,6 +91,8 @@ class ParseItemsToLoad:
             elif parsed.scheme in {'http', 'https'}:
                 # .path returns / before actual link
                 self.urls.add(parsed.path[1:])
+            elif parsed.scheme == PICARD_PROTOCOL_SCHEME:
+                self.custom_urls.add(item)
             elif IS_WIN and self.WINDOWS_DRIVE_TEST.match(item):
                 # Treat all single-character schemes as part of the file spec to allow
                 # specifying a drive identifier on Windows systems.

--- a/picard/remotecommands/handlers.py
+++ b/picard/remotecommands/handlers.py
@@ -48,6 +48,7 @@ import time
 from urllib.parse import urlparse
 
 from picard import (
+    PICARD_PROTOCOL_SCHEME,
     log,
     tagger_instance,
 )
@@ -71,6 +72,7 @@ class ParseItemsToLoad:
         self.files = set()
         self.mbids = set()
         self.urls = set()
+        self.custom_urls = set()
 
         for item in items:
             parsed = urlparse(item)
@@ -85,6 +87,8 @@ class ParseItemsToLoad:
             elif parsed.scheme in {'http', 'https'}:
                 # .path returns / before actual link
                 self.urls.add(parsed.path[1:])
+            elif parsed.scheme == PICARD_PROTOCOL_SCHEME:
+                self.custom_urls.add(item)
             elif IS_WIN and self.WINDOWS_DRIVE_TEST.match(item):
                 # Treat all single-character schemes as part of the file spec to allow
                 # specifying a drive identifier on Windows systems.

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -81,6 +81,7 @@ from picard import (
     PICARD_APP_NAME,
     PICARD_FANCY_VERSION_STR,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     acoustid,
     config as _cfg,
     log,
@@ -820,20 +821,25 @@ class Tagger(QtWidgets.QApplication):
         if config.setting['browser_integration']:
             self.browser_integration.start()
         else:
-            self.browser_integration.stop()
+            self.browser_integration.stop(stop_url_handler=False)
 
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):
             event.run()
         elif event.type() == QtCore.QEvent.Type.FileOpen:
-            file = event.file()
-            self.add_paths([file])
-            if IS_HAIKU:
-                self.bring_tagger_front()
-            # We should just return True here, except that seems to
-            # cause the event's sender to get a -9874 error, so
-            # apparently there's some magic inside QFileOpenEvent...
-            return 1
+            url = event.url()
+            log.debug('Received file open event: %r', url)
+            if url.isLocalFile():
+                self.add_paths([url.toLocalFile()])
+                if IS_HAIKU:
+                    self.bring_tagger_front()
+                # We should just return True here, except that seems to
+                # cause the event's sender to get a -9874 error, so
+                # apparently there's some magic inside QFileOpenEvent...
+                return 1
+            elif url.scheme() == PICARD_PROTOCOL_SCHEME:
+                self.browser_integration.url_handler(url)
+                return 1
         return super().event(event)
 
     def _file_loaded(self, file, target=None, remove_file=False, unmatched_files=None):
@@ -1621,7 +1627,7 @@ If a new instance will not be spawned files/directories will be passed to the ex
 
     args.processable = []
     for path in args.FILE_OR_URL:
-        if not urlparse(path).netloc:
+        if not urlparse(path).scheme:
             try:
                 path = os.path.abspath(path)
             except FileNotFoundError:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -77,6 +77,7 @@ from picard import (
     PICARD_APP_NAME,
     PICARD_FANCY_VERSION_STR,
     PICARD_ORG_NAME,
+    PICARD_PROTOCOL_SCHEME,
     acoustid,
     config as _cfg,
     log,
@@ -847,7 +848,7 @@ class Tagger(QtWidgets.QApplication):
         if config.setting['browser_integration']:
             self.browser_integration.start()
         else:
-            self.browser_integration.stop()
+            self.browser_integration.stop(stop_url_handler=False)
 
     _BATCH_TIME_BUDGET = 0.050  # 50ms per batch (~20 yields/sec)
     _callback_queue: ClassVar[list] = []
@@ -887,14 +888,19 @@ class Tagger(QtWidgets.QApplication):
                 self._callback_timer_running = True
                 QtCore.QTimer.singleShot(0, self._process_callback_batch)
         elif event.type() == QtCore.QEvent.Type.FileOpen:
-            file = event.file()
-            self.add_paths([file])
-            if IS_HAIKU:
-                self.bring_tagger_front()
-            # We should just return True here, except that seems to
-            # cause the event's sender to get a -9874 error, so
-            # apparently there's some magic inside QFileOpenEvent...
-            return 1
+            url = event.url()
+            log.debug('Received file open event: %r', url)
+            if url.isLocalFile():
+                self.add_paths([url.toLocalFile()])
+                if IS_HAIKU:
+                    self.bring_tagger_front()
+                # We should just return True here, except that seems to
+                # cause the event's sender to get a -9874 error, so
+                # apparently there's some magic inside QFileOpenEvent...
+                return 1
+            elif url.scheme() == PICARD_PROTOCOL_SCHEME:
+                self.browser_integration.url_handler(url)
+                return 1
         return super().event(event)
 
     def _process_callback_batch(self) -> None:
@@ -1720,7 +1726,7 @@ def process_cmdline_args():
 
     args.processable = []
     for path in args.FILE_OR_URL:
-        if not urlparse(path).netloc:
+        if not urlparse(path).scheme:
             try:
                 path = os.path.abspath(path)
             except FileNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ from picard import (  # noqa: E402
     PICARD_APP_NAME,
     PICARD_DESKTOP_NAME,
     PICARD_DISPLAY_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION,
 )
 
@@ -176,6 +177,7 @@ class picard_build(build):
             installer_args = {
                 'display-name': PICARD_DISPLAY_NAME,
                 'file-version': file_version_str,
+                'protocol': PICARD_PROTOCOL_SCHEME,
             }
             if os.path.isfile('installer/picard-setup.nsi.in'):
                 generate_file(
@@ -433,6 +435,7 @@ class picard_build_appxmanifest(Command):
                 'short-name': PICARD_APP_NAME,
                 'publisher': os.environ.get('PICARD_APPX_PUBLISHER', default_publisher),
                 'version': '.'.join(str(v) for v in store_version),
+                'protocol': PICARD_PROTOCOL_SCHEME,
             },
         )
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ from picard import (  # noqa: E402
     PICARD_APP_NAME,
     PICARD_DESKTOP_NAME,
     PICARD_DISPLAY_NAME,
+    PICARD_PROTOCOL_SCHEME,
     PICARD_VERSION,
 )
 
@@ -164,6 +165,7 @@ class picard_build(build):
             installer_args = {
                 'display-name': PICARD_DISPLAY_NAME,
                 'file-version': file_version_str,
+                'protocol': PICARD_PROTOCOL_SCHEME,
             }
             if os.path.isfile('installer/picard-setup.nsi.in'):
                 generate_file(
@@ -419,6 +421,7 @@ class picard_build_appxmanifest(Command):
                 'short-name': PICARD_APP_NAME,
                 'publisher': os.environ.get('PICARD_APPX_PUBLISHER', default_publisher),
                 'version': '.'.join(str(v) for v in store_version),
+                'protocol': PICARD_PROTOCOL_SCHEME,
             },
         )
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3040
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This PR implements a custom URL handler in an attempt to provide a solution for PICARD-3040. This PR focuses on adding the ability to handle the protocol to Picard and register the handler on various systems.

The handler allows opening URIs like `org.musicbrainz.picard:openalbum?id=3fd4b04a-28fa-45b7-89d7-bcb883be287c`.

# Solution

- Implement the protocol handler based on the existing browser integration
- Enable support for handling the custom URLs via command line (Linux and Windows) and via a handler registered with `QDesktopServices.setUrlHandler` (macOS).
- Register the handler on macOS, Linux and Windows. This depends both on the system and the installation method.


# Action
- Test on different systems
- This PR does not in any way actually use the handler. For OAuth this would require setting the callback URL accordingly (which currently requires us to register a separate "App" on MusicBrainz.org with the custom handler). For tagger buttons this would need some changes on MusicBrainz.org itself.
