### PR TITLE
PICARD-3038: Fix crashes and editing of wrong indexes in edit tag dialog

### DIFF
--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -233,6 +233,7 @@ class EditTagDialog(PicardDialog):
         model = self.ui.value_list.model()
         model.rowsInserted.connect(self.on_rows_inserted)
         model.rowsRemoved.connect(self.on_rows_removed)
+        model.rowsMoved.connect(self.on_rows_moved)
 
     def keyPressEvent(self, event):
         if (event.modifiers() == QtCore.Qt.KeyboardModifier.NoModifier
@@ -307,6 +308,13 @@ class EditTagDialog(PicardDialog):
     def on_rows_removed(self, parent, first, last):
         for row in range(first, last + 1):
             del self._modified_tag()[row]
+
+    def on_rows_moved(self, parent, start, end, destination, row):
+        modified_tag = self._modified_tag()
+        moved_values = modified_tag[start:end + 1]
+        del modified_tag[start:end + 1]
+        for value in reversed(moved_values):
+            modified_tag.insert(row, value)
 
     def move_row_up(self):
         """Move the currently selected row up in the list."""

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -203,7 +203,7 @@ class EditTagDialog(PicardDialog):
     def _setup_tag_combobox(self):
         """Set up the tag name combobox with supported tags."""
         self.default_tags = self._get_supported_tags()
-        visible_tags = [tn for tn in self.default_tags if not tn.startswith("~")]
+        visible_tags = (tn for tn in self.default_tags if not tn.startswith("~"))
 
         self.ui.tag_names.addItem("")
         self.ui.tag_names.addItems(visible_tags)
@@ -461,7 +461,6 @@ class EditTagDialog(PicardDialog):
         Args:
             values: List of tag values to add
         """
-        values = [v for v in values if v] or [""]
         for value in values:
             item = self._create_value_item(value)
             self.value_list.addItem(item)
@@ -511,7 +510,7 @@ class EditTagDialog(PicardDialog):
         """
         return self.modified_tags.setdefault(
             self.tag,
-            list(self.metadata_box.tag_diff.new[self.tag]) or [""]
+            list(self.metadata_box.tag_diff.new[self.tag])
         )
 
     def _modified_tags_without_empty_values(self):

--- a/picard/ui/edittagdialog.py
+++ b/picard/ui/edittagdialog.py
@@ -267,8 +267,7 @@ class EditTagDialog(PicardDialog):
 
     def add_value(self):
         """Add a new empty value to the value list and start editing it."""
-        item = QtWidgets.QListWidgetItem()
-        item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsEditable)
+        item = self._create_value_item('')
         self.value_list.addItem(item)
         self.value_list.setCurrentItem(item)
         self.value_list.editItem(item)


### PR DESCRIPTION
The visual representation could differ from the underlying storage. This could cause index out of range exceptions. Also empty values were omitted in display, causing the wrong indexes to update when editing.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3038
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This change addresses crashes and editing issues in the edit tag dialog. Specifically this fixes two issues:

- When removing all values from a tag, then switching to another tag and back to the original, editing or removing the shown empty row causes an "index out of range" exception.
- When clearing values (empty value, but keeping the row, then switching to another tag and back to the original, editing would update the wrong indexes of the underlying stored data (because empty values were not displayed but still present in the underlying data).

See my comment in PICARD-3038 for more details on how to reproduce both issues.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. Keep empty rows when switching between tags. This keeps the same display if user switches between tags and avoids the displayed data being stored differently from the data. Empty rows will still be removed on saving.
2. Do not add an empty `[""]` when preparing the displayed data. This was the cause for the crash after removing all values, as the underlying data was an empty list. Also this is not needed, as `add_or_edit_value()` takes care of adding and displaying at least one empty row.

For 1. an alternative way would be to cleanup empty rows in stored data when switching tags. But my reasoning is that the user, if they emptied a row and just switch back and forth between tags, should still see the same view.

I could not reproduce the exact issue as originally reported in PICARD-3038, where there is an unexpected empty row added, so I cannot verify it is solved. As the exception is also about "index out of range" it clearly is also caused by differences in data storage in `modified_tags`  and the visual representation. I think there are good chances this is hence also fixed by these changes, as it eliminates the two reasons I could find for differences in data.