### PR TITLE
PICARD-2192: Fix macos arm builds

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -13,20 +13,14 @@ jobs:
         - macos-deployment-version: '11.0'
           runner: 'macos-13'
           target-arch: 'x86_64'
-          python-version: 3.13.1-macos11
-          python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b
         - macos-deployment-version: '11.0'
           runner: 'macos-14'
           target-arch: 'arm64'
-          python-version: 3.13.1-macos11
-          python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b
     env:
       DISCID_VERSION: 0.6.4
       DISCID_SHA256SUM: 829133dd38acbdaa2b989de59e256c8d139ac34cb4dd4b8fd3c9d55a97c824f3
       FPCALC_VERSION: 1.5.1
       FPCALC_SHA256SUM: d4d8faff4b5f7c558d9be053da47804f9501eaa6c2f87906a9f040f38d61c860
-      PYTHON_VERSION: ${{ matrix.setup.python-version }}
-      PYTHON_SHA256SUM: ${{ matrix.setup.python-sha256sum }}
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.setup.macos-deployment-version }}
       TARGET_ARCH: ${{ matrix.setup.target-arch }}
       CODESIGN: 0
@@ -35,6 +29,14 @@ jobs:
       with:
         fetch-depth: 0  # Fetch entire history, needed for setting the build number
     - run: git fetch --depth=1 origin +refs/tags/release-*:refs/tags/release-*
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements-build.txt
+          requirements-macos-11.0.txt
     - name: Setup macOS build environment
       run: |
         ./scripts/package/macos-setup.sh

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -6,15 +6,17 @@ permissions: {}
 
 jobs:
   package-macos:
-    runs-on: macos-13
+    runs-on: ${{ matrix.setup.runner }}
     strategy:
       matrix:
         setup:
         - macos-deployment-version: '11.0'
+          runner: 'macos-13'
           target-arch: 'x86_64'
           python-version: 3.13.1-macos11
           python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b
         - macos-deployment-version: '11.0'
+          runner: 'macos-14'
           target-arch: 'arm64'
           python-version: 3.13.1-macos11
           python-sha256sum: 67c6f0a3190851e0013214d5abd725a42ec398ff1b50eec47826820fd052d86b

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -85,12 +85,12 @@ jobs:
         python-version: 3.13
     - uses: actions/download-artifact@v4
       with:
-        name: macos-app-10.14
+        name: macos-app-11.0-x86_64
         path: artifacts/
-    # - uses: actions/download-artifact@v4
-    #   with:
-    #     name: windows-signed-app
-    #     path: artifacts/
+    - uses: actions/download-artifact@v4
+      with:
+        name: macos-app-11.0-arm64
+        path: artifacts/
     - uses: actions/download-artifact@v4
       with:
         name: windows-store-app

--- a/scripts/package/macos-package-app.sh
+++ b/scripts/package/macos-package-app.sh
@@ -71,7 +71,7 @@ if [ "$CODESIGN" = '1' ]; then
 fi
 
 # Only test the app if it was codesigned, otherwise execution likely fails
-if [ "$CODESIGN" = '1' ] && [ "$TARGET_ARCH" = 'x86_64' ]; then
+if [ "$CODESIGN" = '1' ]; then
   "$APP_BUNDLE/Contents/MacOS/picard-run" --long-version --no-crash-dialog || echo "Failed running picard-run"
   VERSIONS=$("$APP_BUNDLE/Contents/MacOS/picard-run" --long-version --no-crash-dialog)
   echo "$VERSIONS"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2192
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Actually build on an arm64 runner. Previously the build pulled the x86_64 binaries for Qt6, which prevented the app to run. Also this way the code to test running the executable can be actually be run during build.

This also changes the install to use Python via actions/setup-python. This is consistent with other builds we have, and it fixes an issue with the system wide installation specifically on ARM refusing to install PyPI packages.

The builds actually should use a venv, but that's another story :D