### PR TITLE
PICARD-3044: Fix ~filepath sometimes being editable in metadata list

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -644,8 +644,8 @@ class MetadataBox(QtWidgets.QTableWidget):
 
         self.setRowCount(len(self.tag_diff.tag_names))
 
-        orig_flags = QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled
-        new_flags = orig_flags | QtCore.Qt.ItemFlag.ItemIsEditable
+        readonly_item_flags = QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled
+        editable_item_flags = readonly_item_flags | QtCore.Qt.ItemFlag.ItemIsEditable
         alignment = QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
 
         for i, tag in enumerate(self.tag_diff.tag_names):
@@ -655,7 +655,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             tag_item = self.item(i, self.COLUMN_TAG)
             if not tag_item:
                 tag_item = QtWidgets.QTableWidgetItem()
-                tag_item.setFlags(orig_flags)
+                tag_item.setFlags(readonly_item_flags)
                 font = tag_item.font()
                 font.setBold(True)
                 tag_item.setFont(font)
@@ -666,7 +666,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             orig_item = self.item(i, self.COLUMN_ORIG)
             if not orig_item:
                 orig_item = QtWidgets.QTableWidgetItem()
-                orig_item.setFlags(orig_flags)
+                orig_item.setFlags(readonly_item_flags)
                 orig_item.setTextAlignment(alignment)
                 self.setItem(i, self.COLUMN_ORIG, orig_item)
             self._set_item_value(orig_item, self.tag_diff.orig, tag)
@@ -676,11 +676,12 @@ class MetadataBox(QtWidgets.QTableWidget):
             if not new_item:
                 new_item = QtWidgets.QTableWidgetItem()
                 new_item.setTextAlignment(alignment)
-                if self.tag_diff.is_readonly(tag):
-                    new_item.setFlags(orig_flags)
-                else:
-                    new_item.setFlags(new_flags)
                 self.setItem(i, self.COLUMN_NEW, new_item)
+
+            if self.tag_diff.is_readonly(tag):
+                new_item.setFlags(readonly_item_flags)
+            else:
+                new_item.setFlags(editable_item_flags)
             self._set_item_value(new_item, self.tag_diff.new, tag)
             font = new_item.font()
             strikeout = self.tag_diff.tag_status(tag) == TagStatus.REMOVED


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3044
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Always set the QTableWidgetItem flags, as items can be reused. If a previously readable QTableWidgetItem was reused the field meant to be readonly was suddenly writable.
