### PR TITLE
PICARD-3045: Fail safe if the parameter passed to format_time cannot be converted to a float

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -274,8 +274,14 @@ class MetadataBox(QtWidgets.QTableWidget):
                 value = self.tag_diff.orig[tag]
             elif column == self.COLUMN_NEW:
                 value = self.tag_diff.new[tag]
+
             if tag == '~length':
-                value = [format_time(value or 0), ]
+                try:
+                    value = float(value)
+                    value = [format_time(value or 0), ]
+                except (TypeError, ValueError):
+                    value = ['']
+                
             if value is not None:
                 self.tagger.clipboard().setText(MULTI_VALUED_JOINER.join(value))
                 self.clipboard = value

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -278,7 +278,8 @@ class MetadataBox(QtWidgets.QTableWidget):
             if tag == '~length':
                 try:
                     value = [format_time(value or 0), ]
-                except (TypeError, ValueError):
+                except (TypeError, ValueError) as why:
+                    log.warning(why)
                     value = ['']
 
             if value is not None:

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -280,7 +280,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                     value = [format_time(value or 0), ]
                 except (TypeError, ValueError):
                     value = ['']
-                
+
             if value is not None:
                 self.tagger.clipboard().setText(MULTI_VALUED_JOINER.join(value))
                 self.clipboard = value

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -40,6 +40,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import log
 from picard.album import Album
 from picard.browser.filelookup import FileLookup
 from picard.cluster import Cluster

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -277,7 +277,6 @@ class MetadataBox(QtWidgets.QTableWidget):
 
             if tag == '~length':
                 try:
-                    value = float(value)
                     value = [format_time(value or 0), ]
                 except (TypeError, ValueError):
                     value = ['']

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -302,10 +302,7 @@ def samefile(path1, path2):
 def format_time(ms, display_zero=False):
     """Formats time in milliseconds to a string representation."""
     # Ensure that the input represents a number
-    try:
-        ms = float(ms)
-    except (TypeError, ValueError):
-        ms = 0
+    ms = float(ms)
 
     if ms == 0 and not display_zero:
         return "?:??"

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -301,7 +301,12 @@ def samefile(path1, path2):
 
 def format_time(ms, display_zero=False):
     """Formats time in milliseconds to a string representation."""
-    ms = float(ms)
+    # Ensure that the input represents a number
+    try:
+        ms = float(ms)
+    except (TypeError, ValueError):
+        ms = 0
+    
     if ms == 0 and not display_zero:
         return "?:??"
     duration_seconds = round(ms / 1000)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -306,7 +306,7 @@ def format_time(ms, display_zero=False):
         ms = float(ms)
     except (TypeError, ValueError):
         ms = 0
-    
+
     if ms == 0 and not display_zero:
         return "?:??"
     duration_seconds = round(ms / 1000)

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -301,9 +301,7 @@ def samefile(path1, path2):
 
 def format_time(ms, display_zero=False):
     """Formats time in milliseconds to a string representation."""
-    # Ensure that the input represents a number
     ms = float(ms)
-
     if ms == 0 and not display_zero:
         return "?:??"
     duration_seconds = round(ms / 1000)


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Added exception handling for passing bad data to format_time()

# Problem
Calls to `format_time()` can pass data that cannot be converted to a float, causing a crash.
* JIRA ticket: PICARD-3045

# Solution
Wrapping
```ms = float(ms)```
With exception handling means that callers can pass non-numerical strings or unexpected datatypes without causing a crash

