### PR TITLE
Ensure that format_time() only expects integer values for ms

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -300,8 +300,18 @@ def samefile(path1, path2):
 
 
 def format_time(ms, display_zero=False):
-    """Formats time in milliseconds to a string representation."""
+    """Formats time in milliseconds to a string representation.
+
+    Args:
+        ms: Time in milliseconds, must be positive.
+        display_zero: If False, times of 0ms are displayed as '?:??'
+    Raises:
+        ValueError: If `ms` is negative.
+        TypeError: If `ms` is not convertable to an integer.
+    """
     ms = float(ms)
+    if ms < 0:
+        raise ValueError("ms must be greater than or equal to 0")
     if ms == 0 and not display_zero:
         return "?:??"
     duration_seconds = round(ms / 1000)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -258,10 +258,17 @@ class FormatTimeTest(PicardTestCase):
         self.assertEqual("0:00", util.format_time(0, display_zero=True))
         self.assertEqual("3:00", util.format_time(179750))
         self.assertEqual("3:00", util.format_time(179500))
+        self.assertEqual("3:00", util.format_time(179500.5))
         self.assertEqual("2:59", util.format_time(179499))
         self.assertEqual("59:59", util.format_time(3599499))
         self.assertEqual("1:00:00", util.format_time(3599500))
         self.assertEqual("1:02:59", util.format_time(3779499))
+        with self.assertRaises(ValueError):
+            util.format_time(-40000)
+        with self.assertRaises(ValueError):
+            util.format_time("Hello World")
+        with self.assertRaises(TypeError):
+            util.format_time(list())
 
 
 class HiddenFileTest(PicardTestCase):


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [X] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

# Problem
`format_time()` should only expect to work for positive numbers, however it currently handles negative values and returns negative times.

# Solution
Raise a ValueError if the passed value is a negative.

Added function documentation and tests.
