### PR TITLE
Added utility function to update tag_names in TagDiff

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -608,25 +608,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
                 tag_diff.objects += 1
 
-        all_tags = set(list(tag_diff.old) + list(tag_diff.new))
-        common_tags = [tag for tag in top_tags if tag in all_tags]
-        tag_names = common_tags + sorted(all_tags.difference(common_tags),
-                                         key=lambda x: display_tag_name(x).lower())
-
-        if config.persist['show_changes_first']:
-            tags_by_status = {}
-
-            for tag in tag_names:
-                tags_by_status.setdefault(tag_diff.tag_status(tag), []).append(tag)
-
-            for status in (TagStatus.CHANGED, TagStatus.ADDED,
-                           TagStatus.REMOVED, TagStatus.UNCHANGED):
-                tag_diff.tag_names += tags_by_status.pop(status, [])
-        else:
-            tag_diff.tag_names = [
-                tag for tag in tag_names if
-                tag_diff.status[tag] != TagStatus.EMPTY]
-
+        tag_diff.update_tag_names(config.persist['show_changes_first'], top_tags)
         return tag_diff
 
     def _update_items(self, result=None, error=None):

--- a/picard/ui/metadatabox/tagdiff.py
+++ b/picard/ui/metadatabox/tagdiff.py
@@ -41,7 +41,7 @@ from collections import (
 from picard.i18n import ngettext
 from picard.metadata import MULTI_VALUED_JOINER
 from picard.util import format_time
-
+from picard.util.tags import display_tag_name
 
 class TagStatus:
     NONE = 0
@@ -311,3 +311,33 @@ class TagDiff:
             if status & s == s:
                 return s
         return TagStatus.UNCHANGED
+
+    def update_tag_names(self, changes_first=False, top_tags=[]):
+        """
+        Updates the list of tag names to be displayed.
+
+        The tag names are sorted based on their name with the top_tags, and optionally 
+        the changed tags, first.
+
+        Args:
+            changes_first (bool): Whether to display changed tags first.
+            top_tags (set): Set of tags to always be displayed at the top.
+        """
+        all_tags = set(list(self.old) + list(self.new))
+        common_tags = [tag for tag in top_tags if tag in all_tags]
+        tag_names = common_tags + sorted(all_tags.difference(common_tags),
+                                         key=lambda x: display_tag_name(x).lower())
+
+        if changes_first:
+            tags_by_status = {}
+
+            for tag in tag_names:
+                tags_by_status.setdefault(self.tag_status(tag), []).append(tag)
+
+            for status in (TagStatus.CHANGED, TagStatus.ADDED,
+                           TagStatus.REMOVED, TagStatus.UNCHANGED):
+                self.tag_names += tags_by_status.pop(status, [])
+        else:
+            self.tag_names = [
+                tag for tag in tag_names if
+                self.status[tag] != TagStatus.EMPTY]

--- a/test/test_tagdiff.py
+++ b/test/test_tagdiff.py
@@ -205,6 +205,34 @@ class TestTagDiff(PicardTestCase):
         self.tag_diff.add("artist", old=["Artist 1"], new=["Artist 2"], removable=False)
         self.assertEqual(self.tag_diff.status["artist"], TagStatus.CHANGED | TagStatus.NOTREMOVABLE)
 
+    def test_update_tag_names(self):
+        self.tag_diff.add("title", old=["Title 1"], new=["Title 2"])
+        self.tag_diff.add("album", old=["Album 1"])
+        self.tag_diff.add("artist", new=["Artist 2"])
+        self.tag_diff.update_tag_names()
+        self.assertEqual(self.tag_diff.tag_names, ["album", "artist", "title"])
+
+    def test_update_tag_names_top_tags(self):
+        self.tag_diff.add("title", old=["Title 1"], new=["Title 2"])
+        self.tag_diff.add("album", old=["Album 1"])
+        self.tag_diff.add("artist", new=["Artist 2"])
+        self.tag_diff.update_tag_names(top_tags={"title"})
+        self.assertEqual(self.tag_diff.tag_names, ["title", "album", "artist"])
+
+    def test_update_tag_names_changes_first(self):
+        self.tag_diff.add("title", old=["Title 1"], new=["Title 2"])
+        self.tag_diff.add("album", old=["Album 1"])
+        self.tag_diff.add("artist", new=["Artist 2"])
+        self.tag_diff.update_tag_names(changes_first=True)
+        self.assertEqual(self.tag_diff.tag_names, ["title", "artist", "album"])
+
+    def test_update_tag_names_top_tags_and_changes(self):
+        self.tag_diff.add("title", old=["Title 1"])
+        self.tag_diff.add("album", old=["Album 1"])
+        self.tag_diff.add("artist", new=["Artist 2"])
+        self.tag_diff.update_tag_names(changes_first=True, top_tags={"title"})
+        self.assertEqual(self.tag_diff.tag_names, ["artist", "title", "album"])
+
     @staticmethod
     def _special_handler(old, new):
         for old_value, new_value in zip(old, new):


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [X] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

`TagDiff` has a `tag_names` member to represent the order that the tags should be displayed. It has some quite involved logic about what order they should be sorted in, though it is deterministic based on the contents of `new` and `old` members of the `TagDiff`

# Solution

Moved the ordering logic into the `TagDiff` class, so `MetaDataBox.updateTags()` populates the contents of the `TagDiff` and lets the `TagDiff` populate its `tag_names` member.

Added tests for this functionality.

# Action
