### PR TITLE
PICARD-3029: Incorrect mapping of case-variant tags in MP4 files

### DIFF
--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -265,7 +265,19 @@ class MP4File(File):
                 name = 'lyrics'
             if name == 'comment:':
                 name = 'comment'
-            if name in self.__r_text_tags:
+            if name in self.__r_freeform_tags_ci:
+                values = [v.encode('utf-8') for v in values]
+                delall_ci(tags, self.__r_freeform_tags_ci[name])
+                if name in self.__casemap:
+                    name = self.__casemap[name]
+                else:
+                    name = self.__r_freeform_tags_ci[name]
+                tags[name] = values
+            elif name in self.__casemap:
+                values = [v.encode('utf-8') for v in values]
+                name = self.__casemap.get(name, name)
+                tags['----:com.apple.iTunes:' + name] = values
+            elif name in self.__r_text_tags:
                 tags[self.__r_text_tags[name]] = values
             elif name in self.__r_bool_tags:
                 tags[self.__r_bool_tags[name]] = (values[0] == '1')
@@ -277,14 +289,6 @@ class MP4File(File):
             elif name in self.__r_freeform_tags:
                 values = [v.encode('utf-8') for v in values]
                 tags[self.__r_freeform_tags[name]] = values
-            elif name in self.__r_freeform_tags_ci:
-                values = [v.encode('utf-8') for v in values]
-                delall_ci(tags, self.__r_freeform_tags_ci[name])
-                if name in self.__casemap:
-                    name = self.__casemap[name]
-                else:
-                    name = self.__r_freeform_tags_ci[name]
-                tags[name] = values
             elif name == 'musicip_fingerprint':
                 tags['----:com.apple.iTunes:fingerprint'] = [b'MusicMagic Fingerprint%s' % v.encode('ascii') for v in values]
             elif self.supports_tag(name) and name not in self.__other_supported_tags:
@@ -353,7 +357,12 @@ class MP4File(File):
     def _get_tag_name(self, name):
         if name.startswith('lyrics:'):
             name = 'lyrics'
-        if name in self.__r_text_tags:
+        if name in self.__r_freeform_tags_ci:
+            return self.__r_freeform_tags_ci[name]
+        if name in self.__casemap:
+            name = self.__casemap.get(name, name)
+            return '----:com.apple.iTunes:' + name
+        elif name in self.__r_text_tags:
             return self.__r_text_tags[name]
         elif name in self.__r_bool_tags:
             return self.__r_bool_tags[name]
@@ -361,8 +370,6 @@ class MP4File(File):
             return self.__r_int_tags[name]
         elif name in self.__r_freeform_tags:
             return self.__r_freeform_tags[name]
-        elif name in self.__r_freeform_tags_ci:
-            return self.__r_freeform_tags_ci[name]
         elif name == 'musicip_fingerprint':
             return '----:com.apple.iTunes:fingerprint'
         elif name in {'tracknumber', 'totaltracks'}:

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -359,7 +359,7 @@ class MP4File(File):
             name = 'lyrics'
         if name in self.__r_freeform_tags_ci:
             return self.__r_freeform_tags_ci[name]
-        if name in self.__casemap:
+        elif name in self.__casemap:
             name = self.__casemap.get(name, name)
             return '----:com.apple.iTunes:' + name
         elif name in self.__r_text_tags:

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -81,7 +81,7 @@ class CommonMP4Tests:
         def test_ci_tags_preserve_case(self):
             # Ensure values are not duplicated on repeated save and are saved
             # case preserving.
-            for name in ('Replaygain_Album_Peak', "Label", 'Custom', 'äöüéß\0'):
+            for name in ('Replaygain_Album_Peak', 'Label', 'Custom', 'äöüéß\0'):
                 tags = mutagen.mp4.MP4Tags()
                 tags['----:com.apple.iTunes:' + name] = [b'foo']
                 save_raw(self.filename, tags)

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -81,7 +81,7 @@ class CommonMP4Tests:
         def test_ci_tags_preserve_case(self):
             # Ensure values are not duplicated on repeated save and are saved
             # case preserving.
-            for name in ('Replaygain_Album_Peak', 'Custom', 'äöüéß\0'):
+            for name in ('Replaygain_Album_Peak', "Label", 'Custom', 'äöüéß\0'):
                 tags = mutagen.mp4.MP4Tags()
                 tags['----:com.apple.iTunes:' + name] = [b'foo']
                 save_raw(self.filename, tags)


### PR DESCRIPTION
# Summary  

* This is a…  
  * [X] Bug fix  
  * [ ] Feature addition  
  * [ ] Refactoring  
  * [ ] Minor/simple change (e.g., a typo)  
  * [ ] Other  

* **Description (1-2 sentences):**  
  A change has been applied to `mp4.py`, ensuring that `_casemap` is checked before applying pre-mappings. This prevents duplicate tags from being saved in the file.  

---  

# Problem  

Although `_casemap` correctly stores the capitalization of a tag when loading, an issue arises if a stored tag (e.g., `----:com.apple.iTunes:Label`) shares the same internal Picard tag as one of the pre-mapped cases (e.g., `label`). In such cases, the internal tag would be converted to the pre-mapped format (e.g., `----:com.apple.iTunes:LABEL`) when saving. This leads to duplicate tags in the saved file.  

* JIRA ticket (_optional_): [PICARD-3029](https://tickets.metabrainz.org/projects/PICARD/issues/PICARD-3029)  

---  

# Solution  

The fix prioritizes maintaining the original tag capitalization. When saving or deleting a tag, `_casemap` is checked before applying the pre-mapped cases.  

---  

# Action  

Additional actions required:  
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) 
* [ ] Other (please specify below)  

