### PR TITLE
PICARD-3054: Add new artist country variables

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -28,7 +28,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections import OrderedDict
 from types import SimpleNamespace
 
 from picard import log
@@ -43,6 +42,7 @@ from picard.util import (
     linear_combination_of_weights,
     parse_amazon_url,
     translate_from_sortname,
+    uniqify,
 )
 from picard.util.script_detector_weighted import detect_script_weighted
 
@@ -388,16 +388,6 @@ def artist_credit_from_node(node):
     return (artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries)
 
 
-def _format_artist_countries(countries: list):
-    if not countries:
-        return ''
-    # Use an OrderedDict to get a list of unique countries in the original countries order.
-    unique_countries = OrderedDict()
-    for country in countries:
-        unique_countries[country] = None
-    return ', '.join(list(unique_countries.keys()))
-
-
 def artist_credit_to_metadata(node, m, release=False):
     ids = [n['artist']['id'] for n in node]
     artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries = artist_credit_from_node(node)
@@ -407,7 +397,7 @@ def artist_credit_to_metadata(node, m, release=False):
         m['albumartistsort'] = artist_sort_name
         m['~albumartists'] = artist_names
         m['~albumartists_sort'] = artist_sort_names
-        m['~albumartistcountry'] = _format_artist_countries(artist_countries)
+        m['~albumartistcountry'] = ', '.join(uniqify(artist_countries))
         m['~albumartists_countries'] = artist_countries
     else:
         m['musicbrainz_artistid'] = ids
@@ -415,7 +405,7 @@ def artist_credit_to_metadata(node, m, release=False):
         m['artistsort'] = artist_sort_name
         m['artists'] = artist_names
         m['~artists_sort'] = artist_sort_names
-        m['~artistcountry'] = _format_artist_countries(artist_countries)
+        m['~artistcountry'] = ', '.join(uniqify(artist_countries))
         m['~artists_countries'] = artist_countries
 
 

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -369,7 +369,7 @@ def artist_credit_from_node(node):
         artist = artist_info['artist']
         if artist and 'id' in artist and artist['id']:
             # Add artist's country code if specified, otherwise 'XX' (Unknown Country)
-            artist_countries.append(artist['country'] if 'country' in artist else 'XX')
+            artist_countries.append(artist['country'] if 'country' in artist and artist['country'] else 'XX')
         translated_name, sort_name = _translate_artist_node(artist, config=config)
         has_translation = (translated_name != artist['name'])
         if has_translation:

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -395,10 +395,7 @@ def _format_artist_countries(countries: list):
     unique_countries = OrderedDict()
     for country in countries:
         unique_countries[country] = None
-    unique_countries = list(unique_countries.keys())
-    if len(unique_countries) < 2:
-        return unique_countries[0]
-    return f"{', '.join(unique_countries[0:-1])} & {unique_countries[-1]}"
+    return ', '.join(list(unique_countries.keys()))
 
 
 def artist_credit_to_metadata(node, m, release=False):

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -42,7 +42,6 @@ from picard.util import (
     linear_combination_of_weights,
     parse_amazon_url,
     translate_from_sortname,
-    uniqify,
 )
 from picard.util.script_detector_weighted import detect_script_weighted
 
@@ -397,7 +396,6 @@ def artist_credit_to_metadata(node, m, release=False):
         m['albumartistsort'] = artist_sort_name
         m['~albumartists'] = artist_names
         m['~albumartists_sort'] = artist_sort_names
-        m['~albumartistcountry'] = ', '.join(uniqify(artist_countries))
         m['~albumartists_countries'] = artist_countries
     else:
         m['musicbrainz_artistid'] = ids
@@ -405,7 +403,6 @@ def artist_credit_to_metadata(node, m, release=False):
         m['artistsort'] = artist_sort_name
         m['artists'] = artist_names
         m['~artists_sort'] = artist_sort_names
-        m['~artistcountry'] = ', '.join(uniqify(artist_countries))
         m['~artists_countries'] = artist_countries
 
 

--- a/test/data/ws_data/recording.json
+++ b/test/data/ws_data/recording.json
@@ -26,6 +26,7 @@
             "name": "Ed Sheeran",
             "joinphrase": "",
             "artist": {
+                "country": "GB",
                 "disambiguation": "famous UK singer-songwriter",
                 "name": "Ed Sheeran",
                 "sort-name": "Sheeran, Ed",

--- a/test/data/ws_data/recording_multi_artists_1.json
+++ b/test/data/ws_data/recording_multi_artists_1.json
@@ -1,0 +1,48 @@
+{
+    "disambiguation": "",
+    "video": false,
+    "id": "7684982a-efee-49e5-baf0-82a466f12508",
+    "title": "1000 Nights",
+    "length": 212306,
+    "artist-credit": [
+        {
+            "name": "Ed Sheeran",
+            "joinphrase": " feat. ",
+            "artist": {
+                "sort-name": "Sheeran, Ed",
+                "id": "b8a7c51f-362c-4dcb-a259-bc6e0095f0a6",
+                "name": "Ed Sheeran",
+                "disambiguation": "UK singer-songwriter, “Shape of You”",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "country": "GB",
+                "type": "Person"
+            }
+        },
+        {
+            "joinphrase": " & ",
+            "name": "Meek Mill",
+            "artist": {
+                "name": "Meek Mill",
+                "sort-name": "Meek Mill",
+                "id": "31bcadcc-e1da-4cad-bec8-2f4f1d41b095",
+                "country": "US",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": ""
+                }
+        },
+        {
+            "artist": {
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "",
+                "country": "US",
+                "type": "Person",
+                "sort-name": "Boogie Wit da Hoodie, A",
+                "id": "c1708d03-8a66-46eb-848e-fe0d233ffb39",
+                "name": "A Boogie Wit da Hoodie"
+            },
+            "joinphrase": "",
+            "name": "A Boogie Wit da Hoodie"
+        }
+    ]
+}

--- a/test/data/ws_data/recording_multi_artists_2.json
+++ b/test/data/ws_data/recording_multi_artists_2.json
@@ -1,0 +1,47 @@
+{
+    "disambiguation": "",
+    "video": false,
+    "id": "7684982a-efee-49e5-baf0-82a466f12508",
+    "title": "1000 Nights",
+    "length": 212306,
+    "artist-credit": [
+        {
+            "name": "Ed Sheeran",
+            "joinphrase": " feat. ",
+            "artist": {
+                "sort-name": "Sheeran, Ed",
+                "id": "b8a7c51f-362c-4dcb-a259-bc6e0095f0a6",
+                "name": "Ed Sheeran",
+                "disambiguation": "UK singer-songwriter, “Shape of You”",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "country": "GB",
+                "type": "Person"
+            }
+        },
+        {
+            "joinphrase": " & ",
+            "name": "Meek Mill",
+            "artist": {
+                "name": "Meek Mill",
+                "sort-name": "Meek Mill",
+                "id": "31bcadcc-e1da-4cad-bec8-2f4f1d41b095",
+                "country": "US",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": ""
+                }
+        },
+        {
+            "artist": {
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "",
+                "type": "Person",
+                "sort-name": "Boogie Wit da Hoodie, A",
+                "id": "c1708d03-8a66-46eb-848e-fe0d233ffb39",
+                "name": "A Boogie Wit da Hoodie"
+            },
+            "joinphrase": "",
+            "name": "A Boogie Wit da Hoodie"
+        }
+    ]
+}

--- a/test/data/ws_data/release.json
+++ b/test/data/ws_data/release.json
@@ -38,7 +38,8 @@
                     "id": "83d91898-7763-47d7-b03b-b92132375c47",
                     "disambiguation": "",
                     "sort-name": "Pink Floyd",
-                    "name": "Pink Floyd"
+                    "name": "Pink Floyd",
+                    "country": "GB"
                 },
                 "joinphrase": ""
             }
@@ -360,7 +361,8 @@
                     }
                 ],
                 "sort-name": "Pink Floyd",
-                "name": "Pink Floyd"
+                "name": "Pink Floyd",
+                "country": "GB"
             },
             "joinphrase": "",
             "name": "Pink Floyd"

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2018-2023, 2025 Philipp Wolfer
 # Copyright (C) 2020 dukeyin
-# Copyright (C) 2021 Bob Swift
+# Copyright (C) 2021, 2025 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
 # Copyright (C) 2023 David Kellner
 # Copyright (C) 2024 Rakim Middya
@@ -126,8 +126,10 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['releasecountry'], 'GB')
         self.assertEqual(m['releasestatus'], 'official')
         self.assertEqual(m['script'], 'Latn')
+        self.assertEqual(m['~albumartistcountry'], 'GB')
         self.assertEqual(m['~albumartists'], 'Pink Floyd')
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
+        self.assertEqual(m['~albumartists_countries'], 'GB')
         self.assertEqual(m['~releasecomment'], 'stereo')
         self.assertEqual(m['~releaseannotation'], 'Original Vinyl release')
         self.assertEqual(m['~releaselanguage'], 'eng')
@@ -298,6 +300,8 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~recordingtitle'], 'Thinking Out Loud')
         self.assertEqual(m['~recording_firstreleasedate'], '2014-06-20')
         self.assertEqual(m['~video'], '')
+        self.assertEqual(m['~artistcountry'], 'GB')
+        self.assertEqual(m['~artists_countries'], 'GB')
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
         self.assertEqual(t.folksonomy_tags, {
@@ -315,6 +319,34 @@ class RecordingTest(MBJSONTest):
         recording_to_metadata(self.json_doc, m, t)
         self.assertEqual(m['performer:vocals'], 'Ed Sheeran')
         self.assertEqual(m['performer:acoustic guitar'], 'Ed Sheeran')
+
+
+class RecordingMultiArtistsTest1(MBJSONTest):
+    """Test multiple artists with some common contries.
+    """
+
+    filename = 'recording_multi_artists_1.json'
+
+    def test_recording_multi_artists_1(self):
+        m = Metadata()
+        t = Track('1')
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['~artistcountry'], 'GB & US')
+        self.assertEqual(m['~artists_countries'], 'GB; US; US')
+
+
+class RecordingMultiArtistsTest2(MBJSONTest):
+    """Test multiple artists with one unknown (missing) country.
+    """
+
+    filename = 'recording_multi_artists_2.json'
+
+    def test_recording_multi_artists_2(self):
+        m = Metadata()
+        t = Track('1')
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['~artistcountry'], 'GB, US & XX')
+        self.assertEqual(m['~artists_countries'], 'GB; US; XX')
 
 
 class RecordingComposerCreditsTest(MBJSONTest):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -331,7 +331,7 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         m = Metadata()
         t = Track('1')
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['~artistcountry'], 'GB & US')
+        self.assertEqual(m['~artistcountry'], 'GB, US')
         self.assertEqual(m['~artists_countries'], 'GB; US; US')
 
 
@@ -345,7 +345,7 @@ class RecordingMultiArtistsTest2(MBJSONTest):
         m = Metadata()
         t = Track('1')
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['~artistcountry'], 'GB, US & XX')
+        self.assertEqual(m['~artistcountry'], 'GB, US, XX')
         self.assertEqual(m['~artists_countries'], 'GB; US; XX')
 
 

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -126,7 +126,6 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m['releasecountry'], 'GB')
         self.assertEqual(m['releasestatus'], 'official')
         self.assertEqual(m['script'], 'Latn')
-        self.assertEqual(m['~albumartistcountry'], 'GB')
         self.assertEqual(m['~albumartists'], 'Pink Floyd')
         self.assertEqual(m['~albumartists_sort'], 'Pink Floyd')
         self.assertEqual(m['~albumartists_countries'], 'GB')
@@ -300,7 +299,6 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~recordingtitle'], 'Thinking Out Loud')
         self.assertEqual(m['~recording_firstreleasedate'], '2014-06-20')
         self.assertEqual(m['~video'], '')
-        self.assertEqual(m['~artistcountry'], 'GB')
         self.assertEqual(m['~artists_countries'], 'GB')
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
@@ -331,7 +329,6 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         m = Metadata()
         t = Track('1')
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['~artistcountry'], 'GB, US')
         self.assertEqual(m['~artists_countries'], 'GB; US; US')
 
 
@@ -345,7 +342,6 @@ class RecordingMultiArtistsTest2(MBJSONTest):
         m = Metadata()
         t = Track('1')
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['~artistcountry'], 'GB, US, XX')
         self.assertEqual(m['~artists_countries'], 'GB; US; XX')
 
 


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

* **Describe this change in 1-2 sentences**:  Add new artist country variables.

# Problem

Changes have been made to the MusicBrainz webservice to include country information for all artists.  This is useful information that some users would like to be able to access from scripting within Picard.

* JIRA ticket (_optional_): PICARD-3054

# Solution

Add the following new variables:

~~**\_albumartistcountry**: A string showing a unique list of the country codes for all album artists.  If a country code is not provided by the webservice the code "XX" will be used.  Examples are "GB" (where all artists are from Great Britain), "GB & US" (where one or more artists are from Great Britain and one or more artists are from the United States), or "GB, US & XX" (where one or more artists are from Great Britain, one or more artists are from the United States, and one or more artists have no country code assigned).~~

**\_albumartists_countries**: A multi-value variable listing the country codes for all of the credited album artists, in the same order as the artists.  Duplicate country codes will be shown if there are more than one artist from the same country.  If a country code is not provided by the webservice the code "XX" will be used.  For example, if the first credited artist is from Great Britain and there are two other credited artists from Canada, the value would be "GB; CA; CA".

~~**\_artistcountry**: A string showing a unique list of the country codes for all track artists.  If a country code is not provided by the webservice the code "XX" will be used.  Examples are "GB" (where all artists are from Great Britain), "GB & US" (where one or more artists are from Great Britain and one or more artists are from the United States), or "GB, US & XX" (where one or more artists are from Great Britain, one or more artists are from the United States, and one or more artists have no country code assigned).~~

**\_artists_countries**: A multi-value variable listing the country codes for all of the credited track artists, in the same order as the artists.  Duplicate country codes will be shown if there are more than one artist from the same country.  If a country code is not provided by the webservice the code "XX" will be used.  For example, if the first credited artist is from Great Britain and there are two other credited artists from Canada, the value would be "GB; CA; CA".

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

We need to decide whether we want all four of these new variables, and if we want to use different variable names from those initially assigned.  **[Complete: Keep multi-value variables only.]**

We need to confirm the format of the values for the **\_albumartistcountry** and **\_artistcountry** variables, if we decide to keep them.  **[Complete: Variables removed.]**

We need to confirm how we want to handle artists with no country codes provided.  The initial code submission shows them with an Unknown Country code "XX".  This was done to ensure that the multi-value variables contain the same number of entries as there are credited artists to allow individual matching of country to artist.