### PR TITLE
PICARD-2750: Handle invalid LINK frames when saving MP3 files

### DIFF
--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -136,6 +136,7 @@ TAG_NAMES = {
     'totaltracks': N_('Total Tracks'),
     'tracknumber': N_('Track Number'),
     'website': N_('Artist Website'),
+    'user_website': N_('User Defined Website'),
     'work': N_('Work'),
     'writer': N_('Writer'),
 }


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
  
* **Description**: MP3 files with LINK frames that do not follow the ID3 specification cause mutagen exceptions when saving with ID3 v2.3 format. This fix handles invalid LINK frames to prevent errors during save operations.


# Problem

When processing MP3 files containing LINK frames that don't follow the ID3 specification, Picard returns an error of "Invalid frame ID" exception when saving with ID3 v2.3 format enabled.

Files from archive.org (like https://archive.org/details/yallcomesoundrec00page) store a null byte followed by a URL in the LINK frame instead of the required frame ID followed by URL. This invalid format causes mutagen to raise an exception during the ID3 v2.3 downgrade process.

Current workarounds include setting ID3 format to v2.4 or enabling "Clear existing tags" to remove the problematic frames. This fix proposes a handle for malformed LINK frames, preventing exceptions when saving with ID3 v2.3.

* JIRA ticket: PICARD-2750


# Solution

This fix addresses the exception by detecting and handling malformed LINK frames in MP3 files during the ID3 v2.3 saving process. When an invalid LINK frame is encountered (containing a null byte followed by URL instead of proper frame ID), it's transformed into a WXXX frame (user-defined website metadata/label).

This approach preserves the URL data from the malformed LINK frames by converting them to the appropriate frame type for URLs, rather than simply discarding the information. The conversion only happens when saving in ID3 v2.3 format, which would otherwise cause errors with these malformed frames.

While not the most comprehensive solution, this approach specifically targets the common issue with archive.org files without requiring UI changes or affecting performance. A more robust solution as suggested in the [community discussion](https://community.metabrainz.org/t/why-does-picard-refuse-to-save-these-mp3s/653191/11) could involve user prompts to review and decide on invalid tag data, but that would be a larger feature enhancement rather than a focused bug fix.

This implementation prioritizes stability for users of archive.org files while intelligently preserving the URL data in a proper ID3 frame format.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
