### PR TITLE
PICARD-3056: Set cover art local file chooser to FileMode.ExistingFiles

### DIFF
--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -275,8 +275,8 @@ class CoverArtBox(QtWidgets.QGroupBox):
         ])
         if file_chooser.exec():
             file_urls = file_chooser.selectedUrls()
-            if file_urls:
-                self.fetch_remote_image(file_urls[0])
+            for url in file_urls:
+                self.fetch_remote_image(url)
 
     def choose_image_from_url(self):
         url, ok = ImageURLDialog.display(parent=self)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -266,6 +266,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
     def choose_local_file(self):
         file_chooser = FileDialog(parent=self)
+        file_chooser.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFiles)
         extensions = ['*' + ext for ext in imageinfo.get_supported_extensions()]
         extensions.sort()
         file_chooser.setNameFilters([


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3056
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On macOS the cover art local file picker can crash. By default it seems to be allowing the selection of directories.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Ensure the cover art file picker can only select existing files, and not directories or new files, by setting `FileMode.ExistingFiles`.

Also I think there was no reason to limit this to the first selected file, allow adding all selected files as cover art.