### PR TITLE
Add new `_*artists_countries` variables to autocomplete list.

### DIFF
--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -65,8 +65,10 @@ from picard.ui.theme import theme
 
 EXTRA_VARIABLES = (
     '~absolutetracknumber',
+    '~albumartists_countries',
     '~albumartists_sort',
     '~albumartists',
+    '~artists_countries',
     '~artists_sort',
     '~datatrack',
     '~discpregap',


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds the new `%_albumartists_countries%` and `%_artists_countries%` variables to the script editor autocomplete list.

# Problem

Two new variables `%_albumartists_countries%` and `%_artists_countries%` were added in https://github.com/metabrainz/picard/pull/2628 but were not added to the script editor autocomplete list at that time (because I forgot).

* JIRA ticket (_optional_): PICARD-XXX

# Solution

This change adds the new `%_albumartists_countries%` and `%_artists_countries%` variables to the script editor autocomplete list.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

None.
