### PR TITLE
PICARD-3061: Add long descriptions to tags, display them in tooltips

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2017 Antonio Larrosa
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
-# Copyright (C) 2018, 2021, 2023 Bob Swift
+# Copyright (C) 2018, 2021, 2023, 2025 Bob Swift
 # Copyright (C) 2020 RomFouq
 # Copyright (C) 2021 Gabriel Ferreira
 # Copyright (C) 2021 Vladislav Karbovskii
@@ -86,6 +86,7 @@ PICARD_URLS = {
     'chromaprint':             "https://acoustid.org/chromaprint#download",
     'acoustid_apikey':         "https://acoustid.org/api-key",
     'acoustid_track':          "https://acoustid.org/track/",
+    'mb_doc':                  "https://musicbrainz.org/doc/",
 }
 
 # Various Artists MBID

--- a/picard/options.py
+++ b/picard/options.py
@@ -439,8 +439,11 @@ def init_options():
     pass
 
 
-def get_option_title(text):
-    key = ('setting', text)
-    if key not in Option.registry or not Option.registry[key].title:
-        return N_('No option title available')
-    return Option.registry[key].title
+def get_option_title(name):
+    key = ('setting', name)
+    if key not in Option.registry:
+        return None
+    title = Option.registry[key].title
+    if title:
+        return title
+    return N_("No title for setting '%s'") % name

--- a/picard/options.py
+++ b/picard/options.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2024 Giorgio Fontanive
 # Copyright (C) 2024 Laurent Monin
 # Copyright (C) 2025 Philipp Wolfer
+# Copyright (C) 2025 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -436,3 +437,10 @@ BoolOption('persist', 'script_editor_wordwrap', False)
 
 def init_options():
     pass
+
+
+def get_option_title(text):
+    key = ('setting', text)
+    if key not in Option.registry or not Option.registry[key].title:
+        return N_('No option title available')
+    return Option.registry[key].title

--- a/picard/options.py
+++ b/picard/options.py
@@ -208,10 +208,10 @@ ListOption('persist', 'options_pages_tree_state', [])
 # Fingerprinting
 TextOption('setting', 'acoustid_apikey', '')
 TextOption('setting', 'acoustid_fpcalc', '')
-TextOption('setting', 'fingerprinting_system', 'acoustid')
+TextOption('setting', 'fingerprinting_system', 'acoustid', title=N_('Use AcoustID audio fingerprinting'))
 IntOption('setting', 'fpcalc_threads', DEFAULT_FPCALC_THREADS)
 BoolOption('setting', 'ignore_existing_acoustid_fingerprints', False)
-BoolOption('setting', 'save_acoustid_fingerprints', False)
+BoolOption('setting', 'save_acoustid_fingerprints', False, title=N_('Save AcoustID fingerprints'))
 
 # picard/ui/options/general.py
 # General

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2021 Vladislav Karbovskii
-# Copyright (C) 2021-2023 Bob Swift
+# Copyright (C) 2021-2023, 2025 Bob Swift
 # Copyright (C) 2021-2023 Philipp Wolfer
 # Copyright (C) 2021-2024 Laurent Monin
 # Copyright (C) 2022 Marcin Szalowicz
@@ -35,6 +35,7 @@ _settings_groups = {}
 _groups_order = defaultdict(lambda: -1)
 _groups_count = 0
 _known_settings = set()
+_settings_titles = {}
 
 
 def profile_groups_order(group):
@@ -51,6 +52,7 @@ def profile_groups_add_setting(group, option_name, highlights, title=None):
         _settings_groups[group]['settings'] = []
     _settings_groups[group]['settings'].append(SettingDesc(option_name, highlights))
     _known_settings.add(option_name)
+    _settings_titles[option_name] = title
 
 
 def profile_groups_all_settings():
@@ -92,3 +94,9 @@ def profile_groups_reset():
     _groups_order = defaultdict(lambda: -1)
     _groups_count = 0
     _known_settings = set()
+
+
+def profile_setting_title(option_name):
+    if option_name not in _settings_titles:
+        return None
+    return _settings_titles[option_name]

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -35,7 +35,6 @@ _settings_groups = {}
 _groups_order = defaultdict(lambda: -1)
 _groups_count = 0
 _known_settings = set()
-_settings_titles = {}
 
 
 def profile_groups_order(group):
@@ -52,7 +51,6 @@ def profile_groups_add_setting(group, option_name, highlights, title=None):
         _settings_groups[group]['settings'] = []
     _settings_groups[group]['settings'].append(SettingDesc(option_name, highlights))
     _known_settings.add(option_name)
-    _settings_titles[option_name] = title
 
 
 def profile_groups_all_settings():
@@ -94,9 +92,3 @@ def profile_groups_reset():
     _groups_order = defaultdict(lambda: -1)
     _groups_count = 0
     _known_settings = set()
-
-
-def profile_setting_title(option_name):
-    if option_name not in _settings_titles:
-        return None
-    return _settings_titles[option_name]

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2021 Vladislav Karbovskii
-# Copyright (C) 2021-2023, 2025 Bob Swift
+# Copyright (C) 2021-2023 Bob Swift
 # Copyright (C) 2021-2023 Philipp Wolfer
 # Copyright (C) 2021-2024 Laurent Monin
 # Copyright (C) 2022 Marcin Szalowicz

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -62,7 +62,10 @@ from picard.util import (
     throttle,
 )
 from picard.util.preservedtags import PreservedTags
-from picard.util.tags import display_tag_name
+from picard.util.tags import (
+    display_tag_name,
+    display_tag_tooltip,
+)
 
 from .edittagdialog import (
     EditTagDialog,
@@ -790,6 +793,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         font = item.font()
         font.setBold(True)
         item.setFont(font)
+        item.setToolTip(display_tag_tooltip(tag))
 
     @staticmethod
     def _set_item_value(item, tags, tag, color, strikeout=False):

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2014 m42i
 # Copyright (C) 2020-2024 Laurent Monin
 # Copyright (C) 2020-2024 Philipp Wolfer
-# Copyright (C) 2021-2022 Bob Swift
+# Copyright (C) 2021-2022, 2025 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -53,7 +53,7 @@ from picard.script import (
     script_function_names,
 )
 from picard.util.tags import (
-    display_tag_name,
+    display_tag_tooltip,
     script_variable_tag_names,
 )
 
@@ -262,7 +262,7 @@ class VariableScriptToken(DocumentedScriptToken):
         if self._doc.characterAt(position) != '%':
             return None
         tag = self._read_allowed_chars(position + 1)
-        return display_tag_name(tag)
+        return display_tag_tooltip(tag)
 
 
 class UnicodeEscapeScriptToken(DocumentedScriptToken):

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -102,12 +102,12 @@ class TagVar:
                         contain markdown.
         is_preserved: the tag is preserved (boolean, default: False)
         is_hidden: the tag is "hidden", name will be prefixed with "~" (boolean, default: False)
-        is_script_variable: the tag cannot be used as script variable (boolean, default: True)
+        is_script_variable: the tag can be used as script variable (boolean, default: True)
         is_tag: the tag is an actual tag (not a calculated or derived one) (boolean, default: True)
         is_calculated: the tag is obtained by external calculation (boolean, default: False)
         is_file_info: the tag is a file information, displayed in file info box (boolean, default: False)
         is_from_mb: the tag information is provided from the MusicBrainz database (boolean, default: True)
-        is_populated_by_picard: the tag information is not populated by stock Picard (boolean, default: False)
+        is_populated_by_picard: the tag information is populated by stock Picard (boolean, default: True)
         see_also: an iterable containing ids of related tags
         related_options: an iterable containing the related option settings (see picard/options.py)
         doc_links: an iterable containing links to external documentation (DocumentLink tuples)

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -624,11 +624,15 @@ ALL_TAGS = TagVars(
         is_from_mb=False,
     ),
     TagVar(
-        # TODO: Check if this actually exists or if it should be %_musicbrainz_discid%
         'discid',
-        shortdesc=N_('Disc ID'),
-        longdesc=N_('The identification number of the disc.'),
+        shortdesc=N_('FreeDB Disc ID'),
+        longdesc=N_('The identification number of the disc in the FreeDB database.'),
         see_also=('musicbrainz_discid', ),
+        doc_links=(
+            DocumentLink(N_('FreeDB'), 'https://wikipedia.org/wiki/Freedb'),
+            DocumentLink(N_('FreeDB DiscID Calculation'), 'https://wikipedia.org/wiki/CDDB#Example_calculation_of_a_CDDB1_(FreeDB)_disc_ID'),
+            DocumentLink(N_('FreeDB DiscID including Calculation Example (French)'), 'https://fr.wikipedia.org/wiki/DiscId'),
+        ),
     ),
     TagVar(
         'discnumber',
@@ -880,12 +884,15 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_discid',
-        shortdesc=N_('Disc MBID'),
+        shortdesc=N_('MusicBrainz DiscID'),
         longdesc=N_(
             'The Disc ID is the code number which MusicBrainz uses to link a physical CD to a release listing. '
             'This is based on the table of contents (TOC) information read from the disc. This tag contains the '
             'Disc ID if the album information was retrieved using `Tools > Lookup CD` from the menu.'
         ),
+        see_also=('discid', ),
+        is_calculated=True,
+        doc_links=(DocumentLink(N_('Disc ID Calculations'), PICARD_URLS['mb_doc'] + 'Disc_ID_Calculation'), ),
     ),
     TagVar(
         'musicbrainz_discids',
@@ -1056,7 +1063,7 @@ ALL_TAGS = TagVars(
         is_hidden=True,
         is_tag=False,
         see_also=('releasetype', '_secondaryreleasetype'),
-        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
+        doc_links=(DocumentLink(N_('Release group types'), PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'producer',
@@ -1278,7 +1285,7 @@ ALL_TAGS = TagVars(
         longdesc=N_('The types of release assigned to the release group.'),
         is_multi_value=True,
         see_also=('_primaryreleasetype', '_secondaryreleasetype'),
-        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
+        doc_links=(DocumentLink(N_('Release group types'), PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'remixer',
@@ -1364,7 +1371,7 @@ ALL_TAGS = TagVars(
         is_tag=False,
         is_multi_value=True,
         see_also=('releasetype', '_primaryreleasetype'),
-        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
+        doc_links=(DocumentLink(N_('Release group types'), PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'silence',

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -58,6 +58,7 @@ DocumentLink = namedtuple('DocumentLink', ('title', 'link'))
 TEXT_NOTES = N_('Notes:')
 TEXT_SETTINGS = N_('Option Settings:')
 TEXT_LINKS = N_('Links:')
+TEXT_SEE_ALSO = N_('See Also:')
 TEXT_NO_DESCRIPTION = N_('No description available.')
 
 ATTRIB2NOTE = OrderedDict(
@@ -169,6 +170,12 @@ class TagVar:
             return None
         for doclink in self.doc_links:
             yield f"<a href='{doclink.link}'>{doclink.title}</a>"
+
+    def see_alsos(self):
+        if not self.see_also:
+            return None
+        for item in self.see_also:
+            yield item
 
 
 class TagVars(MutableSequence):
@@ -286,6 +293,16 @@ class TagVars(MutableSequence):
         links = tuple(item.links()) if item else tuple()
         if links:
             title += self._add_section(_(TEXT_LINKS), links)
+
+        alsos = tuple(item.see_alsos()) if item else tuple()
+        if alsos:
+            temp = set()
+            for also_name in alsos:
+                also_name, _also_desc, _also_search_name, also_item = self.item_from_name(also_name)
+                if also_item:
+                    temp.add('%' + also_name + '%')
+            if temp:
+                title += self._add_section(_(TEXT_SEE_ALSO), temp)
 
         if tagdesc:
             return f"<p><em>%{name}%</em> [{tagdesc}]</p>{title}"

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -184,7 +184,7 @@ class TagVar:
 
     def related_options_titles(self):
         if not self.related_options:
-            return None
+            return
         for setting in self.related_options:
             title = get_option_title(setting)
             if title:
@@ -192,15 +192,17 @@ class TagVar:
 
     def links(self):
         if not self.doc_links:
-            return None
+            return
         for doclink in self.doc_links:
             yield f"<a href='{doclink.link}'>{doclink.title}</a>"
 
     def see_alsos(self):
         if not self.see_also:
-            return None
-        for item in self.see_also:
-            yield f"%{item}%"
+            return
+        for tag in self.see_also:
+            name = ALL_TAGS.script_name_from_name(tag)
+            if name:
+                yield f"%{name}%"
 
     def _gen_sections(self, fmt, include_sections):
         for section_id in include_sections:
@@ -273,6 +275,12 @@ class TagVars(MutableSequence):
         item: TagVar = self._name2item.get(search_name, None)
 
         return name, tagdesc, search_name, item
+
+    def script_name_from_name(self, name):
+        tagname, tagdesc, search_name, item = self.item_from_name(name)
+        if item:
+            return str(item)
+        return None
 
     def display_name(self, name):
         name, tagdesc, search_name, item = self.item_from_name(name)
@@ -892,7 +900,7 @@ ALL_TAGS = TagVars(
         ),
         see_also=('discid', ),
         is_calculated=True,
-        doc_links=(DocumentLink(N_('Disc ID Calculations'), PICARD_URLS['mb_doc'] + 'Disc_ID_Calculation'), ),
+        doc_links=(DocumentLink(N_('Disc ID Calculation'), PICARD_URLS['mb_doc'] + 'Disc_ID_Calculation'), ),
     ),
     TagVar(
         'musicbrainz_discids',

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -75,6 +75,7 @@ SECTIONS = {
 TEXT_NO_DESCRIPTION = N_('No description available.')
 
 ATTRIB2NOTE = OrderedDict(
+    is_multi_value=N_('multi-value variable'),
     is_preserved=N_('preserved read-only'),
     not_script_variable=N_('not for use in scripts'),
     is_calculated=N_('calculated'),
@@ -88,8 +89,8 @@ class TagVar:
     def __init__(
         self, name, shortdesc=None, longdesc=None, additionaldesc=None,
         is_preserved=False, is_hidden=False, is_script_variable=True, is_tag=True, is_calculated=False,
-        is_file_info=False, is_from_mb=True, is_populated_by_picard=True, see_also=None, related_options=None,
-        doc_links=None
+        is_file_info=False, is_from_mb=True, is_populated_by_picard=True, is_multi_value=False,
+        see_also=None, related_options=None, doc_links=None
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
@@ -108,6 +109,7 @@ class TagVar:
         is_file_info: the tag is a file information, displayed in file info box (boolean, default: False)
         is_from_mb: the tag information is provided from the MusicBrainz database (boolean, default: True)
         is_populated_by_picard: the tag information is populated by stock Picard (boolean, default: True)
+        is_multi_value: the tag is a multi-value variable (boolean, default: False)
         see_also: an iterable containing ids of related tags
         related_options: an iterable containing the related option settings (see picard/options.py)
         doc_links: an iterable containing links to external documentation (DocumentLink tuples)
@@ -124,6 +126,7 @@ class TagVar:
         self.is_file_info = is_file_info
         self.is_from_mb = is_from_mb
         self.is_populated_by_picard = is_populated_by_picard
+        self.is_multi_value = is_multi_value
         self.see_also = see_also
         self.related_options = related_options
         self.doc_links = doc_links
@@ -385,24 +388,25 @@ ALL_TAGS = TagVars(
         'albumartists',
         shortdesc=N_('Album Artists'),
         longdesc=N_(
-            "A multi-value variable containing the names of the album's artists. These could be "
-            'either "standardized" or "as credited" depending on whether the "Use standardized '
-            'artist names" metadata option is enabled.'
+            'The artists primarily credited on the release. These could be either "standardized" or '
+            '"as credited" depending on whether the "Use standardized artist names" metadata option is enabled.'
         ),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'albumartists_countries',
         shortdesc=N_('Album Artists Countries'),
         longdesc=N_(
-            'A multi-value variable containing the country codes for all of the credited album artists, '
-            'in the same order as the artists. Duplicate country codes will be shown if there are more '
-            'than one artist from the same country. If a country code is not provided by the webservice '
-            'the code "XX" will be used to indicate an unknown country.'
+            'The country codes for all of the credited album artists, in the same order as the artists. '
+            'Duplicate country codes will be shown if there are more than one artist from the same country. '
+            'If a country code is not provided by the webservice the code "XX" will be used to indicate an '
+            'unknown country.'
         ),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'albumartistsort',
@@ -414,9 +418,10 @@ ALL_TAGS = TagVars(
     TagVar(
         'albumartists_sort',
         shortdesc=N_('Album Artists Sort Names'),
-        longdesc=N_("A multi-value variable containing the sort names of the album's artists."),
+        longdesc=N_("The sort names of the album's artists."),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'album',
@@ -450,39 +455,41 @@ ALL_TAGS = TagVars(
         'artists',
         shortdesc=N_('Artists'),
         longdesc=N_(
-            'A multi-value tag containing the track artist names. These could be either "standardized" '
-            'or "as credited" depending on whether the "Use standardized artist names" metadata option '
-            'is enabled.'
+            'The track artist names. These could be either "standardized" or "as credited" depending on '
+            'whether the "Use standardized artist names" metadata option is enabled.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'artists_countries',
         shortdesc=N_('Artists Countries'),
         longdesc=N_(
-            'A multi-value variable containing the country codes for all of the credited track artists, '
-            'in the same order as the artists. Duplicate country codes will be shown if there are more '
-            'than one artist from the same country. If a country code is not provided by the webservice '
-            'the code "XX" will be used to indicate an unknown country.'
+            'The country codes for all of the credited track artists, in the same order as the artists. '
+            'Duplicate country codes will be shown if there are more than one artist from the same country. '
+            'If a country code is not provided by the webservice the code "XX" will be used to indicate an '
+            'unknown country.'
         ),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'artistsort',
         shortdesc=N_('Artist Sort Order'),
-        longdesc=N_('The track artists sort names, separated by the specified join phrases.'),
+        longdesc=N_("The sort names of the track's artists, separated by the specified join phrases."),
     ),
     TagVar(
         'artists_sort',
         shortdesc=N_('Artists Sort Names'),
-        longdesc=N_("A multi-value variable containing the sort names of the track's artists."),
+        longdesc=N_("The sort names of the track's artists."),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'asin',
         shortdesc=N_('ASIN'),
-        longdesc=N_('The Amazon Standard Identification Number - the number identifying the item on Amazon.'),
+        longdesc=N_('The Amazon Standard Identification Number, which is the number identifying the item on Amazon.'),
     ),
     TagVar(
         'barcode',
@@ -523,10 +530,10 @@ ALL_TAGS = TagVars(
         'catalognumber',
         shortdesc=N_('Catalog Number'),
         longdesc=N_(
-            'A multi-value tag contining the numbers assigned to the release by the labels, '
-            'which can often be found on the spine or near the barcode. There may be more than '
-            'one, especially when multiple labels are involved.'
+            'The catalog numbers assigned to the release by the labels, which can often be found on the spine '
+            'or near the barcode. There may be more than one, especially when multiple labels are involved.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'channels',
@@ -558,11 +565,13 @@ ALL_TAGS = TagVars(
         'composer',
         shortdesc=N_('Composer'),
         longdesc=N_('The names of the composers for the associated work.'),
+        is_multi_value=True,
     ),
     TagVar(
         'composersort',
         shortdesc=N_('Composer Sort Order'),
         longdesc=N_('The sort names of the composers for the associated work.'),
+        is_multi_value=True,
     ),
     TagVar(
         'conductor',
@@ -571,6 +580,7 @@ ALL_TAGS = TagVars(
             'The names of the conductors associated with the track. These can include the conductor '
             'and chorus master, and could be associated with the release or recording.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'copyright',
@@ -600,6 +610,7 @@ ALL_TAGS = TagVars(
             'The director of a track as provided by the "*Video Director*" or "*Audio Director*" relationship '
             'in MusicBrainz.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'dirname',
@@ -639,6 +650,7 @@ ALL_TAGS = TagVars(
         'djmixer',
         shortdesc=N_('DJ-Mixer'),
         longdesc=N_('The names of the DJ mixers for the track.'),
+        is_multi_value=True,
     ),
     TagVar(
         'encodedby',
@@ -656,6 +668,7 @@ ALL_TAGS = TagVars(
         'engineer',
         shortdesc=N_('Engineer'),
         longdesc=N_('The names of the engineers associated with the track.'),
+        is_multi_value=True,
     ),
     TagVar(
         'extension',
@@ -730,9 +743,10 @@ ALL_TAGS = TagVars(
         'genre',
         shortdesc=N_('Genre'),
         longdesc=N_(
-            'A multi-value tag containing the specified genre information from MusicBrainz.'
+            'The specified genre information from MusicBrainz.'
         ),
         related_options=('use_genres', ),
+        is_multi_value=True,
     ),
     TagVar(
         # TODO: Check if this actually exists or if it was provided by the last.fm plugin.
@@ -745,9 +759,10 @@ ALL_TAGS = TagVars(
         'isrc',
         shortdesc=N_('ISRC'),
         longdesc=N_(
-            'The International Standard Recording Code - an international standard code for uniquely '
+            'The International Standard Recording Code, which is an international standard code for uniquely '
             'identifying sound recordings and music video recordings.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'key',
@@ -758,7 +773,8 @@ ALL_TAGS = TagVars(
     TagVar(
         'label',
         shortdesc=N_('Record Label'),
-        longdesc=N_('A multi-value tag containing the names of the labels associated with the release.'),
+        longdesc=N_('The names of the labels associated with the release.'),
+        is_multi_value=True,
     ),
     TagVar(
         'language',
@@ -775,17 +791,19 @@ ALL_TAGS = TagVars(
     TagVar(
         'license',
         shortdesc=N_('License'),
-        longdesc=N_('The licenses associated with the track, either through the release or recording relationships.'),
+        longdesc=N_('The license associated with the track, either through the release or recording relationships.'),
     ),
     TagVar(
         'lyricist',
         shortdesc=N_('Lyricist'),
         longdesc=N_('The names of the lyricists for the associated work.'),
+        is_multi_value=True,
     ),
     TagVar(
         'lyricistsort',
         shortdesc=N_('Lyricist Sort'),
         longdesc=N_('The sort names of the lyricists for the associated work.'),
+        is_multi_value=True,
         is_hidden=True,
     ),
     TagVar(
@@ -803,6 +821,7 @@ ALL_TAGS = TagVars(
         'mixer',
         shortdesc=N_('Mixer'),
         longdesc=N_('The names of the "*Mixed By*" engineers associated with the track.'),
+        is_multi_value=True,
     ),
     TagVar(
         'mood',
@@ -843,7 +862,8 @@ ALL_TAGS = TagVars(
     TagVar(
         'musicbrainz_albumartistid',
         shortdesc=N_('Release Artist MBID'),
-        longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the release artists.'),
+        longdesc=N_('The MusicBrainz Identifiers (MBIDs) for the release artists.'),
+        is_multi_value=True,
     ),
     TagVar(
         'musicbrainz_albumid',
@@ -853,7 +873,8 @@ ALL_TAGS = TagVars(
     TagVar(
         'musicbrainz_artistid',
         shortdesc=N_('Artist MBID'),
-        longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists.'),
+        longdesc=N_('The MusicBrainz Identifiers (MBIDs) for the track artists.'),
+        is_multi_value=True,
     ),
     TagVar(
         'musicbrainz_discid',
@@ -868,13 +889,16 @@ ALL_TAGS = TagVars(
         'musicbrainz_discids',
         shortdesc=N_('Disc IDs'),
         longdesc=N_(
-            'A multi-value variable containing a list of all of the disc ids attached to the selected release. '
-            'The list provided for each medium only includes the disc ids attached to that medium. For example, '
-            'the list provided for Disc 1 of a three CD set will not include the disc ids attached to discs 2 '
-            'and 3 of the set.'
+            'A list of all of the disc ids attached to the selected release. The list provided for each medium only '
+            'includes the disc ids attached to that medium.'
+        ),
+        additionaldesc=N_(
+            'For example, the list provided for Disc 1 of a three CD set will not include the disc ids attached to '
+            'discs 2 and 3 of the set.'
         ),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'musicbrainz_originalalbumid',
@@ -888,9 +912,10 @@ ALL_TAGS = TagVars(
         'musicbrainz_originalartistid',
         shortdesc=N_('Original Artist MBID'),
         longdesc=N_(
-            'A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists of the original '
-            'recording. This is only available if the recording has been merged with another recording.'
+            'The MusicBrainz Identifiers (MBIDs) for the track artists of the original recording. This is only '
+            'available if the recording has been merged with another recording.'
         ),
+        is_multi_value=True,
     ),
     TagVar(
         'musicbrainz_recordingid',
@@ -920,6 +945,7 @@ ALL_TAGS = TagVars(
         'musicbrainz_workid',
         shortdesc=N_('Work MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the Work if a related work exists.'),
+        is_multi_value=True,    # TODO: Need to confirm multi-value.
     ),
     TagVar(
         'musicip_fingerprint',
@@ -979,10 +1005,12 @@ ALL_TAGS = TagVars(
     TagVar(
         'performance_attributes',
         shortdesc=N_('Performance Attributes'),
-        longdesc=N_(
-            'List of performance attributes for the work (e.g.: "*live*", "*cover*", "*medley*"). Use `$inmulti()` '
-            'to check for a specific type (e.g.: `$if($inmulti(%_performance_attributes%,medley), (Medley),)`).'
+        longdesc=N_('List of performance attributes for the work (e.g.: "*live*", "*cover*", "*medley*").'),
+        additionaldesc=N_(
+            'Use `$inmulti()` to check for a specific type (e.g.: `$if($inmulti(%_performance_attributes%,medley), '
+            '(Medley),)`).'
         ),
+        is_multi_value=True,
         is_hidden=True,
         is_tag=False,
     ),
@@ -996,6 +1024,7 @@ ALL_TAGS = TagVars(
             '- the orchestra for the associated release or recording, where "type" is "*orchestra*"\n'
             '- the concert master for the associated release or recording, where "type" is "*concertmaster*"'
         ),
+        is_multi_value=True,    # TODO: Confirm that this is a multi-value
     ),
     TagVar(
         'podcast',
@@ -1006,7 +1035,7 @@ ALL_TAGS = TagVars(
     TagVar(
         'podcasturl',
         shortdesc=N_('Podcast URL'),
-        longdesc=N_('The associated url if the recording is a podcast.'),
+        longdesc=N_('The associated URL if the recording is a podcast.'),
         is_from_mb=False,
     ),
     TagVar(
@@ -1024,23 +1053,25 @@ ALL_TAGS = TagVars(
         ),
         is_hidden=True,
         is_tag=False,
+        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'producer',
         shortdesc=N_('Producer'),
         longdesc=N_('The names of the producers for the associated release or recording.'),
+        is_multi_value=True,
     ),
     TagVar(
         'r128_album_gain',
         shortdesc=N_('R128 Album Gain'),
-        longdesc=N_('Album gain as determined by EBU R 128 analysis.'),
+        longdesc=N_('Album gain as determined by European Broadcasting Union "R 128" analysis.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'r128_track_gain',
         shortdesc=N_('R128 Track Gain'),
-        longdesc=N_('Track gain as determined by EBU R 128 analysis.'),
+        longdesc=N_('Track gain as determined by European Broadcasting Union "R 128" analysis.'),
         is_calculated=True,
         is_from_mb=False,
     ),
@@ -1060,26 +1091,30 @@ ALL_TAGS = TagVars(
     TagVar(
         'recording_series',
         shortdesc=N_('Recording Series'),
-        longdesc=N_('A multi-value variable containing the series titles associated with the recording.'),
+        longdesc=N_('The series titles associated with the recording.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'recording_seriescomment',
         shortdesc=N_('Recording Series Comment'),
-        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the recording.'),
+        longdesc=N_('The series disambiguation comments associated with the recording.'),
+        is_multi_value=True,
         is_hidden=True,
     ),
     TagVar(
         'recording_seriesid',
         shortdesc=N_('Recording Series MBID'),
-        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the recording.'),
+        longdesc=N_('The series MusicBrainz Identifiers (MBIDs) associated with the recording.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'recording_seriesnumber',
         shortdesc=N_('Recording Series Number'),
-        longdesc=N_('A multi-value variable containing the series numbers associated with the recording.'),
+        longdesc=N_('The series numbers associated with the recording.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'recordingcomment',
@@ -1112,9 +1147,10 @@ ALL_TAGS = TagVars(
     TagVar(
         'releasecountries',
         shortdesc=N_('Release Countries'),
-        longdesc=N_('A multi-value variable containing the complete list of release countries for the release.'),
+        longdesc=N_('The complete list of release countries for the release.'),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
     ),
     TagVar(
         'releasecountry',
@@ -1127,8 +1163,8 @@ ALL_TAGS = TagVars(
     TagVar(
         'releasedate',
         shortdesc=N_('Release Date'),
-        longdesc=N_(
-            'The date that the release (album) was issued, in the format `YYYY-MM-DD`.'
+        longdesc=N_('The date that the release (album) was issued, in the format `YYYY-MM-DD`.'),
+        additionaldesc=N_(
             'This tag exists for specific use in scripts and plugins, but is not filled by default. In most cases it is '
             'recommended to use the `%date%` tag instead for compatibility with existing software.'
         ),
@@ -1158,26 +1194,30 @@ ALL_TAGS = TagVars(
     TagVar(
         'releasegroup_series',
         shortdesc=N_('RG Series'),
-        longdesc=N_('A multi-value variable containing the series titles associated with the release group.'),
+        longdesc=N_('The series titles associated with the release group.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'releasegroup_seriescomment',
         shortdesc=N_('RG Series Comment'),
-        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the release group.'),
+        longdesc=N_('The series disambiguation comments associated with the release group.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'releasegroup_seriesid',
         shortdesc=N_('RG Series MBID'),
-        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release group.'),
+        longdesc=N_('The series MusicBrainz Identifiers (MBIDs) associated with the release group.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'releasegroup_seriesnumber',
         shortdesc=N_('RG Series Number'),
-        longdesc=N_('A multi-value variable containing the series numbers associated with the release group.'),
+        longdesc=N_('The series numbers associated with the release group.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'releasegroupcomment',
@@ -1196,26 +1236,30 @@ ALL_TAGS = TagVars(
     TagVar(
         'release_series',
         shortdesc=N_('Release Series'),
-        longdesc=N_('A multi-value variable containing the series titles associated with the release.'),
+        longdesc=N_('The series titles associated with the release.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'release_seriescomment',
         shortdesc=N_('Release Series Comment'),
-        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the release.'),
+        longdesc=N_('The series disambiguation comments associated with the release.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'release_seriesid',
         shortdesc=N_('Release Series MBID'),
-        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release.'),
+        longdesc=N_('The series MusicBrainz Identifiers (MBIDs) associated with the release.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'release_seriesnumber',
         shortdesc=N_('Release Series Number'),
-        longdesc=N_('A multi-value variable containing the series numbers associated with the release.'),
+        longdesc=N_('The series numbers associated with the release.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'releasestatus',
@@ -1228,15 +1272,16 @@ ALL_TAGS = TagVars(
     TagVar(
         'releasetype',
         shortdesc=N_('Release Type'),
-        longdesc=N_(
-            'A multi-value tag containing the types of release assigned to the release group.'
-        ),
+        longdesc=N_('The types of release assigned to the release group.'),
+        is_multi_value=True,
         see_also=('primaryreleasetype', 'secondaryreleasetype'),
+        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'remixer',
         shortdesc=N_('Remixer'),
         longdesc=N_('The names of the remixer engineers associated with the track.'),
+        is_multi_value=True,
     ),
     TagVar(
         'replaygain_album_gain',
@@ -1314,6 +1359,8 @@ ALL_TAGS = TagVars(
         ),
         is_hidden=True,
         is_tag=False,
+        is_multi_value=True,
+        doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
         'silence',
@@ -1333,9 +1380,11 @@ ALL_TAGS = TagVars(
         shortdesc=N_('Show Work & Movement'),
         longdesc=N_(
             'Show work and movement. If this tag is set to "1" players supporting this tag, such as iTunes and MusicBee, '
-            'will display the work, movement number and movement name instead of the track title. For example, the track '
-            'will be displayed as "Symphony no. 5 in C minor, op. 67: II. Andante con moto" regardless of the value of the '
-            'title tag.'
+            'will display the work, movement number and movement name instead of the track title.'
+        ),
+        additionaldesc=N_(
+            'For example, the track will be displayed as "Symphony no. 5 in C minor, op. 67: II. Andante con moto" '
+            'regardless of the value of the title tag.'
         ),
         is_from_mb=False,
     ),
@@ -1406,35 +1455,40 @@ ALL_TAGS = TagVars(
     TagVar(
         'work',
         shortdesc=N_('Work'),
-        longdesc=N_(
-            'The name of the work associated with the track (e.g.: "Symphony no. 5 in C minor, op. 67").\n\nNote: If you '
-            'are using iTunes together with MP3 files you should activate the "Save iTunes compatible grouping and work" '
-            'option in order for the work to be displayed correctly.'
+        longdesc=N_('The name of the work associated with the track (e.g.: "Symphony no. 5 in C minor, op. 67").'),
+        additionaldesc=N_(
+            'Note: If you are using iTunes together with MP3 files you should activate the "Save iTunes compatible '
+            'grouping and work" option in order for the work to be displayed correctly.'
         ),
+        related_options=('itunes_compatible_grouping', )
     ),
     TagVar(
         'work_series',
         shortdesc=N_('Work Series'),
-        longdesc=N_('A multi-value variable containing the series titles associated with the work.'),
+        longdesc=N_('The series titles associated with the work.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'work_seriescomment',
         shortdesc=N_('Work Series Comment'),
-        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the work.'),
+        longdesc=N_('The series disambiguation comments associated with the work.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'work_seriesid',
         shortdesc=N_('Work Series MBID'),
-        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the work.'),
+        longdesc=N_('The series MusicBrainz Identifiers (MBIDs) associated with the work.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'work_seriesnumber',
         shortdesc=N_('Work Series Number'),
-        longdesc=N_('A multi-value variable containing the series numbers associated with the work.'),
+        longdesc=N_('The series numbers associated with the work.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
     TagVar(
         'workcomment',
@@ -1446,16 +1500,18 @@ ALL_TAGS = TagVars(
         'writer',
         shortdesc=N_('Writer'),
         longdesc=N_(
-            'A multi-value tag containing the names of the writers associated with the related work. This is '
-            'not written to most file formats automatically. You can merge this with composers with a script '
-            'like `$copymerge(composer,writer)`.'
+            'The names of the writers associated with the related work. This is not written to most file formats '
+            'automatically.'
         ),
+        additionaldesc=N_('You can merge this with composers with a script like `$copymerge(composer,writer)`.'),
+        is_multi_value=True,
     ),
     TagVar(
         'writersort',
         shortdesc=N_('Writer Sort'),
         longdesc=N_('The sort names of the writers for the work.'),
         is_hidden=True,
+        is_multi_value=True,
     ),
 )
 

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -180,7 +180,7 @@ class TagVar:
     def notes(self):
         for attrib, note in ATTRIB2NOTE.items():
             if getattr(self, attrib):
-                yield note
+                yield _(note)
 
     def related_options_titles(self):
         if not self.related_options:

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -1463,7 +1463,7 @@ def script_variable_tag_names():
     yield from (
         tagvar.script_name()
         for tagvar in ALL_TAGS
-        if not tagvar.not_script_variable
+        if tagvar.is_script_variable
     )
 
 

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -194,7 +194,8 @@ class TagVar:
         if not self.doc_links:
             return
         for doclink in self.doc_links:
-            yield f"<a href='{doclink.link}'>{doclink.title}</a>"
+            translated_title = _(doclink.title)
+            yield f"<a href='{doclink.link}'>{translated_title}</a>"
 
     def see_alsos(self):
         if not self.see_also:
@@ -303,10 +304,10 @@ class TagVars(MutableSequence):
     def _base_description(self, tagname):
         name, tagdesc, _search_name, item = self.item_from_name(tagname)
         content = self._markdown(_(item.longdesc) if item and item.longdesc else _(TEXT_NO_DESCRIPTION))
-        if tagdesc:
-            return f"<p><em>%{name}%</em> [{tagdesc}]</p>{content}"
-        else:
-            return f"<p><em>%{name}%</em></p>{content}"
+        fmt_tagdesc = _("<p><em>%{name}%</em> [{tagdesc}]</p>{content}")
+        fmt_normal = _("<p><em>%{name}%</em></p>{content}")
+        fmt = fmt_tagdesc if tagdesc else fmt_normal
+        return fmt.format(name=name, content=content, tagdesc=tagdesc)
 
     def _add_sections(self, item, include_sections):
         # Note: format has to be translatable, for languages not using left-to-right for example

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -862,7 +862,7 @@ ALL_TAGS = TagVars(
         'originalyear',
         shortdesc=N_('Original Year'),
         longdesc=N_(
-            'The year of the original release date in the format YYYY. By default this is set to the earliest '
+            'The year of the original release date in the format `YYYY`. By default this is set to the earliest '
             'release in the release group. This can provide, for example, the release year of the vinyl version '
             'of what you have on CD.'
         ),
@@ -1020,7 +1020,7 @@ ALL_TAGS = TagVars(
         shortdesc=N_('Release Date'),
         # TODO: Confirm long description and that this is not provided from the MB data.
         longdesc=N_(
-            'The date that the release (album) was issued, in the format YYYY-MM-DD.'
+            'The date that the release (album) was issued, in the format `YYYY-MM-DD`.'
             'This tag exists for specific use in scripts and plugins, but is not filled by default. In most cases it is '
             'recommended to use the `%date%` tag instead for compatibility with existing software.'
         ),

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -343,7 +343,7 @@ class TagVars(MutableSequence):
 ALL_TAGS = TagVars(
     TagVar(
         'absolutetracknumber',
-        shortdesc=N_('FIXME:absolutetracknumber'),
+        shortdesc=N_('Absolute Track No.'),
         longdesc=N_(
             'The absolute number of this track disregarding the disc number. For example, '
             'this value would be 11 for the second track on disc 2 where disc 1 has 9 tracks.'
@@ -383,7 +383,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'albumartists',
-        shortdesc=N_('FIXME:albumartists'),
+        shortdesc=N_('Album Artists'),
         longdesc=N_(
             "A multi-value variable containing the names of the album's artists. These could be "
             'either "standardized" or "as credited" depending on whether the "Use standardized '
@@ -394,7 +394,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'albumartists_countries',
-        shortdesc=N_('FIXME:albumartists_countries'),
+        shortdesc=N_('Album Artists Countries'),
         longdesc=N_(
             'A multi-value variable containing the country codes for all of the credited album artists, '
             'in the same order as the artists. Duplicate country codes will be shown if there are more '
@@ -413,7 +413,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'albumartists_sort',
-        shortdesc=N_('FIXME:albumartists_sort'),
+        shortdesc=N_('Album Artists Sort Names'),
         longdesc=N_("A multi-value variable containing the sort names of the album's artists."),
         is_hidden=True,
         is_tag=False,
@@ -457,7 +457,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'artists_countries',
-        shortdesc=N_('FIXME:artists_countries'),
+        shortdesc=N_('Artists Countries'),
         longdesc=N_(
             'A multi-value variable containing the country codes for all of the credited track artists, '
             'in the same order as the artists. Duplicate country codes will be shown if there are more '
@@ -474,7 +474,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'artists_sort',
-        shortdesc=N_('FIXME:artists_sort'),
+        shortdesc=N_('Artists Sort Names'),
         longdesc=N_("A multi-value variable containing the sort names of the track's artists."),
         is_hidden=True,
         is_tag=False,
@@ -583,7 +583,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'datatrack',
-        shortdesc=N_('FIXME:datatrack'),
+        shortdesc=N_('Data Track'),
         longdesc=N_('Set to 1 if the track is a "data track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
@@ -613,8 +613,8 @@ ALL_TAGS = TagVars(
     TagVar(
         # TODO: Check if this actually exists or if it should be %_musicbrainz_discid%
         'discid',
-        shortdesc=N_('Disc Id'),
-        longdesc=N_(''),
+        shortdesc=N_('Disc ID'),
+        longdesc=N_('The identification number of the disc.'),
         see_also=('musicbrainz_discid', ),
     ),
     TagVar(
@@ -624,7 +624,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'discpregap',
-        shortdesc=N_('FIXME:discpregap'),
+        shortdesc=N_('Disc Has Pregap'),
         longdesc=N_('Set to 1 if the disc the track is on has a "pregap track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
@@ -659,7 +659,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'extension',
-        shortdesc=N_('File extension'),
+        shortdesc=N_('File Extension'),
         longdesc=N_("The file's extension."),
         is_hidden=True,
         is_preserved=True,
@@ -668,7 +668,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'file_created_timestamp',
-        shortdesc=N_('File created timestamp'),
+        shortdesc=N_('File Created Timestamp'),
         longdesc=N_('The file creation timestamp in the form `YYYY-MM-DD HH:MM:SS` as reported by the file system.'),
         is_hidden=True,
         is_preserved=True,
@@ -677,7 +677,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'file_modified_timestamp',
-        shortdesc=N_('File modified timestamp'),
+        shortdesc=N_('File Modified Timestamp'),
         longdesc=N_('The file modification timestamp in the form `YYYY-MM-DD HH:MM:SS` as reported by the file system.'),
         is_hidden=True,
         is_preserved=True,
@@ -686,7 +686,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'filename',
-        shortdesc=N_('File name'),
+        shortdesc=N_('File Name'),
         longdesc=N_('The name of the file without extension.'),
         is_hidden=True,
         is_preserved=True,
@@ -703,7 +703,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'filesize',
-        shortdesc=N_('File size'),
+        shortdesc=N_('File Size'),
         longdesc=N_('Size of the file in bytes.'),
         is_file_info=True,
         is_hidden=True,
@@ -712,7 +712,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'format',
-        shortdesc=N_('File format'),
+        shortdesc=N_('File Format'),
         longdesc=N_('Media format of the file (e.g.: MPEG-1 Audio).'),
         is_file_info=True,
         is_hidden=True,
@@ -738,7 +738,7 @@ ALL_TAGS = TagVars(
         # TODO: Check if this actually exists or if it was provided by the last.fm plugin.
         'grouping',
         shortdesc=N_('Grouping'),
-        longdesc=N_(''),
+        longdesc=N_('Genre grouping associated with the track'),
         is_from_mb=False,
     ),
     TagVar(
@@ -833,7 +833,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'multiartist',
-        shortdesc=N_('FIXME:multiartist'),
+        shortdesc=N_('Multiple Artists'),
         longdesc=N_(
             'Set to 1 if not all of the tracks on the album have the same primary artist, otherwise empty.'
         ),
@@ -842,22 +842,22 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_albumartistid',
-        shortdesc=N_('MusicBrainz Release Artist Id'),
+        shortdesc=N_('Release Artist MBID'),
         longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the release artists.'),
     ),
     TagVar(
         'musicbrainz_albumid',
-        shortdesc=N_('MusicBrainz Release Id'),
+        shortdesc=N_('Release MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the release.'),
     ),
     TagVar(
         'musicbrainz_artistid',
-        shortdesc=N_('MusicBrainz Artist Id'),
+        shortdesc=N_('Artist MBID'),
         longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists.'),
     ),
     TagVar(
         'musicbrainz_discid',
-        shortdesc=N_('MusicBrainz Disc Id'),
+        shortdesc=N_('Disc MBID'),
         longdesc=N_(
             'The Disc ID is the code number which MusicBrainz uses to link a physical CD to a release listing. '
             'This is based on the table of contents (TOC) information read from the disc. This tag contains the '
@@ -866,7 +866,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_discids',
-        shortdesc=N_('FIXME:musicbrainz_discids'),
+        shortdesc=N_('Disc IDs'),
         longdesc=N_(
             'A multi-value variable containing a list of all of the disc ids attached to the selected release. '
             'The list provided for each medium only includes the disc ids attached to that medium. For example, '
@@ -878,7 +878,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_originalalbumid',
-        shortdesc=N_('MusicBrainz Original Release Id'),
+        shortdesc=N_('Original Release MBID'),
         longdesc=N_(
             'The MusicBrainz Identifier (MBID) for the original release. This is only available if the release '
             'has been merged with another release.'
@@ -886,7 +886,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_originalartistid',
-        shortdesc=N_('MusicBrainz Original Artist Id'),
+        shortdesc=N_('Original Artist MBID'),
         longdesc=N_(
             'A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists of the original '
             'recording. This is only available if the recording has been merged with another recording.'
@@ -894,22 +894,22 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_recordingid',
-        shortdesc=N_('MusicBrainz Recording Id'),
+        shortdesc=N_('Recording MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the recording.'),
     ),
     TagVar(
         'musicbrainz_releasegroupid',
-        shortdesc=N_('MusicBrainz Release Group Id'),
+        shortdesc=N_('Release Group MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the release group.'),
     ),
     TagVar(
         'musicbrainz_trackid',
-        shortdesc=N_('MusicBrainz Track Id'),
+        shortdesc=N_('Track MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the track.'),
     ),
     TagVar(
         'musicbrainz_tracknumber',
-        shortdesc=N_('FIXME:musicbrainz_tracknumber'),
+        shortdesc=N_('Track Number Shown'),
         longdesc=N_(
             'The track number written as on the MusicBrainz release, such as vinyl numbering (A1, A2, etc.)'
         ),
@@ -918,7 +918,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'musicbrainz_workid',
-        shortdesc=N_('MusicBrainz Work Id'),
+        shortdesc=N_('Work MBID'),
         longdesc=N_('The MusicBrainz Identifier (MBID) for the Work if a related work exists.'),
     ),
     TagVar(
@@ -978,7 +978,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'performance_attributes',
-        shortdesc=N_('FIXME:performance_attributes'),
+        shortdesc=N_('Performance Attributes'),
         longdesc=N_(
             'List of performance attributes for the work (e.g.: "*live*", "*cover*", "*medley*"). Use `$inmulti()` '
             'to check for a specific type (e.g.: `$if($inmulti(%_performance_attributes%,medley), (Medley),)`).'
@@ -1011,14 +1011,14 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'pregap',
-        shortdesc=N_('FIXME:pregap'),
+        shortdesc=N_('Pregap Track'),
         longdesc=N_('Set to 1 if the track is a "pregap track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'primaryreleasetype',
-        shortdesc=N_('FIXME:primaryreleasetype'),
+        shortdesc=N_('Primary Release Type'),
         longdesc=N_(
             'The primary type of the release group (i.e.: *album*, *single*, *ep*, *broadcast*, or *other*).'
         ),
@@ -1033,14 +1033,14 @@ ALL_TAGS = TagVars(
     TagVar(
         'r128_album_gain',
         shortdesc=N_('R128 Album Gain'),
-        longdesc=N_(''),
+        longdesc=N_('Album gain as determined by EBU R 128 analysis.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'r128_track_gain',
         shortdesc=N_('R128 Track Gain'),
-        longdesc=N_(''),
+        longdesc=N_('Track gain as determined by EBU R 128 analysis.'),
         is_calculated=True,
         is_from_mb=False,
     ),
@@ -1052,66 +1052,66 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'recording_firstreleasedate',
-        shortdesc=N_('FIXME:recording_firstreleasedate'),
+        shortdesc=N_('Recording First Released'),
         longdesc=N_('The date of the earliest recording for a track in the format `YYYY-MM-DD`.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'recording_series',
-        shortdesc=N_('FIXME:recording_series'),
+        shortdesc=N_('Recording Series'),
         longdesc=N_('A multi-value variable containing the series titles associated with the recording.'),
         is_hidden=True,
     ),
     TagVar(
         'recording_seriescomment',
-        shortdesc=N_('FIXME:recording_seriescomment'),
+        shortdesc=N_('Recording Series Comment'),
         longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the recording.'),
         is_hidden=True,
     ),
     TagVar(
         'recording_seriesid',
-        shortdesc=N_('FIXME:recording_seriesid'),
+        shortdesc=N_('Recording Series MBID'),
         longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the recording.'),
         is_hidden=True,
     ),
     TagVar(
         'recording_seriesnumber',
-        shortdesc=N_('FIXME:recording_seriesnumber'),
+        shortdesc=N_('Recording Series Number'),
         longdesc=N_('A multi-value variable containing the series numbers associated with the recording.'),
         is_hidden=True,
     ),
     TagVar(
         'recordingcomment',
-        shortdesc=N_('FIXME:recordingcomment'),
+        shortdesc=N_('Recording Comment'),
         longdesc=N_('The disambiguation comment for the recording associated with a track.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'recordingtitle',
-        shortdesc=N_('FIXME:recordingtitle'),
+        shortdesc=N_('Recording Title'),
         longdesc=N_('Recording title - normally the same as the track title, but can be different.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releaseannotation',
-        shortdesc=N_('FIXME:releaseannotation'),
+        shortdesc=N_('Release Annotation'),
         longdesc=N_('The annotation comment for the release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releasecomment',
-        shortdesc=N_('FIXME:releasecomment'),
+        shortdesc=N_('Release Comment'),
         longdesc=N_('The disambiguation comment for the release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releasecountries',
-        shortdesc=N_('FIXME:releasecountries'),
+        shortdesc=N_('Release Countries'),
         longdesc=N_('A multi-value variable containing the complete list of release countries for the release.'),
         is_hidden=True,
         is_tag=False,
@@ -1137,7 +1137,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'releasegroup',
-        shortdesc=N_('FIXME:releasegroup'),
+        shortdesc=N_('Release Group'),
         longdesc=N_(
             'The title of the release group. This is typically the same as the album title, but can be different.'
         ),
@@ -1146,7 +1146,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'releasegroup_firstreleasedate',
-        shortdesc=N_('FIXME:releasegroup_firstreleasedate'),
+        shortdesc=N_('RG First Released'),
         longdesc=N_(
             'The date of the earliest release in the release group in the format `YYYY-MM-DD`. This is intended to '
             'provide, for example, the release date of the vinyl version of what you have on CD.'
@@ -1169,7 +1169,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'releasegroup_seriesid',
-        shortdesc=N_('RG Series Id'),
+        shortdesc=N_('RG Series MBID'),
         longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release group.'),
         is_hidden=True,
     ),
@@ -1181,14 +1181,14 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'releasegroupcomment',
-        shortdesc=N_('FIXME:releasegroupcomment'),
+        shortdesc=N_('RG Comment'),
         longdesc=N_('The disambiguation comment for the release group.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releaselanguage',
-        shortdesc=N_('FIXME:releaselanguage'),
+        shortdesc=N_('Release Language'),
         longdesc=N_('The language of the release as per ISO 639-3.'),
         is_hidden=True,
         is_tag=False,
@@ -1207,7 +1207,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'release_seriesid',
-        shortdesc=N_('Release Series Id'),
+        shortdesc=N_('Release Series MBID'),
         longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release.'),
         is_hidden=True,
     ),
@@ -1241,55 +1241,55 @@ ALL_TAGS = TagVars(
     TagVar(
         'replaygain_album_gain',
         shortdesc=N_('ReplayGain Album Gain'),
-        longdesc=N_(''),
+        longdesc=N_('Album gain setting resulting from ReplayGain analysis of the album.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_album_peak',
         shortdesc=N_('ReplayGain Album Peak'),
-        longdesc=N_(''),
+        longdesc=N_('Album peak setting resulting from ReplayGain analysis of the album.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_album_range',
         shortdesc=N_('ReplayGain Album Range'),
-        longdesc=N_(''),
+        longdesc=N_('Album range setting resulting from ReplayGain analysis of the album.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_reference_loudness',
         shortdesc=N_('ReplayGain Reference Loudness'),
-        longdesc=N_(''),
+        longdesc=N_('Album reference loudness setting resulting from ReplayGain analysis of the album.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_gain',
         shortdesc=N_('ReplayGain Track Gain'),
-        longdesc=N_(''),
+        longdesc=N_('Track gain setting resulting from ReplayGain analysis of the track.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_peak',
         shortdesc=N_('ReplayGain Track Peak'),
-        longdesc=N_(''),
+        longdesc=N_('Track peak setting resulting from ReplayGain analysis of the track.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_range',
         shortdesc=N_('ReplayGain Track Range'),
-        longdesc=N_(''),
+        longdesc=N_('Track range setting resulting from ReplayGain analysis of the track.'),
         is_calculated=True,
         is_from_mb=False,
     ),
     TagVar(
         'sample_rate',
-        shortdesc=N_('File sample rate'),
+        shortdesc=N_('Sample Rate'),
         longdesc=N_('The sample rate of the audio file.'),
         is_file_info=True,
         is_hidden=True,
@@ -1307,7 +1307,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'secondaryreleasetype',
-        shortdesc=N_('FIXME:secondaryreleasetype'),
+        shortdesc=N_('Secondary Release Type'),
         longdesc=N_(
             'Zero or more secondary types (i.e.: *audiobook*, *compilation*, *dj-mix*, *interview*, '
             '*live*, *mixtape/street*, *remix*, *soundtrack*, or *spokenword*) for the release group.'
@@ -1317,7 +1317,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'silence',
-        shortdesc=N_('FIXME:silence'),
+        shortdesc=N_('Silence'),
         longdesc=N_('1 if the track title is "[silence]"'),
         is_hidden=True,
         is_tag=False,
@@ -1370,7 +1370,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'totalalbumtracks',
-        shortdesc=N_('FIXME:totalalbumtracks'),
+        shortdesc=N_('Total Album Tracks'),
         longdesc=N_('The total number of tracks across all discs of this release.'),
         is_hidden=True,
         is_tag=False,
@@ -1392,7 +1392,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'video',
-        shortdesc=N_('File video flag'),
+        shortdesc=N_('Video'),
         longdesc=N_('Set to "1" if the track is a video.'),
         is_hidden=True,
         is_preserved=True,
@@ -1426,7 +1426,7 @@ ALL_TAGS = TagVars(
     ),
     TagVar(
         'work_seriesid',
-        shortdesc=N_('Work Series Id'),
+        shortdesc=N_('Work Series MBID'),
         longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the work.'),
         is_hidden=True,
     ),
@@ -1448,7 +1448,7 @@ ALL_TAGS = TagVars(
         longdesc=N_(
             'A multi-value tag containing the names of the writers associated with the related work. This is '
             'not written to most file formats automatically. You can merge this with composers with a script '
-            'like:\n\n`$copymerge(composer, writer)`'
+            'like `$copymerge(composer,writer)`.'
         ),
     ),
     TagVar(

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -51,7 +51,7 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
-from picard.profile import profile_setting_title
+from picard.options import get_option_title
 
 
 DocumentLink = namedtuple('DocumentLink', ('title', 'link'))
@@ -186,7 +186,7 @@ class TagVar:
         if not self.related_options:
             return None
         for setting in self.related_options:
-            title = profile_setting_title(setting)
+            title = get_option_title(setting)
             if title:
                 yield _(title)
 

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -11,7 +11,7 @@
 # Copyright (C) 2013-2014, 2019-2021, 2023-2024 Laurent Monin
 # Copyright (C) 2013-2015, 2017 Sophist-UK
 # Copyright (C) 2019 Zenara Daley
-# Copyright (C) 2023 Bob Swift
+# Copyright (C) 2023, 2025 Bob Swift
 # Copyright (C) 2023 certuna
 # Copyright (C) 2024 Arnab Chakraborty
 # Copyright (C) 2024 Giorgio Fontanive
@@ -35,6 +35,12 @@
 from collections.abc import MutableSequence
 import re
 
+
+try:
+    from markdown import markdown
+except ImportError:
+    markdown = None
+
 from picard.i18n import (
     N_,
     gettext as _,
@@ -45,20 +51,23 @@ class TagVar:
     def __init__(
         self, name, shortdesc=None, longdesc=None,
         is_preserved=False, is_hidden=False, is_script_variable=True,
-        is_tag=True, is_calculated=False, is_file_info=False
+        is_tag=True, is_calculated=False, is_file_info=False,
+        is_from_mb=True
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
                    for a column header.
         longdesc: Brief description in sentence case describing the tag/variable.  This should
                   be similar (within reasonable length constraints) to the description in the Picard User
-                  Guide documentation, and could be used as a tooltip when reviewing a script.
+                  Guide documentation, and could be used as a tooltip when reviewing a script.  May
+                  contain markup.
         is_preserved: the tag is preserved (boolean, default: False)
         is_hidden: the tag is "hidden", name will be prefixed with "~" (boolean, default: False)
         is_script_variable: the tag can be used as script variable (boolean, default: True)
         is_tag: the tag is an actual tag (not a calculated or derived one) (boolean, default: True)
         is_calculated: the tag is obtained by external calculation (boolean, default: False)
         is_file_info: the tag is a file information, displayed in file info box (boolean, default: False)
+        is_from_mb: the tag information is provided from the MusicBrainz database (boolean, default: True)
         """
         self._name = name
         self._shortdesc = shortdesc
@@ -69,19 +78,20 @@ class TagVar:
         self.is_tag = is_tag
         self.is_calculated = is_calculated
         self.is_file_info = is_file_info
+        self.is_from_mb = is_from_mb
 
     @property
     def shortdesc(self):
         """default to name"""
         if self._shortdesc:
-            return self._shortdesc
+            return self._shortdesc.strip()
         return str(self)
 
     @property
     def longdesc(self):
         """default to shortdesc"""
         if self._longdesc:
-            return self._longdesc
+            return self._longdesc.strip()
         return self.shortdesc
 
     def __str__(self):
@@ -97,6 +107,16 @@ class TagVar:
             return '_' + self._name
         else:
             return self._name
+
+
+TEXT_NOTES = N_('**Notes:**')
+TEXT_READ_ONLY = N_('read-only')
+TEXT_FROM_FILE = N_('provided from the file')
+TEXT_NAMING_ONLY = N_('available in naming scripts only')
+TEXT_NOT_FOR_SCRIPTING = N_('not available for use in scripts')
+TEXT_CALCULATED = N_('calculated variable')
+TEXT_NOT_FROM_MB = N_('not provided from MusicBrainz data')
+TEXT_NO_DESCRIPTION = N_('No description available.')
 
 
 class TagVars(MutableSequence):
@@ -156,6 +176,46 @@ class TagVars(MutableSequence):
         else:
             return title
 
+    def display_tooltip(self, name):
+        tagdesc = None
+
+        if name and name.startswith('_'):
+            name = name.replace('_', '~', 1)
+
+        if ':' in name:
+            name, tagdesc = name.split(':', 1)
+
+        item: TagVar = self._name2item.get(name, None)
+        title = _(item.longdesc) if item and item.longdesc else _(TEXT_NO_DESCRIPTION)
+
+        notes = []
+        if item:
+            if item.is_preserved:
+                notes.append(_(TEXT_READ_ONLY))
+            if item.is_calculated:
+                notes.append(_(TEXT_CALCULATED))
+            if item.is_file_info:
+                notes.append(_(TEXT_FROM_FILE))
+            if not item.is_script_variable:
+                notes.append(_(TEXT_NOT_FOR_SCRIPTING))
+            if not item.is_from_mb and not item.is_file_info:
+                notes.append(_(TEXT_NOT_FROM_MB))
+        if notes:
+            title += f"\n\n{_(TEXT_NOTES)} {'; '.join(notes)}."
+
+        if markdown is None:
+            title = '<p>' + title.replace('\n', '<br />') + '</p>'
+        else:
+            title = markdown(title)
+
+        if name and name.startswith('~'):
+            name = name.replace('~', '_', 1)
+
+        if tagdesc:
+            return f"<p><em>%{name}%</em> [{tagdesc}]</p>{title}"
+        else:
+            return f"<p><em>%{name}%</em></p>{title}"
+
     def names(self, selector=None):
         for item in self._items:
             if selector is None or selector(item):
@@ -166,637 +226,1066 @@ ALL_TAGS = TagVars(
     TagVar(
         'absolutetracknumber',
         shortdesc=N_('FIXME:absolutetracknumber'),
+        longdesc=N_(
+            'The absolute number of this track disregarding the disc number. For example, '
+            'this value would be 11 for the second track on disc 2 where disc 1 has 9 tracks.'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'acoustid_fingerprint',
         shortdesc=N_('AcoustID Fingerprint'),
+        longdesc=N_(
+            'The Acoustic Fingerprint for the track. The fingerprint is based on the audio information '
+            'found in a file, and is calculated using the Chromaprint software.'
+        ),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'acoustid_id',
         shortdesc=N_('AcoustID'),
+        longdesc=N_(
+            'The AcoustID associated with the track. The AcoustID is the identifier assigned to an audio '
+            'file based on its acoustic fingerprint. Multiple fingerprints may be assigned the same AcoustID '
+            'if the fingerprints are similar enough.'
+        ),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'albumartist',
         shortdesc=N_('Album Artist'),
+        longdesc=N_(
+            'The artists primarily credited on the release, separated by the specified join phrases. '
+            'These could be either "standardized" or "as credited" depending on whether the "Use '
+            'standardized artist names" metadata option is enabled.'
+        ),
     ),
     TagVar(
         'albumartists',
         shortdesc=N_('FIXME:albumartists'),
+        longdesc=N_(
+            "A multi-value variable containing the names of the album's artists. These could be "
+            'either "standardized" or "as credited" depending on whether the "Use standardized '
+            'artist names" metadata option is enabled.'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'albumartists_countries',
         shortdesc=N_('FIXME:albumartists_countries'),
+        longdesc=N_(
+            'A multi-value variable containing the country codes for all of the credited album artists, '
+            'in the same order as the artists. Duplicate country codes will be shown if there are more '
+            'than one artist from the same country. If a country code is not provided by the webservice '
+            'the code "XX" will be used to indicate an unknown country. For example, if the first '
+            'credited artist is from Great Britain and there are two other credited artists from Canada, '
+            'the value would be "GB; CA; CA".'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'albumartistsort',
         shortdesc=N_('Album Artist Sort Order'),
+        longdesc=N_(
+            'The release artists sort names, separated by the specified join phrases. (e.g.: "Beatles, The")'
+        ),
     ),
     TagVar(
         'albumartists_sort',
         shortdesc=N_('FIXME:albumartists_sort'),
+        longdesc=N_("A multi-value variable containing the sort names of the album's artists."),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'album',
         shortdesc=N_('Album'),
+        longdesc=N_('The title of the release.'),
     ),
     TagVar(
         'albumsort',
         shortdesc=N_('Album Sort Order'),
+        longdesc=N_('The sort name of the title of the release.'),
+        is_from_mb=False,
     ),
     TagVar(
         'arranger',
         shortdesc=N_('Arranger'),
+        longdesc=N_(
+            'The names of the arrangers associated with the track. These can include the instrument '
+            'and orchestra arrangers, and could be associated with the release, recording or work.'
+        ),
     ),
     TagVar(
         'artist',
         shortdesc=N_('Artist'),
+        longdesc=N_(
+            'The track artist names, separated by the specified join phrases. These could be either '
+            '"standardized" or "as credited" depending on whether the "Use standardized artist names" '
+            'metadata option is enabled.'
+        ),
     ),
     TagVar(
         'artists',
         shortdesc=N_('Artists'),
+        longdesc=N_(
+            'A multi-value tag containing the track artist names. These could be either "standardized" '
+            'or "as credited" depending on whether the "Use standardized artist names" metadata option '
+            'is enabled.'
+        ),
     ),
     TagVar(
         'artists_countries',
         shortdesc=N_('FIXME:artists_countries'),
+        longdesc=N_(
+            'A multi-value variable containing the country codes for all of the credited track artists, '
+            'in the same order as the artists. Duplicate country codes will be shown if there are more '
+            'than one artist from the same country. If a country code is not provided by the webservice '
+            'the code "XX" will be used to indicate an unknown country. For example, if the first '
+            'credited artist is from Great Britain and there are two other credited artists from Canada, '
+            'the value would be "GB; CA; CA".'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'artistsort',
         shortdesc=N_('Artist Sort Order'),
+        longdesc=N_('The track artists sort names, separated by the specified join phrases.'),
     ),
     TagVar(
         'artists_sort',
         shortdesc=N_('FIXME:artists_sort'),
+        longdesc=N_("A multi-value variable containing the sort names of the track's artists."),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'asin',
         shortdesc=N_('ASIN'),
+        longdesc=N_('The Amazon Standard Identification Number - the number identifying the item on Amazon.'),
     ),
     TagVar(
         'barcode',
         shortdesc=N_('Barcode'),
+        longdesc=N_('The barcode assigned to the release.'),
     ),
     TagVar(
         'bpm',
         shortdesc=N_('BPM'),
+        longdesc=N_('Beats per minute of the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'bitrate',
         shortdesc=N_('Bitrate'),
+        longdesc=N_('Approximate bitrate in kbps.'),
         is_file_info=True,
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'bits_per_sample',
         shortdesc=N_('Bits per sample'),
+        longdesc=N_('Bits of data per sample.'),
         is_file_info=True,
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'catalognumber',
         shortdesc=N_('Catalog Number'),
+        longdesc=N_(
+            'A multi-value tag contining the numbers assigned to the release by the labels, '
+            'which can often be found on the spine or near the barcode. There may be more than '
+            'one, especially when multiple labels are involved.'
+        ),
     ),
     TagVar(
         'channels',
         shortdesc=N_('Channels'),
+        longdesc=N_('Number of audio channels in the file.'),
         is_file_info=True,
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
 
     TagVar(
         'comment',
         shortdesc=N_('Comment'),
+        longdesc=N_(
+            'The disambiguation comment entered to help distinguish one release from another (e.g.: '
+            'Deluxe version with 2 bonus tracks). This is not populated by stock Picard. It may be '
+            'used and populated by certain plugins. Picard stores this information in the '
+            '`%_releasecomment%` variable.'
+        ),
     ),
     TagVar(
         'compilation',
         shortdesc=N_('Compilation (iTunes)'),
+        longdesc=N_('1 for Various Artist albums, otherwise empty.'),
     ),
     TagVar(
         'composer',
         shortdesc=N_('Composer'),
+        longdesc=N_('The names of the composers for the associated work.'),
     ),
     TagVar(
         'composersort',
         shortdesc=N_('Composer Sort Order'),
+        longdesc=N_('The sort names of the composers for the associated work.'),
     ),
     TagVar(
         'conductor',
         shortdesc=N_('Conductor'),
+        longdesc=N_(
+            'The names of the conductors associated with the track. These can include the conductor '
+            'and chorus master, and could be associated with the release or recording.'
+        ),
     ),
     TagVar(
         'copyright',
         shortdesc=N_('Copyright'),
+        longdesc=N_(
+            'The copyright message for the copyright holder of the original sound, beginning with a '
+            'year and a space character.'
+        ),
+        is_from_mb=False,
     ),
     TagVar(
         'datatrack',
         shortdesc=N_('FIXME:datatrack'),
+        longdesc=N_('Set to 1 if the track is a "data track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'date',
         shortdesc=N_('Date'),
+        longdesc=N_('The date that the release (album) was issued, in the format YYYY-MM-DD.'),
     ),
     TagVar(
         'director',
         shortdesc=N_('Director'),
+        longdesc=N_(
+            'The director of a track as provided by the "*Video Director*" or "*Audio Director*" relationship '
+            'in MusicBrainz.'
+        ),
     ),
     TagVar(
         'dirname',
         shortdesc=N_('Directory name'),
+        longdesc=N_('The name of the directory containing the file at the point of being loaded into Picard.'),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
+        # TODO: Check if this actually exists or if it should be %_musicbrainz_discid%
         'discid',
         shortdesc=N_('Disc Id'),
+        longdesc=N_(''),
     ),
     TagVar(
         'discnumber',
         shortdesc=N_('Disc Number'),
+        longdesc=N_('The number of the disc in the release that contains this track.'),
     ),
     TagVar(
         'discpregap',
         shortdesc=N_('FIXME:discpregap'),
+        longdesc=N_('Set to 1 if the disc the track is on has a "pregap track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'discsubtitle',
         shortdesc=N_('Disc Subtitle'),
+        longdesc=N_('The media title given to a specific disc in the release.'),
     ),
     TagVar(
         'djmixer',
         shortdesc=N_('DJ-Mixer'),
+        longdesc=N_('The names of the DJ mixers for the track.'),
     ),
     TagVar(
         'encodedby',
         shortdesc=N_('Encoded By'),
+        longdesc=N_('The person or organization that encoded the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'encodersettings',
         shortdesc=N_('Encoder Settings'),
+        longdesc=N_('The settings used when encoding the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'engineer',
         shortdesc=N_('Engineer'),
+        longdesc=N_('The names of the engineers associated with the track.'),
     ),
     TagVar(
         'extension',
         shortdesc=N_('File extension'),
+        longdesc=N_("The file's extension."),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'file_created_timestamp',
         shortdesc=N_('File created timestamp'),
+        longdesc=N_('The file creation timestamp in the form "YYYY-MM-DD HH:MM:SS" as reported by the file system.'),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'file_modified_timestamp',
         shortdesc=N_('File modified timestamp'),
+        longdesc=N_('The file modification timestamp in the form "YYYY-MM-DD HH:MM:SS" as reported by the file system.'),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'filename',
         shortdesc=N_('File name'),
+        longdesc=N_('The name of the file without extension.'),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'filepath',
         shortdesc=N_('File Path'),
+        longdesc=N_('Full path and name of the file.'),
         is_hidden=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'filesize',
         shortdesc=N_('File size'),
+        longdesc=N_('Size of the file in bytes.'),
         is_file_info=True,
         is_hidden=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'format',
         shortdesc=N_('File format'),
+        longdesc=N_('Media format of the file (e.g.: MPEG-1 Audio).'),
         is_file_info=True,
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'gapless',
         shortdesc=N_('Gapless Playback'),
+        longdesc=N_('Indicates whether or not there are gaps between the recordings on the release.'),
+        is_from_mb=False,
     ),
     TagVar(
         'genre',
         shortdesc=N_('Genre'),
+        longdesc=N_(
+            'A multi-value tag containing the specified genre information from MusicBrainz. Requires the '
+            '"Use genres from MusicBrainz" option setting be enabled.'
+        ),
     ),
     TagVar(
+        # TODO: Check if this actually exists or if it was provided by the last.fm plugin.
         'grouping',
         shortdesc=N_('Grouping'),
+        longdesc=N_(''),
+        is_from_mb=False,
     ),
     TagVar(
         'isrc',
         shortdesc=N_('ISRC'),
+        longdesc=N_(
+            'The International Standard Recording Code - an international standard code for uniquely '
+            'identifying sound recordings and music video recordings.'
+        ),
     ),
     TagVar(
         'key',
         shortdesc=N_('Key'),
+        longdesc=N_('The key of the music.'),
+        is_from_mb=False,
     ),
     TagVar(
         'label',
         shortdesc=N_('Record Label'),
+        longdesc=N_('A multi-value tag containing the names of the labels associated with the release.'),
     ),
     TagVar(
         'language',
         shortdesc=N_('Language'),
+        longdesc=N_('Work lyric language as per ISO 639-3 if a related work exists.'),
     ),
     TagVar(
         'length',
         shortdesc=N_('Length'),
+        longdesc=N_('The length of the track in format mins:secs.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'license',
         shortdesc=N_('License'),
+        longdesc=N_('The licenses associated with the track, either through the release or recording relationships.'),
     ),
     TagVar(
         'lyricist',
         shortdesc=N_('Lyricist'),
+        longdesc=N_('The names of the lyricists for the associated work.'),
+    ),
+    TagVar(
+        'lyricistsort',
+        shortdesc=N_('Lyricist Sort'),
+        longdesc=N_('The sort names of the lyricists for the associated work.'),
+        is_hidden=True,
     ),
     TagVar(
         'lyrics',
         shortdesc=N_('Lyrics'),
+        longdesc=N_('The lyrics for the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'media',
         shortdesc=N_('Media'),
+        # TODO: Confirm this is a multi-value.
+        longdesc=N_('A multi-value tag containing the media on which the release was distributed (e.g.: CD).'),
     ),
     TagVar(
         'mixer',
         shortdesc=N_('Mixer'),
+        longdesc=N_('The names of the "*Mixed By*" engineers associated with the track.'),
     ),
     TagVar(
+        # TODO: Check if this actually exists or if it was provided by the last.fm plugin.
         'mood',
         shortdesc=N_('Mood'),
+        longdesc=N_(''),
+        is_from_mb=False,
     ),
     TagVar(
         'movement',
         shortdesc=N_('Movement'),
+        longdesc=N_('Name of the movement (e.g.: "Andante con moto").'),
+        is_from_mb=False,
     ),
     TagVar(
         'movementnumber',
         shortdesc=N_('Movement Number'),
+        longdesc=N_(
+            'Movement number in Arabic numerals (e.g.: "2"). Players explicitly supporting this tag will often '
+            'display it in Roman numerals (e.g.: "II").'
+        ),
+        is_from_mb=False,
     ),
     TagVar(
         'movementtotal',
         shortdesc=N_('Movement Count'),
+        longdesc=N_('Total number of movements in the work (e.g.: "4").'),
+        is_from_mb=False,
     ),
     TagVar(
         'multiartist',
         shortdesc=N_('FIXME:multiartist'),
+        longdesc=N_(
+            'Set to 1 if not all of the tracks on the album have the same primary artist, otherwise empty.'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'musicbrainz_albumartistid',
         shortdesc=N_('MusicBrainz Release Artist Id'),
+        longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the release artists.'),
     ),
     TagVar(
         'musicbrainz_albumid',
         shortdesc=N_('MusicBrainz Release Id'),
+        longdesc=N_('The MusicBrainz Identifier (MBID) for the release.'),
     ),
     TagVar(
         'musicbrainz_artistid',
         shortdesc=N_('MusicBrainz Artist Id'),
+        longdesc=N_('A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists.'),
     ),
     TagVar(
         'musicbrainz_discid',
         shortdesc=N_('MusicBrainz Disc Id'),
+        longdesc=N_(
+            'The Disc ID is the code number which MusicBrainz uses to link a physical CD to a release listing. '
+            'This is based on the table of contents (TOC) information read from the disc. This tag contains the '
+            'Disc ID if the album information was retrieved using `Tools > Lookup CD` from the menu.'
+        ),
     ),
     TagVar(
         'musicbrainz_discids',
         shortdesc=N_('FIXME:musicbrainz_discids'),
+        longdesc=N_(
+            'A multi-value variable containing a list of all of the disc ids attached to the selected release. '
+            'The list provided for each medium only includes the disc ids attached to that medium. For example, '
+            'the list provided for Disc 1 of a three CD set will not include the disc ids attached to discs 2 '
+            'and 3 of the set.'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'musicbrainz_originalalbumid',
         shortdesc=N_('MusicBrainz Original Release Id'),
+        longdesc=N_(
+            'The MusicBrainz Identifier (MBID) for the original release. This is only available if the release '
+            'has been merged with another release.'
+        ),
     ),
     TagVar(
         'musicbrainz_originalartistid',
         shortdesc=N_('MusicBrainz Original Artist Id'),
+        longdesc=N_(
+            'A multi-value tag containing the MusicBrainz Identifiers (MBIDs) for the track artists of the original '
+            'recording. This is only available if the recording has been merged with another recording.'
+        ),
     ),
     TagVar(
         'musicbrainz_recordingid',
         shortdesc=N_('MusicBrainz Recording Id'),
+        longdesc=N_('The MusicBrainz Identifier (MBID) for the recording.'),
     ),
     TagVar(
         'musicbrainz_releasegroupid',
         shortdesc=N_('MusicBrainz Release Group Id'),
+        longdesc=N_('The MusicBrainz Identifier (MBID) for the release group.'),
     ),
     TagVar(
         'musicbrainz_trackid',
         shortdesc=N_('MusicBrainz Track Id'),
+        longdesc=N_('The MusicBrainz Identifier (MBID) for the track.'),
     ),
     TagVar(
         'musicbrainz_tracknumber',
         shortdesc=N_('FIXME:musicbrainz_tracknumber'),
+        longdesc=N_(
+            'The track number written as on the MusicBrainz release, such as vinyl numbering (A1, A2, etc.)'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'musicbrainz_workid',
         shortdesc=N_('MusicBrainz Work Id'),
+        longdesc=N_('The MusicBrainz Identifier (MBID) for the Work if a related work exists.'),
     ),
     TagVar(
         'musicip_fingerprint',
         shortdesc=N_('MusicIP Fingerprint'),
+        longdesc=N_('The MusicIP Fingerprint for the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'musicip_puid',
         shortdesc=N_('MusicIP PUID'),
+        longdesc=N_('The MusicIP PUIDs associated with the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'originalalbum',
         shortdesc=N_('Original Album'),
+        longdesc=N_(
+            'The release title of the earliest release in the release group intended for the title of the '
+            'original recording.'
+        ),
+        is_from_mb=False,
     ),
     TagVar(
         'originalartist',
         shortdesc=N_('Original Artist'),
+        longdesc=N_(
+            'The track artist of the earliest release in the release group intended for the performers of '
+            'the original recording.'
+        ),
+        is_from_mb=False,
     ),
     TagVar(
         'originaldate',
         shortdesc=N_('Original Release Date'),
+        longdesc=N_(
+            'The original release date in the format YYYY-MM-DD. By default this is set to the earliest '
+            'release in the release group. This can provide, for example, the release date of the vinyl '
+            'version of what you have on CD.\n\nThis is the same information provided in the '
+            '`%_releasegroup_firstreleasedate%` variable, and is consistent across all tracks in the '
+            'release. If you prefer to have this tag populated with the date of the earliest recording of '
+            'the track in the database, which will likely be different for each track in the release, '
+            'this can be achieved by enabling a one-line tagging script as:\n\n'
+            '`$set(originaldate,%_recording_firstreleasedate%)`\n\nBe aware that setting this can cause a '
+            'release to be scattered across multiple directories if you use `%originaldate%` as part of '
+            'the path portion of your file naming script.\n\n**Note:** If you are storing tags in MP3 files as '
+            'ID3v2.3 then the original date can only be stored as a year.'
+        ),
     ),
     TagVar(
         'originalfilename',
         shortdesc=N_('Original Filename'),
+        longdesc=N_('The original name of the audio file.'),
+        is_from_mb=False,
     ),
     TagVar(
         'originalyear',
         shortdesc=N_('Original Year'),
+        longdesc=N_(
+            'The year of the original release date in the format YYYY. By default this is set to the earliest '
+            'release in the release group. This can provide, for example, the release year of the vinyl version '
+            'of what you have on CD.'
+        ),
     ),
     TagVar(
         'performance_attributes',
         shortdesc=N_('FIXME:performance_attributes'),
+        longdesc=N_(
+            'List of performance attributes for the work (e.g.: "*live*", "*cover*", "*medley*"). Use `$inmulti()` '
+            'to check for a specific type (i.e.: `$if($inmulti(%_performance_attributes%,medley), (Medley),)`).'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'performer',
         shortdesc=N_('Performer'),
+        longdesc=N_(
+            'The names of the performers for the specified type. These types include:\n\n'
+            '- vocals or instruments for the associated release or recording, where "type" can be "*vocal*", '
+            '"*guest guitar*", "*solo violin*", etc.\n'
+            '- the orchestra for the associated release or recording, where "type" is "*orchestra*"\n'
+            '- the concert master for the associated release or recording, where "type" is "*concertmaster*"'
+        ),
     ),
     TagVar(
         'podcast',
         shortdesc=N_('Podcast'),
+        longdesc=N_('Indicates whether or not the recording is a podcast.'),
+        is_from_mb=False,
     ),
     TagVar(
         'podcasturl',
         shortdesc=N_('Podcast URL'),
+        longdesc=N_('The associated url if the recording is a podcast.'),
+        is_from_mb=False,
     ),
     TagVar(
         'pregap',
         shortdesc=N_('FIXME:pregap'),
+        longdesc=N_('Set to 1 if the track is a "pregap track", otherwise empty.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'primaryreleasetype',
         shortdesc=N_('FIXME:primaryreleasetype'),
+        longdesc=N_(
+            'The primary type of the release group (i.e.: *album*, *single*, *ep*, *broadcast*, or *other*).'
+        ),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'producer',
         shortdesc=N_('Producer'),
+        longdesc=N_('The names of the producers for the associated release or recording.'),
     ),
     TagVar(
         'r128_album_gain',
         shortdesc=N_('R128 Album Gain'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'r128_track_gain',
         shortdesc=N_('R128 Track Gain'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'rating',
         shortdesc=N_('Rating'),
+        longdesc=N_('The rating of the track from 0-5 by MusicBrainz users.'),
         is_hidden=True,
     ),
     TagVar(
         'recording_firstreleasedate',
         shortdesc=N_('FIXME:recording_firstreleasedate'),
+        longdesc=N_('The date of the earliest recording for a track in the format YYYY-MM-DD.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
+        'recording_series',
+        shortdesc=N_('FIXME:recording_series'),
+        longdesc=N_('A multi-value variable containing the series titles associated with the recording.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'recording_seriescomment',
+        shortdesc=N_('FIXME:recording_seriescomment'),
+        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the recording.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'recording_seriesid',
+        shortdesc=N_('FIXME:recording_seriesid'),
+        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the recording.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'recording_seriesnumber',
+        shortdesc=N_('FIXME:recording_seriesnumber'),
+        longdesc=N_('A multi-value variable containing the series numbers associated with the recording.'),
+        is_hidden=True,
+    ),
+    TagVar(
         'recordingcomment',
         shortdesc=N_('FIXME:recordingcomment'),
+        longdesc=N_('The disambiguation comment for the recording associated with a track.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'recordingtitle',
         shortdesc=N_('FIXME:recordingtitle'),
+        longdesc=N_('Recording title - normally the same as the track title, but can be different.'),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        'releaseannotation',
+        shortdesc=N_('FIXME:releaseannotation'),
+        longdesc=N_('The annotation comment for the release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releasecomment',
         shortdesc=N_('FIXME:releasecomment'),
+        longdesc=N_('The disambiguation comment for the release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releasecountries',
         shortdesc=N_('FIXME:releasecountries'),
-        is_hidden=True,
-        is_tag=False,
-    ),
-    TagVar(
-        'releasegroup',
-        shortdesc=N_('FIXME:releasegroup'),
-        is_hidden=True,
-        is_tag=False,
-    ),
-    TagVar(
-        'releasegroup_firstreleasedate',
-        shortdesc=N_('FIXME:releasegroup_firstreleasedate'),
-        is_hidden=True,
-        is_tag=False,
-    ),
-    TagVar(
-        'releasegroupcomment',
-        shortdesc=N_('FIXME:releasegroupcomment'),
-        is_hidden=True,
-        is_tag=False,
-    ),
-    TagVar(
-        'releaselanguage',
-        shortdesc=N_('FIXME:releaselanguage'),
+        longdesc=N_('A multi-value variable containing the complete list of release countries for the release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'releasecountry',
         shortdesc=N_('Release Country'),
+        longdesc=N_(
+            'The two-character code for the country in which the release was issued. If more than one release country '
+            'was specified, this tag will contain the first one in the list.'
+        ),
     ),
     TagVar(
         'releasedate',
         shortdesc=N_('Release Date'),
+        # TODO: Confirm long description and that this is not provided from the MB data.
+        longdesc=N_(
+            'The date that the release (album) was issued, in the format YYYY-MM-DD.'
+            'This tag exists for specific use in scripts and plugins, but is not filled by default. In most cases it is '
+            'recommended to use the `%date%` tag instead for compatibility with existing software.'
+        ),
+        is_from_mb=False,
+    ),
+    TagVar(
+        'releasegroup',
+        shortdesc=N_('FIXME:releasegroup'),
+        longdesc=N_(
+            'The title of the release group. This is typically the same as the album title, but can be different.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        'releasegroup_firstreleasedate',
+        shortdesc=N_('FIXME:releasegroup_firstreleasedate'),
+        longdesc=N_(
+            'The date of the earliest release in the release group in the format YYYY-MM-DD. This is intended to '
+            'provide, for example, the release date of the vinyl version of what you have on CD.'
+            '\n\n'
+            'Note: This is the same information provided in the `%originaldate%` tag.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        'releasegroup_series',
+        shortdesc=N_('RG Series'),
+        longdesc=N_('A multi-value variable containing the series titles associated with the release group.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'releasegroup_seriescomment',
+        shortdesc=N_('RG Series Comment'),
+        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the release group.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'releasegroup_seriesid',
+        shortdesc=N_('RG Series Id'),
+        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release group.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'releasegroup_seriesnumber',
+        shortdesc=N_('RG Series Number'),
+        longdesc=N_('A multi-value variable containing the series numbers associated with the release group.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'releasegroupcomment',
+        shortdesc=N_('FIXME:releasegroupcomment'),
+        longdesc=N_('The disambiguation comment for the release group.'),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        'releaselanguage',
+        shortdesc=N_('FIXME:releaselanguage'),
+        longdesc=N_('The language of the release as per ISO 639-3.'),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        'release_series',
+        shortdesc=N_('Release Series'),
+        longdesc=N_('A multi-value variable containing the series titles associated with the release.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'release_seriescomment',
+        shortdesc=N_('Release Series Comment'),
+        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the release.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'release_seriesid',
+        shortdesc=N_('Release Series Id'),
+        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the release.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'release_seriesnumber',
+        shortdesc=N_('Release Series Number'),
+        longdesc=N_('A multi-value variable containing the series numbers associated with the release.'),
+        is_hidden=True,
     ),
     TagVar(
         'releasestatus',
         shortdesc=N_('Release Status'),
+        longdesc=N_(
+            'An indicator of the "official" status of the release. Possible values include "*official*", '
+            '"*promotional*", "*bootleg*", and "*pseudo-release*".'
+        ),
     ),
     TagVar(
         'releasetype',
         shortdesc=N_('Release Type'),
+        longdesc=N_(
+            'A multi-value tag containing the types of release assigned to the release group. See also '
+            '`%_primaryreleasetype%` and `%_secondaryreleasetype%`.'
+        ),
     ),
     TagVar(
         'remixer',
         shortdesc=N_('Remixer'),
+        longdesc=N_('The names of the remixer engineers associated with the track.'),
     ),
     TagVar(
         'replaygain_album_gain',
         shortdesc=N_('ReplayGain Album Gain'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_album_peak',
         shortdesc=N_('ReplayGain Album Peak'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_album_range',
         shortdesc=N_('ReplayGain Album Range'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_reference_loudness',
         shortdesc=N_('ReplayGain Reference Loudness'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_gain',
         shortdesc=N_('ReplayGain Track Gain'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_peak',
         shortdesc=N_('ReplayGain Track Peak'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'replaygain_track_range',
         shortdesc=N_('ReplayGain Track Range'),
+        longdesc=N_(''),
         is_calculated=True,
+        is_from_mb=False,
     ),
     TagVar(
         'sample_rate',
         shortdesc=N_('File sample rate'),
+        longdesc=N_(''),
         is_file_info=True,
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
-    ),
-    TagVar(
-        'secondaryreleasetype',
-        shortdesc=N_('FIXME:secondaryreleasetype'),
-        is_hidden=True,
-        is_tag=False,
+        is_from_mb=False,
     ),
     TagVar(
         'script',
         shortdesc=N_('Script'),
+        longdesc=N_(
+            "The script used to write the release's track list. The possible values are taken from the "
+            'ISO 15924 standard.'
+        ),
     ),
     TagVar(
+        'secondaryreleasetype',
+        shortdesc=N_('FIXME:secondaryreleasetype'),
+        longdesc=N_(
+            'Zero or more secondary types (i.e.: *audiobook*, *compilation*, *dj-mix*, *interview*, '
+            '*live*, *mixtape/street*, *remix*, *soundtrack*, or *spokenword*) for the release group.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
+        # TODO: Does this actually exist and does it come from MusicBrainz?  Is it an indicator if a track is silence?
         'silence',
         shortdesc=N_('FIXME:silence'),
+        longdesc=N_(''),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'show',
         shortdesc=N_('Show Name'),
-    ),
-    TagVar(
-        'showsort',
-        shortdesc=N_('Show Name Sort Order'),
+        longdesc=N_('The name of the show if the recording is associated with a television program.'),
+        is_from_mb=False,
     ),
     TagVar(
         'showmovement',
         shortdesc=N_('Show Work & Movement'),
+        longdesc=N_(
+            'Show work and movement. If this tag is set to "1" players supporting this tag, such as iTunes and MusicBee, '
+            'will display the work, movement number and movement name instead of the track title. For example, the track '
+            'will be displayed as "Symphony no. 5 in C minor, op. 67: II. Andante con moto" regardless of the value of the '
+            'title tag.'
+        ),
+        is_from_mb=False,
+    ),
+    TagVar(
+        'showsort',
+        shortdesc=N_('Show Name Sort Order'),
+        longdesc=N_('The sort name of the show if the recording is associated with a television program.'),
+        is_from_mb=False,
     ),
     TagVar(
         'subtitle',
         shortdesc=N_('Subtitle'),
+        longdesc=N_('This is used for information directly related to the contents title.'),
+        is_from_mb=False,
     ),
     TagVar(
         'syncedlyrics',
         shortdesc=N_('Synced Lyrics'),
+        longdesc=N_('Synchronized lyrics for the track.'),
+        is_from_mb=False,
     ),
     TagVar(
         'title',
         shortdesc=N_('Title'),
+        longdesc=N_('The title of the track.'),
     ),
     TagVar(
         'titlesort',
         shortdesc=N_('Title Sort Order'),
+        longdesc=N_('The sort name of the track title.'),
+        is_from_mb=False,
     ),
     TagVar(
         'totalalbumtracks',
         shortdesc=N_('FIXME:totalalbumtracks'),
+        longdesc=N_('The total number of tracks across all discs of this release.'),
         is_hidden=True,
         is_tag=False,
     ),
     TagVar(
         'totaldiscs',
         shortdesc=N_('Total Discs'),
+        longdesc=N_('The total number of discs in this release.'),
     ),
     TagVar(
         'totaltracks',
         shortdesc=N_('Total Tracks'),
+        longdesc=N_('The total number of tracks on this disc.'),
     ),
     TagVar(
         'tracknumber',
         shortdesc=N_('Track Number'),
+        longdesc=N_('The number of the track on the disc.'),
     ),
     TagVar(
         'video',
         shortdesc=N_('File video flag'),
+        longdesc=N_('Set to "1" if the track is a video.'),
         is_hidden=True,
         is_preserved=True,
         is_tag=False,
@@ -804,14 +1293,61 @@ ALL_TAGS = TagVars(
     TagVar(
         'website',
         shortdesc=N_('Artist Website'),
+        longdesc=N_('The official website for the artist.'),
     ),
     TagVar(
         'work',
         shortdesc=N_('Work'),
+        longdesc=N_(
+            'The name of the work associated with the track (e.g.: "Symphony no. 5 in C minor, op. 67").\n\nNote: If you '
+            'are using iTunes together with MP3 files you should activate the "Save iTunes compatible grouping and work" '
+            'option in order for the work to be displayed correctly.'
+        ),
+    ),
+    TagVar(
+        'work_series',
+        shortdesc=N_('Work Series'),
+        longdesc=N_('A multi-value variable containing the series titles associated with the work.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'work_seriescomment',
+        shortdesc=N_('Work Series Comment'),
+        longdesc=N_('A multi-value variable containing the series disambiguation comments associated with the work.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'work_seriesid',
+        shortdesc=N_('Work Series Id'),
+        longdesc=N_('A multi-value variable containing the series MusicBrainz Identifiers (MBIDs) associated with the work.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'work_seriesnumber',
+        shortdesc=N_('Work Series Number'),
+        longdesc=N_('A multi-value variable containing the series numbers associated with the work.'),
+        is_hidden=True,
+    ),
+    TagVar(
+        'workcomment',
+        shortdesc=N_('Work Comment'),
+        longdesc=N_('The disambiguation comment associated with the work.'),
+        is_hidden=True,
     ),
     TagVar(
         'writer',
         shortdesc=N_('Writer'),
+        longdesc=N_(
+            'A multi-value tag containing the names of the writers associated with the related work. This is '
+            'not written to most file formats automatically. You can merge this with composers with a script '
+            'like:\n\n`$copymerge(composer, writer)`'
+        ),
+    ),
+    TagVar(
+        'writersort',
+        shortdesc=N_('Writer Sort'),
+        longdesc=N_('The sort names of the writers for the work.'),
+        is_hidden=True,
     ),
 )
 
@@ -850,6 +1386,10 @@ def script_variable_tag_names():
 
 def display_tag_name(name):
     return ALL_TAGS.display_name(name)
+
+
+def display_tag_tooltip(name):
+    return ALL_TAGS.display_tooltip(name)
 
 
 RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -363,6 +363,7 @@ ALL_TAGS = TagVars(
         ),
         is_calculated=True,
         is_from_mb=False,
+        related_options=('fingerprinting_system', 'save_acoustid_fingerprints'),
     ),
     TagVar(
         'acoustid_id',
@@ -374,6 +375,7 @@ ALL_TAGS = TagVars(
         ),
         is_calculated=True,
         is_from_mb=False,
+        related_options=('fingerprinting_system', 'save_acoustid_fingerprints'),
     ),
     TagVar(
         'albumartist',
@@ -554,7 +556,7 @@ ALL_TAGS = TagVars(
             'Deluxe version with 2 bonus tracks).'
         ),
         is_populated_by_picard=False,
-        see_also=('releasecomment', ),
+        see_also=('_releasecomment', ),
     ),
     TagVar(
         'compilation',
@@ -1053,6 +1055,7 @@ ALL_TAGS = TagVars(
         ),
         is_hidden=True,
         is_tag=False,
+        see_also=('releasetype', '_secondaryreleasetype'),
         doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
@@ -1274,7 +1277,7 @@ ALL_TAGS = TagVars(
         shortdesc=N_('Release Type'),
         longdesc=N_('The types of release assigned to the release group.'),
         is_multi_value=True,
-        see_also=('primaryreleasetype', 'secondaryreleasetype'),
+        see_also=('_primaryreleasetype', '_secondaryreleasetype'),
         doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(
@@ -1360,6 +1363,7 @@ ALL_TAGS = TagVars(
         is_hidden=True,
         is_tag=False,
         is_multi_value=True,
+        see_also=('releasetype', '_primaryreleasetype'),
         doc_links=(DocumentLink('Release group types', PICARD_URLS['mb_doc'] + 'Release_Group/Type'),),
     ),
     TagVar(

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -55,7 +55,11 @@ class TestPicardConfigCommon(PicardTestCase):
 
         self.config.application["version"] = "testing"
         logging.disable(logging.ERROR)
+        self.old_registry = dict(Option.registry)
         Option.registry = {}
+
+    def tearDown(self):
+        Option.registry = self.old_registry
 
     def cleanup_config_obj(self):
         # Ensure QSettings do not recreate the file on exit

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -39,7 +39,7 @@ class OptionsUtilitiesTest(PicardTestCase):
         self.assertEqual(get_option_title('invalid_option'), 'No option title available')
 
         # No title assigned to the option
-        self.assertEqual(get_option_title('log_verbosity'), 'No option title available')
+        self.assertEqual(get_option_title('test_option_without_title'), 'No option title available')
 
         # Title assigned to the option
-        self.assertEqual(get_option_title('ignore_hidden_files'), 'Ignore hidden files')
+        self.assertEqual(get_option_title('test_option_with_title'), 'Test option with title')

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from test.picardtestcase import PicardTestCase
+
+from picard.config import Option
+from picard.i18n import N_
+from picard.options import get_option_title
+
+
+class OptionsUtilitiesTest(PicardTestCase):
+
+    def test_option_titles(self):
+        # Add test option settings
+        if ('setting', 'test_option_with_title') not in Option.registry:
+            Option('setting', 'test_option_with_title', None, title=N_('Test option with title'))
+        if ('setting', 'test_option_without_title') not in Option.registry:
+            Option('setting', 'test_option_without_title', None)
+
+        # Invalid option name
+        self.assertEqual(get_option_title('invalid_option'), 'No option title available')
+
+        # No title assigned to the option
+        self.assertEqual(get_option_title('log_verbosity'), 'No option title available')
+
+        # Title assigned to the option
+        self.assertEqual(get_option_title('ignore_hidden_files'), 'Ignore hidden files')

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -36,10 +36,10 @@ class OptionsUtilitiesTest(PicardTestCase):
             Option('setting', 'test_option_without_title', None)
 
         # Invalid option name
-        self.assertEqual(get_option_title('invalid_option'), 'No option title available')
+        self.assertEqual(get_option_title('invalid_option'), None)
 
         # No title assigned to the option
-        self.assertEqual(get_option_title('test_option_without_title'), 'No option title available')
+        self.assertEqual(get_option_title('test_option_without_title'), "No title for setting 'test_option_without_title'")
 
         # Title assigned to the option
         self.assertEqual(get_option_title('test_option_with_title'), 'Test option with title')

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2021, 2023 Bob Swift
+# Copyright (C) 2021, 2023, 2025 Bob Swift
 # Copyright (C) 2022 Philipp Wolfer
 # Copyright (C) 2024 Laurent Monin
 #
@@ -66,6 +66,7 @@ class TestPicardProfilesCommon(PicardTestCase):
 
         self.config.application["version"] = "testing"
         logging.disable(logging.ERROR)
+        self.old_registry = dict(Option.registry)
         Option.registry = {}
 
         ListOption('profiles', self.PROFILES_KEY, [])
@@ -89,6 +90,9 @@ class TestPicardProfilesCommon(PicardTestCase):
         BoolOption("setting", self.test_setting_1, True)
         IntOption("setting", self.test_setting_2, 42)
         TextOption("setting", self.test_setting_3, "xyz")
+
+    def tearDown(self):
+        Option.registry = self.old_registry
 
     def cleanup_config_obj(self):
         # Ensure QSettings do not recreate the file on exit

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -430,5 +430,19 @@ class UtilTagsOptionsTest(PicardTestCase):
                 continue
             for opt in tv.related_options:
                 title = get_option_title(opt)
-                self.assertIsNotNone(title, f"Missing related option setting '{opt}'")
-            self.assertFalse(title.startswith('No title for setting'), f"Missing title for option setting '{opt}'")
+                self.assertIsNotNone(title, f"Missing related option setting '{opt}' in '{str(tv)}'")
+            self.assertFalse(title.startswith('No title for setting'), f"Missing title for option setting '{opt}' in '{str(tv)}'")
+
+
+class UtilTagsSeeAlsoTest(PicardTestCase):
+    def test_see_alsos_exist(self):
+        """Ensure all `see_also` tags actually exist in the `ALL_TAGS` collection and that a tag's
+        `see_also` tags do not refer to itself.
+        """
+        for tv in ALL_TAGS:
+            if tv.see_also is None:
+                continue
+            for also in tv.see_also:
+                name = ALL_TAGS.script_name_from_name(also)
+                self.assertIsNotNone(name, f"Invalid see_also '{also}' in '{str(tv)}' tag")
+                self.assertNotEqual(name, str(tv), f"Circular see_also reference in '{str(tv)}' tag")

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -60,6 +60,7 @@ class TagVarTest(PicardTestCase):
         self.assertFalse(tv.is_file_info)
         self.assertTrue(tv.is_from_mb)
         self.assertTrue(tv.is_populated_by_picard)
+        self.assertFalse(tv.is_multi_value)
         self.assertIsNone(tv.see_also)
         self.assertIsNone(tv.related_options)
         self.assertIsNone(tv.doc_links)
@@ -370,7 +371,8 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(display_tag_tooltip('performer'), result)
 
     def test_display_tag_full_description(self):
-        profile_groups_add_setting('junk', 'use_genres', None, 'Use genres from MusicBrainz')
+        if ('setting', 'use_genres') not in Option.registry:
+            Option('setting', 'use_genres', None, title='Use genres from MusicBrainz')
         result = (
             '<p><em>%genre%</em></p><p>The specified genre information from MusicBrainz.</p><p><strong>Notes:</strong> multi-value '
             'variable.</p><p><strong>Option Settings:</strong> Use genres from MusicBrainz.</p>'

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -27,8 +27,10 @@ import unittest.mock as mock
 
 from test.picardtestcase import PicardTestCase
 
+from picard.const import PICARD_URLS
 from picard.profile import profile_groups_add_setting
 from picard.util.tags import (
+    DocumentLink,
     TagVar,
     TagVars,
     display_tag_full_description,
@@ -54,6 +56,10 @@ class TagVarsTest(PicardTestCase):
                                    is_file_info=True, is_hidden=True, is_script_variable=False)
         self.tagvar_notes2 = TagVar('notes2', shortdesc='notes2_sd', longdesc='notes2_ld', is_file_info=True, is_from_mb=False)
         self.tagvar_notes3 = TagVar('notes3', shortdesc='notes3_sd', longdesc='notes3_ld', is_from_mb=False)
+        self.tagvar_everything = TagVar('everything', shortdesc='everything sd', longdesc='everything ld.', is_preserved=True,
+                                        is_script_variable=False, is_tag=False, is_calculated=True, is_file_info=True, is_from_mb=False,
+                                        is_populated_by_picard=False, see_also=('artist', 'title'), related_options=('everything_test', ),
+                                        doc_links=(DocumentLink('Test link', PICARD_URLS['mb_doc'] + 'test'),))
 
     def test_invalid_tagvar(self):
         with self.assertRaises(TypeError):
@@ -216,6 +222,21 @@ class TagVarsTest(PicardTestCase):
             '<p><strong>Notes:</strong> not provided from MusicBrainz data.</p>'
         )
         self.assertEqual(tagvars.display_tooltip('notes3'), result)
+
+    def test_tagvars_full_description(self):
+        tagvars = TagVars(
+            self.tagvar_everything,
+        )
+        profile_groups_add_setting('junk', 'everything_test', None, 'Everything test option setting')
+        result = (
+            '<p><em>%everything%</em></p><p>everything ld.</p>'
+            '<p><strong>Notes:</strong> preserved read-only; not for use in scripts; calculated; '
+            'info from audio file; not provided from MusicBrainz data; not populated by stock Picard.</p>'
+            '<p><strong>Option Settings:</strong> Everything test option setting.</p>'
+            "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/test'>Test link</a>.</p>"
+            '<p><strong>See Also:</strong> %artist%; %title%.</p>'
+        )
+        self.assertEqual(tagvars.display_full_description('everything'), result)
 
 
 class UtilTagsTest(PicardTestCase):

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -474,3 +474,17 @@ class UtilTagsSeeAlsoTest(PicardTestCase):
                 name = ALL_TAGS.script_name_from_name(also)
                 self.assertIsNotNone(name, f"Invalid see_also '{also}' in '{str(tv)}' tag")
                 self.assertNotEqual(name, str(tv), f"Circular see_also reference in '{str(tv)}' tag")
+
+
+class UtilTagsLinksTest(PicardTestCase):
+    def test_links_completeness(self):
+        """Ensure all `doc_links` entries have both a title and a link.
+        """
+        for tv in ALL_TAGS:
+            if tv.doc_links is None:
+                continue
+            for doc_link in tv.doc_links:
+                title = doc_link.title.strip()
+                link = doc_link.link.strip()
+                self.assertNotEqual(title, '', f"Invalid link (missing title) in '{str(tv)}' tag")
+                self.assertNotEqual(link, '', f"Invalid link (missing URL) in '{str(tv)}' tag")

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -56,7 +56,8 @@ class TagVarsTest(PicardTestCase):
                                    is_file_info=True, is_hidden=True, is_script_variable=False)
         self.tagvar_notes2 = TagVar('notes2', shortdesc='notes2_sd', longdesc='notes2_ld', is_file_info=True, is_from_mb=False)
         self.tagvar_notes3 = TagVar('notes3', shortdesc='notes3_sd', longdesc='notes3_ld', is_from_mb=False)
-        self.tagvar_everything = TagVar('everything', shortdesc='everything sd', longdesc='everything ld.', is_preserved=True,
+        self.tagvar_everything = TagVar('everything', shortdesc='everything sd', longdesc='everything ld.',
+                                        additionaldesc='Test additional description.', is_preserved=True,
                                         is_script_variable=False, is_tag=False, is_calculated=True, is_file_info=True, is_from_mb=False,
                                         is_populated_by_picard=False, see_also=('artist', 'title'), related_options=('everything_test', ),
                                         doc_links=(DocumentLink('Test link', PICARD_URLS['mb_doc'] + 'test'),))
@@ -230,6 +231,7 @@ class TagVarsTest(PicardTestCase):
         profile_groups_add_setting('junk', 'everything_test', None, 'Everything test option setting')
         result = (
             '<p><em>%everything%</em></p><p>everything ld.</p>'
+            '<p>Test additional description.</p>'
             '<p><strong>Notes:</strong> preserved read-only; not for use in scripts; calculated; '
             'info from audio file; not provided from MusicBrainz data; not populated by stock Picard.</p>'
             '<p><strong>Option Settings:</strong> Everything test option setting.</p>'

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -298,7 +298,7 @@ class TagVarsTest(PicardTestCase):
             '<p><strong>Notes:</strong> multi-value variable; preserved read-only; not for use in scripts; '
             'calculated; info from audio file; not provided from MusicBrainz data; not populated by stock '
             'Picard.</p>'
-            '<p><strong>Option Settings:</strong> Everything test setting; No option title available.</p>'
+            '<p><strong>Option Settings:</strong> Everything test setting.</p>'
             "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/test'>Test link</a>.</p>"
             '<p><strong>See Also:</strong> %artist%; %title%.</p>'
         )

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -43,6 +43,64 @@ from picard.util.tags import (
 )
 
 
+class TagVarTest(PicardTestCase):
+    def test_basic_properties(self):
+        tv = TagVar('name')
+
+        # native properties
+        self.assertEqual(tv._name, 'name')
+        self.assertIsNone(tv._shortdesc)
+        self.assertIsNone(tv._longdesc)
+        self.assertIsNone(tv._additionaldesc)
+        self.assertFalse(tv.is_preserved)
+        self.assertFalse(tv.is_hidden)
+        self.assertTrue(tv.is_script_variable)
+        self.assertTrue(tv.is_tag)
+        self.assertFalse(tv.is_calculated)
+        self.assertFalse(tv.is_file_info)
+        self.assertTrue(tv.is_from_mb)
+        self.assertTrue(tv.is_populated_by_picard)
+        self.assertIsNone(tv.see_also)
+        self.assertIsNone(tv.related_options)
+        self.assertIsNone(tv.doc_links)
+
+        # derived properties
+        self.assertEqual(tv.shortdesc, 'name')
+        self.assertEqual(tv.longdesc, 'name')
+        self.assertEqual(tv.additionaldesc, '')
+
+        self.assertFalse(tv.not_from_mb)
+        self.assertFalse(tv.not_script_variable)
+        self.assertFalse(tv.not_populated_by_picard)
+
+        # basic methods
+        self.assertEqual(tv.script_name(), 'name')
+        self.assertEqual(str(tv), 'name')
+
+    def test_basic_hidden_script_name(self):
+        tv = TagVar('name', is_hidden=True)
+        self.assertEqual(tv.script_name(), '_name')
+
+    def test_basic_notes(self):
+        see_also = ('a', 'b',)
+        related_options = ('o1', 'o2',)
+        doc_links = (
+            DocumentLink('L1', 'U1'),
+            DocumentLink('L2', 'U2'),
+        )
+
+        tv = TagVar(
+            'name',
+            see_also=see_also,
+            related_options=related_options,
+            doc_links=doc_links,
+        )
+
+        self.assertEqual(tv.see_also, see_also)
+        self.assertEqual(tv.related_options, related_options)
+        self.assertEqual(tv.doc_links, doc_links)
+
+
 class TagVarsTest(PicardTestCase):
 
     def setUp(self):

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -22,12 +22,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
 import unittest.mock as mock
 
 from test.picardtestcase import PicardTestCase
 
 from picard.const import PICARD_URLS
+from picard.options import Option
 from picard.profile import profile_groups_add_setting
 from picard.util.tags import (
     DocumentLink,
@@ -117,8 +117,12 @@ class TagVarsTest(PicardTestCase):
         self.tagvar_everything = TagVar('everything', shortdesc='everything sd', longdesc='everything ld.',
                                         additionaldesc='Test additional description.', is_preserved=True,
                                         is_script_variable=False, is_tag=False, is_calculated=True, is_file_info=True, is_from_mb=False,
-                                        is_populated_by_picard=False, see_also=('artist', 'title'), related_options=('everything_test', ),
+                                        is_populated_by_picard=False, is_multi_value=True,
+                                        see_also=('artist', 'title'),
+                                        related_options=('everything_test', 'not_a_valid_option_setting'),
                                         doc_links=(DocumentLink('Test link', PICARD_URLS['mb_doc'] + 'test'),))
+        if ('setting', 'everything_test') not in Option.registry:
+            Option('setting', 'everything_test', None, title='Everything test setting')
 
     def test_invalid_tagvar(self):
         with self.assertRaises(TypeError):
@@ -290,9 +294,10 @@ class TagVarsTest(PicardTestCase):
         result = (
             '<p><em>%everything%</em></p><p>everything ld.</p>'
             '<p>Test additional description.</p>'
-            '<p><strong>Notes:</strong> preserved read-only; not for use in scripts; calculated; '
-            'info from audio file; not provided from MusicBrainz data; not populated by stock Picard.</p>'
-            '<p><strong>Option Settings:</strong> Everything test option setting.</p>'
+            '<p><strong>Notes:</strong> multi-value variable; preserved read-only; not for use in scripts; '
+            'calculated; info from audio file; not provided from MusicBrainz data; not populated by stock '
+            'Picard.</p>'
+            '<p><strong>Option Settings:</strong> Everything test setting; No option title available.</p>'
             "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/test'>Test link</a>.</p>"
             '<p><strong>See Also:</strong> %artist%; %title%.</p>'
         )

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -330,7 +330,7 @@ class UtilTagsTest(PicardTestCase):
 
         self.assertEqual(
             display_tag_tooltip('_albumartists_sort'),
-            "<p><em>%_albumartists_sort%</em></p><p>A multi-value variable containing the sort names of the album's artists.</p>"
+            "<p><em>%_albumartists_sort%</em></p><p>The sort names of the album's artists.</p><p><strong>Notes:</strong> multi-value variable.</p>"
         )
 
         result = (
@@ -353,21 +353,22 @@ class UtilTagsTest(PicardTestCase):
             '"<em>guest guitar</em>", "<em>solo violin</em>", etc.</li>\n'
             '<li>the orchestra for the associated release or recording, where "type" is "<em>orchestra</em>"</li>\n'
             '<li>the concert master for the associated release or recording, where "type" is "<em>concertmaster</em>"</li>\n'
-            '</ul>'
+            '</ul><p><strong>Notes:</strong> multi-value variable.</p>'
         ) if markdown is not None else (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
             '<br /><br />'
             '- vocals or instruments for the associated release or recording, where "type" can be "*vocal*", "*guest guitar*", "*solo violin*", etc.<br />'
             '- the orchestra for the associated release or recording, where "type" is "*orchestra*"<br />'
             '- the concert master for the associated release or recording, where "type" is "*concertmaster*"</p>'
+            '<p><strong>Notes:</strong> multi-value variable.</p>'
         )
         self.assertEqual(display_tag_tooltip('performer'), result)
 
     def test_display_tag_full_description(self):
         profile_groups_add_setting('junk', 'use_genres', None, 'Use genres from MusicBrainz')
         result = (
-            '<p><em>%genre%</em></p><p>A multi-value tag containing the specified genre information from MusicBrainz.</p>'
-            '<p><strong>Option Settings:</strong> Use genres from MusicBrainz.</p>'
+            '<p><em>%genre%</em></p><p>The specified genre information from MusicBrainz.</p><p><strong>Notes:</strong> multi-value '
+            'variable.</p><p><strong>Option Settings:</strong> Use genres from MusicBrainz.</p>'
         )
         self.assertEqual(display_tag_full_description('genre'), result)
 
@@ -392,11 +393,13 @@ class UtilTagsTest(PicardTestCase):
             '<li>the orchestra for the associated release or recording, where "type" is "<em>orchestra</em>"</li>\n'
             '<li>the concert master for the associated release or recording, where "type" is "<em>concertmaster</em>"</li>\n'
             '</ul>'
+            '<p><strong>Notes:</strong> multi-value variable.</p>'
         ) if markdown is not None else (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
             '<br /><br />'
             '- vocals or instruments for the associated release or recording, where "type" can be "*vocal*", "*guest guitar*", "*solo violin*", etc.<br />'
             '- the orchestra for the associated release or recording, where "type" is "*orchestra*"<br />'
             '- the concert master for the associated release or recording, where "type" is "*concertmaster*"</p>'
+            '<p><strong>Notes:</strong> multi-value variable.</p>'
         )
         self.assertEqual(display_tag_full_description('performer'), result)

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -49,9 +49,9 @@ class TagVarsTest(PicardTestCase):
         self.tagvar_notag = TagVar('notag', is_tag=False)
         self.tagvar_nodesc = TagVar('nodesc')
         self.tagvar_notes1 = TagVar('notes1', shortdesc='notes1_sd', longdesc='notes1_ld', is_preserved=True, is_calculated=True,
-                                   is_file_info=True, is_hidden=True, is_script_variable=False)
-        self.tagvar_notes2 = TagVar('notes2', shortdesc='notes2_sd', longdesc='notes2_ld', is_file_info=True, is_from_mb=False)
-        self.tagvar_notes3 = TagVar('notes3', shortdesc='notes3_sd', longdesc='notes3_ld', is_from_mb=False)
+                                   is_file_info=True, is_hidden=True, not_script_variable=True)
+        self.tagvar_notes2 = TagVar('notes2', shortdesc='notes2_sd', longdesc='notes2_ld', is_file_info=True, not_from_mb=True)
+        self.tagvar_notes3 = TagVar('notes3', shortdesc='notes3_sd', longdesc='notes3_ld', not_from_mb=True)
 
     def test_invalid_tagvar(self):
         with self.assertRaises(TypeError):
@@ -174,7 +174,7 @@ class TagVarsTest(PicardTestCase):
             self.tagvar_only_sd,
             self.tagvar_sd_ld,
         )
-        self.tagvar_sd_ld.is_script_variable = False
+        self.tagvar_sd_ld.not_script_variable = True
 
         with mock.patch('picard.util.tags.ALL_TAGS', tagvars):
             self.assertEqual(
@@ -198,22 +198,22 @@ class TagVarsTest(PicardTestCase):
 
         result = (
             '<p><em>%_notes1%</em></p><p>notes1_ld</p>\n'
-            '<p><strong>Notes:</strong> read-only; calculated variable; provided from the file; not available for use in scripts.</p>'
+            '<p><strong>Notes:</strong> preserved read-only; not for use in scripts; calculated; info from audio file.</p>'
         ) if markdown is not None else (
             '<p><em>%_notes1%</em></p><p>notes1_ld'
             '<br /><br />'
-            '**Notes:** read-only; calculated variable; provided from the file; not available for use in scripts.</p>'
+            '**Notes:** preserved read-only; not for use in scripts; calculated; info from audio file.</p>'
         )
         self.assertEqual(tagvars.display_tooltip('_notes1'), result)
         self.assertEqual(tagvars.display_tooltip('~notes1'), result)
 
         result = (
             '<p><em>%notes2%</em></p><p>notes2_ld</p>\n'
-            '<p><strong>Notes:</strong> provided from the file.</p>'
+            '<p><strong>Notes:</strong> info from audio file; not provided from MusicBrainz data.</p>'
         ) if markdown is not None else (
             '<p><em>%notes2%</em></p><p>notes2_ld'
             '<br /><br />'
-            '**Notes:** provided from the file.</p>'
+            '**Notes:** info from audio file; not provided from MusicBrainz data.</p>'
         )
         self.assertEqual(tagvars.display_tooltip('notes2'), result)
 
@@ -274,11 +274,11 @@ class UtilTagsTest(PicardTestCase):
 
         result = (
             '<p><em>%_bitrate%</em></p><p>Approximate bitrate in kbps.</p>\n'
-            '<p><strong>Notes:</strong> read-only; provided from the file.</p>'
+            '<p><strong>Notes:</strong> preserved read-only; info from audio file; not provided from MusicBrainz data.</p>'
         ) if markdown is not None else (
             '<p><em>%_bitrate%</em></p><p>Approximate bitrate in kbps.'
             '<br /><br />'
-            '**Notes:** read-only; provided from the file.</p>'
+            '**Notes:** preserved read-only; info from audio file; not provided from MusicBrainz data.</p>'
         )
         self.assertEqual(display_tag_tooltip('_bitrate'), result)
         self.assertEqual(display_tag_tooltip('~bitrate'), result)


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:  Add tooltip descriptions to `PRESERVED_TAGS` and `EXTRA_VARIABLES`

# Problem

The tooltips shown for the tags and variables in the script editor only showed information for the `TAG_NAMES`.  There were no tooltip descriptions for `PRESERVED_TAGS` and `EXTRA_VARIABLES`.

* JIRA ticket (_optional_): PICARD-3061

# Solution

Add tooltip descriptions to `PRESERVED_TAGS` and `EXTRA_VARIABLES`.  Add test for tooltips on tags and variables.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

Since this change will result in some new and changed string for translation, please review the new and existing tag description strings to ensure that any desired changes are captured prior to merging this PR.
