### PR TITLE
PICARD-3062: Add tag documentation to script editor help

### DIFF
--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -80,9 +80,7 @@ from picard.ui.options.scripting import (
     OptionsCheckError,
     ScriptCheckError,
 )
-from picard.ui.widgets.scriptdocumentation import (
-    ScriptingDocumentationWidget,
-)
+from picard.ui.widgets.scriptdocumentation import ScriptingDocumentationWidget
 
 
 class ScriptFileError(OptionsCheckError):

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -80,7 +80,9 @@ from picard.ui.options.scripting import (
     OptionsCheckError,
     ScriptCheckError,
 )
-from picard.ui.widgets.scriptdocumentation import ScriptingDocumentationWidget
+from picard.ui.widgets.scriptdocumentation import (
+    ScriptingDocumentationWidget,
+)
 
 
 class ScriptFileError(OptionsCheckError):
@@ -170,6 +172,14 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
         self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Help)
         self.ui.buttonbox.helpRequested.connect(self.show_help)
 
+        # Prevent splitter from completely hiding editor or documentation panels
+        self.ui.splitter_between_editor_and_documentation.setCollapsible(0, False)
+        self.ui.splitter_between_editor_and_documentation.setCollapsible(1, False)
+
+        # Prevent splitter from completely hiding before or after example panels
+        self.ui.splitter_between_before_and_after.setCollapsible(0, False)
+        self.ui.splitter_between_before_and_after.setCollapsible(1, False)
+
         # Add links to edit script metadata
         self.ui.script_title.installEventFilter(self)
         self.ui.script_title.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.ActionsContextMenu)
@@ -177,7 +187,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
 
         self.ui.file_naming_format.setEnabled(True)
 
-        # Add scripting documentation to parent frame.
+        # Add documentation to frame
         doc_widget = ScriptingDocumentationWidget(include_link=False, parent=self)
         self.ui.documentation_frame_layout.addWidget(doc_widget)
 
@@ -194,7 +204,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
 
         synchronize_vertical_scrollbars((self.ui.example_filename_before, self.ui.example_filename_after))
 
-        self.toggle_documentation()  # Force update to display
+        self.toggle_documentation()         # Force update to display
         self.examples_current_row = -1
 
         self.selected_script_index = 0
@@ -405,6 +415,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog):
     def closeEvent(self, event):
         """Custom close event handler to check for unsaved changes.
         """
+        self.save_geometry()
         if self.unsaved_changes_in_profile_confirmation():
             self.reset_script_in_settings()
             self.set_selector_states(save_enabled=True)

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -125,8 +125,6 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             'inline_start': 'right' if text_direction == 'rtl' else 'left'
         }
 
-        self.selected_panel = 1
-
         # Scripting code is always left-to-right. Qt does not support the dir
         # attribute on inline tags, insert explicit left-right-marks instead.
         if text_direction == 'rtl':

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -111,7 +111,7 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             template = '<dt>%s</dt><dd>%s</dd>'
             tag_title = '%' + tag.script_name() + '%'
             tag_desc = tag.full_description_content()
-            return template % ("<code>%s</code>" % tag_title, tag_desc)
+            return template % (f'<a id="{tag.script_name()}"><code>{tag_title}</code></a>', tag_desc)
 
         tagdoc = ''
         for tag in sorted(ALL_TAGS, key=lambda x: x.script_name()):

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -48,7 +48,7 @@ dt {
 }
 dd {
     /* Qt does not support margin-inline-start, use margin-left/margin-right instead */
-    margin-%(inline_start)s: 50px;
+    margin-%(inline_start)s: 20px;
     margin-bottom: 50px;
 }
 code {
@@ -139,63 +139,40 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout.setObjectName('docs_verticalLayout')
 
-        self.selected_docs = QtWidgets.QLabel(self)
-        self.selected_docs.setText(_('Functions:'))
-        self.selected_docs.setStyleSheet('font-weight: bold;')
+        self.tabs = QtWidgets.QTabWidget(self)
+        self.tabs.setContentsMargins(0, 0, 0, 0)
 
-        self.pb_spacer = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
+        self.func_page = QtWidgets.QWidget(self)
+        self.func_page_layout = QtWidgets.QVBoxLayout()
+        self.func_page_layout.setContentsMargins(0, 0, 0, 0)
+        self.func_page.setLayout(self.func_page_layout)
 
-        self.pb_toggle = QtWidgets.QPushButton(self)
-        self.pb_toggle.setText(_('Tags:'))
-        self.pb_toggle.setEnabled(True)
-        self.pb_toggle.clicked.connect(self._pb_toggle_clicked)
+        self.func_browser = QtWidgets.QTextBrowser(self)
+        self.func_browser.setEnabled(True)
+        self.func_browser.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.func_browser.setObjectName('func_browser')
+        self.func_browser.setHtml(func_html)
+        self.func_browser.show()
+        self.func_page_layout.addWidget(self.func_browser)
 
-        self.pb_layout = QtWidgets.QHBoxLayout()
-        self.pb_layout.setObjectName('docs_pb_layout')
-        self.pb_layout.addWidget(self.selected_docs)
-        self.pb_layout.addItem(self.pb_spacer)
-        self.pb_layout.addWidget(self.pb_toggle)
-        self.verticalLayout.addItem(self.pb_layout)
+        self.tags_page = QtWidgets.QWidget(self)
+        self.tags_page_layout = QtWidgets.QVBoxLayout()
+        self.tags_page_layout.setContentsMargins(0, 0, 0, 0)
+        self.tags_page.setLayout(self.tags_page_layout)
 
-        self.frame_1 = QtWidgets.QFrame(parent=self)
-        self.frame_1.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        self.frame_1.setFrameShadow(QtWidgets.QFrame.Shadow.Raised)
-        self.frame_1.setContentsMargins(0, 0, 0, 0)
-        self.frame_1.setObjectName("docs_frame_1")
-        self.frame_1.show()
+        self.tags_browser = QtWidgets.QTextBrowser(self)
+        self.tags_browser.setEnabled(True)
+        self.tags_browser.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.tags_browser.setObjectName('tags_browser')
+        self.tags_browser.setOpenExternalLinks(True)
+        self.tags_browser.setHtml(tag_html)
+        self.tags_browser.show()
+        self.tags_page_layout.addWidget(self.tags_browser)
 
-        self.frame_1_layout = QtWidgets.QVBoxLayout(self.frame_1)
-        self.frame_1_layout.setContentsMargins(0, 0, 0, 0)
+        self.tabs.addTab(self.func_page, _("Functions"))
+        self.tabs.addTab(self.tags_page, _("Tags"))
 
-        self.textBrowser_1 = QtWidgets.QTextBrowser(self)
-        self.textBrowser_1.setEnabled(True)
-        self.textBrowser_1.setMinimumSize(QtCore.QSize(0, 0))
-        self.textBrowser_1.setObjectName('function_docs_textBrowser')
-        self.textBrowser_1.setHtml(func_html)
-        self.textBrowser_1.show()
-        self.frame_1_layout.addWidget(self.textBrowser_1)
-
-        self.frame_2 = QtWidgets.QFrame(parent=self)
-        self.frame_2.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        self.frame_2.setFrameShadow(QtWidgets.QFrame.Shadow.Raised)
-        self.frame_2.setContentsMargins(0, 0, 0, 0)
-        self.frame_2.setObjectName("docs_frame_2")
-        self.frame_2.show()
-
-        self.frame_2_layout = QtWidgets.QVBoxLayout(self.frame_2)
-        self.frame_2_layout.setContentsMargins(0, 0, 0, 0)
-
-        self.textBrowser_2 = QtWidgets.QTextBrowser(self)
-        self.textBrowser_2.setEnabled(True)
-        self.textBrowser_2.setMinimumSize(QtCore.QSize(0, 0))
-        self.textBrowser_2.setObjectName('tags_docs_textBrowser')
-        self.textBrowser_2.setOpenExternalLinks(True)
-        self.textBrowser_2.setHtml(tag_html)
-        self.textBrowser_2.show()
-        self.frame_2_layout.addWidget(self.textBrowser_2)
-
-        self.verticalLayout.addWidget(self.frame_1)
-        self.verticalLayout.addWidget(self.frame_2)
+        self.verticalLayout.addWidget(self.tabs)
 
         self.horizontalLayout = QtWidgets.QHBoxLayout()
         self.horizontalLayout.setContentsMargins(-1, 0, -1, -1)
@@ -216,22 +193,4 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             self.scripting_doc_link.show()
             self.horizontalLayout.addWidget(self.scripting_doc_link)
         self.verticalLayout.addLayout(self.horizontalLayout)
-        self.display_panel()
-
-    def display_panel(self):
-        if self.selected_panel == 1:
-            self.frame_1.setVisible(True)
-            self.frame_2.setVisible(False)
-            self.selected_docs.setText(_('Functions:'))
-            self.pb_toggle.setText(_('Tags'))
-        else:
-            self.frame_1.setVisible(False)
-            self.frame_2.setVisible(True)
-            self.selected_docs.setText(_('Tags:'))
-            self.pb_toggle.setText(_('Functions'))
-
-    def _pb_toggle_clicked(self):
-        self.selected_panel += 1
-        if self.selected_panel > 2:
-            self.selected_panel = 1
-        self.display_panel()
+        self.show()

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -108,10 +108,10 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         }
 
         def process_tag(tag: TagVar):
-            template = '<dt>%s</dt><dd>%s</dd>'
-            tag_title = '%' + tag.script_name() + '%'
+            tag_name = tag.script_name()
             tag_desc = tag.full_description_content()
-            return template % (f'<a id="{tag.script_name()}"><code>{tag_title}</code></a>', tag_desc)
+            tag_title = f'<a id="{tag_name}"><code>%{tag_name}%</code></a>'
+            return f'<dt>{tag_title}</dt><dd>{tag_desc}</dd>'
 
         tagdoc = ''
         for tag in sorted(ALL_TAGS, key=lambda x: x.script_name()):

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -66,10 +66,6 @@ code {
 class ScriptingDocumentationWidget(QtWidgets.QWidget):
     """Custom widget to display the scripting documentation.
     """
-    # TODO: Select better colors, and create different settings for dark theme as appropriate.
-    BUTTON_STYLE_SELECTED = 'padding: 3px; border: 1px solid; border-radius: 7px; background: #8FBC8F; color: #000;'
-    BUTTON_STYLE_NOT_SELECTED = 'padding: 3px; border: 1px solid; border-radius: 7px; background: #A9A9A9; color: #000;'
-
     def __init__(self, include_link=True, parent=None):
         """Custom widget to display the scripting documentation.
 
@@ -114,7 +110,7 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         def process_tag(tag: TagVar):
             template = '<dt>%s</dt><dd>%s</dd>'
             tag_title = '%' + tag.script_name() + '%'
-            tag_desc = tag.full_description()
+            tag_desc = tag.full_description_content()
             return template % ("<code>%s</code>" % tag_title, tag_desc)
 
         tagdoc = ''
@@ -143,27 +139,23 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout.setObjectName('docs_verticalLayout')
 
-        self.pb_functions = QtWidgets.QPushButton(self)
-        self.pb_functions.setText(_('Functions'))
-        self.pb_functions.clicked.connect(self._pb_functions_clicked)
+        self.selected_docs = QtWidgets.QLabel(self)
+        self.selected_docs.setText(_('Functions:'))
+        self.selected_docs.setStyleSheet('font-weight: bold;')
 
-        self.pb_tags = QtWidgets.QPushButton(self)
-        self.pb_tags.setText(_('Tags'))
-        self.pb_tags.clicked.connect(self._pb_tags_clicked)
+        self.pb_spacer = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
 
-        self.pb_frame = QtWidgets.QFrame(self)
-        self.pb_frame.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        self.pb_frame.setFrameShadow(QtWidgets.QFrame.Shadow.Raised)
-        self.pb_frame.setContentsMargins(0, 0, 0, 0)
-        self.pb_frame.setObjectName("docs_pb_frame")
-        self.pb_frame.show()
+        self.pb_toggle = QtWidgets.QPushButton(self)
+        self.pb_toggle.setText(_('Tags:'))
+        self.pb_toggle.setEnabled(True)
+        self.pb_toggle.clicked.connect(self._pb_toggle_clicked)
 
-        self.pb_layout = QtWidgets.QHBoxLayout(self.pb_frame)
-        self.pb_layout.setContentsMargins(0, 0, 0, 0)
+        self.pb_layout = QtWidgets.QHBoxLayout()
         self.pb_layout.setObjectName('docs_pb_layout')
-        self.pb_layout.addWidget(self.pb_functions)
-        self.pb_layout.addWidget(self.pb_tags)
-        self.verticalLayout.addWidget(self.pb_frame)
+        self.pb_layout.addWidget(self.selected_docs)
+        self.pb_layout.addItem(self.pb_spacer)
+        self.pb_layout.addWidget(self.pb_toggle)
+        self.verticalLayout.addItem(self.pb_layout)
 
         self.frame_1 = QtWidgets.QFrame(parent=self)
         self.frame_1.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
@@ -230,18 +222,16 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         if self.selected_panel == 1:
             self.frame_1.setVisible(True)
             self.frame_2.setVisible(False)
-            self.pb_functions.setStyleSheet(self.BUTTON_STYLE_SELECTED)
-            self.pb_tags.setStyleSheet(self.BUTTON_STYLE_NOT_SELECTED)
+            self.selected_docs.setText(_('Functions:'))
+            self.pb_toggle.setText(_('Tags'))
         else:
             self.frame_1.setVisible(False)
             self.frame_2.setVisible(True)
-            self.pb_functions.setStyleSheet(self.BUTTON_STYLE_NOT_SELECTED)
-            self.pb_tags.setStyleSheet(self.BUTTON_STYLE_SELECTED)
+            self.selected_docs.setText(_('Tags:'))
+            self.pb_toggle.setText(_('Functions'))
 
-    def _pb_functions_clicked(self):
-        self.selected_panel = 1
-        self.display_panel()
-
-    def _pb_tags_clicked(self):
-        self.selected_panel = 2
+    def _pb_toggle_clicked(self):
+        self.selected_panel += 1
+        if self.selected_panel > 2:
+            self.selected_panel = 1
         self.display_panel()

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -137,15 +137,15 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout.setObjectName('docs_verticalLayout')
 
-        self.tabs = QtWidgets.QTabWidget(self)
+        self.tabs = QtWidgets.QTabWidget()
         self.tabs.setContentsMargins(0, 0, 0, 0)
 
-        self.func_page = QtWidgets.QWidget(self)
+        self.func_page = QtWidgets.QWidget()
         self.func_page_layout = QtWidgets.QVBoxLayout()
         self.func_page_layout.setContentsMargins(0, 0, 0, 0)
         self.func_page.setLayout(self.func_page_layout)
 
-        self.func_browser = QtWidgets.QTextBrowser(self)
+        self.func_browser = QtWidgets.QTextBrowser()
         self.func_browser.setEnabled(True)
         self.func_browser.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.func_browser.setObjectName('func_browser')
@@ -153,12 +153,12 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.func_browser.show()
         self.func_page_layout.addWidget(self.func_browser)
 
-        self.tags_page = QtWidgets.QWidget(self)
+        self.tags_page = QtWidgets.QWidget()
         self.tags_page_layout = QtWidgets.QVBoxLayout()
         self.tags_page_layout.setContentsMargins(0, 0, 0, 0)
         self.tags_page.setLayout(self.tags_page_layout)
 
-        self.tags_browser = QtWidgets.QTextBrowser(self)
+        self.tags_browser = QtWidgets.QTextBrowser()
         self.tags_browser.setEnabled(True)
         self.tags_browser.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.tags_browser.setObjectName('tags_browser')
@@ -175,12 +175,15 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
         self.horizontalLayout = QtWidgets.QHBoxLayout()
         self.horizontalLayout.setContentsMargins(-1, 0, -1, -1)
         self.horizontalLayout.setObjectName('docs_horizontalLayout')
-        self.scripting_doc_link = QtWidgets.QLabel(self)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.scripting_doc_link.sizePolicy().hasHeightForWidth())
+
         if include_link:
+            self.scripting_doc_link = QtWidgets.QLabel()
+
+            sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
+            sizePolicy.setHorizontalStretch(0)
+            sizePolicy.setVerticalStretch(0)
+            sizePolicy.setHeightForWidth(self.scripting_doc_link.sizePolicy().hasHeightForWidth())
+
             self.scripting_doc_link.setSizePolicy(sizePolicy)
             self.scripting_doc_link.setMinimumSize(QtCore.QSize(0, 20))
             self.scripting_doc_link.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -190,5 +193,6 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             self.scripting_doc_link.setText(link)
             self.scripting_doc_link.show()
             self.horizontalLayout.addWidget(self.scripting_doc_link)
+
         self.verticalLayout.addLayout(self.horizontalLayout)
         self.show()

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -114,7 +114,7 @@ class ScriptingDocumentationWidget(QtWidgets.QWidget):
             return template % ("<code>%s</code>" % tag_title, tag_desc)
 
         tagdoc = ''
-        for tag in ALL_TAGS:
+        for tag in sorted(ALL_TAGS, key=lambda x: x.script_name()):
             tagdoc += process_tag(tag)
 
         tag_html = DOCUMENTATION_HTML_TEMPLATE % {

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -217,6 +217,35 @@ class TagVar:
                 values='; '.join(values),
             )
 
+    @staticmethod
+    def _markdown(text: str):
+        if markdown is None:
+            return '<p>' + text.replace('\n', '<br />') + '</p>'
+        return markdown(text)
+
+    def _add_sections(self, include_sections):
+        # Note: format has to be translatable, for languages not using left-to-right for example
+        fmt = _("<p><strong>{title}:</strong> {values}.</p>")
+        return ''.join(self._gen_sections(fmt, include_sections))
+
+    def full_description(self):
+        content = self._markdown(_(self.longdesc) if self.longdesc else _(TEXT_NO_DESCRIPTION))
+
+        # Append additional description
+        if self.additionaldesc:
+            content += self._markdown(_(self.additionaldesc))
+
+        # Append additional sections as required
+        include_sections = (
+            Section.notes,
+            Section.options,
+            Section.links,
+            Section.see_also,
+        )
+        content += self._add_sections(include_sections)
+
+        return content
+
 
 class TagVars(MutableSequence):
     """Mutable sequence for TagVar items

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -38,6 +38,7 @@ from collections import (
 )
 from collections.abc import MutableSequence
 from enum import IntEnum
+import html
 import re
 
 
@@ -58,6 +59,7 @@ DocumentLink = namedtuple('DocumentLink', ('title', 'link'))
 
 
 def _markdown(text: str):
+    text = html.escape(text)
     if markdown is None:
         return '<p>' + text.replace('\n', '<br />') + '</p>'
     return markdown(text)
@@ -186,7 +188,7 @@ class TagVar:
     def notes(self):
         for attrib, note in ATTRIB2NOTE.items():
             if getattr(self, attrib):
-                yield _(note)
+                yield html.escape(_(note))
 
     def related_options_titles(self):
         if not self.related_options:
@@ -194,13 +196,13 @@ class TagVar:
         for setting in self.related_options:
             title = get_option_title(setting)
             if title:
-                yield _(title)
+                yield html.escape(_(title))
 
     def links(self):
         if not self.doc_links:
             return
         for doclink in self.doc_links:
-            translated_title = _(doclink.title)
+            translated_title = html.escape(_(doclink.title))
             yield f"<a href='{doclink.link}'>{translated_title}</a>"
 
     def see_alsos(self):

--- a/picard/util/tags.py
+++ b/picard/util/tags.py
@@ -209,7 +209,7 @@ class TagVar:
         for tag in self.see_also:
             name = ALL_TAGS.script_name_from_name(tag)
             if name:
-                yield f"%{name}%"
+                yield f'<a href="#{tag}">%{tag}%</a>'
 
     def _base_description(self):
         return _markdown(_(self.longdesc) if self.longdesc else _(TEXT_NO_DESCRIPTION))

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -336,7 +336,7 @@ class TagVarsTest(PicardTestCase):
             'Picard.</p>'
             '<p><strong>Option Settings:</strong> Everything test setting.</p>'
             "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/test'>Test link</a>.</p>"
-            '<p><strong>See Also:</strong> %artist%; %title%.</p>'
+            '<p><strong>See Also:</strong> <a href="#artist">%artist%</a>; <a href="#title">%title%</a>.</p>'
         )
         self.assertEqual(tagvars.display_full_description('everything'), result)
 

--- a/test/test_util_tags.py
+++ b/test/test_util_tags.py
@@ -372,7 +372,10 @@ class UtilTagsTest(PicardTestCase):
 
         self.assertEqual(
             display_tag_tooltip('_albumartists_sort'),
-            "<p><em>%_albumartists_sort%</em></p><p>The sort names of the album's artists.</p><p><strong>Notes:</strong> multi-value variable.</p>"
+            (
+                '<p><em>%_albumartists_sort%</em></p><p>The sort names of the album&#x27;s artists.</p><p><strong>Notes:'
+                '</strong> multi-value variable.</p>'
+            )
         )
 
         result = (
@@ -391,17 +394,18 @@ class UtilTagsTest(PicardTestCase):
         result = (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:</p>\n'
             '<ul>\n'
-            '<li>vocals or instruments for the associated release or recording, where "type" can be "<em>vocal</em>", '
-            '"<em>guest guitar</em>", "<em>solo violin</em>", etc.</li>\n'
-            '<li>the orchestra for the associated release or recording, where "type" is "<em>orchestra</em>"</li>\n'
-            '<li>the concert master for the associated release or recording, where "type" is "<em>concertmaster</em>"</li>\n'
+            '<li>vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;<em>vocal</em>&quot;, '
+            '&quot;<em>guest guitar</em>&quot;, &quot;<em>solo violin</em>&quot;, etc.</li>\n'
+            '<li>the orchestra for the associated release or recording, where &quot;type&quot; is &quot;<em>orchestra</em>&quot;</li>\n'
+            '<li>the concert master for the associated release or recording, where &quot;type&quot; is &quot;<em>concertmaster</em>&quot;</li>\n'
             '</ul><p><strong>Notes:</strong> multi-value variable.</p>'
         ) if markdown is not None else (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
             '<br /><br />'
-            '- vocals or instruments for the associated release or recording, where "type" can be "*vocal*", "*guest guitar*", "*solo violin*", etc.<br />'
-            '- the orchestra for the associated release or recording, where "type" is "*orchestra*"<br />'
-            '- the concert master for the associated release or recording, where "type" is "*concertmaster*"</p>'
+            '- vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;*vocal*&quot;, &quot;*guest '
+            'guitar*&quot;, &quot;*solo violin*&quot;, etc.<br />'
+            '- the orchestra for the associated release or recording, where &quot;type&quot; is &quot;*orchestra*&quot;<br />'
+            '- the concert master for the associated release or recording, where &quot;type&quot; is &quot;*concertmaster*&quot;</p>'
             '<p><strong>Notes:</strong> multi-value variable.</p>'
         )
         self.assertEqual(display_tag_tooltip('performer'), result)
@@ -431,18 +435,19 @@ class UtilTagsTest(PicardTestCase):
         result = (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:</p>\n'
             '<ul>\n'
-            '<li>vocals or instruments for the associated release or recording, where "type" can be "<em>vocal</em>", '
-            '"<em>guest guitar</em>", "<em>solo violin</em>", etc.</li>\n'
-            '<li>the orchestra for the associated release or recording, where "type" is "<em>orchestra</em>"</li>\n'
-            '<li>the concert master for the associated release or recording, where "type" is "<em>concertmaster</em>"</li>\n'
+            '<li>vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;<em>vocal</em>&quot;, '
+            '&quot;<em>guest guitar</em>&quot;, &quot;<em>solo violin</em>&quot;, etc.</li>\n'
+            '<li>the orchestra for the associated release or recording, where &quot;type&quot; is &quot;<em>orchestra</em>&quot;</li>\n'
+            '<li>the concert master for the associated release or recording, where &quot;type&quot; is &quot;<em>concertmaster</em>&quot;</li>\n'
             '</ul>'
             '<p><strong>Notes:</strong> multi-value variable.</p>'
         ) if markdown is not None else (
             '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
             '<br /><br />'
-            '- vocals or instruments for the associated release or recording, where "type" can be "*vocal*", "*guest guitar*", "*solo violin*", etc.<br />'
-            '- the orchestra for the associated release or recording, where "type" is "*orchestra*"<br />'
-            '- the concert master for the associated release or recording, where "type" is "*concertmaster*"</p>'
+            '- vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;*vocal*&quot;, '
+            '&quot;*guest guitar*&quot;, &quot;*solo violin*&quot;, etc.<br />'
+            '- the orchestra for the associated release or recording, where &quot;type&quot; is &quot;*orchestra*&quot;<br />'
+            '- the concert master for the associated release or recording, where &quot;type&quot; is &quot;*concertmaster*&quot;</p>'
             '<p><strong>Notes:</strong> multi-value variable.</p>'
         )
         self.assertEqual(display_tag_full_description('performer'), result)


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds tag and variable documentation to the script editors help system

# Problem

The script editors (Options > Script and File Naming Script Editor) both provide help documentation regarding available functions (one through a new window and the other as a sidebar).  The available tags and variables help should be added to this.

* JIRA ticket (_optional_): PICARD-3062

# Solution

Add the full descriptions for the tags and variables to a new panel in the existing help display widget, and provide a button to toggle between the function help and the tags help.

Consider adding a section to the Picard User Guide showing the File Naming Script Editor and how it is used.

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
