### PR TITLE
PICARD-3065: Don't return None in `rsearch` when capture group does not match

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -246,22 +246,34 @@ def func_rreplace(parser, text, old, new):
 
 
 @script_function(documentation=N_(
-    """`$rsearch(text,pattern)`
+    """`$rsearch(text,pattern[,group])`
 
 [Regular expression](https://docs.python.org/3/library/re.html#regular-expression-syntax) search.
-    This function will return the first matching group."""
+    This function will return the first matching group.
+
+    If the optional `group` parameter is specified, return the
+    specified group."""
 ))
-def func_rsearch(parser, text, pattern):
+def func_rsearch(parser, text, pattern, group=None):
     try:
         match_ = re.search(pattern, text)
     except re.error:
         return ''
     if match_:
-        try:
-            if match_.group(1) is not None:
-                return match_.group(1)
-            return match_.group(0)
-        except IndexError:
+        if group:
+            try:
+                group = int(group)
+            except ValueError:
+                group = group.strip()
+
+            try:
+                return match_.group(group) or ''
+            except IndexError:
+                return ''
+        else:
+            for value in match_.groups():
+                if value is not None:
+                    return value
             return match_.group(0)
     return ''
 

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -258,7 +258,9 @@ def func_rsearch(parser, text, pattern):
         return ''
     if match_:
         try:
-            return match_.group(1)
+            if match_.group(1) is not None:
+                return match_.group(1)
+            return match_.group(0)
         except IndexError:
             return match_.group(0)
     return ''

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -249,10 +249,24 @@ def func_rreplace(parser, text, old, new):
     """`$rsearch(text,pattern[,group])`
 
 [Regular expression](https://docs.python.org/3/library/re.html#regular-expression-syntax) search.
-    This function will return the first matching group.
 
-    If the optional `group` parameter is specified, return the
-    specified group."""
+If the optional `group` parameter is not provided or is empty, return the first
+capture group which matched something (including the empty string) or the
+entire match.
+
+If `group` is an integer, return the capture group in the position matching this integer.
+Otherwise, return the capture group named `group`, sans surrounding whitespace.
+
+Examples:
+
+    $rsearch(disc: 1,disc: \\(\\\\d+\\)) => "1"
+    $rsearch(disc: 2,\\(\\\\w+\\): \\(\\\\d+\\),1) => "disc"
+    $rsearch(disc: 3,\\(\\\\w+\\): \\(\\\\d+\\),2) => "3"
+    $rsearch(disc: 4,disc: \\(?P<disc>\\\\d+\\),disc) => "4"
+    $rsearch(disc: none,disc\\(: \\\\d+\\)?) => "disc"
+    $rsearch(disc: /5,disc: \\(\\\\d+\\)?/\\\\d+,1) => ""
+
+_group parameter since Picard 3.0_"""
 ))
 def func_rsearch(parser, text, pattern, group=None):
     try:

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -588,6 +588,12 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals(r"$rsearch(test,x)", "")
         self.assertScriptResultEquals(r'''$rsearch(test,[t)''', "")
         self.assertScriptResultEquals(r'$rsearch(foo,foo|\(bar\))', "foo")
+        self.assertScriptResultEquals(r'$rsearch(quux,foo|\(bar\)|\(baz\)|quux)', "quux")
+        self.assertScriptResultEquals(r'$rsearch(foobar,foo\(?:\(baz\)|\(bar\)\))', "bar")
+        self.assertScriptResultEquals(r'$rsearch(test \(disc 1\),\(?:\(?P<name>.+\)\\s+\)?\\\(disc \(?P<disc>\\d+\)\\\), disc)', "1")
+        self.assertScriptResultEquals(r'$rsearch(test \(disc 1\),\(?:\(?P<name>.+\)\\s+\)?\\\(disc \(?P<disc>\\d+\)\\\), name)', "test")
+        self.assertScriptResultEquals(r'$rsearch(\(disc 1\),\(?:\(?P<name>.+\)\\s+\)?\\\(disc \(?P<disc>\\d+\)\\\))', "1")
+        self.assertScriptResultEquals(r'$rsearch(\(disc 1\),\(?:\(?P<name>.+\)\\s+\)?\\\(disc \(?P<disc>\\d+\)\\\), name)', "")
 
     def test_arguments(self):
         self.assertTrue(

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -587,6 +587,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals(r"$rsearch(test \(disc 1\),\\\(disc \\d+\\\))", "(disc 1)")
         self.assertScriptResultEquals(r"$rsearch(test,x)", "")
         self.assertScriptResultEquals(r'''$rsearch(test,[t)''', "")
+        self.assertScriptResultEquals(r'$rsearch(foo,foo|\(bar\))', "foo")
 
     def test_arguments(self):
         self.assertTrue(


### PR DESCRIPTION
* picard/script/functions.py (rsearch): When the first group exists but is None, return the whole match instead.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other

# Problem
PICARD-3065

When the pattern has a group, but does not match it, like `foo|(bar)`, `rsearch` will return `None`, even though it should really return `"foo"`.  This is because the current code only catches the situation where a capture group does not exist at all.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution
If the capture group has not been matched, return the whole match instead.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
