### PR TITLE
PICARD-3064: Fix ID3File hiding File._save_images

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2009, 2011-2012 Lukáš Lalinský
-# Copyright (C) 2008-2011, 2014, 2018-2021, 2023 Philipp Wolfer
+# Copyright (C) 2008-2011, 2014, 2018-2021, 2023, 2025 Philipp Wolfer
 # Copyright (C) 2009 Carlin Mangar
 # Copyright (C) 2011-2012 Johannes Weißl
 # Copyright (C) 2011-2014 Michael Wiencek
@@ -522,7 +522,7 @@ class ID3File(File):
         }
 
         self._save_track_disc_movement_numbers(tags, metadata)
-        self._save_images(tags, metadata)
+        self._save_images_to_tags(tags, metadata)
 
         for name, values in metadata.rawitems():
             name = id3text(name, encoding)
@@ -715,7 +715,7 @@ class ID3File(File):
                 text=id3text(text, Id3Encoding.LATIN1)
             ))
 
-    def _save_images(self, tags, metadata):
+    def _save_images_to_tags(self, tags, metadata):
         """Save cover art images to tags."""
         images_to_save = list(metadata.images.to_be_saved_to_tags())
         if not images_to_save:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3064
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

After recent refactorings the ID3File class overwrote the File._save_images method, triggering an exception on saving.

The issue was introduced in c36e4a47b66235d2ce4e4bd76a9017a19b564152

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Rename `ID3File._save_images` to `ID3File._save_images_to_tags`.