### PR TITLE
PICARD-3066: Fix theme initialization and set generic accent color in dark mode

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2022, 2024 Philipp Wolfer
+# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021-2024 Laurent Monin
 #
@@ -114,6 +114,9 @@ class BaseTheme:
         palette = QtGui.QPalette(app.palette())
         base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
         self._dark_theme = base_color.lightness() < 128
+        self._accent_color = None
+        if self._dark_theme:
+            self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
 
         is_dark_theme = self.is_dark_theme
         accent_color = self.accent_color
@@ -141,7 +144,7 @@ class BaseTheme:
 
     @property
     def accent_color(self):  # pylint: disable=no-self-use
-        return None
+        return self._accent_color
 
     # pylint: disable=no-self-use
     def update_palette(self, palette, dark_theme, accent_color):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3066
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

There are actually two changes in this PR:

1. The first commit is a straight forward fix to the theme being initialized too late since https://github.com/metabrainz/picard/commit/a2dd9df9ee75332958ed63e65ae90eaba31f7c4d . This is fixed by moving the theme setup as early as possible, but after all logging setup.
2. It attempts to have a solution for the link color in dark mode not being readable on Linux on some systems. The color in this case is system defined, so results varies. This change assumes the color for highlighting active UI elements is a good choice as the accent color (because if there was such an accent color defined by the system it would be used as the highlight color).

The latter change has no effect on Windows and macOS. In both cases there is a defined accent color, and it already gets used as the link color as well.