### PR TITLE
Added a condition to strip dots after the tracknumber in filenames

### DIFF
--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -647,7 +647,9 @@ def tracknum_and_title_from_filename(base_filename):
         stripped_filename = filename.lstrip('0')
         tnlen = len(tracknumber)
         if stripped_filename[:tnlen] == tracknumber:
-            title = stripped_filename[tnlen:].lstrip()
+            # Strip the dot in front of the tracknumber, if present
+            dot_offset = 1 if stripped_filename[tnlen:][0] == '.' else 0
+            title = stripped_filename[tnlen + dot_offset:].lstrip()
 
     return GuessedFromFilename(tracknumber, title)
 


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

# Problem

A lot of music files are named following the template `<tracknumber>. <title>.<extension>`, Picard recognizes this and interprets the tracknumber, but takes the whole rest as the title, resulting in titles beginning by a dot and then a space. 

Real world example right after importing a folder of yet-untagged music :

![image](https://github.com/user-attachments/assets/020cedf8-0636-4299-91ba-32499629b2f1)

# Solution

I added an offset to skip the dot when it is present, and the following space is stripped like it would have if the filename started with some whitespace.

There could be (extreme) edge cases where titles actually start with a dot altogether with specific file naming (for example `715.TOTO.flac` could mean the title is `.TOTO` or `TOTO` and there would be no way of programmatically telling), so I thought it could be useful to add a configuration option for this, but I don't know the software nor the codebase enough to do that properly.