### PR TITLE
PICARD-3056: Disallow selection of directories for cover art and ripper log file chooser

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1049,6 +1049,7 @@ class Tagger(QtWidgets.QApplication):
 
     def lookup_discid_from_logfile(self):
         file_chooser = FileDialog(parent=self.window)
+        file_chooser.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
         file_chooser.setNameFilters([
             _("All supported log files") + " (*.log *.txt)",
             _("EAC / XLD / Whipper / fre:ac log files") + " (*.log)",

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -275,8 +275,8 @@ class CoverArtBox(QtWidgets.QGroupBox):
         ])
         if file_chooser.exec():
             file_urls = file_chooser.selectedUrls()
-            if file_urls:
-                self.fetch_remote_image(file_urls[0])
+            for url in file_urls:
+                self.fetch_remote_image(url)
 
     def choose_image_from_url(self):
         url, ok = ImageURLDialog.display(parent=self)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -266,6 +266,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
     def choose_local_file(self):
         file_chooser = FileDialog(parent=self)
+        file_chooser.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFiles)
         extensions = ['*' + ext for ext in imageinfo.get_supported_extensions()]
         extensions.sort()
         file_chooser.setNameFilters([


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3056
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The file chooser dialogs for local cover art and ripper log don't set the selectable files. Specifically on macOS this leads to directories being selectable. For cover art this can lead to a crash, and generally it is not useful.

This PR fixes the issue for the 3.x branch. This is the changes from the previous attempt in #2631 again, but extended to the ripper log case as well. I reviewed the code and think the approach is correct. Other than in the 2.x branch we now have a generic `FileDialog` subclass of `QFileDialog`. But setting the file mode still needs to be done depending on the specific use case.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
- For cover art selection set the file mode to `FileMode.ExistingFiles`. Handle opening multiple images files at once.
- For ripper log selection set the file mode to `FileMode.ExistingFile` (single file).

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
