### PR TITLE
CI: Update libdiscid for binary packages to 0.6.5

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -17,8 +17,8 @@ jobs:
           runner: 'macos-14'
           target-arch: 'arm64'
     env:
-      DISCID_VERSION: 0.6.4
-      DISCID_SHA256SUM: 829133dd38acbdaa2b989de59e256c8d139ac34cb4dd4b8fd3c9d55a97c824f3
+      DISCID_VERSION: 0.6.5
+      DISCID_SHA256SUM: 8aa187dd5afdecc06441b49e086dd9a46b3ffac818fd9c1dae0cb55780d846f2
       FPCALC_VERSION: 1.5.1
       FPCALC_SHA256SUM: d4d8faff4b5f7c558d9be053da47804f9501eaa6c2f87906a9f040f38d61c860
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.setup.macos-deployment-version }}

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -39,8 +39,8 @@ jobs:
         Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64"
         New-Item -Name .\artifacts -ItemType Directory
       env:
-        DISCID_VERSION: 0.6.4
-        DISCID_SHA256SUM: 330199495d71f71251e91eb0b4e3103b6c663fea09ffc9fd3e5108d48e0452c8
+        DISCID_VERSION: 0.6.5
+        DISCID_SHA256SUM: a1198731d417a04b3d8499bcc10b6a8ddcab06476c855ebff0fb4134888b1be5
         FPCALC_VERSION: 1.5.1
         FPCALC_SHA256SUM: 36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc
     - name: Install gettext


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem
This upates the bundled libdiscid for the mac and windows builds to the latest 0.6.5. As there is no functional change to libdiscid itself this is mainly for staying up-to-date. But the binaries are now also code-signed.

See https://github.com/metabrainz/libdiscid/releases/tag/v0.6.5