### PR TITLE
PICARD-2784: Drop python 3.9

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, windows-2019]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest, windows-2019]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -53,13 +53,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
         dependencies: [
-          "PyQt6==6.5.3 PyQt6-Qt6==6.5.3 mutagen==1.37 python-dateutil==2.7 PyYAML==5.1",  # minimal versions, minimum dependencies
-          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 discid==1.0",
-          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 python-libdiscid",
-          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 charset-normalizer==2.0.6",
-          "PyQt6>=6.5.3 mutagen~=1.37 python-dateutil~=2.7 PyYAML~=6.0 chardet==3.0.4",
+          "PyQt6==6.5.3 PyQt6-Qt6==6.5.3 mutagen==1.43 python-dateutil==2.7 PyYAML==5.1",  # minimal versions, minimum dependencies
+          "PyQt6>=6.5.3 mutagen~=1.43 python-dateutil~=2.7 PyYAML~=6.0 discid==1.0",
+          "PyQt6>=6.5.3 mutagen~=1.43 python-dateutil~=2.7 PyYAML~=6.0 python-libdiscid",
+          "PyQt6>=6.5.3 mutagen~=1.43 python-dateutil~=2.7 PyYAML~=6.0 charset-normalizer==2.0.6",
+          "PyQt6>=6.5.3 mutagen~=1.43 python-dateutil~=2.7 PyYAML~=6.0 chardet==3.0.4",
         ]
 
     steps:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,9 +8,9 @@ Before installing Picard from source, you need to check you have the following d
 
 Required:
 
-* [Python 3.9 or newer](https://www.python.org/downloads/)
+* [Python 3.10 or newer](https://www.python.org/downloads/)
 * [PyQt 6.5 or newer](https://riverbankcomputing.com/software/pyqt/download)
-* [Mutagen 1.37 or newer](https://mutagen.readthedocs.io/)
+* [Mutagen 1.43 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)
 * [python-dateutil](https://dateutil.readthedocs.io/en/stable/)
 * gettext:

--- a/picard/log.py
+++ b/picard/log.py
@@ -188,23 +188,14 @@ def name_filter(record):
     # It provides a significant but short name from the filepath of the module
     path = Path(record.pathname).with_suffix('')
     # PyInstaller paths are already relative
-    # FIXME: With Python 3.9 this should better use
-    # path.is_relative_to(picard_module_path.parent)
-    # to avoid the exception handling.
-    if path.is_absolute():
-        try:
-            path = path.resolve().relative_to(picard_module_path)
-        except ValueError:
-            pass
+    if path.is_relative_to(picard_module_path):
+        path = path.resolve().relative_to(picard_module_path)
 
-    if path.is_absolute() and not DebugOpt.PLUGIN_FULLPATH.enabled:
-        try:
-            path = path.resolve().relative_to(USER_PLUGIN_DIR)
-            parts = list(path.parts)
-            parts.insert(0, 'plugins')
-            path = Path(*parts)
-        except ValueError:
-            pass
+    if path.is_relative_to(USER_PLUGIN_DIR) and not DebugOpt.PLUGIN_FULLPATH.enabled:
+        path = path.resolve().relative_to(USER_PLUGIN_DIR)
+        parts = list(path.parts)
+        parts.insert(0, 'plugins')
+        path = Path(*parts)
 
     parts = list(path.parts)
     if parts[-1] == '__init__':

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -283,10 +283,7 @@ class AbstractPipe(metaclass=ABCMeta):
         log.debug("Stopping pipe")
         self.pipe_running = False
         self.send_to_pipe(self.MESSAGE_TO_IGNORE)
-        try:
-            self.__thread_pool.shutdown(wait=True, cancel_futures=True)
-        except TypeError:  # cancel_futures is not supported on Python < 3.9
-            self.__thread_pool.shutdown(wait=True)
+        self.__thread_pool.shutdown(wait=True, cancel_futures=True)
 
 
 class UnixPipe(AbstractPipe):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Picard is a cross-platform music tagger powered by the MusicBrain
 authors = [{name = "The MusicBrainz Team"}]
 license = {text = "GPL-2.0-or-later"}
 keywords = ["musicbrainz", "tagging", "audio"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Development Status :: 5 - Production/Stable",
@@ -17,7 +17,6 @@ classifiers = [
     "Environment :: X11 Applications :: Qt",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discid~=1.0
 Markdown~=3.2
-mutagen~=1.37
+mutagen~=1.43
 PyJWT~=2.0
 pyobjc-core>=6.2, <12; sys_platform == 'darwin'
 pyobjc-framework-Cocoa>=6.2, <12; sys_platform == 'darwin'

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ from picard import (  # noqa: E402
 )
 
 
-if sys.version_info < (3, 9):
-    sys.exit("ERROR: You need Python 3.9 or higher to use Picard.")
+if sys.version_info < (3, 10):
+    sys.exit("ERROR: You need Python 3.10 or higher to use Picard.")
 
 PACKAGE_NAME = "picard"
 APPDATA_FILE = PICARD_APP_ID + '.appdata.xml'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2784
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->
As Python 3.9 both approaches its EOL and we get into trouble with some newer dependencies which already drop support for it in the plugins-v3 branch, this PR increases the minimum Python version to 3.10.


# Solution

- Make Python 3.10 the minimum required Python version
- Update tests
- Mutagen 1.43 is now the lowest supported version, as older versions are not Python 3.10 compatible
- Drop Python 3.9 legacy code
