### PR TITLE
Identify filterable tags

### DIFF
--- a/picard/const/tags.py
+++ b/picard/const/tags.py
@@ -412,6 +412,7 @@ ALL_TAGS = TagVars(
         is_preserved=True,
         is_tag=False,
         is_from_mb=False,
+        is_filterable=True,
     ),
     TagVar(
         'filepath',
@@ -420,6 +421,7 @@ ALL_TAGS = TagVars(
         is_hidden=True,
         is_tag=False,
         is_from_mb=False,
+        is_filterable=True,
     ),
     TagVar(
         'filesize',


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:  Identify the tags that can be filtered

# Problem

Pull request https://github.com/metabrainz/picard/pull/2668 introduces the ability to filter the items displayed in Picard's main window.  This PR is intended to identify the tags that can be used for filtering by setting the `is_filterable` attribute.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Set the `is_filterable` attribute to `True` on the appropriate tags.


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
