### PR TITLE
Move ExtensionPoint and related code to extension_points package

### DIFF
--- a/picard/extension_points/__init__.py
+++ b/picard/extension_points/__init__.py
@@ -2,7 +2,22 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2024 Laurent Monin
+# Copyright (C) 2007-2008 Lukáš Lalinský
+# Copyright (C) 2009 Carlin Mangar
+# Copyright (C) 2009, 2014, 2017-2021, 2023, 2025 Philipp Wolfer
+# Copyright (C) 2011 johnny64
+# Copyright (C) 2011-2013 Michael Wiencek
+# Copyright (C) 2013 Sebastian Ramacher
+# Copyright (C) 2013 Wieland Hoffmann
+# Copyright (C) 2013 brainz34
+# Copyright (C) 2013-2014 Sophist-UK
+# Copyright (C) 2014 Johannes Dewender
+# Copyright (C) 2014 Shadab Zafar
+# Copyright (C) 2014-2015, 2018-2021, 2023-2024 Laurent Monin
+# Copyright (C) 2016-2018 Sambhav Kothari
+# Copyright (C) 2017 Frederik “Freso” S. Olesen
+# Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2023 tuspar
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -17,3 +32,65 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from collections import defaultdict
+
+from picard import log
+from picard.config import get_config
+
+
+PLUGIN_MODULE_PREFIX = "picard.plugins."
+PLUGIN_MODULE_PREFIX_LEN = len(PLUGIN_MODULE_PREFIX)
+
+_extension_points = []
+
+
+class ExtensionPoint:
+
+    def __init__(self, label=None):
+        if label is None:
+            import uuid
+            self.label = uuid.uuid4()
+        else:
+            self.label = label
+        self.__dict = defaultdict(list)
+        _extension_points.append(self)
+
+    def register(self, module, item):
+        if module.startswith(PLUGIN_MODULE_PREFIX):
+            name = module[PLUGIN_MODULE_PREFIX_LEN:]
+            log.debug("ExtensionPoint: %s register <- plugin=%r item=%r", self.label, name, item)
+        else:
+            name = None
+            # uncomment to debug internal extensions loaded at startup
+            # print("ExtensionPoint: %s register <- item=%r" % (self.label, item))
+        self.__dict[name].append(item)
+
+    def unregister_module(self, name):
+        try:
+            del self.__dict[name]
+        except KeyError:
+            # NOTE: needed due to defaultdict behaviour:
+            # >>> d = defaultdict(list)
+            # >>> del d['a']
+            # KeyError: 'a'
+            # >>> d['a']
+            # []
+            # >>> del d['a']
+            # >>> #^^ no exception, after first read
+            pass
+
+    def __iter__(self):
+        config = get_config()
+        enabled_plugins = config.setting['enabled_plugins'] if config else []
+        for name in self.__dict:
+            if name is None or name in enabled_plugins:
+                yield from self.__dict[name]
+
+    def __repr__(self):
+        return f"ExtensionPoint(label='{self.label}')"
+
+
+def unregister_module_extensions(module):
+    for ep in _extension_points:
+        ep.unregister_module(module)

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -33,13 +33,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
 from collections import defaultdict
 import os.path
 
 from picard import log
-from picard.config import get_config
 from picard.const import USER_PLUGIN_DIR
+from picard.extension_points import (
+    PLUGIN_MODULE_PREFIX,
+    PLUGIN_MODULE_PREFIX_LEN,
+    ExtensionPoint,
+)
 from picard.version import (
     Version,
     VersionError,
@@ -54,62 +57,6 @@ except ImportError:
         if not text:
             return ''
         return text.strip().replace('\n', '<br>\n')
-
-_PLUGIN_MODULE_PREFIX = "picard.plugins."
-_PLUGIN_MODULE_PREFIX_LEN = len(_PLUGIN_MODULE_PREFIX)
-
-_extension_points = []
-
-
-def _unregister_module_extensions(module):
-    for ep in _extension_points:
-        ep.unregister_module(module)
-
-
-class ExtensionPoint:
-
-    def __init__(self, label=None):
-        if label is None:
-            import uuid
-            self.label = uuid.uuid4()
-        else:
-            self.label = label
-        self.__dict = defaultdict(list)
-        _extension_points.append(self)
-
-    def register(self, module, item):
-        if module.startswith(_PLUGIN_MODULE_PREFIX):
-            name = module[_PLUGIN_MODULE_PREFIX_LEN:]
-            log.debug("ExtensionPoint: %s register <- plugin=%r item=%r", self.label, name, item)
-        else:
-            name = None
-            # uncomment to debug internal extensions loaded at startup
-            # print("ExtensionPoint: %s register <- item=%r" % (self.label, item))
-        self.__dict[name].append(item)
-
-    def unregister_module(self, name):
-        try:
-            del self.__dict[name]
-        except KeyError:
-            # NOTE: needed due to defaultdict behaviour:
-            # >>> d = defaultdict(list)
-            # >>> del d['a']
-            # KeyError: 'a'
-            # >>> d['a']
-            # []
-            # >>> del d['a']
-            # >>> #^^ no exception, after first read
-            pass
-
-    def __iter__(self):
-        config = get_config()
-        enabled_plugins = config.setting['enabled_plugins'] if config else []
-        for name in self.__dict:
-            if name is None or name in enabled_plugins:
-                yield from self.__dict[name]
-
-    def __repr__(self):
-        return f"ExtensionPoint(label='{self.label}')"
 
 
 class PluginShared:
@@ -138,8 +85,8 @@ class PluginWrapper(PluginShared):
     @property
     def module_name(self):
         name = self.module.__name__
-        if name.startswith(_PLUGIN_MODULE_PREFIX):
-            name = name[_PLUGIN_MODULE_PREFIX_LEN:]
+        if name.startswith(PLUGIN_MODULE_PREFIX):
+            name = name[PLUGIN_MODULE_PREFIX_LEN:]
         return name
 
     @property

--- a/picard/pluginmanager.py
+++ b/picard/pluginmanager.py
@@ -44,15 +44,17 @@ from picard.const import (
     USER_PLUGIN_DIR,
 )
 from picard.const.sys import IS_FROZEN
+from picard.extension_points import (
+    PLUGIN_MODULE_PREFIX,
+    unregister_module_extensions,
+)
 from picard.i18n import (
     N_,
     gettext as _,
 )
 from picard.plugin import (
-    _PLUGIN_MODULE_PREFIX,
     PluginData,
     PluginWrapper,
-    _unregister_module_extensions,
 )
 import picard.plugins
 from picard.version import (
@@ -295,7 +297,7 @@ class PluginManager(QtCore.QObject):
         module_pathname = None
         zip_importer = None
         manifest_data = None
-        full_module_name = _PLUGIN_MODULE_PREFIX + name
+        full_module_name = PLUGIN_MODULE_PREFIX + name
         plugin_dir = None
 
         spec = PluginMetaPathFinder().find_spec(full_module_name, [])
@@ -397,7 +399,7 @@ class PluginManager(QtCore.QObject):
 
     def _remove_plugin(self, plugin_name, with_update=False):
         self._remove_plugin_files(plugin_name, with_update)
-        _unregister_module_extensions(plugin_name)
+        unregister_module_extensions(plugin_name)
         self.plugins = [p for p in self.plugins if p.module_name != plugin_name]
 
     def remove_plugin(self, plugin_name, with_update=False):
@@ -537,9 +539,9 @@ class PluginManager(QtCore.QObject):
 
 class PluginMetaPathFinder(MetaPathFinder):
     def find_spec(self, fullname, path, target=None):
-        if not fullname.startswith(_PLUGIN_MODULE_PREFIX):
+        if not fullname.startswith(PLUGIN_MODULE_PREFIX):
             return None
-        plugin_name = fullname[len(_PLUGIN_MODULE_PREFIX):]
+        plugin_name = fullname[len(PLUGIN_MODULE_PREFIX):]
         for plugin_dir in plugin_dirs():
             for file_path in self._plugin_file_paths(plugin_dir, plugin_name):
                 if os.path.exists(file_path):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -30,10 +30,10 @@ from test.picardtestcase import PicardTestCase
 
 import picard
 from picard.const import USER_PLUGIN_DIR
+from picard.extension_points import unregister_module_extensions
 from picard.plugin import (
     PluginFunctions,
     PluginWrapper,
-    _unregister_module_extensions,
 )
 from picard.pluginmanager import (
     PluginManager,
@@ -92,7 +92,7 @@ _testplugins = _get_test_plugins()
 
 def unload_plugin(plugin_name):
     """for testing purposes"""
-    _unregister_module_extensions(plugin_name)
+    unregister_module_extensions(plugin_name)
     if hasattr(picard.plugins, plugin_name):
         delattr(picard.plugins, plugin_name)
     if plugin_name in sys.modules:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

This moves the `ExtensionPoint` class and related code into the new `extension_points` package (see PR 
#2461 and related).

As extension points will be reused in v3 plugins this makes the code better separated. I pulled this change out from my current WIP of implementing the CLI for plugin management (PR coming soon).

