### PR TITLE
PICARD-2828: Separate options for standardized instrument/vocal credits

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'dev', 5)
+PICARD_VERSION = Version(3, 0, 0, 'dev', 6)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -561,6 +561,12 @@ def upgrade_to_v3_0_0dev5(config):
     config.setting['replace_dir_separator'] = replace_dir_separator
 
 
+def upgrade_to_v3_0_0dev6(config):
+    """New independent option "standardize_vocals" should use the value of the old shared option"""
+    standardize_instruments_and_vocals = config.setting['standardize_instruments']
+    config.setting['standardize_vocals'] = standardize_instruments_and_vocals
+
+
 def rename_option(config, old_opt, new_opt, option_type, default):
     _s = config.setting
     if old_opt in _s:

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -8,7 +8,7 @@
 # Copyright (C) 2018-2023 Philipp Wolfer
 # Copyright (C) 2019 Michael Wiencek
 # Copyright (C) 2020 dukeyin
-# Copyright (C) 2020, 2023 David Kellner
+# Copyright (C) 2020, 2023, 2025 David Kellner
 # Copyright (C) 2021, 2025 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
 # Copyright (C) 2024 Rakim Middya
@@ -156,7 +156,7 @@ def _relations_to_metadata_target_type_artist(relation, m, context):
     reltype = relation['type']
     attribs = _relation_attributes(relation)
     if reltype in {'vocal', 'instrument', 'performer'}:
-        if context.use_instrument_credits:
+        if (reltype == 'instrument' and context.use_instrument_credits) or (reltype == 'vocal' and context.use_vocal_credits):
             attr_credits = relation.get('attribute-credits', {})
         else:
             attr_credits = {}
@@ -250,6 +250,7 @@ def _relations_to_metadata(relations, m, instrumental=False, config=None, entity
         instrumental=instrumental,
         use_credited_as=not config.setting['standardize_artists'],
         use_instrument_credits=not config.setting['standardize_instruments'],
+        use_vocal_credits=not config.setting['standardize_vocals'],
         metadata_was_cleared=dict(),
     )
     for relation in relations:

--- a/picard/options.py
+++ b/picard/options.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2024 Laurent Monin
 # Copyright (C) 2025 Philipp Wolfer
 # Copyright (C) 2025 Bob Swift
+# Copyright (C) 2025 David Kellner
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -303,7 +304,8 @@ TextOption('setting', 'nat_name', '[standalone recordings]', title=N_("Standalon
 BoolOption('setting', 'release_ars', True, title=N_("Use release relationships"))
 ListOption('setting', 'script_exceptions', [], title=N_("Translation script exceptions"))
 BoolOption('setting', 'standardize_artists', False, title=N_("Use standardized artist names"))
-BoolOption('setting', 'standardize_instruments', True, title=N_("Use standardized instrument and vocal credits"))
+BoolOption('setting', 'standardize_instruments', True, title=N_("Use standardized instrument credits"))
+BoolOption('setting', 'standardize_vocals', True, title=N_("Use standardized vocal credits"))
 BoolOption('setting', 'track_ars', False, title=N_("Use track and release relationships"))
 BoolOption('setting', 'translate_artist_names', False, title=N_("Translate artist names"))
 BoolOption('setting', 'translate_artist_names_script_exception', False, title=N_("Translate artist names exception"))

--- a/picard/ui/forms/ui_options_metadata.py
+++ b/picard/ui/forms/ui_options_metadata.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options_metadata.ui'
 #
-# Created by: PyQt6 UI code generator 6.6.1
+# Created by: PyQt6 UI code generator 6.9.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -65,6 +65,9 @@ class Ui_MetadataOptionsPage(object):
         self.standardize_instruments = QtWidgets.QCheckBox(parent=self.metadata_groupbox)
         self.standardize_instruments.setObjectName("standardize_instruments")
         self.verticalLayout_3.addWidget(self.standardize_instruments)
+        self.standardize_vocals = QtWidgets.QCheckBox(parent=self.metadata_groupbox)
+        self.standardize_vocals.setObjectName("standardize_vocals")
+        self.verticalLayout_3.addWidget(self.standardize_vocals)
         self.convert_punctuation = QtWidgets.QCheckBox(parent=self.metadata_groupbox)
         self.convert_punctuation.setObjectName("convert_punctuation")
         self.verticalLayout_3.addWidget(self.convert_punctuation)
@@ -122,7 +125,8 @@ class Ui_MetadataOptionsPage(object):
         MetadataOptionsPage.setTabOrder(self.selected_scripts, self.select_scripts)
         MetadataOptionsPage.setTabOrder(self.select_scripts, self.standardize_artists)
         MetadataOptionsPage.setTabOrder(self.standardize_artists, self.standardize_instruments)
-        MetadataOptionsPage.setTabOrder(self.standardize_instruments, self.convert_punctuation)
+        MetadataOptionsPage.setTabOrder(self.standardize_instruments, self.standardize_vocals)
+        MetadataOptionsPage.setTabOrder(self.standardize_vocals, self.convert_punctuation)
         MetadataOptionsPage.setTabOrder(self.convert_punctuation, self.release_ars)
         MetadataOptionsPage.setTabOrder(self.release_ars, self.track_ars)
         MetadataOptionsPage.setTabOrder(self.track_ars, self.guess_tracknumber_and_title)
@@ -138,7 +142,8 @@ class Ui_MetadataOptionsPage(object):
         self.translate_artist_names_script_exception.setText(_("Ignore artist name translation for these language scripts:"))
         self.select_scripts.setText(_("Select…"))
         self.standardize_artists.setText(_("Use standardized artist names"))
-        self.standardize_instruments.setText(_("Use standardized instrument and vocal credits"))
+        self.standardize_instruments.setText(_("Use standardized instrument credits"))
+        self.standardize_vocals.setText(_("Use standardized vocal credits"))
         self.convert_punctuation.setText(_("Convert Unicode punctuation characters to ASCII"))
         self.release_ars.setText(_("Use release relationships"))
         self.track_ars.setText(_("Use track relationships"))

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -92,6 +92,7 @@ class MetadataOptionsPage(OptionsPage):
         ('script_exceptions', ['selected_scripts']),
         ('standardize_artists', ['standardize_artists']),
         ('standardize_instruments', ['standardize_instruments']),
+        ('standardize_vocals', ['standardize_vocals']),
         ('convert_punctuation', ['convert_punctuation']),
         ('release_ars', ['release_ars']),
         ('track_ars', ['track_ars']),
@@ -127,6 +128,7 @@ class MetadataOptionsPage(OptionsPage):
         self.ui.nat_name.setText(config.setting['nat_name'])
         self.ui.standardize_artists.setChecked(config.setting['standardize_artists'])
         self.ui.standardize_instruments.setChecked(config.setting['standardize_instruments'])
+        self.ui.standardize_vocals.setChecked(config.setting['standardize_vocals'])
         self.ui.guess_tracknumber_and_title.setChecked(config.setting['guess_tracknumber_and_title'])
 
         self.set_enabled_states()
@@ -162,6 +164,7 @@ class MetadataOptionsPage(OptionsPage):
                 self.tagger.nats.update()
         config.setting['standardize_artists'] = self.ui.standardize_artists.isChecked()
         config.setting['standardize_instruments'] = self.ui.standardize_instruments.isChecked()
+        config.setting['standardize_vocals'] = self.ui.standardize_vocals.isChecked()
         config.setting['guess_tracknumber_and_title'] = self.ui.guess_tracknumber_and_title.isChecked()
 
     def set_va_name_default(self):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -9,7 +9,7 @@
 # Copyright (C) 2020 dukeyin
 # Copyright (C) 2021, 2025 Bob Swift
 # Copyright (C) 2021 Vladislav Karbovskii
-# Copyright (C) 2023 David Kellner
+# Copyright (C) 2023, 2025 David Kellner
 # Copyright (C) 2024 Rakim Middya
 #
 # This program is free software; you can redistribute it and/or
@@ -69,6 +69,7 @@ settings = {
     "translate_artist_names": True,
     "translate_artist_names_script_exception": False,
     "standardize_instruments": True,
+    "standardize_vocals": True,
     "release_ars": True,
     "preferred_release_countries": [],
     "artist_locales": ['en'],
@@ -315,8 +316,16 @@ class RecordingTest(MBJSONTest):
         t = Track('1')
         config.setting['standardize_instruments'] = False
         recording_to_metadata(self.json_doc, m, t)
-        self.assertEqual(m['performer:vocals'], 'Ed Sheeran')
+        self.assertEqual(m['performer:lead vocals'], 'Ed Sheeran')
         self.assertEqual(m['performer:acoustic guitar'], 'Ed Sheeran')
+
+    def test_recording_vocal_credits(self):
+        m = Metadata()
+        t = Track('1')
+        config.setting['standardize_vocals'] = False
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['performer:vocals'], 'Ed Sheeran')
+        self.assertEqual(m['performer:guitar family'], 'Ed Sheeran')
 
 
 class RecordingMultiArtistsTest1(MBJSONTest):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -61,6 +61,7 @@ settings = {
     'preferred_release_formats': [],
     'standardize_artists': False,
     'standardize_instruments': False,
+    'standardize_vocals': False,
     'translate_artist_names': False,
     'release_ars': True,
     'release_type_scores': [

--- a/ui/options_metadata.ui
+++ b/ui/options_metadata.ui
@@ -98,7 +98,14 @@
       <item>
        <widget class="QCheckBox" name="standardize_instruments">
         <property name="text">
-         <string>Use standardized instrument and vocal credits</string>
+         <string>Use standardized instrument credits</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="standardize_vocals">
+        <property name="text">
+         <string>Use standardized vocal credits</string>
         </property>
        </widget>
       </item>
@@ -221,6 +228,7 @@
   <tabstop>select_scripts</tabstop>
   <tabstop>standardize_artists</tabstop>
   <tabstop>standardize_instruments</tabstop>
+  <tabstop>standardize_vocals</tabstop>
   <tabstop>convert_punctuation</tabstop>
   <tabstop>release_ars</tabstop>
   <tabstop>track_ars</tabstop>


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

PICARD-1354 added an option to use standardized credit attributes for both instruments and vocals or to use no standardization at all.
I would like to standardize instrument credits, but keep vocals as credited because the vocal credit is often used to name roles of actors in audio dramas and operas.

* JIRA ticket (_optional_): PICARD-2828

# Solution

- Introduce a new boolean option (checkbox) `standardize_vocals` in all places where `standardize_instruments` appears.
- The old option affects only instrument credits from now on, while the new option does the same for vocal credits independently.

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Migrate existing user settings, `standardize_vocals` should be initialized with the value of `standardize_instruments` to avoid a change in behavior
* [ ] Backport for Picard 2.x?