### PR TITLE
PICARD-3081: Replace forbidden filenames for Windows

### DIFF
--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -8,7 +8,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2017 Ville Skyttä
 # Copyright (C) 2018 Antonio Larrosa
-# Copyright (C) 2019-2022, 2024 Philipp Wolfer
+# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
 # Copyright (C) 2022 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
@@ -539,7 +539,10 @@ WINDOWS_FORBIDDEN_NAMES = {
 }
 
 WINDOWS_FORBIDDEN_NAMES_RE = re.compile(
-    r'^(%s)(\.|$)' % '|'.join(re.escape(name) for name in WINDOWS_FORBIDDEN_NAMES),
+    r'(^|[{separators}])({names})(?=$|[\.{separators}])'.format(
+        separators=re.escape(os.path.sep + (os.altsep if os.altsep else '')),
+        names='|'.join(re.escape(name) for name in WINDOWS_FORBIDDEN_NAMES),
+    ),
     re.IGNORECASE
 )
 
@@ -554,17 +557,9 @@ def replace_windows_forbidden_names(path):
 
     Args:
         path: filename or path to clean
-    Returns: sanitized path
+    Returns: Path with escaped forbidden names
     """
-    parts = [
-        WINDOWS_FORBIDDEN_NAMES_RE.sub(r'\1_\2', part)
-        for part in path.split(os.path.normpath(os.path.sep))
-    ]
-    if parts[0] == '':
-        # If the first part is empty, it means the path started with a separator
-        # and is a root path (e.g. "/foo/bar"). Add back the leading separator.
-        parts[0] = os.path.sep
-    return os.path.join(*parts)
+    return WINDOWS_FORBIDDEN_NAMES_RE.sub(r'\1\2_', path)
 
 
 def get_available_filename(new_path, old_path=None):

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -499,6 +499,8 @@ def make_save_path(path, win_compat=False, mac_compat=False):
 
     - If win_compat is True, trailing dots in file and directory names will
       be removed, as they are unsupported on Windows (dot is a delimiter for the file extension)
+    - If win_compat is True, forbidden filenames like "CON", "PRN", "AUX", "NUL", "COM1" etc. will
+      be replaced with a trailing underscore.
     - Leading dots in file and directory names will be removed. These files cannot be properly
       handled by Windows Explorer and on Unix like systems they count as hidden
     - If mac_compat is True, normalize precomposed Unicode characters on macOS
@@ -515,6 +517,7 @@ def make_save_path(path, win_compat=False, mac_compat=False):
         path = path.replace('./', '_/').replace('.\\', '_\\')
         if path.endswith('.'):
             path = path[:-1] + '_'
+        path = replace_windows_forbidden_names(path)
     # replace . at the beginning of file and directory names
     path = path.replace('/.', '/_').replace('\\.', '\\_')
     if path.startswith('.'):
@@ -525,6 +528,43 @@ def make_save_path(path, win_compat=False, mac_compat=False):
     # Remove unicode zero-width space (\u200B) from path
     path = path.replace("\u200B", "")
     return path
+
+
+WINDOWS_FORBIDDEN_NAMES = {
+    'CON', 'PRN', 'AUX', 'NUL',
+    *('COM%d' % i for i in range(1, 10)),
+    'COM¹', 'COM²', 'COM³',
+    *('LPT%d' % i for i in range(1, 10)),
+    'LPT¹', 'LPT²', 'LPT³',
+}
+
+WINDOWS_FORBIDDEN_NAMES_RE = re.compile(
+    r'^(%s)(\.|$)' % '|'.join(re.escape(name) for name in WINDOWS_FORBIDDEN_NAMES),
+    re.IGNORECASE
+)
+
+
+def replace_windows_forbidden_names(path):
+    """Replaces Windows forbidden file names with a trailing underscore.
+
+    Windows forbids the following file names:
+    CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+    COM¹, COM², COM³, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,
+    LPT¹, LPT², and LPT³.
+
+    Args:
+        path: filename or path to clean
+    Returns: sanitized path
+    """
+    parts = [
+        WINDOWS_FORBIDDEN_NAMES_RE.sub(r'\1_\2', part)
+        for part in path.split(os.path.normpath(os.path.sep))
+    ]
+    if parts[0] == '':
+        # If the first part is empty, it means the path started with a separator
+        # and is a root path (e.g. "/foo/bar"). Add back the leading separator.
+        parts[0] = os.path.sep
+    return os.path.join(*parts)
 
 
 def get_available_filename(new_path, old_path=None):

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2016 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2018-2022 Laurent Monin
-# Copyright (C) 2019-2022 Philipp Wolfer
+# Copyright (C) 2019-2022, 2025 Philipp Wolfer
 # Copyright (C) 2022 Bob Swift
 #
 # This program is free software; you can redistribute it and/or


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3081
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Forbidden names like NUL are replaced with a trailing underscore. Add a new replace_windows_forbidden_names utility function. Call it as part of make_save_path in win_compat mode.


