### PR TITLE
Make Metadata.length a property and raises exception if set to negati…

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -179,6 +179,7 @@ class Metadata(MutableMapping):
 
     def __init__(self, *args, deleted_tags=None, images=None, length=None, **kwargs):
         self._lock = ReadWriteLockContext()
+        self._length = None
         self._store = dict()
         self.deleted_tags = set()
         self.length = 0
@@ -194,13 +195,24 @@ class Metadata(MutableMapping):
             for tag in deleted_tags:
                 del self[tag]
         if length is not None:
-            self.length = int(length)
+            self.length = length
 
     def __bool__(self):
         return bool(len(self))
 
     def __len__(self):
         return len(self._store) + len(self.images)
+
+    @property
+    def length(self):
+        return self._length
+
+    @length.setter
+    def length(self, value):
+        length = int(value)
+        if length < 0:
+            raise ValueError("negative value: %d" % length)
+        self._length = length
 
     @staticmethod
     def length_score(a, b):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -111,6 +111,16 @@ class CommonTests:
             self.assertEqual(self.multi3, self.metadata.getraw("multi3"))
             self.assertEqual(["hidden-value"], self.metadata.getraw("~hidden"))
 
+        def test_metadata_length_invalid(self):
+            m = Metadata()
+            with self.assertRaisesRegex(ValueError, r"^invalid literal"):
+                m.length = 'x'
+
+        def test_metadata_length_negative(self):
+            m = Metadata()
+            with self.assertRaisesRegex(ValueError, r"^negative value"):
+                m.length = -1
+
         def test_metadata_set_all_values_as_string(self):
             for val in (0, 2, True):
                 str_val = str(val)


### PR DESCRIPTION
…ve value

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Metadata.length can be set to a negative value and it shouldn't happen, so ensure we raise an exception in this case.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
