### PR TITLE
Sanitize HTTP header values in browser integration

### DIFF
--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2006-2007, 2011 Lukáš Lalinský
 # Copyright (C) 2011-2013 Michael Wiencek
 # Copyright (C) 2012 Chad Wilson
-# Copyright (C) 2012-2013, 2018, 2021-2022, 2024 Philipp Wolfer
+# Copyright (C) 2012-2013, 2018, 2021-2022, 2024-2025 Philipp Wolfer
 # Copyright (C) 2013, 2018, 2020-2021, 2024 Laurent Monin
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2017 Sambhav Kothari
@@ -172,7 +172,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         origin = self.headers['origin']
         if _is_valid_origin(origin):
             self.send_response(204)
-            self.send_header('Access-Control-Allow-Origin', origin)
+            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
             self.send_header('Access-Control-Allow-Methods', 'GET')
             self.send_header('Access-Control-Allow-Credentials', 'false')
             self.send_header('Access-Control-Allow-Private-Network', 'true')
@@ -272,7 +272,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.send_header('Cache-Control', 'max-age=0')
         origin = self.headers['origin']
         if _is_valid_origin(origin):
-            self.send_header('Access-Control-Allow-Origin', origin)
+            self.send_header('Access-Control-Allow-Origin', clean_header(origin))
             self.send_header('Vary', 'Origin')
         self.end_headers()
         self.wfile.write(content.encode())
+
+
+def clean_header(header):
+    return re.sub("[\r\n:]", "", header)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2018, 2020-2022 Laurent Monin
-# Copyright (C) 2019, 2022, 2024 Philipp Wolfer
+# Copyright (C) 2019, 2022, 2024-2025 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -35,6 +35,7 @@ from urllib.parse import (
 from test.picardtestcase import PicardTestCase
 
 from picard.browser.filelookup import FileLookup
+from picard.browser.server import clean_header
 from picard.util import webbrowser2
 
 
@@ -250,3 +251,10 @@ class BrowserLookupTest(PicardTestCase):
                 'tport': '8000',
             }
             self.assert_mb_url_matches(url, '/search/textsearch', query_args)
+
+
+class BrowserIntegrationTest(PicardTestCase):
+
+    def test_clean_header(self):
+        bad_header = "foo\nSome-Header: bar"
+        self.assertEqual("fooSome-Header bar", clean_header(bad_header))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This is a fix for potential HTTP Response Splitting, as the Access-Control-Allow-Origin was set from incoming data. In practice this was not a vulnerability, though. For one this data was read from HTTP headers and cannot contain line breaks. But also origins are validated against a known list of valid hostnames.

Fixes security code scanning alerts #2591 and #2592

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Introduce a new "clean_header" function that removes new lines and colons from the supplied value.