### PR TITLE
PICARD-2300: Linux dark theme detection

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -155,8 +155,9 @@ class BaseTheme:
             self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
 
         # Linux-specific: If SYSTEM theme, try to detect system dark mode
+        # Do not apply override if already dark theme
         is_dark_theme = self.is_dark_theme
-        if (not IS_WIN and not IS_MACOS and not IS_HAIKU and self._loaded_config_theme == UiTheme.SYSTEM):
+        if (not self._dark_theme and not IS_WIN and not IS_MACOS and not IS_HAIKU and self._loaded_config_theme == UiTheme.SYSTEM):
             is_dark_theme = self._detect_linux_dark_mode()
             if is_dark_theme:
                 # Apply a dark palette centrally defined

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
+# Copyright (C) 2020-2021 Gabriel Ferreira
+# Copyright (C) 2021-2024 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from pathlib import Path
+import subprocess
+
+from picard import log
+
+
+def gsettings_get(key: str) -> str | None:
+    """Helper to get a gsettings value. Returns string or None."""
+    try:
+        result = subprocess.run(
+            [
+                'gsettings', 'get', 'org.gnome.desktop.interface', key,
+            ], capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip().strip("'\"")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        log.debug(f"gsettings get {key} failed.")
+        return None
+
+def detect_gnome_color_scheme_dark() -> bool:
+    value = gsettings_get('color-scheme')
+    if value and 'dark' in value.lower():
+        log.debug("Detected GNOME color-scheme: dark")
+        return True
+    return False
+
+def detect_gnome_gtk_theme_dark() -> bool:
+    theme = gsettings_get('gtk-theme')
+    if theme and 'dark' in theme.lower():
+        log.debug(f"Detected GNOME gtk-theme: {theme} (dark)")
+        return True
+    return False
+
+def detect_kde_colorscheme_dark() -> bool:
+    kdeglobals = Path.home() / ".config" / "kdeglobals"
+    if kdeglobals.exists():
+        try:
+            with open(kdeglobals, 'r') as f:
+                for line in f:
+                    if line.strip().startswith("ColorScheme="):
+                        scheme = line.split('=', 1)[1].strip().lower()
+                        if 'dark' in scheme:
+                            log.debug(f"Detected KDE ColorScheme: {scheme} (dark)")
+                            return True
+        except OSError as e:
+            log.debug(f"KDE ColorScheme detection failed: {e}")
+    return False
+
+def detect_xfce_dark_theme() -> bool:
+    try:
+        result = subprocess.run(
+            [
+                'xfconf-query', '-c', 'xsettings', '-p', '/Net/ThemeName',
+            ], capture_output=True, text=True, check=True,
+        )
+        theme = result.stdout.strip().lower()
+        if 'dark' in theme:
+            log.debug(f"Detected XFCE theme: {theme} (dark)")
+            return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        log.debug("xfconf-query detection failed.")
+    return False
+
+def detect_lxqt_dark_theme() -> bool:
+    lxqt_conf = Path.home() / ".config" / "lxqt" / "session.conf"
+    if lxqt_conf.exists():
+        try:
+            with open(lxqt_conf, 'r') as f:
+                for line in f:
+                    if line.strip().startswith("theme="):
+                        theme = line.split('=', 1)[1].strip().lower()
+                        if 'dark' in theme:
+                            log.debug(f"Detected LXQt theme: {theme} (dark)")
+                            return True
+        except OSError as e:
+            log.debug(f"LXQt theme detection failed: {e}")
+    return False
+
+def get_linux_dark_mode_strategies() -> list:
+    """Return the list of dark mode detection strategies in order of priority."""
+    return [
+        detect_gnome_color_scheme_dark,
+        detect_gnome_gtk_theme_dark,
+        detect_kde_colorscheme_dark,
+        detect_xfce_dark_theme,
+        detect_lxqt_dark_theme,
+    ]

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -32,13 +32,20 @@ def gsettings_get(key: str) -> str | None:
     try:
         result = subprocess.run(
             [
-                'gsettings', 'get', 'org.gnome.desktop.interface', key,
-            ], capture_output=True, text=True, check=True,
+                'gsettings',
+                'get',
+                'org.gnome.desktop.interface',
+                key,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
         )
         return result.stdout.strip().strip("'\"")
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.debug(f"gsettings get {key} failed.")
         return None
+
 
 def detect_gnome_color_scheme_dark() -> bool:
     value = gsettings_get('color-scheme')
@@ -47,12 +54,14 @@ def detect_gnome_color_scheme_dark() -> bool:
         return True
     return False
 
+
 def detect_gnome_gtk_theme_dark() -> bool:
     theme = gsettings_get('gtk-theme')
     if theme and 'dark' in theme.lower():
         log.debug(f"Detected GNOME gtk-theme: {theme} (dark)")
         return True
     return False
+
 
 def detect_kde_colorscheme_dark() -> bool:
     kdeglobals = Path.home() / ".config" / "kdeglobals"
@@ -69,12 +78,20 @@ def detect_kde_colorscheme_dark() -> bool:
             log.debug(f"KDE ColorScheme detection failed: {e}")
     return False
 
+
 def detect_xfce_dark_theme() -> bool:
     try:
         result = subprocess.run(
             [
-                'xfconf-query', '-c', 'xsettings', '-p', '/Net/ThemeName',
-            ], capture_output=True, text=True, check=True,
+                'xfconf-query',
+                '-c',
+                'xsettings',
+                '-p',
+                '/Net/ThemeName',
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
         )
         theme = result.stdout.strip().lower()
         if 'dark' in theme:
@@ -83,6 +100,7 @@ def detect_xfce_dark_theme() -> bool:
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.debug("xfconf-query detection failed.")
     return False
+
 
 def detect_lxqt_dark_theme() -> bool:
     lxqt_conf = Path.home() / ".config" / "lxqt" / "session.conf"
@@ -99,6 +117,7 @@ def detect_lxqt_dark_theme() -> bool:
             log.debug(f"LXQt theme detection failed: {e}")
     return False
 
+
 def detect_freedesktop_color_scheme_dark() -> bool:
     """Detect dark mode using org.freedesktop.appearance.color-scheme (XDG portal, cross-desktop)."""
     value = gsettings_get('color-scheme')
@@ -106,8 +125,14 @@ def detect_freedesktop_color_scheme_dark() -> bool:
     try:
         result = subprocess.run(
             [
-                'gsettings', 'get', 'org.freedesktop.appearance', 'color-scheme',
-            ], capture_output=True, text=True, check=True,
+                'gsettings',
+                'get',
+                'org.freedesktop.appearance',
+                'color-scheme',
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
         )
         value = result.stdout.strip().strip("'\"")
         if value == '1':
@@ -119,6 +144,7 @@ def detect_freedesktop_color_scheme_dark() -> bool:
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.debug("gsettings get org.freedesktop.appearance.color-scheme failed.")
     return False
+
 
 def get_current_desktop_environment() -> str:
     """Detect the current desktop environment (DE) as a lowercase string."""
@@ -134,29 +160,36 @@ def get_current_desktop_environment() -> str:
         return os.environ["DESKTOP_SESSION"].lower()
     return ""
 
+
 # Wrappers for DE-specific detection
+
 
 def detect_gnome_dark_wrapper() -> bool:
     if get_current_desktop_environment() in {"gnome", "unity"}:
         return detect_gnome_color_scheme_dark() or detect_gnome_gtk_theme_dark()
     return False
 
+
 def detect_kde_dark_wrapper() -> bool:
     if get_current_desktop_environment() == "kde":
         return detect_kde_colorscheme_dark()
     return False
+
 
 def detect_xfce_dark_wrapper() -> bool:
     if get_current_desktop_environment() == "xfce":
         return detect_xfce_dark_theme()
     return False
 
+
 def detect_lxqt_dark_wrapper() -> bool:
     if get_current_desktop_environment() == "lxqt":
         return detect_lxqt_dark_theme()
     return False
 
+
 # Update the strategy list to use wrappers
+
 
 def get_linux_dark_mode_strategies() -> list:
     """Return the list of dark mode detection strategies in order of priority."""

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -127,7 +127,6 @@ def detect_lxqt_dark_theme() -> bool:
 
 def detect_freedesktop_color_scheme_dark() -> bool:
     """Detect dark mode using org.freedesktop.appearance.color-scheme (XDG portal, cross-desktop)."""
-    value = gsettings_get("color-scheme")
     # Try org.freedesktop.appearance first
     try:
         result = subprocess.run(  # nosec B603 B607

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -20,21 +20,23 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+"""Dark mode detection utilities for various Linux desktop environments."""
+
 import os
+import subprocess  # noqa: S404
 from pathlib import Path
-import subprocess
 
 from picard import log
 
 
 def gsettings_get(key: str) -> str | None:
-    """Helper to get a gsettings value. Returns string or None."""
+    """Get a gsettings value as a string or None."""
     try:
         result = subprocess.run(
             [
-                'gsettings',
-                'get',
-                'org.gnome.desktop.interface',
+                "gsettings",
+                "get",
+                "org.gnome.desktop.interface",
                 key,
             ],
             capture_output=True,
@@ -48,30 +50,33 @@ def gsettings_get(key: str) -> str | None:
 
 
 def detect_gnome_color_scheme_dark() -> bool:
-    value = gsettings_get('color-scheme')
-    if value and 'dark' in value.lower():
+    """Detect if GNOME color-scheme is set to dark."""
+    value = gsettings_get("color-scheme")
+    if value and "dark" in value.lower():
         log.debug("Detected GNOME color-scheme: dark")
         return True
     return False
 
 
 def detect_gnome_gtk_theme_dark() -> bool:
-    theme = gsettings_get('gtk-theme')
-    if theme and 'dark' in theme.lower():
+    """Detect if GNOME gtk-theme is set to dark."""
+    theme = gsettings_get("gtk-theme")
+    if theme and "dark" in theme.lower():
         log.debug(f"Detected GNOME gtk-theme: {theme} (dark)")
         return True
     return False
 
 
 def detect_kde_colorscheme_dark() -> bool:
+    """Detect if KDE ColorScheme is set to dark."""
     kdeglobals = Path.home() / ".config" / "kdeglobals"
     if kdeglobals.exists():
         try:
-            with open(kdeglobals, 'r') as f:
+            with kdeglobals.open() as f:
                 for line in f:
                     if line.strip().startswith("ColorScheme="):
-                        scheme = line.split('=', 1)[1].strip().lower()
-                        if 'dark' in scheme:
+                        scheme = line.split("=", 1)[1].strip().lower()
+                        if "dark" in scheme:
                             log.debug(f"Detected KDE ColorScheme: {scheme} (dark)")
                             return True
         except OSError as e:
@@ -80,21 +85,22 @@ def detect_kde_colorscheme_dark() -> bool:
 
 
 def detect_xfce_dark_theme() -> bool:
+    """Detect if XFCE theme is set to dark."""
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607
             [
-                'xfconf-query',
-                '-c',
-                'xsettings',
-                '-p',
-                '/Net/ThemeName',
+                "xfconf-query",
+                "-c",
+                "xsettings",
+                "-p",
+                "/Net/ThemeName",
             ],
             capture_output=True,
             text=True,
             check=True,
         )
         theme = result.stdout.strip().lower()
-        if 'dark' in theme:
+        if "dark" in theme:
             log.debug(f"Detected XFCE theme: {theme} (dark)")
             return True
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -103,14 +109,15 @@ def detect_xfce_dark_theme() -> bool:
 
 
 def detect_lxqt_dark_theme() -> bool:
+    """Detect if LXQt theme is set to dark."""
     lxqt_conf = Path.home() / ".config" / "lxqt" / "session.conf"
     if lxqt_conf.exists():
         try:
-            with open(lxqt_conf, 'r') as f:
+            with lxqt_conf.open() as f:
                 for line in f:
                     if line.strip().startswith("theme="):
-                        theme = line.split('=', 1)[1].strip().lower()
-                        if 'dark' in theme:
+                        theme = line.split("=", 1)[1].strip().lower()
+                        if "dark" in theme:
                             log.debug(f"Detected LXQt theme: {theme} (dark)")
                             return True
         except OSError as e:
@@ -120,25 +127,25 @@ def detect_lxqt_dark_theme() -> bool:
 
 def detect_freedesktop_color_scheme_dark() -> bool:
     """Detect dark mode using org.freedesktop.appearance.color-scheme (XDG portal, cross-desktop)."""
-    value = gsettings_get('color-scheme')
+    value = gsettings_get("color-scheme")
     # Try org.freedesktop.appearance first
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607
             [
-                'gsettings',
-                'get',
-                'org.freedesktop.appearance',
-                'color-scheme',
+                "gsettings",
+                "get",
+                "org.freedesktop.appearance",
+                "color-scheme",
             ],
             capture_output=True,
             text=True,
             check=True,
         )
         value = result.stdout.strip().strip("'\"")
-        if value == '1':
+        if value == "1":
             log.debug("Detected org.freedesktop.appearance.color-scheme: dark (1)")
             return True
-        elif value == '0':
+        if value == "0":
             log.debug("Detected org.freedesktop.appearance.color-scheme: light (0)")
             return False
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -165,30 +172,31 @@ def get_current_desktop_environment() -> str:
 
 
 def detect_gnome_dark_wrapper() -> bool:
+    """Detect dark mode for GNOME or Unity desktop environments."""
     if get_current_desktop_environment() in {"gnome", "unity"}:
         return detect_gnome_color_scheme_dark() or detect_gnome_gtk_theme_dark()
     return False
 
 
 def detect_kde_dark_wrapper() -> bool:
+    """Detect dark mode for KDE desktop environment."""
     if get_current_desktop_environment() == "kde":
         return detect_kde_colorscheme_dark()
     return False
 
 
 def detect_xfce_dark_wrapper() -> bool:
+    """Detect dark mode for XFCE desktop environment."""
     if get_current_desktop_environment() == "xfce":
         return detect_xfce_dark_theme()
     return False
 
 
 def detect_lxqt_dark_wrapper() -> bool:
+    """Detect dark mode for LXQt desktop environment."""
     if get_current_desktop_environment() == "lxqt":
         return detect_lxqt_dark_theme()
     return False
-
-
-# Update the strategy list to use wrappers
 
 
 def get_linux_dark_mode_strategies() -> list:

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -23,8 +23,8 @@
 """Dark mode detection utilities for various Linux desktop environments."""
 
 import os
-import subprocess  # noqa: S404
 from pathlib import Path
+import subprocess  # noqa: S404
 
 from picard import log
 

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -50,6 +50,7 @@ def kde_config_dir(tmp_path: Path) -> Path:
     config_dir.mkdir()
     return config_dir
 
+
 @pytest.mark.parametrize(
     ("key", "stdout", "expected"),
     [
@@ -68,6 +69,7 @@ def test_gsettings_detection(key: str, stdout: str, expected: bool) -> None:
         else:
             assert theme_detect.detect_gnome_gtk_theme_dark() is expected
 
+
 @pytest.mark.parametrize(
     ("side_effect",),
     [
@@ -78,6 +80,7 @@ def test_gsettings_detection(key: str, stdout: str, expected: bool) -> None:
 def test_gsettings_get_failure(side_effect) -> None:
     with patch("subprocess.run", side_effect=side_effect):
         assert theme_detect.gsettings_get("color-scheme") is None
+
 
 @pytest.mark.parametrize(
     ("file_content", "expected"),
@@ -93,6 +96,7 @@ def test_kde_colorscheme_detection(file_content: str, expected: bool, kde_config
     with patch("pathlib.Path.home", return_value=kde_config_dir.parent):
         assert theme_detect.detect_kde_colorscheme_dark() is expected
 
+
 @pytest.mark.parametrize(
     ("color_scheme", "gtk_theme", "kde_content", "expected", "de"),
     [
@@ -102,7 +106,9 @@ def test_kde_colorscheme_detection(file_content: str, expected: bool, kde_config
         ("default", "Adwaita", "ColorScheme=Breeze\n", False, "kde"),
     ],
 )
-def test_detect_linux_dark_mode_integration(color_scheme: str, gtk_theme: str, kde_content: str, expected: bool, de: str, kde_config_dir: Path) -> None:
+def test_detect_linux_dark_mode_integration(
+    color_scheme: str, gtk_theme: str, kde_content: str, expected: bool, de: str, kde_config_dir: Path
+) -> None:
     kdeglobals = kde_config_dir / "kdeglobals"
     kdeglobals.write_text(f"[General]\n{kde_content}")
     with patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": de}, clear=True):
@@ -120,6 +126,7 @@ def test_detect_linux_dark_mode_integration(color_scheme: str, gtk_theme: str, k
                         break
                 assert result is expected
 
+
 # Integration: freedesktop takes priority
 def test_detect_linux_dark_mode_priority(tmp_path: Path) -> None:
     # If freedesktop returns dark, it should take priority over others
@@ -136,6 +143,7 @@ def test_detect_linux_dark_mode_priority(tmp_path: Path) -> None:
                 break
         assert result is True
 
+
 # --- XFCE dark mode detection ---
 @pytest.mark.parametrize(
     ("stdout", "expected"),
@@ -151,6 +159,7 @@ def test_xfce_dark_theme_detection(stdout: str, expected: bool) -> None:
         mock_run.return_value.returncode = 0
         assert theme_detect.detect_xfce_dark_theme() is expected
 
+
 @pytest.mark.parametrize(
     ("side_effect",),
     [
@@ -161,6 +170,7 @@ def test_xfce_dark_theme_detection(stdout: str, expected: bool) -> None:
 def test_xfce_dark_theme_detection_failure(side_effect) -> None:
     with patch("subprocess.run", side_effect=side_effect):
         assert theme_detect.detect_xfce_dark_theme() is False
+
 
 # --- LXQt dark mode detection ---
 @pytest.mark.parametrize(
@@ -178,6 +188,7 @@ def test_lxqt_dark_theme_detection(file_content: str, expected: bool, tmp_path: 
     session_conf.write_text(file_content)
     with patch("pathlib.Path.home", return_value=tmp_path):
         assert theme_detect.detect_lxqt_dark_theme() is expected
+
 
 @pytest.mark.parametrize(
     ("file_exists", "raises"),
@@ -199,6 +210,7 @@ def test_lxqt_dark_theme_detection_failure(file_exists: bool, raises, tmp_path: 
         elif not file_exists:
             assert theme_detect.detect_lxqt_dark_theme() is False
 
+
 @pytest.mark.parametrize(
     ("gsettings_value", "expected"),
     [
@@ -213,6 +225,7 @@ def test_freedesktop_color_scheme_detection(gsettings_value: str, expected: bool
         mock_run.return_value.returncode = 0
         assert theme_detect.detect_freedesktop_color_scheme_dark() is expected
 
+
 @pytest.mark.parametrize(
     ("side_effect",),
     [
@@ -223,6 +236,7 @@ def test_freedesktop_color_scheme_detection(gsettings_value: str, expected: bool
 def test_freedesktop_color_scheme_detection_failure(side_effect) -> None:
     with patch("subprocess.run", side_effect=side_effect):
         assert theme_detect.detect_freedesktop_color_scheme_dark() is False
+
 
 # Shared expected dark palette colors (should match DARK_PALETTE_COLORS in theme.py)
 EXPECTED_DARK_PALETTE_COLORS = {
@@ -244,18 +258,26 @@ EXPECTED_DARK_PALETTE_COLORS = {
     (QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.HighlightedText): QtCore.Qt.GlobalColor.white,
 }
 
+
 def assert_palette_matches_expected(palette, expected_colors):
     for key, expected in expected_colors.items():
         if isinstance(key, tuple):
             group, role = key
             actual = palette.color(group, role)
         else:
-            actual = palette.color(QtGui.QPalette.ColorGroup.Active, key) if isinstance(key, QtGui.QPalette.ColorRole) else palette.color(key)
+            actual = (
+                palette.color(QtGui.QPalette.ColorGroup.Active, key)
+                if isinstance(key, QtGui.QPalette.ColorRole)
+                else palette.color(key)
+            )
         if isinstance(expected, QtGui.QColor):
             # Compare by value, not object identity
-            assert actual.getRgb() == expected.getRgb(), f"Color for {key} should be {expected.getRgb()}, got {actual.getRgb()}"
+            assert actual.getRgb() == expected.getRgb(), (
+                f"Color for {key} should be {expected.getRgb()}, got {actual.getRgb()}"
+            )
         else:
             assert actual == QtGui.QColor(expected), f"Color for {key} should be {expected}, got {actual}"
+
 
 # Only check these roles for light mode, as they are guaranteed to differ
 LIGHT_MODE_DISTINCT_ROLES = [
@@ -264,6 +286,7 @@ LIGHT_MODE_DISTINCT_ROLES = [
     QtGui.QPalette.ColorRole.Button,
     QtGui.QPalette.ColorRole.AlternateBase,
 ]
+
 
 def assert_palette_not_dark(palette, expected_colors):
     for key, expected in expected_colors.items():
@@ -274,17 +297,22 @@ def assert_palette_not_dark(palette, expected_colors):
             continue
         actual = palette.color(QtGui.QPalette.ColorGroup.Active, key)
         if isinstance(expected, QtGui.QColor):
-            assert actual.getRgb() != expected.getRgb(), f"Color for {key} should differ from dark mode in light mode; got {actual.getRgb()}"
+            assert actual.getRgb() != expected.getRgb(), (
+                f"Color for {key} should differ from dark mode in light mode; got {actual.getRgb()}"
+            )
         else:
-            assert actual != QtGui.QColor(expected), f"Color for {key} should differ from dark mode in light mode; got {actual}"
+            assert actual != QtGui.QColor(expected), (
+                f"Color for {key} should differ from dark mode in light mode; got {actual}"
+            )
+
 
 @pytest.mark.parametrize(
     "already_dark_theme, dark_mode, expect_dark_palette",
     [
-        (True, True, False),   # Already dark, detection True: do NOT override
+        (True, True, False),  # Already dark, detection True: do NOT override
         (True, False, False),  # Already dark, detection False: do NOT override
-        (False, True, True),   # Not dark, detection True: override
-        (False, False, False), # Not dark, detection False: do NOT override
+        (False, True, True),  # Not dark, detection True: override
+        (False, False, False),  # Not dark, detection False: do NOT override
     ],
 )
 def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, expect_dark_palette):
@@ -299,28 +327,39 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, ex
     # Patch _detect_linux_dark_mode to return dark_mode
     theme = theme_mod.BaseTheme()
     theme._detect_linux_dark_mode = lambda: dark_mode
+
     # Mock app and palette
     class DummyPalette(QtGui.QPalette):
         def __init__(self):
             super().__init__()
             # Set a unique color to detect override
-            self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window, QtGui.QColor(123, 123, 123))
+            self.setColor(
+                QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window, QtGui.QColor(123, 123, 123)
+            )
             # Set base color to dark or light to control self._dark_theme
             if already_dark_theme:
                 self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(0, 0, 0))
             else:
-                self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(255, 255, 255))
+                self.setColor(
+                    QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(255, 255, 255)
+                )
+
     class DummyApp:
         def __init__(self):
             self._palette = DummyPalette()
+
         def setStyle(self, style):
             pass
+
         def setStyleSheet(self, stylesheet):
             pass
+
         def palette(self):
             return self._palette
+
         def setPalette(self, palette):
             self._palette = palette
+
     app = DummyApp()
     theme.setup(app)
     palette = app._palette
@@ -329,10 +368,14 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, ex
     else:
         # The Window color should remain the unique color if not overridden
         window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
-        assert window_color == QtGui.QColor(123, 123, 123), f"Palette should not be overridden, got {window_color.getRgb()}"
+        assert window_color == QtGui.QColor(123, 123, 123), (
+            f"Palette should not be overridden, got {window_color.getRgb()}"
+        )
+
 
 @pytest.mark.parametrize(
-    ("apps_use_light_theme", "expected_dark"), [
+    ("apps_use_light_theme", "expected_dark"),
+    [
         (0, True),
         (1, False),
     ],
@@ -343,22 +386,29 @@ def test_windows_dark_theme_palette(monkeypatch, apps_use_light_theme, expected_
     # Patch winreg
     winreg_mock = types.SimpleNamespace()
     monkeypatch.setattr(theme_mod, "winreg", winreg_mock)
+
     # Mock OpenKey and QueryValueEx for dark mode
     class DummyKey:
-        def __enter__(self): return self
-        def __exit__(self, exc_type, exc_val, exc_tb): pass
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
     def openkey_side_effect(key, subkey):
         if "Personalize" in subkey:
             return DummyKey()
         if "DWM" in subkey:
             return DummyKey()
         raise FileNotFoundError
+
     def queryvalueex_side_effect(key, value):
         if value == "AppsUseLightTheme":
             return (apps_use_light_theme,)
         if value == "ColorizationColor":
             return (0x123456,)
         raise FileNotFoundError
+
     winreg_mock.HKEY_CURRENT_USER = 0
     winreg_mock.OpenKey = openkey_side_effect
     winreg_mock.QueryValueEx = queryvalueex_side_effect
@@ -368,19 +418,29 @@ def test_windows_dark_theme_palette(monkeypatch, apps_use_light_theme, expected_
     monkeypatch.setattr(theme_mod, "get_config", lambda: config_mock)
     # Instantiate WindowsTheme and run setup
     theme = theme_mod.WindowsTheme()
+
     class DummyPalette(QtGui.QPalette):
         pass
+
     class DummyApp:
         def __init__(self):
             self._palette = DummyPalette()
+
         def setStyle(self, style):
             pass
+
         def setStyleSheet(self, stylesheet):
             pass
+
         def palette(self):
             return self._palette
+
         def setPalette(self, palette):
             self._palette = palette
+
+        def style(self):
+            return None
+
     app = DummyApp()
     theme.setup(app)
     palette = app._palette
@@ -405,14 +465,25 @@ def test_get_current_desktop_environment_param(env, expected):
     with patch.dict(os.environ, env, clear=True):
         assert theme_detect.get_current_desktop_environment() == expected
 
+
 @pytest.mark.parametrize(
     "args",
     [
-        ("gnome", theme_detect.detect_gnome_dark_wrapper, "picard.ui.theme_detect.detect_gnome_color_scheme_dark", True),
+        (
+            "gnome",
+            theme_detect.detect_gnome_dark_wrapper,
+            "picard.ui.theme_detect.detect_gnome_color_scheme_dark",
+            True,
+        ),
         ("kde", theme_detect.detect_kde_dark_wrapper, "picard.ui.theme_detect.detect_kde_colorscheme_dark", True),
         ("xfce", theme_detect.detect_xfce_dark_wrapper, "picard.ui.theme_detect.detect_xfce_dark_theme", True),
         ("lxqt", theme_detect.detect_lxqt_dark_wrapper, "picard.ui.theme_detect.detect_lxqt_dark_theme", True),
-        ("other", theme_detect.detect_gnome_dark_wrapper, "picard.ui.theme_detect.detect_gnome_color_scheme_dark", False),
+        (
+            "other",
+            theme_detect.detect_gnome_dark_wrapper,
+            "picard.ui.theme_detect.detect_gnome_color_scheme_dark",
+            False,
+        ),
         ("other", theme_detect.detect_kde_dark_wrapper, "picard.ui.theme_detect.detect_kde_colorscheme_dark", False),
         ("other", theme_detect.detect_xfce_dark_wrapper, "picard.ui.theme_detect.detect_xfce_dark_theme", False),
         ("other", theme_detect.detect_lxqt_dark_wrapper, "picard.ui.theme_detect.detect_lxqt_dark_theme", False),
@@ -431,16 +502,19 @@ def test_de_specific_wrappers_only_run_for_matching_de_param(args):
                 mock_detect.assert_not_called()
                 assert result is False
 
+
 @pytest.mark.parametrize(
     "already_dark_theme, linux_dark_mode_detected, expect_dark_palette",
     [
-        (True, True, False),   # Already dark, detection True: do NOT override
+        (True, True, False),  # Already dark, detection True: do NOT override
         (True, False, False),  # Already dark, detection False: do NOT override
-        (False, True, True),   # Not dark, detection True: override
-        (False, False, False), # Not dark, detection False: do NOT override
+        (False, True, True),  # Not dark, detection True: override
+        (False, False, False),  # Not dark, detection False: do NOT override
     ],
 )
-def test_linux_dark_palette_override_only_if_not_already_dark(monkeypatch, already_dark_theme, linux_dark_mode_detected, expect_dark_palette):
+def test_linux_dark_palette_override_only_if_not_already_dark(
+    monkeypatch, already_dark_theme, linux_dark_mode_detected, expect_dark_palette
+):
     monkeypatch.setattr(theme_mod, "IS_WIN", False)
     monkeypatch.setattr(theme_mod, "IS_MACOS", False)
     monkeypatch.setattr(theme_mod, "IS_HAIKU", False)
@@ -452,23 +526,33 @@ def test_linux_dark_palette_override_only_if_not_already_dark(monkeypatch, alrea
         def __init__(self):
             super().__init__()
             # Set a unique color to detect override
-            self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window, QtGui.QColor(123, 123, 123))
+            self.setColor(
+                QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window, QtGui.QColor(123, 123, 123)
+            )
             # Set base color to dark or light to control self._dark_theme
             if already_dark_theme:
                 self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(0, 0, 0))
             else:
-                self.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(255, 255, 255))
+                self.setColor(
+                    QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base, QtGui.QColor(255, 255, 255)
+                )
+
     class DummyApp:
         def __init__(self):
             self._palette = DummyPalette()
+
         def setStyle(self, style):
             pass
+
         def setStyleSheet(self, stylesheet):
             pass
+
         def palette(self):
             return self._palette
+
         def setPalette(self, palette):
             self._palette = palette
+
     app = DummyApp()
     theme = theme_mod.BaseTheme()
     theme._detect_linux_dark_mode = lambda: linux_dark_mode_detected
@@ -479,4 +563,6 @@ def test_linux_dark_palette_override_only_if_not_already_dark(monkeypatch, alrea
     else:
         # The Window color should remain the unique color if not overridden
         window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
-        assert window_color == QtGui.QColor(123, 123, 123), f"Palette should not be overridden, got {window_color.getRgb()}"
+        assert window_color == QtGui.QColor(123, 123, 123), (
+            f"Palette should not be overridden, got {window_color.getRgb()}"
+        )

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
+# Copyright (C) 2020-2021 Gabriel Ferreira
+# Copyright (C) 2021-2024 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from pathlib import Path
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from picard.ui.theme import BaseTheme
+
+
+@pytest.fixture
+def theme() -> BaseTheme:
+    return BaseTheme()
+
+@pytest.fixture
+def kde_config_dir(tmp_path: Path) -> Path:
+    config_dir = tmp_path / ".config"
+    config_dir.mkdir()
+    return config_dir
+
+@pytest.mark.parametrize(
+    "key,stdout,expected",
+    [
+        ("color-scheme", "prefer-dark", True),
+        ("color-scheme", "default", False),
+        ("gtk-theme", "Adwaita-dark", True),
+        ("gtk-theme", "Adwaita", False),
+    ],
+)
+def test_gsettings_detection(theme: BaseTheme, key: str, stdout: str, expected: bool) -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.stdout = stdout
+        mock_run.return_value.returncode = 0
+        if key == "color-scheme":
+            assert theme._detect_gnome_color_scheme_dark() is expected
+        else:
+            assert theme._detect_gnome_gtk_theme_dark() is expected
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        FileNotFoundError(),
+        subprocess.CalledProcessError(1, "gsettings"),
+    ],
+)
+def test_gsettings_get_failure(theme: BaseTheme, side_effect) -> None:
+    with patch("subprocess.run", side_effect=side_effect):
+        assert theme._gsettings_get("color-scheme") is None
+
+@pytest.mark.parametrize(
+    "file_content,expected",
+    [
+        ("[General]\nColorScheme=BreezeDark\n", True),
+        ("[General]\nColorScheme=Breeze\n", False),
+        ("", False),
+    ],
+)
+def test_kde_colorscheme_detection(theme: BaseTheme, file_content: str, expected: bool, kde_config_dir: Path) -> None:
+    kdeglobals = kde_config_dir / "kdeglobals"
+    kdeglobals.write_text(file_content)
+    with patch("pathlib.Path.home", return_value=kde_config_dir.parent):
+        assert theme._detect_kde_colorscheme_dark() is expected
+
+@pytest.mark.parametrize(
+    "color_scheme,gtk_theme,kde_content,expected",
+    [
+        ("prefer-dark", "Adwaita", "ColorScheme=Breeze\n", True),
+        ("default", "Adwaita-dark", "ColorScheme=Breeze\n", True),
+        ("default", "Adwaita", "ColorScheme=BreezeDark\n", True),
+        ("default", "Adwaita", "ColorScheme=Breeze\n", False),
+    ],
+)
+def test_detect_linux_dark_mode(theme: BaseTheme, color_scheme: str, gtk_theme: str, kde_content: str, expected: bool, kde_config_dir: Path) -> None:
+    kdeglobals = kde_config_dir / "kdeglobals"
+    kdeglobals.write_text(f"[General]\n{kde_content}")
+    with patch("pathlib.Path.home", return_value=kde_config_dir.parent):
+        with patch.object(theme, "_gsettings_get") as mock_gsettings:
+            mock_gsettings.side_effect = [color_scheme, gtk_theme]
+            assert theme._detect_linux_dark_mode() is expected

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -26,12 +26,7 @@ from unittest.mock import patch
 
 import pytest
 
-from picard.ui.theme import BaseTheme
-
-
-@pytest.fixture
-def theme() -> BaseTheme:
-    return BaseTheme()
+from picard.ui import theme_detect
 
 @pytest.fixture
 def kde_config_dir(tmp_path: Path) -> Path:
@@ -40,7 +35,7 @@ def kde_config_dir(tmp_path: Path) -> Path:
     return config_dir
 
 @pytest.mark.parametrize(
-    "key,stdout,expected",
+    ("key", "stdout", "expected"),
     [
         ("color-scheme", "prefer-dark", True),
         ("color-scheme", "default", False),
@@ -48,42 +43,42 @@ def kde_config_dir(tmp_path: Path) -> Path:
         ("gtk-theme", "Adwaita", False),
     ],
 )
-def test_gsettings_detection(theme: BaseTheme, key: str, stdout: str, expected: bool) -> None:
+def test_gsettings_detection(key: str, stdout: str, expected: bool) -> None:
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.stdout = stdout
         mock_run.return_value.returncode = 0
         if key == "color-scheme":
-            assert theme._detect_gnome_color_scheme_dark() is expected
+            assert theme_detect.detect_gnome_color_scheme_dark() is expected
         else:
-            assert theme._detect_gnome_gtk_theme_dark() is expected
+            assert theme_detect.detect_gnome_gtk_theme_dark() is expected
 
 @pytest.mark.parametrize(
-    "side_effect",
+    ("side_effect",),
     [
-        FileNotFoundError(),
-        subprocess.CalledProcessError(1, "gsettings"),
+        (FileNotFoundError(),),
+        (subprocess.CalledProcessError(1, "gsettings"),),
     ],
 )
-def test_gsettings_get_failure(theme: BaseTheme, side_effect) -> None:
+def test_gsettings_get_failure(side_effect) -> None:
     with patch("subprocess.run", side_effect=side_effect):
-        assert theme._gsettings_get("color-scheme") is None
+        assert theme_detect.gsettings_get("color-scheme") is None
 
 @pytest.mark.parametrize(
-    "file_content,expected",
+    ("file_content", "expected"),
     [
         ("[General]\nColorScheme=BreezeDark\n", True),
         ("[General]\nColorScheme=Breeze\n", False),
         ("", False),
     ],
 )
-def test_kde_colorscheme_detection(theme: BaseTheme, file_content: str, expected: bool, kde_config_dir: Path) -> None:
+def test_kde_colorscheme_detection(file_content: str, expected: bool, kde_config_dir: Path) -> None:
     kdeglobals = kde_config_dir / "kdeglobals"
     kdeglobals.write_text(file_content)
     with patch("pathlib.Path.home", return_value=kde_config_dir.parent):
-        assert theme._detect_kde_colorscheme_dark() is expected
+        assert theme_detect.detect_kde_colorscheme_dark() is expected
 
 @pytest.mark.parametrize(
-    "color_scheme,gtk_theme,kde_content,expected",
+    ("color_scheme", "gtk_theme", "kde_content", "expected"),
     [
         ("prefer-dark", "Adwaita", "ColorScheme=Breeze\n", True),
         ("default", "Adwaita-dark", "ColorScheme=Breeze\n", True),
@@ -91,10 +86,81 @@ def test_kde_colorscheme_detection(theme: BaseTheme, file_content: str, expected
         ("default", "Adwaita", "ColorScheme=Breeze\n", False),
     ],
 )
-def test_detect_linux_dark_mode(theme: BaseTheme, color_scheme: str, gtk_theme: str, kde_content: str, expected: bool, kde_config_dir: Path) -> None:
+def test_detect_linux_dark_mode_integration(color_scheme: str, gtk_theme: str, kde_content: str, expected: bool, kde_config_dir: Path) -> None:
     kdeglobals = kde_config_dir / "kdeglobals"
     kdeglobals.write_text(f"[General]\n{kde_content}")
     with patch("pathlib.Path.home", return_value=kde_config_dir.parent):
-        with patch.object(theme, "_gsettings_get") as mock_gsettings:
+        with patch("picard.ui.theme_detect.gsettings_get") as mock_gsettings:
+            # Simulate gsettings: first call for color-scheme, second for gtk-theme
             mock_gsettings.side_effect = [color_scheme, gtk_theme]
-            assert theme._detect_linux_dark_mode() is expected
+            # Compose the strategies in order
+            strategies = theme_detect.get_linux_dark_mode_strategies()
+            result = False
+            for strategy in strategies:
+                if strategy():
+                    result = True
+                    break
+            assert result is expected
+
+# --- XFCE dark mode detection ---
+@pytest.mark.parametrize(
+    ("stdout", "expected"),
+    [
+        ("Greybird-dark", True),
+        ("Greybird", False),
+        ("", False),
+    ],
+)
+def test_xfce_dark_theme_detection(stdout: str, expected: bool) -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.stdout = stdout
+        mock_run.return_value.returncode = 0
+        assert theme_detect.detect_xfce_dark_theme() is expected
+
+@pytest.mark.parametrize(
+    ("side_effect",),
+    [
+        (FileNotFoundError(),),
+        (subprocess.CalledProcessError(1, "xfconf-query"),),
+    ],
+)
+def test_xfce_dark_theme_detection_failure(side_effect) -> None:
+    with patch("subprocess.run", side_effect=side_effect):
+        assert theme_detect.detect_xfce_dark_theme() is False
+
+# --- LXQt dark mode detection ---
+@pytest.mark.parametrize(
+    ("file_content", "expected"),
+    [
+        ("theme=DarkTheme\n", True),
+        ("theme=LightTheme\n", False),
+        ("", False),
+    ],
+)
+def test_lxqt_dark_theme_detection(file_content: str, expected: bool, tmp_path: Path) -> None:
+    lxqt_dir = tmp_path / ".config" / "lxqt"
+    lxqt_dir.mkdir(parents=True)
+    session_conf = lxqt_dir / "session.conf"
+    session_conf.write_text(file_content)
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        assert theme_detect.detect_lxqt_dark_theme() is expected
+
+@pytest.mark.parametrize(
+    ("file_exists", "raises"),
+    [
+        (True, OSError("fail")),
+        (False, None),
+    ],
+)
+def test_lxqt_dark_theme_detection_failure(file_exists: bool, raises, tmp_path: Path) -> None:
+    lxqt_dir = tmp_path / ".config" / "lxqt"
+    lxqt_dir.mkdir(parents=True)
+    session_conf = lxqt_dir / "session.conf"
+    if file_exists:
+        session_conf.write_text("theme=DarkTheme\n")
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        if file_exists and raises:
+            with patch("builtins.open", side_effect=raises):
+                assert theme_detect.detect_lxqt_dark_theme() is False
+        elif not file_exists:
+            assert theme_detect.detect_lxqt_dark_theme() is False

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -20,27 +20,28 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import os
-import subprocess
-import types
 from itertools import (
     chain,
     repeat,
 )
+import os
 from pathlib import Path
+import subprocess
+import types
 from unittest.mock import (
     MagicMock,
     patch,
 )
 
-import pytest
 from PyQt6 import (
     QtCore,
     QtGui,
 )
 
-import picard.ui.theme as theme_mod
+import pytest
+
 from picard.ui import theme_detect
+import picard.ui.theme as theme_mod
 
 
 @pytest.fixture

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -20,10 +20,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from itertools import (
-    chain,
-    repeat,
-)
 import os
 from pathlib import Path
 import subprocess
@@ -123,10 +119,15 @@ def test_detect_linux_dark_mode_integration(
         patch("pathlib.Path.home", return_value=kde_config_dir.parent),
         patch("picard.ui.theme_detect.gsettings_get") as mock_gsettings,
     ):
-        # First call: freedesktop (simulate not set, return '')
-        # Second: gnome color-scheme
-        # Third: gnome gtk-theme
-        mock_gsettings.side_effect = chain(["", color_scheme, gtk_theme], repeat(""))
+
+        def gsettings_get_side_effect(key):
+            if key == "color-scheme":
+                return color_scheme
+            if key == "gtk-theme":
+                return gtk_theme
+            return ""
+
+        mock_gsettings.side_effect = gsettings_get_side_effect
         strategies = theme_detect.get_linux_dark_mode_strategies()
         result = False
         for strategy in strategies:


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

* **Describe this change in 1-2 sentences**:  
  This change ensures that Picard correctly detects and applies the system dark mode on Linux when the “System” UI theme is selected, supporting multiple desktop environments and providing comprehensive tests.

# Problem

Picard did not honor the system’s dark mode setting on Linux when the “System” theme was selected, especially if Qt’s platform theme integration was missing or incomplete. This led to inconsistent user experience for users with dark system themes on GNOME, KDE, XFCE, LXQt, and similar environments.

* JIRA ticket (_optional_): [PICARD-2300](https://tickets.metabrainz.org/browse/PICARD-2300)

# Solution

- Refactored dark mode detection logic into a dedicated module using the Strategy Pattern.
- Added support for detecting dark mode on GNOME, KDE, XFCE, and LXQt desktop environments.
- Modularized detection strategies for easy extension and maintenance.
- Updated and expanded unit tests to cover all supported environments and edge cases, using pytest and proper parameterization.
- Ensured all code is DRY, single-responsibility, and follows Picard’s contribution guidelines.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)