### PR TITLE
PICARD-2300: Add qt's stylehints to theme.py for a consistent exp. across platforms

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'dev', 6)
+PICARD_VERSION = Version(3, 0, 0, 'dev', 7)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -62,6 +62,8 @@ from picard.version import (
     VersionError,
 )
 
+from picard.ui.theme import UiTheme
+
 
 # All upgrade functions have to start with following prefix
 UPGRADE_FUNCTION_PREFIX = 'upgrade_to_v'
@@ -573,6 +575,12 @@ def upgrade_to_v3_0_0dev6(config):
     """New independent option "standardize_vocals" should use the value of the old shared option"""
     standardize_instruments_and_vocals = config.setting['standardize_instruments']
     config.setting['standardize_vocals'] = standardize_instruments_and_vocals
+
+
+def upgrade_to_v3_0_0dev7(config):
+    """Change theme option SYSTEM to DEFAULT"""
+    if config.setting['ui_theme'] == "system":
+        config.setting['ui_theme'] = UiTheme.DEFAULT
 
 
 def rename_option(config, old_opt, new_opt, option_type, default):

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -385,11 +385,9 @@ def upgrade_to_v2_6_0beta2(config):
 
 def upgrade_to_v2_6_0beta3(config):
     """Replace use_system_theme with ui_theme options"""
-    from picard.ui.theme import UiTheme
-
     _s = config.setting
     if _s.value('use_system_theme', BoolOption):
-        _s['ui_theme'] = str(UiTheme.SYSTEM)
+        _s['ui_theme'] = 'system'
     _s.remove('use_system_theme')
 
 

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -177,13 +177,6 @@ class InterfaceOptionsPage(OptionsPage):
         notes = []
         if new_theme_setting != config.setting['ui_theme']:
             warnings.append(_("You have changed the application theme."))
-            if new_theme_setting == str(UiTheme.SYSTEM):
-                notes.append(
-                    _(
-                        'Please note that using the system theme might cause the user interface to be not shown correctly. '
-                        'If this is the case select the "Default" theme option to use Picard\'s default theme again.'
-                    )
-                )
             config.setting['ui_theme'] = new_theme_setting
         if new_language != config.setting['ui_language']:
             config.setting['ui_language'] = new_language

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -97,10 +97,6 @@ class InterfaceOptionsPage(OptionsPage):
             'label': N_("Light"),
             'desc': N_("A light display theme"),
         },
-        UiTheme.SYSTEM: {
-            'label': N_("System"),
-            'desc': N_("The Qt6 theme configured in the desktop environment"),
-        },
     }
 
     def __init__(self, parent=None):

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -224,10 +224,12 @@ class BaseTheme:
             self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
 
         # Linux-specific: If DEFAULT theme, try to detect system dark mode
-        # Do not apply override if already dark theme
+        # Do not apply override if already dark theme, or if a subclass already
+        # determined a dark theme state (e.g., WindowsTheme via registry on tests).
         is_dark_theme = self.is_dark_theme
         if (
             not self._dark_theme
+            and not is_dark_theme
             and not IS_WIN
             and not IS_MACOS
             and not IS_HAIKU

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -109,12 +109,8 @@ def _style_hints_available() -> bool:
 # Theme availability based on platform capabilities
 if IS_HAIKU:
     # Haiku doesn't support themes - UI is hidden anyway, but keep empty for consistency
-    # Platform Detection: `IS_HAIKU` is detected via sys.platform == 'haiku1'
-    # Feature Flag: `OS_SUPPORTS_THEMES` is set to False for Haiku
-    # Empty Options: `AVAILABLE_UI_THEMES` is set to an empty list [] for Haiku
-    # UI Hiding: The ui_theme_container widget is hidden when `OS_SUPPORTS_THEMES` is False (see `interface.py`)
     AVAILABLE_UI_THEMES = []
-elif not IS_WIN and not IS_MACOS:  # Linux
+elif not IS_WIN and not IS_MACOS:  # Non-Windows and non-macOS platforms
     if _style_hints_available():
         # All themes available when style hints are supported
         AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
@@ -122,7 +118,7 @@ elif not IS_WIN and not IS_MACOS:  # Linux
         # Only DEFAULT theme available when style hints are not available
         AVAILABLE_UI_THEMES = [UiTheme.DEFAULT]
 else:
-    # Windows and macOS: consistent structure
+    # All others, like Windows and macOS: consistent structure
     AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
 
 

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -86,7 +86,6 @@ class UiTheme(Enum):
     DEFAULT = 'default'
     DARK = 'dark'
     LIGHT = 'light'
-    SYSTEM = 'system'
 
     def __str__(self):
         return self.value
@@ -197,8 +196,8 @@ class BaseTheme:
         self._loaded_config_theme = UiTheme(config.setting['ui_theme'])
 
         # Use the new fusion style from PyQt6 for a modern and consistent look
-        # across all OSes, except when using system default theme on Linux.
-        if not IS_MACOS and not IS_HAIKU and not (not IS_WIN and self._loaded_config_theme == UiTheme.DEFAULT):
+        # across all OSes, except for macOS and Haiku.
+        if not IS_MACOS and not IS_HAIKU:
             app.setStyle('Fusion')
         elif IS_MACOS:
             app.setStyle(MacOverrideStyle(app.style()))
@@ -215,7 +214,7 @@ class BaseTheme:
             elif self._loaded_config_theme == UiTheme.LIGHT:
                 set_color_scheme(QtCore.Qt.ColorScheme.Light)
             else:
-                # For DEFAULT and SYSTEM themes, let Qt follow system settings
+                # For DEFAULT theme, let Qt follow system settings
                 set_color_scheme(QtCore.Qt.ColorScheme.Unknown)
 
         palette = QtGui.QPalette(app.palette())

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -109,16 +109,11 @@ def _style_hints_available() -> bool:
 if IS_HAIKU:
     # Haiku doesn't support themes - UI is hidden anyway, but keep empty for consistency
     AVAILABLE_UI_THEMES = []
-elif not IS_WIN and not IS_MACOS:  # Non-Windows and non-macOS platforms
-    if _style_hints_available():
-        # All themes available when style hints are supported
-        AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
-    else:
-        # Only DEFAULT theme available when style hints are not available
-        AVAILABLE_UI_THEMES = [UiTheme.DEFAULT]
-else:
-    # All others, like Windows and macOS: consistent structure
+elif IS_WIN or IS_MACOS or _style_hints_available():
     AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
+else:
+    # Use only default theme on platforms without style hints
+    AVAILABLE_UI_THEMES = [UiTheme.DEFAULT]
 
 
 class MacOverrideStyle(QtWidgets.QProxyStyle):

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -96,17 +96,33 @@ class UiTheme(Enum):
         return cls.DEFAULT
 
 
+def get_style_hints() -> QtGui.QStyleHints | None:
+    """Get style hints from QGuiApplication, returning None if unavailable."""
+    return QtGui.QGuiApplication.styleHints()
+
+
+def _style_hints_available() -> bool:
+    """Check if style hints are available on the current system."""
+    return get_style_hints() is not None
+
+
 # Theme availability based on platform capabilities
 if IS_HAIKU:
     # Haiku doesn't support themes - UI is hidden anyway, but keep empty for consistency
     # Platform Detection: `IS_HAIKU` is detected via sys.platform == 'haiku1'
     # Feature Flag: `OS_SUPPORTS_THEMES` is set to False for Haiku
-    # Empty Options: `AVAILABLE_UI_THEMES`` is set to an empty list [] for Haiku
+    # Empty Options: `AVAILABLE_UI_THEMES` is set to an empty list [] for Haiku
     # UI Hiding: The ui_theme_container widget is hidden when `OS_SUPPORTS_THEMES` is False (see `interface.py`)
     AVAILABLE_UI_THEMES = []
+elif not IS_WIN and not IS_MACOS:  # Linux
+    if _style_hints_available():
+        # All themes available when style hints are supported
+        AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
+    else:
+        # Only DEFAULT theme available when style hints are not available
+        AVAILABLE_UI_THEMES = [UiTheme.DEFAULT]
 else:
-    # All other platforms: consistent structure
-    # It is now safe to add these to linux since `QtGui.QGuiApplication.styleHints().setColorScheme()` is available
+    # Windows and macOS: consistent structure
     AVAILABLE_UI_THEMES = [UiTheme.DEFAULT, UiTheme.LIGHT, UiTheme.DARK]
 
 
@@ -123,6 +139,44 @@ class MacOverrideStyle(QtWidgets.QProxyStyle):
         return super().styleHint(hint, option, widget, returnData)
 
 
+def apply_dark_palette_colors(palette):
+    """Apply dark palette colors to the given palette."""
+    for key, value in DARK_PALETTE_COLORS.items():
+        if isinstance(key, tuple):
+            group, role = key
+            palette.setColor(group, role, value)
+        else:
+            palette.setColor(key, value)
+
+
+def set_color_scheme(color_scheme: QtCore.Qt.ColorScheme):
+    """Set the color scheme using style hints if available.
+
+    Args:
+        color_scheme: The Qt color scheme to set
+    """
+    style_hints = get_style_hints()
+    if style_hints is not None:
+        style_hints.setColorScheme(color_scheme)
+
+
+def apply_dark_theme_to_palette(palette: QtGui.QPalette):
+    """Apply dark theme colors to the given palette using Qt's color scheme or manual fallback.
+
+    This method tries to use Qt's built-in color scheme first, and falls back to
+    manually applying dark colors if style hints are unavailable.
+
+    Args:
+        palette: The palette to apply dark colors to
+    """
+    style_hints = get_style_hints()
+    if style_hints is not None:
+        style_hints.setColorScheme(QtCore.Qt.ColorScheme.Dark)
+    else:
+        # Fall back to manually applying dark colors
+        apply_dark_palette_colors(palette)
+
+
 class BaseTheme:
     def __init__(self):
         self._loaded_config_theme = UiTheme.DEFAULT
@@ -130,45 +184,6 @@ class BaseTheme:
         self._accent_color = None
         # Registry of dark mode detection strategies for Linux DEs
         self._dark_mode_strategies = get_linux_dark_mode_strategies()
-
-    def _apply_dark_palette_colors(self, palette):
-        """Apply dark palette colors to the given palette."""
-        for key, value in DARK_PALETTE_COLORS.items():
-            if isinstance(key, tuple):
-                group, role = key
-                palette.setColor(group, role, value)
-            else:
-                palette.setColor(key, value)
-
-    def _get_style_hints(self) -> QtGui.QStyleHints | None:
-        """Get style hints from QGuiApplication, returning None if unavailable."""
-        return QtGui.QGuiApplication.styleHints()
-
-    def _set_color_scheme(self, color_scheme: QtCore.Qt.ColorScheme):
-        """Set the color scheme using style hints if available.
-
-        Args:
-            color_scheme: The Qt color scheme to set
-        """
-        style_hints = self._get_style_hints()
-        if style_hints is not None:
-            style_hints.setColorScheme(color_scheme)
-
-    def _apply_dark_theme_to_palette(self, palette: QtGui.QPalette):
-        """Apply dark theme colors to the given palette using Qt's color scheme or manual fallback.
-
-        This method tries to use Qt's built-in color scheme first, and falls back to
-        manually applying dark colors if style hints are unavailable.
-
-        Args:
-            palette: The palette to apply dark colors to
-        """
-        style_hints = self._get_style_hints()
-        if style_hints is not None:
-            style_hints.setColorScheme(QtCore.Qt.ColorScheme.Dark)
-        else:
-            # Fall back to manually applying dark colors
-            self._apply_dark_palette_colors(palette)
 
     def _detect_linux_dark_mode(self) -> bool:
         # Iterate through all registered strategies
@@ -195,15 +210,15 @@ class BaseTheme:
         )
 
         # Set color scheme based on theme configuration
-        style_hints = self._get_style_hints()
+        style_hints = get_style_hints()
         if style_hints is not None:
             if self._loaded_config_theme == UiTheme.DARK:
-                self._set_color_scheme(QtCore.Qt.ColorScheme.Dark)
+                set_color_scheme(QtCore.Qt.ColorScheme.Dark)
             elif self._loaded_config_theme == UiTheme.LIGHT:
-                self._set_color_scheme(QtCore.Qt.ColorScheme.Light)
+                set_color_scheme(QtCore.Qt.ColorScheme.Light)
             else:
                 # For DEFAULT and SYSTEM themes, let Qt follow system settings
-                self._set_color_scheme(QtCore.Qt.ColorScheme.Unknown)
+                set_color_scheme(QtCore.Qt.ColorScheme.Unknown)
 
         palette = QtGui.QPalette(app.palette())
         base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
@@ -225,7 +240,7 @@ class BaseTheme:
             is_dark_theme = self._detect_linux_dark_mode()
             if is_dark_theme:
                 # Apply dark theme to palette using Qt's color scheme or manual fallback
-                self._apply_dark_theme_to_palette(palette)
+                apply_dark_theme_to_palette(palette)
                 self._dark_theme = True
                 self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
             else:
@@ -318,7 +333,7 @@ class WindowsTheme(BaseTheme):
         super().update_palette(palette, dark_theme, accent_color)
         if dark_theme:
             # Apply dark theme to palette using Qt's color scheme or manual fallback
-            self._apply_dark_theme_to_palette(palette)
+            apply_dark_theme_to_palette(palette)
 
 
 if IS_WIN:

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -168,9 +168,11 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette):
     style_hints = get_style_hints()
     if style_hints is not None:
         style_hints.setColorScheme(QtCore.Qt.ColorScheme.Dark)
-    else:
-        # Fall back to manually applying dark colors
-        apply_dark_palette_colors(palette)
+        # Test whether the change was successful
+        if style_hints.colorScheme() == QtCore.Qt.ColorScheme.Dark:
+            return
+    # Fall back to manually applying dark colors
+    apply_dark_palette_colors(palette)
 
 
 class BaseTheme:

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -69,11 +69,13 @@ from picard.config_upgrade import (
     upgrade_to_v3_0_0dev3,
     upgrade_to_v3_0_0dev4,
     upgrade_to_v3_0_0dev5,
+    upgrade_to_v3_0_0dev7,
 )
 from picard.const.defaults import (
     DEFAULT_FILE_NAMING_FORMAT,
     DEFAULT_REPLACEMENT,
     DEFAULT_SCRIPT_NAME,
+    DEFAULT_THEME_NAME,
 )
 from picard.util import unique_numbered_title
 from picard.version import Version
@@ -561,3 +563,9 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
             self.config.setting['replace_dir_separator'] = os.altsep
             upgrade_to_v3_0_0dev5(self.config)
             self.assertEqual(DEFAULT_REPLACEMENT, self.config.setting['replace_dir_separator'])
+
+    def test_upgrade_to_v3_0_0dev7(self):
+        TextOption('setting', 'ui_theme', DEFAULT_THEME_NAME)
+        self.config.setting['ui_theme'] = 'system'
+        upgrade_to_v3_0_0dev7(self.config)
+        self.assertEqual(DEFAULT_THEME_NAME, self.config.setting['ui_theme'])

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -446,7 +446,7 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_6_0beta3(self.config)
         self.assertNotIn('use_system_theme', self.config.setting)
         self.assertIn('ui_theme', self.config.setting)
-        self.assertEqual(str(UiTheme.SYSTEM), self.config.setting['ui_theme'])
+        self.assertEqual('system', self.config.setting['ui_theme'])
 
     def test_upgrade_to_v2_7_0dev3(self):
         # Legacy settings

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -479,6 +479,10 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, ex
 def test_windows_dark_theme_palette(monkeypatch, apps_use_light_theme, expected_dark):
     import picard.ui.theme as theme_mod
 
+    monkeypatch.setattr(theme_mod, "IS_WIN", True)
+    monkeypatch.setattr(theme_mod, "IS_MACOS", False)
+    monkeypatch.setattr(theme_mod, "IS_HAIKU", False)
+
     # Patch winreg
     winreg_mock = types.SimpleNamespace()
     monkeypatch.setattr(theme_mod, "winreg", winreg_mock)

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -396,9 +396,9 @@ def assert_palette_matches_expected(palette, expected_colors):
             )
         if isinstance(expected, QtGui.QColor):
             # Compare by value, not object identity
-            assert (
-                actual.getRgb() == expected.getRgb()
-            ), f"Color for {key} should be {expected.getRgb()}, got {actual.getRgb()}"
+            assert actual.getRgb() == expected.getRgb(), (
+                f"Color for {key} should be {expected.getRgb()}, got {actual.getRgb()}"
+            )
         else:
             assert actual == QtGui.QColor(expected), f"Color for {key} should be {expected}, got {actual}"
 
@@ -421,13 +421,13 @@ def assert_palette_not_dark(palette, expected_colors):
             continue
         actual = palette.color(QtGui.QPalette.ColorGroup.Active, key)
         if isinstance(expected, QtGui.QColor):
-            assert (
-                actual.getRgb() != expected.getRgb()
-            ), f"Color for {key} should differ from dark mode in light mode; got {actual.getRgb()}"
+            assert actual.getRgb() != expected.getRgb(), (
+                f"Color for {key} should differ from dark mode in light mode; got {actual.getRgb()}"
+            )
         else:
-            assert actual != QtGui.QColor(
-                expected
-            ), f"Color for {key} should differ from dark mode in light mode; got {actual}"
+            assert actual != QtGui.QColor(expected), (
+                f"Color for {key} should differ from dark mode in light mode; got {actual}"
+            )
 
 
 @pytest.mark.parametrize(

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -66,25 +66,25 @@ class TestStyleHintsMethods:
 
     def test_get_style_hints_returns_style_hints(self, base_theme, mock_style_hints):
         """Test _get_style_hints returns QGuiApplication.styleHints()."""
-        with patch('picard.ui.theme.QtGui.QGuiApplication.styleHints', return_value=mock_style_hints):
+        with patch("picard.ui.theme.QtGui.QGuiApplication.styleHints", return_value=mock_style_hints):
             result = base_theme._get_style_hints()
             assert result is mock_style_hints
 
     def test_get_style_hints_returns_none_when_unavailable(self, base_theme):
         """Test _get_style_hints returns None when styleHints() is unavailable."""
-        with patch('picard.ui.theme.QtGui.QGuiApplication.styleHints', return_value=None):
+        with patch("picard.ui.theme.QtGui.QGuiApplication.styleHints", return_value=None):
             result = base_theme._get_style_hints()
             assert result is None
 
     def test_set_color_scheme_with_style_hints(self, base_theme, mock_style_hints):
         """Test _set_color_scheme calls setColorScheme when style hints available."""
-        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+        with patch.object(base_theme, "_get_style_hints", return_value=mock_style_hints):
             base_theme._set_color_scheme(QtCore.Qt.ColorScheme.Dark)
             mock_style_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
 
     def test_set_color_scheme_without_style_hints(self, base_theme):
         """Test _set_color_scheme does nothing when style hints unavailable."""
-        with patch.object(base_theme, '_get_style_hints', return_value=None):
+        with patch.object(base_theme, "_get_style_hints", return_value=None):
             # Should not raise any exception
             base_theme._set_color_scheme(QtCore.Qt.ColorScheme.Dark)
 
@@ -98,7 +98,7 @@ class TestStyleHintsMethods:
     )
     def test_set_color_scheme_with_different_schemes(self, base_theme, mock_style_hints, color_scheme):
         """Test _set_color_scheme works with different color schemes."""
-        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+        with patch.object(base_theme, "_get_style_hints", return_value=mock_style_hints):
             base_theme._set_color_scheme(color_scheme)
             mock_style_hints.setColorScheme.assert_called_once_with(color_scheme)
 
@@ -138,13 +138,13 @@ class TestApplyDarkThemeToPalette:
 
     def test_apply_dark_theme_to_palette_with_style_hints(self, base_theme, mock_palette, mock_style_hints):
         """Test _apply_dark_theme_to_palette uses style hints when available."""
-        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+        with patch.object(base_theme, "_get_style_hints", return_value=mock_style_hints):
             base_theme._apply_dark_theme_to_palette(mock_palette)
             mock_style_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
 
     def test_apply_dark_theme_to_palette_without_style_hints(self, base_theme, mock_palette):
         """Test _apply_dark_theme_to_palette falls back to manual colors when style hints unavailable."""
-        with patch.object(base_theme, '_get_style_hints', return_value=None):
+        with patch.object(base_theme, "_get_style_hints", return_value=None):
             base_theme._apply_dark_theme_to_palette(mock_palette)
 
             # Should have applied manual dark colors
@@ -154,8 +154,8 @@ class TestApplyDarkThemeToPalette:
     def test_apply_dark_theme_to_palette_calls_manual_fallback(self, base_theme, mock_palette):
         """Test _apply_dark_theme_to_palette calls _apply_dark_palette_colors when style hints unavailable."""
         with (
-            patch.object(base_theme, '_get_style_hints', return_value=None),
-            patch.object(base_theme, '_apply_dark_palette_colors') as mock_apply,
+            patch.object(base_theme, "_get_style_hints", return_value=None),
+            patch.object(base_theme, "_apply_dark_palette_colors") as mock_apply,
         ):
             base_theme._apply_dark_theme_to_palette(mock_palette)
             mock_apply.assert_called_once_with(mock_palette)
@@ -184,7 +184,7 @@ class TestSetupColorScheme:
     """Test the color scheme setting logic in setup method."""
 
     @pytest.mark.parametrize(
-        "theme_value,expected_color_scheme",
+        ("theme_value", "expected_color_scheme"),
         [
             ("dark", QtCore.Qt.ColorScheme.Dark),
             ("light", QtCore.Qt.ColorScheme.Light),
@@ -202,7 +202,7 @@ class TestSetupColorScheme:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints),
+            patch.object(base_theme, "_get_style_hints", return_value=mock_style_hints),
         ):
             base_theme.setup(mock_app)
             mock_style_hints.setColorScheme.assert_called_once_with(expected_color_scheme)
@@ -215,7 +215,7 @@ class TestSetupColorScheme:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(base_theme, '_get_style_hints', return_value=None),
+            patch.object(base_theme, "_get_style_hints", return_value=None),
         ):
             # Should not raise any exception
             base_theme.setup(mock_app)
@@ -228,7 +228,7 @@ class TestWindowsTheme:
         """Test WindowsTheme uses _apply_dark_theme_to_palette in update_palette."""
         theme = theme_mod.WindowsTheme()
 
-        with patch.object(theme, '_apply_dark_theme_to_palette') as mock_apply:
+        with patch.object(theme, "_apply_dark_theme_to_palette") as mock_apply:
             theme.update_palette(mock_palette, True, None)
             mock_apply.assert_called_once_with(mock_palette)
 
@@ -236,7 +236,7 @@ class TestWindowsTheme:
         """Test WindowsTheme does not apply dark theme when dark_theme is False."""
         theme = theme_mod.WindowsTheme()
 
-        with patch.object(theme, '_apply_dark_theme_to_palette') as mock_apply:
+        with patch.object(theme, "_apply_dark_theme_to_palette") as mock_apply:
             theme.update_palette(mock_palette, False, None)
             mock_apply.assert_not_called()
 
@@ -253,7 +253,7 @@ class TestLinuxDarkModeDetection:
         return theme_mod.BaseTheme()
 
     @pytest.mark.parametrize(
-        "config_theme,detect_result,expected_apply_called",
+        ("config_theme", "detect_result", "expected_apply_called"),
         [
             ("default", True, True),  # Should apply dark theme
             ("default", False, False),  # Should not apply dark theme
@@ -277,9 +277,9 @@ class TestLinuxDarkModeDetection:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(linux_theme, '_detect_linux_dark_mode', return_value=detect_result),
-            patch.object(linux_theme, '_apply_dark_theme_to_palette') as mock_apply,
-            patch.object(linux_theme, '_get_style_hints', return_value=None),
+            patch.object(linux_theme, "_detect_linux_dark_mode", return_value=detect_result),
+            patch.object(linux_theme, "_apply_dark_theme_to_palette") as mock_apply,
+            patch.object(linux_theme, "_get_style_hints", return_value=None),
         ):
             linux_theme.setup(mock_app)
 
@@ -301,9 +301,9 @@ class TestLinuxDarkModeDetection:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(linux_theme, '_detect_linux_dark_mode', return_value=True),
-            patch.object(linux_theme, '_apply_dark_theme_to_palette') as mock_apply,
-            patch.object(linux_theme, '_get_style_hints', return_value=None),
+            patch.object(linux_theme, "_detect_linux_dark_mode", return_value=True),
+            patch.object(linux_theme, "_apply_dark_theme_to_palette") as mock_apply,
+            patch.object(linux_theme, "_get_style_hints", return_value=None),
         ):
             linux_theme.setup(mock_app)
             mock_apply.assert_not_called()
@@ -319,7 +319,7 @@ class TestIntegration:
 
         # Test with style hints available
         mock_hints = MagicMock()
-        with patch.object(base_theme, '_get_style_hints', return_value=mock_hints):
+        with patch.object(base_theme, "_get_style_hints", return_value=mock_hints):
             base_theme._apply_dark_theme_to_palette(palette)
             mock_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
             # Palette should not be modified when using style hints
@@ -331,7 +331,7 @@ class TestIntegration:
         original_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
 
         # Test without style hints (manual fallback)
-        with patch.object(base_theme, '_get_style_hints', return_value=None):
+        with patch.object(base_theme, "_get_style_hints", return_value=None):
             base_theme._apply_dark_theme_to_palette(palette)
             # Palette should be modified with dark colors
             new_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
@@ -350,7 +350,7 @@ class TestIntegration:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(theme, '_get_style_hints', return_value=mock_hints),
+            patch.object(theme, "_get_style_hints", return_value=mock_hints),
         ):
             theme.setup(mock_app)
 

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
+# Copyright (C) 2020-2021 Gabriel Ferreira
+# Copyright (C) 2021-2024 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the GNU General Public License version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6 import QtCore, QtGui
+
+import pytest
+
+import picard.ui.theme as theme_mod
+
+
+@pytest.fixture
+def base_theme():
+    """Create a BaseTheme instance for testing."""
+    return theme_mod.BaseTheme()
+
+
+@pytest.fixture
+def mock_style_hints():
+    """Create a mock QStyleHints object."""
+    mock_hints = MagicMock()
+    mock_hints.setColorScheme = MagicMock()
+    return mock_hints
+
+
+@pytest.fixture
+def mock_palette():
+    """Create a mock QPalette object."""
+    palette = QtGui.QPalette()
+    # Set some initial colors to verify changes
+    palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColor(255, 255, 255))
+    palette.setColor(QtGui.QPalette.ColorRole.WindowText, QtGui.QColor(0, 0, 0))
+    return palette
+
+
+@pytest.fixture
+def mock_app():
+    """Create a mock app for testing."""
+    app = MagicMock()
+    app.palette.return_value = QtGui.QPalette()
+    return app
+
+
+class TestStyleHintsMethods:
+    """Test the new style hints related methods."""
+
+    def test_get_style_hints_returns_style_hints(self, base_theme, mock_style_hints):
+        """Test _get_style_hints returns QGuiApplication.styleHints()."""
+        with patch('picard.ui.theme.QtGui.QGuiApplication.styleHints', return_value=mock_style_hints):
+            result = base_theme._get_style_hints()
+            assert result is mock_style_hints
+
+    def test_get_style_hints_returns_none_when_unavailable(self, base_theme):
+        """Test _get_style_hints returns None when styleHints() is unavailable."""
+        with patch('picard.ui.theme.QtGui.QGuiApplication.styleHints', return_value=None):
+            result = base_theme._get_style_hints()
+            assert result is None
+
+    def test_set_color_scheme_with_style_hints(self, base_theme, mock_style_hints):
+        """Test _set_color_scheme calls setColorScheme when style hints available."""
+        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+            base_theme._set_color_scheme(QtCore.Qt.ColorScheme.Dark)
+            mock_style_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
+
+    def test_set_color_scheme_without_style_hints(self, base_theme):
+        """Test _set_color_scheme does nothing when style hints unavailable."""
+        with patch.object(base_theme, '_get_style_hints', return_value=None):
+            # Should not raise any exception
+            base_theme._set_color_scheme(QtCore.Qt.ColorScheme.Dark)
+
+    @pytest.mark.parametrize(
+        "color_scheme",
+        [
+            QtCore.Qt.ColorScheme.Dark,
+            QtCore.Qt.ColorScheme.Light,
+            QtCore.Qt.ColorScheme.Unknown,
+        ],
+    )
+    def test_set_color_scheme_with_different_schemes(self, base_theme, mock_style_hints, color_scheme):
+        """Test _set_color_scheme works with different color schemes."""
+        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+            base_theme._set_color_scheme(color_scheme)
+            mock_style_hints.setColorScheme.assert_called_once_with(color_scheme)
+
+
+class TestApplyDarkPaletteColors:
+    """Test the _apply_dark_palette_colors method."""
+
+    def test_apply_dark_palette_colors_applies_all_colors(self, base_theme, mock_palette):
+        """Test _apply_dark_palette_colors applies all expected colors."""
+        base_theme._apply_dark_palette_colors(mock_palette)
+
+        # Check that the palette colors were changed to dark theme colors
+        window_color = mock_palette.color(QtGui.QPalette.ColorRole.Window)
+        assert window_color.getRgb() == (51, 51, 51, 255)
+
+        window_text_color = mock_palette.color(QtGui.QPalette.ColorRole.WindowText)
+        assert window_text_color == QtCore.Qt.GlobalColor.white
+
+        base_color = mock_palette.color(QtGui.QPalette.ColorRole.Base)
+        assert base_color.getRgb() == (31, 31, 31, 255)
+
+    def test_apply_dark_palette_colors_applies_tuple_keys(self, base_theme, mock_palette):
+        """Test _apply_dark_palette_colors correctly handles tuple keys (group, role)."""
+        base_theme._apply_dark_palette_colors(mock_palette)
+
+        # Check disabled text color (tuple key)
+        disabled_text_color = mock_palette.color(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text)
+        assert disabled_text_color == QtCore.Qt.GlobalColor.darkGray
+
+        # Check disabled base color (tuple key)
+        disabled_base_color = mock_palette.color(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Base)
+        assert disabled_base_color.getRgb() == (60, 60, 60, 255)
+
+
+class TestApplyDarkThemeToPalette:
+    """Test the _apply_dark_theme_to_palette method."""
+
+    def test_apply_dark_theme_to_palette_with_style_hints(self, base_theme, mock_palette, mock_style_hints):
+        """Test _apply_dark_theme_to_palette uses style hints when available."""
+        with patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints):
+            base_theme._apply_dark_theme_to_palette(mock_palette)
+            mock_style_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
+
+    def test_apply_dark_theme_to_palette_without_style_hints(self, base_theme, mock_palette):
+        """Test _apply_dark_theme_to_palette falls back to manual colors when style hints unavailable."""
+        with patch.object(base_theme, '_get_style_hints', return_value=None):
+            base_theme._apply_dark_theme_to_palette(mock_palette)
+
+            # Should have applied manual dark colors
+            window_color = mock_palette.color(QtGui.QPalette.ColorRole.Window)
+            assert window_color.getRgb() == (51, 51, 51, 255)
+
+    def test_apply_dark_theme_to_palette_calls_manual_fallback(self, base_theme, mock_palette):
+        """Test _apply_dark_theme_to_palette calls _apply_dark_palette_colors when style hints unavailable."""
+        with (
+            patch.object(base_theme, '_get_style_hints', return_value=None),
+            patch.object(base_theme, '_apply_dark_palette_colors') as mock_apply,
+        ):
+            base_theme._apply_dark_theme_to_palette(mock_palette)
+            mock_apply.assert_called_once_with(mock_palette)
+
+
+class TestThemeAvailability:
+    """Test the updated theme availability logic."""
+
+    def test_available_ui_themes_includes_all_themes_except_haiku(self):
+        """Test AVAILABLE_UI_THEMES includes DEFAULT, LIGHT, and DARK themes."""
+        # The current implementation includes all themes for all platforms except Haiku
+        expected_themes = [theme_mod.UiTheme.DEFAULT, theme_mod.UiTheme.LIGHT, theme_mod.UiTheme.DARK]
+
+        # Check that all expected themes are present
+        for theme in expected_themes:
+            assert theme in theme_mod.AVAILABLE_UI_THEMES
+
+        # Check that we have exactly the expected themes (for non-Haiku platforms)
+        if not theme_mod.IS_HAIKU:
+            assert len(theme_mod.AVAILABLE_UI_THEMES) == len(expected_themes)
+            for theme in theme_mod.AVAILABLE_UI_THEMES:
+                assert theme in expected_themes
+
+
+class TestSetupColorScheme:
+    """Test the color scheme setting logic in setup method."""
+
+    @pytest.mark.parametrize(
+        "theme_value,expected_color_scheme",
+        [
+            ("dark", QtCore.Qt.ColorScheme.Dark),
+            ("light", QtCore.Qt.ColorScheme.Light),
+            ("default", QtCore.Qt.ColorScheme.Unknown),
+            ("system", QtCore.Qt.ColorScheme.Unknown),
+        ],
+    )
+    def test_setup_sets_color_scheme_based_on_theme(
+        self, base_theme, mock_app, mock_style_hints, theme_value, expected_color_scheme
+    ):
+        """Test setup method sets color scheme based on theme configuration."""
+        # Mock config
+        config_mock = MagicMock()
+        config_mock.setting = {"ui_theme": theme_value}
+
+        with (
+            patch.object(theme_mod, "get_config", return_value=config_mock),
+            patch.object(base_theme, '_get_style_hints', return_value=mock_style_hints),
+        ):
+            base_theme.setup(mock_app)
+            mock_style_hints.setColorScheme.assert_called_once_with(expected_color_scheme)
+
+    def test_setup_handles_no_style_hints(self, base_theme, mock_app):
+        """Test setup method handles case when style hints are unavailable."""
+        # Mock config
+        config_mock = MagicMock()
+        config_mock.setting = {"ui_theme": "dark"}
+
+        with (
+            patch.object(theme_mod, "get_config", return_value=config_mock),
+            patch.object(base_theme, '_get_style_hints', return_value=None),
+        ):
+            # Should not raise any exception
+            base_theme.setup(mock_app)
+
+
+class TestWindowsTheme:
+    """Test the WindowsTheme class updates."""
+
+    def test_windows_theme_apply_dark_theme_to_palette(self, mock_palette):
+        """Test WindowsTheme uses _apply_dark_theme_to_palette in update_palette."""
+        theme = theme_mod.WindowsTheme()
+
+        with patch.object(theme, '_apply_dark_theme_to_palette') as mock_apply:
+            theme.update_palette(mock_palette, True, None)
+            mock_apply.assert_called_once_with(mock_palette)
+
+    def test_windows_theme_does_not_apply_dark_theme_when_not_dark(self, mock_palette):
+        """Test WindowsTheme does not apply dark theme when dark_theme is False."""
+        theme = theme_mod.WindowsTheme()
+
+        with patch.object(theme, '_apply_dark_theme_to_palette') as mock_apply:
+            theme.update_palette(mock_palette, False, None)
+            mock_apply.assert_not_called()
+
+
+class TestLinuxDarkModeDetection:
+    """Test the Linux dark mode detection logic."""
+
+    @pytest.fixture
+    def linux_theme(self, monkeypatch):
+        """Create a BaseTheme instance with Linux platform settings."""
+        monkeypatch.setattr(theme_mod, "IS_WIN", False)
+        monkeypatch.setattr(theme_mod, "IS_MACOS", False)
+        monkeypatch.setattr(theme_mod, "IS_HAIKU", False)
+        return theme_mod.BaseTheme()
+
+    @pytest.mark.parametrize(
+        "config_theme,detect_result,expected_apply_called",
+        [
+            ("default", True, True),  # Should apply dark theme
+            ("default", False, False),  # Should not apply dark theme
+            ("dark", True, False),  # Should not apply (already dark)
+            ("light", True, False),  # Should not apply (explicit light)
+            ("system", True, False),  # Should not apply (system theme)
+        ],
+    )
+    def test_linux_dark_mode_detection_logic(
+        self, linux_theme, mock_app, config_theme, detect_result, expected_apply_called
+    ):
+        """Test Linux dark mode detection logic in setup method."""
+        # Mock config
+        config_mock = MagicMock()
+        config_mock.setting = {"ui_theme": config_theme}
+
+        # Mock palette with light base color (not already dark)
+        palette = QtGui.QPalette()
+        palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(255, 255, 255))
+        mock_app.palette.return_value = palette
+
+        with (
+            patch.object(theme_mod, "get_config", return_value=config_mock),
+            patch.object(linux_theme, '_detect_linux_dark_mode', return_value=detect_result),
+            patch.object(linux_theme, '_apply_dark_theme_to_palette') as mock_apply,
+            patch.object(linux_theme, '_get_style_hints', return_value=None),
+        ):
+            linux_theme.setup(mock_app)
+
+            if expected_apply_called:
+                mock_apply.assert_called_once()
+            else:
+                mock_apply.assert_not_called()
+
+    def test_linux_dark_mode_not_applied_when_already_dark(self, linux_theme, mock_app):
+        """Test Linux dark mode is not applied when palette is already dark."""
+        # Mock config
+        config_mock = MagicMock()
+        config_mock.setting = {"ui_theme": "default"}
+
+        # Mock palette with dark base color (already dark)
+        palette = QtGui.QPalette()
+        palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(0, 0, 0))
+        mock_app.palette.return_value = palette
+
+        with (
+            patch.object(theme_mod, "get_config", return_value=config_mock),
+            patch.object(linux_theme, '_detect_linux_dark_mode', return_value=True),
+            patch.object(linux_theme, '_apply_dark_theme_to_palette') as mock_apply,
+            patch.object(linux_theme, '_get_style_hints', return_value=None),
+        ):
+            linux_theme.setup(mock_app)
+            mock_apply.assert_not_called()
+
+
+class TestIntegration:
+    """Integration tests for the new functionality."""
+
+    def test_style_hints_integration_with_real_palette(self, base_theme):
+        """Test integration of style hints with real palette objects."""
+        palette = QtGui.QPalette()
+        original_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
+
+        # Test with style hints available
+        mock_hints = MagicMock()
+        with patch.object(base_theme, '_get_style_hints', return_value=mock_hints):
+            base_theme._apply_dark_theme_to_palette(palette)
+            mock_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
+            # Palette should not be modified when using style hints
+            assert palette.color(QtGui.QPalette.ColorRole.Window) == original_window_color
+
+    def test_manual_fallback_integration(self, base_theme):
+        """Test integration of manual fallback with real palette objects."""
+        palette = QtGui.QPalette()
+        original_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
+
+        # Test without style hints (manual fallback)
+        with patch.object(base_theme, '_get_style_hints', return_value=None):
+            base_theme._apply_dark_theme_to_palette(palette)
+            # Palette should be modified with dark colors
+            new_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
+            assert new_window_color.getRgb() == (51, 51, 51, 255)
+            assert new_window_color != original_window_color
+
+    def test_theme_setup_integration(self, mock_app):
+        """Test complete theme setup integration."""
+        theme = theme_mod.BaseTheme()
+
+        # Mock all dependencies
+        config_mock = MagicMock()
+        config_mock.setting = {"ui_theme": "dark"}
+
+        mock_hints = MagicMock()
+
+        with (
+            patch.object(theme_mod, "get_config", return_value=config_mock),
+            patch.object(theme, '_get_style_hints', return_value=mock_hints),
+        ):
+            theme.setup(mock_app)
+
+            # Verify style hints were used
+            mock_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -306,7 +306,6 @@ class TestLinuxDarkModeDetection:
             ("default", False, False),  # Should not apply dark theme
             ("dark", True, False),  # Should not apply (already dark)
             ("light", True, False),  # Should not apply (explicit light)
-            ("system", True, False),  # Should not apply (system theme)
         ],
     )
     def test_linux_dark_mode_detection_logic(

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -203,6 +203,7 @@ class TestSetupColorScheme:
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
             patch.object(base_theme, "_get_style_hints", return_value=mock_style_hints),
+            patch.object(theme_mod, "MacOverrideStyle") as _,
         ):
             base_theme.setup(mock_app)
             mock_style_hints.setColorScheme.assert_called_once_with(expected_color_scheme)
@@ -216,6 +217,7 @@ class TestSetupColorScheme:
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
             patch.object(base_theme, "_get_style_hints", return_value=None),
+            patch.object(theme_mod, "MacOverrideStyle"),
         ):
             # Should not raise any exception
             base_theme.setup(mock_app)
@@ -351,6 +353,7 @@ class TestIntegration:
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
             patch.object(theme, "_get_style_hints", return_value=mock_hints),
+            patch.object(theme_mod, "MacOverrideStyle"),
         ):
             theme.setup(mock_app)
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Added Qt6 style hints support to theme system and made appearance menu consistent across all platforms by enabling DEFAULT, LIGHT, and DARK themes everywhere except Haiku.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2300
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The theme system was inconsistent across platforms - Linux only had DEFAULT and SYSTEM themes while Windows/macOS had DEFAULT, LIGHT, and DARK. Qt6's style hints provide a better way to handle dark themes with automatic fallback to manual color application.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Added new style hints methods to `BaseTheme`:
- `_get_style_hints()`: Gets QGuiApplication.styleHints()
- `_set_color_scheme()`: Sets color scheme using style hints
- `_apply_dark_palette_colors()`: Manual dark color application
- `_apply_dark_theme_to_palette()`: Uses Qt color scheme or manual fallback

Updated `AVAILABLE_UI_THEMES` to include DEFAULT, LIGHT, and DARK on all platforms except Haiku, making the appearance menu consistent.

Enhanced setup logic to use Qt's built-in color scheme when available, with automatic fallback to manual color application.

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (See PICARD-3103)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->