### PR TITLE
PICARD-442: Add match quality column and allow sorting

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -594,7 +594,11 @@ class Album(MetadataItem):
 
         self.tagger.window.set_statusbar_message(
             N_('Album %(id)s loaded: %(artist)s - %(album)s'),
-            {'id': self.id, 'artist': self.metadata['albumartist'], 'album': self.metadata['album']},
+            {
+                'id': self.id,
+                'artist': self.metadata['albumartist'],
+                'album': self.metadata['album'],
+            },
             timeout=3000,
         )
         for func, _run_on_error in self._after_load_callbacks:
@@ -646,7 +650,10 @@ class Album(MetadataItem):
         if self._requests:
             log.info("Not reloading, some requests are still active.")
             return
-        self.tagger.window.set_statusbar_message(N_("Loading album %(id)s …"), {'id': self.id})
+        self.tagger.window.set_statusbar_message(
+            N_("Loading album %(id)s …"),
+            {'id': self.id},
+        )
         self.loaded = False
         self.status = AlbumStatus.LOADING
         if self.release_group:

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -74,7 +74,8 @@ from picard.ui.columns import (
 )
 from picard.ui.itemviews.basetreeview import BaseTreeView
 from picard.ui.itemviews.columns import (
-    ITEMVIEW_COLUMNS,
+    ALBUMVIEW_COLUMNS,
+    FILEVIEW_COLUMNS,
     IconColumn,
 )
 from picard.ui.itemviews.match_quality_column import MatchQualityColumn
@@ -98,8 +99,8 @@ class MainPanel(QtWidgets.QSplitter):
         self.window = window
         self.create_icons()
         self._views = [
-            FileTreeView(ITEMVIEW_COLUMNS, window, parent=self),
-            AlbumTreeView(ITEMVIEW_COLUMNS, window, parent=self),
+            FileTreeView(FILEVIEW_COLUMNS, window, parent=self),
+            AlbumTreeView(ALBUMVIEW_COLUMNS, window, parent=self),
         ]
         self._selected_view = self._views[0]
         self._ignore_selection_changes = False
@@ -333,8 +334,6 @@ class AlbumTreeView(BaseTreeView):
 
 
 class TreeItem(QtWidgets.QTreeWidgetItem):
-    columns = ITEMVIEW_COLUMNS
-
     def __init__(self, obj, sortable=False, filterable=True, parent=None):
         super().__init__(parent)
         self._obj = None
@@ -343,6 +342,18 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         self.filterable = filterable
         self._sortkeys = {}
         self.post_init()
+
+    @property
+    def columns(self):
+        """Get columns from the tree widget this item belongs to.
+        Falls back to file-view columns while the item is not yet attached."""
+        # Different views use different column sets: file view uses FILEVIEW_COLUMNS; album view uses ALBUMVIEW_COLUMNS (with the Match column)
+        tree_widget = self.treeWidget()
+        if tree_widget and hasattr(tree_widget, 'columns'):
+            return tree_widget.columns
+        # During construction some items call update() before being added to a view
+        # Return a safe default to avoid crashes; once attached, the view columns apply
+        return FILEVIEW_COLUMNS
 
     @property
     def obj(self):

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -77,6 +77,7 @@ from picard.ui.itemviews.columns import (
     ITEMVIEW_COLUMNS,
     IconColumn,
 )
+from picard.ui.itemviews.match_quality_column import MatchQualityColumn
 
 
 def get_match_color(similarity, basecolor):
@@ -392,6 +393,9 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
             if bgcolor is not None:
                 self.setBackground(i, bgcolor)
             if isinstance(column, IconColumn):
+                self.setSizeHint(i, column.size)
+            elif isinstance(column, MatchQualityColumn):
+                # Progress columns are handled by delegate, just set size hint
                 self.setSizeHint(i, column.size)
             else:
                 if column.align == ColumnAlign.RIGHT:

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -91,6 +91,7 @@ from picard.util import (
 from picard.ui.collectionmenu import CollectionMenu
 from picard.ui.enums import MainAction
 from picard.ui.filter import Filter
+from picard.ui.itemviews.match_quality_column import MatchQualityColumn, MatchQualityColumnDelegate
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
 from picard.ui.util import menu_builder
@@ -409,6 +410,13 @@ class BaseTreeView(QtWidgets.QTreeWidget):
     def _init_header(self):
         header = ConfigurableColumnsHeader(self.columns, parent=self)
         self.setHeader(header)
+
+        # Set up delegate for progress columns
+        progress_delegate = MatchQualityColumnDelegate(self)
+        for i, column in enumerate(self.columns):
+            if isinstance(column, MatchQualityColumn):
+                self.setItemDelegateForColumn(i, progress_delegate)
+
         self.restore_default_columns()
         self.restore_state()
 

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -45,6 +45,7 @@
 
 from PyQt6 import QtCore
 
+from picard.album import AlbumStatus
 from picard.i18n import N_
 from picard.util import icontheme
 
@@ -81,10 +82,16 @@ def _sortkey_match_quality(obj):
     """Sort key for match quality column - sort by completion percentage."""
     if hasattr(obj, 'get_num_matched_tracks') and hasattr(obj, 'tracks'):
         # Album object
+        # Check if album is still loading - if so, return 0 to avoid premature sorting
+        if hasattr(obj, 'status') and obj.status == AlbumStatus.LOADING:
+            return 0.0
+
         matched = obj.get_num_matched_tracks()
         total = len(obj.tracks) if obj.tracks else 0
         if total > 0:
-            return matched / total
+            # Return negative percentage so that higher percentages (closer to 1.0)
+            # appear first in ascending sort order
+            return -(matched / total)
         return 0.0
     # For track objects, return 0 since we don't show icons at track level
     return 0.0

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -46,6 +46,7 @@
 from PyQt6 import QtCore
 
 from picard.album import AlbumStatus
+from picard.const.sys import IS_LINUX
 from picard.i18n import N_
 from picard.util import icontheme
 
@@ -89,7 +90,9 @@ def _sortkey_match_quality(obj):
         matched = obj.get_num_matched_tracks()
         total = len(obj.tracks) if obj.tracks else 0
         if total > 0:
-            return matched / total
+            # Column sorting is reversed on Linux
+            multiplier = -1 if IS_LINUX else 1
+            return matched / total * multiplier
         return 0.0
     # For track objects, return 0 since we don't show icons at track level
     return 0.0

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -193,8 +193,6 @@ _common_columns = (
 FILEVIEW_COLUMNS = Columns(_common_columns, default_width=100)
 
 # Album view columns (with match quality column)
-# Insert `_match_quality_column` at index 4, after Title, Length, Artist, Album Artist
-ALBUMVIEW_COLUMNS = Columns(
-    _common_columns[:4] + (_match_quality_column,) + _common_columns[4:],
-    default_width=100,
-)
+# Insert `_match_quality_column` after Title, Length, Artist, Album Artist
+ALBUMVIEW_COLUMNS = Columns(_common_columns, default_width=100)
+ALBUMVIEW_COLUMNS.insert(ALBUMVIEW_COLUMNS.pos('albumartist') + 1, _match_quality_column)

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -89,9 +89,7 @@ def _sortkey_match_quality(obj):
         matched = obj.get_num_matched_tracks()
         total = len(obj.tracks) if obj.tracks else 0
         if total > 0:
-            # Return negative percentage so that higher percentages (closer to 1.0)
-            # appear first in ascending sort order
-            return -(matched / total)
+            return matched / total
         return 0.0
     # For track objects, return 0 since we don't show icons at track level
     return 0.0
@@ -134,13 +132,15 @@ _fingerprint_column = IconColumn(N_("Fingerprint status"), '~fingerprint')
 _fingerprint_column.header_icon_func = lambda: icontheme.lookup('fingerprint-gray', icontheme.ICON_SIZE_MENU)
 _fingerprint_column.set_header_icon_size(16, 16, 1)
 
-_match_quality_column = MatchQualityColumn(N_("Match Quality"), '~match_quality', width=100)
+_match_quality_column = MatchQualityColumn(N_("Match"), '~match_quality', width=57)
 _match_quality_column.sortable = True
 _match_quality_column.sort_type = ColumnSortType.SORTKEY
 _match_quality_column.sortkey = _sortkey_match_quality
+_match_quality_column.always_visible = True
 
 ITEMVIEW_COLUMNS = Columns(
     (
+        _match_quality_column,
         DefaultColumn(
             N_("Title"), 'title', sort_type=ColumnSortType.NAT, width=250, always_visible=True, status_icon=True
         ),
@@ -180,7 +180,6 @@ ITEMVIEW_COLUMNS = Columns(
         ),
         Column(N_("Genre"), 'genre'),
         _fingerprint_column,
-        _match_quality_column,
         Column(N_("Date"), 'date'),
         Column(N_("Original Release Date"), 'originaldate'),
         Column(N_("Release Date"), 'releasedate'),

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -56,6 +56,7 @@ from picard.ui.columns import (
     DefaultColumn,
     ImageColumn,
 )
+from picard.ui.itemviews.match_quality_column import MatchQualityColumn
 
 
 def _sortkey_length(obj):
@@ -74,6 +75,19 @@ def _sortkey_bitrate(obj):
         return float(obj.metadata['~bitrate'] or obj.orig_metadata['~bitrate'] or 0)
     except (ValueError, TypeError):
         return 0
+
+
+def _sortkey_match_quality(obj):
+    """Sort key for match quality column - sort by completion percentage."""
+    if hasattr(obj, 'get_num_matched_tracks') and hasattr(obj, 'tracks'):
+        # Album object
+        matched = obj.get_num_matched_tracks()
+        total = len(obj.tracks) if obj.tracks else 0
+        if total > 0:
+            return matched / total
+        return 0.0
+    # For track objects, return 0 since we don't show icons at track level
+    return 0.0
 
 
 class IconColumn(ImageColumn):
@@ -113,6 +127,10 @@ _fingerprint_column = IconColumn(N_("Fingerprint status"), '~fingerprint')
 _fingerprint_column.header_icon_func = lambda: icontheme.lookup('fingerprint-gray', icontheme.ICON_SIZE_MENU)
 _fingerprint_column.set_header_icon_size(16, 16, 1)
 
+_match_quality_column = MatchQualityColumn(N_("Match Quality"), '~match_quality', width=100)
+_match_quality_column.sortable = True
+_match_quality_column.sort_type = ColumnSortType.SORTKEY
+_match_quality_column.sortkey = _sortkey_match_quality
 
 ITEMVIEW_COLUMNS = Columns(
     (
@@ -155,6 +173,7 @@ ITEMVIEW_COLUMNS = Columns(
         ),
         Column(N_("Genre"), 'genre'),
         _fingerprint_column,
+        _match_quality_column,
         Column(N_("Date"), 'date'),
         Column(N_("Original Release Date"), 'originaldate'),
         Column(N_("Release Date"), 'releasedate'),

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -142,53 +142,59 @@ _match_quality_column.sortkey = _sortkey_match_quality
 _match_quality_column.always_visible = True
 
 
-ITEMVIEW_COLUMNS = Columns(
-    (
-        _match_quality_column,
-        DefaultColumn(
-            N_("Title"), 'title', sort_type=ColumnSortType.NAT, width=250, always_visible=True, status_icon=True
-        ),
-        DefaultColumn(
-            N_("Length"),
-            '~length',
-            align=ColumnAlign.RIGHT,
-            sort_type=ColumnSortType.SORTKEY,
-            sortkey=_sortkey_length,
-            width=50,
-        ),
-        DefaultColumn(N_("Artist"), 'artist', width=200),
-        Column(N_("Album Artist"), 'albumartist'),
-        Column(N_("Composer"), 'composer'),
-        Column(N_("Album"), 'album', sort_type=ColumnSortType.NAT),
-        Column(N_("Disc Subtitle"), 'discsubtitle', sort_type=ColumnSortType.NAT),
-        Column(N_("Track No."), 'tracknumber', align=ColumnAlign.RIGHT, sort_type=ColumnSortType.NAT),
-        Column(N_("Disc No."), 'discnumber', align=ColumnAlign.RIGHT, sort_type=ColumnSortType.NAT),
-        Column(N_("Catalog No."), 'catalognumber', sort_type=ColumnSortType.NAT),
-        Column(N_("Barcode"), 'barcode'),
-        Column(N_("Media"), 'media'),
-        Column(
-            N_("Size"),
-            '~filesize',
-            align=ColumnAlign.RIGHT,
-            sort_type=ColumnSortType.SORTKEY,
-            sortkey=_sortkey_filesize,
-        ),
-        Column(N_("File Type"), '~format', width=120),
-        Column(
-            N_("Bitrate"),
-            '~bitrate',
-            align=ColumnAlign.RIGHT,
-            sort_type=ColumnSortType.SORTKEY,
-            sortkey=_sortkey_bitrate,
-            width=80,
-        ),
-        Column(N_("Genre"), 'genre'),
-        _fingerprint_column,
-        Column(N_("Date"), 'date'),
-        Column(N_("Original Release Date"), 'originaldate'),
-        Column(N_("Release Date"), 'releasedate'),
-        Column(N_("Cover"), 'covercount'),
-        Column(N_("Cover Dimensions"), 'coverdimensions'),
+# Common columns used by both views
+_common_columns = (
+    DefaultColumn(N_("Title"), 'title', sort_type=ColumnSortType.NAT, width=250, always_visible=True, status_icon=True),
+    DefaultColumn(
+        N_("Length"),
+        '~length',
+        align=ColumnAlign.RIGHT,
+        sort_type=ColumnSortType.SORTKEY,
+        sortkey=_sortkey_length,
+        width=50,
     ),
+    DefaultColumn(N_("Artist"), 'artist', width=200),
+    Column(N_("Album Artist"), 'albumartist'),
+    Column(N_("Composer"), 'composer'),
+    Column(N_("Album"), 'album', sort_type=ColumnSortType.NAT),
+    Column(N_("Disc Subtitle"), 'discsubtitle', sort_type=ColumnSortType.NAT),
+    Column(N_("Track No."), 'tracknumber', align=ColumnAlign.RIGHT, sort_type=ColumnSortType.NAT),
+    Column(N_("Disc No."), 'discnumber', align=ColumnAlign.RIGHT, sort_type=ColumnSortType.NAT),
+    Column(N_("Catalog No."), 'catalognumber', sort_type=ColumnSortType.NAT),
+    Column(N_("Barcode"), 'barcode'),
+    Column(N_("Media"), 'media'),
+    Column(
+        N_("Size"),
+        '~filesize',
+        align=ColumnAlign.RIGHT,
+        sort_type=ColumnSortType.SORTKEY,
+        sortkey=_sortkey_filesize,
+    ),
+    Column(N_("File Type"), '~format', width=120),
+    Column(
+        N_("Bitrate"),
+        '~bitrate',
+        align=ColumnAlign.RIGHT,
+        sort_type=ColumnSortType.SORTKEY,
+        sortkey=_sortkey_bitrate,
+        width=80,
+    ),
+    Column(N_("Genre"), 'genre'),
+    _fingerprint_column,
+    Column(N_("Date"), 'date'),
+    Column(N_("Original Release Date"), 'originaldate'),
+    Column(N_("Release Date"), 'releasedate'),
+    Column(N_("Cover"), 'covercount'),
+    Column(N_("Cover Dimensions"), 'coverdimensions'),
+)
+
+
+# File view columns (without match quality column)
+FILEVIEW_COLUMNS = Columns(_common_columns, default_width=100)
+
+# Album view columns (with match quality column)
+# Insert `_match_quality_column` at index 4, after Title, Length, Artist, Album Artist
+ALBUMVIEW_COLUMNS = Columns(
+    _common_columns[:4] + (_match_quality_column,) + _common_columns[4:],
     default_width=100,
 )

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -139,7 +139,7 @@ _match_quality_column = MatchQualityColumn(N_("Match"), '~match_quality', width=
 _match_quality_column.sortable = True
 _match_quality_column.sort_type = ColumnSortType.SORTKEY
 _match_quality_column.sortkey = _sortkey_match_quality
-_match_quality_column.always_visible = True
+_match_quality_column.is_default = True
 
 
 # Common columns used by both views

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -87,11 +87,11 @@ def _sortkey_match_quality(obj):
         if hasattr(obj, 'status') and obj.status == AlbumStatus.LOADING:
             return 0.0
 
-        matched = obj.get_num_matched_tracks()
         total = len(obj.tracks) if obj.tracks else 0
         if total > 0:
             # Column sorting is reversed on Linux
             multiplier = -1 if IS_LINUX else 1
+            matched = obj.get_num_matched_tracks()
             return matched / total * multiplier
         return 0.0
     # For track objects, return 0 since we don't show icons at track level

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt6 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 from picard.ui.columns import ImageColumn
 
@@ -132,7 +132,7 @@ class MatchQualityColumn(ImageColumn):
 
 
 class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
-    """Delegate for rendering match quality icons and text in tree items."""
+    """Delegate for rendering match quality icons in tree items."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -168,31 +168,6 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
             return None, None, None
 
         return obj, column, stats
-
-    def _format_status_text(self, stats):
-        """Format stats into compact status text for display.
-
-        Args:
-            stats: Dictionary containing match statistics
-
-        Returns:
-            str: Formatted status text
-        """
-        status_parts = []
-
-        # Core match info: matched/total (always show)
-        if stats["total"] > 0:
-            status_parts.append(f"{stats['matched']}/{stats['total']}")
-        else:
-            status_parts.append("0/0")
-
-        # Always show all stats in consistent format: matched/total; missing; duplicates; extra; unmatched
-        status_parts.append(f"{stats['missing']}")
-        status_parts.append(f"{stats['duplicates']}")
-        status_parts.append(f"{stats['extra']}")
-        status_parts.append(f"{stats['unmatched']}")
-
-        return "; ".join(status_parts)
 
     def _format_tooltip_text(self, stats):
         """Format stats into detailed tooltip text.
@@ -239,37 +214,15 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
         # Get the match icon
         icon = column.get_match_icon(obj)
 
-        # Format status text
-        status_text = self._format_status_text(stats)
-
-        # Set text color for good contrast
-        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
-            painter.setPen(QtGui.QPen(option.palette.highlightedText().color()))
-        else:
-            painter.setPen(QtGui.QPen(option.palette.text().color()))
-
-        # Calculate layout - always show both icon and text
+        # Calculate layout
         icon_size = column.size
         icon_margin = 2
-        text_margin = 4
 
-        # Always draw icon and text, regardless of column width
+        # Always draw icon, regardless of column width
         if icon:
             x = option.rect.x() + icon_margin
             y = option.rect.y() + (option.rect.height() - icon_size.height()) // 2
             icon.paint(painter, QtCore.QRect(x, y, icon_size.width(), icon_size.height()))
-            text_x = x + icon_size.width() + text_margin
-        else:
-            # Fallback to text only if no icon
-            text_x = option.rect.x() + text_margin
-
-        # Draw text
-        text_rect = QtCore.QRect(
-            text_x, option.rect.y(), option.rect.width() - text_x - text_margin, option.rect.height()
-        )
-        painter.drawText(
-            text_rect, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter, status_text
-        )
 
     def helpEvent(self, event, view, option, index):
         """Show tooltip with explanation of the stats."""
@@ -287,4 +240,4 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
 
     def sizeHint(self, option, index):
         # Return a size that accommodates both icon and text
-        return QtCore.QSize(200, 16)
+        return QtCore.QSize(57, 16)

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -24,6 +24,19 @@ from PyQt6 import QtCore, QtWidgets
 from picard.ui.columns import ImageColumn
 
 
+# Mapping of minimum percentage threshold to icon index.
+# Checked in descending order so the highest matching threshold wins.
+THRESHOLD_TO_ICON_INDEX = {
+    1.0: 5,  # 100%
+    0.9: 4,  # 90%
+    0.8: 3,  # 80%
+    0.7: 2,  # 70%
+    0.6: 1,  # 60%
+    0.5: 0,  # 50%
+    0.0: 0,  # <50%
+}
+
+
 class MatchQualityColumn(ImageColumn):
     """Column that displays match quality using match icons at the release level."""
 
@@ -59,21 +72,11 @@ class MatchQualityColumn(ImageColumn):
         # Calculate match percentage
         percentage = matched / total
 
-        # Determine which icon to use based on percentage
-        if percentage >= 1.0:
-            icon_index = 5  # 100% match
-        elif percentage >= 0.9:
-            icon_index = 4  # 90% match
-        elif percentage >= 0.8:
-            icon_index = 3  # 80% match
-        elif percentage >= 0.7:
-            icon_index = 2  # 70% match
-        elif percentage >= 0.6:
-            icon_index = 1  # 60% match
-        elif percentage >= 0.5:
-            icon_index = 0  # 50% match
-        else:
-            icon_index = 0  # Worst match icon for less than 50%
+        # Determine which icon to use based on percentage using thresholds
+        for threshold in sorted(THRESHOLD_TO_ICON_INDEX.keys(), reverse=True):
+            if percentage >= threshold:
+                icon_index = THRESHOLD_TO_ICON_INDEX[threshold]
+                break
 
         # Get the match icons from FileItem
         from picard.ui.itemviews import FileItem

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -89,7 +89,7 @@ class MatchQualityColumn(ImageColumn):
         # Get the match icons from FileItem
         from picard.ui.itemviews import FileItem
 
-        if hasattr(FileItem, "match_icons") and icon_index < len(FileItem.match_icons):
+        if hasattr(FileItem, 'match_icons') and icon_index < len(FileItem.match_icons):
             return FileItem.match_icons[icon_index]
 
         return None
@@ -97,7 +97,7 @@ class MatchQualityColumn(ImageColumn):
     def get_match_stats(self, obj):
         """Get comprehensive match statistics for the given object."""
         # Only show stats at the release (album) level, not track level
-        if not hasattr(obj, "get_num_matched_tracks") or not hasattr(obj, "tracks"):
+        if not hasattr(obj, 'get_num_matched_tracks') or not hasattr(obj, 'tracks'):
             return None
 
         # Album object
@@ -116,7 +116,7 @@ class MatchQualityColumn(ImageColumn):
             track_file_counts[track] = len(track.files)
 
         # Count unmatched files
-        unmatched_files = obj.unmatched_files.files if hasattr(obj, "unmatched_files") else []
+        unmatched_files = obj.unmatched_files.files if hasattr(obj, 'unmatched_files') else []
 
         # Calculate duplicates (tracks with more than one file)
         for file_count in track_file_counts.values():
@@ -133,12 +133,12 @@ class MatchQualityColumn(ImageColumn):
                 missing += 1
 
         return {
-            "matched": matched,
-            "total": total,
-            "unmatched": unmatched,
-            "duplicates": duplicates,
-            "extra": extra,
-            "missing": missing,
+            'matched': matched,
+            'total': total,
+            'unmatched': unmatched,
+            'duplicates': duplicates,
+            'extra': extra,
+            'missing': missing,
         }
 
 
@@ -160,14 +160,14 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
             return None
 
         item = tree_widget.itemFromIndex(index)
-        if not hasattr(item, "obj") or not item.obj:
+        if not hasattr(item, 'obj') or not item.obj:
             return None
 
         obj = item.obj
 
         # Get the column to determine if this is a match quality column
         column_index = index.column()
-        columns = getattr(item, "columns", None)
+        columns = getattr(item, 'columns', None)
         if not columns or column_index >= len(columns):
             return None
 
@@ -193,24 +193,24 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
         tooltip_parts = []
 
         # Core match info
-        if stats["total"] > 0:
-            percentage = (stats["matched"] / stats["total"]) * 100
+        if stats['total'] > 0:
+            percentage = (stats['matched'] / stats['total']) * 100
         else:
             percentage = 0.0
         tooltip_parts.append(
             _("Match: %(matched)d/%(total)d (%(percent).1f%%)")
             % {
-                "matched": stats["matched"],
-                "total": stats["total"],
-                "percent": percentage,
+                'matched': stats['matched'],
+                'total': stats['total'],
+                'percent': percentage,
             }
         )
 
         # Additional stats with explanations
-        tooltip_parts.append(_("Missing tracks: %(count)d") % {"count": stats["missing"]})
-        tooltip_parts.append(_("Duplicate files: %(count)d") % {"count": stats["duplicates"]})
-        tooltip_parts.append(_("Extra files: %(count)d") % {"count": stats["extra"]})
-        tooltip_parts.append(_("Unmatched files: %(count)d") % {"count": stats["unmatched"]})
+        tooltip_parts.append(_("Missing tracks: %(count)d") % {'count': stats['missing']})
+        tooltip_parts.append(_("Duplicate files: %(count)d") % {'count': stats['duplicates']})
+        tooltip_parts.append(_("Extra files: %(count)d") % {'count': stats['extra']})
+        tooltip_parts.append(_("Unmatched files: %(count)d") % {'count': stats['unmatched']})
 
         return "\n".join(tooltip_parts)
 

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -41,7 +41,7 @@ class MatchQualityColumn(ImageColumn):
     def get_match_icon(self, obj):
         """Get the appropriate match icon for the given object."""
         # Only show icons at the release (album) level, not track level
-        if not hasattr(obj, "get_num_matched_tracks") or not hasattr(obj, "tracks"):
+        if not hasattr(obj, 'get_num_matched_tracks') or not hasattr(obj, 'tracks'):
             return None
 
         # Album object
@@ -52,7 +52,7 @@ class MatchQualityColumn(ImageColumn):
             # Use pending icon for zero tracks
             from picard.ui.itemviews import FileItem
 
-            if hasattr(FileItem, "match_pending_icons") and len(FileItem.match_pending_icons) > 5:
+            if hasattr(FileItem, 'match_pending_icons') and len(FileItem.match_pending_icons) > 5:
                 return FileItem.match_pending_icons[5]  # match-pending-100.png
             return None
 
@@ -108,7 +108,7 @@ class MatchQualityColumn(ImageColumn):
         unmatched_files = obj.unmatched_files.files if hasattr(obj, "unmatched_files") else []
 
         # Calculate duplicates (tracks with more than one file)
-        for _, file_count in track_file_counts.items():
+        for file_count in track_file_counts.values():
             if file_count > 1:
                 duplicates += file_count - 1
 

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -21,6 +21,8 @@
 
 from PyQt6 import QtCore, QtWidgets
 
+from picard.i18n import gettext as _
+
 from picard.ui.columns import ImageColumn
 
 
@@ -186,15 +188,22 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
         # Core match info
         if stats["total"] > 0:
             percentage = (stats["matched"] / stats["total"]) * 100
-            tooltip_parts.append(f"Match: {stats['matched']}/{stats['total']} ({percentage:.1f}%)")
         else:
-            tooltip_parts.append("Match: 0/0 (0%)")
+            percentage = 0.0
+        tooltip_parts.append(
+            _("Match: %(matched)d/%(total)d (%(percent).1f%%)")
+            % {
+                "matched": stats["matched"],
+                "total": stats["total"],
+                "percent": percentage,
+            }
+        )
 
         # Additional stats with explanations
-        tooltip_parts.append(f"Missing tracks: {stats['missing']}")
-        tooltip_parts.append(f"Duplicate files: {stats['duplicates']}")
-        tooltip_parts.append(f"Extra files: {stats['extra']}")
-        tooltip_parts.append(f"Unmatched files: {stats['unmatched']}")
+        tooltip_parts.append(_("Missing tracks: %(count)d") % {"count": stats["missing"]})
+        tooltip_parts.append(_("Duplicate files: %(count)d") % {"count": stats["duplicates"]})
+        tooltip_parts.append(_("Extra files: %(count)d") % {"count": stats["extra"]})
+        tooltip_parts.append(_("Unmatched files: %(count)d") % {"count": stats["unmatched"]})
 
         return "\n".join(tooltip_parts)
 

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the GNU General Public License Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from picard.ui.columns import ImageColumn
+
+
+class MatchQualityColumn(ImageColumn):
+    """Column that displays match quality using match icons at the release level."""
+
+    def __init__(self, title, key, width=120):
+        super().__init__(title, key, width=width)
+        self.size = QtCore.QSize(16, 16)  # Icon size
+        self.width = width
+
+    def paint(self, painter, rect):
+        """Override paint method to prevent NotImplementedError from base class."""
+        # This column is painted by the delegate, not the header
+        # So we just do nothing here to prevent the error
+        pass
+
+    def get_match_icon(self, obj):
+        """Get the appropriate match icon for the given object."""
+        # Only show icons at the release (album) level, not track level
+        if not hasattr(obj, "get_num_matched_tracks") or not hasattr(obj, "tracks"):
+            return None
+
+        # Album object
+        matched = obj.get_num_matched_tracks()
+        total = len(obj.tracks) if obj.tracks else 0
+
+        if total == 0:
+            # Use pending icon for zero tracks
+            from picard.ui.itemviews import FileItem
+
+            if hasattr(FileItem, "match_pending_icons") and len(FileItem.match_pending_icons) > 5:
+                return FileItem.match_pending_icons[5]  # match-pending-100.png
+            return None
+
+        # Calculate match percentage
+        percentage = matched / total
+
+        # Determine which icon to use based on percentage
+        if percentage >= 1.0:
+            icon_index = 5  # 100% match
+        elif percentage >= 0.9:
+            icon_index = 4  # 90% match
+        elif percentage >= 0.8:
+            icon_index = 3  # 80% match
+        elif percentage >= 0.7:
+            icon_index = 2  # 70% match
+        elif percentage >= 0.6:
+            icon_index = 1  # 60% match
+        elif percentage >= 0.5:
+            icon_index = 0  # 50% match
+        else:
+            icon_index = 0  # Worst match icon for less than 50%
+
+        # Get the match icons from FileItem
+        from picard.ui.itemviews import FileItem
+
+        if hasattr(FileItem, "match_icons") and icon_index < len(FileItem.match_icons):
+            return FileItem.match_icons[icon_index]
+
+        return None
+
+    def get_match_stats(self, obj):
+        """Get comprehensive match statistics for the given object."""
+        # Only show stats at the release (album) level, not track level
+        if not hasattr(obj, "get_num_matched_tracks") or not hasattr(obj, "tracks"):
+            return None
+
+        # Album object
+        matched = obj.get_num_matched_tracks()
+        total = len(obj.tracks) if obj.tracks else 0
+        unmatched = obj.get_num_unmatched_files()
+
+        # Calculate duplicates and extra tracks
+        duplicates = 0
+        extra = 0
+        missing = 0
+
+        # Count files per track to detect duplicates
+        track_file_counts = {}
+        for track in obj.tracks:
+            track_file_counts[track] = len(track.files)
+
+        # Count unmatched files
+        unmatched_files = obj.unmatched_files.files if hasattr(obj, "unmatched_files") else []
+
+        # Calculate duplicates (tracks with more than one file)
+        for _, file_count in track_file_counts.items():
+            if file_count > 1:
+                duplicates += file_count - 1
+
+        # Calculate extra tracks (unmatched files beyond total tracks)
+        if unmatched_files:
+            extra = len(unmatched_files)
+
+        # Calculate missing tracks (tracks with no files)
+        for track in obj.tracks:
+            if len(track.files) == 0:
+                missing += 1
+
+        return {
+            "matched": matched,
+            "total": total,
+            "unmatched": unmatched,
+            "duplicates": duplicates,
+            "extra": extra,
+            "missing": missing,
+        }
+
+
+class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
+    """Delegate for rendering match quality icons and text in tree items."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def paint(self, painter, option, index):
+        # Initialize the style option
+        self.initStyleOption(option, index)
+
+        # Draw the background
+        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
+            fill_brush = option.palette.highlight()
+        else:
+            fill_brush = option.palette.base()
+        painter.fillRect(option.rect, fill_brush)
+
+        # Get the item object - use the correct method for QTreeWidget
+        tree_widget = self.parent()
+        if not tree_widget:
+            return
+
+        item = tree_widget.itemFromIndex(index)
+        if not hasattr(item, "obj") or not item.obj:
+            return
+
+        obj = item.obj
+
+        # Get the column to determine if this is a match quality column
+        column_index = index.column()
+        columns = getattr(item, "columns", None)
+        if not columns or column_index >= len(columns):
+            return
+
+        column = columns[column_index]
+        if not isinstance(column, MatchQualityColumn):
+            return
+
+        # Get the match icon and stats
+        icon = column.get_match_icon(obj)
+        stats = column.get_match_stats(obj)
+
+        if not stats:
+            return
+
+        # Build the status text with compact format
+        status_parts = []
+
+        # Core match info: matched/total (always show)
+        if stats["total"] > 0:
+            status_parts.append(f"{stats['matched']}/{stats['total']}")
+        else:
+            status_parts.append("0/0")
+
+        # Always show all stats in consistent format: matched/total; missing; duplicates; extra; unmatched
+        status_parts.append(f"{stats['missing']}")
+        status_parts.append(f"{stats['duplicates']}")
+        status_parts.append(f"{stats['extra']}")
+        status_parts.append(f"{stats['unmatched']}")
+
+        status_text = "; ".join(status_parts)
+
+        # Set text color for good contrast
+        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
+            painter.setPen(QtGui.QPen(option.palette.highlightedText().color()))
+        else:
+            painter.setPen(QtGui.QPen(option.palette.text().color()))
+
+        # Calculate layout - always show both icon and text
+        icon_size = column.size
+        icon_margin = 2
+        text_margin = 4
+
+        # Always draw icon and text, regardless of column width
+        if icon:
+            x = option.rect.x() + icon_margin
+            y = option.rect.y() + (option.rect.height() - icon_size.height()) // 2
+            icon.paint(painter, QtCore.QRect(x, y, icon_size.width(), icon_size.height()))
+            text_x = x + icon_size.width() + text_margin
+        else:
+            # Fallback to text only if no icon
+            text_x = option.rect.x() + text_margin
+
+        # Draw text
+        text_rect = QtCore.QRect(
+            text_x, option.rect.y(), option.rect.width() - text_x - text_margin, option.rect.height()
+        )
+        painter.drawText(
+            text_rect, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter, status_text
+        )
+
+    def helpEvent(self, event, view, option, index):
+        """Show tooltip with explanation of the stats."""
+        # Get the item object
+        tree_widget = view
+        if not tree_widget:
+            return False
+
+        item = tree_widget.itemFromIndex(index)
+        if not hasattr(item, "obj") or not item.obj:
+            return False
+
+        obj = item.obj
+
+        # Get the column to determine if this is a match quality column
+        column_index = index.column()
+        columns = getattr(item, "columns", None)
+        if not columns or column_index >= len(columns):
+            return False
+
+        column = columns[column_index]
+        if not isinstance(column, MatchQualityColumn):
+            return False
+
+        # Get the stats
+        stats = column.get_match_stats(obj)
+        if not stats:
+            return False
+
+        # Build tooltip text
+        tooltip_parts = []
+
+        # Core match info
+        if stats["total"] > 0:
+            percentage = (stats["matched"] / stats["total"]) * 100
+            tooltip_parts.append(f"Match: {stats['matched']}/{stats['total']} ({percentage:.1f}%)")
+        else:
+            tooltip_parts.append("Match: 0/0 (0%)")
+
+        # Additional stats with explanations
+        tooltip_parts.append(f"Missing tracks: {stats['missing']}")
+        tooltip_parts.append(f"Duplicate files: {stats['duplicates']}")
+        tooltip_parts.append(f"Extra files: {stats['extra']}")
+        tooltip_parts.append(f"Unmatched files: {stats['unmatched']}")
+
+        tooltip_text = "\n".join(tooltip_parts)
+
+        # Show the tooltip
+        QtWidgets.QToolTip.showText(event.globalPos(), tooltip_text, view)
+        return True
+
+    def sizeHint(self, option, index):
+        # Return a size that accommodates both icon and text
+        return QtCore.QSize(200, 16)

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -66,7 +66,6 @@ class MatchQualityColumn(ImageColumn):
             return None
 
         # Album object
-        matched = obj.get_num_matched_tracks()
         total = len(obj.tracks) if obj.tracks else 0
 
         if total == 0:
@@ -78,6 +77,7 @@ class MatchQualityColumn(ImageColumn):
             return None
 
         # Calculate match percentage
+        matched = obj.get_num_matched_tracks()
         percentage = matched / total
 
         # Determine which icon to use based on percentage using thresholds

--- a/test/test_album_loading_sorting.py
+++ b/test/test_album_loading_sorting.py
@@ -48,7 +48,7 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == -0.6  # 3/5 = 0.6, but returned as negative for proper sorting
+        assert result == 0.6
 
     def test_sortkey_no_status_attribute_works_normally(self):
         """Test that objects without status attribute work normally."""
@@ -58,7 +58,7 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock()]  # 3 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == pytest.approx(-0.6666666666666666, rel=1e-10)  # 2/3 ≈ 0.666, but returned as negative
+        assert result == pytest.approx(0.6666666666666666, rel=1e-10)  # 2/3 ≈ 0.666
 
     def test_sortkey_error_status_works_normally(self):
         """Test that albums with error status work normally."""
@@ -68,7 +68,7 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock()]  # 2 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == -0.5  # 1/2 = 0.5, but returned as negative
+        assert result == 0.5
 
     def test_sortkey_none_status_works_normally(self):
         """Test that albums with None status work normally."""
@@ -78,4 +78,4 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == -0.8  # 4/5 = 0.8, but returned as negative
+        assert result == 0.8

--- a/test/test_album_loading_sorting.py
+++ b/test/test_album_loading_sorting.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the GNU General Public License Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from unittest.mock import Mock
+
+from picard.album import AlbumStatus
+
+import pytest
+
+from picard.ui.itemviews.columns import _sortkey_match_quality
+
+
+class TestAlbumLoadingSorting:
+    """Test that sorting works correctly during album loading."""
+
+    def test_sortkey_during_loading_returns_zero(self):
+        """Test that sort key returns 0.0 when album is still loading."""
+        album = Mock()
+        album.status = AlbumStatus.LOADING
+        album.get_num_matched_tracks.return_value = 3
+        album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
+
+        result = _sortkey_match_quality(album)
+        assert result == 0.0
+
+    def test_sortkey_after_loading_returns_correct_percentage(self):
+        """Test that sort key returns correct percentage after album is loaded."""
+        album = Mock()
+        album.status = AlbumStatus.LOADED
+        album.get_num_matched_tracks.return_value = 3
+        album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
+
+        result = _sortkey_match_quality(album)
+        assert result == -0.6  # 3/5 = 0.6, but returned as negative for proper sorting
+
+    def test_sortkey_no_status_attribute_works_normally(self):
+        """Test that objects without status attribute work normally."""
+        album = Mock()
+        # No status attribute
+        album.get_num_matched_tracks.return_value = 2
+        album.tracks = [Mock(), Mock(), Mock()]  # 3 tracks
+
+        result = _sortkey_match_quality(album)
+        assert result == pytest.approx(-0.6666666666666666, rel=1e-10)  # 2/3 ≈ 0.666, but returned as negative
+
+    def test_sortkey_error_status_works_normally(self):
+        """Test that albums with error status work normally."""
+        album = Mock()
+        album.status = AlbumStatus.ERROR
+        album.get_num_matched_tracks.return_value = 1
+        album.tracks = [Mock(), Mock()]  # 2 tracks
+
+        result = _sortkey_match_quality(album)
+        assert result == -0.5  # 1/2 = 0.5, but returned as negative
+
+    def test_sortkey_none_status_works_normally(self):
+        """Test that albums with None status work normally."""
+        album = Mock()
+        album.status = None
+        album.get_num_matched_tracks.return_value = 4
+        album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
+
+        result = _sortkey_match_quality(album)
+        assert result == -0.8  # 4/5 = 0.8, but returned as negative

--- a/test/test_album_loading_sorting.py
+++ b/test/test_album_loading_sorting.py
@@ -21,10 +21,17 @@
 from unittest.mock import Mock
 
 from picard.album import AlbumStatus
+from picard.const.sys import IS_LINUX
 
 import pytest
 
 from picard.ui.itemviews.columns import _sortkey_match_quality
+
+
+def _apply_platform_multiplier(value):
+    """Apply the same platform-specific multiplier logic as in _sortkey_match_quality."""
+    multiplier = -1 if IS_LINUX else 1
+    return value * multiplier
 
 
 class TestAlbumLoadingSorting:
@@ -48,7 +55,8 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == 0.6
+        expected = _apply_platform_multiplier(0.6)
+        assert result == expected
 
     def test_sortkey_no_status_attribute_works_normally(self):
         """Test that objects without status attribute work normally."""
@@ -58,7 +66,8 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock()]  # 3 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == pytest.approx(0.6666666666666666, rel=1e-10)  # 2/3 ≈ 0.666
+        expected = _apply_platform_multiplier(0.6666666666666666)
+        assert result == pytest.approx(expected, rel=1e-10)  # 2/3 ≈ 0.666
 
     def test_sortkey_error_status_works_normally(self):
         """Test that albums with error status work normally."""
@@ -68,7 +77,8 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock()]  # 2 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == 0.5
+        expected = _apply_platform_multiplier(0.5)
+        assert result == expected
 
     def test_sortkey_none_status_works_normally(self):
         """Test that albums with None status work normally."""
@@ -78,4 +88,5 @@ class TestAlbumLoadingSorting:
         album.tracks = [Mock(), Mock(), Mock(), Mock(), Mock()]  # 5 tracks
 
         result = _sortkey_match_quality(album)
-        assert result == 0.8
+        expected = _apply_platform_multiplier(0.8)
+        assert result == expected

--- a/test/test_itemviews_columns_split.py
+++ b/test/test_itemviews_columns_split.py
@@ -1,0 +1,123 @@
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the GNU General Public License Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from __future__ import annotations
+
+import pytest
+
+from picard.ui.itemviews import TreeItem
+from picard.ui.itemviews.columns import (
+    ALBUMVIEW_COLUMNS,
+    FILEVIEW_COLUMNS,
+)
+from picard.ui.itemviews.match_quality_column import MatchQualityColumn
+
+
+@pytest.fixture
+def album_keys() -> list[str]:
+    return [c.key for c in ALBUMVIEW_COLUMNS]
+
+
+@pytest.fixture
+def file_keys() -> list[str]:
+    return [c.key for c in FILEVIEW_COLUMNS]
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_present"),
+    [
+        ("~match_quality", True),
+        ("title", True),
+        ("albumartist", True),
+    ],
+)
+def test_album_view_expected_columns(album_keys: list[str], key: str, expected_present: bool) -> None:
+    assert (key in album_keys) is expected_present
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_present"),
+    [
+        ("~match_quality", False),
+        ("title", True),
+        ("albumartist", True),
+    ],
+)
+def test_file_view_expected_columns(file_keys: list[str], key: str, expected_present: bool) -> None:
+    assert (key in file_keys) is expected_present
+
+
+def _index_of(columns_keys: list[str], key: str) -> int:
+    return next(i for i, k in enumerate(columns_keys) if k == key)
+
+
+def test_album_view_match_after_albumartist(album_keys: list[str]) -> None:
+    idx_albumartist: int = _index_of(album_keys, "albumartist")
+    idx_match: int = _index_of(album_keys, "~match_quality")
+    assert idx_match == idx_albumartist + 1
+
+
+def test_album_view_match_is_match_quality_column_type() -> None:
+    # Ensure the actual column instance at the expected index is MatchQualityColumn
+    keys: list[str] = [c.key for c in ALBUMVIEW_COLUMNS]
+    idx_match: int = _index_of(keys, "~match_quality")
+    assert isinstance(ALBUMVIEW_COLUMNS[idx_match], MatchQualityColumn)
+
+
+class _DummyObj:
+    # Minimal object to satisfy TreeItem expectations
+    ui_item: TreeItem | None = None
+
+    def column(self, key: str) -> str:
+        return ""
+
+
+def test_treeitem_columns_fallback_when_detached() -> None:
+    # When item is not attached to any view, it should safely fall back to FILEVIEW_COLUMNS
+    item: TreeItem = TreeItem(_DummyObj(), parent=None)
+    # Force detach simulation: ensure treeWidget() returns None
+    assert item.treeWidget() is None
+    assert item.columns is FILEVIEW_COLUMNS
+
+
+def test_treeitem_columns_uses_tree_widget_columns() -> None:
+    # When item is attached (or treeWidget returns a holder with a 'columns' attr), it should use those
+    item: TreeItem = TreeItem(_DummyObj(), parent=None)
+
+    class _Holder:
+        def __init__(self, cols):
+            self.columns = cols
+
+    # Monkeypatch instance method treeWidget to return our holder
+    item.treeWidget = lambda: _Holder(ALBUMVIEW_COLUMNS)  # type: ignore[method-assign]
+    assert item.columns is ALBUMVIEW_COLUMNS
+
+
+@pytest.mark.parametrize(
+    ("keys", "must_exist"),
+    [
+        (["title", "~length", "artist", "albumartist"], True),
+        (["~bitrate", "genre"], True),
+    ],
+)
+def test_required_keys_present(keys: list[str], must_exist: bool, album_keys: list[str], file_keys: list[str]) -> None:
+    for key in keys:
+        assert (key in album_keys) is must_exist
+        assert (key in file_keys) is must_exist

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -450,6 +450,9 @@ class TestMatchQualityColumnDelegate:
         index.column.return_value = 2
         mock_tree_widget.itemFromIndex.return_value = mock_item
 
+        # Set up delegate's parent relationship
+        delegate.parent = lambda: mock_tree_widget
+
         # Mock the column
         mock_column = Mock(spec=MatchQualityColumn)
         stats = {"matched": 5, "total": 10, "missing": 2, "duplicates": 1, "extra": 1, "unmatched": 2}

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -1,0 +1,627 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the GNU General Public License Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from unittest.mock import Mock, patch
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from picard.album import Album
+from picard.track import Track
+
+import pytest
+
+from picard.ui.itemviews import TreeItem
+from picard.ui.itemviews.columns import ITEMVIEW_COLUMNS
+from picard.ui.itemviews.match_quality_column import (
+    MatchQualityColumn,
+    MatchQualityColumnDelegate,
+)
+
+
+class TestMatchQualityColumn:
+    """Test the MatchQualityColumn class."""
+
+    @pytest.fixture
+    def match_quality_column(self) -> MatchQualityColumn:
+        """Create a MatchQualityColumn instance for testing."""
+        return MatchQualityColumn("Match Quality", "~match_quality", width=120)
+
+    @pytest.fixture
+    def mock_album(self) -> Mock:
+        """Create a mock album with tracks and files."""
+        album = Mock(spec=Album)
+        album.tracks = []
+        album.get_num_matched_tracks.return_value = 0
+        album.get_num_unmatched_files.return_value = 0
+        album.unmatched_files = Mock()
+        album.unmatched_files.files = []
+        return album
+
+    @pytest.fixture
+    def mock_track(self) -> Mock:
+        """Create a mock track."""
+        track = Mock(spec=Track)
+        track.files = []
+        return track
+
+    def test_init(self, match_quality_column: MatchQualityColumn) -> None:
+        """Test MatchQualityColumn initialization."""
+        assert match_quality_column.title == "Match Quality"
+        assert match_quality_column.key == "~match_quality"
+        assert match_quality_column.width == 120
+        assert match_quality_column.size == QtCore.QSize(16, 16)
+
+    def test_paint_does_nothing(self, match_quality_column: MatchQualityColumn) -> None:
+        """Test that paint method does nothing (handled by delegate)."""
+        painter = Mock()
+        rect = QtCore.QRect(0, 0, 100, 20)
+        # Should not raise any exception
+        match_quality_column.paint(painter, rect)
+
+    @pytest.mark.parametrize(
+        ("matched", "total", "expected_icon_index"),
+        [
+            (0, 0, 5),  # No tracks - use pending icon
+            (5, 10, 0),  # 50% match
+            (6, 10, 1),  # 60% match
+            (7, 10, 2),  # 70% match
+            (8, 10, 3),  # 80% match
+            (9, 10, 4),  # 90% match
+            (10, 10, 5),  # 100% match
+            (3, 10, 0),  # 30% match - use worst icon
+        ],
+    )
+    def test_get_match_icon_percentage_based(
+        self,
+        match_quality_column: MatchQualityColumn,
+        mock_album: Mock,
+        matched: int,
+        total: int,
+        expected_icon_index: int,
+    ) -> None:
+        """Test get_match_icon returns correct icon based on percentage."""
+        # Setup mock album
+        mock_album.get_num_matched_tracks.return_value = matched
+        mock_album.tracks = [Mock() for _ in range(total)]
+
+        # Mock FileItem.match_icons - patch the import inside the method
+        with patch("picard.ui.itemviews.FileItem") as mock_file_item:
+            mock_file_item.match_icons = [Mock() for _ in range(6)]
+            mock_file_item.match_pending_icons = [Mock() for _ in range(6)]
+
+            icon = match_quality_column.get_match_icon(mock_album)
+
+            if total == 0:
+                # Should use pending icon for zero tracks
+                assert icon == mock_file_item.match_pending_icons[5]
+            else:
+                # Should use match icon based on percentage
+                assert icon == mock_file_item.match_icons[expected_icon_index]
+
+    def test_get_match_icon_no_album_attributes(self, match_quality_column: MatchQualityColumn) -> None:
+        """Test get_match_icon returns None for objects without album attributes."""
+        obj = Mock()
+        # Remove album attributes
+        del obj.get_num_matched_tracks
+        del obj.tracks
+
+        icon = match_quality_column.get_match_icon(obj)
+        assert icon is None
+
+    def test_get_match_icon_no_fileitem_icons(self, match_quality_column: MatchQualityColumn, mock_album: Mock) -> None:
+        """Test get_match_icon handles missing FileItem icons gracefully."""
+        mock_album.get_num_matched_tracks.return_value = 5
+        mock_album.tracks = [Mock() for _ in range(10)]
+
+        with patch("picard.ui.itemviews.FileItem") as mock_file_item:
+            # Remove match_icons attribute
+            del mock_file_item.match_icons
+
+            icon = match_quality_column.get_match_icon(mock_album)
+            assert icon is None
+
+    @pytest.mark.parametrize(
+        ("matched", "total", "unmatched", "duplicates", "extra", "missing"),
+        [
+            (5, 10, 2, 1, 1, 2),  # Normal case
+            (0, 0, 0, 0, 0, 0),  # Empty album
+            (10, 10, 0, 0, 0, 0),  # Perfect match
+            (0, 10, 5, 0, 5, 10),  # No matches
+        ],
+    )
+    def test_get_match_stats(
+        self,
+        match_quality_column: MatchQualityColumn,
+        mock_album: Mock,
+        matched: int,
+        total: int,
+        unmatched: int,
+        duplicates: int,
+        extra: int,
+        missing: int,
+    ) -> None:
+        """Test get_match_stats returns correct statistics."""
+        # Setup mock album
+        mock_album.get_num_matched_tracks.return_value = matched
+        mock_album.get_num_unmatched_files.return_value = unmatched
+        mock_album.tracks = [Mock() for _ in range(total)]
+        mock_album.unmatched_files.files = [Mock() for _ in range(extra)]
+
+        # Setup tracks with appropriate file counts
+        for i, track in enumerate(mock_album.tracks):
+            if i < missing:
+                track.files = []  # Missing tracks
+            elif i < missing + duplicates:
+                track.files = [Mock(), Mock()]  # Duplicate files
+            else:
+                track.files = [Mock()]  # Normal tracks
+
+        stats = match_quality_column.get_match_stats(mock_album)
+
+        assert stats is not None
+        assert stats["matched"] == matched
+        assert stats["total"] == total
+        assert stats["unmatched"] == unmatched
+        assert stats["duplicates"] == duplicates
+        assert stats["extra"] == extra
+        assert stats["missing"] == missing
+
+    def test_get_match_stats_no_album_attributes(self, match_quality_column: MatchQualityColumn) -> None:
+        """Test get_match_stats returns None for objects without album attributes."""
+        obj = Mock()
+        # Remove album attributes
+        del obj.get_num_matched_tracks
+        del obj.tracks
+
+        stats = match_quality_column.get_match_stats(obj)
+        assert stats is None
+
+
+class TestMatchQualityColumnDelegate:
+    """Test the MatchQualityColumnDelegate class."""
+
+    @pytest.fixture
+    def delegate(self) -> MatchQualityColumnDelegate:
+        """Create a MatchQualityColumnDelegate instance for testing."""
+        return MatchQualityColumnDelegate()
+
+    @pytest.fixture
+    def mock_tree_widget(self) -> Mock:
+        """Create a mock tree widget."""
+        widget = Mock(spec=QtWidgets.QTreeWidget)
+        return widget
+
+    @pytest.fixture
+    def mock_item(self) -> Mock:
+        """Create a mock tree item."""
+        item = Mock(spec=TreeItem)
+        item.obj = Mock()
+        item.columns = [Mock(), Mock(), Mock()]  # 3 columns
+        return item
+
+    @pytest.fixture
+    def mock_index(self) -> Mock:
+        """Create a mock model index."""
+        index = Mock()
+        index.column.return_value = 2  # Third column
+        return index
+
+    @pytest.fixture
+    def mock_option(self) -> Mock:
+        """Create a mock style option."""
+        option = Mock()
+        option.rect = QtCore.QRect(0, 0, 200, 20)
+        option.state = QtWidgets.QStyle.StateFlag.State_Enabled
+        option.palette = Mock()
+        option.palette.base.return_value = QtGui.QBrush(QtGui.QColor(255, 255, 255))
+        option.palette.text.return_value = QtGui.QColor(0, 0, 0)
+        return option
+
+    def test_init(self, delegate: MatchQualityColumnDelegate) -> None:
+        """Test MatchQualityColumnDelegate initialization."""
+        assert delegate is not None
+
+    def test_paint_without_parent(
+        self, delegate: MatchQualityColumnDelegate, mock_option: Mock, mock_index: Mock
+    ) -> None:
+        """Test paint method when parent is None."""
+        painter = Mock()
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_paint_without_item(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_option: Mock, mock_index: Mock
+    ) -> None:
+        """Test paint method when item is None."""
+        painter = Mock()
+        delegate.parent = lambda: mock_tree_widget
+        mock_tree_widget.itemFromIndex.return_value = None
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_paint_without_obj(
+        self,
+        delegate: MatchQualityColumnDelegate,
+        mock_tree_widget: Mock,
+        mock_item: Mock,
+        mock_option: Mock,
+        mock_index: Mock,
+    ) -> None:
+        """Test paint method when item has no obj."""
+        painter = Mock()
+        delegate.parent = lambda: mock_tree_widget
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.obj = None
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_paint_without_columns(
+        self,
+        delegate: MatchQualityColumnDelegate,
+        mock_tree_widget: Mock,
+        mock_item: Mock,
+        mock_option: Mock,
+        mock_index: Mock,
+    ) -> None:
+        """Test paint method when item has no columns."""
+        painter = Mock()
+        delegate.parent = lambda: mock_tree_widget
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.columns = None
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_paint_wrong_column_type(
+        self,
+        delegate: MatchQualityColumnDelegate,
+        mock_tree_widget: Mock,
+        mock_item: Mock,
+        mock_option: Mock,
+        mock_index: Mock,
+    ) -> None:
+        """Test paint method when column is not MatchQualityColumn."""
+        painter = Mock()
+        delegate.parent = lambda: mock_tree_widget
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.columns[2] = Mock()  # Not MatchQualityColumn
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_paint_without_stats(
+        self,
+        delegate: MatchQualityColumnDelegate,
+        mock_tree_widget: Mock,
+        mock_item: Mock,
+        mock_option: Mock,
+        mock_index: Mock,
+    ) -> None:
+        """Test paint method when get_match_stats returns None."""
+        painter = Mock()
+        delegate.parent = lambda: mock_tree_widget
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+
+        # Mock the column to return None for stats
+        mock_column = Mock(spec=MatchQualityColumn)
+        mock_column.get_match_stats.return_value = None
+        mock_item.columns[2] = mock_column
+
+        # Mock initStyleOption to avoid Qt type issues
+        with patch.object(delegate, "initStyleOption"):
+            delegate.paint(painter, mock_option, mock_index)
+
+        # Should return early without error
+        painter.drawText.assert_not_called()
+
+    def test_helpEvent_without_parent(self, delegate: MatchQualityColumnDelegate) -> None:
+        """Test helpEvent method when parent is None."""
+        event = Mock()
+        view = None
+        option = Mock()
+        index = Mock()
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_without_item(self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock) -> None:
+        """Test helpEvent method when item is None."""
+        event = Mock()
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        mock_tree_widget.itemFromIndex.return_value = None
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_without_obj(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_item: Mock
+    ) -> None:
+        """Test helpEvent method when item has no obj."""
+        event = Mock()
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.obj = None
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_without_columns(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_item: Mock
+    ) -> None:
+        """Test helpEvent method when item has no columns."""
+        event = Mock()
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.columns = None
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_wrong_column_type(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_item: Mock
+    ) -> None:
+        """Test helpEvent method when column is not MatchQualityColumn."""
+        event = Mock()
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        index.column.return_value = 2
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+        mock_item.columns[2] = Mock()  # Not MatchQualityColumn
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_without_stats(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_item: Mock
+    ) -> None:
+        """Test helpEvent method when get_match_stats returns None."""
+        event = Mock()
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        index.column.return_value = 2
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+
+        # Mock the column to return None for stats
+        mock_column = Mock(spec=MatchQualityColumn)
+        mock_column.get_match_stats.return_value = None
+        mock_item.columns[2] = mock_column
+
+        result = delegate.helpEvent(event, view, option, index)
+        assert result is False
+
+    def test_helpEvent_with_stats(
+        self, delegate: MatchQualityColumnDelegate, mock_tree_widget: Mock, mock_item: Mock
+    ) -> None:
+        """Test helpEvent method with valid stats."""
+        event = Mock()
+        event.globalPos.return_value = QtCore.QPoint(100, 100)
+        view = mock_tree_widget
+        option = Mock()
+        index = Mock()
+        index.column.return_value = 2
+        mock_tree_widget.itemFromIndex.return_value = mock_item
+
+        # Mock the column
+        mock_column = Mock(spec=MatchQualityColumn)
+        stats = {"matched": 5, "total": 10, "missing": 2, "duplicates": 1, "extra": 1, "unmatched": 2}
+        mock_column.get_match_stats.return_value = stats
+        mock_item.columns[2] = mock_column
+
+        with patch("picard.ui.itemviews.match_quality_column.QtWidgets.QToolTip") as mock_tooltip:
+            result = delegate.helpEvent(event, view, option, index)
+
+            assert result is True
+            mock_tooltip.showText.assert_called_once()
+
+            # Check that tooltip text contains expected parts
+            call_args = mock_tooltip.showText.call_args
+            tooltip_text = call_args[0][1]
+            expected_parts = [
+                "Match: 5/10 (50.0%)",
+                "Missing tracks: 2",
+                "Duplicate files: 1",
+                "Extra files: 1",
+                "Unmatched files: 2",
+            ]
+            for part in expected_parts:
+                assert part in tooltip_text
+
+    def test_sizeHint(self, delegate: MatchQualityColumnDelegate) -> None:
+        """Test sizeHint method returns expected size."""
+        option = Mock()
+        index = Mock()
+
+        size = delegate.sizeHint(option, index)
+
+        assert size == QtCore.QSize(200, 16)
+
+
+class TestItemViewsIntegration:
+    """Test integration of MatchQualityColumn with existing itemviews system."""
+
+    @pytest.fixture
+    def mock_album(self) -> Mock:
+        """Create a mock album for testing."""
+        album = Mock(spec=Album)
+        album.tracks = [Mock() for _ in range(5)]
+        album.get_num_matched_tracks.return_value = 3
+        album.get_num_unmatched_files.return_value = 1
+        album.unmatched_files = Mock()
+        album.unmatched_files.files = [Mock()]
+        return album
+
+    def test_match_quality_column_in_itemview_columns(self) -> None:
+        """Test that MatchQualityColumn is included in ITEMVIEW_COLUMNS."""
+        # Find the match quality column
+        match_quality_column = None
+        for column in ITEMVIEW_COLUMNS:
+            if isinstance(column, MatchQualityColumn):
+                match_quality_column = column
+                break
+
+        assert match_quality_column is not None
+        assert match_quality_column.title == "Match Quality"
+        assert match_quality_column.key == "~match_quality"
+        assert match_quality_column.sortable is True
+        assert match_quality_column.sort_type is not None
+        assert match_quality_column.sortkey is not None
+
+    def test_sortkey_progress_function(self) -> None:
+        """Test the _sortkey_progress function used by MatchQualityColumn."""
+        from picard.ui.itemviews.columns import _sortkey_match_quality
+
+        # Test with album object
+        album = Mock()
+        album.get_num_matched_tracks.return_value = 3
+        album.tracks = [Mock() for _ in range(5)]
+
+        result = _sortkey_match_quality(album)
+        assert result == 0.6  # 3/5 = 0.6
+
+        # Test with track object (should return 0.0)
+        track = Mock()
+        # Mock hasattr to return False for track objects
+        with patch("builtins.hasattr", return_value=False):
+            result = _sortkey_match_quality(track)
+            assert result == 0.0
+
+        # Test with album with no tracks
+        album.tracks = []
+        result = _sortkey_match_quality(album)
+        assert result == 0.0
+
+    def test_treeitem_handles_match_quality_column(self, mock_album: Mock) -> None:
+        """Test that TreeItem properly handles MatchQualityColumn."""
+        # Create a mock column
+        column = Mock(spec=MatchQualityColumn)
+        column.size = QtCore.QSize(16, 16)
+
+        # Create a mock item
+        item = Mock(spec=TreeItem)
+        item.columns = [Mock(), column, Mock()]
+
+        # Mock the update_colums_text method
+        with patch.object(TreeItem, "update_colums_text"):
+            # Simulate the condition in update_colums_text
+            if isinstance(column, MatchQualityColumn):
+                item.setSizeHint(1, column.size)
+
+            # Verify setSizeHint was called
+            item.setSizeHint.assert_called_once_with(1, column.size)
+
+    def test_basetreeview_delegate_setup(self) -> None:
+        """Test that BaseTreeView properly sets up delegates for MatchQualityColumn."""
+        from picard.ui.itemviews.match_quality_column import MatchQualityColumnDelegate
+
+        # Verify that the delegate class exists and can be instantiated
+        delegate = MatchQualityColumnDelegate()
+        assert delegate is not None
+
+
+class TestCodeFormattingChanges:
+    """Test that code formatting changes don't break functionality."""
+
+    def test_get_match_color_formatting(self) -> None:
+        """Test that get_match_color function works with new formatting."""
+        from picard.ui.itemviews import get_match_color
+
+        basecolor = QtGui.QColor(255, 255, 255)
+        similarity = 0.5
+
+        result = get_match_color(similarity, basecolor)
+
+        assert isinstance(result, QtGui.QColor)
+        # Verify the color calculation still works
+        assert result.red() >= 0
+        assert result.red() <= 255
+        assert result.green() >= 0
+        assert result.green() <= 255
+        assert result.blue() >= 0
+        assert result.blue() <= 255
+
+    def test_album_item_formatting(self) -> None:
+        """Test that AlbumItem tooltip formatting works with new formatting."""
+        from picard.ui.itemviews import AlbumItem
+
+        # Verify that AlbumItem can be instantiated
+        album = Mock()
+        item = AlbumItem(album, parent=None)
+        assert item is not None
+
+    def test_track_item_formatting(self) -> None:
+        """Test that TrackItem tooltip formatting works with new formatting."""
+        from picard.ui.itemviews import TrackItem
+
+        # Verify that TrackItem can be instantiated
+        track = Mock()
+        item = TrackItem(track, parent=None)
+        assert item is not None
+
+    def test_file_item_formatting(self) -> None:
+        """Test that FileItem tooltip formatting works with new formatting."""
+        from picard.ui.itemviews import FileItem
+
+        # Verify that FileItem can be instantiated
+        file = Mock()
+        item = FileItem(file, parent=None)
+        assert item is not None
+
+    def test_cluster_item_formatting(self) -> None:
+        """Test that ClusterItem initialization works with new formatting."""
+        from picard.ui.itemviews import ClusterItem
+
+        # Verify that ClusterItem can be instantiated
+        cluster = Mock()
+        # Mock the icon_dir attribute that's set during runtime
+        with patch.object(ClusterItem, "icon_dir", QtGui.QIcon(), create=True):
+            item = ClusterItem(cluster, parent=None)
+            assert item is not None

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -541,16 +541,19 @@ class TestItemViewsIntegration:
         assert match_quality_column is None
 
     def test_album_view_has_match_quality_column_after_album_artist(self) -> None:
-        """Test that the match quality column is after the Album Artist column in album view."""
+        """Test that the match quality column is immediately after the Album Artist column in album view."""
         from picard.ui.itemviews.columns import ALBUMVIEW_COLUMNS
 
-        # The match quality column should be at index 4 (after Title, Length, Artist, Album Artist)
-        match_quality_column = ALBUMVIEW_COLUMNS[4]
+        idx_albumartist = ALBUMVIEW_COLUMNS.pos("albumartist")
+        idx_match = ALBUMVIEW_COLUMNS.pos("~match_quality")
+
+        assert idx_match == idx_albumartist + 1
+
+        match_quality_column = ALBUMVIEW_COLUMNS[idx_match]
         assert isinstance(match_quality_column, MatchQualityColumn)
         assert match_quality_column.key == "~match_quality"
 
-        # Verify that Album Artist is at index 3 (before match quality)
-        album_artist_column = ALBUMVIEW_COLUMNS[3]
+        album_artist_column = ALBUMVIEW_COLUMNS[idx_albumartist]
         assert album_artist_column.key == "albumartist"
 
     def test_sortkey_progress_function(self) -> None:

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -485,7 +485,7 @@ class TestMatchQualityColumnDelegate:
 
         size = delegate.sizeHint(option, index)
 
-        assert size == QtCore.QSize(200, 16)
+        assert size == QtCore.QSize(57, 16)
 
 
 class TestItemViewsIntegration:
@@ -512,7 +512,7 @@ class TestItemViewsIntegration:
                 break
 
         assert match_quality_column is not None
-        assert match_quality_column.title == "Match Quality"
+        assert match_quality_column.title == "Match"
         assert match_quality_column.key == "~match_quality"
         assert match_quality_column.sortable is True
         assert match_quality_column.sort_type is not None
@@ -528,7 +528,7 @@ class TestItemViewsIntegration:
         album.tracks = [Mock() for _ in range(5)]
 
         result = _sortkey_match_quality(album)
-        assert result == -0.6  # 3/5 = 0.6, but returned as negative for proper sorting
+        assert result == 0.6
 
         # Test with track object (should return 0.0)
         track = Mock()
@@ -667,8 +667,8 @@ class TestMatchQualitySorting:
     def test_sortkey_match_quality_loaded_album(self, mock_album_loaded):
         """Test that loaded albums return correct match percentage."""
         result = _sortkey_match_quality(mock_album_loaded)
-        # 3 matched out of 5 total = 0.6, but returned as negative for proper sorting
-        assert result == -0.6
+        # 3 matched out of 5 total = 0.6
+        assert result == 0.6
 
     def test_sortkey_match_quality_track_object(self, mock_track):
         """Test that track objects return 0.0."""
@@ -687,7 +687,7 @@ class TestMatchQualitySorting:
         """Test that albums with all tracks matched return -1.0."""
         mock_album_loaded.get_num_matched_tracks.return_value = 5
         result = _sortkey_match_quality(mock_album_loaded)
-        assert result == -1.0
+        assert result == 1.0
 
     def test_sortkey_match_quality_no_matches(self, mock_album_loaded):
         """Test that albums with no matches return 0.0."""
@@ -699,8 +699,8 @@ class TestMatchQualitySorting:
         """Test that albums with partial matches return correct percentage."""
         mock_album_loaded.get_num_matched_tracks.return_value = 2
         result = _sortkey_match_quality(mock_album_loaded)
-        # 2 matched out of 5 total = 0.4, but returned as negative for proper sorting
-        assert result == -0.4
+        # 2 matched out of 5 total = 0.4
+        assert result == 0.4
 
     def test_sortkey_match_quality_no_status_attribute(self):
         """Test that objects without status attribute are handled gracefully."""
@@ -709,19 +709,19 @@ class TestMatchQualitySorting:
         obj.tracks = [Mock(), Mock(), Mock()]  # 3 tracks
         # No status attribute
         result = _sortkey_match_quality(obj)
-        # Should calculate normally: 2/3 = 0.666..., but returned as negative
-        assert result == pytest.approx(-0.6666666666666666, rel=1e-10)
+        # Should calculate normally: 2/3 = 0.666...
+        assert result == pytest.approx(0.6666666666666666, rel=1e-10)
 
     def test_sortkey_match_quality_error_status(self, mock_album_loaded):
         """Test that albums with error status are handled correctly."""
         mock_album_loaded.status = AlbumStatus.ERROR
         result = _sortkey_match_quality(mock_album_loaded)
         # Should still calculate the match percentage
-        assert result == -0.6
+        assert result == 0.6
 
     def test_sortkey_match_quality_none_status(self, mock_album_loaded):
         """Test that albums with None status are handled correctly."""
         mock_album_loaded.status = None
         result = _sortkey_match_quality(mock_album_loaded)
         # Should still calculate the match percentage
-        assert result == -0.6
+        assert result == 0.6


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds a new "Match Quality" column to the album view that displays match statistics using visual icons and text, showing matched/total tracks, missing tracks, duplicates, and extra files.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-442
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Users need a quick visual way to assess the quality of their file-to-track matches in albums. Currently, users must manually inspect each track to understand match status, which is time-consuming and error-prone.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Added `MatchQualityColumn` class that displays match statistics at the album level
- Implemented custom delegate (`MatchQualityColumnDelegate`) for rendering icons and text
- Column shows format: "matched/total; missing; duplicates; extra; unmatched"
- Uses existing match icons from FileItem for visual consistency
- Added re-sort trigger in Album._finalize_loading() to ensure accurate sorting after album loads
- Column integrates with existing item views system and respects sorting/filtering

<img width="416" height="285" alt="image" src="https://github.com/user-attachments/assets/3cf92e1d-2b64-4041-84f6-d3ae2891177c" />


# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (PICARD-3102)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
```