### PR TITLE
Add missing comma

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -238,7 +238,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             "rename_files",
             "selected_file_naming_script_id",
             "standardize_artists",
-            "user_profile_settings"
+            "user_profile_settings",
             "user_profiles",
             "va_name",
             "windows_compatibility",


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

There is a comma missing between items in the `settings_to_watch` set in the `MetadataBox:_on_setting_changed()` method.

* JIRA ticket (_optional_): PICARD-XXX


# Solution

Add the missing comma.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

