### PR TITLE
Run `ruff format` and add ruff format check ci workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - name: Ruff lint
+        uses: astral-sh/ruff-action@v3
         with:
-          version: "latest"
           args: "check --output-format=github"
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -37,6 +37,8 @@ from picard.const.tags import ALL_TAGS
 
 
 RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
+
+
 def parse_comment_tag(name):  # noqa: E302
     """
     Parses a tag name like "comment:XXX:desc", where XXX is the language.
@@ -121,11 +123,7 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
-    yield from (
-        tagvar.script_name()
-        for tagvar in ALL_TAGS
-        if tagvar.is_script_variable
-    )
+    yield from (tagvar.script_name() for tagvar in ALL_TAGS if tagvar.is_script_variable)
 
 
 def display_tag_name(name):

--- a/picard/tags/preserved.py
+++ b/picard/tags/preserved.py
@@ -24,7 +24,6 @@ from picard.config import get_config
 
 
 class UserPreservedTags:
-
     opt_name = 'preserved_tags'
 
     def __init__(self):

--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -80,10 +80,24 @@ ATTRIB2NOTE = OrderedDict(
 
 class TagVar:
     def __init__(
-        self, name, shortdesc=None, longdesc=None, additionaldesc=None,
-        is_preserved=False, is_hidden=False, is_script_variable=True, is_tag=True, is_calculated=False,
-        is_file_info=False, is_from_mb=True, is_populated_by_picard=True, is_multi_value=False,
-        is_filterable=False, see_also=None, related_options=None, doc_links=None
+        self,
+        name,
+        shortdesc=None,
+        longdesc=None,
+        additionaldesc=None,
+        is_preserved=False,
+        is_hidden=False,
+        is_script_variable=True,
+        is_tag=True,
+        is_calculated=False,
+        is_file_info=False,
+        is_from_mb=True,
+        is_populated_by_picard=True,
+        is_multi_value=False,
+        is_filterable=False,
+        see_also=None,
+        related_options=None,
+        doc_links=None,
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
@@ -178,6 +192,7 @@ class TagVars(MutableSequence):
     It maintains an internal dict object for display names.
     Also it doesn't allow to add a TagVar of the same name more than once.
     """
+
     def __init__(self, *tagvars):
         self._items = []
         self._name2item = dict()
@@ -306,7 +321,7 @@ class TagVars(MutableSequence):
 
     def tooltip_content(self, item: TagVar):
         content = self._base_description(item)
-        content += self._add_sections(item, (Section.notes, ))
+        content += self._add_sections(item, (Section.notes,))
         return content
 
     def full_description_content(self, item: TagVar):


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* Added a CI step to run `ruff format --check` and aligned `ruff-action` to use the Ruff version from `pyproject.toml` by removing `version: "latest"`.

# Problem

* CI did not enforce code formatting, and pinning `ruff-action` to `latest` could diverge from the repo’s configured Ruff version.

* JIRA ticket (optional): PICARD-XXX

# Solution

* Add `ruff format --check` to `.github/workflows/lint.yml`.
* Remove `version: "latest"` so `ruff-action` uses the version defined in `pyproject.toml`.  see: https://github.com/astral-sh/ruff-action?tab=readme-ov-file#install-specific-versions
* Ran `ruff format` on the repo, causing changes in `picard/tags/__init__.py`, `picard/tags/preserved.py`, `picard/tags/tagvar.py`.

# Action

Additional actions required:
* [ ] Update Picard documentation
* [ ] Other (please specify below)