### PR TITLE
PICARD-3011: Add ui quick toggles for cover art

### DIFF
--- a/picard/ui/enums.py
+++ b/picard/ui/enums.py
@@ -74,6 +74,8 @@ class MainAction(str, Enum):
     ENABLE_MOVING = 'enable_moving_action'
     ENABLE_RENAMING = 'enable_renaming_action'
     ENABLE_TAG_SAVING = 'enable_tag_saving_action'
+    ENABLE_SAVE_IMAGES_TO_TAGS = 'enable_save_images_to_tags_action'
+    ENABLE_SAVE_IMAGES_TO_FILES = 'enable_save_images_to_files_action'
     EXIT = 'exit_action'
     GENERATE_FINGERPRINTS = 'generate_fingerprints_action'
     HELP = 'help_action'

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -294,6 +294,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.actions[MainAction.ENABLE_MOVING].setChecked(new_value)
         elif name == 'dont_write_tags':
             self.actions[MainAction.ENABLE_TAG_SAVING].setChecked(not new_value)
+        elif name == 'save_images_to_tags':
+            self.actions[MainAction.ENABLE_SAVE_IMAGES_TO_TAGS].setChecked(new_value)
+        elif name == 'save_images_to_files':
+            self.actions[MainAction.ENABLE_SAVE_IMAGES_TO_FILES].setChecked(new_value)
         elif name in {'file_renaming_scripts', 'selected_file_naming_script_id'}:
             self._make_script_selector_menu()
 
@@ -617,11 +621,21 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         config = get_config()
         config.setting['dont_write_tags'] = not checked
 
+    def toggle_save_images_to_tags(self, checked):
+        config = get_config()
+        config.setting['save_images_to_tags'] = checked
+
+    def toggle_save_images_to_files(self, checked):
+        config = get_config()
+        config.setting['save_images_to_files'] = checked
+
     def _reset_option_menu_state(self):
         config = get_config()
         self.actions[MainAction.ENABLE_RENAMING].setChecked(config.setting['rename_files'])
         self.actions[MainAction.ENABLE_MOVING].setChecked(config.setting['move_files'])
         self.actions[MainAction.ENABLE_TAG_SAVING].setChecked(not config.setting['dont_write_tags'])
+        self.actions[MainAction.ENABLE_SAVE_IMAGES_TO_TAGS].setChecked(config.setting['save_images_to_tags'])
+        self.actions[MainAction.ENABLE_SAVE_IMAGES_TO_FILES].setChecked(config.setting['save_images_to_files'])
         self._make_script_selector_menu()
         self._init_cd_lookup_menu()
 
@@ -695,6 +709,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.ENABLE_RENAMING,
             MainAction.ENABLE_MOVING,
             MainAction.ENABLE_TAG_SAVING,
+            MainAction.ENABLE_SAVE_IMAGES_TO_TAGS,
+            MainAction.ENABLE_SAVE_IMAGES_TO_FILES,
             '-',
             self.script_quick_selector_menu,
             MainAction.SHOW_SCRIPT_EDITOR,

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -46,8 +46,13 @@
 
 
 from functools import partial
+from typing import TYPE_CHECKING
 
 from PyQt6 import QtGui
+
+
+if TYPE_CHECKING:
+    from picard.ui.mainwindow import MainWindow
 
 from picard.browser import addrelease
 from picard.config import get_config
@@ -474,6 +479,26 @@ def _create_enable_tag_saving_action(parent):
     action.setCheckable(True)
     action.setChecked(not config.setting['dont_write_tags'])
     action.triggered.connect(parent.toggle_tag_saving)
+    return action
+
+
+@add_action(MainAction.ENABLE_SAVE_IMAGES_TO_TAGS)
+def _create_enable_save_images_to_tags_action(parent: 'MainWindow') -> QtGui.QAction:
+    config = get_config()
+    action = QtGui.QAction(_("Save images to tags"), parent)
+    action.setCheckable(True)
+    action.setChecked(config.setting['save_images_to_tags'])
+    action.triggered.connect(parent.toggle_save_images_to_tags)
+    return action
+
+
+@add_action(MainAction.ENABLE_SAVE_IMAGES_TO_FILES)
+def _create_enable_save_images_to_files_action(parent: 'MainWindow') -> QtGui.QAction:
+    config = get_config()
+    action = QtGui.QAction(_("Save images to files"), parent)
+    action.setCheckable(True)
+    action.setChecked(config.setting['save_images_to_files'])
+    action.triggered.connect(parent.toggle_save_images_to_files)
     return action
 
 

--- a/test/test_ui_cover_quick_toggles.py
+++ b/test/test_ui_cover_quick_toggles.py
@@ -89,7 +89,7 @@ class _FakeAction:
             self.triggered._slot(self._checked)
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_qaction() -> Iterator[None]:
     p = patch('picard.ui.mainwindow.actions.QtGui.QAction', new=_FakeAction)
     p.start()
@@ -99,13 +99,13 @@ def patch_qaction() -> Iterator[None]:
         p.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def setup_config() -> None:
     PicardTestCase.init_config()
 
 
 @pytest.mark.parametrize(
-    "create_fn,key",
+    ('create_fn', 'key'),
     [
         (_create_enable_save_images_to_tags_action, "save_images_to_tags"),
         (_create_enable_save_images_to_files_action, "save_images_to_files"),
@@ -135,7 +135,7 @@ def test_action_toggle(
 
 
 @pytest.mark.parametrize(
-    "method_name,key,value",
+    ('method_name', 'key', 'value'),
     [
         ("toggle_save_images_to_tags", "save_images_to_tags", False),
         ("toggle_save_images_to_tags", "save_images_to_tags", True),

--- a/test/test_ui_cover_quick_toggles.py
+++ b/test/test_ui_cover_quick_toggles.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+"""Focused tests for cover art quick toggles in Options menu.
+
+Covers only the newly added actions and handlers.
+"""
+
+from collections.abc import Callable, Iterator
+from unittest.mock import patch
+
+from PyQt6 import QtCore, QtGui
+
+from test.picardtestcase import PicardTestCase
+
+from picard.config import get_config
+
+import pytest
+
+from picard.ui.mainwindow.actions import (
+    _create_enable_save_images_to_files_action,
+    _create_enable_save_images_to_tags_action,
+)
+
+
+class _DummyParent(QtCore.QObject):
+    def __init__(self, set_to_config_key: str | None = None) -> None:
+        super().__init__()
+        self.invoked_with: bool | None = None
+        self._config_key = set_to_config_key
+
+    def toggle_save_images_to_tags(self, checked: bool) -> None:
+        self.invoked_with = checked
+        if self._config_key:
+            get_config().setting[self._config_key] = checked
+
+    def toggle_save_images_to_files(self, checked: bool) -> None:
+        self.invoked_with = checked
+        if self._config_key:
+            get_config().setting[self._config_key] = checked
+
+
+class _FakeSignal:
+    def __init__(self) -> None:
+        self._slot: Callable[[bool], None] | None = None
+
+    def connect(self, slot: Callable[[bool], None]) -> None:
+        self._slot = slot
+
+
+class _FakeAction:
+    def __init__(self, _text: str, _parent: QtCore.QObject) -> None:
+        self._checkable = False
+        self._checked = False
+        self.triggered = _FakeSignal()
+
+    def setCheckable(self, value: bool) -> None:
+        self._checkable = value
+
+    def setChecked(self, value: bool) -> None:
+        self._checked = value
+
+    def isCheckable(self) -> bool:
+        return self._checkable
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+    def trigger(self) -> None:
+        if self.triggered._slot:
+            self.triggered._slot(self._checked)
+
+
+@pytest.fixture()
+def patch_qaction() -> Iterator[None]:
+    p = patch('picard.ui.mainwindow.actions.QtGui.QAction', new=_FakeAction)
+    p.start()
+    try:
+        yield None
+    finally:
+        p.stop()
+
+
+@pytest.fixture()
+def setup_config() -> None:
+    PicardTestCase.init_config()
+
+
+@pytest.mark.parametrize(
+    "create_fn,key",
+    [
+        (_create_enable_save_images_to_tags_action, "save_images_to_tags"),
+        (_create_enable_save_images_to_files_action, "save_images_to_files"),
+    ],
+)
+@pytest.mark.parametrize("initial", [False, True])
+def test_action_toggle(
+    create_fn: Callable[[QtCore.QObject], QtGui.QAction],
+    key: str,
+    initial: bool,
+    patch_qaction: None,
+    setup_config: None,
+) -> None:
+    get_config().setting[key] = initial
+    parent = _DummyParent(set_to_config_key=key)
+
+    action = create_fn(parent)
+
+    assert action.isCheckable()
+    assert action.isChecked() is initial
+
+    action.setChecked(not initial)
+    action.trigger()
+
+    assert parent.invoked_with is (not initial)
+    assert get_config().setting[key] is (not initial)
+
+
+@pytest.mark.parametrize(
+    "method_name,key,value",
+    [
+        ("toggle_save_images_to_tags", "save_images_to_tags", False),
+        ("toggle_save_images_to_tags", "save_images_to_tags", True),
+        ("toggle_save_images_to_files", "save_images_to_files", False),
+        ("toggle_save_images_to_files", "save_images_to_files", True),
+    ],
+)
+def test_toggle_updates_config(method_name: str, key: str, value: bool, setup_config: None) -> None:
+    from picard.ui.mainwindow.__init__ import MainWindow as _MW
+
+    # Methods don't use instance state; pass a dummy self
+    getattr(_MW, method_name)(object(), value)
+    assert get_config().setting[key] is value


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* Describe this change in 1-2 sentences:
  Add two quick toggles to Options menu: “Save images to tags” and “Save images to files”, mirroring existing cover art settings for fast on/off control without opening Options.

# Problem

Users frequently switch cover art saving behaviors (embed vs file) and want quick toggles akin to “Save Tags/Rename/Move” to avoid navigating the Options dialog.

* JIRA ticket (optional): PICARD-3011

# Solution

- Add actions to `MainAction`: `ENABLE_SAVE_IMAGES_TO_TAGS`, `ENABLE_SAVE_IMAGES_TO_FILES`.
- Implement actions in `picard/ui/mainwindow/actions.py` and handlers in `picard/ui/mainwindow/__init__.py`.
- Insert both under “Save Tags” in Options menu and keep checked state synced with `save_images_to_tags` and `save_images_to_files`.
- Focused tests in `test/test_ui_cover_quick_toggles.py` validate action state, triggers, and handler config updates (with Qt action mocked).

# Action

Additional actions required:
* [x] Update Picard documentation (add the two new quick toggles under Options)
* [ ] Other (please specify below)