### PR TITLE
PICARD-3121: Allow user to set metadata processor plugin execution order

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -14,7 +14,7 @@
 # Copyright (C) 2017 Suhas
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2021 Gabriel Ferreira
-# Copyright (C) 2021-2022 Bob Swift
+# Copyright (C) 2021-2022, 2025 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -71,6 +71,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     matching,
     metadata,
     network,
+    plugin_execution_order,
     plugins,
     profiles,
     ratings,

--- a/picard/ui/options/plugin_execution_order.py
+++ b/picard/ui/options/plugin_execution_order.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections import namedtuple
+import sys
+
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+
+from picard.config import (
+    Option,
+    get_config,
+)
+from picard.metadata import (
+    _album_metadata_processors,
+    _track_metadata_processors,
+)
+from picard.plugin import EXEC_ORDER_KEY
+
+from markdown import markdown
+
+from picard.ui.options import (
+    OptionsPage,
+    register_options_page,
+)
+from picard.ui.ui_options_plugin_execution_order import (
+    Ui_PluginExecutionOrderOptionsPage,
+)
+from picard.ui.widgets.orderabletableview import OrderableTableView
+
+
+PluginInformation = namedtuple('PluginInformation', ['key', 'name', 'description', 'function_description', 'priority'])
+
+
+class PluginExecutionOrderOptionsPage(OptionsPage):
+
+    NAME = 'plugin_execution_order'
+    TITLE = N_("Plugin Execution Order")
+    PARENT = 'advanced'
+    SORT_ORDER = 50
+    ACTIVE = True
+    HELP_URL = "/config/options_plugin_execution_order.html"
+
+    options = [
+        Option.add_if_missing('setting', EXEC_ORDER_KEY, dict()),
+    ]
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_PluginExecutionOrderOptionsPage()
+        self.ui.setupUi(self)
+
+        self.title_text = N_("Plugin Metadata Processing Order")
+
+        self.ui.description.setText(_(
+            "Each plugin that works with an album or track's metadata has their various processing "
+            "functions registered with an execution priority set by the plugin author within the "
+            "plugin itself. A plugin may contain multiple different processing functions, each with "
+            "its own specified priority. These priorities determine the order in which the functions "
+            "are executed, and are generally set as HIGH, NORMAL or LOW.\n\n"
+            "Most of the time this grouping of execution priorities is sufficient, however there may be "
+            "a situation where one plugin processing function must be executed before another plugin "
+            "function with the same priority in order to avoid unintended results. This option setting "
+            "allows you to specify the order that the plugin metadata processing functions are executed, "
+            "regardless of the initial registered priority for the function. In this way, you can avoid "
+            "unexpected results that might otherwise occur.\n\n"
+            "When the execution order editor is opened, it will display all of the enabled plugin "
+            "metadata processing functions in the order in which they are executed by Picard. You can "
+            "change the order by moving the plugin processing functions up or down by selecting the "
+            "function to move and then use the up or down button, or by using your mouse to drag the "
+            "function to the desired location in the list.\n\n"
+            "Hovering your cursor over a plugin's name will display a description of the function, and "
+            "hovering over a plugin's processing function will display a description of the function "
+            "if available."
+        ))
+
+        self.ui.edit_plugin_order.clicked.connect(self.show_execution_order_editor)
+
+        self.setup_editor_dialog()
+
+    def setup_editor_dialog(self):
+        self.order_dialog = QtWidgets.QDialog(self)
+        self.order_dialog.setWindowTitle(_(self.title_text))
+        self.order_dialog.setMinimumWidth(650)
+
+        layout = QtWidgets.QVBoxLayout(self.order_dialog)
+
+        instructions = QtWidgets.QLabel(
+            _(
+                "This displays the order in which the plugin metadata processing functions are executed "
+                "by Picard. You can change the order by moving the functions up or down by selecting "
+                "the funcion to move and then use the up or down button, or by using your mouse to "
+                "drag the function to the desired location in the list."
+            )
+        )
+        instructions.setWordWrap(True)
+        layout.addWidget(instructions)
+
+        self.tableview = OrderableTableView(self.order_dialog)
+
+        self.tableview.model.setHorizontalHeaderLabels(
+            [
+                _('Plugin Name'),
+                _('Processor'),
+                _('Method/Function Called'),
+            ]
+        )
+
+        for idx, width in enumerate([260, 70, 230]):
+            self.tableview.setColumnWidth(idx, width)
+
+        for idx, text in enumerate(
+            [
+                _("The name of the plugin"),
+                _("The type of metadata processor used (album or track)"),
+                _("The method or function within the plugin module that is called"),
+            ]
+        ):
+            self.tableview.model.horizontalHeaderItem(idx).setToolTip(text)
+
+        self.tableview.selectionModel().selectionChanged.connect(self._set_up_down_button_states)
+        layout.addWidget(self.tableview)
+
+        button_layout = QtWidgets.QHBoxLayout()
+
+        # Move Label
+        move_label = QtWidgets.QLabel(_("Move row"))
+        button_layout.addWidget(move_label)
+
+        # Up button
+        self.up_button = QtWidgets.QToolButton()
+        up_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarShadeButton)
+        self.up_button.setIcon(up_icon)
+        self.up_button.setToolTip(_("Move selected plugin up"))
+        self.up_button.clicked.connect(self.tableview.move_row_up)
+        button_layout.addWidget(self.up_button)
+
+        # Down button
+        self.dn_button = QtWidgets.QToolButton()
+        dn_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarUnshadeButton)
+        self.dn_button.setIcon(dn_icon)
+        self.dn_button.setToolTip(_("Move selected plugin down"))
+        self.dn_button.clicked.connect(self.tableview.move_row_down)
+        button_layout.addWidget(self.dn_button)
+
+        # spacer
+        spacer = QtWidgets.QSpacerItem(
+            20, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
+        )
+        button_layout.addItem(spacer)
+
+        # OK
+        ok_button = QtWidgets.QPushButton(_('OK'))
+        ok_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogOkButton)
+        ok_button.setIcon(ok_icon)
+        ok_button.clicked.connect(self.order_dialog.accept)
+        button_layout.addWidget(ok_button)
+        ok_button.setDefault(True)  # default selected button
+
+        # Cancel
+        cancel_button = QtWidgets.QPushButton(_('Cancel'))
+        cancel_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogCancelButton)
+        cancel_button.setIcon(cancel_icon)
+        cancel_button.clicked.connect(self.order_dialog.reject)
+        button_layout.addWidget(cancel_button)
+
+        layout.addLayout(button_layout)
+
+    def load(self):
+        config = get_config()
+        self.plugin_exec_order = config.setting[EXEC_ORDER_KEY]
+
+    def save(self):
+        config = get_config()
+        config.setting[EXEC_ORDER_KEY] = self.plugin_exec_order
+
+    def show_execution_order_editor(self):
+        "Open a dialog to allow the user to manually set the execution order of metadata processor plugins"
+
+        # Get list of all registered metadata processor plugins
+        plugins = []
+        for processor in [_album_metadata_processors, _track_metadata_processors]:
+            for (priority, function, key) in processor.get_exec_order():
+                function_desc = function.__doc__ or "No description provided"
+                module_name = key.split(':')[0]
+                # Don't include internal plugins
+                if module_name.startswith('picard.'):
+                    continue
+                module_name = 'picard.plugins.' + module_name
+                name = getattr(sys.modules[module_name], 'PLUGIN_NAME', "Unknown Plugin") if module_name in sys.modules else "No Name"
+                module_desc = getattr(sys.modules[module_name], 'PLUGIN_DESCRIPTION', "Unknown Plugin") if module_name in sys.modules else "No description provided"
+                plugins.append(PluginInformation(key, name, markdown(module_desc), markdown(function_desc), priority))
+
+        if not plugins:
+            msg = QtWidgets.QMessageBox(self)
+            msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+            msg.setText(_("There were no installed metadata processing plugins found."))
+            msg.setWindowTitle(_(self.title_text))
+            msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+            msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+            msg.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
+            msg.show()
+
+            return
+
+        self.tableview.blockSignals(True)
+        i = self.tableview.model.rowCount()
+        while i > 0:
+            i -= 1
+            self.tableview.model.removeRow(i)
+
+        for plugin in sorted(plugins, key=lambda i: i.priority, reverse=True):
+            plugin: PluginInformation
+            module_name, processor_type, function_name = plugin.key.split(':', 2)
+
+            column1 = QtGui.QStandardItem(plugin.name)
+            column1.setEditable(False)
+            column1.setDropEnabled(False)
+            column1.setToolTip(plugin.description)
+            column1.setData(plugin.key, QtCore.Qt.ItemDataRole.UserRole)
+
+            column2 = QtGui.QStandardItem(processor_type)
+            column2.setEditable(False)
+            column2.setDropEnabled(False)
+            column2.setTextAlignment(QtCore.Qt.AlignCenter)
+
+            column3 = QtGui.QStandardItem(function_name)
+            column3.setEditable(False)
+            column3.setDropEnabled(False)
+            column3.setToolTip(plugin.function_description)
+
+            self.tableview.model.appendRow([column1, column2, column3])
+
+        self.tableview.setCurrentIndex(self.tableview.model.index(0, 0))
+        self.tableview.blockSignals(False)
+
+        self._set_up_down_button_states()
+
+        # Show dialog and process result
+        if self.order_dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            self.plugin_exec_order = dict()
+            for idx in range(self.tableview.model.rowCount()):
+                item = self.tableview.model.item(idx, 0)
+                key = item.data(QtCore.Qt.ItemDataRole.UserRole)
+                priority = -1 - idx
+                self.plugin_exec_order[key] = priority
+
+    def _set_up_down_button_states(self):
+        row = self.tableview.currentIndex().row()
+        self.up_button.setDisabled(row < 1)
+        self.dn_button.setDisabled(row >= self.tableview.model.rowCount() - 1)
+
+
+register_options_page(PluginExecutionOrderOptionsPage)

--- a/picard/ui/options/plugin_execution_order.py
+++ b/picard/ui/options/plugin_execution_order.py
@@ -19,12 +19,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections import namedtuple
 import sys
 
 from PyQt5 import (
     QtCore,
-    QtGui,
     QtWidgets,
 )
 
@@ -44,13 +42,13 @@ from picard.ui.options import (
     OptionsPage,
     register_options_page,
 )
+from picard.ui.plugin_order_selector import (
+    PluginInformation,
+    display_plugin_order_selector,
+)
 from picard.ui.ui_options_plugin_execution_order import (
     Ui_PluginExecutionOrderOptionsPage,
 )
-from picard.ui.widgets.orderabletableview import OrderableTableView
-
-
-PluginInformation = namedtuple('PluginInformation', ['key', 'name', 'description', 'function_description', 'priority'])
 
 
 class PluginExecutionOrderOptionsPage(OptionsPage):
@@ -97,96 +95,6 @@ class PluginExecutionOrderOptionsPage(OptionsPage):
 
         self.ui.edit_plugin_order.clicked.connect(self.show_execution_order_editor)
 
-        self.setup_editor_dialog()
-
-    def setup_editor_dialog(self):
-        self.order_dialog = QtWidgets.QDialog(self)
-        self.order_dialog.setWindowTitle(_(self.title_text))
-        self.order_dialog.setMinimumWidth(650)
-
-        layout = QtWidgets.QVBoxLayout(self.order_dialog)
-
-        instructions = QtWidgets.QLabel(
-            _(
-                "This displays the order in which the plugin metadata processing functions are executed "
-                "by Picard. You can change the order by moving the functions up or down by selecting "
-                "the funcion to move and then use the up or down button, or by using your mouse to "
-                "drag the function to the desired location in the list."
-            )
-        )
-        instructions.setWordWrap(True)
-        layout.addWidget(instructions)
-
-        self.tableview = OrderableTableView(self.order_dialog)
-
-        self.tableview.model.setHorizontalHeaderLabels(
-            [
-                _('Plugin Name'),
-                _('Processor'),
-                _('Method/Function Called'),
-            ]
-        )
-
-        for idx, width in enumerate([260, 70, 230]):
-            self.tableview.setColumnWidth(idx, width)
-
-        for idx, text in enumerate(
-            [
-                _("The name of the plugin"),
-                _("The type of metadata processor used (album or track)"),
-                _("The method or function within the plugin module that is called"),
-            ]
-        ):
-            self.tableview.model.horizontalHeaderItem(idx).setToolTip(text)
-
-        self.tableview.selectionModel().selectionChanged.connect(self._set_up_down_button_states)
-        layout.addWidget(self.tableview)
-
-        button_layout = QtWidgets.QHBoxLayout()
-
-        # Move Label
-        move_label = QtWidgets.QLabel(_("Move row"))
-        button_layout.addWidget(move_label)
-
-        # Up button
-        self.up_button = QtWidgets.QToolButton()
-        up_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarShadeButton)
-        self.up_button.setIcon(up_icon)
-        self.up_button.setToolTip(_("Move selected plugin up"))
-        self.up_button.clicked.connect(self.tableview.move_row_up)
-        button_layout.addWidget(self.up_button)
-
-        # Down button
-        self.dn_button = QtWidgets.QToolButton()
-        dn_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarUnshadeButton)
-        self.dn_button.setIcon(dn_icon)
-        self.dn_button.setToolTip(_("Move selected plugin down"))
-        self.dn_button.clicked.connect(self.tableview.move_row_down)
-        button_layout.addWidget(self.dn_button)
-
-        # spacer
-        spacer = QtWidgets.QSpacerItem(
-            20, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
-        )
-        button_layout.addItem(spacer)
-
-        # OK
-        ok_button = QtWidgets.QPushButton(_('OK'))
-        ok_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogOkButton)
-        ok_button.setIcon(ok_icon)
-        ok_button.clicked.connect(self.order_dialog.accept)
-        button_layout.addWidget(ok_button)
-        ok_button.setDefault(True)  # default selected button
-
-        # Cancel
-        cancel_button = QtWidgets.QPushButton(_('Cancel'))
-        cancel_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogCancelButton)
-        cancel_button.setIcon(cancel_icon)
-        cancel_button.clicked.connect(self.order_dialog.reject)
-        button_layout.addWidget(cancel_button)
-
-        layout.addLayout(button_layout)
-
     def load(self):
         config = get_config()
         self.plugin_exec_order = config.setting[EXEC_ORDER_KEY]
@@ -219,7 +127,7 @@ class PluginExecutionOrderOptionsPage(OptionsPage):
             msg = QtWidgets.QMessageBox(self)
             msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
             msg.setText(_("There were no installed metadata processing plugins found."))
-            msg.setWindowTitle(_(self.title_text))
+            msg.setWindowTitle(_("No Data"))
             msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
             msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
             msg.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
@@ -227,52 +135,9 @@ class PluginExecutionOrderOptionsPage(OptionsPage):
 
             return
 
-        self.tableview.blockSignals(True)
-        i = self.tableview.model.rowCount()
-        while i > 0:
-            i -= 1
-            self.tableview.model.removeRow(i)
-
-        for plugin in sorted(plugins, key=lambda i: i.priority, reverse=True):
-            plugin: PluginInformation
-            module_name, processor_type, function_name = plugin.key.split(':', 2)
-
-            column1 = QtGui.QStandardItem(plugin.name)
-            column1.setEditable(False)
-            column1.setDropEnabled(False)
-            column1.setToolTip(plugin.description)
-            column1.setData(plugin.key, QtCore.Qt.ItemDataRole.UserRole)
-
-            column2 = QtGui.QStandardItem(processor_type)
-            column2.setEditable(False)
-            column2.setDropEnabled(False)
-            column2.setTextAlignment(QtCore.Qt.AlignCenter)
-
-            column3 = QtGui.QStandardItem(function_name)
-            column3.setEditable(False)
-            column3.setDropEnabled(False)
-            column3.setToolTip(plugin.function_description)
-
-            self.tableview.model.appendRow([column1, column2, column3])
-
-        self.tableview.setCurrentIndex(self.tableview.model.index(0, 0))
-        self.tableview.blockSignals(False)
-
-        self._set_up_down_button_states()
-
-        # Show dialog and process result
-        if self.order_dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
-            self.plugin_exec_order = dict()
-            for idx in range(self.tableview.model.rowCount()):
-                item = self.tableview.model.item(idx, 0)
-                key = item.data(QtCore.Qt.ItemDataRole.UserRole)
-                priority = -1 - idx
-                self.plugin_exec_order[key] = priority
-
-    def _set_up_down_button_states(self):
-        row = self.tableview.currentIndex().row()
-        self.up_button.setDisabled(row < 1)
-        self.dn_button.setDisabled(row >= self.tableview.model.rowCount() - 1)
+        new_order, return_state = display_plugin_order_selector(parent=self, plugins=plugins)
+        if return_state:
+            self.plugin_exec_order = new_order
 
 
 register_options_page(PluginExecutionOrderOptionsPage)

--- a/picard/ui/options/plugin_execution_order.py
+++ b/picard/ui/options/plugin_execution_order.py
@@ -208,8 +208,11 @@ class PluginExecutionOrderOptionsPage(OptionsPage):
                 if module_name.startswith('picard.'):
                     continue
                 module_name = 'picard.plugins.' + module_name
-                name = getattr(sys.modules[module_name], 'PLUGIN_NAME', "Unknown Plugin") if module_name in sys.modules else "No Name"
-                module_desc = getattr(sys.modules[module_name], 'PLUGIN_DESCRIPTION', "Unknown Plugin") if module_name in sys.modules else "No description provided"
+                if module_name in sys.modules:
+                    name = getattr(sys.modules[module_name], 'PLUGIN_NAME', "No name provided")
+                    module_desc = getattr(sys.modules[module_name], 'PLUGIN_DESCRIPTION', "No description provided")
+                else:
+                    name = module_desc = "Unknown Plugin"
                 plugins.append(PluginInformation(key, name, markdown(module_desc), markdown(function_desc), priority))
 
         if not plugins:

--- a/picard/ui/plugin_order_selector.py
+++ b/picard/ui/plugin_order_selector.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections import namedtuple
+
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+
+from picard.ui import PicardDialog
+from picard.ui.util import StandardButton
+from picard.ui.widgets.orderabletableview import OrderableTableView
+
+
+PluginInformation = namedtuple('PluginInformation', ['key', 'name', 'description', 'function_description', 'priority'])
+
+
+class PluginOrderSelectorDialog(PicardDialog):
+    help_url = 'options_plugin_execution_order'
+
+    def __init__(
+        self, parent=None, plugins=None
+    ):
+        """Display dialog box to select the metadata processing plugins execution order.
+
+        Args:
+            parent ([type], optional): Parent of the QDialog object being created. Defaults to None.
+            plugins (list, optional): List of plugin items to order. Defaults to None.
+        """
+        super().__init__(parent)
+        self.plugins = plugins or []
+        self.plugin_exec_order = dict()
+
+        self.setWindowTitle(_("Plugin Metadata Processing Order"))
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self.setMinimumWidth(650)
+        self.layout = QtWidgets.QVBoxLayout(self)
+        # self.layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
+
+        instructions = QtWidgets.QLabel(
+            _(
+                "This displays the order in which the plugin metadata processing functions are executed "
+                "by Picard. You can change the order by moving the functions up or down by selecting "
+                "the funcion to move and then use the up or down button, or by using your mouse to "
+                "drag the function to the desired location in the list."
+            )
+        )
+        instructions.setWordWrap(True)
+        self.layout.addWidget(instructions)
+
+        self.tableview = OrderableTableView(self)
+
+        self.tableview.model.setHorizontalHeaderLabels(
+            [
+                _('Plugin Name'),
+                _('Processor'),
+                _('Method/Function Called'),
+            ]
+        )
+
+        for idx, width in enumerate([260, 70, 260]):
+            self.tableview.setColumnWidth(idx, width)
+
+        for idx, text in enumerate(
+            [
+                _("The name of the plugin"),
+                _("The type of metadata processor used (album or track)"),
+                _("The method or function within the plugin module that is called"),
+            ]
+        ):
+            self.tableview.model.horizontalHeaderItem(idx).setToolTip(text)
+
+        for plugin in sorted(self.plugins, key=lambda i: i.priority, reverse=True):
+            plugin: PluginInformation
+            _module_name, processor_type, function_name = plugin.key.split(':', 2)
+
+            column1 = QtGui.QStandardItem(plugin.name)
+            column1.setEditable(False)
+            column1.setDropEnabled(False)
+            column1.setToolTip(plugin.description)
+            column1.setData(plugin.key, QtCore.Qt.ItemDataRole.UserRole)
+
+            column2 = QtGui.QStandardItem(processor_type)
+            column2.setEditable(False)
+            column2.setDropEnabled(False)
+            column2.setTextAlignment(QtCore.Qt.AlignCenter)
+
+            column3 = QtGui.QStandardItem(function_name)
+            column3.setEditable(False)
+            column3.setDropEnabled(False)
+            column3.setToolTip(plugin.function_description)
+
+            self.tableview.model.appendRow([column1, column2, column3])
+
+        self.tableview.setCurrentIndex(self.tableview.model.index(0, 0))
+
+        self.tableview.selectionModel().selectionChanged.connect(self._set_up_down_button_states)
+        self.layout.addWidget(self.tableview)
+
+        self.button_layout = QtWidgets.QHBoxLayout()
+
+        # Move Label
+        move_label = QtWidgets.QLabel(_("Move row"))
+        self.button_layout.addWidget(move_label)
+
+        # Up button
+        self.up_button = QtWidgets.QToolButton()
+        up_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarShadeButton)
+        self.up_button.setIcon(up_icon)
+        self.up_button.setToolTip(_("Move selected plugin up"))
+        self.up_button.clicked.connect(self.tableview.move_row_up)
+        self.button_layout.addWidget(self.up_button)
+
+        # Down button
+        self.dn_button = QtWidgets.QToolButton()
+        dn_icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarUnshadeButton)
+        self.dn_button.setIcon(dn_icon)
+        self.dn_button.setToolTip(_("Move selected plugin down"))
+        self.dn_button.clicked.connect(self.tableview.move_row_down)
+        self.button_layout.addWidget(self.dn_button)
+
+        # spacer
+        spacer = QtWidgets.QSpacerItem(
+            20, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
+        )
+        self.button_layout.addItem(spacer)
+
+        self.buttonbox = QtWidgets.QDialogButtonBox(self)
+        self.buttonbox.setOrientation(QtCore.Qt.Orientation.Horizontal)
+        self.buttonbox.addButton(
+            StandardButton(StandardButton.OK), QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonbox.addButton(StandardButton(StandardButton.CANCEL),
+                                 QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
+
+        self.buttonbox.accepted.connect(self.accept)
+        self.buttonbox.rejected.connect(self.reject)
+        self.buttonbox.helpRequested.connect(self.show_help)
+
+        self.button_layout.addWidget(self.buttonbox)
+
+        self.layout.addLayout(self.button_layout)
+
+        self._set_up_down_button_states()
+
+    def _set_up_down_button_states(self):
+        row = self.tableview.currentIndex().row()
+        self.up_button.setDisabled(row < 1)
+        self.dn_button.setDisabled(row >= self.tableview.model.rowCount() - 1)
+
+    def get_updated_order(self):
+        plugin_exec_order = dict()
+        for idx in range(self.tableview.model.rowCount()):
+            item = self.tableview.model.item(idx, 0)
+            key = item.data(QtCore.Qt.ItemDataRole.UserRole)
+            priority = -1 - idx
+            plugin_exec_order[key] = priority
+        return plugin_exec_order
+
+
+def display_plugin_order_selector(**kwargs):
+    dialog = PluginOrderSelectorDialog(**kwargs)
+    result = dialog.exec_()
+    return (dialog.get_updated_order(), result == QtWidgets.QDialog.DialogCode.Accepted)

--- a/picard/ui/plugin_order_selector.py
+++ b/picard/ui/plugin_order_selector.py
@@ -55,7 +55,6 @@ class PluginOrderSelectorDialog(PicardDialog):
         self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setMinimumWidth(650)
         self.layout = QtWidgets.QVBoxLayout(self)
-        # self.layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
 
         instructions = QtWidgets.QLabel(
             _(
@@ -67,6 +66,8 @@ class PluginOrderSelectorDialog(PicardDialog):
         )
         instructions.setWordWrap(True)
         self.layout.addWidget(instructions)
+
+        self.table_layout = QtWidgets.QHBoxLayout()
 
         self.tableview = OrderableTableView(self)
 
@@ -115,13 +116,16 @@ class PluginOrderSelectorDialog(PicardDialog):
         self.tableview.setCurrentIndex(self.tableview.model.index(0, 0))
 
         self.tableview.selectionModel().selectionChanged.connect(self._set_up_down_button_states)
-        self.layout.addWidget(self.tableview)
 
-        self.button_layout = QtWidgets.QHBoxLayout()
+        self.button_layout = QtWidgets.QVBoxLayout()
 
-        # Move Label
-        move_label = QtWidgets.QLabel(_("Move row"))
-        self.button_layout.addWidget(move_label)
+        # spacers
+        self.spacer1 = QtWidgets.QSpacerItem(
+            0, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
+        self.spacer2 = QtWidgets.QSpacerItem(
+            0, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
 
         # Up button
         self.up_button = QtWidgets.QToolButton()
@@ -129,7 +133,6 @@ class PluginOrderSelectorDialog(PicardDialog):
         self.up_button.setIcon(up_icon)
         self.up_button.setToolTip(_("Move selected plugin up"))
         self.up_button.clicked.connect(self.tableview.move_row_up)
-        self.button_layout.addWidget(self.up_button)
 
         # Down button
         self.dn_button = QtWidgets.QToolButton()
@@ -137,13 +140,16 @@ class PluginOrderSelectorDialog(PicardDialog):
         self.dn_button.setIcon(dn_icon)
         self.dn_button.setToolTip(_("Move selected plugin down"))
         self.dn_button.clicked.connect(self.tableview.move_row_down)
-        self.button_layout.addWidget(self.dn_button)
 
-        # spacer
-        spacer = QtWidgets.QSpacerItem(
-            20, 0, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
-        )
-        self.button_layout.addItem(spacer)
+        self.button_layout.addItem(self.spacer1)
+        self.button_layout.addWidget(self.up_button)
+        self.button_layout.addWidget(self.dn_button)
+        self.button_layout.addItem(self.spacer2)
+
+        self.table_layout.addWidget(self.tableview)
+        self.table_layout.addLayout(self.button_layout)
+
+        self.layout.addLayout(self.table_layout)
 
         self.buttonbox = QtWidgets.QDialogButtonBox(self)
         self.buttonbox.setOrientation(QtCore.Qt.Orientation.Horizontal)
@@ -156,9 +162,7 @@ class PluginOrderSelectorDialog(PicardDialog):
         self.buttonbox.rejected.connect(self.reject)
         self.buttonbox.helpRequested.connect(self.show_help)
 
-        self.button_layout.addWidget(self.buttonbox)
-
-        self.layout.addLayout(self.button_layout)
+        self.layout.addWidget(self.buttonbox)
 
         self._set_up_down_button_states()
 

--- a/picard/ui/ui_options_plugin_execution_order.py
+++ b/picard/ui/ui_options_plugin_execution_order.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Automatically generated - don't edit.
+# Use `python setup.py build_ui` to update it.
+
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+
+class Ui_PluginExecutionOrderOptionsPage(object):
+    def setupUi(self, PluginExecutionOrderOptionsPage):
+        PluginExecutionOrderOptionsPage.setObjectName("PluginExecutionOrderOptionsPage")
+        PluginExecutionOrderOptionsPage.resize(413, 612)
+        self.vboxlayout = QtWidgets.QVBoxLayout(PluginExecutionOrderOptionsPage)
+        self.vboxlayout.setObjectName("vboxlayout")
+        self.label = QtWidgets.QLabel(PluginExecutionOrderOptionsPage)
+        font = QtGui.QFont()
+        font.setBold(True)
+        font.setWeight(75)
+        self.label.setFont(font)
+        self.label.setObjectName("label")
+        self.vboxlayout.addWidget(self.label)
+        self.description = QtWidgets.QLabel(PluginExecutionOrderOptionsPage)
+        self.description.setWordWrap(True)
+        self.description.setObjectName("description")
+        self.vboxlayout.addWidget(self.description)
+        self.horizontalLayout = QtWidgets.QHBoxLayout()
+        self.horizontalLayout.setContentsMargins(-1, 0, -1, -1)
+        self.horizontalLayout.setObjectName("horizontalLayout")
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        self.horizontalLayout.addItem(spacerItem)
+        self.edit_plugin_order = QtWidgets.QPushButton(PluginExecutionOrderOptionsPage)
+        self.edit_plugin_order.setObjectName("edit_plugin_order")
+        self.horizontalLayout.addWidget(self.edit_plugin_order)
+        self.vboxlayout.addLayout(self.horizontalLayout)
+        spacerItem1 = QtWidgets.QSpacerItem(20, 41, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        self.vboxlayout.addItem(spacerItem1)
+
+        self.retranslateUi(PluginExecutionOrderOptionsPage)
+        QtCore.QMetaObject.connectSlotsByName(PluginExecutionOrderOptionsPage)
+
+    def retranslateUi(self, PluginExecutionOrderOptionsPage):
+        _translate = QtCore.QCoreApplication.translate
+        self.label.setText(_("Plugin Execution Order"))
+        self.description.setText(_("TextLabel"))
+        self.edit_plugin_order.setText(_("Edit Execution Order…"))

--- a/picard/ui/widgets/orderabletableview.py
+++ b/picard/ui/widgets/orderabletableview.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025 Bob Swift
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from PyQt5 import (
+    QtGui,
+    QtWidgets,
+)
+
+
+class OrderableTableView(QtWidgets.QTableView):
+    """QListView widget allowing line reordering via moving the currently selected line
+    up or down one position, or via drag 'n' drop into the new position."""
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.verticalHeader().hide()
+        self.setSelectionBehavior(self.SelectRows)
+        self.setSelectionMode(self.SingleSelection)
+        self.setShowGrid(True)
+        self.setDragDropMode(self.InternalMove)
+        self.setDragDropOverwriteMode(False)
+
+        # Set our custom style - this draws the drop indicator across the whole row
+        self.setStyle(OrderableTableViewStyle())
+
+        # Set our custom model - this prevents row shifting
+        self.model = OrderableTableViewModel()
+        self.setModel(self.model)
+
+    def move_row_up(self):
+        """Moves the current row up one position"""
+        current_row = self.currentIndex().row()
+        if current_row < 1:
+            return
+        self._do_move(current_row, current_row - 1)
+
+    def move_row_down(self):
+        """Moves the current row down one position"""
+        current_row = self.currentIndex().row()
+        if current_row >= self.model.rowCount() - 1:
+            return
+        self._do_move(current_row, current_row + 1)
+
+    def _do_move(self, old_row, new_row):
+        current_item = self.model.takeRow(old_row)
+        self.model.insertRow(new_row, current_item)
+        self.setCurrentIndex(self.model.index(new_row, 0))
+
+
+class OrderableTableViewModel(QtGui.QStandardItemModel):
+    def dropMimeData(self, data, action, row, col, parent):
+        """Always move the entire row, and don't allow column shifting"""
+        return super().dropMimeData(data, action, row, 0, parent)
+
+
+class OrderableTableViewStyle(QtWidgets.QProxyStyle):
+    def drawPrimitive(self, element, option, painter, widget=None):
+        """Draw a line across the entire row rather than just the column we're hovering over"""
+        if element == self.PE_IndicatorItemViewItemDrop and not option.rect.isNull():
+            option_new = QtWidgets.QStyleOption(option)
+            option_new.rect.setLeft(0)
+            if widget:
+                option_new.rect.setRight(widget.width())
+            option = option_new
+        super().drawPrimitive(element, option, painter, widget)

--- a/ui/options_plugin_execution_order.ui
+++ b/ui/options_plugin_execution_order.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PluginExecutionOrderOptionsPage</class>
+ <widget class="QWidget" name="PluginExecutionOrderOptionsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>413</width>
+    <height>612</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Plugin Execution Order</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="description">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="edit_plugin_order">
+       <property name="text">
+        <string>Edit Execution Order…</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>41</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:  Adds ability for the user to set the execution order of metadata processing plugins.

# Problem

Currently each plugin is registered with a priority (1-100) which sets the order of execution.  Most plugin authors (myself included) don't pay sufficient attention to this, which can result in plugins being executed in the wrong order, yielding undesired results.

This is the Picard v2.x version of the change related to PICARD-3104 which is marked for Picard v3 implementation.

I wasn't sure if we wanted to include this new functionality in the final release version of Picard 2.x, but even if we don't it can serve as a possible model for the Picard 3 implementation.

* JIRA ticket (_optional_): PICARD-3121

# Solution

Provide a new dialog from the Options... > Plugins page to provide a list of the registered metadata processor plugins, which can be rearranged to determine the plugin execution order.  The execution order is stored in a new user setting.

Modify the `PluginFunctions` class to use the new execution order setting.

# Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

We need to determine if we want to include this setting in the user profiles.  Currently we have no plugin settings as part of the option profiles, and I am reluctant to add this one.