### PR TITLE
Force pytest to run pre-push instead of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -45,5 +46,6 @@ repos:
         entry: uv run --frozen pytest -n auto -x
         language: python
         types: [python]
+        stages: [pre-push]
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

I personally find the pytest run on every commit a bit annoying. This makes every commit take quite some time, while I can easily run pytest on demand and do so during development anyway. I'd rather prefer to run pytest mandatorily pre-push.

This PR changes the pre-commit configuration to setup both a pre-commit and pre-push hook and run pytest only pre-push. All other tasks will be run both pre-commit and pre-push.

One needs to re-run `pre-commit install` to apply the changes.

This is now a push can look like with this config:

```
(picard) phw@bender ~/devel/musicbrainz/picard % git push phw
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
mixed line ending........................................................Passed
ruff (legacy alias)..................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Sync uv.lock with pyproject.toml.........................................Passed
pip-compile requirements.txt.............................................Passed
pip-compile requirements-build.txt.......................................Passed
pip-compile requirements-dev.txt.........................................Passed
pip-compile requirements-plugins.txt.....................................Passed
Run pytest...............................................................Passed
Objekte aufzählen: 5, fertig.
Zähle Objekte: 100% (5/5), fertig.
Delta-Kompression verwendet bis zu 16 Threads.
Komprimiere Objekte: 100% (3/3), fertig.
Schreibe Objekte: 100% (3/3), 1021 Bytes | 1021.00 KiB/s, fertig.
Gesamt 3 (Delta 2), Wiederverwendet 0 (Delta 0), Pack wiederverwendet 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: 
remote: Create a pull request for 'test' on GitHub by visiting:
remote:      https://github.com/phw/picard/pull/new/test
remote: 
To github.com:phw/picard.git
 * [new branch]          test -> test
 ```