### PR TITLE
Explicitly set the "strict" parameter for builtin zip()

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -670,7 +670,7 @@ class ID3File(File):
             remaining_ms = ms % 1000
             return f"{minutes:02d}:{seconds:02d}.{remaining_ms:03d}"
 
-        all_lyrics, milliseconds = zip(*text)
+        all_lyrics, milliseconds = zip(*text, strict=False)
         milliseconds = (*milliseconds, length * 1000)
         first_timestamp = milliseconds_to_timestamp(milliseconds[0])
         lrc_lyrics = [f"[{first_timestamp}]"]

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -143,7 +143,7 @@ class TagsFromFileNamesDialog(PicardDialog):
         headers = [_("File Name")] + list(map(display_tag_name, columns))
         self.ui.files.setColumnCount(len(headers))
         self.ui.files.setHeaderLabels(headers)
-        for item, file in zip(self.items, self.files):
+        for item, file in zip(self.items, self.files, strict=True):
             matches = expression.match_file(file.filename)
             for i, column in enumerate(columns):
                 values = matches.get(column, [])

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -83,7 +83,7 @@ def _parse_linux_cdrom_info(f):
             if line.startswith(CAN_PLAY_AUDIO):
                 drive_audio_caps = [v == '1' for v in line[len(CAN_PLAY_AUDIO) :].split()]
                 break
-    yield from zip(drive_names, drive_audio_caps)
+    yield from zip(drive_names, drive_audio_caps, strict=False)
 
 
 if IS_WIN:

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -801,7 +801,7 @@ class ID3FileTest(PicardTestCase):
             "[00:00.000]<00:00.000>Test empty lyrics at the end\n[00:01.000]<00:01.000>",
             "[00:00.000]<00:00.000>Test timestamp estimation<00:01.000>in the\n[00:01.352]last phrase",
         )
-        for sylt, correct_lrc in zip(sylts, correct_lrcs):
+        for sylt, correct_lrc in zip(sylts, correct_lrcs, strict=True):
             lrc = self.file._parse_sylt_text(sylt, 2)
             self.assertEqual(lrc, correct_lrc)
 
@@ -830,6 +830,6 @@ class ID3FileTest(PicardTestCase):
             [("input\nTest invalid", 0), ("input", 1000)],
             [],
         )
-        for lrc, correct_sylt in zip(lrcs, correct_sylts):
+        for lrc, correct_sylt in zip(lrcs, correct_sylts, strict=True):
             sylt = self.file._parse_lrc_text(lrc)
             self.assertEqual(sylt, correct_sylt)

--- a/test/test_tagdiff.py
+++ b/test/test_tagdiff.py
@@ -249,7 +249,7 @@ class TestTagDiff(PicardTestCase):
 
     @staticmethod
     def _special_handler(old, new):
-        for old_value, new_value in zip(old, new):
+        for old_value, new_value in zip(old, new, strict=True):
             try:
                 if abs(int(old_value) - int(new_value)) > 2000:
                     return True


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Explicitly set the "strict" parameter for builtin [zip()](https://docs.python.org/3/library/functions.html#zip). This parameter is available since Python 3.10, and Ruff wants it to be used in Python 3.10 mode. Which makes sense to explicitly state the behavior.

Since our current minimum supported version is also 3.10 we should also run Ruff in Python 3.10 mode.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Use strict=True for code we internally control. Use strict=False for external data, where we have no control over the input. Specifically for the case of reading `/proc/sys/dev/cdrom/info` on Linux the input should be equal amount of elements. But if it wouldn't be it would still be better to return all devices that had both entries.

For the ID3 SYLT case we could maybe also be strict, but again I thought it better to be more relaxed here and don't change existing behavior.
