### PR TITLE
PICARD-3109: Add in missing profile when saving settings

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -439,7 +439,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 self._show_page_error(page, e)
                 return
 
-        for page in sorted(self.loaded_pages, key=lambda x: x.SORT_ORDER):
+        for page in sorted(self.loaded_pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
             try:
                 page.save()
             except Exception as e:

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -14,7 +14,7 @@
 # Copyright (C) 2017 Suhas
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2021 Gabriel Ferreira
-# Copyright (C) 2021-2023 Bob Swift
+# Copyright (C) 2021-2023, 2025 Bob Swift
 # Copyright (C) 2024 Giorgio Fontanive
 #
 # This program is free software; you can redistribute it and/or
@@ -439,14 +439,13 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 self._show_page_error(page, e)
                 return
 
-        for page in self.loaded_pages:
+        for page in sorted(self.loaded_pages, key=lambda x: x.SORT_ORDER):
             try:
                 page.save()
             except Exception as e:
                 log.exception("Failed saving options page %r", page)
                 self._show_page_error(page, e)
                 return
-
         super().accept()
 
     def _show_page_error(self, page, error):

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -61,7 +61,9 @@ class ProfilesOptionsPage(OptionsPage):
     NAME = 'profiles'
     TITLE = N_("Option Profiles")
     PARENT = None
-    SORT_ORDER = 10
+    # Set SORT_ORDER to negative number to ensure the profiles page is saved first to avoid
+    # an error when saving settings to a new profile that has been marked as enabled.
+    SORT_ORDER = -100
     ACTIVE = True
     HELP_URL = "/config/options_profiles.html"
 


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Option saving would fail when saving a new enabled profile with settings selected.  Steps to reproduce:

1. Remove all profiles and save the changes by clicking "Make It So!".
2. Re-open the option settings.  Confirm that there are no profiles.
3. Create a new profile with one or more profile settings selected.
4. Enable the new profile.
5. Close the option settings by clicking "Make It So!"
6. The operation will fail with a `KeyError` because the system is trying to save the values to a profile that has not yet been added to the config.settings.

* JIRA ticket (_optional_): PICARD-3109

# Solution

Save the `profiles` page before any of the other option pages.  This will ensure that the proper profile keys are in place when the other option settings are saved.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
