### PR TITLE
Force `profiles` options page to always save first

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -481,7 +481,13 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 self._show_page_error(page, e)
                 return
 
-        for page in sorted(self.loaded_pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
+        # Force the `profiles` page to always save first to avoid an error when
+        # saving settings to a new profile that has been marked as enabled.
+        pages = [
+            self.get_page('profiles'),
+        ]
+        pages.extend(x for x in sorted(self.loaded_pages, key=lambda p: (p.SORT_ORDER, p.NAME)) if x.NAME != 'profiles')
+        for page in pages:
             try:
                 page.save()
             except Exception as e:

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -61,9 +61,7 @@ class ProfilesOptionsPage(OptionsPage):
     NAME = 'profiles'
     TITLE = N_("Option Profiles")
     PARENT = None
-    # Set SORT_ORDER to negative number to ensure the profiles page is saved first to avoid
-    # an error when saving settings to a new profile that has been marked as enabled.
-    SORT_ORDER = -100
+    SORT_ORDER = 10
     ACTIVE = True
     HELP_URL = "/config/options_profiles.html"
 


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Using the options pages `SORT_ORDER` attribute to force the `profiles` page to save first also resulted in the `profiles` page appearing first in the Options tree.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

Create a page sort order that always saves the `profiles` page first, independent of the `SORT_ORDER` attributes used to place the pages in the Options tree.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
