### PR TITLE
Clarify label: 'Move additional files and/or folders'

### DIFF
--- a/picard/ui/forms/ui_options_renaming.py
+++ b/picard/ui/forms/ui_options_renaming.py
@@ -156,7 +156,7 @@ class Ui_RenamingOptionsPage(object):
         self.move_files.setTitle(_("Move files when saving"))
         self.label.setText(_("Destination directory:"))
         self.move_files_to_browse.setText(_("Browse…"))
-        self.move_additional_files.setText(_("Move additional files (case insensitive):"))
+        self.move_additional_files.setText(_("Move additional files and subfolders (case insensitive):"))
         self.delete_empty_dirs.setText(_("Delete empty directories"))
         self.rename_files.setText(_("Rename files when saving"))
         self.label_2.setText(_("Selected file naming script:"))


### PR DESCRIPTION
# Summary
* This is a…
  * [X] Minor / simple change (like a typo)
* **Describe this change in 1-2 sentences**: Clarifies the "File Naming" preferences label: 'Move additional files' to notate that it supports moving folders as well.

# Problem
I was unaware "move additional files" could move folders as well. I came here to add that functionality, and then realized it already worked this way. I also found others confused, since this is a minor documentation point and not really called out anywhere. See https://www.reddit.com/r/musichoarder/comments/q4zbdy/how_to_move_subfolders_when_renaming_in_picard/

# Solution
Update the label to be more descriptive. I didn't find documentation updates needed; let me know if I can help there too.

# Action
I updated the .ui file picard/ui/forms/ui_options_renaming.py using QT Design Studio and rebuilt it using setup.py build_ui.

Additional actions required:
* [?] Update Picard [documentation](https://github.com/metabrainz/picard-docs)