### PR TITLE
PICARD-2300: Check for setColorScheme for Qt <6.8 compatibility

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -97,7 +97,11 @@ class UiTheme(Enum):
 
 def get_style_hints() -> QtGui.QStyleHints | None:
     """Get style hints from QGuiApplication, returning None if unavailable."""
-    return QtGui.QGuiApplication.styleHints()
+    style_hints = QtGui.QGuiApplication.styleHints()
+    # setColorScheme was added in Qt 6.8
+    if not hasattr(style_hints, 'setColorScheme'):
+        return None
+    return style_hints
 
 
 def _style_hints_available() -> bool:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2300
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

A small addition to #2693 . this introduced the usage of `QStyleHints.setColorScheme`, which was only added in Qt 6.8 (see https://doc.qt.io/qt-6/qstylehints.html#setColorScheme).

We have Qt 6.6.1 currently defined as the minimum. I think something like the styles is no reason to not maintain compatibility with older versions.

# Solution

Check for existance of `QStyleHints.setColorScheme`. If this is not available then the system is handled as having no style hints.