### PR TITLE
PICARD-150: Set default filter columns for tree view filters

### DIFF
--- a/picard/const/defaults.py
+++ b/picard/const/defaults.py
@@ -169,3 +169,5 @@ DEFAULT_COVER_RESIZE_MODE = ResizeModes.MAINTAIN_ASPECT_RATIO
 DEFAULT_COVER_CONVERTING_FORMAT = 'JPEG'
 
 DEFAULT_QUICK_MENU_ITEMS = ['save_images_to_tags', 'save_images_to_files']
+
+DEFAULT_FILTER_COLUMNS = ['album', 'title', 'albumartist', 'artist']

--- a/picard/options.py
+++ b/picard/options.py
@@ -52,6 +52,7 @@ from picard.const.defaults import (
     DEFAULT_COVER_RESIZE_MODE,
     DEFAULT_CURRENT_BROWSER_PATH,
     DEFAULT_DRIVES,
+    DEFAULT_FILTER_COLUMNS,
     DEFAULT_FPCALC_THREADS,
     DEFAULT_LOCAL_COVER_ART_REGEX,
     DEFAULT_LONG_PATHS,
@@ -144,8 +145,8 @@ BoolOption('persist', 'view_toolbar', True)
 BoolOption('persist', 'view_filterbar', False)
 BoolOption('persist', 'window_maximized', False)
 Option('persist', 'window_state', QtCore.QByteArray())
-ListOption('persist', 'filters_FileTreeView', None)
-ListOption('persist', 'filters_AlbumTreeView', None)
+ListOption('persist', 'filters_FileTreeView', DEFAULT_FILTER_COLUMNS)
+ListOption('persist', 'filters_AlbumTreeView', DEFAULT_FILTER_COLUMNS)
 
 # picard/ui/metadatabox.py
 #


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-150
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is extending #2668 to add default columns for the tree view filter. I found that starting with a blank config this filtering is confusing to use. Once you enable the filtering in the View menu it shows the search input. But entering text there doesn't do anything, unless you also select some columns to filter by.

I think we need some default, so filtering works by default for the common cases.

# Solution
By default filter by album, title, albumartist and artist