### PR TITLE
Use consistent parameter names in FileDialog static helpers

### DIFF
--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -271,7 +271,7 @@ class ScriptSerializer:
         filename, file_type = FileDialog.getOpenFileName(
             parent=parent,
             caption=dialog_title,
-            dir=default_script_directory,
+            directory=default_script_directory,
             filter=dialog_file_types,
         )
         if not filename:

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -936,7 +936,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         formats.insert(1, _("All files") + " (*)")
         files, _filter = FileDialog.getOpenFileNames(
             parent=self,
-            dir=current_directory,
+            directory=current_directory,
             filter=";;".join(formats),
         )
         if files:
@@ -953,7 +953,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if not config.setting['allow_multi_dirs_selection']:
             directory = FileDialog.getExistingDirectory(
                 parent=self,
-                dir=current_directory,
+                directory=current_directory,
             )
             if directory:
                 dir_list.append(directory)

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -126,7 +126,7 @@ class FingerprintingOptionsPage(OptionsPage):
     def acoustid_fpcalc_browse(self):
         path, _filter = FileDialog.getOpenFileName(
             parent=self,
-            dir=self.ui.acoustid_fpcalc.text(),
+            directory=self.ui.acoustid_fpcalc.text(),
         )
         if path:
             path = os.path.normpath(path)

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -191,7 +191,7 @@ class InterfaceOptionsPage(OptionsPage):
         item = self.ui.starting_directory_path
         path = FileDialog.getExistingDirectory(
             parent=self,
-            dir=item.text(),
+            directory=item.text(),
         )
         if path:
             path = os.path.normpath(path)

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -168,7 +168,7 @@ class InterfaceToolbarOptionsPage(OptionsPage):
         item = self.ui.starting_directory_path
         path = FileDialog.getExistingDirectory(
             parent=self,
-            dir=item.text(),
+            directory=item.text(),
         )
         if path:
             path = os.path.normpath(path)

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -144,7 +144,7 @@ class MaintenanceOptionsPage(OptionsPage):
     def _dialog_autobackup_dir_browse(self):
         path = FileDialog.getExistingDirectory(
             parent=self,
-            dir=self.get_current_autobackup_dir(),
+            directory=self.get_current_autobackup_dir(),
         )
         if path:
             self.set_current_autobackup_dir(path)
@@ -244,7 +244,7 @@ class MaintenanceOptionsPage(OptionsPage):
         filename, file_type = FileDialog.getSaveFileName(
             parent=self,
             caption=_("Backup Configuration File"),
-            dir=default_path,
+            directory=default_path,
             filter=self._get_dialog_filetypes(ext),
         )
         return filename
@@ -322,7 +322,7 @@ class MaintenanceOptionsPage(OptionsPage):
         filename, file_type = FileDialog.getOpenFileName(
             parent=self,
             caption=_("Select Configuration File to Load"),
-            dir=directory,
+            directory=directory,
             filter=self._get_dialog_filetypes(ext),
         )
         return filename

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -652,7 +652,7 @@ class PluginsOptionsPage(OptionsPage):
     def open_plugins(self):
         files, _filter = FileDialog.getOpenFileNames(
             parent=self,
-            dir=QtCore.QDir.homePath(),
+            directory=QtCore.QDir.homePath(),
             filter="Picard plugin (*.py *.pyc *.zip)",
         )
         if files:

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -290,7 +290,7 @@ class RenamingOptionsPage(OptionsPage):
     def move_files_to_browse(self):
         path = FileDialog.getExistingDirectory(
             parent=self,
-            dir=self.ui.move_files_to.text(),
+            directory=self.ui.move_files_to.text(),
         )
         if path:
             path = os.path.normpath(path)

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -79,52 +79,52 @@ class FileDialog(QtWidgets.QFileDialog):
         super().__init__(parent=parent, caption=caption, directory=directory, filter=filter)
 
     @staticmethod
-    def getSaveFileName(parent=None, caption="", dir="", filter="", selectedFilter="", options=None):
+    def getSaveFileName(parent=None, caption="", directory="", filter="", initialFilter="", options=None):
         caption = _filedialog_caption(caption, _("Select a target file"))
         options = _filedialog_options(options)
         return QtWidgets.QFileDialog.getSaveFileName(
             parent=parent,
             caption=caption,
-            directory=dir,
+            directory=directory,
             filter=filter,
-            initialFilter=selectedFilter,
+            initialFilter=initialFilter,
             options=options,
         )
 
     @staticmethod
-    def getOpenFileName(parent=None, caption="", dir="", filter="", selectedFilter="", options=None):
+    def getOpenFileName(parent=None, caption="", directory="", filter="", initialFilter="", options=None):
         caption = _filedialog_caption(caption, _("Select a file"))
         options = _filedialog_options(options)
         return QtWidgets.QFileDialog.getOpenFileName(
             parent=parent,
             caption=caption,
-            directory=dir,
+            directory=directory,
             filter=filter,
-            initialFilter=selectedFilter,
+            initialFilter=initialFilter,
             options=options,
         )
 
     @staticmethod
-    def getOpenFileNames(parent=None, caption="", dir="", filter="", selectedFilter="", options=None):
+    def getOpenFileNames(parent=None, caption="", directory="", filter="", initialFilter="", options=None):
         caption = _filedialog_caption(caption, _("Select one or more files"))
         options = _filedialog_options(options)
         return QtWidgets.QFileDialog.getOpenFileNames(
             parent=parent,
             caption=caption,
-            directory=dir,
+            directory=directory,
             filter=filter,
-            initialFilter=selectedFilter,
+            initialFilter=initialFilter,
             options=options,
         )
 
     @staticmethod
-    def getExistingDirectory(parent=None, caption="", dir="", options=None):
+    def getExistingDirectory(parent=None, caption="", directory="", options=None):
         caption = _filedialog_caption(caption, _("Select a directory"))
         options = _filedialog_options(options, default=QtWidgets.QFileDialog.Option.ShowDirsOnly)
         return QtWidgets.QFileDialog.getExistingDirectory(
             parent=parent,
             caption=caption,
-            directory=dir,
+            directory=directory,
             options=options,
         )
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

FileDialog re-implements static helpers of QFileDialog. Use the same parameter names as the upstream implementation.

