### PR TITLE
Added script for easy .ui file compilation in plugins

### DIFF
--- a/scripts/plugin_compile_ui.py
+++ b/scripts/plugin_compile_ui.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Convert Qt6 .ui files into Python files for use by Picard plugins.
+
+Usage:
+    plugin_compile_ui.py --help
+    plugin_compile_ui.py <ui_file>
+
+Options:
+    -h, --help   show this help message and exit
+    --force, -f  Force compilation even if up-to-date
+
+Examples:
+    # Compile ui_options.ui to ui_options.py
+    plugin_compile_ui.py /path/to/plugin/ui_options.ui
+"""
+
+import argparse
+from io import StringIO
+import os
+from pathlib import Path
+import re
+import sys
+
+from PyQt6 import uic
+
+
+def compile_ui(ui_file: Path, py_file: Path) -> None:
+    print(f"compiling {ui_file} -> {py_file}")
+    tmp_out = StringIO()
+    uic.compileUi(str(ui_file), tmp_out)
+    output = tmp_out.getvalue()
+    output = rewrite_ui_code(output)
+    with open(py_file, "w") as f:
+        f.write(output)
+
+
+def newer(file1: Path, file2: Path) -> bool:
+    """Returns True, if file1 has been modified after file2"""
+    if not file2.exists():
+        return True
+    return os.path.getmtime(file1) > os.path.getmtime(file2)
+
+
+replacements = (
+    (re.compile(r'(from PyQt6.*)'), r'\1\n\nfrom picard.plugin3 import PluginApi'),
+    (
+        re.compile(r'QtCore\.QCoreApplication.translate'),
+        'PluginApi.get_api().tr',
+    ),
+    (re.compile(r'\b_translate\(.*?, (.*?)(?:, None)?\)'), r'_translate(\1)'),
+)
+
+
+def rewrite_ui_code(ui_code: str) -> str:
+    for pattern, replace in replacements:
+        ui_code = pattern.sub(replace, ui_code)
+
+    return ui_code
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert Qt6 .ui files into Python files for use by Picard plugins.')
+    parser.add_argument('ui_file', help='Path to a .ui file')
+    parser.add_argument('--force', '-f', action='store_true', help='Force compilation even if up-to-date')
+    args = parser.parse_args()
+
+    ui_file = Path(args.ui_file)
+    py_file = ui_file.parent.joinpath(os.path.splitext(ui_file)[0] + '.py')
+
+    if not ui_file.exists():
+        print(f"File {ui_file} does not exist.")
+        sys.exit(1)
+
+    if newer(ui_file, py_file) or args.force:
+        compile_ui(ui_file, py_file)
+    else:
+        print(f"skipping {ui_file} -> {py_file}: up to date")
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This also handles the translation system and allows easy translation of UI labels with the plugin3 translation system.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

If plugins ship Qt designer .ui files (e.g. for option pages) those needs to be converted to Python code. For plugin authors this should be a simple process.

# Solution
This PR adds a `plugin_compile_ui.py` script to handle two things:

1. Generally simplify the process
2. Rewrite the resulting Python code to use the plugin3 translation system

Plugin authors should use the translation keys instead of actual text when designing the .ui file, e.g. like this:

<img width="1102" height="1064" alt="image" src="https://github.com/user-attachments/assets/b235d6c1-32f6-4f9c-883c-78270ecad9a8" />

The .ui file can then be compiled to Python like this:

```
plugin_compile_ui.py ui_options.ui
```

The resulting code directly uses `PluginApi.tr` for translations.

Example: https://git.sr.ht/~phw/picard-plugin-xqaf/tree/main/item/ui_options.py