### PR TITLE
Add `editing` flag to `ScriptParser`

### DIFF
--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -229,6 +229,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         webservice_manager.authenticationRequired.connect(self._show_password_dialog)
         webservice_manager.proxyAuthenticationRequired.connect(self._show_proxy_dialog)
 
+        self._options_open = False
+
     def register_suspend_while_loading(self, on_enter=None, on_exit=None):
         funcs = SuspendWhileLoadingFuncs(on_enter=on_enter, on_exit=on_exit)
         self._suspend_while_loading_funcs.append(funcs)
@@ -1174,6 +1176,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def show_options(self, page=None):
         ReadTheDocs.update_documentation_items()  # Retry updates if required
+        self._options_open = True
         options_dialog = OptionsDialog.show_instance(page, self)
         options_dialog.finished.connect(self._options_closed)
         if self.script_editor_dialog is not None:
@@ -1184,6 +1187,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return options_dialog
 
     def _options_closed(self):
+        self._options_open = False
         if self.script_editor_dialog is not None:
             self.open_file_naming_script_editor()
             self.script_editor_dialog.show()
@@ -1192,6 +1196,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._make_profile_selector_menu()
         self._make_script_selector_menu()
         self._make_settings_selector_menu()
+
+    def is_editing_scripts(self) -> bool:
+        return self._options_open or self.script_editor_dialog is not None
 
     def show_help(self):
         webbrowser2.open('documentation')


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: This adds an `editing` flag to the `ScriptParser` class to indicate that the script is currently being edited.

# Problem

There may be occasions when a script function should not execute some of its code during the development of a script containing the function.  An example is https://github.com/rdswift/picard-plugin-file-writer which would actually write to the file when the function is entered into the script under development.

* JIRA ticket (_optional_): PICARD-XXX

# Solution

~~Add an `editing` boolean attribute (defaulting to False) to the `ScriptParser` class that can be checked within the script function.  Set this value to true for the parsers defined during tagging or file naming script development.  This new attribute is not checked in any internal script function definitions, so has no effect on existing code.~~

Changed to an alternate approach, which is actually much simpler. This provides an `is_editing_scripts()` method to `MainWindow` which returns True if either the Options window or the File Naming Script Editor window is open. It can be checked easily from the api using `api.tagger.window.is_editing_scripts()`.

# Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
