### PR TITLE
PICARD-3160: custom columns bug fixes

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -389,7 +389,11 @@ class UnclusteredFiles(Cluster):
 class ClusterList(list, Item):
     """A list of clusters."""
 
-    def __init__(self):
+    def __init__(self, name=None):
+        if not name:
+            self._name = _('Clusters')
+        else:
+            self._name = name
         super().__init__()
 
     def __hash__(self):
@@ -399,6 +403,12 @@ class ClusterList(list, Item):
         # An existing Item object should not be considered False, even if it
         # is based on a list.
         return True
+
+    def column(self, column: str) -> str:
+        if column == 'title':
+            return '%s (%d)' % (self._name, len(self))
+        else:
+            return ''
 
     def iterfiles(self, save=False):
         for cluster in self:

--- a/picard/item.py
+++ b/picard/item.py
@@ -64,6 +64,10 @@ class Item:
     def ui_item(self, value: 'TreeItem | None'):
         self._ui_item = weakref.ref(value) if value is not None else None
 
+    def column(self, column: str) -> str:
+        """Subclasses should return a display value for the specified column."""
+        return ''
+
     @property
     def can_save(self) -> bool:
         """Return if this object can be saved."""

--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -45,7 +45,10 @@ from PyQt6 import (  # type: ignore[unresolved-import]
 from picard.i18n import gettext as _
 
 from picard.ui import PicardDialog
-from picard.ui.itemviews.custom_columns.column_controller import ColumnController, analyze_first_invalid
+from picard.ui.itemviews.custom_columns.column_controller import (
+    ColumnController,
+    analyze_first_invalid,
+)
 from picard.ui.itemviews.custom_columns.column_form_handler import ColumnFormHandler
 from picard.ui.itemviews.custom_columns.column_spec_service import ColumnSpecService
 from picard.ui.itemviews.custom_columns.shared import (
@@ -262,10 +265,6 @@ class CustomColumnsManagerDialog(PicardDialog):
                     return
             # If reply is Discard, just continue without committing
 
-        # Only commit if there are no uncommitted changes (normal case)
-        if not self._has_uncommitted_changes:
-            self._commit_form_to_model()
-
         # Apply changes and check if successful
         if not self._on_apply():
             return  # Don't close dialog if apply failed
@@ -386,7 +385,6 @@ class CustomColumnsManagerDialog(PicardDialog):
 
     def _on_form_changed(self, *args) -> None:  # type: ignore[no-untyped-def]
         """Handle form changes by automatically updating the selected row."""
-        del args
         if self._populating:
             return
         self._has_uncommitted_changes = True
@@ -561,7 +559,9 @@ class CustomColumnsManagerDialog(PicardDialog):
 
     def _on_apply(self) -> bool:
         """Validate, persist, and register custom column specifications."""
-        self._commit_form_to_model()
+        # Only commit if there are no uncommitted changes (normal case)
+        if not self._has_uncommitted_changes:
+            self._commit_form_to_model()
 
         # Validate specs before persisting
         all_specs = self._model.specs()

--- a/picard/ui/widgets/checkboxmenuitem.py
+++ b/picard/ui/widgets/checkboxmenuitem.py
@@ -76,7 +76,8 @@ class CheckboxMenuItem(QtWidgets.QWidget):
         event.accept()
 
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
-        self.checkbox.toggle()
+        if self.checkbox.isDown():
+            self.checkbox.toggle()
         self.checkbox.setDown(False)
         event.accept()
 

--- a/picard/ui/widgets/configurablecolumnsheader.py
+++ b/picard/ui/widgets/configurablecolumnsheader.py
@@ -206,7 +206,7 @@ class ConfigurableColumnsHeader(LockableHeaderView):
             dlg.exec()
 
         manage_action = QtGui.QAction(_("Manage custom columns…"), menu)
-        manage_action.setEnabled(not self.is_locked and CustomColumnsManagerDialog is not None)
+        manage_action.setEnabled(not self.is_locked)
         manage_action.triggered.connect(_open_manager)
         menu.addAction(manage_action)
         return manage_action
@@ -234,7 +234,7 @@ class ConfigurableColumnsHeader(LockableHeaderView):
             for checkbox in column_checkboxes:
                 checkbox.setEnabled(not is_locked)
             restore_action.setEnabled(not is_locked)
-            manage_action.setEnabled(not is_locked and CustomColumnsManagerDialog is not None)
+            manage_action.setEnabled(not is_locked)
 
         return _on_lock_toggled
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3160
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This fixes the two issues reported in PICARD-3160


# Solution

1. After accepting the custom  columns config dialog, the "Clusters" special item lost its title.

The main cause was "Clusters" being a `ClusterList` object, and it had special handling for setting the text. Unified this by introducing `ClisterList.column` and a `ClisterList` ui item class. This allowed removing the special handling and have Clusters treated mostly like any other item.


2. The columns context menu toggled the first item

This was caused by the mouse release even after opening the context menu. This mouse release already caused the `CheckboxMenuItem` to toggle. Updated the implementation to only toggle if the item was previously "down" (pressed).

3. Also some minor code cleanup in columns implementation