### PR TITLE
Github Actions: do not compile libgit2 for Windows and macOS

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -46,12 +46,6 @@ jobs:
         echo "TARGET_ARCH=$(uname -m)" >> $GITHUB_ENV
         mkdir artifacts
         python3 -m pip install --upgrade pip setuptools wheel
-    - name: Install libgit2
-      run: |
-        brew install libgit2
-        echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-        echo "CFLAGS=-I$(brew --prefix)/include" >> $GITHUB_ENV
-        echo "LDFLAGS=-L$(brew --prefix)/lib" >> $GITHUB_ENV
     - name: Install dependencies
       run: uv sync --group build --group dev --extra plugins
       env:

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -96,9 +96,6 @@ jobs:
       env:
         GETTEXT_VERSION: 0.22.4
         GETTEXT_SHA256SUM: 220068ac0b9e7aedda03534a3088e584640ac1e639800b3a0baa9410aa6d012a
-    - name: Install libgit2 (macOS)
-      if: runner.os == 'macOS'
-      run: brew install libgit2
     - name: Install dependencies (Linux)
       if: runner.os == 'linux'
       run: |

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -99,14 +99,6 @@ jobs:
     - name: Install libgit2 (macOS)
       if: runner.os == 'macOS'
       run: brew install libgit2
-    - name: Install libgit2 (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        vcpkg install libgit2:x64-windows
-        $vcpkgRoot = "C:\vcpkg\installed\x64-windows"
-        echo "INCLUDE=$vcpkgRoot\include;$env:INCLUDE" >> $env:GITHUB_ENV
-        echo "LIB=$vcpkgRoot\lib;$env:LIB" >> $env:GITHUB_ENV
-      shell: pwsh
     - name: Install dependencies (Linux)
       if: runner.os == 'linux'
       run: |

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -54,14 +54,6 @@ jobs:
       env:
         GETTEXT_VERSION: 0.22.4
         GETTEXT_SHA256SUM: 220068ac0b9e7aedda03534a3088e584640ac1e639800b3a0baa9410aa6d012a
-    - name: Install libgit2
-      run: |
-        vcpkg install libgit2:x64-windows
-        $vcpkgRoot = "C:\vcpkg\installed\x64-windows"
-        echo "INCLUDE=$vcpkgRoot\include;$env:INCLUDE" >> $env:GITHUB_ENV
-        echo "LIB=$vcpkgRoot\lib;$env:LIB" >> $env:GITHUB_ENV
-        echo "LIBPATH=$vcpkgRoot\lib;$env:LIBPATH" >> $env:GITHUB_ENV
-      shell: pwsh
     - name: Install dependencies
       run: uv sync --group build --group dev --extra plugins
     - name: Patch build version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,9 +39,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gettext libegl1
-    - name: Install libgit2 (macOS)
-      if: runner.os == 'macOS'
-      run: brew install libgit2
     - name: Install gettext (Windows)
       if: runner.os == 'Windows'
       run: |
@@ -120,9 +117,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gettext libegl1 libgit2-dev
-    - name: Install libgit2 (macOS)
-      if: runner.os == 'macOS'
-      run: brew install libgit2
     - name: Install gettext (Windows)
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,14 +42,6 @@ jobs:
     - name: Install libgit2 (macOS)
       if: runner.os == 'macOS'
       run: brew install libgit2
-    - name: Install libgit2 (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        vcpkg install libgit2:x64-windows
-        $vcpkgRoot = "C:\vcpkg\installed\x64-windows"
-        echo "INCLUDE=$vcpkgRoot\include;$env:INCLUDE" >> $env:GITHUB_ENV
-        echo "LIB=$vcpkgRoot\lib;$env:LIB" >> $env:GITHUB_ENV
-      shell: pwsh
     - name: Install gettext (Windows)
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

During CI runs no longer compile libgit2 for Windows and macOS. This is currently no longer needed, as libgit2 provides binary wheels for those platforms.

Specifically on Windows compiling libgit2 took over three minutes, increasing the workflow run significantly.

Note: This was mostly caused by us trying to use pygit2 also with newer Python versions. We might get into the situation again with the next Python release, if libgit2 takes a while to provide new packages. In this case we might either need to wait or re-add the libgit2 compiling. But if we do so we should ideally compile libgit2 once in one workflow, have the build result cached and use the result in all other workflows needing it. Especially on Windows, where this takes so long.