### PR TITLE
PICARD-2025: Actually set ~filepath in metadata

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -942,6 +942,7 @@ class File(MetadataItem):
             return ext.lower() in cls.EXTENSIONS
 
     def _update_filesystem_metadata(self, metadata):
+        metadata['~filepath'] = self.filename
         metadata['~dirname'] = os.path.dirname(self.filename)
         filename_no_ext, extension = os.path.splitext(os.path.basename(self.filename))
         metadata['~filename'] = filename_no_ext


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

Complements PICARD-2025

The ~filepath variable was documented as part of the TagVar list, but actually not available. Instead this was only an internal variable name used by the metadatabox and itemview filters.

Make this variable actually available to complement existing ~filename and ~dirname.

See also https://github.com/metabrainz/picard/pull/2563