### PR TITLE
Fix custom_columns option not being registered

### DIFF
--- a/picard/options.py
+++ b/picard/options.py
@@ -577,6 +577,10 @@ ListOption('setting', 'plugins3_enabled_plugins', [])
 ListOption('persist', 'plugins3_do_not_update', [], title=N_("Plugins to exclude from updates"))
 Option('persist', 'plugins3_updates', {})
 
+# picard/ui/itemviews/custom_columns
+#
+Option('setting', 'custom_columns', [])
+
 
 def init_options():
     pass

--- a/picard/ui/itemviews/custom_columns/storage.py
+++ b/picard/ui/itemviews/custom_columns/storage.py
@@ -428,27 +428,25 @@ class CustomColumnConfigManager:
         self._rebuild_cache()
 
     def _config_list(self) -> list[dict[str, Any]]:
-        cfg = get_config()
-        settings = cfg.setting
-        # Read the raw value directly; Option may not be registered for this key
-        lst = settings.raw_value(self._config_key)
-        if isinstance(lst, list):
-            return lst
-        # If not set or wrong type, treat as empty without mutating config here
-        if lst is not None:
+        config = get_config()
+        data_list = config.setting[self._config_key]
+        if isinstance(data_list, list):
+            return data_list
+        else:
+            # If not set or wrong type, treat as empty without mutating config here
             log.debug(
                 "Custom columns config '%s' has unexpected type %s; treating as empty",
                 self._config_key,
-                type(lst).__name__,
+                type(data_list).__name__,
             )
-        return []
+            return []
 
     def load_specs(self) -> list[CustomColumnSpec]:
         self._ensure_cache()
         return list(self.__class__._cache_specs or [])
 
     def save_specs(self, specs: Iterable[CustomColumnSpec]) -> None:
-        cfg = get_config()
+        config = get_config()
         # Use QSettings API to write a JSON-like list under 'setting/<key>'
         # De-duplicate by key keeping the last occurrence to match UI expectations
         original_list = list(specs)
@@ -461,8 +459,8 @@ class CustomColumnConfigManager:
             dedup_reversed.append(spec)
         specs_list = list(reversed(dedup_reversed))
         data_list = [CustomColumnSpecSerializer.to_dict(spec) for spec in specs_list]
-        cfg.setting[self._config_key] = data_list
-        cfg.sync()
+        config.setting[self._config_key] = data_list
+        config.sync()
         # Update shared caches
         cls = self.__class__
         cls._cache_specs = specs_list


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The custom columns implementation did not actually register the "custom_columns" config option and was working with raw values instead. This is discouraged and only meant to be used if lower level config access is required (mostly during migration).

Registering the option enables default value handling and simplifies access.