### PR TITLE
PICARD-3170: Drop deprecated parameter from $matchedtracks function

### DIFF
--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -755,7 +755,7 @@ def func_performer(parser, pattern="", join=", "):
 _Since Picard 0.12_"""
     ),
 )
-def func_matchedtracks(parser, *args):
+def func_matchedtracks(parser):
     # only works in file naming scripts, always returns zero in tagging scripts
     file = parser.file
     if file and file.parent_item and getattr(file.parent_item, 'album', None):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1415,8 +1415,9 @@ class ScriptParserTest(PicardTestCase):
         file.parent_item.album.get_num_matched_tracks.return_value = 42
         self.assertScriptResultEquals("$matchedtracks()", "42", file=file)
         self.assertScriptResultEquals("$matchedtracks()", "0")
-        # The following only is possible for backward compatibility, arg is unused
-        self.assertScriptResultEquals("$matchedtracks(arg)", "0")
+        # The function no longer accepts an argument (opposed to Picard 2)
+        with self.assertRaises(ScriptSyntaxError):
+            self.assertScriptResultEquals("$matchedtracks(arg)", "0")
 
     def test_cmd_matchedtracks_with_cluster(self):
         file = MagicMock()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3170
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`$matchedtracks()` was never supposed to accept arguments. Due to a mistake in the original definition however it does accept an arbitrary number of arguments. For backward compatibility this was kept, see PICARD-637.

With Picard 3 we can finally clean this up and fix the function signature.


# Solution

Drop the `*args` from `func_matchedtracks`