### PR TITLE
PICARD-3182: Fixed browser lookup for clusters

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -134,7 +134,6 @@ from picard.i18n import (
     gettext as _,
     setup_gettext,
 )
-from picard.item import MetadataItem
 from picard.options import init_options
 
 
@@ -1030,12 +1029,15 @@ class Tagger(QtWidgets.QApplication):
         """Lookup the object's metadata on the MusicBrainz website."""
         lookup = self.get_file_lookup()
         metadata = item.metadata
-        # Only lookup via MB IDs if matched to a MetadataItem; otherwise ignore and use metadata details
-        if isinstance(item, MetadataItem):
+        # Only lookup via MB IDs if matched to a Track or Album;
+        # otherwise ignore and search by metadata details
+        is_track = isinstance(item, Track)
+        is_album = isinstance(item, Album)
+        if is_track or is_album:
             itemid = item.id
-            if isinstance(item, Track):
+            if is_track:
                 lookup.recording_lookup(itemid)
-            elif isinstance(item, Album):
+            elif is_album:
                 lookup.album_lookup(itemid)
         else:
             lookup.tag_lookup(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3182
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

"Lookup in Browser" no longer works for clusters.


## Solution

Cluster is now also a MetadataItem, hence the old detection of lookup method does not work anymore.

