### PR TITLE
Make external file change detection explicit in save pipeline

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -606,8 +606,7 @@ class File(MetadataItem):
             # Report summary of skipped files (once batch finishes)
             if self.tagger._external_change_count > 0 and not self.is_pending():
                 log.warning(
-                    "%d files were skipped because they were modified externally.",
-                    self.tagger._external_change_count
+                    "%d files were skipped because they were modified externally.", self.tagger._external_change_count
                 )
                 self.tagger._external_change_count = 0
             self._update_filesystem_metadata(self.orig_metadata)

--- a/picard/file.py
+++ b/picard/file.py
@@ -461,6 +461,12 @@ class File(MetadataItem):
         return self.state == File.State.ERROR
 
     def save(self):
+        # Allow retry if previous save failed due to external modification
+        if self.state == File.State.ERROR:
+            change = self._external_file_change(self.filename)
+            if change == ExternalChange.MODIFIED:
+                self._loaded_identity = FileIdentity(self.filename)
+                self.clear_errors()
         self.set_pending()
         run_file_pre_save_processors(self)
         metadata = Metadata()
@@ -568,7 +574,9 @@ class File(MetadataItem):
             if isinstance(error, ExternalFileModifiedError):
                 self.clear_pending(signal=False)
                 self.state = File.State.ERROR
-                self.error_append(_("Cannot save file: it was modified externally after being loaded."))
+                self.error_append(_("Cannot save file: it was modified externally after loading."))
+                # Track batch external changes
+                self.tagger._external_change_count += 1
                 self.update()
                 return
             self._set_error(error)
@@ -595,6 +603,13 @@ class File(MetadataItem):
             self.orig_metadata.update(temp_info)
             self.clear_errors()
             self.clear_pending(signal=False)
+            # Report summary of skipped files (once batch finishes)
+            if self.tagger._external_change_count > 0 and not self.is_pending():
+                log.warning(
+                    _("%d files were skipped because they were modified externally.")
+                    % self.tagger._external_change_count
+                )
+                self.tagger._external_change_count = 0
             self._update_filesystem_metadata(self.orig_metadata)
             if images_changed:
                 self.metadata_images_changed.emit()

--- a/picard/file.py
+++ b/picard/file.py
@@ -50,7 +50,6 @@ from enum import (
 )
 import fnmatch
 from functools import partial
-from enum import Enum, auto
 import hashlib
 import os
 import os.path
@@ -68,6 +67,8 @@ from mutagen import (
     FileType,
     MutagenError,
 )
+
+from PyQt6.QtWidgets import QMessageBox
 
 from picard import (
     PICARD_APP_NAME,
@@ -143,6 +144,14 @@ FILE_COMPARISON_WEIGHTS = {
 class ExternalChange(Enum):
     MISSING = auto()
     MODIFIED = auto()
+
+
+class ExternalFileModifiedError(Exception):
+    """Raised when file changed externally before save."""
+
+    pass
+
+
 class FileIdentityError(Exception):
     pass
 
@@ -453,6 +462,27 @@ class File(MetadataItem):
     def has_error(self):
         return self.state == File.State.ERROR
 
+    def _handle_external_modification(self):
+        msg = QMessageBox(self.tagger.window)
+        msg.setIcon(QMessageBox.Icon.Warning)
+        msg.setWindowTitle(_("File Modified Externally"))
+        msg.setText(_("The file \"%(filename)s\" was modified by another program.") % {"filename": self.base_filename})
+
+        overwrite_btn = msg.addButton(_("Overwrite"), QMessageBox.ButtonRole.AcceptRole)
+        reload_btn = msg.addButton(_("Reload from Disk"), QMessageBox.ButtonRole.DestructiveRole)
+        cancel_btn = msg.addButton(_("Cancel"), QMessageBox.ButtonRole.RejectRole)
+
+        msg.setDefaultButton(cancel_btn)
+        msg.exec()
+
+        clicked = msg.clickedButton()
+
+        if clicked == overwrite_btn:
+            self._retry_overwrite_after_external_change()
+
+        elif clicked == reload_btn:
+            self.load(lambda *_: None)
+
     def save(self):
         self.set_pending()
         run_file_pre_save_processors(self)
@@ -462,6 +492,7 @@ class File(MetadataItem):
             partial(self._save_and_rename, self.filename, metadata),
             self._saving_finished,
             thread_pool=self.tagger.save_thread_pool,
+            traceback=False,
         )
 
     def _preserve_times(self, filename, func):
@@ -498,6 +529,13 @@ class File(MetadataItem):
             return ExternalChange.MODIFIED
         return None
 
+    def _retry_overwrite_after_external_change(self):
+        try:
+            self._loaded_identity = FileIdentity(self.filename)
+            self.save()
+        except Exception as e:
+            log.error("Failed to retry overwrite: %s", e)
+            self._set_error(e)
 
     def _save_and_rename(self, old_filename, metadata):
         """Save the metadata."""
@@ -515,11 +553,9 @@ class File(MetadataItem):
             # Detect source changes before saving (debug only)
             change = self._external_file_change(old_filename)
             if change == ExternalChange.MISSING:
-                log.warning("File missing!")
-                return
+                raise FileNotFoundError(f"{old_filename} no longer exists")
             elif change:
-                log.warning("File externally modified.")
-                return
+                raise ExternalFileModifiedError(f"{old_filename} was modified externally")
             save = partial(self._save, old_filename, metadata)
             if config.setting['preserve_timestamps']:
                 try:
@@ -560,6 +596,11 @@ class File(MetadataItem):
             return
         old_filename = new_filename = self.filename
         if error is not None:
+            if isinstance(error, ExternalFileModifiedError):
+                self.clear_pending(signal=False)
+                self._handle_external_modification()
+                self.update()
+                return
             self._set_error(error)
         else:
             self.filename = new_filename = result

--- a/picard/file.py
+++ b/picard/file.py
@@ -606,8 +606,8 @@ class File(MetadataItem):
             # Report summary of skipped files (once batch finishes)
             if self.tagger._external_change_count > 0 and not self.is_pending():
                 log.warning(
-                    _("%d files were skipped because they were modified externally.")
-                    % self.tagger._external_change_count
+                    "%d files were skipped because they were modified externally.",
+                    self.tagger._external_change_count
                 )
                 self.tagger._external_change_count = 0
             self._update_filesystem_metadata(self.orig_metadata)

--- a/picard/file.py
+++ b/picard/file.py
@@ -50,6 +50,7 @@ from enum import (
 )
 import fnmatch
 from functools import partial
+from enum import Enum, auto
 import hashlib
 import os
 import os.path
@@ -139,6 +140,9 @@ FILE_COMPARISON_WEIGHTS = {
 }
 
 
+class ExternalChange(Enum):
+    MISSING = auto()
+    MODIFIED = auto()
 class FileIdentityError(Exception):
     pass
 
@@ -480,6 +484,21 @@ class File(MetadataItem):
             raise self.PreserveTimesUtimeError(errmsg) from None
         return (st.st_atime_ns, st.st_mtime_ns)
 
+    def _external_file_change(self, filename):
+        if not self._loaded_identity:
+            return None
+        try:
+            current = FileIdentity(filename)
+        except FileNotFoundError:
+            return ExternalChange.MISSING
+        except OSError as e:
+            log.warning("Cannot stat file %r: %s", filename, e)
+            return None
+        if current != self._loaded_identity:
+            return ExternalChange.MODIFIED
+        return None
+
+
     def _save_and_rename(self, old_filename, metadata):
         """Save the metadata."""
         config = get_config()
@@ -494,11 +513,13 @@ class File(MetadataItem):
         new_filename = old_filename
         if config.setting['enable_tag_saving']:
             # Detect source changes before saving (debug only)
-            current = FileIdentity(old_filename)
-            if current and current != self._loaded_identity:
-                log.warning("File externally modified.")
-            elif not current:
+            change = self._external_file_change(old_filename)
+            if change == ExternalChange.MISSING:
                 log.warning("File missing!")
+                return
+            elif change:
+                log.warning("File externally modified.")
+                return
             save = partial(self._save, old_filename, metadata)
             if config.setting['preserve_timestamps']:
                 try:

--- a/picard/file.py
+++ b/picard/file.py
@@ -529,7 +529,7 @@ class File(MetadataItem):
             change = self._external_file_change(old_filename)
             if change == ExternalChange.MISSING:
                 raise FileNotFoundError(f"{old_filename} no longer exists")
-            elif change:
+            elif change == ExternalChange.MODIFIED:
                 raise ExternalFileModifiedError(f"{old_filename} was modified externally")
             save = partial(self._save, old_filename, metadata)
             if config.setting['preserve_timestamps']:
@@ -603,12 +603,6 @@ class File(MetadataItem):
             self.orig_metadata.update(temp_info)
             self.clear_errors()
             self.clear_pending(signal=False)
-            # Report summary of skipped files (once batch finishes)
-            if self.tagger._external_change_count > 0 and not self.is_pending():
-                log.warning(
-                    "%d files were skipped because they were modified externally.", self.tagger._external_change_count
-                )
-                self.tagger._external_change_count = 0
             self._update_filesystem_metadata(self.orig_metadata)
             if images_changed:
                 self.metadata_images_changed.emit()

--- a/picard/file.py
+++ b/picard/file.py
@@ -68,8 +68,6 @@ from mutagen import (
     MutagenError,
 )
 
-from PyQt6.QtWidgets import QMessageBox
-
 from picard import (
     PICARD_APP_NAME,
     log,
@@ -462,27 +460,6 @@ class File(MetadataItem):
     def has_error(self):
         return self.state == File.State.ERROR
 
-    def _handle_external_modification(self):
-        msg = QMessageBox(self.tagger.window)
-        msg.setIcon(QMessageBox.Icon.Warning)
-        msg.setWindowTitle(_("File Modified Externally"))
-        msg.setText(_("The file \"%(filename)s\" was modified by another program.") % {"filename": self.base_filename})
-
-        overwrite_btn = msg.addButton(_("Overwrite"), QMessageBox.ButtonRole.AcceptRole)
-        reload_btn = msg.addButton(_("Reload from Disk"), QMessageBox.ButtonRole.DestructiveRole)
-        cancel_btn = msg.addButton(_("Cancel"), QMessageBox.ButtonRole.RejectRole)
-
-        msg.setDefaultButton(cancel_btn)
-        msg.exec()
-
-        clicked = msg.clickedButton()
-
-        if clicked == overwrite_btn:
-            self._retry_overwrite_after_external_change()
-
-        elif clicked == reload_btn:
-            self.load(lambda *_: None)
-
     def save(self):
         self.set_pending()
         run_file_pre_save_processors(self)
@@ -528,14 +505,6 @@ class File(MetadataItem):
         if current != self._loaded_identity:
             return ExternalChange.MODIFIED
         return None
-
-    def _retry_overwrite_after_external_change(self):
-        try:
-            self._loaded_identity = FileIdentity(self.filename)
-            self.save()
-        except Exception as e:
-            log.error("Failed to retry overwrite: %s", e)
-            self._set_error(e)
 
     def _save_and_rename(self, old_filename, metadata):
         """Save the metadata."""
@@ -598,7 +567,8 @@ class File(MetadataItem):
         if error is not None:
             if isinstance(error, ExternalFileModifiedError):
                 self.clear_pending(signal=False)
-                self._handle_external_modification()
+                self.state = File.State.ERROR
+                self.error_append(_("Cannot save file: it was modified externally after being loaded."))
                 self.update()
                 return
             self._set_error(error)

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -445,6 +445,7 @@ class Tagger(QtWidgets.QApplication):
     def _init_tagger_entities(self):
         """Initialize tagger objects/entities"""
         self._pending_files_count = 0
+        self._external_change_count = 0
         self.files = {}
         self.clusters = ClusterList()
         self.albums = {}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
Make external file change detection explicit in the save pipeline and prevent silent overwrites by aborting the save and marking the file as error when the on-disk file has changed after loading.
## Problem
PR #2963 introduced FileIdentity to detect external file changes.
However, when a file was modified or replaced on disk after being loaded, Picard would only log a warning and continue, potentially overwriting external changes silently.
This could lead to unintended data loss without user awareness.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

## Solution
This change:
	•	Reuses FileIdentity to detect external modifications before saving.
	•	Raises ExternalFileModifiedError if the file was modified or deleted.
	•	Aborts the save operation.
	•	Marks the file as ERROR state with a clear message:
“Cannot save file: it was modified externally after being loaded.”
	•	Ensures no silent overwrite occurs.
	•	Keeps behavior batch-safe (no blocking dialogs per file).

This keeps the logic deterministic and avoids UI complexity for batch operations.
## Limitation
	•	No conflict resolution UI is implemented in this PR.
	•	When multiple files are modified externally, each file is marked as error individually.
	•	No batch policy (“overwrite all”, “reload all”) is included yet.
	•	No diff view of tag differences.

These can be explored in a future PR if desired.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
