### PR TITLE
PICARD-3186: Improve plugin options handling plugins being unavailable

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -280,7 +280,7 @@ class Tagger(QtWidgets.QApplication):
         self._debug_opts = cmdline_args.debug_opts
         self._debug = cmdline_args.debug or 'PICARD_DEBUG' in os.environ
         self._no_player = cmdline_args.no_player
-        self._no_plugins = cmdline_args.no_plugins
+        self._no_plugins = not HAS_PLUGIN3 or cmdline_args.no_plugins
         self._no_restore = cmdline_args.no_restore
         self._to_load = cmdline_args.processable
 
@@ -400,11 +400,10 @@ class Tagger(QtWidgets.QApplication):
 
     def _init_plugins(self):
         """Initialize and load plugins"""
-        if HAS_PLUGIN3:
+        if not self._no_plugins:
             self._pluginmanager3 = PluginManager(self)
             self._pluginmanager3.plugin_state_changed.connect(self._on_plugin_status_changed)
-            if not self._no_plugins:
-                self._pluginmanager3.add_directory(plugin_folder(), primary=True)
+            self._pluginmanager3.add_directory(plugin_folder(), primary=True)
         else:
             self._pluginmanager3 = None
             log.warning('Plugin3 system not available (git backend not available)')

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -280,7 +280,7 @@ class Tagger(QtWidgets.QApplication):
         self._debug_opts = cmdline_args.debug_opts
         self._debug = cmdline_args.debug or 'PICARD_DEBUG' in os.environ
         self._no_player = cmdline_args.no_player
-        self._no_plugins = not HAS_PLUGIN3 or cmdline_args.no_plugins
+        self._no_plugins = cmdline_args.no_plugins
         self._no_restore = cmdline_args.no_restore
         self._to_load = cmdline_args.processable
 
@@ -400,7 +400,7 @@ class Tagger(QtWidgets.QApplication):
 
     def _init_plugins(self):
         """Initialize and load plugins"""
-        if not self._no_plugins:
+        if HAS_PLUGIN3 and not self._no_plugins:
             self._pluginmanager3 = PluginManager(self)
             self._pluginmanager3.plugin_state_changed.connect(self._on_plugin_status_changed)
             self._pluginmanager3.add_directory(plugin_folder(), primary=True)
@@ -415,6 +415,19 @@ class Tagger(QtWidgets.QApplication):
             PluginManager or None: The plugin manager instance if available, None otherwise.
         """
         return getattr(self, '_pluginmanager3', None)
+
+    def get_plugins_available(self) -> tuple[bool, str]:
+        """Returns whether the plugin system is available.
+
+        Returns a tuple, where the first element is a boolean indicating the
+        availability and the second element is a string with a reason if the
+        plugin system is unavailable.
+        """
+        if not HAS_PLUGIN3:
+            return False, _('Git backend not available')
+        elif self._no_plugins:
+            return False, _('Disabled by command line parameter')
+        return True, ""
 
     def _on_plugin_status_changed(self):
         self.format_registry.rebuild_extension_map()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -82,6 +82,21 @@ class Plugins3OptionsPage(OptionsPage):
         """Setup the UI."""
         layout = QtWidgets.QVBoxLayout(self)
 
+        # Check whether plugins are available
+        available, unavailable_reason = self.tagger.get_plugins_available()
+        if not available:
+            no_plugins_box = QtWidgets.QFrame(self)
+            no_plugins_box.setStyleSheet("QFrame { background-color: #ffc107; color: black }")
+            no_plugins_box.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+            no_plugins_box_layout = QtWidgets.QVBoxLayout(no_plugins_box)
+            no_plugins_label = QtWidgets.QLabel(
+                _("Plugins unavailable: {reason}.").format(reason=unavailable_reason), parent=no_plugins_box
+            )
+            no_plugins_box_layout.addWidget(no_plugins_label)
+            layout.addWidget(no_plugins_box)
+            layout.addStretch()
+            return
+
         # Toolbar
         toolbar_layout = QtWidgets.QHBoxLayout()
 
@@ -164,7 +179,10 @@ class Plugins3OptionsPage(OptionsPage):
         QtWidgets.QApplication.processEvents()
 
     def load(self):
-        """Load plugins from plugin manager."""
+        if not self.plugin_manager:
+            return
+
+        # Load plugins from plugin manager.
         self._show_status(_("Loading plugins…"))
         # Load plugins immediately when page is loaded
         try:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3186
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard can be started with plugins being disabled for currently two reasons: Either pygit2 is not available, or Picard is started with `--no-plugins`.

Both cases would cause issues in the plugin options:

1. If pygit2 was unavailable, the plugin options would fail to initialize and the default error fallback options page would be shown
2. If plugins got disabled with `--no-plugins` this only disabled loading plugins, but still kept the plugin manager. The options UI would load and generally work, but e.g. fail on plugin install.


## Solution

Treat both cases, poygit2 missing or `--no-plugins` parameter, the same when loading Picard and completely disabled initializing the plugin system.

In plugin options show an warning like message with a reason for why the plugins are unavailable:

<img width="906" height="738" alt="grafik" src="https://github.com/user-attachments/assets/a92a46b8-97a5-4616-b43d-40a9666c01cd" />

<img width="906" height="738" alt="grafik" src="https://github.com/user-attachments/assets/48e77cba-5479-4ece-aaa9-da8e05ff65db" />

For consistency the warning message is shown the same as the warning in general options when choosing a non-default server.

Note: I first considered not showing the plugin options at all. But I think showing the reason makes it easier for the user to understand why plugins are not available.