### PR TITLE
PICARD-3187: Add config upgrade hook to update usage of $matchedtracks()

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'alpha', 1)
+PICARD_VERSION = Version(3, 0, 0, 'alpha', 2)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -625,7 +625,7 @@ def upgrade_to_v3_0_0dev10(config):
 def upgrade_to_v3_0_0a2(config):
     """Update $matchedtracks() usage in scripts"""
 
-    matched_tracks_regex = re.compile(r'\$matchedtracks\([^)]+\)')
+    matched_tracks_regex = re.compile(r'\$matchedtracks\([^)$]+\)')
 
     def fix_matchedtracks(script):
         return matched_tracks_regex.sub('$matchedtracks()', script)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -20,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-
-
 import os
 
 from PyQt6.QtCore import QByteArray
@@ -66,6 +64,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_7_0dev4,
     upgrade_to_v2_7_0dev5,
     upgrade_to_v2_8_0dev2,
+    upgrade_to_v3_0_0a2,
     upgrade_to_v3_0_0dev3,
     upgrade_to_v3_0_0dev4,
     upgrade_to_v3_0_0dev5,
@@ -616,3 +615,34 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
 
         self.assertEqual('webp', self.config.setting['cover_tags_convert_to_format'])
         self.assertEqual('png', self.config.setting['cover_file_convert_to_format'])
+
+    def test_upgrade_to_v3_0_0a2(self):
+        Option('setting', 'file_renaming_scripts', {})
+        ListOption('setting', 'list_of_scripts', [])
+
+        test_script = '$set(foo,$matchedtracks(baz)-$matchedtracks()-$matchedtracks(%album%))'
+        expected_script = '$set(foo,$matchedtracks()-$matchedtracks()-$matchedtracks())'
+
+        self.config.setting['file_renaming_scripts'] = {
+            '766bb2ce-5170-45f1-900c-02e7f9bd41cb': {
+                "id": "766bb2ce-5170-45f1-900c-02e7f9bd41cb",
+                "title": "Script 1",
+                "script": test_script,
+            },
+        }
+        self.config.setting['list_of_scripts'] = [
+            (0, 'Script 1', True, test_script),
+        ]
+
+        upgrade_to_v3_0_0a2(self.config)
+
+        result_naming_script = self.config.setting['file_renaming_scripts']['766bb2ce-5170-45f1-900c-02e7f9bd41cb']
+        self.assertEqual(
+            expected_script,
+            result_naming_script['script'],
+        )
+        result_tagger_script = self.config.setting['list_of_scripts'][0]
+        self.assertEqual(
+            expected_script,
+            result_tagger_script[3],
+        )

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -620,8 +620,10 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         Option('setting', 'file_renaming_scripts', {})
         ListOption('setting', 'list_of_scripts', [])
 
-        test_script = '$set(foo,$matchedtracks(baz)-$matchedtracks()-$matchedtracks(%album%))'
-        expected_script = '$set(foo,$matchedtracks()-$matchedtracks()-$matchedtracks())'
+        test_script = (
+            r'$set(foo,$matchedtracks(baz)-$matchedtracks()-$matchedtracks(%album%)-$matchedtracks(foo$get(bar)))'
+        )
+        expected_script = '$set(foo,$matchedtracks()-$matchedtracks()-$matchedtracks()-$matchedtracks(foo$get(bar)))'
 
         self.config.setting['file_renaming_scripts'] = {
             '766bb2ce-5170-45f1-900c-02e7f9bd41cb': {

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1417,7 +1417,7 @@ class ScriptParserTest(PicardTestCase):
         self.assertScriptResultEquals("$matchedtracks()", "0")
         # The function no longer accepts an argument (opposed to Picard 2)
         with self.assertRaises(ScriptSyntaxError):
-            self.assertScriptResultEquals("$matchedtracks(arg)", "0")
+            self.parser.eval("$matchedtracks(arg)")
 
     def test_cmd_matchedtracks_with_cluster(self):
         file = MagicMock()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3187
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Config upgrade to remove the (previously optional) parameter from $matchedtracks() calls in scripts. This does not change the function of scripts, as the parameter was previously optional and unused.