### PR TITLE
PICARD-3196: Implement custom persistence for column state in ConfigurableColumnsHeader

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'alpha', 2)
+PICARD_VERSION = Version(3, 0, 0, 'alpha', 3)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -644,6 +644,12 @@ def upgrade_to_v3_0_0a2(config):
     config.setting['list_of_scripts'] = tagger_scripts
 
 
+def upgrade_to_v3_0_0a3(config):
+    """Remove persisted column configuration"""
+    config.persist.remove('album_view_header_state')
+    config.persist.remove('file_view_header_state')
+
+
 @contextmanager
 def temp_option(option_type: type[Option], section: str, name: str, default: ConfigValueType):
     opt = option_type(section, name, default)

--- a/picard/options.py
+++ b/picard/options.py
@@ -127,12 +127,12 @@ BoolOption('persist', 'show_hidden_files', False)
 
 # Store Album View Header State
 #
-Option('persist', 'album_view_header_state', QtCore.QByteArray())
+Option('persist', 'album_view_header_columns', {})
 BoolOption('persist', 'album_view_header_locked', False)
 
 # Store File View Header State
 #
-Option('persist', 'file_view_header_state', QtCore.QByteArray())
+Option('persist', 'file_view_header_columns', {})
 BoolOption('persist', 'file_view_header_locked', False)
 
 # picard/ui/logview.py

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -285,7 +285,7 @@ class FileTreeView(BaseTreeView):
     NAME = N_("File view")
     DESCRIPTION = N_("Contains unmatched files and clusters")
 
-    header_state = 'file_view_header_state'
+    header_state = 'file_view_header_columns'
     header_locked = 'file_view_header_locked'
 
     def __init__(self, columns, window, parent=None):
@@ -317,7 +317,7 @@ class AlbumTreeView(BaseTreeView):
     NAME = N_("Album view")
     DESCRIPTION = N_("Contains albums and matched files")
 
-    header_state = 'album_view_header_state'
+    header_state = 'album_view_header_columns'
     header_locked = 'album_view_header_locked'
 
     def __init__(self, columns, window, parent=None):

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -385,24 +385,18 @@ class BaseTreeView(QtWidgets.QTreeWidget):
     @restore_method
     def restore_state(self):
         config = get_config()
-        header_state = config.persist[self.header_state]
         header = self.header()
-        if header_state and header.restoreState(header_state):
-            log.debug("Restoring state of %s" % header)
-            for i in range(0, self.columnCount()):
-                header.show_column(i, not self.isColumnHidden(i))
-
+        header_state = config.persist[self.header_state]
+        if header_state:
+            header.restore_columns_state(header_state)
         header.lock(config.persist[self.header_locked])
 
     def save_state(self):
         config = get_config()
         header = self.header()
-        if header.prelock_state is not None:
-            state = header.prelock_state
-        else:
-            state = header.saveState()
-        log.debug("Saving state of %s" % header)
-        config.persist[self.header_state] = state
+        if not header:
+            return
+        config.persist[self.header_state] = header.get_columns_state()
         config.persist[self.header_locked] = header.is_locked
 
     def _set_header_labels(self, update_column_count=False):

--- a/picard/ui/widgets/configurablecolumnsheader.py
+++ b/picard/ui/widgets/configurablecolumnsheader.py
@@ -299,7 +299,8 @@ class ConfigurableColumnsHeader(LockableHeaderView):
             self.show_column(i, column_state.get('visible', column.always_visible))
             resize_mode = column_state.get('resize_mode', QtWidgets.QHeaderView.ResizeMode.Interactive.value)
             self.setSectionResizeMode(i, QtWidgets.QHeaderView.ResizeMode(resize_mode))
-            self.resizeSection(i, column_state.get('width', column.width or 100))
+            if resize_mode in {QtWidgets.QHeaderView.ResizeMode.Fixed, QtWidgets.QHeaderView.ResizeMode.Interactive}:
+                self.resizeSection(i, column_state.get('width', column.width or 100))
             current_pos = self.visualIndex(i)
             new_pos = column_state.get('position', -1)
             if current_pos > 0 and new_pos > 0 and current_pos != new_pos:

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import os
 
+import PyQt6.QtCore
 from PyQt6.QtCore import QByteArray
 
 from test.picardtestcase import PicardTestCase
@@ -65,6 +66,7 @@ from picard.config_upgrade import (
     upgrade_to_v2_7_0dev5,
     upgrade_to_v2_8_0dev2,
     upgrade_to_v3_0_0a2,
+    upgrade_to_v3_0_0a3,
     upgrade_to_v3_0_0dev3,
     upgrade_to_v3_0_0dev4,
     upgrade_to_v3_0_0dev5,
@@ -649,3 +651,14 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
             expected_script,
             result_tagger_script[3],
         )
+
+    def test_upgrade_to_v3_0_0a3(self):
+        Option('persist', 'album_view_header_state', PyQt6.QtCore.QByteArray())
+        Option('persist', 'file_view_header_state', PyQt6.QtCore.QByteArray())
+        self.config.persist['album_view_header_state'] = b'a'
+        self.config.persist['file_view_header_state'] = b'a'
+
+        upgrade_to_v3_0_0a3(self.config)
+
+        self.assertNotIn('album_view_header_state', self.config.persist)
+        self.assertNotIn('file_view_header_state', self.config.persist)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3196
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Changing the default columns for the main views can break the column display as the persisted state does not match the column model anymore. See e.g. #3040 and the example screenshot there.

## Solution
Instead of relying on an opaque binary structure based on logical column indices use a custom structure which stores the state of each column based on its name. This fixes issues with column state breaking if the indices of the default columns change, e.g. when new default columns are addded or removed.

As there is not clean upgrade path there is a config upgrade to remove the old states. The columns will reset to their default state on upgrade.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
