### PR TITLE
PICARD-3199: Map unsyncedlyrics Vorbis tag to lyrics on load

### DIFF
--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -191,6 +191,10 @@ class VCommentFile(File):
                     if 'totaldiscs' in file.tags:
                         continue
                     name = 'totaldiscs'
+                elif name == 'unsyncedlyrics':
+                    if 'lyrics' in file.tags:
+                        continue
+                    name = 'lyrics'
                 elif name == 'metadata_block_picture':
                     try:
                         image = mutagen.flac.Picture(base64.standard_b64decode(value))

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -196,6 +196,23 @@ class CommonVorbisTests:
             self.assertEqual('2023-04-18', metadata['date'])
             self.assertEqual('foo', metadata['title'])
 
+        @skipUnlessTestfile
+        def test_unsyncedlyrics_mapped_to_lyrics(self):
+            # unsyncedlyrics is used by some software as an alternative to lyrics.
+            # On load, Picard should map it to the standard lyrics tag.
+            save_raw(self.filename, {'unsyncedlyrics': 'some lyrics'})
+            metadata = load_metadata(self.format_registry, self.filename)
+            self.assertEqual('some lyrics', metadata['lyrics'])
+            self.assertNotIn('unsyncedlyrics', metadata)
+
+        @skipUnlessTestfile
+        def test_unsyncedlyrics_not_overwrite_lyrics(self):
+            # If both lyrics and unsyncedlyrics exist, lyrics takes priority.
+            save_raw(self.filename, {'lyrics': 'standard', 'unsyncedlyrics': 'alternative'})
+            metadata = load_metadata(self.format_registry, self.filename)
+            self.assertEqual('standard', metadata['lyrics'])
+            self.assertNotIn('unsyncedlyrics', metadata)
+
 
 class FLACTest(CommonVorbisTests.VorbisTestCase):
     testfile = 'test.flac'


### PR DESCRIPTION
* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Map the `unsyncedlyrics` Vorbis comment tag to Picard's internal `lyrics` tag on load, so files tagged by software like beets/lrclib display lyrics correctly in Picard.

# Problem

Some software writes unsynced lyrics to an `unsyncedlyrics` Vorbis comment (e.g. beets with the lrclib plugin) instead of the standard `lyrics` tag. Picard currently treats `unsyncedlyrics` as an unknown custom tag, so the lyrics content is invisible to users.

JIRA ticket: [PICARD-3199](https://tickets.metabrainz.org/browse/PICARD-3199)

# Solution

In `VCommentFile._load()`, remap `unsyncedlyrics` to `lyrics` when loading Vorbis comment files (FLAC, Ogg Vorbis, Opus, etc.). If the file already has a standard `lyrics` tag, `unsyncedlyrics` is skipped to avoid overwriting it. This follows the same pattern used for the `tracktotal`/`totaltracks` and `disctotal`/`totaldiscs` alias handling.

No changes to the save path: Picard continues to write the standard `lyrics` Vorbis comment, normalising away the non-standard tag name.

# Tests

Two tests added to `CommonVorbisTests.VorbisTestCase` (run against FLAC, Ogg Vorbis, Ogg Opus, Ogg Speex, Ogg Theora, Ogg FLAC):

- `test_unsyncedlyrics_mapped_to_lyrics`: verifies that a file with only `unsyncedlyrics` loads with `lyrics` populated and no `unsyncedlyrics` key in metadata.
- `test_unsyncedlyrics_not_overwrite_lyrics`: verifies that when both tags exist, the standard `lyrics` value wins and `unsyncedlyrics` does not appear in metadata.