### PR TITLE
Fix ASF: deleting totaldiscs also removes discnumber

### DIFF
--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -300,6 +300,11 @@ class ASFFile(File):
     def _remove_deleted_tags(self, metadata, tags):
         """Remove the tags from the file that were deleted in the UI"""
         for tag in metadata.deleted_tags:
+            if tag == 'totaldiscs' and 'discnumber' in metadata:
+                # WM/PartOfSet stores both discnumber and totaldiscs.
+                # Only delete it if discnumber is also absent; otherwise
+                # the save loop has already written the value without the total.
+                continue
             real_name = self._get_tag_name(tag)
             if real_name and real_name in tags:
                 del tags[real_name]

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -30,10 +30,13 @@ from test.picardtestcase import (
 
 from picard.formats import asf
 
+from picard.metadata import Metadata
+
 from .common import (
     CommonTests,
     load_metadata,
     load_raw,
+    save_and_load_metadata,
     save_metadata,
     save_raw,
     skipUnlessTestfile,
@@ -87,6 +90,19 @@ class CommonAsfTests:
         def test_ignore_invalid_wm_picture(self):
             # A picture that cannot be unpacked
             self._test_invalid_picture(b'notapicture')
+
+        @skipUnlessTestfile
+        def test_delete_totaldiscs_keeps_discnumber(self):
+            # Deleting totaldiscs must not remove discnumber. Both are stored
+            # in WM/PartOfSet, so a naive delete would wipe the disc number too.
+            metadata = Metadata({'discnumber': '2', 'totaldiscs': '4'})
+            original_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual('2', original_metadata['discnumber'])
+            self.assertEqual('4', original_metadata['totaldiscs'])
+            del metadata['totaldiscs']
+            new_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual('2', new_metadata['discnumber'])
+            self.assertNotIn('totaldiscs', new_metadata)
 
 
 class ASFTest(CommonAsfTests.AsfTestCase):


### PR DESCRIPTION
## Summary

- `WM/PartOfSet` in ASF/WMA files stores both `discnumber` and `totaldiscs` as a single `"disc/total"` string.
- When the user deleted only `totaldiscs` from the UI, `_remove_deleted_tags` looked up `WM/PartOfSet` via `_get_tag_name('totaldiscs')` and deleted the entire tag, silently wiping `discnumber` from the file as well.
- Fix: skip the `WM/PartOfSet` deletion when `totaldiscs` is removed but `discnumber` is still present in metadata. The save loop already writes `WM/PartOfSet` with just the disc number before `_remove_deleted_tags` runs, so no further action is needed.

## Test plan

- Added `test_delete_totaldiscs_keeps_discnumber` to `CommonAsfTests.AsfTestCase`, which saves a file with both `discnumber` and `totaldiscs`, then deletes `totaldiscs` and verifies `discnumber` is preserved and `totaldiscs` is gone.
- Runs for all three ASF test subclasses (ASF, WMA, WMV).
- All 100 ASF format tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)