### PR TITLE
Broad exception swallowing in `find_git_ref` hides repository/backend failures

### DIFF
--- a/picard/git/ref_utils.py
+++ b/picard/git/ref_utils.py
@@ -34,20 +34,16 @@ def find_git_ref(repo, ref_name):
     if not ref_name:
         return None
 
-    try:
-        references = repo.list_references()
+    references = repo.list_references()
 
-        # Check shortname first (most common case)
-        for git_ref in references:
-            if git_ref.shortname == ref_name:
-                return git_ref
+    # Check shortname first (most common case)
+    for git_ref in references:
+        if git_ref.shortname == ref_name:
+            return git_ref
 
-        # Check full name
-        for git_ref in references:
-            if git_ref.name == ref_name:
-                return git_ref
-
-    except Exception:
-        pass
+    # Check full name
+    for git_ref in references:
+        if git_ref.name == ref_name:
+            return git_ref
 
     return None


### PR DESCRIPTION
## Summary

`find_git_ref` catches `Exception` and silently returns `None`. This makes real failures (e.g., repository I/O errors, backend API breakage, permission issues) indistinguishable from a normal "ref not found" result. Callers can then take wrong code paths (e.g., treating a broken repo as missing ref) and continue with invalid state, which is a classic silent-failure bug.

## Files changed

- `picard/git/ref_utils.py` (modified)

## Testing

- Not run in this environment.




## Summary



* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem



* JIRA ticket (_optional_): PICARD-XXX




## Solution





## AI Usage



In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)





## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)


