### PR TITLE
Public plugin API module has no module-level contract documentation

### DIFF
--- a/picard/plugin3/api.py
+++ b/picard/plugin3/api.py
@@ -17,6 +17,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+"""Public Plugin API for Picard plugins v3.
+
+Import plugin-facing classes and helpers from this module only:
+
+    from picard.plugin3.api import PluginApi, Metadata
+
+This module is the supported import surface for plugin authors. Names listed in
+``__all__`` are part of the public API contract for plugins. Imports from
+internal modules (for example ``picard.plugin3.api_impl``) are implementation
+details and may change without notice.
+
+Exported names:
+- Core API: ``PluginApi``
+- Data models: ``Album``, ``Track``, ``File``, ``Metadata``, ``Cluster``
+- Actions and options: ``BaseAction``, ``OptionsPage``
+- Cover art: ``CoverArtProvider``, ``CoverArtImage``, ``ImageProcessor``,
+  ``ImageInfo``, ``ProcessingImage``, ``ProviderOptions``
+- Utilities: ``ScriptParser``, ``t_``
+"""
+
 from picard.cluster import Cluster
 from picard.extension_points.cover_art_processors import ProcessingImage
 from picard.plugin3.api_impl import (


### PR DESCRIPTION
## Summary

`picard/plugin3/api.py` is the public import surface for plugin authors (`__all__` defines the exposed API), but it has no module docstring documenting what is stable, how to import from it, or what each exported symbol represents. For an extension API, this increases misuse risk and creates support burden because plugin authors must inspect internals instead of relying on an explicit contract.

## Files changed

- `picard/plugin3/api.py` (modified)

## Testing

- Not run in this environment.




## Summary



* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem



* JIRA ticket (_optional_): PICARD-XXX




## Solution





## AI Usage



In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)





## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)


