### PR TITLE
When running inside a Snap set app ID for Unity Launcher integration separately

### DIFF
--- a/picard/ui/statusindicator/unity.py
+++ b/picard/ui/statusindicator/unity.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2023 Philipp Wolfer
+# Copyright (C) 2019-2023, 2026 Philipp Wolfer
 # Copyright (C) 2020 Julius Michaelis
 # Copyright (C) 2020-2021, 2023-2024 Laurent Monin
 # Copyright (C) 2021 Gabriel Ferreira
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+import os
+
 from PyQt6.QtCore import (
     QObject,
     pyqtClassInfo,
@@ -30,6 +32,7 @@ from PyQt6.QtDBus import (
     QDBusConnection,
     QDBusMessage,
 )
+from PyQt6.QtWidgets import QMainWindow
 
 from picard import PICARD_DESKTOP_NAME
 
@@ -37,10 +40,11 @@ from . import AbstractProgressStatusIndicator
 
 
 DBUS_INTERFACE = 'com.canonical.Unity.LauncherEntry'
+APP_ID = PICARD_DESKTOP_NAME if not os.getenv('SNAP') else 'picard_picard.desktop'
 
 
 class UnityLauncherEntryService(QObject):
-    def __init__(self, bus, app_id):
+    def __init__(self, bus: QDBusConnection, app_id: str):
         super().__init__()
         self._bus = bus
         self._app_uri = 'application://' + app_id
@@ -61,7 +65,7 @@ class UnityLauncherEntryService(QObject):
     def is_available(self):
         return self._available
 
-    def update(self, progress, visible=True):
+    def update(self, progress: float, visible: bool = True) -> None:
         self._progress = progress
         self._visible = visible
         # Automatic forwarding of Qt signals does not work in this case
@@ -101,10 +105,10 @@ class UnityLauncherEntryAdaptor(QDBusAbstractAdaptor):
 
 
 class UnityLauncherEntryStatusIndicator(AbstractProgressStatusIndicator):
-    def __init__(self, window):
+    def __init__(self, window: QMainWindow):
         super().__init__()
         bus = QDBusConnection.sessionBus()
-        self._service = UnityLauncherEntryService(bus, PICARD_DESKTOP_NAME)
+        self._service = UnityLauncherEntryService(bus, APP_ID)
 
     @property
     def is_available(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Inside the snap package the app ID is always "{snap}_{part}.desktop", in our case picard_picard.desktop.

This PR aims to be able to get rid of https://github.com/metabrainz/picard-snap/blob/30a118de0ed87d2205ddf652bf147349d7883091/patching/picard/unity-launcher-entry.patch (the only remaining patch needed by the snap build after the WIP migration for Picard 3).


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Detect when running inside a snap by checking for the `SNAP` environment variable (is set to the path of the running snap), and use hard coded `picard_picard.desktop` for the Unity Launcher app ID.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
