### PR TITLE
PICARD-3249: Fix tag name autocompletion in Edit Tag dialog

### DIFF
--- a/picard/ui/metadatabox/edittagdialog.py
+++ b/picard/ui/metadatabox/edittagdialog.py
@@ -202,7 +202,7 @@ class EditTagDialog(PicardDialog):
     def _setup_tag_combobox(self):
         """Set up the tag name combobox with supported tags."""
         self.default_tags = self._get_supported_tags()
-        visible_tags = (tn for tn in self.default_tags if not tn.startswith("~"))  # TODO: use TagVar.is_hidden?
+        visible_tags = [tn for tn in self.default_tags if not tn.startswith("~")]  # TODO: use TagVar.is_hidden?
 
         self.ui.tag_names.addItem("")
         self.ui.tag_names.addItems(visible_tags)
@@ -217,7 +217,7 @@ class EditTagDialog(PicardDialog):
         Returns:
             List of supported tag names
         """
-        tags = sorted(list(tag_names()) + self.metadata_box.tag_diff.tag_names)
+        tags = sorted(set(tag_names()) | set(self.metadata_box.tag_diff.tag_names))
         if len(self.metadata_box.files) == 1:
             current_file = list(self.metadata_box.files)[0]
             tags = list(filter(current_file.supports_tag, tags))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Tag auto-completion doesn't work anymore in Edit Tag dialog.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3249
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

The visible_tags generator expression was exhausted by addItems(), leaving the QCompleter with no completion candidates.

Use a list comprehension instead so the data can be consumed by both addItems() and QCompleter.

Introduced in d765211120fe ("Replace TAG_NAMES dict by a generator tag_names()").

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
