### PR TITLE
PICARD-3256: Fix preferred release settings loosing sort order

### DIFF
--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -27,6 +27,7 @@
 
 
 from functools import partial
+from operator import itemgetter
 
 from PyQt6 import (
     QtCore,
@@ -291,6 +292,7 @@ class ReleasesOptionsPage(OptionsPage):
             return sort_key(x[1])
 
         source_list = [(c[0], translate_func(c[1])) for c in source.items()]
+        target_list = []
         source_list.sort(key=fcmp)
         config = get_config()
         saved_data = config.setting[setting]
@@ -298,10 +300,14 @@ class ReleasesOptionsPage(OptionsPage):
             item = QtWidgets.QListWidgetItem(name)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, data)
             try:
-                saved_data.index(data)
-                list2.addItem(item)
+                i = saved_data.index(data)
+                target_list.append((i, item))
             except ValueError:
                 list1.addItem(item)
+
+        target_list.sort(key=itemgetter(0))
+        for _i, item in target_list:
+            list2.addItem(item)
 
     def _save_list_items(self, setting, list1):
         data = [item.data(QtCore.Qt.ItemDataRole.UserRole) for item in qlistwidget_items(list1)]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3256
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When loading the settings the saved sort order for preferred release types / countries is reset to alphabetic order.

This fixes a regression introduced in 6938bd5ace4b749f48af41b5eece078da0e0c862


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

6938bd5ace4b749f48af41b5eece078da0e0c862 was overeager to simplify the code, but lost the sorting. This restores the relevant code mostly as it was, with slightly different naming.

The code as it was was actually good, since it solves two issues efficiently:

- The order of the saved items is preserved
- By primarily iterating over the full item list saved items are still validated against the full list of available items. So any removed value would also be dropped from the saved list.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
