### PR TITLE
PICARD-3258: Check if `Album.ui_item` exists to avoid triggering an exception

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -738,7 +738,7 @@ class Album(MetadataItem):
         for func, _run_on_error in self._after_load_callbacks:
             func()
         self._after_load_callbacks = []
-        if self.ui_item.isSelected():
+        if self.ui_item and self.ui_item.isSelected():
             self.tagger.window.refresh_metadatabox()
             self.tagger.window.cover_art_box.update_metadata()
 


### PR DESCRIPTION

<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

In some cases (for example through a plugin), an album could be removed prior to the `_finalize_loading_album()` being called.  This could result in an execption when trying to refresh the UI.

* JIRA ticket (_optional_): PICARD-3258


## Solution

Check if `Album.ui_item` exists prior to checking the value of `Album.ui_item.isSelected()` to avoid triggering an exception.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
