### PR TITLE
PICARD-3261: better non unicode encoding of tags

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -112,7 +112,7 @@ def id3text(text, encoding):
     """
 
     if encoding == Id3Encoding.LATIN1:
-        return text.encode('latin1', 'replace').decode('latin1')
+        return text.encode('latin1', errors='simplify').decode('latin1')
     return text
 
 

--- a/picard/formats/wav.py
+++ b/picard/formats/wav.py
@@ -144,7 +144,7 @@ class RiffListInfo(MutableMapping):
         return value.rstrip('\0')
 
     def __encode_data(self, value):
-        return value.encode(self.encoding, errors='replace') + b'\x00'
+        return value.encode(self.encoding, errors='simplify') + b'\x00'
 
     def __contains__(self, name):
         return self.__tags.__contains__(name)

--- a/picard/util/textencoding.py
+++ b/picard/util/textencoding.py
@@ -466,3 +466,21 @@ def _replace_char(mapping, ch, pathsave=False, win_compat=False):
         return result
     except KeyError:
         return ch
+
+
+def error_simplify(e: UnicodeError) -> tuple[str | bytes, int]:
+    """Encoding error handler that attempts to replace the character with a simplified equivalent.
+    If no replacement can be found, it behaves like the standard "replace" error handler.
+    """
+    if isinstance(e, UnicodeEncodeError):
+        chars = e.object[e.start : e.end]
+        chars = unicode_simplify_combinations(chars)
+        chars = unicode_simplify_punctuation(chars)
+        chars = unicode_simplify_compatibility(chars)
+        chars = unicode_simplify_accents(chars)
+        repl = chars.encode(e.encoding, errors='replace')
+        return (repl, e.end)
+    raise e
+
+
+codecs.register_error('simplify', error_simplify)

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -765,8 +765,8 @@ class Id3UtilTest(PicardTestCase):
         self.assertEqual(id3.Id3Encoding.UTF8, id3.Id3Encoding.from_config('utf-8'))
 
     def test_id3text(self):
-        teststring = '日本語testÖäß'
-        self.assertEqual(id3.id3text(teststring, id3.Id3Encoding.LATIN1), '???testÖäß')
+        teststring = '日本語testÖäßŌš…'
+        self.assertEqual(id3.id3text(teststring, id3.Id3Encoding.LATIN1), '???testÖäßOs...')
         self.assertEqual(id3.id3text(teststring, id3.Id3Encoding.UTF16), teststring)
         self.assertEqual(id3.id3text(teststring, id3.Id3Encoding.UTF16BE), teststring)
         self.assertEqual(id3.id3text(teststring, id3.Id3Encoding.UTF8), teststring)

--- a/test/formats/test_wav.py
+++ b/test/formats/test_wav.py
@@ -123,16 +123,16 @@ class WAVTest(CommonId3Tests.Id3TestCase):
     @skipUnlessTestfile
     def test_riff_info_encoding_windows_1252(self):
         info = RiffListInfo()
-        info['INAM'] = 'fooßü‰€œžŸ文字'
+        info['INAM'] = 'fooßü‰€œžŸŌš文字…'
         info.save(self.filename)
         loaded_info = RiffListInfo()
         loaded_info.load(self.filename)
-        self.assertEqual('fooßü‰€œžŸ??', loaded_info['INAM'])
+        self.assertEqual('fooßü‰€œžŸOš??…', loaded_info['INAM'])
 
     @skipUnlessTestfile
     def test_riff_info_encoding_utf_8(self):
         info = RiffListInfo(encoding="utf-8")
-        info['INAM'] = 'fooßü‰€œžŸ文字'
+        info['INAM'] = 'fooßü‰€œžŸŌš文字…'
         info.save(self.filename)
         loaded_info = RiffListInfo()
         loaded_info.load(self.filename)

--- a/test/test_textencoding.py
+++ b/test/test_textencoding.py
@@ -254,6 +254,38 @@ class ReplaceNonAsciiTest(PicardTestCase):
         self.assertNotEqual(util.textencoding.replace_non_ascii("Lukáš"), "Luk____")
 
 
+class CodecErrorHandlerSimplifyTest(PicardTestCase):
+    def test_encode_simplify(self):
+        self.assertEqual(
+            "Lukáš".encode('iso-8859-1', errors='simplify'),
+            b"Luk\xe1s",
+        )
+        self.assertEqual(
+            "Lukáš".encode('ascii', errors='simplify'),
+            b"Lukas",
+        )
+        self.assertEqual(
+            "Ēbn-Ōzn".encode('iso-8859-1', errors='simplify'),
+            b"Ebn-Ozn",
+        )
+        self.assertEqual(
+            "Ænima".encode('iso-8859-2', errors='simplify'),
+            b"AEnima",
+        )
+
+    def test_encode_simplify_no_change(self):
+        self.assertEqual(
+            "Lukáš".encode('iso-8859-2', errors='simplify'),
+            b"Luk\xe1\xb9",
+        )
+
+    def test_encode_simplify_replacement(self):
+        self.assertEqual(
+            "小室哲哉".encode('iso-8859-1', errors='simplify'),
+            b"????",
+        )
+
+
 if show_latin2ascii_coverage:
     # The following code set blocks are taken from:
     # http://en.wikipedia.org/wiki/Latin_script_in_Unicode


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3261
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When storing tags with non-Unicode encoding, e.g. ISO-8859-1/latin1 in ID3 or Windows-1252 in WAV, any character not supported by the encoding gets replaced with a "?" by using `string.encode(..., errors="replace")`. No attempt is made to use any more readable character.

E.g. the band name "Ēbn-Ōzn" gets stored as "?bn-?zn", since both Ē and Ō cannot be encoded in neither ISO-8859-1 nor Windows-1252. But it would be more helpful to store it as "Ebn-Ozn".

We do have extensive functionality to convert Unicode to a more simplified format. But functions like `replace_non_ascii` assume ASCII compatibility, and will even replace characters that would be encodable in the target encoding.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Register a "simplify" encoding error handler. This error handler attempts to first simplify the Unicode characters, it falls back to encoding with the "replace" error handler.

E.g.

```python
"Ēbn-Ōzn".encode("latin1", errors="replace")  # This would output "?bn-?zn"
"Ēbn-Ōzn".encode("latin1", errors="simplify")  # This would output "Ebn-Ozn"
```

By having this an error handler:

- It is universally usable in every call of `encode`
- Encoding aware: Any character already encodable in the target encoding does not trigger the error handler
- A simplified character is used, if possible. If not the use of the "replace" error handler when encoding the replacement ensures we fall back to the default replacement behavior

Use `errors="simplify"` when encoding WAVE and ID3 tags.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
