### PR TITLE
PICARD-3296: Haiku's `sys.platform` returns just 'haiku' in the most recent versions of their Python packages interpreters

### DIFF
--- a/picard/const/sys.py
+++ b/picard/const/sys.py
@@ -26,7 +26,7 @@ import sys
 IS_WIN = sys.platform == 'win32'
 IS_LINUX = sys.platform == 'linux'
 IS_MACOS = sys.platform == 'darwin'
-IS_HAIKU = sys.platform == 'haiku1'
+IS_HAIKU = sys.platform == 'haiku'
 
 # These variables are set by pyinstaller if running from a packaged build
 # See http://pyinstaller.readthedocs.io/en/stable/runtime-information.html

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ class picard_build(build):
             )
 
             self.run_command('build_appxmanifest')
-        elif sys.platform not in {'darwin', 'haiku1', 'win32'}:
+        elif sys.platform not in {'darwin', 'haiku', 'win32'}:
             self.run_command('build_appdata')
             self.run_command('build_desktop_file')
         super().run()
@@ -721,7 +721,7 @@ def make_executable(filename):
     os.chmod(filename, os.stat(filename).st_mode | stat.S_IEXEC)
 
 
-if sys.platform not in {'darwin', 'haiku1', 'win32'}:
+if sys.platform not in {'darwin', 'haiku', 'win32'}:
     args['data_files'].append(('share/applications', [PICARD_DESKTOP_NAME]))
     args['data_files'].append(('share/icons/hicolor/scalable/apps', ['resources/%s.svg' % PICARD_APP_ID]))
     for size in (16, 24, 32, 48, 128, 256):


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

On all current Python interpreter versions on Haiku, `sys.platform` now returns just plain 'haiku' (was 'haiku1' before). See relevant change for the Python 3.14 package here: https://github.com/haikuports/haikuports/pull/13929.

PICARD-3296

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)
