### PR TITLE
mbjson type hints and refactorings

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -204,6 +204,7 @@ class Album(MetadataItem):
         self.status = AlbumStatus.NONE
         self._album_artists = []
         self.update_children_metadata_attrs = {'metadata', 'orig_metadata'}
+        self.per_medium_metadata: defaultdict[int, Metadata] = defaultdict(Metadata)
 
     def __repr__(self):
         return '<Album %s %r>' % (self.id, self.metadata['album'])
@@ -624,10 +625,6 @@ class Album(MetadataItem):
 
         va = self._new_metadata['musicbrainz_albumartistid'] == VARIOUS_ARTISTS_ID
 
-        djmix_ars = {}
-        if hasattr(self._new_metadata, '_djmix_ars'):
-            djmix_ars = self._new_metadata._djmix_ars
-
         for medium_node in self._release_node['media']:
             mm = Metadata()
             mm.copy(self._new_metadata)
@@ -636,8 +633,9 @@ class Album(MetadataItem):
             if fmt:
                 all_media.append(fmt)
 
-            for dj in djmix_ars.get(mm['discnumber'], []):
-                mm.add('djmixer', dj)
+            for key, values in self.per_medium_metadata[medium_node['position']].rawitems():
+                for v in values:
+                    mm.add_unique(key, v)
 
             if va:
                 mm['compilation'] = '1'

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -30,6 +30,7 @@
 from collections import defaultdict
 from collections.abc import (
     Callable,
+    Generator,
     Iterable,
 )
 from dataclasses import dataclass
@@ -61,7 +62,9 @@ from picard.util.script_detector_weighted import detect_script_weighted
 
 if TYPE_CHECKING:
     from picard.album import Album
+    from picard.item import MetadataItem
     from picard.metadata import Metadata
+    from picard.releasegroup import ReleaseGroup
     from picard.track import Track
 
 
@@ -178,18 +181,18 @@ class RelFuncContext:
     use_instrument_credits: bool
     use_vocal_credits: bool
     metadata_was_cleared: dict[str, bool]
-    per_medium_metadata: defaultdict[int, Metadata]
+    per_medium_metadata: 'defaultdict[int, Metadata]'
 
 
 @dataclass
 class RelFunc:
     """Encapsulates a relation function with a clear_metadata_first flag."""
 
-    func: Callable[[Node, Metadata, RelFuncContext], None]
+    func: 'Callable[[Node, Metadata, RelFuncContext], None]'
     clear_metadata_first: bool = False
 
 
-def _parse_attributes(attrs, reltype, attr_credits):
+def _parse_attributes(attrs: Iterable[str], reltype: str, attr_credits: dict[str, str]) -> str:
     prefixes = []
     nouns = []
     for attr in attrs:
@@ -209,14 +212,14 @@ def _parse_attributes(attrs, reltype, attr_credits):
     return " ".join([prefix, result]).strip()
 
 
-def _relation_attributes(relation):
+def _relation_attributes(relation: Node) -> tuple[str, ...]:
     try:
         return tuple(relation['attributes'])
     except KeyError:
         return tuple()
 
 
-def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', context: RelFuncContext):
+def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
     artist = relation['artist']
     translated_alias = _translate_artist_node(artist, config=context.config)
     has_translation = translated_alias.name != artist['name']
@@ -262,7 +265,7 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
         m.add_unique('~writersort', translated_alias.sort_name)
 
 
-def _relations_to_metadata_target_type_work(relation: Node, m: 'Metadata', context: RelFuncContext):
+def _relations_to_metadata_target_type_work(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
     if relation['type'] == 'performance':
         performance_attributes = _relation_attributes(relation)
         for attribute in performance_attributes:
@@ -271,7 +274,7 @@ def _relations_to_metadata_target_type_work(relation: Node, m: 'Metadata', conte
         work_to_metadata(relation['work'], m, instrumental)
 
 
-def _relations_to_metadata_target_type_url(relation: Node, m: 'Metadata', context: RelFuncContext):
+def _relations_to_metadata_target_type_url(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
     if relation['type'] == 'amazon asin' and 'asin' not in m:
         amz = parse_amazon_url(relation['url']['resource'])
         if amz is not None:
@@ -281,7 +284,7 @@ def _relations_to_metadata_target_type_url(relation: Node, m: 'Metadata', contex
         m.add('license', url)
 
 
-def _relations_to_metadata_target_type_series(relation: Node, m: 'Metadata', context: RelFuncContext):
+def _relations_to_metadata_target_type_series(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
     if relation['type'] == 'part of':
         entity = context.entity
         series = relation['series']
@@ -305,7 +308,7 @@ def _relations_to_metadata_target_type_series(relation: Node, m: 'Metadata', con
         m.add(number, relation['attribute-values'].get('number', ''))
 
 
-def _relations_to_metadata_target_type_label(relation: Node, m: 'Metadata', context: RelFuncContext):
+def _relations_to_metadata_target_type_label(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
     if relation['type'] == 'broadcast' and 'begin' in relation:
         m['~broadcast_date'] = relation['begin']
 
@@ -449,7 +452,7 @@ def _find_localized_alias_name(aliases: list[Node] | None, preferred_locales: li
     return _first_alias_match_in_order(root_order, locales)
 
 
-def _is_script_exception_enabled(config: Any) -> bool:
+def _is_script_exception_enabled(config: Config) -> bool:
     """
     Check whether script-exception matching is enabled.
 
@@ -467,7 +470,7 @@ def _is_script_exception_enabled(config: Any) -> bool:
     return config.setting['translate_artist_names_script_exception']
 
 
-def _get_script_exceptions(config: Any) -> list[tuple[str, int]]:
+def _get_script_exceptions(config: Config) -> list[tuple[str, int]]:
     """
     Get configured script-exception thresholds.
 
@@ -633,7 +636,7 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
     return ArtistCreditInfo(artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries)
 
 
-def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = False):
+def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = False) -> None:
     ids = [n['artist']['id'] for n in node]
     credits = artist_credit_from_node(node)
     if release:
@@ -652,12 +655,12 @@ def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = F
         m['~artists_countries'] = credits.countries
 
 
-def _release_event_iter(node):
+def _release_event_iter(node: Node) -> Generator[Node, None, None]:
     if 'release-events' in node:
         yield from node['release-events']
 
 
-def _country_from_release_event(release_event):
+def _country_from_release_event(release_event: Node) -> str | None:
     try:
         return release_event['area']['iso-3166-1-codes'][0]
     # TypeError in case object is None
@@ -666,7 +669,7 @@ def _country_from_release_event(release_event):
     return None
 
 
-def countries_from_node(node):
+def countries_from_node(node: Node) -> list[str]:
     countries = []
     for release_event in _release_event_iter(node):
         country_code = _country_from_release_event(release_event)
@@ -675,7 +678,7 @@ def countries_from_node(node):
     return sorted(countries)
 
 
-def release_dates_and_countries_from_node(node):
+def release_dates_and_countries_from_node(node: Node) -> tuple[list[str], list[str]]:
     dates = []
     countries = []
     for release_event in _release_event_iter(node):
@@ -686,7 +689,7 @@ def release_dates_and_countries_from_node(node):
     return dates, countries
 
 
-def label_info_from_node(node):
+def label_info_from_node(node: list[Node]) -> tuple[list[str], list[str]]:
     labels = []
     catalog_numbers = []
     for label_info in node:
@@ -701,7 +704,7 @@ def label_info_from_node(node):
     return (labels, catalog_numbers)
 
 
-def media_formats_from_node(node):
+def media_formats_from_node(node: list[Node]) -> str:
     formats_count = {}
     formats_order = []
     for medium in node:
@@ -727,7 +730,7 @@ def _node_skip_empty_iter(node):
             yield key, value
 
 
-def track_to_metadata(node, track):
+def track_to_metadata(node: Node, track: 'Track') -> None:
     m = track.metadata
     recording_to_metadata(node['recording'], m, track)
     config = get_config()
@@ -748,7 +751,7 @@ def track_to_metadata(node, track):
         m['~length'] = format_time(m.length)
 
 
-def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = None):
+def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = None) -> None:
     m.length = 0
     m.add_unique('musicbrainz_recordingid', node['id'])
     config = get_config()
@@ -786,7 +789,7 @@ def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = Non
         m['~length'] = format_time(m.length)
 
 
-def work_to_metadata(work, m, instrumental=False):
+def work_to_metadata(work: Node, m: 'Metadata', instrumental: bool = False) -> None:
     m.add_unique('musicbrainz_workid', work['id'])
     if instrumental:
         m.add_unique('language', 'zxx')  # no lyrics
@@ -803,7 +806,7 @@ def work_to_metadata(work, m, instrumental=False):
         _relations_to_metadata(work['relations'], m, instrumental, entity='work')
 
 
-def medium_to_metadata(node, m):
+def medium_to_metadata(node: Node, m: 'Metadata') -> None:
     for key, value in _node_skip_empty_iter(node):
         if key in _MEDIUM_TO_METADATA:
             m[_MEDIUM_TO_METADATA[key]] = value
@@ -814,7 +817,7 @@ def medium_to_metadata(node, m):
         m['totaltracks'] = totaltracks
 
 
-def artist_to_metadata(node, m):
+def artist_to_metadata(node: Node, m: 'Metadata') -> None:
     """Make metadata dict from a JSON 'artist' node."""
     m.add_unique('musicbrainz_artistid', node['id'])
     for key, value in _node_skip_empty_iter(node):
@@ -835,7 +838,7 @@ def artist_to_metadata(node, m):
             m['endarea'] = value['name']
 
 
-def release_to_metadata(node: Node, m: 'Metadata', album: 'Album | None' = None):
+def release_to_metadata(node: Node, m: 'Metadata', album: 'Album | None' = None) -> None:
     """Make metadata dict from a JSON 'release' node."""
     config = get_config()
     m.add_unique('musicbrainz_albumid', node['id'])
@@ -880,7 +883,7 @@ def release_to_metadata(node: Node, m: 'Metadata', album: 'Album | None' = None)
     add_genres_from_node(node, album)
 
 
-def release_group_to_metadata(node, m, release_group=None):
+def release_group_to_metadata(node: Node, m: 'Metadata', release_group: 'ReleaseGroup | None' = None) -> None:
     """Make metadata dict from a JSON 'release-group' node taken from inside a 'release' node."""
     config = get_config()
     m.add_unique('musicbrainz_releasegroupid', node['id'])
@@ -900,12 +903,12 @@ def release_group_to_metadata(node, m, release_group=None):
     m['releasetype'] = m.getall('~primaryreleasetype') + m.getall('~secondaryreleasetype')
 
 
-def add_secondary_release_types(node, m):
+def add_secondary_release_types(node: list[str], m: 'Metadata') -> None:
     for secondary_type in node:
         m.add_unique('~secondaryreleasetype', secondary_type.lower())
 
 
-def add_genres_from_node(node, obj):
+def add_genres_from_node(node: Node, obj: 'MetadataItem | None') -> None:
     if obj is None:
         return
     if 'tags' in node:
@@ -918,32 +921,32 @@ def add_genres_from_node(node, obj):
         add_user_genres(node['user-genres'], obj)
 
 
-def add_genres(node, obj):
+def add_genres(node: list[Node], obj: 'MetadataItem') -> None:
     for tag in node:
         obj.add_genre(tag['name'], tag['count'])
 
 
-def add_user_genres(node, obj):
+def add_user_genres(node: list[Node], obj: 'MetadataItem') -> None:
     for tag in node:
         obj.add_genre(tag['name'], 1)
 
 
-def add_tags(node, obj):
+def add_tags(node: list[Node], obj: 'MetadataItem') -> None:
     for tag in node:
         obj.add_folksonomy_tag(tag['name'], tag['count'])
 
 
-def add_user_tags(node, obj):
+def add_user_tags(node: list[Node], obj: 'MetadataItem') -> None:
     for tag in node:
         obj.add_folksonomy_tag(tag['name'], 1)
 
 
-def add_isrcs_to_metadata(node, metadata):
+def add_isrcs_to_metadata(node: list[str], metadata: 'Metadata') -> None:
     for isrc in node:
         metadata.add('isrc', isrc)
 
 
-def get_score(node):
+def get_score(node: Node) -> float:
     """Returns the score attribute for a node.
     The score is expected to be an integer between 0 and 100, it is returned as
     a value between 0.0 and 1.0. If there is no score attribute or it has an

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -30,7 +30,10 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any
+from typing import (
+    Any,
+    TypeAlias,
+)
 
 from picard import log
 from picard.config import get_config
@@ -119,6 +122,9 @@ _RELEASE_GROUP_TO_METADATA = {
 
 _PREFIX_ATTRS = {'guest', 'additional', 'minor', 'solo'}
 _BLANK_SPECIAL_RELTYPES = {'vocal': 'vocals'}
+
+
+Node: TypeAlias = dict[str, Any]
 
 
 @dataclass
@@ -292,9 +298,7 @@ def _relations_to_metadata(relations, m, instrumental=False, config=None, entity
             relfunc.func(relation, m, context)
 
 
-def _locales_from_aliases(
-    aliases: list[dict[str, Any]],
-) -> dict[str, AliasMatch]:
+def _locales_from_aliases(aliases: list[Node]) -> dict[str, AliasMatch]:
     def check_higher_score(locale_dict: dict[str, AliasMatch], locale: str, score: float) -> bool:
         return locale not in locale_dict or score > locale_dict[locale].score
 
@@ -356,7 +360,7 @@ def _first_alias_match_in_order(order: Iterable[str], mapping: dict[str, AliasMa
     return None
 
 
-def _find_localized_alias_name(aliases: list[dict[str, Any]] | None, preferred_locales: list[str]) -> Alias | None:
+def _find_localized_alias_name(aliases: list[Node] | None, preferred_locales: list[str]) -> Alias | None:
     """
     Select a localized alias by preferred locales for non-artist entities.
 
@@ -365,7 +369,7 @@ def _find_localized_alias_name(aliases: list[dict[str, Any]] | None, preferred_l
 
     Parameters
     ----------
-    aliases : list[dict[str, Any]] or None
+    aliases : list[Node] or None
         Alias entries as provided by the web service, each containing at
         least ``name`` and ``locale``.
     preferred_locales : list[str]

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -27,6 +27,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import defaultdict
 from collections.abc import (
     Callable,
     Iterable,
@@ -59,6 +60,7 @@ from picard.util.script_detector_weighted import detect_script_weighted
 
 
 if TYPE_CHECKING:
+    from picard.album import Album
     from picard.metadata import Metadata
     from picard.track import Track
 
@@ -165,6 +167,7 @@ class RelFuncContext:
     use_instrument_credits: bool
     use_vocal_credits: bool
     metadata_was_cleared: dict[str, bool]
+    per_medium_metadata: defaultdict[int, Metadata]
 
 
 @dataclass
@@ -221,10 +224,13 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
             attr_credits = {}
         name = 'performer:' + _parse_attributes(attribs, reltype, attr_credits)
     elif reltype == 'mix-DJ' and attribs:
-        if not hasattr(m, '_djmix_ars'):
-            m._djmix_ars = {}
         for attr in attribs:
-            m._djmix_ars.setdefault(attr.split()[1], []).append(translated_alias.name)
+            if attr.startswith('medium'):
+                try:
+                    medium_no = int(attr.split()[1])
+                    context.per_medium_metadata[medium_no].add_unique('djmixer', translated_alias.name)
+                except ValueError:
+                    log.warning('Invalid medium number in mix-DJ attribute: %s', attr)
         return
     else:
         try:
@@ -311,7 +317,9 @@ def _relations_to_metadata(
     instrumental: bool = False,
     config: Config | None = None,
     entity: str | None = None,
-):
+) -> RelFuncContext:
+    from picard.metadata import Metadata  # inline import to avoid circular imports
+
     config = config or get_config()
     context = RelFuncContext(
         config=config,
@@ -321,6 +329,7 @@ def _relations_to_metadata(
         use_instrument_credits=not config.setting['standardize_instruments'],
         use_vocal_credits=not config.setting['standardize_vocals'],
         metadata_was_cleared=dict(),
+        per_medium_metadata=defaultdict(Metadata),
     )
     for relation in relations:
         target = relation['target-type']
@@ -329,6 +338,7 @@ def _relations_to_metadata(
             if target not in context.metadata_was_cleared:
                 context.metadata_was_cleared[target] = not relfunc.clear_metadata_first
             relfunc.func(relation, m, context)
+    return context
 
 
 def _locales_from_aliases(aliases: list[Node]) -> dict[str, AliasMatch]:
@@ -814,7 +824,7 @@ def artist_to_metadata(node, m):
             m['endarea'] = value['name']
 
 
-def release_to_metadata(node, m, album=None):
+def release_to_metadata(node: Node, m: 'Metadata', album: 'Album | None' = None):
     """Make metadata dict from a JSON 'release' node."""
     config = get_config()
     m.add_unique('musicbrainz_albumid', node['id'])
@@ -832,7 +842,9 @@ def release_to_metadata(node, m, album=None):
                     artist_obj = album.append_album_artist(artist['id'])
                     add_genres_from_node(artist, artist_obj)
         elif key == 'relations' and config.setting['release_ars']:
-            _relations_to_metadata(value, m, config=config, entity='release')
+            context = _relations_to_metadata(value, m, config=config, entity='release')
+            if album:
+                album.per_medium_metadata = context.per_medium_metadata
         elif key == 'label-info':
             m['label'], m['catalognumber'] = label_info_from_node(value)
         elif key == 'text-representation':

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -149,6 +149,17 @@ class Alias:
 
 
 @dataclass
+class ArtistCreditInfo:
+    """Artist credit info, including the combined name and all individual artist names and countries."""
+
+    name: str
+    sort_name: str
+    names: list[str]
+    sort_names: list[str]
+    countries: list[str]
+
+
+@dataclass
 class AliasMatch:
     """Combines an alias with a matching score when selecting the best matching alias for an entity."""
 
@@ -571,7 +582,7 @@ def _should_skip_translation_due_to_scripts(text: str | None, config: Any | None
     return matched
 
 
-def _translate_artist_node(node, config=None) -> Alias:
+def _translate_artist_node(node: Node, config: Config | None = None) -> Alias:
     config = config or get_config()
     if config.setting['translate_artist_names']:
         if _should_skip_translation_due_to_scripts(node['name'], config=config):
@@ -591,7 +602,7 @@ def _translate_artist_node(node, config=None) -> Alias:
     return Alias(translated_name, sort_name)
 
 
-def artist_credit_from_node(node):
+def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
     artist_name = ''
     artist_sort_name = ''
     artist_names = []
@@ -619,26 +630,26 @@ def artist_credit_from_node(node):
         if 'joinphrase' in artist_info:
             artist_name += artist_info['joinphrase'] or ''
             artist_sort_name += artist_info['joinphrase'] or ''
-    return (artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries)
+    return ArtistCreditInfo(artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries)
 
 
-def artist_credit_to_metadata(node, m, release=False):
+def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = False):
     ids = [n['artist']['id'] for n in node]
-    artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries = artist_credit_from_node(node)
+    credits = artist_credit_from_node(node)
     if release:
         m['musicbrainz_albumartistid'] = ids
-        m['albumartist'] = artist_name
-        m['albumartistsort'] = artist_sort_name
-        m['~albumartists'] = artist_names
-        m['~albumartists_sort'] = artist_sort_names
-        m['~albumartists_countries'] = artist_countries
+        m['albumartist'] = credits.name
+        m['albumartistsort'] = credits.sort_name
+        m['~albumartists'] = credits.names
+        m['~albumartists_sort'] = credits.sort_names
+        m['~albumartists_countries'] = credits.countries
     else:
         m['musicbrainz_artistid'] = ids
-        m['artist'] = artist_name
-        m['artistsort'] = artist_sort_name
-        m['artists'] = artist_names
-        m['~artists_sort'] = artist_sort_names
-        m['~artists_countries'] = artist_countries
+        m['artist'] = credits.name
+        m['artistsort'] = credits.sort_name
+        m['artists'] = credits.names
+        m['~artists_sort'] = credits.sort_names
+        m['~artists_countries'] = credits.countries
 
 
 def _release_event_iter(node):

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -27,16 +27,22 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from collections.abc import Iterable
+from collections.abc import (
+    Callable,
+    Iterable,
+)
 from dataclasses import dataclass
-from types import SimpleNamespace
 from typing import (
+    TYPE_CHECKING,
     Any,
     TypeAlias,
 )
 
 from picard import log
-from picard.config import get_config
+from picard.config import (
+    Config,
+    get_config,
+)
 from picard.const import (
     ALIAS_TYPE_ARTIST_NAME_ID,
     ALIAS_TYPE_LEGAL_NAME_ID,
@@ -50,6 +56,11 @@ from picard.util import (
     translate_from_sortname,
 )
 from picard.util.script_detector_weighted import detect_script_weighted
+
+
+if TYPE_CHECKING:
+    from picard.metadata import Metadata
+    from picard.track import Track
 
 
 _ARTIST_REL_TYPES = {
@@ -143,6 +154,27 @@ class AliasMatch:
     alias: Alias
 
 
+@dataclass
+class RelFuncContext:
+    """Give context for a RelFunc."""
+
+    config: Config
+    entity: str | None
+    instrumental: bool
+    use_credited_as: bool
+    use_instrument_credits: bool
+    use_vocal_credits: bool
+    metadata_was_cleared: dict[str, bool]
+
+
+@dataclass
+class RelFunc:
+    """Encapsulates a relation function with a clear_metadata_first flag."""
+
+    func: Callable[[Node, Metadata, RelFuncContext], None]
+    clear_metadata_first: bool = False
+
+
 def _parse_attributes(attrs, reltype, attr_credits):
     prefixes = []
     nouns = []
@@ -170,7 +202,7 @@ def _relation_attributes(relation):
         return tuple()
 
 
-def _relations_to_metadata_target_type_artist(relation, m, context):
+def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', context: RelFuncContext):
     artist = relation['artist']
     translated_alias = _translate_artist_node(artist, config=context.config)
     has_translation = translated_alias.name != artist['name']
@@ -213,7 +245,7 @@ def _relations_to_metadata_target_type_artist(relation, m, context):
         m.add_unique('~writersort', translated_alias.sort_name)
 
 
-def _relations_to_metadata_target_type_work(relation, m, context):
+def _relations_to_metadata_target_type_work(relation: Node, m: 'Metadata', context: RelFuncContext):
     if relation['type'] == 'performance':
         performance_attributes = _relation_attributes(relation)
         for attribute in performance_attributes:
@@ -222,7 +254,7 @@ def _relations_to_metadata_target_type_work(relation, m, context):
         work_to_metadata(relation['work'], m, instrumental)
 
 
-def _relations_to_metadata_target_type_url(relation, m, context):
+def _relations_to_metadata_target_type_url(relation: Node, m: 'Metadata', context: RelFuncContext):
     if relation['type'] == 'amazon asin' and 'asin' not in m:
         amz = parse_amazon_url(relation['url']['resource'])
         if amz is not None:
@@ -232,7 +264,7 @@ def _relations_to_metadata_target_type_url(relation, m, context):
         m.add('license', url)
 
 
-def _relations_to_metadata_target_type_series(relation, m, context):
+def _relations_to_metadata_target_type_series(relation: Node, m: 'Metadata', context: RelFuncContext):
     if relation['type'] == 'part of':
         entity = context.entity
         series = relation['series']
@@ -256,14 +288,9 @@ def _relations_to_metadata_target_type_series(relation, m, context):
         m.add(number, relation['attribute-values'].get('number', ''))
 
 
-def _relations_to_metadata_target_type_label(relation, m, context):
+def _relations_to_metadata_target_type_label(relation: Node, m: 'Metadata', context: RelFuncContext):
     if relation['type'] == 'broadcast' and 'begin' in relation:
         m['~broadcast_date'] = relation['begin']
-
-
-class RelFunc(SimpleNamespace):
-    clear_metadata_first = False
-    func = None
 
 
 _RELATIONS_TO_METADATA_TARGET_TYPE_FUNC = {
@@ -278,9 +305,15 @@ _RELATIONS_TO_METADATA_TARGET_TYPE_FUNC = {
 }
 
 
-def _relations_to_metadata(relations, m, instrumental=False, config=None, entity=None):
+def _relations_to_metadata(
+    relations: list[Node],
+    m: 'Metadata',
+    instrumental: bool = False,
+    config: Config | None = None,
+    entity: str | None = None,
+):
     config = config or get_config()
-    context = SimpleNamespace(
+    context = RelFuncContext(
         config=config,
         entity=entity,
         instrumental=instrumental,
@@ -694,7 +727,7 @@ def track_to_metadata(node, track):
         m['~length'] = format_time(m.length)
 
 
-def recording_to_metadata(node, m, track=None):
+def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = None):
     m.length = 0
     m.add_unique('musicbrainz_recordingid', node['id'])
     config = get_config()

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -279,7 +279,7 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
 
             if 'albumartist' in self and 'albumartist' in weights:
                 a = self['albumartist']
-                b = artist_credit_from_node(release['artist-credit'])[0]
+                b = artist_credit_from_node(release['artist-credit']).name
                 parts.append((similarity2(a, b), weights['albumartist']))
 
             if 'totaltracks' in weights:
@@ -393,7 +393,7 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
             if 'artist' in self:
                 a = self['artist']
                 artist_credits = track.get('artist-credit', [])
-                b = artist_credit_from_node(artist_credits)[0]
+                b = artist_credit_from_node(artist_credits).name
                 parts.append((similarity2(a, b), weights["artist"]))
 
             a = self.length

--- a/picard/ui/cdlookup.py
+++ b/picard/ui/cdlookup.py
@@ -112,7 +112,7 @@ class CDLookupDialog(PicardDialog):
                     selected = item
                 values = {
                     'album': release['title'],
-                    'artist': artist_credit_from_node(release['artist-credit'])[0],
+                    'artist': artist_credit_from_node(release['artist-credit']).name,
                     'dates': myjoin(dates),
                     'countries': myjoin(countries),
                     'labels': myjoin(labels),

--- a/test/data/ws_data/release_djmix.json
+++ b/test/data/ws_data/release_djmix.json
@@ -1,0 +1,291 @@
+{
+  "quality": "normal",
+  "status": "Official",
+  "relations": [
+    {
+      "type-id": "f3b80a09-5ebf-4ad2-9c46-3e6bce971d1b",
+      "attribute-ids": {},
+      "type": "art direction",
+      "target-credit": "",
+      "attributes": [],
+      "direction": "backward",
+      "attribute-values": {},
+      "source-credit": "",
+      "ended": false,
+      "artist": {
+        "id": "c4f0a476-4362-4d90-a4b4-3145fd3b587c",
+        "disambiguation": "UK art direction",
+        "name": "Red Design",
+        "country": "GB",
+        "sort-name": "Red Design",
+        "type": "Other",
+        "type-id": "ac897045-5043-3294-969b-187360e45d86"
+      },
+      "begin": null,
+      "target-type": "artist",
+      "end": null
+    },
+    {
+      "ended": false,
+      "artist": {
+        "type": "Other",
+        "type-id": "ac897045-5043-3294-969b-187360e45d86",
+        "country": "GB",
+        "sort-name": "Red Design",
+        "disambiguation": "UK art direction",
+        "name": "Red Design",
+        "id": "c4f0a476-4362-4d90-a4b4-3145fd3b587c"
+      },
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "type-id": "307e95dd-88b5-419b-8223-b146d4a0d439",
+      "type": "design/illustration",
+      "attribute-ids": {},
+      "target-credit": "",
+      "attributes": [],
+      "attribute-values": {},
+      "direction": "backward",
+      "source-credit": ""
+    },
+    {
+      "end": null,
+      "begin": null,
+      "target-type": "artist",
+      "artist": {
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "sort-name": "Seveso, Alberto",
+        "country": "GB",
+        "disambiguation": "",
+        "name": "Alberto Seveso",
+        "id": "70b6de03-77b7-4f80-8b0d-c1fe5c2e2d6a"
+      },
+      "ended": false,
+      "attributes": [],
+      "direction": "backward",
+      "source-credit": "",
+      "attribute-values": {},
+      "target-credit": "",
+      "type-id": "307e95dd-88b5-419b-8223-b146d4a0d439",
+      "attribute-ids": {},
+      "type": "design/illustration"
+    },
+    {
+      "type-id": "f30c29d3-a3f1-420d-9b6c-a750fd6bc2aa",
+      "attribute-ids": {},
+      "type": "editor",
+      "attributes": [],
+      "attribute-values": {},
+      "source-credit": "",
+      "direction": "backward",
+      "target-credit": "",
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "ended": false,
+      "artist": {
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "sort-name": "Frankmusik",
+        "country": "GB",
+        "name": "Frankmusik",
+        "disambiguation": "",
+        "id": "612231ce-633b-4ebc-99bf-9b14e8d1cb74"
+      }
+    },
+    {
+      "end": null,
+      "begin": null,
+      "target-type": "artist",
+      "artist": {
+        "name": "Tim Debney",
+        "disambiguation": "",
+        "id": "a7344984-8027-4ad3-89f9-cbaa25d1166a",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "type": "Person",
+        "country": "GB",
+        "sort-name": "Debney, Tim"
+      },
+      "ended": false,
+      "target-credit": "",
+      "attributes": [],
+      "attribute-values": {},
+      "source-credit": "",
+      "direction": "backward",
+      "type-id": "84453d28-c3e8-4864-9aae-25aa968bcf9e",
+      "type": "mastering",
+      "attribute-ids": {}
+    },
+    {
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "ended": false,
+      "artist": {
+        "name": "John Webber",
+        "disambiguation": "mastering engineer",
+        "id": "e724dab4-ee52-4f8d-a844-dd827b615a66",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "country": "GB",
+        "sort-name": "Webber, John"
+      },
+      "type-id": "84453d28-c3e8-4864-9aae-25aa968bcf9e",
+      "type": "mastering",
+      "attribute-ids": {},
+      "attributes": [],
+      "attribute-values": {},
+      "direction": "backward",
+      "source-credit": "",
+      "target-credit": ""
+    },
+    {
+      "direction": "backward",
+      "source-credit": "",
+      "attribute-values": {},
+      "attributes": ["medium 2"],
+      "target-credit": "",
+      "type": "mix-DJ",
+      "attribute-ids": { "medium 2": "5a2cd122-6104-3fae-a4c1-56f0b3ad07bc" },
+      "type-id": "9162dedd-790c-446c-838e-240f877dbfe2",
+      "artist": {
+        "disambiguation": "",
+        "name": "Frankmusik",
+        "id": "612231ce-633b-4ebc-99bf-9b14e8d1cb74",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "country": "GB",
+        "sort-name": "Frankmusik"
+      },
+      "ended": false,
+      "end": null,
+      "target-type": "artist",
+      "begin": null
+    },
+    {
+      "type-id": "0b58dc9b-9c49-4b19-bb58-9c06d41c8fbf",
+      "attribute-ids": {},
+      "type": "photography",
+      "target-credit": "",
+      "attributes": [],
+      "source-credit": "",
+      "direction": "backward",
+      "attribute-values": {},
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "ended": false,
+      "artist": {
+        "country": null,
+        "sort-name": "Beard, Tom",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "type": "Person",
+        "id": "895d7272-8ebd-46c5-a927-956762e4080b",
+        "disambiguation": "photographer",
+        "name": "Tom Beard"
+      }
+    },
+    {
+      "type-id": "8bf377ba-8d71-4ecc-97f2-7bb2d8a2a75f",
+      "type": "producer",
+      "attribute-ids": { "executive": "e0039285-6667-4f94-80d6-aa6520c6d359" },
+      "attributes": ["executive"],
+      "source-credit": "",
+      "attribute-values": {},
+      "direction": "backward",
+      "target-credit": "",
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "ended": false,
+      "artist": {
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "type": "Person",
+        "sort-name": "Frankmusik",
+        "country": "GB",
+        "disambiguation": "",
+        "name": "Frankmusik",
+        "id": "612231ce-633b-4ebc-99bf-9b14e8d1cb74"
+      }
+    },
+    {
+      "ended": false,
+      "artist": {
+        "name": "David Norland",
+        "disambiguation": "",
+        "id": "1cbe3926-9250-481e-88e6-42d91c274231",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "type": "Person",
+        "sort-name": "Norland, David",
+        "country": null
+      },
+      "begin": null,
+      "target-type": "artist",
+      "end": null,
+      "type-id": "8bf377ba-8d71-4ecc-97f2-7bb2d8a2a75f",
+      "type": "producer",
+      "attribute-ids": { "executive": "e0039285-6667-4f94-80d6-aa6520c6d359" },
+      "target-credit": "",
+      "attributes": ["executive"],
+      "direction": "backward",
+      "source-credit": "",
+      "attribute-values": {}
+    },
+    {
+      "target-type": "artist",
+      "begin": null,
+      "end": null,
+      "ended": false,
+      "artist": {
+        "id": "612231ce-633b-4ebc-99bf-9b14e8d1cb74",
+        "disambiguation": "",
+        "name": "Frankmusik",
+        "country": "GB",
+        "sort-name": "Frankmusik",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "type": "remixer",
+      "attribute-ids": {},
+      "type-id": "ac6a86db-f757-4815-a07e-744428d2382b",
+      "target-credit": "",
+      "direction": "backward",
+      "source-credit": "",
+      "attribute-values": {},
+      "attributes": []
+    }
+  ],
+  "disambiguation": "",
+  "id": "9ba03e85-de11-411c-914c-4e956e53e292",
+  "date": "2009-08-03",
+  "asin": "B002C73VZK",
+  "packaging": null,
+  "text-representation": { "script": "Latn", "language": "eng" },
+  "cover-art-archive": {
+    "back": true,
+    "darkened": false,
+    "count": 22,
+    "artwork": true,
+    "front": true
+  },
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "country": "GB",
+  "title": "Complete Me",
+  "barcode": "0602527121956",
+  "release-events": [
+    {
+      "date": "2009-08-03",
+      "area": {
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "disambiguation": "",
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "iso-3166-1-codes": ["GB"],
+        "type": null,
+        "type-id": null
+      }
+    }
+  ],
+  "packaging-id": null
+}

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -42,12 +42,15 @@ from picard.const import (
 from picard.mbjson import (
     Alias,
     AliasMatch,
+    ArtistCreditInfo,
     _locales_from_aliases,
     _node_skip_empty_iter,
     _parse_attributes,
     _relations_to_metadata,
     _relations_to_metadata_target_type_url,
     _translate_artist_node,
+    artist_credit_from_node,
+    artist_credit_to_metadata,
     artist_to_metadata,
     countries_from_node,
     get_score,
@@ -421,6 +424,51 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         t = Track('1')
         recording_to_metadata(self.json_doc, m, t)
         self.assertEqual(m['~artists_countries'], 'GB; US; US')
+
+    def test_artist_credit_from_node(self):
+        credits = artist_credit_from_node(self.json_doc['artist-credit'])
+        expected = ArtistCreditInfo(
+            'Ed Sheeran feat. Meek Mill & A Boogie Wit da Hoodie',
+            'Sheeran, Ed feat. Meek Mill & Boogie Wit da Hoodie, A',
+            ['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'],
+            ['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'],
+            ['GB', 'US', 'US'],
+        )
+        self.assertEqual(expected, credits)
+
+    def test_artist_credit_to_metadata_track(self):
+        m = Metadata()
+        artist_credit_to_metadata(self.json_doc['artist-credit'], m)
+        self.assertEqual(
+            [
+                'b8a7c51f-362c-4dcb-a259-bc6e0095f0a6',
+                '31bcadcc-e1da-4cad-bec8-2f4f1d41b095',
+                'c1708d03-8a66-46eb-848e-fe0d233ffb39',
+            ],
+            m.getall('musicbrainz_artistid'),
+        )
+        self.assertEqual('Ed Sheeran feat. Meek Mill & A Boogie Wit da Hoodie', m['artist'])
+        self.assertEqual('Sheeran, Ed feat. Meek Mill & Boogie Wit da Hoodie, A', m['artistsort'])
+        self.assertEqual(['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'], m.getall('artists'))
+        self.assertEqual(['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'], m.getall('~artists_sort'))
+        self.assertEqual(['GB', 'US', 'US'], m.getall('~artists_countries'))
+
+    def test_artist_credit_to_metadata_release(self):
+        m = Metadata()
+        artist_credit_to_metadata(self.json_doc['artist-credit'], m, release=True)
+        self.assertEqual(
+            [
+                'b8a7c51f-362c-4dcb-a259-bc6e0095f0a6',
+                '31bcadcc-e1da-4cad-bec8-2f4f1d41b095',
+                'c1708d03-8a66-46eb-848e-fe0d233ffb39',
+            ],
+            m.getall('musicbrainz_albumartistid'),
+        )
+        self.assertEqual('Ed Sheeran feat. Meek Mill & A Boogie Wit da Hoodie', m['albumartist'])
+        self.assertEqual('Sheeran, Ed feat. Meek Mill & Boogie Wit da Hoodie, A', m['albumartistsort'])
+        self.assertEqual(['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'], m.getall('~albumartists'))
+        self.assertEqual(['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'], m.getall('~albumartists_sort'))
+        self.assertEqual(['GB', 'US', 'US'], m.getall('~albumartists_countries'))
 
 
 class RecordingMultiArtistsTest2(MBJSONTest):

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -296,6 +296,55 @@ class ReleaseTest(MBJSONTest):
         self.assertEqual(m.getall('~releasegroup_seriesnumber'), ['15'])
 
 
+class DjMixReleaseTest(MBJSONTest):
+    filename = 'release_djmix.json'
+
+    def test_release_djmix(self):
+        m = Metadata()
+        a = Album("1")
+        release_to_metadata(self.json_doc, m, a)
+        expected_medium_metadata = {
+            2: Metadata({'djmixer': ['Frankmusik']}),
+        }
+        self.assertNotIn('djmixer', m)
+        self.assertEqual(expected_medium_metadata, dict(a.per_medium_metadata))
+
+    def test_release_djmix_with_all_medium_ar(self):
+        m = Metadata()
+        a = Album("1")
+        self.json_doc['relations'].append(
+            {
+                "direction": "backward",
+                "source-credit": "",
+                "attribute-values": {},
+                "attributes": [],
+                "target-credit": "",
+                "type": "mix-DJ",
+                "attribute-ids": {},
+                "type-id": "9162dedd-790c-446c-838e-240f877dbfe2",
+                "artist": {
+                    "disambiguation": "",
+                    "name": "Global DJ",
+                    "id": "3dc9ba23-0126-464a-90cc-4924b6bb37b4",
+                    "type": "Person",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "GB",
+                    "sort-name": "Global DJ",
+                },
+                "ended": False,
+                "end": None,
+                "target-type": "artist",
+                "begin": None,
+            }
+        )
+        release_to_metadata(self.json_doc, m, a)
+        expected_medium_metadata = {
+            2: Metadata({'djmixer': ['Frankmusik']}),
+        }
+        self.assertEqual(m.getall('djmixer'), ['Global DJ'])
+        self.assertEqual(expected_medium_metadata, dict(a.per_medium_metadata))
+
+
 class NullReleaseTest(MBJSONTest):
     filename = 'release_null.json'
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

This PR adds extensive typehints to `mbjson.py` and also refactors some aspects for better type safety and reusability.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Add extensive type hints
- Convert `RelFunc` from `SimpleNamespace` to a dataclass (9b44d1b55545bd2890ceec759bfb17e81bc392ae). This fixes a typing error reported when calling the `RelFunc.func` callable.
- Introduce a `Node: TypeAlias = dict[str, Any]` type alias (68446748136e4e8844e0a7c6092d81d88ce5c00d)
- Refactor the handling of per-medium djmix ARs and added tests (3bd7e3afdaa0b661841ed71f615ea758f91220cf). This refactors the functionality originally implemented in PICARD-20, see also the example release http://musicbrainz.org/release/9ba03e85-de11-411c-914c-4e956e53e292. 
- Add a `ArtistCreditInfo` dataclass (351d327f9e41b222175f4ee77680cf20ff95b762)
- 


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion): trivial autocompletion of type hints and variable names only
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
