### PR TITLE
Add user defined locale and long description to MANIFEST template

### DIFF
--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -58,7 +58,11 @@ from picard.git.utils import (
     get_local_repository_path,
 )
 from picard.options import init_options
-from picard.plugin3.constants import CATEGORIES as VALID_CATEGORIES, LICENSES
+from picard.plugin3.constants import (
+    CATEGORIES as VALID_CATEGORIES,
+    DEFAULT_SOURCE_LOCALE,
+    LICENSES,
+)
 from picard.plugin3.init_templates import (
     get_git_author,
     get_git_config_author,
@@ -1888,7 +1892,7 @@ class PluginCLI:
         with_i18n = getattr(self._args, 'with_translations', False) or self._out.yesno(
             'Include translation support (i18n)?', default='N'
         )
-        source_locale = getattr(self._args, 'source_locale', 'en')
+        source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
         if with_i18n:
             locale_input = input(f'{self._out.bold("Source locale")} [{self._out.dim(source_locale)}]: ').strip()
             if locale_input:
@@ -1963,7 +1967,7 @@ class PluginCLI:
 
         # Check --source-locale flag
         if source_locale is None:
-            source_locale = getattr(self._args, 'source_locale', 'en')
+            source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
 
         # Check --no-commit flag
         if git_commit:
@@ -2203,8 +2207,8 @@ def process_cmdline_args():
     group_advanced.add_argument(
         '--source-locale',
         metavar='LOCALE',
-        default='en',
-        help="source locale for --init with --with-translations (default: en)",
+        default=DEFAULT_SOURCE_LOCALE,
+        help=f"source locale for --init with --with-translations (default: {DEFAULT_SOURCE_LOCALE})",
     )
     group_advanced.add_argument(
         '--locale', metavar='LOCALE', default='en', help="locale for displaying plugin info (e.g., 'fr', 'de', 'en')"

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -1885,6 +1885,15 @@ class PluginCLI:
             'license': license_id,
         }
 
+        with_i18n = getattr(self._args, 'with_translations', False) or self._out.yesno(
+            'Include translation support (i18n)?', default='N'
+        )
+        source_locale = getattr(self._args, 'source_locale', 'en')
+        if with_i18n:
+            locale_input = input(f'{self._out.bold("Source locale")} [{self._out.dim(source_locale)}]: ').strip()
+            if locale_input:
+                source_locale = locale_input
+
         return self._create_plugin_project(
             name,
             description,
@@ -1894,8 +1903,8 @@ class PluginCLI:
             license_url,
             author_email=author_email,
             target=target,
-            with_i18n=getattr(self._args, 'with_translations', False)
-            or self._out.yesno('Include translation support (i18n)?', default='N'),
+            with_i18n=with_i18n,
+            source_locale=source_locale,
             git_commit=not getattr(self._args, 'no_commit', False)
             and self._out.yesno('Create initial git commit?', default='Y'),
         )
@@ -1912,6 +1921,7 @@ class PluginCLI:
         target=None,
         git_commit=True,
         with_i18n=False,
+        source_locale=None,
     ):
         """Create the plugin project directory and files.
 
@@ -1926,6 +1936,7 @@ class PluginCLI:
             target: Explicit target directory (overrides --parent-dir/--target-dir)
             git_commit: Whether to create an initial git commit
             with_i18n: Whether to generate translation-enabled skeleton
+            source_locale: Source locale for translations
 
         Returns:
             ExitCode
@@ -1949,6 +1960,10 @@ class PluginCLI:
         # Check --with-translations flag
         if not with_i18n:
             with_i18n = getattr(self._args, 'with_translations', False)
+
+        # Check --source-locale flag
+        if source_locale is None:
+            source_locale = getattr(self._args, 'source_locale', 'en')
 
         # Check --no-commit flag
         if git_commit:
@@ -1987,6 +2002,7 @@ class PluginCLI:
                 license_url,
                 with_i18n=with_i18n,
                 report_bugs_to=report_bugs_to,
+                source_locale=source_locale,
             )
         except OSError as e:
             self._out.error(f'Failed to create plugin project: {e}')
@@ -2184,6 +2200,12 @@ def process_cmdline_args():
         '--with-translations', action='store_true', help="include translation support (locale files and examples)"
     )
     group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit with --init")
+    group_advanced.add_argument(
+        '--source-locale',
+        metavar='LOCALE',
+        default='en',
+        help="source locale for --init with --with-translations (default: en)",
+    )
     group_advanced.add_argument(
         '--locale', metavar='LOCALE', default='en', help="locale for displaying plugin info (e.g., 'fr', 'de', 'en')"
     )

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -93,6 +93,7 @@ from picard.plugin3.plugin import (
     PluginSourceGit,
     short_commit_id,
 )
+from picard.plugin3.project_config import PluginProjectConfig
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import (
     RegistryFetchError,
@@ -1996,18 +1997,18 @@ class PluginCLI:
         # Create directory and files
         report_bugs_to = f'mailto:{author_email}' if author_email else ''
         try:
-            filenames = write_plugin_project(
-                target,
-                name,
-                description,
-                authors,
-                categories,
-                license_id,
-                license_url,
+            project = PluginProjectConfig(
+                name=name,
+                description=description,
+                authors=authors or [],
+                categories=categories or [],
+                license_id=license_id,
+                license_url=license_url,
                 with_i18n=with_i18n,
                 report_bugs_to=report_bugs_to,
                 source_locale=source_locale,
             )
+            filenames = write_plugin_project(target, project)
         except OSError as e:
             self._out.error(f'Failed to create plugin project: {e}')
             return ExitCode.ERROR

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -1791,7 +1791,7 @@ class PluginCLI:
                 return ExitCode.ERROR
             return self._cmd_init_interactive()
 
-        return self._create_plugin_project(name)
+        return self._create_plugin_project(PluginProjectConfig(name=name))
 
     def _cmd_init_interactive(self):
         """Run interactive plugin project creation."""
@@ -1900,75 +1900,64 @@ class PluginCLI:
                 source_locale = locale_input
 
         return self._create_plugin_project(
-            name,
-            description,
-            authors,
-            categories,
-            license_id,
-            license_url,
+            PluginProjectConfig(
+                name=name,
+                description=description,
+                authors=authors or [],
+                categories=categories or [],
+                license_id=license_id,
+                license_url=license_url,
+                with_i18n=with_i18n,
+                source_locale=source_locale,
+            ),
             author_email=author_email,
             target=target,
-            with_i18n=with_i18n,
-            source_locale=source_locale,
             git_commit=not getattr(self._args, 'no_commit', False)
             and self._out.yesno('Create initial git commit?', default='Y'),
         )
 
     def _create_plugin_project(
         self,
-        name,
-        description='',
-        authors=None,
-        categories=None,
-        license_id='',
-        license_url='',
+        project: PluginProjectConfig,
+        *,
         author_email='',
         target=None,
         git_commit=True,
-        with_i18n=False,
-        source_locale=None,
     ):
         """Create the plugin project directory and files.
 
         Args:
-            name: Plugin name
-            description: Short description
-            authors: List of author names
-            categories: List of category strings
-            license_id: SPDX license identifier
-            license_url: License URL
+            project: Plugin project configuration
             author_email: Author email for git commit
             target: Explicit target directory (overrides --parent-dir/--target-dir)
             git_commit: Whether to create an initial git commit
-            with_i18n: Whether to generate translation-enabled skeleton
-            source_locale: Source locale for translations
 
         Returns:
             ExitCode
         """
         # Validate name length
-        if len(name) > MAX_NAME_LENGTH:
+        if len(project.name) > MAX_NAME_LENGTH:
             self._out.error(f'Plugin name exceeds maximum length of {MAX_NAME_LENGTH} characters')
             return ExitCode.ERROR
 
         # Collect optional values from CLI flags
         author = getattr(self._args, 'author', None)
-        if author and not authors:
+        if author and not project.authors:
             parsed_name, parsed_email = parse_author_string(author)
-            authors = [parsed_name]
+            project.authors = [parsed_name]
             if parsed_email and not author_email:
                 author_email = parsed_email
         category = getattr(self._args, 'category', None)
-        if category and not categories:
-            categories = [category]
+        if category and not project.categories:
+            project.categories = [category]
 
         # Check --with-translations flag
-        if not with_i18n:
-            with_i18n = getattr(self._args, 'with_translations', False)
+        if not project.with_i18n:
+            project.with_i18n = getattr(self._args, 'with_translations', False)
 
         # Check --source-locale flag
-        if source_locale is None:
-            source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
+        if project.source_locale == DEFAULT_SOURCE_LOCALE:
+            project.source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
 
         # Check --no-commit flag
         if git_commit:
@@ -1983,7 +1972,7 @@ class PluginCLI:
             if target_dir:
                 target = base / target_dir
             else:
-                slug = slugify_name(name)
+                slug = slugify_name(project.name)
                 if not slug:
                     self._out.error('Cannot derive directory name from plugin name, use --target-dir to specify one')
                     return ExitCode.ERROR
@@ -1995,25 +1984,15 @@ class PluginCLI:
             return ExitCode.ERROR
 
         # Create directory and files
-        report_bugs_to = f'mailto:{author_email}' if author_email else ''
+        if not project.report_bugs_to and author_email:
+            project.report_bugs_to = f'mailto:{author_email}'
         try:
-            project = PluginProjectConfig(
-                name=name,
-                description=description,
-                authors=authors or [],
-                categories=categories or [],
-                license_id=license_id,
-                license_url=license_url,
-                with_i18n=with_i18n,
-                report_bugs_to=report_bugs_to,
-                source_locale=source_locale,
-            )
             filenames = write_plugin_project(target, project)
         except OSError as e:
             self._out.error(f'Failed to create plugin project: {e}')
             return ExitCode.ERROR
 
-        self._out.success(f'Created plugin {self._out.d_name(name)} in {self._out.d_path(target)}')
+        self._out.success(f'Created plugin {self._out.d_name(project.name)} in {self._out.d_path(target)}')
         for filename in filenames:
             self._out.info(filename)
 
@@ -2023,7 +2002,7 @@ class PluginCLI:
             repo = backend.init_repository(target)
             try:
                 if git_commit:
-                    author_name, commit_email = get_git_author(authors, author_email)
+                    author_name, commit_email = get_git_author(project.authors or None, author_email)
                     backend.add_and_commit_files(
                         repo,
                         'Initial plugin scaffold',

--- a/picard/plugin3/constants.py
+++ b/picard/plugin3/constants.py
@@ -26,6 +26,9 @@ REGISTRY_TRUST_LEVELS = ['official', 'trusted', 'community']
 # Plugin categories
 CATEGORIES = ['metadata', 'coverart', 'ui', 'scripting', 'formats', 'other']
 
+# Default source locale for plugin translations
+DEFAULT_SOURCE_LOCALE = 'en'
+
 # Common SPDX licenses for plugins
 LICENSES = {
     'GPL-2.0-or-later': 'https://www.gnu.org/licenses/gpl-2.0.html',

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -212,20 +212,25 @@ def markdown_escape(text: str) -> str:
     return text
 
 
-def generate_readme(name: str) -> str:
+def generate_readme(name: str, long_description: str | None = None) -> str:
     """Generate a basic README.md for a new plugin.
 
     Args:
         name: Plugin name
+        long_description: Long description
 
     Returns:
         str: README.md content
     """
     slug = slugify_name(name)
     escaped_name = markdown_escape(name)
+    if type(long_description) is str:
+        long_description = long_description.strip()
+    if not long_description:
+        long_description = "A plugin for [MusicBrainz Picard](https://picard.musicbrainz.org/)."
     return f'''# {escaped_name}
 
-A plugin for [MusicBrainz Picard](https://picard.musicbrainz.org/).
+{long_description}
 
 ## Installation
 

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import re
 import unicodedata
 
+from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 from picard.plugin3.validator import generate_uuid
 
 
@@ -79,7 +80,7 @@ def generate_manifest(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
-    source_locale: str = 'en',
+    source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
 ) -> str:
     """Generate a filled-in MANIFEST.toml for a new plugin.
@@ -124,7 +125,7 @@ def generate_manifest(
     if long_description:
         lines.append(f'long_description = "{toml_escape(long_description)}"')
     if with_i18n:
-        source_locale = source_locale.strip() or 'en'
+        source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
         lines.append(f'source_locale = "{toml_escape(source_locale)}"')
         lines.append('')
@@ -286,7 +287,7 @@ def write_plugin_project(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
-    source_locale: str = 'en',
+    source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
@@ -309,7 +310,7 @@ def write_plugin_project(
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
-    source_locale = source_locale.strip() or 'en'
+    source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
         generate_manifest(

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -79,6 +79,8 @@ def generate_manifest(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
+    source_locale: str = 'en',
+    long_description: str = '',
 ) -> str:
     """Generate a filled-in MANIFEST.toml for a new plugin.
 
@@ -91,6 +93,8 @@ def generate_manifest(
         license_url: License URL
         with_i18n: Whether to include translation fields
         report_bugs_to: Bug tracker URL or mailto: address
+        source_locale: Locale for the source strings
+        long_description: Long description
 
     Returns:
         str: MANIFEST.toml content
@@ -117,14 +121,22 @@ def generate_manifest(
         lines.append(f'report_bugs_to = "{toml_escape(report_bugs_to)}"')
     else:
         lines.append('# report_bugs_to = "https://your.plugin.bugtracker/issues"')
+    if long_description:
+        lines.append(f'long_description = "{toml_escape(long_description)}"')
     if with_i18n:
-        lines.append('source_locale = "en"')
+        source_locale = source_locale.strip() or 'en'
+        other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
+        lines.append(f'source_locale = "{source_locale}"')
         lines.append('')
         lines.append('# [name_i18n]')
-        lines.append('# de = ""')
+        lines.append(f'# {other_locale} = ""')
         lines.append('')
         lines.append('# [description_i18n]')
-        lines.append('# de = ""')
+        lines.append(f'# {other_locale} = ""')
+        if long_description:
+            lines.append('')
+            lines.append('# [long_description_i18n]')
+            lines.append(f'# {other_locale} = ""')
     lines.append('')  # trailing newline
     return '\n'.join(lines)
 

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -126,7 +126,7 @@ def generate_manifest(
     if with_i18n:
         source_locale = source_locale.strip() or 'en'
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
-        lines.append(f'source_locale = "{source_locale}"')
+        lines.append(f'source_locale = "{toml_escape(source_locale)}"')
         lines.append('')
         lines.append('# [name_i18n]')
         lines.append(f'# {other_locale} = ""')

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -286,6 +286,8 @@ def write_plugin_project(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
+    source_locale: str = 'en',
+    long_description: str = '',
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -301,6 +303,8 @@ def write_plugin_project(
         license_url: License URL
         with_i18n: Whether to generate translation-enabled skeleton
         report_bugs_to: Bug tracker URL or mailto: address
+        source_locale: Locale for the source strings
+        long_description: Long description
 
     Returns:
         list: Filenames/dirs created (for display purposes)
@@ -316,6 +320,8 @@ def write_plugin_project(
             license_url,
             with_i18n=with_i18n,
             report_bugs_to=report_bugs_to,
+            source_locale=source_locale,
+            long_description=long_description,
         ),
         encoding='utf-8',
     )

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -315,7 +315,11 @@ def write_plugin_project(
         ),
         encoding='utf-8',
     )
-    init_py_content = project.init_py_content.strip() or generate_plugin_init_py(with_i18n=project.with_i18n)
+    init_py_content = (
+        project.init_py_content
+        if project.init_py_content is not None
+        else generate_plugin_init_py(with_i18n=project.with_i18n)
+    )
     (target / '__init__.py').write_text(init_py_content, encoding='utf-8')
     (target / 'README.md').write_text(generate_readme(project.name, project.long_description), encoding='utf-8')
     (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
@@ -324,7 +328,9 @@ def write_plugin_project(
         locale_dir = target / 'locale'
         locale_dir.mkdir()
         locale_filename = source_locale + '.toml'
-        locale_toml_content = project.locale_toml_content.strip() or generate_source_locale_toml()
+        locale_toml_content = (
+            project.locale_toml_content if project.locale_toml_content is not None else generate_source_locale_toml()
+        )
         (locale_dir / locale_filename).write_text(locale_toml_content, encoding='utf-8')
         filenames.append('locale/')
     return filenames

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -27,6 +27,7 @@ import re
 import unicodedata
 
 from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
+from picard.plugin3.project_config import PluginProjectConfig
 from picard.plugin3.validator import generate_uuid
 
 
@@ -284,18 +285,7 @@ def generate_source_locale_toml() -> str:
 
 def write_plugin_project(
     target: Path,
-    name: str,
-    description: str = '',
-    authors: list[str] | None = None,
-    categories: list[str] | None = None,
-    license_id: str = '',
-    license_url: str = '',
-    with_i18n: bool = False,
-    report_bugs_to: str = '',
-    source_locale: str = DEFAULT_SOURCE_LOCALE,
-    long_description: str = '',
-    init_py_content: str = '',
-    locale_toml_content: str = '',
+    project: PluginProjectConfig,
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -303,49 +293,38 @@ def write_plugin_project(
 
     Args:
         target: Path to the plugin directory
-        name: Plugin name
-        description: Short description
-        authors: List of author names
-        categories: List of category strings
-        license_id: SPDX license identifier
-        license_url: License URL
-        with_i18n: Whether to generate translation-enabled skeleton
-        report_bugs_to: Bug tracker URL or mailto: address
-        source_locale: Locale for the source strings
-        long_description: Long description
-        init_py_content: Alternate content to use for __init__.py
-        locale_toml_content: Alternate content to use for locale/*.toml
+        project: Plugin project configuration
 
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
-    source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
+    source_locale = project.source_locale.strip() or DEFAULT_SOURCE_LOCALE
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
         generate_manifest(
-            name,
-            description,
-            authors,
-            categories,
-            license_id,
-            license_url,
-            with_i18n=with_i18n,
-            report_bugs_to=report_bugs_to,
+            project.name,
+            project.description,
+            project.authors or None,
+            project.categories or None,
+            project.license_id,
+            project.license_url,
+            with_i18n=project.with_i18n,
+            report_bugs_to=project.report_bugs_to,
             source_locale=source_locale,
-            long_description=long_description,
+            long_description=project.long_description,
         ),
         encoding='utf-8',
     )
-    init_py_content = init_py_content.strip() or generate_plugin_init_py(with_i18n=with_i18n)
+    init_py_content = project.init_py_content.strip() or generate_plugin_init_py(with_i18n=project.with_i18n)
     (target / '__init__.py').write_text(init_py_content, encoding='utf-8')
-    (target / 'README.md').write_text(generate_readme(name), encoding='utf-8')
+    (target / 'README.md').write_text(generate_readme(project.name), encoding='utf-8')
     (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
     filenames = ['MANIFEST.toml', '__init__.py', 'README.md', '.gitignore']
-    if with_i18n:
+    if project.with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
         locale_filename = source_locale + '.toml'
-        locale_toml_content = locale_toml_content.strip() or generate_source_locale_toml()
+        locale_toml_content = project.locale_toml_content.strip() or generate_source_locale_toml()
         (locale_dir / locale_filename).write_text(locale_toml_content, encoding='utf-8')
         filenames.append('locale/')
     return filenames

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -294,7 +294,8 @@ def write_plugin_project(
     report_bugs_to: str = '',
     source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
-    write_init: bool = True,
+    init_py_content: str = '',
+    locale_toml_content: str = '',
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -312,7 +313,8 @@ def write_plugin_project(
         report_bugs_to: Bug tracker URL or mailto: address
         source_locale: Locale for the source strings
         long_description: Long description
-        write_init: Write the __init__.py file
+        init_py_content: Alternate content to use for __init__.py
+        locale_toml_content: Alternate content to use for locale/*.toml
 
     Returns:
         list: Filenames/dirs created (for display purposes)
@@ -334,18 +336,17 @@ def write_plugin_project(
         ),
         encoding='utf-8',
     )
-    if write_init:
-        (target / '__init__.py').write_text(generate_plugin_init_py(with_i18n=with_i18n), encoding='utf-8')
+    init_py_content = init_py_content.strip() or generate_plugin_init_py(with_i18n=with_i18n)
+    (target / '__init__.py').write_text(init_py_content, encoding='utf-8')
     (target / 'README.md').write_text(generate_readme(name), encoding='utf-8')
     (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
     filenames = ['MANIFEST.toml', '__init__.py', 'README.md', '.gitignore']
-    if not write_init:
-        filenames.remove('__init__.py')
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
         locale_filename = source_locale + '.toml'
-        (locale_dir / locale_filename).write_text(generate_source_locale_toml(), encoding='utf-8')
+        locale_toml_content = locale_toml_content.strip() or generate_source_locale_toml()
+        (locale_dir / locale_filename).write_text(locale_toml_content, encoding='utf-8')
         filenames.append('locale/')
     return filenames
 

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -225,7 +225,7 @@ def generate_readme(name: str, long_description: str | None = None) -> str:
     """
     slug = slugify_name(name)
     escaped_name = markdown_escape(name)
-    if type(long_description) is str:
+    if isinstance(long_description, str):
         long_description = long_description.strip()
     if not long_description:
         long_description = "A plugin for [MusicBrainz Picard](https://picard.musicbrainz.org/)."

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -309,6 +309,7 @@ def write_plugin_project(
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
+    source_locale = source_locale.strip() or 'en'
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
         generate_manifest(
@@ -332,7 +333,7 @@ def write_plugin_project(
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
-        locale_filename = (source_locale.strip() or 'en') + '.toml'
+        locale_filename = source_locale + '.toml'
         (locale_dir / locale_filename).write_text(generate_source_locale_toml(), encoding='utf-8')
         filenames.append('locale/')
     return filenames

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -91,6 +91,9 @@ def generate_manifest(project: PluginProjectConfig) -> str:
     if project.authors:
         authors_str = ', '.join(f'"{toml_escape(a)}"' for a in project.authors)
         lines.append(f'authors = [{authors_str}]')
+    if project.maintainers:
+        maintainers_str = ', '.join(f'"{toml_escape(m)}"' for m in project.maintainers)
+        lines.append(f'maintainers = [{maintainers_str}]')
     if project.license_id:
         lines.append(f'license = "{toml_escape(project.license_id)}"')
     if project.license_url:
@@ -105,6 +108,8 @@ def generate_manifest(project: PluginProjectConfig) -> str:
         lines.append('# report_bugs_to = "https://your.plugin.bugtracker/issues"')
     if project.long_description:
         lines.append(f'long_description = "{toml_escape(project.long_description)}"')
+    if project.min_python_version:
+        lines.append(f'min_python_version = "{toml_escape(project.min_python_version)}"')
     if project.with_i18n:
         source_locale = project.source_locale.strip() or DEFAULT_SOURCE_LOCALE
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -107,7 +107,10 @@ def generate_manifest(project: PluginProjectConfig) -> str:
     else:
         lines.append('# report_bugs_to = "https://your.plugin.bugtracker/issues"')
     if project.long_description:
-        lines.append(f'long_description = "{toml_escape(project.long_description)}"')
+        if '\n' in project.long_description:
+            lines.append(f'long_description = """\n{project.long_description}\n"""')
+        else:
+            lines.append(f'long_description = "{toml_escape(project.long_description)}"')
     if project.min_python_version:
         lines.append(f'min_python_version = "{toml_escape(project.min_python_version)}"')
     if project.with_i18n:

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -317,7 +317,7 @@ def write_plugin_project(
     )
     init_py_content = project.init_py_content.strip() or generate_plugin_init_py(with_i18n=project.with_i18n)
     (target / '__init__.py').write_text(init_py_content, encoding='utf-8')
-    (target / 'README.md').write_text(generate_readme(project.name), encoding='utf-8')
+    (target / 'README.md').write_text(generate_readme(project.name, project.long_description), encoding='utf-8')
     (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
     filenames = ['MANIFEST.toml', '__init__.py', 'README.md', '.gitignore']
     if project.with_i18n:

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -332,7 +332,8 @@ def write_plugin_project(
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
-        (locale_dir / 'en.toml').write_text(generate_source_locale_toml(), encoding='utf-8')
+        locale_filename = (source_locale.strip() or 'en') + '.toml'
+        (locale_dir / locale_filename).write_text(generate_source_locale_toml(), encoding='utf-8')
         filenames.append('locale/')
     return filenames
 

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -294,6 +294,7 @@ def write_plugin_project(
     report_bugs_to: str = '',
     source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
+    write_init: bool = True,
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -311,6 +312,7 @@ def write_plugin_project(
         report_bugs_to: Bug tracker URL or mailto: address
         source_locale: Locale for the source strings
         long_description: Long description
+        write_init: Write the __init__.py file
 
     Returns:
         list: Filenames/dirs created (for display purposes)
@@ -332,10 +334,13 @@ def write_plugin_project(
         ),
         encoding='utf-8',
     )
-    (target / '__init__.py').write_text(generate_plugin_init_py(with_i18n=with_i18n), encoding='utf-8')
+    if write_init:
+        (target / '__init__.py').write_text(generate_plugin_init_py(with_i18n=with_i18n), encoding='utf-8')
     (target / 'README.md').write_text(generate_readme(name), encoding='utf-8')
     (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
     filenames = ['MANIFEST.toml', '__init__.py', 'README.md', '.gitignore']
+    if not write_init:
+        filenames.remove('__init__.py')
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -72,31 +72,11 @@ def toml_escape(value: str) -> str:
     return value
 
 
-def generate_manifest(
-    name: str,
-    description: str = '',
-    authors: list[str] | None = None,
-    categories: list[str] | None = None,
-    license_id: str = '',
-    license_url: str = '',
-    with_i18n: bool = False,
-    report_bugs_to: str = '',
-    source_locale: str = DEFAULT_SOURCE_LOCALE,
-    long_description: str = '',
-) -> str:
+def generate_manifest(project: PluginProjectConfig) -> str:
     """Generate a filled-in MANIFEST.toml for a new plugin.
 
     Args:
-        name: Plugin name (required)
-        description: Short description
-        authors: List of author names
-        categories: List of category strings
-        license_id: SPDX license identifier
-        license_url: License URL
-        with_i18n: Whether to include translation fields
-        report_bugs_to: Bug tracker URL or mailto: address
-        source_locale: Locale for the source strings
-        long_description: Long description
+        project: Plugin project configuration
 
     Returns:
         str: MANIFEST.toml content
@@ -104,29 +84,29 @@ def generate_manifest(
     generated_uuid = generate_uuid()
     lines = [
         f'uuid = "{generated_uuid}"',
-        f'name = "{toml_escape(name)}"',
-        f'description = "{toml_escape(description or "A Picard plugin")}"',
+        f'name = "{toml_escape(project.name)}"',
+        f'description = "{toml_escape(project.description or "A Picard plugin")}"',
         'api = ["3.0"]',
     ]
-    if authors:
-        authors_str = ', '.join(f'"{toml_escape(a)}"' for a in authors)
+    if project.authors:
+        authors_str = ', '.join(f'"{toml_escape(a)}"' for a in project.authors)
         lines.append(f'authors = [{authors_str}]')
-    if license_id:
-        lines.append(f'license = "{toml_escape(license_id)}"')
-    if license_url:
-        lines.append(f'license_url = "{toml_escape(license_url)}"')
-    if categories:
-        cats_str = ', '.join(f'"{toml_escape(c)}"' for c in categories)
+    if project.license_id:
+        lines.append(f'license = "{toml_escape(project.license_id)}"')
+    if project.license_url:
+        lines.append(f'license_url = "{toml_escape(project.license_url)}"')
+    if project.categories:
+        cats_str = ', '.join(f'"{toml_escape(c)}"' for c in project.categories)
         lines.append(f'categories = [{cats_str}]')
     lines.append('# homepage = "https://github.com/username/plugin-name"')
-    if report_bugs_to:
-        lines.append(f'report_bugs_to = "{toml_escape(report_bugs_to)}"')
+    if project.report_bugs_to:
+        lines.append(f'report_bugs_to = "{toml_escape(project.report_bugs_to)}"')
     else:
         lines.append('# report_bugs_to = "https://your.plugin.bugtracker/issues"')
-    if long_description:
-        lines.append(f'long_description = "{toml_escape(long_description)}"')
-    if with_i18n:
-        source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
+    if project.long_description:
+        lines.append(f'long_description = "{toml_escape(project.long_description)}"')
+    if project.with_i18n:
+        source_locale = project.source_locale.strip() or DEFAULT_SOURCE_LOCALE
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
         lines.append(f'source_locale = "{toml_escape(source_locale)}"')
         lines.append('')
@@ -135,7 +115,7 @@ def generate_manifest(
         lines.append('')
         lines.append('# [description_i18n]')
         lines.append(f'# {other_locale} = ""')
-        if long_description:
+        if project.long_description:
             lines.append('')
             lines.append('# [long_description_i18n]')
             lines.append(f'# {other_locale} = ""')
@@ -298,21 +278,9 @@ def write_plugin_project(
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
-    source_locale = project.source_locale.strip() or DEFAULT_SOURCE_LOCALE
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
-        generate_manifest(
-            project.name,
-            project.description,
-            project.authors or None,
-            project.categories or None,
-            project.license_id,
-            project.license_url,
-            with_i18n=project.with_i18n,
-            report_bugs_to=project.report_bugs_to,
-            source_locale=source_locale,
-            long_description=project.long_description,
-        ),
+        generate_manifest(project),
         encoding='utf-8',
     )
     init_py_content = (
@@ -327,7 +295,7 @@ def write_plugin_project(
     if project.with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
-        locale_filename = source_locale + '.toml'
+        locale_filename = (project.source_locale.strip() or DEFAULT_SOURCE_LOCALE) + '.toml'
         locale_toml_content = (
             project.locale_toml_content if project.locale_toml_content is not None else generate_source_locale_toml()
         )

--- a/picard/plugin3/manifest.py
+++ b/picard/plugin3/manifest.py
@@ -25,7 +25,10 @@ except (ImportError, ModuleNotFoundError):
 
 from typing import BinaryIO
 
-from picard.plugin3.constants import CATEGORIES
+from picard.plugin3.constants import (
+    CATEGORIES,
+    DEFAULT_SOURCE_LOCALE,
+)
 from picard.plugin3.validator import (
     generate_uuid,
     validate_manifest_dict,
@@ -160,7 +163,7 @@ class PluginManifest:
     @property
     def source_locale(self) -> str:
         """Get source locale for translations, defaults to 'en'."""
-        return self._data.get('source_locale', 'en')
+        return self._data.get('source_locale', DEFAULT_SOURCE_LOCALE)
 
     def validate(self) -> list:
         """Validate manifest and return list of errors.

--- a/picard/plugin3/project_config.py
+++ b/picard/plugin3/project_config.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Configuration dataclass for plugin project scaffolding."""
+
+from __future__ import annotations
+
+from dataclasses import (
+    dataclass,
+    field,
+)
+
+from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
+
+
+@dataclass
+class PluginProjectConfig:
+    """Configuration describing a plugin project to scaffold.
+
+    Groups all plugin metadata fields that flow through write_plugin_project,
+    generate_manifest, and _create_plugin_project.
+    """
+
+    name: str
+    description: str = ''
+    authors: list[str] = field(default_factory=list)
+    categories: list[str] = field(default_factory=list)
+    license_id: str = ''
+    license_url: str = ''
+    long_description: str = ''
+    report_bugs_to: str = ''
+    with_i18n: bool = False
+    source_locale: str = DEFAULT_SOURCE_LOCALE
+    init_py_content: str = ''
+    locale_toml_content: str = ''

--- a/picard/plugin3/project_config.py
+++ b/picard/plugin3/project_config.py
@@ -48,5 +48,5 @@ class PluginProjectConfig:
     report_bugs_to: str = ''
     with_i18n: bool = False
     source_locale: str = DEFAULT_SOURCE_LOCALE
-    init_py_content: str = ''
-    locale_toml_content: str = ''
+    init_py_content: str | None = None
+    locale_toml_content: str | None = None

--- a/picard/plugin3/project_config.py
+++ b/picard/plugin3/project_config.py
@@ -41,6 +41,7 @@ class PluginProjectConfig:
     name: str
     description: str = ''
     authors: list[str] = field(default_factory=list)
+    maintainers: list[str] = field(default_factory=list)
     categories: list[str] = field(default_factory=list)
     license_id: str = ''
     license_url: str = ''
@@ -48,5 +49,6 @@ class PluginProjectConfig:
     report_bugs_to: str = ''
     with_i18n: bool = False
     source_locale: str = DEFAULT_SOURCE_LOCALE
+    min_python_version: str = ''
     init_py_content: str | None = None
     locale_toml_content: str | None = None

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -30,6 +30,7 @@ from picard.git.factory import (
 )
 from picard.plugin3.api import PluginApi
 from picard.plugin3.cli import PluginCLI
+from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.manifest import PluginManifest
 from picard.plugin3.output import PluginOutput
@@ -193,7 +194,7 @@ class MockCliArgs(Mock):
             'locale': 'en',
             'with_translations': False,
             'no_commit': False,
-            'source_locale': 'en',
+            'source_locale': DEFAULT_SOURCE_LOCALE,
         }
         defaults.update(kwargs)
         super().__init__(**defaults)

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -193,6 +193,7 @@ class MockCliArgs(Mock):
             'locale': 'en',
             'with_translations': False,
             'no_commit': False,
+            'source_locale': 'en',
         }
         defaults.update(kwargs)
         super().__init__(**defaults)

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -1410,6 +1410,18 @@ class TestPluginCLIInit(PicardTestCase):
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertNotIn('source_locale', manifest)
 
+    def test_init_with_custom_source_locale(self):
+        """--init --with-translations --source-locale creates correct locale file and manifest."""
+        target = self.tmpdir / 'test-plugin'
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True, source_locale='fr'
+        )
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
+        self.assertIn('source_locale = "fr"', manifest)
+        self.assertTrue((target / 'locale' / 'fr.toml').exists())
+        self.assertFalse((target / 'locale' / 'en.toml').exists())
+
 
 class TestPluginCLIInitInteractive(PicardTestCase):
     """Tests for --init interactive mode."""

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -50,6 +50,7 @@ from picard.plugin3.cli import (
     ExitCode,
     PluginCLI,
 )
+from picard.plugin3.init_templates import generate_readme
 from picard.plugin3.manager import (
     PluginCommitPinnedError,
     PluginManager,
@@ -1232,6 +1233,28 @@ class TestPluginCLIInit(PicardTestCase):
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         readme = (target / 'README.md').read_text(encoding='utf-8')
         self.assertIn('# My Plugin', readme)
+
+    def test_init_creates_readme_with_provided_description(self):
+        """Creates README.md content with provided long description."""
+        long_description = "This the test long description."
+        readme_content = generate_readme('Test Plugin', long_description)
+        self.assertIn(long_description, readme_content)
+
+    def test_init_creates_readme_without_provided_description(self):
+        """Creates README.md content without provided long description."""
+        default_description = "A plugin for [MusicBrainz Picard](https://picard.musicbrainz.org/)."
+        # Test with no long description specified (use default of None)
+        readme_content = generate_readme('Test Plugin')
+        self.assertIn(default_description, readme_content)
+        # Test with long description specified as empty string
+        readme_content = generate_readme('Test Plugin', '')
+        self.assertIn(default_description, readme_content)
+        # Test with long description specified as whitespace only
+        readme_content = generate_readme('Test Plugin', ' ')
+        self.assertIn(default_description, readme_content)
+        # Test with long description specified as newline only
+        readme_content = generate_readme('Test Plugin', '\n')
+        self.assertIn(default_description, readme_content)
 
     def test_init_creates_gitignore(self):
         """--init creates .gitignore."""

--- a/test/plugins3/test_init_templates.py
+++ b/test/plugins3/test_init_templates.py
@@ -147,6 +147,50 @@ class TestGenerateManifest(PicardTestCase):
         data = tomllib.loads(result)
         self.assertEqual(data['name'], "Plugin d'Étiquetage")
 
+    def test_with_source_locale(self):
+        """Custom source_locale is included when i18n is enabled."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='fr')
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'fr')
+
+    def test_source_locale_default(self):
+        """Default source_locale is 'en'."""
+        result = generate_manifest('Test', with_i18n=True)
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'en')
+
+    def test_source_locale_whitespace_fallback(self):
+        """Whitespace-only source_locale falls back to 'en'."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='  ')
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'en')
+
+    def test_other_locale_differs_from_source(self):
+        """i18n example locale differs from source_locale."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='de')
+        self.assertIn('# en = ""', result)
+
+    def test_other_locale_default_is_de(self):
+        """When source_locale is not 'de', example locale is 'de'."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='en')
+        self.assertIn('# de = ""', result)
+
+    def test_with_long_description(self):
+        """long_description produces valid TOML."""
+        result = generate_manifest('Test', long_description='A longer description')
+        data = tomllib.loads(result)
+        self.assertEqual(data['long_description'], 'A longer description')
+
+    def test_long_description_i18n_section(self):
+        """long_description with i18n includes long_description_i18n comment."""
+        result = generate_manifest('Test', long_description='Long desc', with_i18n=True)
+        self.assertIn('# [long_description_i18n]', result)
+
+    def test_no_long_description_i18n_without_long_description(self):
+        """Without long_description, no long_description_i18n section."""
+        result = generate_manifest('Test', with_i18n=True)
+        self.assertNotIn('long_description_i18n', result)
+
 
 class TestGeneratePluginInitPy(PicardTestCase):
     def test_contains_enable(self):

--- a/test/plugins3/test_init_templates.py
+++ b/test/plugins3/test_init_templates.py
@@ -33,6 +33,7 @@ from picard.plugin3.init_templates import (
     generate_readme,
     slugify_name,
 )
+from picard.plugin3.project_config import PluginProjectConfig
 
 
 class TestSlugifyName(PicardTestCase):
@@ -75,47 +76,51 @@ class TestSlugifyName(PicardTestCase):
 
 class TestGenerateManifest(PicardTestCase):
     def test_minimal(self):
-        result = generate_manifest('My Plugin')
+        result = generate_manifest(PluginProjectConfig(name='My Plugin'))
         self.assertIn('name = "My Plugin"', result)
         self.assertIn('api = ["3.0"]', result)
         self.assertIn('uuid = "', result)
         self.assertIn('description = "A Picard plugin"', result)
 
     def test_with_description(self):
-        result = generate_manifest('Test', description='Does things')
+        result = generate_manifest(PluginProjectConfig(name='Test', description='Does things'))
         self.assertIn('description = "Does things"', result)
 
     def test_with_authors(self):
-        result = generate_manifest('Test', authors=['Alice', 'Bob'])
+        result = generate_manifest(PluginProjectConfig(name='Test', authors=['Alice', 'Bob']))
         self.assertIn('authors = ["Alice", "Bob"]', result)
 
     def test_with_license(self):
         result = generate_manifest(
-            'Test', license_id='GPL-2.0-or-later', license_url='https://www.gnu.org/licenses/gpl-2.0.html'
+            PluginProjectConfig(
+                name='Test', license_id='GPL-2.0-or-later', license_url='https://www.gnu.org/licenses/gpl-2.0.html'
+            )
         )
         self.assertIn('license = "GPL-2.0-or-later"', result)
         self.assertIn('license_url = "https://www.gnu.org/licenses/gpl-2.0.html"', result)
 
     def test_with_categories(self):
-        result = generate_manifest('Test', categories=['metadata', 'ui'])
+        result = generate_manifest(PluginProjectConfig(name='Test', categories=['metadata', 'ui']))
         self.assertIn('categories = ["metadata", "ui"]', result)
 
     def test_with_report_bugs_to(self):
-        result = generate_manifest('Test', report_bugs_to='mailto:dev@example.com')
+        result = generate_manifest(PluginProjectConfig(name='Test', report_bugs_to='mailto:dev@example.com'))
         self.assertIn('report_bugs_to = "mailto:dev@example.com"', result)
 
     def test_without_report_bugs_to_has_comment(self):
-        result = generate_manifest('Test')
+        result = generate_manifest(PluginProjectConfig(name='Test'))
         self.assertIn('# report_bugs_to =', result)
 
     def test_report_bugs_to_url(self):
-        result = generate_manifest('Test', report_bugs_to='https://github.com/user/repo/issues')
+        result = generate_manifest(
+            PluginProjectConfig(name='Test', report_bugs_to='https://github.com/user/repo/issues')
+        )
         data = tomllib.loads(result)
         self.assertEqual(data['report_bugs_to'], 'https://github.com/user/repo/issues')
 
     def test_uuid_is_valid(self):
         """Generated manifest should contain a valid UUID."""
-        result = generate_manifest('Test')
+        result = generate_manifest(PluginProjectConfig(name='Test'))
         # Extract UUID from the output
         for line in result.splitlines():
             if line.startswith('uuid = "'):
@@ -126,7 +131,9 @@ class TestGenerateManifest(PicardTestCase):
 
     def test_parseable_toml(self):
         """Generated manifest should be valid TOML."""
-        result = generate_manifest('Test', description='Desc', authors=['Me'], categories=['metadata'])
+        result = generate_manifest(
+            PluginProjectConfig(name='Test', description='Desc', authors=['Me'], categories=['metadata'])
+        )
         data = tomllib.loads(result)
         self.assertEqual(data['name'], 'Test')
         self.assertEqual(data['description'], 'Desc')
@@ -136,59 +143,59 @@ class TestGenerateManifest(PicardTestCase):
 
     def test_special_characters_in_name(self):
         """Names with quotes and backslashes produce valid TOML."""
-        result = generate_manifest('Plugin "Foo" \\Bar', description='A "test" plugin')
+        result = generate_manifest(PluginProjectConfig(name='Plugin "Foo" \\Bar', description='A "test" plugin'))
         data = tomllib.loads(result)
         self.assertEqual(data['name'], 'Plugin "Foo" \\Bar')
         self.assertEqual(data['description'], 'A "test" plugin')
 
     def test_unicode_name(self):
         """Unicode names produce valid TOML."""
-        result = generate_manifest("Plugin d'Étiquetage")
+        result = generate_manifest(PluginProjectConfig(name="Plugin d'Étiquetage"))
         data = tomllib.loads(result)
         self.assertEqual(data['name'], "Plugin d'Étiquetage")
 
     def test_with_source_locale(self):
         """Custom source_locale is included when i18n is enabled."""
-        result = generate_manifest('Test', with_i18n=True, source_locale='fr')
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True, source_locale='fr'))
         data = tomllib.loads(result)
         self.assertEqual(data['source_locale'], 'fr')
 
     def test_source_locale_default(self):
         """Default source_locale is 'en'."""
-        result = generate_manifest('Test', with_i18n=True)
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True))
         data = tomllib.loads(result)
         self.assertEqual(data['source_locale'], 'en')
 
     def test_source_locale_whitespace_fallback(self):
         """Whitespace-only source_locale falls back to 'en'."""
-        result = generate_manifest('Test', with_i18n=True, source_locale='  ')
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True, source_locale='  '))
         data = tomllib.loads(result)
         self.assertEqual(data['source_locale'], 'en')
 
     def test_other_locale_differs_from_source(self):
         """i18n example locale differs from source_locale."""
-        result = generate_manifest('Test', with_i18n=True, source_locale='de')
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True, source_locale='de'))
         self.assertIn('# en = ""', result)
 
     def test_other_locale_default_is_de(self):
         """When source_locale is not 'de', example locale is 'de'."""
-        result = generate_manifest('Test', with_i18n=True, source_locale='en')
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True, source_locale='en'))
         self.assertIn('# de = ""', result)
 
     def test_with_long_description(self):
         """long_description produces valid TOML."""
-        result = generate_manifest('Test', long_description='A longer description')
+        result = generate_manifest(PluginProjectConfig(name='Test', long_description='A longer description'))
         data = tomllib.loads(result)
         self.assertEqual(data['long_description'], 'A longer description')
 
     def test_long_description_i18n_section(self):
         """long_description with i18n includes long_description_i18n comment."""
-        result = generate_manifest('Test', long_description='Long desc', with_i18n=True)
+        result = generate_manifest(PluginProjectConfig(name='Test', long_description='Long desc', with_i18n=True))
         self.assertIn('# [long_description_i18n]', result)
 
     def test_no_long_description_i18n_without_long_description(self):
         """Without long_description, no long_description_i18n section."""
-        result = generate_manifest('Test', with_i18n=True)
+        result = generate_manifest(PluginProjectConfig(name='Test', with_i18n=True))
         self.assertNotIn('long_description_i18n', result)
 
 


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

## Problem

Plugin scaffold generation code does not accommodate user-defined source locale, and does not include `long_description` key in the generated `MANIFEST.toml` file.

* JIRA ticket (_optional_): PICARD-XXX

## Solution

Add optional `source_locale` and `long_description` arguments to the `MANIFEST.toml` generation code.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
