### PR TITLE
PICARD-2197: For artist credit try to find matching sort name in aliases

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -227,7 +227,7 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
     artist_sort_name = translated_alias.sort_name
     if not has_translation and context.use_credited_as and 'target-credit' in relation:
         credited_as = relation['target-credit']
-        if credited_as:
+        if credited_as and credited_as != artist['name']:
             artist_name = credited_as
             artist_sort_name = _select_sort_name_from_aliases(artist, credited_as, config=context.config)
     reltype = relation['type']

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -223,10 +223,13 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
     artist = relation['artist']
     translated_alias = _translate_artist_node(artist, config=context.config)
     has_translation = translated_alias.name != artist['name']
+    artist_name = translated_alias.name
+    artist_sort_name = translated_alias.sort_name
     if not has_translation and context.use_credited_as and 'target-credit' in relation:
         credited_as = relation['target-credit']
         if credited_as:
-            translated_alias.name = credited_as
+            artist_name = credited_as
+            artist_sort_name = _select_sort_name_from_aliases(artist, credited_as, config=context.config)
     reltype = relation['type']
     attribs = _relation_attributes(relation)
     if reltype in {'vocal', 'instrument', 'performer'}:
@@ -242,7 +245,7 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
             if attr.startswith('medium'):
                 try:
                     medium_no = int(attr.split()[1])
-                    context.per_medium_metadata[medium_no].add_unique('djmixer', translated_alias.name)
+                    context.per_medium_metadata[medium_no].add_unique('djmixer', artist_name)
                 except ValueError:
                     log.warning('Invalid medium number in mix-DJ attribute: %s', attr)
         return
@@ -253,16 +256,16 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
             return
     if context.instrumental and name == 'lyricist':
         return
-    m.add_unique(name, translated_alias.name)
+    m.add_unique(name, artist_name)
     artist_id = artist.get('id')
     if name == 'composer':
-        m.add_unique('composersort', translated_alias.sort_name)
+        m.add_unique('composersort', artist_sort_name)
         if artist_id:
             m.add_unique('musicbrainz_composerid', artist_id)
     elif name == 'lyricist':
-        m.add_unique('~lyricistsort', translated_alias.sort_name)
+        m.add_unique('~lyricistsort', artist_sort_name)
     elif name == 'writer':
-        m.add_unique('~writersort', translated_alias.sort_name)
+        m.add_unique('~writersort', artist_sort_name)
 
 
 def _relations_to_metadata_target_type_work(relation: Node, m: 'Metadata', context: RelFuncContext) -> None:
@@ -607,6 +610,23 @@ def _translate_artist_node(node: Node, config: Config | None = None) -> Alias:
     return Alias(translated_name or '', sort_name or '')
 
 
+def _select_sort_name_from_aliases(node: Node, name: str, config: Config | None = None) -> str:
+    if 'aliases' in node:
+        config = config or get_config()
+        candidates = [alias for alias in node['aliases'] if alias['name'] == name and alias['sort-name']]
+
+        # If translation is enabled, use alias from preferred locales first
+        if config.setting['translate_artist_names']:
+            if alias := _find_localized_alias_name(candidates, config.setting['translation_locales']):
+                return alias.sort_name
+
+        # Otherwise, use the first candidate (if any)
+        if candidates:
+            return candidates[0]['sort-name']
+
+    return node['sort-name'] or name
+
+
 def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
     artist_name = ''
     artist_sort_name = ''
@@ -622,16 +642,16 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
             artist_countries.append(artist['country'] if 'country' in artist and artist['country'] else 'XX')
         translated_alias = _translate_artist_node(artist, config=config)
         has_translation = translated_alias.name != artist['name']
-        if has_translation:
-            name = translated_alias.name
-        elif use_credited_as and 'name' in artist_info:
+        if not has_translation and use_credited_as and 'name' in artist_info:
             name = artist_info['name']
+            sort_name = _select_sort_name_from_aliases(artist, name, config=config)
         else:
-            name = artist['name']
+            name = translated_alias.name
+            sort_name = translated_alias.sort_name
         artist_name += name
-        artist_sort_name += translated_alias.sort_name or ''
+        artist_sort_name += sort_name or ''
         artist_names.append(name)
-        artist_sort_names.append(translated_alias.sort_name or '')
+        artist_sort_names.append(sort_name or '')
         if 'joinphrase' in artist_info:
             artist_name += artist_info['joinphrase'] or ''
             artist_sort_name += artist_info['joinphrase'] or ''

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -611,6 +611,12 @@ def _translate_artist_node(node: Node, config: Config | None = None) -> Alias:
 
 
 def _select_sort_name_from_aliases(node: Node, name: str, config: Config | None = None) -> str:
+    """Find a sort name matching the given credited name in the artist's aliases.
+
+    If translation is enabled, prefers an alias whose locale matches the
+    configured translation locales.  Falls back to the artist's default
+    sort-name, or the credited name itself if sort-name is empty.
+    """
     if 'aliases' in node:
         config = config or get_config()
         candidates = [alias for alias in node['aliases'] if alias['name'] == name and alias['sort-name']]
@@ -624,6 +630,7 @@ def _select_sort_name_from_aliases(node: Node, name: str, config: Config | None 
         if candidates:
             return candidates[0]['sort-name']
 
+    # Fallback: use the artist's own sort-name, or the credited name if empty
     return node['sort-name'] or name
 
 

--- a/test/data/ws_data/recording_artist_aliases.json
+++ b/test/data/ws_data/recording_artist_aliases.json
@@ -1,0 +1,37 @@
+{
+  "first-release-date": "2013-02-20",
+  "aliases": [],
+  "title": "そして伝説のように × my burning desire",
+  "length": 289840,
+  "id": "3cf17055-68db-477a-a9b6-a3271f188f27",
+  "video": false,
+  "disambiguation": "",
+  "artist-credit": [
+    {
+      "joinphrase": "",
+      "artist": {
+        "type": "Character",
+        "type-id": "5c1375b0-f18d-3db7-a164-a49d7a63773f",
+        "id": "9d844524-86b7-4424-98d4-4fae85c7eeb8",
+        "sort-name": "Kūko",
+        "disambiguation": "這いよれ！ニャル子さん",
+        "country": "JP",
+        "name": "クー子",
+        "aliases": [
+          {
+            "ended": false,
+            "locale": null,
+            "name": "後ろから這いより隊C",
+            "primary": null,
+            "begin": null,
+            "type": "Artist name",
+            "type-id": "894afba6-2816-3c24-8072-eadb66bd04bc",
+            "end": null,
+            "sort-name": "Ushirokara Haiyoritai C"
+          }
+        ]
+      },
+      "name": "後ろから這いより隊C"
+    }
+  ]
+}

--- a/test/data/ws_data/recording_artist_aliases_locales.json
+++ b/test/data/ws_data/recording_artist_aliases_locales.json
@@ -1,0 +1,48 @@
+{
+  "first-release-date": "2013-02-20",
+  "aliases": [],
+  "title": "そして伝説のように × my burning desire",
+  "length": 289840,
+  "id": "3cf17055-68db-477a-a9b6-a3271f188f27",
+  "video": false,
+  "disambiguation": "",
+  "artist-credit": [
+    {
+      "joinphrase": "",
+      "artist": {
+        "type": "Character",
+        "type-id": "5c1375b0-f18d-3db7-a164-a49d7a63773f",
+        "id": "9d844524-86b7-4424-98d4-4fae85c7eeb8",
+        "sort-name": "Kūko",
+        "disambiguation": "這いよれ！ニャル子さん",
+        "country": "JP",
+        "name": "クー子",
+        "aliases": [
+          {
+            "ended": false,
+            "locale": "ja",
+            "name": "後ろから這いより隊C",
+            "primary": true,
+            "begin": null,
+            "type": "Artist name",
+            "type-id": "894afba6-2816-3c24-8072-eadb66bd04bc",
+            "end": null,
+            "sort-name": "ウシロカラハイヨリタイC"
+          },
+          {
+            "ended": false,
+            "locale": "en",
+            "name": "後ろから這いより隊C",
+            "primary": true,
+            "begin": null,
+            "type": "Artist name",
+            "type-id": "894afba6-2816-3c24-8072-eadb66bd04bc",
+            "end": null,
+            "sort-name": "Ushirokara Haiyoritai C"
+          }
+        ]
+      },
+      "name": "後ろから這いより隊C"
+    }
+  ]
+}

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -545,6 +545,20 @@ class RecordingArtistAliasesTest(MBJSONTest):
         self.assertEqual(m['artistsort'], 'Ushirokara Haiyoritai C')
 
 
+class RecordingArtistAliasesLocalesTest(MBJSONTest):
+    filename = 'recording_artist_aliases_locales.json'
+
+    def test_use_credited_as_with_translation_prefers_locale(self):
+        m = Metadata()
+        t = Track('1')
+        config.setting['translate_artist_names'] = True
+        config.setting['standardize_artists'] = False
+        config.setting['translation_locales'] = ['ja']
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['artist'], '後ろから這いより隊C')
+        self.assertEqual(m['artistsort'], 'ウシロカラハイヨリタイC')
+
+
 class RecordingInstrumentalTest(MBJSONTest):
     filename = 'recording_instrumental.json'
 

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -523,6 +523,28 @@ class RecordingComposerCreditsTest(MBJSONTest):
         self.assertEqual(m['composersort'], 'Tchaikovsky, Pyotr Ilyich')
 
 
+class RecordingArtistAliasesTest(MBJSONTest):
+    filename = 'recording_artist_aliases.json'
+
+    def test_standardize_artists(self):
+        m = Metadata()
+        t = Track('1')
+        config.setting['translate_artist_names'] = False
+        config.setting['standardize_artists'] = True
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['artist'], 'クー子')
+        self.assertEqual(m['artistsort'], 'Kūko')
+
+    def test_use_credited_as(self):
+        m = Metadata()
+        t = Track('1')
+        config.setting['translate_artist_names'] = False
+        config.setting['standardize_artists'] = False
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['artist'], '後ろから這いより隊C')
+        self.assertEqual(m['artistsort'], 'Ushirokara Haiyoritai C')
+
+
 class RecordingInstrumentalTest(MBJSONTest):
     filename = 'recording_instrumental.json'
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2197
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When using the artist name as credited, try to find a sort name that matches the credits in the artist aliases list.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

When using the credited as name, search the alias list for a match. If there are multiple matches and translations are enabled, prefer the configured locales. Otherwise just pick the first match.

Added a corresponding test case.

NOTE: This currently won't work for relationships (e.g. `composersort`) as there are no aliases for this case. This is the same situation as for translations. Fixing this is outside the scope of this PR. See also PICARD-1768.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
