### PR TITLE
PICARD-3269: Store ISWCs of linked work as ~iswc variable

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -833,6 +833,8 @@ def work_to_metadata(work: Node, m: 'Metadata', instrumental: bool = False) -> N
         m.add_unique('~workcomment', work['disambiguation'])
     if 'relations' in work:
         _relations_to_metadata(work['relations'], m, instrumental, entity='work')
+    if 'iswcs' in work:
+        add_iswcs_to_metadata(work['iswcs'], m)
 
 
 def medium_to_metadata(node: Node, m: 'Metadata') -> None:
@@ -973,6 +975,11 @@ def add_user_tags(node: list[Node], obj: 'MetadataItem') -> None:
 def add_isrcs_to_metadata(node: list[str], metadata: 'Metadata') -> None:
     for isrc in node:
         metadata.add('isrc', isrc)
+
+
+def add_iswcs_to_metadata(node: list[str], metadata: 'Metadata') -> None:
+    for iswc in node:
+        metadata.add('~iswc', iswc)
 
 
 def get_score(node: Node) -> float:

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -569,6 +569,7 @@ class RecordingInstrumentalTest(MBJSONTest):
         self.assertIn('instrumental', m.getall('~performance_attributes'))
         self.assertEqual(m['language'], 'zxx')
         self.assertNotIn('lyricist', m)
+        self.assertEqual(m['~iswc'], 'T-070.178.113-6')
 
 
 class MultiWorkRecordingTest(MBJSONTest):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3269
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Provide the ISWCs for the linked works of a recording as `~iswc` variable, so it can e.g. be used in scripting (`%_iswc%`).

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Read the ISWCs in `mbjson.py`, similar to how ISRCs are handled, but on work level. Extend a test to cover this case.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
