### PR TITLE
PICARD-3274: Fix crash when removing standalone recording not in list

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1159,7 +1159,10 @@ class Tagger(QtWidgets.QApplication):
         self.remove_files(list(track.iterfiles()))
         if not self.nats:
             return
-        self.nats.tracks.remove(track)
+        try:
+            self.nats.tracks.remove(track)
+        except ValueError:
+            return
         if not self.nats.tracks:
             self.remove_album(self.nats)
         else:

--- a/test/test_track.py
+++ b/test/test_track.py
@@ -20,18 +20,24 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import Counter
-from unittest.mock import Mock
+from unittest.mock import (
+    MagicMock,
+    Mock,
+)
 
 from test.picardtestcase import PicardTestCase
 
 from picard.album import (
     Album,
     AlbumArtist,
+    NatAlbum,
 )
 from picard.const import VARIOUS_ARTISTS_ID
 from picard.file import File
 from picard.releasegroup import ReleaseGroup
+from picard.tagger import Tagger
 from picard.track import (
+    NonAlbumTrack,
     Track,
     TrackArtist,
 )
@@ -215,3 +221,39 @@ class TrackGenresToMetadataTest(PicardTestCase):
         ret1 = Track._genres_to_metadata(genres_order1, limit=1)
         ret2 = Track._genres_to_metadata(genres_order2, limit=1)
         self.assertEqual(ret1, ret2)
+
+
+class TestRemoveNat(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values(setting={'nat_name': 'Standalone Recordings'})
+        self.nats = NatAlbum()
+        self.tagger.nats = self.nats
+        self.tagger.albums = {'NATS': self.nats}
+        self.tagger.album_removed = MagicMock()
+        self.tagger.remove_files = MagicMock()
+        self.tagger.remove_album = MagicMock()
+
+    def _make_nat(self, nat_id):
+        nat = NonAlbumTrack(nat_id)
+        self.nats.tracks.append(nat)
+        return nat
+
+    def test_remove_nat_track_not_in_list(self):
+        """Removing a NAT track not in self.nats.tracks should not raise ValueError."""
+        nat = NonAlbumTrack('fake-recording-id')
+        # Track is NOT in self.nats.tracks — this must not crash
+        Tagger.remove_nat(self.tagger, nat)
+
+    def test_remove_nat_last_track_removes_album(self):
+        """Removing the last NAT track should remove the NAT album."""
+        nat = self._make_nat('recording-1')
+        Tagger.remove_nat(self.tagger, nat)
+        self.tagger.remove_album.assert_called_once_with(self.nats)
+
+    def test_remove_nat_not_last_track_updates(self):
+        """Removing a NAT track when others remain should update the album."""
+        nat1 = self._make_nat('recording-1')
+        self._make_nat('recording-2')
+        Tagger.remove_nat(self.tagger, nat1)
+        self.assertNotIn(nat1, self.nats.tracks)


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem


User tagged a couple files and after having removed the last item from standalone recordings Picard crashed:

```
Traceback (most recent call last):
  File "picard\ui\mainwindow\__init__.py", line 395, in keyPressEvent
  File "picard\ui\mainwindow\__init__.py", line 1545, in remove_selected_objects
  File "picard\ui\itemviews\__init__.py", line 235, in remove
  File "picard\tagger.py", line 1187, in remove
  File "picard\tagger.py", line 1162, in remove_nat
ValueError: list.remove(x): x not in list
```


<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3274
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

Handle ValueError in remove_nat when the track is no longer in self.nats.tracks, which can occur when the user's selection overlaps with already-removed items.

I couldn't reproduce it in the GUI, but new unit tests confirm the issue and the fix.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
