### PR TITLE
Add additional files and commit message options to plugin scaffold creation

### DIFF
--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -1791,7 +1791,7 @@ class PluginCLI:
                 return ExitCode.ERROR
             return self._cmd_init_interactive()
 
-        return self._create_plugin_project(PluginProjectConfig(name=name))
+        return self.create_plugin_project(PluginProjectConfig(name=name))
 
     def _cmd_init_interactive(self):
         """Run interactive plugin project creation."""
@@ -1899,7 +1899,7 @@ class PluginCLI:
             if locale_input:
                 source_locale = locale_input
 
-        return self._create_plugin_project(
+        return self.create_plugin_project(
             PluginProjectConfig(
                 name=name,
                 description=description,
@@ -1916,7 +1916,7 @@ class PluginCLI:
             and self._out.yesno('Create initial git commit?', default='Y'),
         )
 
-    def _create_plugin_project(
+    def create_plugin_project(
         self,
         project: PluginProjectConfig,
         *,
@@ -1992,7 +1992,7 @@ class PluginCLI:
             self._out.error(f'Failed to create plugin project: {e}')
             return ExitCode.ERROR
 
-        self._out.success(f'Created plugin {self._out.d_name(project.name)} in {self._out.d_path(target)}')
+        self._out.success(f'Created plugin "{self._out.d_name(project.name)}" in {self._out.d_path(target)}')
         for filename in filenames:
             self._out.info(filename)
 
@@ -2002,10 +2002,11 @@ class PluginCLI:
             repo = backend.init_repository(target)
             try:
                 if git_commit:
+                    commit_message = project.commit_message.strip() or 'Initial plugin scaffold'
                     author_name, commit_email = get_git_author(project.authors or None, author_email)
                     backend.add_and_commit_files(
                         repo,
-                        'Initial plugin scaffold',
+                        commit_message,
                         author_name=author_name,
                         author_email=commit_email,
                     )

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -309,6 +309,9 @@ def write_plugin_project(
         )
         (locale_dir / locale_filename).write_text(locale_toml_content, encoding='utf-8')
         filenames.append('locale/')
+    for filename, file_content in project.additional_files:
+        (target / filename).write_text(file_content, encoding='utf-8')
+        filenames.append(filename)
     return filenames
 
 

--- a/picard/plugin3/project_config.py
+++ b/picard/plugin3/project_config.py
@@ -26,6 +26,7 @@ from dataclasses import (
     dataclass,
     field,
 )
+from pathlib import Path
 
 from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 
@@ -36,6 +37,9 @@ class PluginProjectConfig:
 
     Groups all plugin metadata fields that flow through write_plugin_project,
     generate_manifest, and _create_plugin_project.
+
+    Additional files to write are provided through a list of tuples of file name
+    and file content. This could include, for example, GUI definition files.
     """
 
     name: str
@@ -52,3 +56,5 @@ class PluginProjectConfig:
     min_python_version: str = ''
     init_py_content: str | None = None
     locale_toml_content: str | None = None
+    additional_files: list[tuple[str | Path, str]] = field(default_factory=list)
+    commit_message: str = ''


### PR DESCRIPTION

<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Plugin scaffold creation did not allow creation of additional files.

* JIRA ticket (_optional_): PICARD-XXX


## Solution

Allow specification of additional files to be created, as well as the message to use for the initial git commit.  This allows the "Create Local Plugin" plugin to utilize the Picard CLI code for all plugin scaffold code creation and git initialization.

Change `_create_plugin_project()` to a public method as `create_plugin_project()`.

Add double quotes arout the created plugin name in the success notification.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
