### PR TITLE
PICARD-3277: External file cover art had no types and comments set

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -397,7 +397,15 @@ class CoverArtImage:
             raise CoverArtImageIOError(e) from e
 
     def set_external_file_data(self, data: bytes):
-        self.external_file_coverart = CoverArtImage(data=data, url=self.url)
+        self.external_file_coverart = CoverArtImage(
+            data=data,
+            url=self.url,
+            comment=self.comment,
+            types=self.types,
+            support_types=self.support_types,
+            support_multi_types=self.support_multi_types,
+            id3_type=self.id3_type,
+        )
 
     @property
     def maintype(self):

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -143,7 +143,7 @@ def get_test_data_path(*paths):
     return os.path.join('test', 'data', *paths)
 
 
-def create_fake_png(extra):
+def create_fake_png(extra: bytes = b''):
     """Creates fake PNG data that satisfies Picard's internal image type detection"""
     return b'\x89PNG\x0d\x0a\x1a\x0a' + (b'a' * 4) + b'IHDR' + struct.pack('>LL', 100, 100) + extra
 

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -49,7 +49,7 @@ from picard.util import encode_filename
 from picard.util.filenaming import WinPathTooLong
 
 
-def create_image(extra_data, types=None, support_types=False, support_multi_types=False, comment=None, id3_type=None):
+def create_image(extra_data, types=None, support_types=False, support_multi_types=False, comment='', id3_type=None):
     return CoverArtImage(
         data=create_fake_png(extra_data),
         types=types,
@@ -335,6 +335,16 @@ class CoverArtImageTest(PicardTestCase):
             self.assertTrue(os.path.exists(expected_filename_2))
             self.assertEqual(len(image2.data), os.path.getsize(expected_filename_2))
             self.assertEqual(2, counters[counter_filename])
+
+    def test_set_external_file_data(self):
+        image = CoverArtImage(comment='Foo', types=['back', 'spine'], support_types=True, support_multi_types=True)
+        self.assertIsNone(image.external_file_coverart)
+        image.set_external_file_data(create_fake_png())
+        self.assertIsNotNone(image.external_file_coverart)
+        self.assertEqual(image.external_file_coverart.comment, image.comment)
+        self.assertEqual(image.external_file_coverart.types, image.types)
+        self.assertEqual(image.external_file_coverart.support_types, image.support_types)
+        self.assertEqual(image.external_file_coverart.support_multi_types, image.support_multi_types)
 
 
 class DataHashTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3277
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Picard 3 keeps separate data for embedded and external file cover art, due to the new processing functionality. But the external file instance of `CoverArtImage` did not get the types and comment set.

This prevented the image_type_as_filename and cover art scripting variables (%coverart_maintype%, %coverart_comment%, %coverart_types%) to work as expected.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

When creating the `CoverArtImage` instance for `external_file_coverart` copy the types and comment form the original image. Added a test for `CoverArtImage.set_external_file_data`.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
