### PR TITLE
PICARD-3278: fix load all image types

### DIFF
--- a/picard/coverart/setters/__init__.py
+++ b/picard/coverart/setters/__init__.py
@@ -91,7 +91,7 @@ class CoverArtSetter:
         obj
             The object to set the image on
         """
-        if self.mode == CoverArtSetterMode.REPLACE:
+        if self.mode == CoverArtSetterMode.REPLACE and self.coverartimage.is_front_image():
             obj.metadata.images.strip_front_images()
             log.debug("Replacing images with %r in %r", self.coverartimage, obj)
         else:

--- a/picard/coverart/setters/__init__.py
+++ b/picard/coverart/setters/__init__.py
@@ -38,6 +38,8 @@
 from enum import IntEnum
 
 from picard import log
+from picard.coverart.image import CoverArtImage
+from picard.item import MetadataItem
 
 from .handlers import _set_coverart_dispatch
 
@@ -52,7 +54,7 @@ class CoverArtSetterMode(IntEnum):
 class CoverArtSetter:
     """Handles setting cover art on different types of objects using single dispatch pattern."""
 
-    def __init__(self, mode: CoverArtSetterMode, coverartimage, source_obj) -> None:
+    def __init__(self, mode: CoverArtSetterMode, coverartimage: CoverArtImage, source_obj: MetadataItem) -> None:
         """
         Initialize the CoverArtSetter.
 
@@ -80,7 +82,7 @@ class CoverArtSetter:
         """
         return _set_coverart_dispatch(self.source_obj, self)
 
-    def _set_image(self, obj) -> None:
+    def _set_image(self, obj: MetadataItem) -> None:
         """
         Set the cover art image on an object based on the current mode.
 

--- a/picard/coverart/setters/handlers.py
+++ b/picard/coverart/setters/handlers.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import Generator
 from contextlib import ExitStack
 from functools import singledispatch
 
@@ -26,13 +27,16 @@ from picard import log
 from picard.album import Album
 from picard.cluster import Cluster
 from picard.file import File
-from picard.item import FileListItem
+from picard.item import (
+    FileListItem,
+    MetadataItem,
+)
 from picard.track import Track
 
 
 # Single dispatch function - this is the heart of the pattern
 @singledispatch
-def _set_coverart_dispatch(source_obj, setter):
+def _set_coverart_dispatch(source_obj: MetadataItem, setter) -> bool:
     """
     Handle unknown types in the single dispatch pattern.
 
@@ -53,7 +57,7 @@ def _set_coverart_dispatch(source_obj, setter):
 
 
 @_set_coverart_dispatch.register
-def _handle_album(album: Album, setter):
+def _handle_album(album: Album, setter) -> bool:
     """
     Handle Album objects in the single dispatch pattern.
 
@@ -90,7 +94,7 @@ def _handle_album(album: Album, setter):
 
 
 @_set_coverart_dispatch.register
-def _handle_filelist(filelist: FileListItem, setter):
+def _handle_filelist(filelist: FileListItem, setter) -> bool:
     """
     Handle FileListItem objects in the single dispatch pattern.
 
@@ -134,7 +138,7 @@ def _handle_filelist(filelist: FileListItem, setter):
 
 
 @_set_coverart_dispatch.register
-def _handle_file(file: File, setter):
+def _handle_file(file: File, setter) -> bool:
     """
     Handle File objects in the single dispatch pattern.
 
@@ -159,7 +163,7 @@ def _handle_file(file: File, setter):
     return True
 
 
-def _iter_file_parents(file: File):
+def _iter_file_parents(file: File) -> Generator[MetadataItem, None, None]:
     """
     Iterate over the parent objects of a file.
 

--- a/test/test_coverart_setter.py
+++ b/test/test_coverart_setter.py
@@ -40,6 +40,7 @@ from unittest.mock import (
     patch,
 )
 
+from picard.coverart.image import CoverArtImage
 from picard.coverart.setters import (
     CoverArtSetter,
     CoverArtSetterMode,
@@ -179,10 +180,11 @@ class TestCoverArtSetter:
         assert result is expected_result
 
     @pytest.mark.parametrize(
-        ('mode', 'should_strip'),
+        ('mode', 'should_strip', 'mock_image'),
         [
-            (CoverArtSetterMode.REPLACE, True),
-            (CoverArtSetterMode.APPEND, False),
+            (CoverArtSetterMode.REPLACE, True, CoverArtImage(types=['front'])),
+            (CoverArtSetterMode.APPEND, False, CoverArtImage(types=['front'])),
+            (CoverArtSetterMode.REPLACE, False, CoverArtImage(types=['medium'], support_types=True)),
         ],
     )
     def test_set_image_modes(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3278
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

When configuring Picard to not only save a single front image but download all cover art images from CAA, the first non-front image loaded will replace the already loaded front image.

For example:

1. Enable cover art saving to tags or files, but disable to embed / save only a single front image
2. Enable the CAA provider as primary image source, but disable to load only selected images (or select a wide range of image types to load)
3. Load e.g. https://musicbrainz.org/release/cd16cf3b-86b0-4b6f-bd7e-73e8b2451a83/cover-art

Current result will be that the front image shows up after getting loaded, but gets removed again as soon as any other image got loaded.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The reason is that the `CoverArtSetter` gets run in REPLACE mode, which triggers `strip_front_images()`, even if the replacing image was not a front image.

Fix by only performing the replace if the replacing image is a front image. Added a test.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
