### PR TITLE
PICARD-3272: simplify "never replace embedded image" type selection

### DIFF
--- a/picard/const/defaults.py
+++ b/picard/const/defaults.py
@@ -91,8 +91,7 @@ DEFAULT_QUERY_LIMIT = 50
 
 DEFAULT_DRIVES = get_default_cdrom_drives()
 
-DEFAULT_CA_NEVER_REPLACE_TYPE_INCLUDE = ('front',)
-DEFAULT_CA_NEVER_REPLACE_TYPE_EXCLUDE = ('matrix/runout', 'raw/unedited', 'watermark')
+DEFAULT_CA_NEVER_REPLACE_TYPES = ('front',)
 DEFAULT_CA_PROVIDERS = [
     ('Cover Art Archive', True),
     ('UrlRelationships', True),

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -74,10 +74,7 @@ def image_types_filter(data, image_info, album, coverartimage):
     if config.setting['dont_replace_cover_of_types'] and config.setting['save_images_to_tags']:
         downloaded_types = set(coverartimage.normalized_types())
         never_replace_types = config.setting['dont_replace_included_types']
-        always_replace_types = config.setting['dont_replace_excluded_types']
         previous_image_types = album.orig_metadata.images.get_types_dict()
-        if downloaded_types.intersection(always_replace_types):
-            return True
         for previous_image_type in previous_image_types:
             type_already_embedded = downloaded_types.intersection(previous_image_type)
             should_not_replace = downloaded_types.intersection(never_replace_types)

--- a/picard/coverart/utils.py
+++ b/picard/coverart/utils.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2013-2015, 2020-2021, 2023-2024 Laurent Monin
 # Copyright (C) 2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
-# Copyright (C) 2019-2021 Philipp Wolfer
+# Copyright (C) 2019-2021, 2026 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -22,7 +22,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import Iterable
 from enum import IntEnum
+from typing import TypedDict
 
 from picard.const import MB_ATTRIBUTES
 from picard.i18n import (
@@ -32,22 +34,27 @@ from picard.i18n import (
 )
 
 
+class CAAType(TypedDict):
+    name: str
+    title: str
+
+
 # list of types from http://musicbrainz.org/doc/Cover_Art/Types
 # order of declaration is preserved in selection box
-CAA_TYPES = []
+CAA_TYPES: list[CAAType] = []
 for k, v in sorted(MB_ATTRIBUTES.items(), key=lambda k_v: k_v[0]):
     if k.startswith('DB:cover_art_archive.art_type/name:'):
-        CAA_TYPES.append({'name': v.lower(), 'title': v})
+        CAA_TYPES.append(CAAType(name=v.lower(), title=v))
 
 # pseudo type, used for the no type case
 CAA_TYPES.append({'name': 'unknown', 'title': N_("Unknown")})
 
-CAA_TYPES_TR = {}
+CAA_TYPES_TR: dict[str, str] = {}
 for t in CAA_TYPES:
     CAA_TYPES_TR[t['name']] = t['title']
 
 
-def translate_caa_type(name):
+def translate_caa_type(name: str) -> str:
     if name == 'unknown':
         return _(CAA_TYPES_TR[name])
     else:
@@ -96,20 +103,20 @@ __ID3_IMAGE_TYPE_MAP = {
 __ID3_REVERSE_IMAGE_TYPE_MAP = {v: k for k, v in __ID3_IMAGE_TYPE_MAP.items()}
 
 
-def image_type_from_id3_num(id3type):
+def image_type_from_id3_num(id3type: Id3ImageType) -> str:
     return __ID3_REVERSE_IMAGE_TYPE_MAP.get(id3type, 'other')
 
 
-def image_type_as_id3_num(texttype):
+def image_type_as_id3_num(texttype: str) -> Id3ImageType:
     return __ID3_IMAGE_TYPE_MAP.get(texttype, Id3ImageType.OTHER)
 
 
-def types_from_id3(id3type):
+def types_from_id3(id3type: Id3ImageType) -> list[str]:
     return [image_type_from_id3_num(id3type)]
 
 
 TYPES_SEPARATOR = ", "
 
 
-def translated_types_as_string(types, separator=TYPES_SEPARATOR):
+def translated_types_as_string(types: Iterable[str], separator: str = TYPES_SEPARATOR) -> str:
     return separator.join(translate_caa_type(t) for t in types)

--- a/picard/options.py
+++ b/picard/options.py
@@ -38,8 +38,7 @@ from picard.config import (
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.const.defaults import (
     DEFAULT_AUTOBACKUP_DIRECTORY,
-    DEFAULT_CA_NEVER_REPLACE_TYPE_EXCLUDE,
-    DEFAULT_CA_NEVER_REPLACE_TYPE_INCLUDE,
+    DEFAULT_CA_NEVER_REPLACE_TYPES,
     DEFAULT_CA_PROVIDERS,
     DEFAULT_CAA_IMAGE_SIZE,
     DEFAULT_CAA_IMAGE_TYPE_EXCLUDE,
@@ -197,14 +196,8 @@ BoolOption('setting', 'dont_replace_cover_of_types', False, title=N_("Never repl
 ListOption(
     'setting',
     'dont_replace_included_types',
-    DEFAULT_CA_NEVER_REPLACE_TYPE_INCLUDE,
+    DEFAULT_CA_NEVER_REPLACE_TYPES,
     title=N_("Never replace images of these types"),
-)
-ListOption(
-    'setting',
-    'dont_replace_excluded_types',
-    DEFAULT_CA_NEVER_REPLACE_TYPE_EXCLUDE,
-    title=N_("Always replace images of these types"),
 )
 BoolOption(
     'setting',

--- a/picard/ui/dialogs/cover_types_selector.py
+++ b/picard/ui/dialogs/cover_types_selector.py
@@ -24,6 +24,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard.const.defaults import DEFAULT_CA_NEVER_REPLACE_TYPES
 from picard.coverart.utils import (
     CAA_TYPES,
     translate_caa_type,
@@ -44,17 +45,13 @@ class CoverTypesSelectorDialog(PicardDialog):
 
         self._types_list = QtWidgets.QListWidget(self)
 
-        # Ensure selected_types is a set
-        selected_types = set(selected_types or ())
-
         for type in CAA_TYPES:
             name = type['name']
             item = QtWidgets.QListWidgetItem(translate_caa_type(name))
             item.setData(QtCore.Qt.ItemDataRole.UserRole, name)
-            item.setCheckState(
-                QtCore.Qt.CheckState.Checked if name in selected_types else QtCore.Qt.CheckState.Unchecked
-            )
             self._types_list.addItem(item)
+
+        self._update_checked_items(selected_types)
 
         self._layout.addWidget(self._types_list)
 
@@ -63,7 +60,24 @@ class CoverTypesSelectorDialog(PicardDialog):
         buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         buttonbox.accepted.connect(self.accept)
         buttonbox.rejected.connect(self.reject)
+        reset_button = QtWidgets.QPushButton(_("Restore &Defaults"))
+        buttonbox.addButton(reset_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
+        reset_button.clicked.connect(self.reset_to_defaults)
         self._layout.addWidget(buttonbox)
+
+    def _update_checked_items(self, selected_types: Iterable[str] | None):
+        # Ensure selected_types is a set
+        selected_types = set(selected_types or ())
+        for i in range(self._types_list.count()):
+            item = self._types_list.item(i)
+            if item:
+                type_name = item.data(QtCore.Qt.ItemDataRole.UserRole)
+                item.setCheckState(
+                    QtCore.Qt.CheckState.Checked if type_name in selected_types else QtCore.Qt.CheckState.Unchecked
+                )
+
+    def reset_to_defaults(self):
+        self._update_checked_items(DEFAULT_CA_NEVER_REPLACE_TYPES)
 
     def selected_types(self) -> Generator[str, None, None]:
         for i in range(self._types_list.count()):

--- a/picard/ui/dialogs/cover_types_selector.py
+++ b/picard/ui/dialogs/cover_types_selector.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+from collections.abc import Generator, Iterable
+
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
+
+from picard.coverart.utils import (
+    CAA_TYPES,
+    translate_caa_type,
+)
+from picard.i18n import gettext as _
+
+from picard.ui import PicardDialog
+
+
+class CoverTypesSelectorDialog(PicardDialog):
+    defaultsize = QtCore.QSize(400, 460)
+
+    def __init__(self, selected_types: Iterable[str] | None = None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(_("Cover art types"))
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self._layout = QtWidgets.QVBoxLayout(self)
+
+        self._types_list = QtWidgets.QListWidget(self)
+
+        # Ensure selected_types is a set
+        selected_types = set(selected_types or ())
+
+        for type in CAA_TYPES:
+            name = type['name']
+            item = QtWidgets.QListWidgetItem(translate_caa_type(name))
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, name)
+            item.setCheckState(
+                QtCore.Qt.CheckState.Checked if name in selected_types else QtCore.Qt.CheckState.Unchecked
+            )
+            self._types_list.addItem(item)
+
+        self._layout.addWidget(self._types_list)
+
+        buttonbox = QtWidgets.QDialogButtonBox(self)
+        buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+        self._layout.addWidget(buttonbox)
+
+    def selected_types(self) -> Generator[str, None, None]:
+        for i in range(self._types_list.count()):
+            item = self._types_list.item(i)
+            if item and item.checkState() == QtCore.Qt.CheckState.Checked:
+                yield item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+    @classmethod
+    def display(
+        cls,
+        selected_types: Iterable[str] | None = None,
+        parent=None,
+    ) -> tuple[list[str], bool]:
+        dialog = cls(
+            parent=parent,
+            selected_types=selected_types,
+        )
+        result = dialog.exec()
+        return (list(dialog.selected_types()), result == QtWidgets.QDialog.DialogCode.Accepted)

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -3,7 +3,7 @@
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
-# Copyright (C) 2010, 2018-2021, 2024-2025 Philipp Wolfer
+# Copyright (C) 2010, 2018-2021, 2024-2026 Philipp Wolfer
 # Copyright (C) 2012, 2014 Wieland Hoffmann
 # Copyright (C) 2012-2014 Michael Wiencek
 # Copyright (C) 2013-2015, 2018-2021, 2023-2024 Laurent Monin
@@ -33,10 +33,7 @@ from picard.config import (
     Option,
     get_config,
 )
-from picard.const.defaults import (
-    DEFAULT_CA_NEVER_REPLACE_TYPE_EXCLUDE,
-    DEFAULT_CA_NEVER_REPLACE_TYPE_INCLUDE,
-)
+from picard.const.defaults import DEFAULT_CA_NEVER_REPLACE_TYPES
 from picard.coverart.providers import cover_art_providers
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
@@ -44,7 +41,7 @@ from picard.i18n import (
     gettext as _,
 )
 
-from picard.ui.caa_types_selector import CAATypesSelectorDialog
+from picard.ui.dialogs.cover_types_selector import CoverTypesSelectorDialog
 from picard.ui.forms.ui_options_cover import Ui_CoverOptionsPage
 from picard.ui.moveable_list_view import MoveableListView
 from picard.ui.options import OptionsPage
@@ -66,7 +63,6 @@ class CoverOptionsPage(OptionsPage):
         ('dont_replace_with_smaller_cover', ['cb_dont_replace_with_smaller']),
         ('dont_replace_cover_of_types', ['cb_never_replace_types']),
         ('dont_replace_included_types', ['dont_replace_included_types']),
-        ('dont_replace_excluded_types', ['dont_replace_excluded_types']),
         ('save_images_to_files', ['save_images_to_files']),
         ('cover_image_filename', ['cover_image_filename']),
         ('save_images_overwrite', ['save_images_overwrite']),
@@ -90,8 +86,7 @@ class CoverOptionsPage(OptionsPage):
     def restore_defaults(self):
         # Remove previous entries
         self.ui.ca_providers_list.clear()
-        self.dont_replace_included_types = DEFAULT_CA_NEVER_REPLACE_TYPE_INCLUDE
-        self.dont_replace_excluded_types = DEFAULT_CA_NEVER_REPLACE_TYPE_EXCLUDE
+        self.dont_replace_included_types = DEFAULT_CA_NEVER_REPLACE_TYPES
         super().restore_defaults()
 
     def _load_cover_art_providers(self):
@@ -110,7 +105,6 @@ class CoverOptionsPage(OptionsPage):
         self.ui.cb_never_replace_types.setChecked(config.setting['dont_replace_cover_of_types'])
         self.ui.select_types_button.setEnabled(config.setting['dont_replace_cover_of_types'])
         self.dont_replace_included_types = config.setting['dont_replace_included_types']
-        self.dont_replace_excluded_types = config.setting['dont_replace_excluded_types']
         self.ui.save_images_to_files.setChecked(config.setting['save_images_to_files'])
         self.ui.cover_image_filename.setText(config.setting['cover_image_filename'])
         self.ui.save_images_overwrite.setChecked(config.setting['save_images_overwrite'])
@@ -131,7 +125,6 @@ class CoverOptionsPage(OptionsPage):
         config.setting['dont_replace_with_smaller_cover'] = self.ui.cb_dont_replace_with_smaller.isChecked()
         config.setting['dont_replace_cover_of_types'] = self.ui.cb_never_replace_types.isChecked()
         config.setting['dont_replace_included_types'] = self.dont_replace_included_types
-        config.setting['dont_replace_excluded_types'] = self.dont_replace_excluded_types
         config.setting['save_images_to_files'] = self.ui.save_images_to_files.isChecked()
         config.setting['cover_image_filename'] = self.ui.cover_image_filename.text()
         config.setting['save_images_overwrite'] = self.ui.save_images_overwrite.isChecked()
@@ -145,22 +138,12 @@ class CoverOptionsPage(OptionsPage):
         self.ui.ca_providers_groupbox.setEnabled(files_enabled or tags_enabled)
 
     def select_never_replace_image_types(self):
-        instructions_bottom = N_(
-            'Embedded cover art images with a type found in the "Include" list will never be replaced '
-            'by a newly downloaded image UNLESS they also have an image type in the "Exclude" list. '
-            'Images with types found in the "Exclude" list will always be replaced by downloaded images '
-            'of the same type. Images types not appearing in the "Include" or "Exclude" list will '
-            'not be considered when determining whether or not to replace an embedded cover art image.\n'
-        )
-        (included_types, excluded_types, ok) = CAATypesSelectorDialog.display(
-            types_include=self.dont_replace_included_types,
-            types_exclude=self.dont_replace_excluded_types,
+        (included_types, ok) = CoverTypesSelectorDialog.display(
+            selected_types=self.dont_replace_included_types,
             parent=self,
-            instructions_bottom=instructions_bottom,
         )
         if ok:
             self.dont_replace_included_types = included_types
-            self.dont_replace_excluded_types = excluded_types
 
 
 register_options_page(CoverOptionsPage)

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -86,7 +86,6 @@ class ImageFiltersTest(PicardTestCase):
             'dont_replace_with_smaller_cover': True,
             'dont_replace_cover_of_types': True,
             'dont_replace_included_types': ['front', 'booklet'],
-            'dont_replace_excluded_types': ['back'],
             'save_images_to_tags': True,
         }
         self.set_config_values(settings)
@@ -135,7 +134,7 @@ class ImageFiltersTest(PicardTestCase):
         coverartimage5 = CoverArtImage(types=['booklet', 'spine'], support_types=True)
         self.assertFalse(image_types_filter(image, info, album, coverartimage1))
         self.assertTrue(image_types_filter(image, info, album, coverartimage2))
-        self.assertTrue(image_types_filter(image, info, album, coverartimage3))
+        self.assertFalse(image_types_filter(image, info, album, coverartimage3))
         self.assertTrue(image_types_filter(image, info, album, coverartimage4))
         self.assertTrue(image_types_filter(image, info, album, coverartimage5))
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3272
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The option "Never replace selected cover image types" for embedded images currently uses the CAA type selector dialog, with separate include / exclude lists. There are some issues with that:

- The default settings are copied from CAA types, where lower quality types (raw, watermark, matrix) are by default excluded from download. This makes sense. But here it means that Picard will never replace the front, but will do so anyway if there is some watermark or unedited version available.
- More generally, I think the logic is hard to grasp, and I don't really see a need for the exclude list. I think it should just be a list of types to select from.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Simplify this by having only a single list of types not to overwrite. This seems to be sufficient for the use case and avoids the complexity. Use a different UI for selection.


New dialog:

<img width="408" height="469" alt="grafik" src="https://github.com/user-attachments/assets/2cc882ca-7921-4de0-95af-32ace9644077" />

Previous dialog:

<img width="940" height="528" alt="grafik" src="https://github.com/user-attachments/assets/6296de91-d24d-42f4-80db-f999803666c6" />


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

We should eventually rename the config key used, this requires a config migration. See my comment below.