### PR TITLE
Add new debug opt coverart and small improvements to debug opt feature

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -75,52 +75,41 @@ class CoverArt:
     def __repr__(self):
         return "%s for %r" % (self.__class__.__name__, self.album)
 
+    _COVERART_SELECTION_SETTINGS = (
+        'ca_providers',
+        'embed_only_one_front_image',
+        'save_only_one_front_image',
+        'save_images_to_tags',
+        'save_images_to_files',
+        'save_images_overwrite',
+        'cover_image_filename',
+        'image_type_as_filename',
+        'filter_cover_by_size',
+        'cover_minimum_width',
+        'cover_minimum_height',
+        'dont_replace_with_smaller_cover',
+        'dont_replace_cover_of_types',
+        'dont_replace_included_types',
+        'caa_approved_only',
+        'caa_image_size',
+        'caa_restrict_image_types',
+        'caa_image_types',
+        'caa_image_types_to_omit',
+    )
+
     def retrieve(self):
         """Retrieve available cover art images for the release"""
         config = get_config()
         if config.setting['save_images_to_tags'] or config.setting['save_images_to_files']:
             log.debug_if(
                 DebugOpt.COVERART,
-                "Cover art selection settings for %s:"
-                " ca_providers=%r,"
-                " embed_only_one_front_image=%r,"
-                " save_only_one_front_image=%r,"
-                " save_images_to_tags=%r,"
-                " save_images_to_files=%r,"
-                " save_images_overwrite=%r,"
-                " cover_image_filename=%r,"
-                " image_type_as_filename=%r,"
-                " filter_cover_by_size=%r,"
-                " cover_minimum_width=%r,"
-                " cover_minimum_height=%r,"
-                " dont_replace_with_smaller_cover=%r,"
-                " dont_replace_cover_of_types=%r,"
-                " dont_replace_included_types=%r,"
-                " caa_approved_only=%r,"
-                " caa_image_size=%r,"
-                " caa_restrict_image_types=%r,"
-                " caa_image_types=%r,"
-                " caa_image_types_to_omit=%r",
-                self.album,
-                config.setting['ca_providers'],
-                config.setting['embed_only_one_front_image'],
-                config.setting['save_only_one_front_image'],
-                config.setting['save_images_to_tags'],
-                config.setting['save_images_to_files'],
-                config.setting['save_images_overwrite'],
-                config.setting['cover_image_filename'],
-                config.setting['image_type_as_filename'],
-                config.setting['filter_cover_by_size'],
-                config.setting['cover_minimum_width'],
-                config.setting['cover_minimum_height'],
-                config.setting['dont_replace_with_smaller_cover'],
-                config.setting['dont_replace_cover_of_types'],
-                config.setting['dont_replace_included_types'],
-                config.setting['caa_approved_only'],
-                config.setting['caa_image_size'],
-                config.setting['caa_restrict_image_types'],
-                config.setting['caa_image_types'],
-                config.setting['caa_image_types_to_omit'],
+                msg_func=lambda: (
+                    "Cover art selection settings for %s: %s"
+                    % (
+                        self.album,
+                        ', '.join(f"{k}={config.setting[k]!r}" for k in self._COVERART_SELECTION_SETTINGS),
+                    )
+                ),
             )
             self.providers = cover_art_providers()
             self._queue_generator = self._start_queue()

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -274,6 +274,7 @@ class CoverArt:
     def _process_image_data(self, image: CoverArtImage, data, image_info):
         # Skip image if it gets filtered
         if image.can_be_filtered and not run_image_filters(data, image_info, self.album, image):
+            log.debug_if(DebugOpt.COVERART, "Image filtered out: %r", image)
             thread.to_main(self.next_in_queue)
             return
 

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -52,6 +52,7 @@ from picard.coverart.setters import (
     CoverArtSetter,
     CoverArtSetterMode,
 )
+from picard.debug_opts import DebugOpt
 from picard.extension_points.metadata import register_album_metadata_processor
 from picard.i18n import N_
 from picard.metadata import Metadata
@@ -78,6 +79,49 @@ class CoverArt:
         """Retrieve available cover art images for the release"""
         config = get_config()
         if config.setting['save_images_to_tags'] or config.setting['save_images_to_files']:
+            log.debug_if(
+                DebugOpt.COVERART,
+                "Cover art selection settings for %s:"
+                " ca_providers=%r,"
+                " embed_only_one_front_image=%r,"
+                " save_only_one_front_image=%r,"
+                " save_images_to_tags=%r,"
+                " save_images_to_files=%r,"
+                " save_images_overwrite=%r,"
+                " cover_image_filename=%r,"
+                " image_type_as_filename=%r,"
+                " filter_cover_by_size=%r,"
+                " cover_minimum_width=%r,"
+                " cover_minimum_height=%r,"
+                " dont_replace_with_smaller_cover=%r,"
+                " dont_replace_cover_of_types=%r,"
+                " dont_replace_included_types=%r,"
+                " caa_approved_only=%r,"
+                " caa_image_size=%r,"
+                " caa_restrict_image_types=%r,"
+                " caa_image_types=%r,"
+                " caa_image_types_to_omit=%r",
+                self.album,
+                config.setting['ca_providers'],
+                config.setting['embed_only_one_front_image'],
+                config.setting['save_only_one_front_image'],
+                config.setting['save_images_to_tags'],
+                config.setting['save_images_to_files'],
+                config.setting['save_images_overwrite'],
+                config.setting['cover_image_filename'],
+                config.setting['image_type_as_filename'],
+                config.setting['filter_cover_by_size'],
+                config.setting['cover_minimum_width'],
+                config.setting['cover_minimum_height'],
+                config.setting['dont_replace_with_smaller_cover'],
+                config.setting['dont_replace_cover_of_types'],
+                config.setting['dont_replace_included_types'],
+                config.setting['caa_approved_only'],
+                config.setting['caa_image_size'],
+                config.setting['caa_restrict_image_types'],
+                config.setting['caa_image_types'],
+                config.setting['caa_image_types_to_omit'],
+            )
             self.providers = cover_art_providers()
             self._queue_generator = self._start_queue()
             self.next_in_queue()

--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -136,7 +136,8 @@ class CoverArtImageProcessing:
                 "Processing %s: %d bytes, %d x %d, %s;"
                 " save_to_tags=%r, save_to_files=%r,"
                 " tags_resize=%r, file_resize=%r,"
-                " tags_convert=%r, file_convert=%r",
+                " tags_convert=%r, file_convert=%r,"
+                " cover_image_quality=%r",
                 coverartimage,
                 len(initial_data),
                 image_info.width,
@@ -148,6 +149,7 @@ class CoverArtImageProcessing:
                 config.setting['cover_file_resize'],
                 config.setting['cover_tags_convert_images'],
                 config.setting['cover_file_convert_images'],
+                config.setting['cover_image_quality'],
             )
 
             run_queue_common = partial(

--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -36,6 +36,7 @@ from picard.coverart.processing import (  # noqa: F401 # pylint: disable=unused-
     filters,
     processors,
 )
+from picard.debug_opts import DebugOpt
 from picard.extension_points.cover_art_filters import (
     ext_point_cover_art_filters,
     ext_point_cover_art_metadata_filters,
@@ -129,6 +130,25 @@ class CoverArtImageProcessing:
             image = ProcessingImage(initial_data, image_info)
             save_images_to_tags = config.setting['save_images_to_tags']
             save_images_to_files = config.setting['save_images_to_files']
+
+            log.debug_if(
+                DebugOpt.COVERART,
+                "Processing %s: %d bytes, %d x %d, %s;"
+                " save_to_tags=%r, save_to_files=%r,"
+                " tags_resize=%r, file_resize=%r,"
+                " tags_convert=%r, file_convert=%r",
+                coverartimage,
+                len(initial_data),
+                image_info.width,
+                image_info.height,
+                image_info.mime,
+                save_images_to_tags,
+                save_images_to_files,
+                config.setting['cover_tags_resize'],
+                config.setting['cover_file_resize'],
+                config.setting['cover_tags_convert_images'],
+                config.setting['cover_file_convert_images'],
+            )
 
             run_queue_common = partial(
                 self._run_processors_queue,

--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -21,6 +21,7 @@
 
 from picard import log
 from picard.config import get_config
+from picard.debug_opts import DebugOpt
 from picard.extension_points.cover_art_filters import (
     register_cover_art_filter,
     register_cover_art_metadata_filter,
@@ -34,6 +35,14 @@ def _check_threshold_size(width, height):
     # If the given width or height is -1, that dimension is not considered
     min_width = config.setting['cover_minimum_width'] if width != -1 else -1
     min_height = config.setting['cover_minimum_height'] if height != -1 else -1
+    log.debug_if(
+        DebugOpt.COVERART,
+        "Size filter: image %d x %d, minimum %d x %d",
+        width,
+        height,
+        min_width,
+        min_height,
+    )
     if width < min_width or height < min_height:
         log.debug(
             "Discarding cover art due to size. Image size: %d x %d. Minimum: %d x %d",
@@ -63,6 +72,14 @@ def bigger_previous_image_filter(data, image_info, album, coverartimage):
         previous_images = album.orig_metadata.images.get_types_dict()
         if downloaded_types in previous_images:
             previous_image = previous_images[downloaded_types]
+            log.debug_if(
+                DebugOpt.COVERART,
+                "Bigger image filter: new %d x %d vs existing %d x %d",
+                image_info.width,
+                image_info.height,
+                previous_image.width,
+                previous_image.height,
+            )
             if image_info.width < previous_image.width or image_info.height < previous_image.height:
                 log.debug("Discarding cover art. A bigger image with the same types is already embedded.")
                 return False
@@ -74,6 +91,12 @@ def image_types_filter(data, image_info, album, coverartimage):
     if config.setting['dont_replace_cover_of_types'] and config.setting['save_images_to_tags']:
         downloaded_types = set(coverartimage.normalized_types())
         never_replace_types = config.setting['dont_replace_included_types']
+        log.debug_if(
+            DebugOpt.COVERART,
+            "Image types filter: downloaded types %r, never replace types %r",
+            downloaded_types,
+            never_replace_types,
+        )
         previous_image_types = album.orig_metadata.images.get_types_dict()
         for previous_image_type in previous_image_types:
             type_already_embedded = downloaded_types.intersection(previous_image_type)

--- a/picard/coverart/processing/processors.py
+++ b/picard/coverart/processing/processors.py
@@ -26,6 +26,7 @@ from PyQt6.QtCore import Qt
 from picard import log
 from picard.config import get_config
 from picard.const.cover_processing import ResizeModes
+from picard.debug_opts import DebugOpt
 from picard.extension_points.cover_art_processors import (
     ImageProcessor,
     ProcessingImage,
@@ -67,6 +68,18 @@ class ResizeImage(ImageProcessor):
             target_width = config.setting['cover_file_resize_target_width']
             target_height = config.setting['cover_file_resize_target_height']
             resize_mode = config.setting['cover_file_resize_mode']
+
+        log.debug_if(
+            DebugOpt.COVERART,
+            "Resize %s: image %d x %d, target %d x %d, mode %r, enlarge %r",
+            target.name,
+            image.info.width,
+            image.info.height,
+            target_width,
+            target_height,
+            resize_mode,
+            scale_up,
+        )
 
         width_scale_factor = target_width / image.info.width
         height_scale_factor = target_height / image.info.height
@@ -134,6 +147,13 @@ class ConvertImage(ImageProcessor):
             new_format = config.setting['cover_file_convert_to_format']
 
         previous_format = image.info.format_info
+        log.debug_if(
+            DebugOpt.COVERART,
+            "Convert %s: current format %s, target format %s",
+            target.name,
+            previous_format.title,
+            new_format.title,
+        )
         if previous_format == new_format:
             return
         image.info.format_info = new_format

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -58,6 +58,7 @@ from picard.coverart.providers.provider import (
     CoverArtProvider,
     ProviderOptions,
 )
+from picard.debug_opts import DebugOpt
 from picard.i18n import (
     N_,
     gettext as _,
@@ -327,6 +328,12 @@ class CoverArtProviderCaa(CoverArtProvider):
                             image_data = {'width': thumbnail_list[0].width, 'height': -1}
                             filters_result = run_image_metadata_filters(image_data)
                             if not filters_result:
+                                log.debug_if(
+                                    DebugOpt.COVERART,
+                                    "CAA image skipped by metadata filter: %s (width=%d)",
+                                    image['image'],
+                                    thumbnail_list[0].width,
+                                )
                                 continue
                             # FIXME: try other urls in case of 404
                             url = thumbnail_list[0].url

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -110,3 +110,4 @@ class DebugOpt(DebugOptEnum):
     GIT_BACKEND = 4, N_('Git Backend'), N_('Log git backend method calls')
     PLUGIN_TRANSLATIONS = 5, N_('Plugin Translations'), N_('Log plugin translation lookups and fallbacks')
     PLUGIN_UPDATES = 6, N_('Plugin Updates'), N_('Log detailed plugin version checking and update detection')
+    COVERART = 7, N_('Cover Art'), N_('Log cover art filter, resize and convert operations')

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -84,8 +84,15 @@ class DebugOptEnum(int, Enum):
             for o in cls:
                 o.enabled = True
         else:
+            valid_names = {o.optname for o in cls}
             for o in cls:
                 o.enabled = o.optname in opts
+            unknown = opts - valid_names
+            if unknown:
+                import sys
+
+                print(f"Warning: unknown debug option(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+                print(f"Available: {cls.opt_names()}", file=sys.stderr)
 
     @classmethod
     def to_string(cls):

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -89,8 +89,6 @@ class DebugOptEnum(int, Enum):
                 o.enabled = o.optname in opts
             unknown = opts - valid_names
             if unknown:
-                import sys
-
                 print(f"Warning: unknown debug option(s): {', '.join(sorted(unknown))}", file=sys.stderr)
                 print(f"Available: {cls.opt_names()}", file=sys.stderr)
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -247,7 +247,7 @@ def debug_if(debug_opt, msg, *args, **kwargs):
         log.debug_if(DebugOpt.PLUGIN_UPDATES, "Plugin %s: checking version", plugin_name)
     """
     if debug_opt.enabled:
-        main_logger.debug(f"[{debug_opt.optname}] {msg}", *args, **kwargs)
+        main_logger.debug(f"[{debug_opt.optname}] {msg}", *args, stacklevel=2, **kwargs)
 
 
 # HISTORY LOGGING

--- a/picard/log.py
+++ b/picard/log.py
@@ -234,8 +234,41 @@ exception = main_logger.exception
 log = main_logger.log
 
 
+class _DebugLogger:
+    """Callable returned by debug_if when the debug option is enabled."""
+
+    __slots__ = ('_optname',)
+
+    def __init__(self, optname):
+        self._optname = optname
+
+    def __bool__(self):
+        return True
+
+    def __call__(self, msg, *args, stacklevel=2, **kwargs):
+        main_logger.debug(f"[{self._optname}] {msg}", *args, stacklevel=stacklevel, **kwargs)
+
+
+class _NoOpLogger:
+    """Falsy no-op returned by debug_if when the debug option is disabled."""
+
+    __slots__ = ()
+
+    def __bool__(self):
+        return False
+
+    def __call__(self, msg, *args, **kwargs):
+        pass
+
+
+_NOOP_LOGGER = _NoOpLogger()
+
+
 def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
     """Log a debug message only if the specified debug option is enabled.
+
+    Can also be used as a guard that returns a callable logger for blocks
+    of debug statements.
 
     Args:
         debug_opt: A DebugOpt enum value to check
@@ -245,14 +278,30 @@ def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
             debug option is enabled. Mutually exclusive with msg/args.
         **kwargs: Additional keyword arguments passed to logger.debug()
 
+    Returns:
+        A truthy callable logger if the debug option is enabled,
+        a falsy no-op otherwise.
+
     Examples:
-        log.debug_if(DebugOpt.PLUGIN_UPDATES, "Plugin %s: checking version", plugin_name)
-        log.debug_if(DebugOpt.COVERART, msg_func=lambda: "Settings: %s" % expensive_format())
+        # Single message
+        log.debug_if(DebugOpt.COVERART, "Resize: %d x %d", width, height)
+
+        # Lazy formatting with msg_func
+        log.debug_if(DebugOpt.COVERART, msg_func=lambda: "Settings: %s" % expensive())
+
+        # Block guard to skip expensive code entirely when disabled
+        if dbg := log.debug_if(DebugOpt.MATCHING):
+            for item in items:
+                dbg("item: %r", item)
     """
     if debug_opt.enabled:
-        if msg_func is not None:
-            msg = msg_func()
-        main_logger.debug(f"[{debug_opt.optname}] {msg}", *args, stacklevel=2, **kwargs)
+        logger = _DebugLogger(debug_opt.optname)
+        if msg is not None or msg_func is not None:
+            if msg_func is not None:
+                msg = msg_func()
+            logger(msg, *args, stacklevel=3, **kwargs)
+        return logger
+    return _NOOP_LOGGER
 
 
 # HISTORY LOGGING

--- a/picard/log.py
+++ b/picard/log.py
@@ -247,7 +247,7 @@ def debug_if(debug_opt, msg, *args, **kwargs):
         log.debug_if(DebugOpt.PLUGIN_UPDATES, "Plugin %s: checking version", plugin_name)
     """
     if debug_opt.enabled:
-        main_logger.debug(msg, *args, **kwargs)
+        main_logger.debug(f"[{debug_opt.optname}] {msg}", *args, **kwargs)
 
 
 # HISTORY LOGGING

--- a/picard/log.py
+++ b/picard/log.py
@@ -234,19 +234,24 @@ exception = main_logger.exception
 log = main_logger.log
 
 
-def debug_if(debug_opt, msg, *args, **kwargs):
+def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
     """Log a debug message only if the specified debug option is enabled.
 
     Args:
         debug_opt: A DebugOpt enum value to check
         msg: The message format string
         *args: Arguments for the message format string
+        msg_func: A callable returning the message string. Called only if the
+            debug option is enabled. Mutually exclusive with msg/args.
         **kwargs: Additional keyword arguments passed to logger.debug()
 
-    Example:
+    Examples:
         log.debug_if(DebugOpt.PLUGIN_UPDATES, "Plugin %s: checking version", plugin_name)
+        log.debug_if(DebugOpt.COVERART, msg_func=lambda: "Settings: %s" % expensive_format())
     """
     if debug_opt.enabled:
+        if msg_func is not None:
+            msg = msg_func()
         main_logger.debug(f"[{debug_opt.optname}] {msg}", *args, stacklevel=2, **kwargs)
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

We don't have much infos in the debug log about cover art processing.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

### New `coverart` debug option

- Add `DebugOpt.COVERART` (activated via `--debug-opts=coverart`) with logging for:
  - All cover art selection settings at retrieval start (providers, CAA options, filters, save targets, file naming)
  - Image processing settings (resize, convert, quality)
  - Filter decisions (size filter, bigger image filter, image types filter)
  - CAA metadata filter rejections
  - Image filtered-out notifications at the orchestration level

### `debug_if` improvements

`log.debug_if()` has been enhanced with three new capabilities:

1. **Automatic `[optname]` prefix** on all messages, making it trivial to filter:
   ```bash
   picard -d --debug-opts coverart 2>&1 | grep -F ' [coverart] '
   ```

2. **`msg_func` parameter** for lazy formatting — the callable is only invoked when the debug option is enabled, avoiding expensive string formatting when disabled:
   ```python
   log.debug_if(DebugOpt.COVERART, msg_func=lambda: "Settings: %s" % expensive())
   ```

3. **Callable guard object** — `debug_if` now returns a truthy callable when enabled (falsy no-op when disabled), allowing block guards that skip expensive code entirely:
   ```python
   if dbg := log.debug_if(DebugOpt.MATCHING):
       for item in items:
           dbg("item: %r", item)
   ```

4. **Correct caller attribution** via `stacklevel` — log lines now show the actual calling module/function instead of `log.debug_if`.

### Other improvements

- Warn on stderr when unknown debug option names are passed (previously silently ignored).

### Example output

```
D: 15:53:51,046 coverart.retrieve:104: [coverart] Cover art selection settings for <Album fd20f1be ...>: ca_providers=[...], embed_only_one_front_image=False, save_images_to_tags=True, ...
D: 15:53:53,506 coverart/processing._run_image_processors:134: [coverart] Processing CaaCoverArtImage from http://... : 513010 bytes, 1200 x 1200, None; save_to_tags=True, save_to_files=True, tags_resize=True, file_resize=False, tags_convert=True, file_convert=True, cover_image_quality=90
D: 15:53:53,507 coverart/processing/processors.run:150: [coverart] Convert SAME: current format JPEG, target format JPEG
D: 15:53:53,541 coverart/processing/processors.run:72: [coverart] Resize TAGS: image 1200 x 1200, target 800 x 800, mode <ResizeModes.MAINTAIN_ASPECT_RATIO: 0>, enlarge False
```

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
