### PR TITLE
Add PLUGIN_DEVELOPMENT debug option

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1048,7 +1048,7 @@ def enable(api):
    is making changes to metadata and such, but extensive debug logging such as
    that required for troubleshooting a specific plugin can be overwhelming. If
    detailed debug logging is included, it should be used with a blocking guard
-   so that it is only logged when the `PLUGIN_DEVELOPMENT` debug option is
+   so that it is only logged when the `plugin_development` debug option is
    specified on the command line. For example:
    ```python
    # Block guard to avoid extensive debug logging when disabled

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1049,7 +1049,18 @@ def enable(api):
 6. **Pass api to parent classes**: You can use `self.api` in classes inherited from
    base classes meant to be subclassed and imported from `picard.plugin3.api`,
    like `BaseAction` or `OptionsPage`.
+7. **Keep debug log entries to a reasonable amount**: Debug log entries are useful
+   when a user is trying to understand which plugin is making changes to metadata
+   and such, but extensive debug logging such as that required for troubleshooting a
+   specific plugin can be overwhelming. If detailed debug logging is included, it
+   should be used with a blocking guard so that it is only logged when the
+   `PLUGIN_DEVELOPMENT` debug option is specified on the command line, such as:
 
+   ```python
+   # Block guard to avoid extensive debug logging when disabled
+   if dbg := log.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+       dbg("Extensive debug logging output only required for plugin development or troubleshooting")
+   ```
 ---
 
 ## See Also

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1043,24 +1043,24 @@ def enable(api):
 
 1. **Always use the api parameter**: Don't import Picard internals directly
 2. **Use plugin_config for plugin settings**: Keeps your config isolated
-3. **Log appropriately**: Use `debug` for verbose, `info` for important events
-4. **Handle errors gracefully**: Wrap risky operations in try/except
-5. **Set priorities wisely**: Only use non-zero priorities when order matters
-6. **Pass api to parent classes**: You can use `self.api` in classes inherited from
-   base classes meant to be subclassed and imported from `picard.plugin3.api`,
-   like `BaseAction` or `OptionsPage`.
-7. **Keep debug log entries to a reasonable amount**: Debug log entries are useful
-   when a user is trying to understand which plugin is making changes to metadata
-   and such, but extensive debug logging such as that required for troubleshooting a
-   specific plugin can be overwhelming. If detailed debug logging is included, it
-   should be used with a blocking guard so that it is only logged when the
-   `PLUGIN_DEVELOPMENT` debug option is specified on the command line, such as:
+3. **Log appropriately**: Use `debug` for verbose, `info` for important events.
+   Debug log entries are useful when a user is trying to understand which plugin
+   is making changes to metadata and such, but extensive debug logging such as
+   that required for troubleshooting a specific plugin can be overwhelming. If
+   detailed debug logging is included, it should be used with a blocking guard
+   so that it is only logged when the `PLUGIN_DEVELOPMENT` debug option is
+   specified on the command line, such as:
 
    ```python
    # Block guard to avoid extensive debug logging when disabled
    if dbg := log.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
        dbg("Extensive debug logging output only required for plugin development or troubleshooting")
    ```
+4. **Handle errors gracefully**: Wrap risky operations in try/except
+5. **Set priorities wisely**: Only use non-zero priorities when order matters
+6. **Pass api to parent classes**: You can use `self.api` in classes inherited from
+   base classes meant to be subclassed and imported from `picard.plugin3.api`,
+   like `BaseAction` or `OptionsPage`.
 
 ---
 

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1061,6 +1061,7 @@ def enable(api):
    if dbg := log.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
        dbg("Extensive debug logging output only required for plugin development or troubleshooting")
    ```
+
 ---
 
 ## See Also

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1047,13 +1047,21 @@ def enable(api):
    Debug log entries are useful when a user is trying to understand which plugin
    is making changes to metadata and such, but extensive debug logging such as
    that required for troubleshooting a specific plugin can be overwhelming. If
-   detailed debug logging is included, it should be used with a blocking guard
-   so that it is only logged when the `plugin_development` debug option is
-   specified on the command line. For example:
+   detailed debug logging is included, it should be used with the
+   `api.logger.debug_if()` method so that it is only logged when the
+   `plugin_development` debug option is specified on the command line. For example:
    ```python
-   # Block guard to avoid extensive debug logging when disabled
+   # Single message
+   self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Detailed debug message with no parameters")
+   self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Resize: %d x %d", width, height)
+
+   # Lazy formatting with msg_func
+   self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, msg_func=lambda: "Settings: %s" % expensive())
+
+   # Block guard to skip expensive code entirely when disabled
    if dbg := self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
-       dbg("Extensive debug output only required for plugin development or troubleshooting")
+       for item in items:
+           dbg("item: %r", item)
    ```
 4. **Handle errors gracefully**: Wrap risky operations in try/except
 5. **Set priorities wisely**: Only use non-zero priorities when order matters

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1049,12 +1049,11 @@ def enable(api):
    that required for troubleshooting a specific plugin can be overwhelming. If
    detailed debug logging is included, it should be used with a blocking guard
    so that it is only logged when the `PLUGIN_DEVELOPMENT` debug option is
-   specified on the command line, such as:
-
+   specified on the command line. For example:
    ```python
    # Block guard to avoid extensive debug logging when disabled
-   if dbg := log.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
-       dbg("Extensive debug logging output only required for plugin development or troubleshooting")
+   if dbg := self.api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+       dbg("Extensive debug output only required for plugin development or troubleshooting")
    ```
 4. **Handle errors gracefully**: Wrap risky operations in try/except
 5. **Set priorities wisely**: Only use non-zero priorities when order matters

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -117,3 +117,4 @@ class DebugOpt(DebugOptEnum):
     PLUGIN_UPDATES = 6, N_('Plugin Updates'), N_('Log detailed plugin version checking and update detection')
     COVERART = 7, N_('Cover Art'), N_('Log cover art filter, resize and convert operations')
     MATCHING = 8, N_('Matching'), N_('Log similarity scores and match decisions')
+    PLUGIN_DEVELOPMENT = 9, N_('Plugin Development'), N_('Log plugin details typically only used during development')


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Sometimes plugins log an excessive amount of debug information that is only of value during development or troubleshooting, and there is no way to avoid this excessive logging at the debug level.

* JIRA ticket (_optional_): PICARD-XXX


## Solution

Introduce a new command line debug option to allow filtering out the excessive debug log entries, and only display them when the new debug option is enabled.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)


## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

