### PR TITLE
PICARD-3286: Log view rework, filtering, performance

### DIFF
--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -252,6 +252,10 @@ class LogView(LogViewCommon):
         self._delegate = LogItemDelegate(parent=self.list_view)
         self.list_view.setItemDelegate(self._delegate)
 
+        clear_log_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-clear"), _("Clear &Log…"), self.list_view)
+        clear_log_action.triggered.connect(self._clear_log_do)
+        self.list_view.addAction(clear_log_action)
+
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
@@ -289,12 +293,6 @@ class LogView(LogViewCommon):
         self.filter_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly)
         self.filter_button.toggled.connect(self._on_filter_toggled)
         self.hbox.addWidget(self.filter_button)
-
-        # clear log
-        self.clear_log_button = QtWidgets.QPushButton(_("Clear Log…"))
-        self.clear_log_button.setAutoDefault(False)
-        self.hbox.addWidget(self.clear_log_button)
-        self.clear_log_button.clicked.connect(self._clear_log_do)
 
         # save as
         self.save_log_as_button = QtWidgets.QPushButton(_("Save As…"))

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -70,8 +70,9 @@ class LogViewDialog(PicardDialog):
         self.list_view = QtWidgets.QListView()
         self.list_view.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.list_view.setFont(QtGui.QFont(FONT_FAMILY_MONOSPACE))
-        self.list_view.setWordWrap(True)
-        self.list_view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.list_view.setWordWrap(False)
+        self.list_view.setUniformItemSizes(True)
+        self.list_view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.list_view.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.list_view.customContextMenuRequested.connect(self._show_context_menu)
         self.vbox.addWidget(self.list_view)
@@ -111,6 +112,8 @@ class LogViewDialog(PicardDialog):
 
 
 class LogViewCommon(LogViewDialog):
+    _UPDATE_INTERVAL_MS = 100
+
     def __init__(self, log_tail, title, parent=None):
         super().__init__(title, parent=parent)
         self.log_tail = log_tail
@@ -119,6 +122,9 @@ class LogViewCommon(LogViewDialog):
         self._following_tail = True
         self._inhibit_scroll_tracking = False
         self.list_view.verticalScrollBar().valueChanged.connect(self._on_scroll)
+        self._update_timer = QtCore.QTimer(self)
+        self._update_timer.setInterval(self._UPDATE_INTERVAL_MS)
+        self._update_timer.timeout.connect(self._flush_updates)
 
     def _on_scroll(self):
         if self._inhibit_scroll_tracking:
@@ -138,6 +144,7 @@ class LogViewCommon(LogViewDialog):
 
     def hideEvent(self, event):
         reconnect(self.log_tail.updated, None)
+        self._update_timer.stop()
         super().hideEvent(event)
 
     def showEvent(self, event):
@@ -151,6 +158,10 @@ class LogViewCommon(LogViewDialog):
         super().showEvent(event)
 
     def _updated(self):
+        if not self._update_timer.isActive():
+            self._update_timer.start()
+
+    def _flush_updates(self):
         self._model.append_from_tail()
         if self._following_tail:
             self._scroll_to_bottom()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -41,10 +41,7 @@ from PyQt6 import (
 from picard import log
 from picard.debug_opts import DebugOpt
 from picard.i18n import gettext as _
-from picard.util import (
-    reconnect,
-    wildcards_to_regex_pattern,
-)
+from picard.util import reconnect
 
 from picard.ui import (
     FONT_FAMILY_MONOSPACE,
@@ -331,7 +328,7 @@ class LogView(LogViewCommon):
         text = self.filter_input.text()
         if self.filter_button.isChecked() and text:
             try:
-                hl_re = re.compile(wildcards_to_regex_pattern(text), re.IGNORECASE)
+                hl_re = re.compile(re.escape(text), re.IGNORECASE)
             except re.error:
                 hl_re = None
         else:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -269,6 +269,24 @@ class LogView(LogViewCommon):
         self.hbox.addWidget(self.save_log_as_button)
         self.save_log_as_button.clicked.connect(self._save_log_as_do)
 
+        # line count status
+        self.hbox.addStretch()
+        self._status_label = QtWidgets.QLabel()
+        self.hbox.addWidget(self._status_label)
+        self._model.rowsInserted.connect(self._update_status)
+        self._model.modelReset.connect(self._update_status)
+        self._update_status()
+
+    def _update_status(self):
+        if not hasattr(self, '_status_label'):
+            return
+        visible = self._proxy_model.rowCount()
+        total = self._model.rowCount()
+        if visible == total:
+            self._status_label.setText(str(total))
+        else:
+            self._status_label.setText(f"{visible}/{total}")
+
     def _on_filter_changed(self, text):
         if self.filter_button.isChecked():
             self._apply_filter()
@@ -297,6 +315,7 @@ class LogView(LogViewCommon):
         else:
             self._inhibit_scroll_tracking = False
         self.list_view.viewport().update()
+        self._update_status()
 
     def _save_log_as_do(self):
         path, ok = FileDialog.getSaveFileName(
@@ -355,6 +374,7 @@ class LogView(LogViewCommon):
             self._inhibit_scroll_tracking = False
         self.verbosity_menu.set_verbosity(self.verbosity)
         self._update_verbosity_label()
+        self._update_status()
 
     def _verbosity_changed(self, level):
         if level != self.verbosity:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -97,22 +97,25 @@ class LogViewDialog(PicardDialog):
             menu.addAction(action)
         menu.exec(self.list_view.viewport().mapToGlobal(pos))
 
-    def _copy_selection(self):
+    def _get_selected_text(self):
         indexes = self.list_view.selectionModel().selectedIndexes()
-        if indexes:
-            indexes.sort(key=lambda idx: idx.row())
-            text = '\n'.join(idx.data(FullTextRole) or '' for idx in indexes)
+        if not indexes:
+            return None
+        indexes.sort(key=lambda idx: idx.row())
+        return '\n'.join(idx.data(FullTextRole) or '' for idx in indexes)
+
+    def _copy_selection(self):
+        text = self._get_selected_text()
+        if text:
             QtWidgets.QApplication.clipboard().setText(text)
 
     def _select_all(self):
         self.list_view.selectAll()
 
     def _show_detail(self):
-        indexes = self.list_view.selectionModel().selectedIndexes()
-        if not indexes:
+        text = self._get_selected_text()
+        if not text:
             return
-        indexes.sort(key=lambda idx: idx.row())
-        text = '\n'.join(idx.data(FullTextRole) or '' for idx in indexes)
         dlg = QtWidgets.QDialog(self)
         dlg.setWindowTitle(_("Log Detail"))
         dlg.resize(600, 400)
@@ -243,6 +246,7 @@ class LogView(LogViewCommon):
     def __init__(self, parent=None):
         super().__init__(log.main_tail, _("Log"), parent=parent)
         self.verbosity = log.get_effective_level()
+        self._status_label = None
 
         # Set up proxy model for level filtering
         self._proxy_model = LogFilterProxyModel(parent=self)
@@ -315,7 +319,7 @@ class LogView(LogViewCommon):
         self._update_status()
 
     def _update_status(self):
-        if not hasattr(self, '_status_label'):
+        if self._status_label is None:
             return
         visible = self._proxy_model.rowCount()
         total = self._model.rowCount()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -50,7 +50,11 @@ from picard.ui import (
     FONT_FAMILY_MONOSPACE,
     PicardDialog,
 )
-from picard.ui.colors import interface_colors
+from picard.ui.logviewmodel import (
+    LogFilterProxyModel,
+    LogItemDelegate,
+    LogItemModel,
+)
 from picard.ui.util import FileDialog
 
 
@@ -61,80 +65,108 @@ class LogViewDialog(PicardDialog):
         super().__init__(parent=parent)
         self.setWindowFlags(QtCore.Qt.WindowType.Window)
         self.setWindowTitle(title)
-        self.doc = QtGui.QTextDocument()
-        self.textCursor = QtGui.QTextCursor(self.doc)
-        self.browser = QtWidgets.QTextBrowser()
-        self.browser.setDocument(self.doc)
         self.vbox = QtWidgets.QVBoxLayout()
         self.setLayout(self.vbox)
-        self.vbox.addWidget(self.browser)
+        self.list_view = QtWidgets.QListView()
+        self.list_view.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.list_view.setFont(QtGui.QFont(FONT_FAMILY_MONOSPACE))
+        self.list_view.setWordWrap(True)
+        self.list_view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.list_view.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.list_view.customContextMenuRequested.connect(self._show_context_menu)
+        self.vbox.addWidget(self.list_view)
+
+        copy_action = QtGui.QAction(_("&Copy"), self.list_view)
+        copy_action.setShortcut(QtGui.QKeySequence.StandardKey.Copy)
+        copy_action.triggered.connect(self._copy_selection)
+        self.list_view.addAction(copy_action)
+
+        select_all_action = QtGui.QAction(_("Select &All"), self.list_view)
+        select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
+        select_all_action.triggered.connect(self._select_all)
+        self.list_view.addAction(select_all_action)
+
+        deselect_all_action = QtGui.QAction(_("&Deselect All"), self.list_view)
+        deselect_all_action.triggered.connect(self._deselect_all)
+        self.list_view.addAction(deselect_all_action)
+
+    def _show_context_menu(self, pos):
+        menu = QtWidgets.QMenu(self.list_view)
+        for action in self.list_view.actions():
+            menu.addAction(action)
+        menu.exec(self.list_view.viewport().mapToGlobal(pos))
+
+    def _copy_selection(self):
+        indexes = self.list_view.selectionModel().selectedIndexes()
+        if indexes:
+            indexes.sort(key=lambda idx: idx.row())
+            text = '\n'.join(idx.data(QtCore.Qt.ItemDataRole.DisplayRole) or '' for idx in indexes)
+            QtWidgets.QApplication.clipboard().setText(text)
+
+    def _select_all(self):
+        self.list_view.selectAll()
+
+    def _deselect_all(self):
+        self.list_view.clearSelection()
 
 
 class LogViewCommon(LogViewDialog):
     def __init__(self, log_tail, title, parent=None):
         super().__init__(title, parent=parent)
-        self.displaying = False
         self.log_tail = log_tail
-        self._init_doc()
+        self._model = LogItemModel(log_tail, parent=self)
+        self.list_view.setModel(self._model)
+        self._following_tail = True
+        self._inhibit_scroll_tracking = False
+        self.list_view.verticalScrollBar().valueChanged.connect(self._on_scroll)
 
-    def _init_doc(self):
-        self.prev = -1
-        self.doc.clear()
-        self.textCursor.movePosition(QtGui.QTextCursor.MoveOperation.Start)
+    def _on_scroll(self):
+        if self._inhibit_scroll_tracking:
+            return
+        sb = self.list_view.verticalScrollBar()
+        self._following_tail = sb.value() >= sb.maximum() - 1
 
     def closeEvent(self, event):
         self.save_geometry()
         event.ignore()
         self.hide()
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self._following_tail:
+            self._scroll_to_bottom()
+
     def hideEvent(self, event):
         reconnect(self.log_tail.updated, None)
         super().hideEvent(event)
 
     def showEvent(self, event):
-        self.display()
-        reconnect(self.log_tail.updated, self._updated)
+        self._model.append_from_tail()
+        self._scroll_to_bottom()
+        # Disconnect any previous handler, then reconnect with an explicit
+        # QueuedConnection: the signal is emitted from background logging
+        # threads and the slot updates the UI, so it must be queued.
+        reconnect(self.log_tail.updated, None)
+        self.log_tail.updated.connect(self._updated, QtCore.Qt.ConnectionType.QueuedConnection)
         super().showEvent(event)
 
     def _updated(self):
-        if self.displaying:
-            return
-        self.display()
+        self._model.append_from_tail()
+        if self._following_tail:
+            self._scroll_to_bottom()
 
-    def display(self, clear=False):
-        self.displaying = True
-        if clear:
-            self._init_doc()
-        for logitem in self.log_tail.contents(self.prev):
-            self._add_entry(logitem)
-            self.prev = logitem.pos
-        self.displaying = False
-
-    def _add_entry(self, logitem):
-        self.textCursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
-        self.textCursor.insertText(logitem.message)
-        self.textCursor.insertBlock()
-        sb = self.browser.verticalScrollBar()
-        sb.setValue(sb.maximum())
+    def _scroll_to_bottom(self):
+        self._inhibit_scroll_tracking = True
+        self.list_view.scrollToBottom()
+        self._inhibit_scroll_tracking = False
 
     def clear(self):
         self.log_tail.clear()
-        self.display(clear=True)
+        self._model.clear_entries()
 
-
-class Highlighter(QtGui.QSyntaxHighlighter):
-    def __init__(self, string, parent):
-        super().__init__(parent)
-
-        self.fmt = QtGui.QTextCharFormat()
-        self.fmt.setBackground(QtCore.Qt.GlobalColor.lightGray)
-        self.reg = re.compile(wildcards_to_regex_pattern(string), re.IGNORECASE)
-
-    def highlightBlock(self, text):
-        for match in self.reg.finditer(text):
-            index = match.start()
-            length = match.end() - match.start()
-            self.setFormat(index, length, self.fmt)
+    def get_all_text(self):
+        """Return all log messages as plain text."""
+        return self._model.get_all_text()
 
 
 class VerbosityMenu(QtWidgets.QMenu):
@@ -178,14 +210,20 @@ class LogView(LogViewCommon):
         super().__init__(log.main_tail, _("Log"), parent=parent)
         self.verbosity = log.get_effective_level()
 
-        self._setup_formats()
-        self.hl_text = ''
-        self.hl = None
+        # Set up proxy model for level filtering
+        self._proxy_model = LogFilterProxyModel(parent=self)
+        self._proxy_model.setSourceModel(self._model)
+        self._proxy_model.set_min_level(self.verbosity)
+        self.list_view.setModel(self._proxy_model)
+
+        self._delegate = LogItemDelegate(parent=self.list_view)
+        self.list_view.setItemDelegate(self._delegate)
 
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
         self.verbosity_menu_button = QtWidgets.QPushButton()
+        self.verbosity_menu_button.setAutoDefault(False)
         self.verbosity_menu_button.setAccessibleName(_("Verbosity"))
         self.hbox.addWidget(self.verbosity_menu_button)
 
@@ -194,6 +232,7 @@ class LogView(LogViewCommon):
         self.verbosity_menu_button.setMenu(self.verbosity_menu)
 
         self.debug_opts_menu_button = QtWidgets.QPushButton(_("Debug Options"))
+        self.debug_opts_menu_button.setAutoDefault(False)
         self.debug_opts_menu_button.setAccessibleName(_("Debug Options"))
         self.hbox.addWidget(self.debug_opts_menu_button)
 
@@ -202,79 +241,68 @@ class LogView(LogViewCommon):
 
         self._set_verbosity(self.verbosity)
 
-        # highlight input
-        self.highlight_text = QtWidgets.QLineEdit()
-        self.highlight_text.setPlaceholderText(_("String to highlight"))
-        self.highlight_text.textEdited.connect(self._highlight_text_edited)
-        self.hbox.addWidget(self.highlight_text)
+        # filter input with embedded clear button
+        self.filter_input = QtWidgets.QLineEdit()
+        self.filter_input.setPlaceholderText(_("Filter"))
+        self.filter_input.setClearButtonEnabled(True)
+        self.filter_input.textChanged.connect(self._on_filter_changed)
+        self.filter_input.returnPressed.connect(self._on_filter_return)
+        self.hbox.addWidget(self.filter_input)
 
-        # highlight button
-        self.highlight_button = QtWidgets.QPushButton(_("Highlight"))
-        self.hbox.addWidget(self.highlight_button)
-        self.highlight_button.setDefault(True)
-        self.highlight_button.setEnabled(False)
-        self.highlight_button.clicked.connect(self._highlight_do)
-
-        self.highlight_text.returnPressed.connect(self.highlight_button.click)
-
-        # clear highlight button
-        self.clear_highlight_button = QtWidgets.QPushButton(_("Clear Highlight"))
-        self.hbox.addWidget(self.clear_highlight_button)
-        self.clear_highlight_button.setEnabled(False)
-        self.clear_highlight_button.clicked.connect(self._clear_highlight_do)
+        # filter toggle button
+        self.filter_button = QtWidgets.QToolButton()
+        self.filter_button.setText(_("Filter"))
+        self.filter_button.setCheckable(True)
+        self.filter_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.filter_button.toggled.connect(self._on_filter_toggled)
+        self.hbox.addWidget(self.filter_button)
 
         # clear log
         self.clear_log_button = QtWidgets.QPushButton(_("Clear Log…"))
+        self.clear_log_button.setAutoDefault(False)
         self.hbox.addWidget(self.clear_log_button)
         self.clear_log_button.clicked.connect(self._clear_log_do)
 
         # save as
         self.save_log_as_button = QtWidgets.QPushButton(_("Save As…"))
+        self.save_log_as_button.setAutoDefault(False)
         self.hbox.addWidget(self.save_log_as_button)
         self.save_log_as_button.clicked.connect(self._save_log_as_do)
 
-        self._prev_logitem_level = logging.NOTSET
+    def _on_filter_changed(self, text):
+        if self.filter_button.isChecked():
+            self._apply_filter()
 
-    def _clear_highlight_do(self):
-        self.highlight_text.setText('')
-        self.highlight_button.setEnabled(False)
-        self._highlight_do()
+    def _on_filter_return(self):
+        if self.filter_input.text():
+            self.filter_button.setChecked(not self.filter_button.isChecked())
 
-    def _highlight_text_edited(self, text):
-        if text and self.hl_text != text:
-            self.highlight_button.setEnabled(True)
+    def _on_filter_toggled(self, checked):
+        self._apply_filter()
+
+    def _apply_filter(self):
+        text = self.filter_input.text()
+        if self.filter_button.isChecked() and text:
+            try:
+                hl_re = re.compile(wildcards_to_regex_pattern(text), re.IGNORECASE)
+            except re.error:
+                hl_re = None
         else:
-            self.highlight_button.setEnabled(False)
-        if not text:
-            self.clear_highlight_button.setEnabled(bool(self.hl))
-
-    def _highlight_do(self):
-        new_hl_text = self.highlight_text.text()
-        if new_hl_text != self.hl_text:
-            self.hl_text = new_hl_text
-            if self.hl is not None:
-                self.hl.setDocument(None)
-                self.hl = None
-            if self.hl_text:
-                self.hl = Highlighter(self.hl_text, self.doc)
-            self.clear_highlight_button.setEnabled(bool(self.hl))
-
-    def _setup_formats(self):
-        interface_colors.load_from_config()
-        self.formats = {}
-        for level, feat in log.levels_features.items():
-            text_fmt = QtGui.QTextCharFormat()
-            text_fmt.setFontFamilies([FONT_FAMILY_MONOSPACE])
-            text_fmt.setForeground(interface_colors.get_qcolor(feat.color_key))
-            self.formats[level] = text_fmt
-
-    def _format(self, level):
-        return self.formats[level]
+            hl_re = None
+        self._delegate.set_highlight(hl_re)
+        self._inhibit_scroll_tracking = True
+        self._proxy_model.set_text_filter(hl_re)
+        if self._following_tail:
+            QtCore.QTimer.singleShot(0, self._deferred_scroll_to_bottom)
+        else:
+            self._inhibit_scroll_tracking = False
+        self.list_view.viewport().update()
 
     def _save_log_as_do(self):
         path, ok = FileDialog.getSaveFileName(
             parent=self,
             caption=_("Save Log View to File"),
+            filter=_("Text files (*.txt);;All files (*)"),
             options=QtWidgets.QFileDialog.Option.DontConfirmOverwrite,
         )
         if ok and path:
@@ -288,24 +316,19 @@ class LogView(LogViewCommon):
                 if reply != QtWidgets.QMessageBox.StandardButton.Yes:
                     return
 
-            writer = QtGui.QTextDocumentWriter(path)
-            writer.setFormat(b'plaintext')
-            success = writer.write(self.doc)
-            if not success:
+            try:
+                with open(path, 'w', encoding='utf-8') as f:
+                    f.write(self.get_all_text())
+            except OSError:
                 QtWidgets.QMessageBox.critical(
                     self,
                     _("Failed to save Log View to file"),
-                    _('Something prevented data to be written to "%s".') % writer.fileName(),
+                    _('Something prevented data to be written to "%s".') % path,
                 )
 
     def show(self):
-        self.highlight_text.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+        self.filter_input.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
         super().show()
-
-    def display(self, clear=False):
-        if clear:
-            self._prev_logitem_level = logging.NOTSET
-        super().display(clear=clear)
 
     def _clear_log_do(self):
         reply = QtWidgets.QMessageBox.question(
@@ -316,31 +339,27 @@ class LogView(LogViewCommon):
         )
         if reply != QtWidgets.QMessageBox.StandardButton.Yes:
             return
-        self.log_tail.clear()
-        self.display(clear=True)
+        self.clear()
 
-    def is_shown(self, logitem):
-        return logitem.level >= self.verbosity
-
-    def _add_entry(self, logitem):
-        if not self.is_shown(logitem):
-            return
-        if self._prev_logitem_level != logitem.level:
-            self.textCursor.setBlockCharFormat(self._format(logitem.level))
-            self._prev_logitem_level = logitem.level
-        super()._add_entry(logitem)
+    def _deferred_scroll_to_bottom(self):
+        self._scroll_to_bottom()
+        self._inhibit_scroll_tracking = False
 
     def _set_verbosity(self, level):
         self.verbosity = level
+        self._inhibit_scroll_tracking = True
+        self._proxy_model.set_min_level(level)
+        if self._following_tail:
+            QtCore.QTimer.singleShot(0, self._deferred_scroll_to_bottom)
+        else:
+            self._inhibit_scroll_tracking = False
         self.verbosity_menu.set_verbosity(self.verbosity)
         self._update_verbosity_label()
 
     def _verbosity_changed(self, level):
         if level != self.verbosity:
             log.set_verbosity(level, save_to_config=True)
-            self.verbosity = level
-            self._update_verbosity_label()
-            self.display(clear=True)
+            self._set_verbosity(level)
 
     def _update_verbosity_label(self):
         feat = log.levels_features.get(self.verbosity)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -76,7 +76,7 @@ class LogViewDialog(PicardDialog):
         self.vbox.addWidget(self.list_view)
 
         view_detail_action = QtGui.QAction(
-            QtGui.QIcon.fromTheme("document-properties"), _("&View Detail…"), self.list_view
+            QtGui.QIcon.fromTheme("document-properties"), _("&View detail…"), self.list_view
         )
         view_detail_action.triggered.connect(self._show_detail)
         self.list_view.addAction(view_detail_action)
@@ -86,7 +86,7 @@ class LogViewDialog(PicardDialog):
         copy_action.triggered.connect(self._copy_selection)
         self.list_view.addAction(copy_action)
 
-        select_all_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-select-all"), _("Select &All"), self.list_view)
+        select_all_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-select-all"), _("Select &all"), self.list_view)
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self._select_all)
         self.list_view.addAction(select_all_action)
@@ -257,16 +257,16 @@ class LogView(LogViewCommon):
         self._delegate = LogItemDelegate(parent=self.list_view)
         self.list_view.setItemDelegate(self._delegate)
 
-        clear_log_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-clear"), _("Clear &Log…"), self.list_view)
+        clear_log_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-clear"), _("Clear &log…"), self.list_view)
         clear_log_action.triggered.connect(self._clear_log_do)
         self.list_view.addAction(clear_log_action)
 
-        self._regex_action = QtGui.QAction(_("&Regex Filter"), self.list_view)
+        self._regex_action = QtGui.QAction(_("&Regex filter"), self.list_view)
         self._regex_action.setCheckable(True)
         self._regex_action.toggled.connect(self._on_regex_toggled)
         self.list_view.addAction(self._regex_action)
 
-        self._compact_view_action = QtGui.QAction(_("&Compact View"), self.list_view)
+        self._compact_view_action = QtGui.QAction(_("&Compact view"), self.list_view)
         self._compact_view_action.setCheckable(True)
         self._compact_view_action.setChecked(False)
         self._compact_view_action.toggled.connect(self._on_compact_view_toggled)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -51,6 +51,7 @@ from picard.ui import (
     PicardDialog,
 )
 from picard.ui.logviewmodel import (
+    FullTextRole,
     LogFilterProxyModel,
     LogItemDelegate,
     LogItemModel,
@@ -91,6 +92,10 @@ class LogViewDialog(PicardDialog):
         deselect_all_action.triggered.connect(self._deselect_all)
         self.list_view.addAction(deselect_all_action)
 
+        view_detail_action = QtGui.QAction(_("&View Detail…"), self.list_view)
+        view_detail_action.triggered.connect(self._show_detail)
+        self.list_view.addAction(view_detail_action)
+
     def _show_context_menu(self, pos):
         menu = QtWidgets.QMenu(self.list_view)
         for action in self.list_view.actions():
@@ -101,7 +106,7 @@ class LogViewDialog(PicardDialog):
         indexes = self.list_view.selectionModel().selectedIndexes()
         if indexes:
             indexes.sort(key=lambda idx: idx.row())
-            text = '\n'.join(idx.data(QtCore.Qt.ItemDataRole.DisplayRole) or '' for idx in indexes)
+            text = '\n'.join(idx.data(FullTextRole) or '' for idx in indexes)
             QtWidgets.QApplication.clipboard().setText(text)
 
     def _select_all(self):
@@ -109,6 +114,24 @@ class LogViewDialog(PicardDialog):
 
     def _deselect_all(self):
         self.list_view.clearSelection()
+
+    def _show_detail(self):
+        indexes = self.list_view.selectionModel().selectedIndexes()
+        if not indexes:
+            return
+        indexes.sort(key=lambda idx: idx.row())
+        text = '\n'.join(idx.data(FullTextRole) or '' for idx in indexes)
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowTitle(_("Log Detail"))
+        dlg.resize(600, 400)
+        layout = QtWidgets.QVBoxLayout(dlg)
+        text_edit = QtWidgets.QPlainTextEdit(dlg)
+        text_edit.setReadOnly(True)
+        text_edit.setLineWrapMode(QtWidgets.QPlainTextEdit.LineWrapMode.WidgetWidth)
+        text_edit.setFont(self.list_view.font())
+        text_edit.setPlainText(text)
+        layout.addWidget(text_edit)
+        dlg.show()
 
 
 class LogViewCommon(LogViewDialog):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -78,23 +78,21 @@ class LogViewDialog(PicardDialog):
         self.list_view.customContextMenuRequested.connect(self._show_context_menu)
         self.vbox.addWidget(self.list_view)
 
-        copy_action = QtGui.QAction(_("&Copy"), self.list_view)
+        view_detail_action = QtGui.QAction(
+            QtGui.QIcon.fromTheme("document-properties"), _("&View Detail…"), self.list_view
+        )
+        view_detail_action.triggered.connect(self._show_detail)
+        self.list_view.addAction(view_detail_action)
+
+        copy_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-copy"), _("&Copy"), self.list_view)
         copy_action.setShortcut(QtGui.QKeySequence.StandardKey.Copy)
         copy_action.triggered.connect(self._copy_selection)
         self.list_view.addAction(copy_action)
 
-        select_all_action = QtGui.QAction(_("Select &All"), self.list_view)
+        select_all_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-select-all"), _("Select &All"), self.list_view)
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self._select_all)
         self.list_view.addAction(select_all_action)
-
-        deselect_all_action = QtGui.QAction(_("&Deselect All"), self.list_view)
-        deselect_all_action.triggered.connect(self._deselect_all)
-        self.list_view.addAction(deselect_all_action)
-
-        view_detail_action = QtGui.QAction(_("&View Detail…"), self.list_view)
-        view_detail_action.triggered.connect(self._show_detail)
-        self.list_view.addAction(view_detail_action)
 
     def _show_context_menu(self, pos):
         menu = QtWidgets.QMenu(self.list_view)
@@ -111,9 +109,6 @@ class LogViewDialog(PicardDialog):
 
     def _select_all(self):
         self.list_view.selectAll()
-
-    def _deselect_all(self):
-        self.list_view.clearSelection()
 
     def _show_detail(self):
         indexes = self.list_view.selectionModel().selectedIndexes()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -266,6 +266,12 @@ class LogView(LogViewCommon):
         self._regex_action.toggled.connect(self._on_regex_toggled)
         self.list_view.addAction(self._regex_action)
 
+        self._compact_view_action = QtGui.QAction(_("&Compact View"), self.list_view)
+        self._compact_view_action.setCheckable(True)
+        self._compact_view_action.setChecked(False)
+        self._compact_view_action.toggled.connect(self._on_compact_view_toggled)
+        self.list_view.addAction(self._compact_view_action)
+
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
@@ -342,6 +348,9 @@ class LogView(LogViewCommon):
     def _on_regex_toggled(self, checked):
         if self.filter_button.isChecked():
             self._apply_filter()
+
+    def _on_compact_view_toggled(self, checked):
+        self._model.compact_view = checked
 
     def _apply_filter(self):
         text = self.filter_input.text()

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -230,6 +230,13 @@ class DebugOptsMenu(QtWidgets.QMenu):
     def debug_opt_changed(self, debug_opt, checked):
         debug_opt.enabled = checked
 
+    def mouseReleaseEvent(self, event):
+        action = self.activeAction()
+        if action and action.isCheckable():
+            action.trigger()
+            return
+        super().mouseReleaseEvent(event)
+
 
 class LogView(LogViewCommon):
     def __init__(self, parent=None):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -256,6 +256,11 @@ class LogView(LogViewCommon):
         clear_log_action.triggered.connect(self._clear_log_do)
         self.list_view.addAction(clear_log_action)
 
+        self._regex_action = QtGui.QAction(_("&Regex Filter"), self.list_view)
+        self._regex_action.setCheckable(True)
+        self._regex_action.toggled.connect(self._on_regex_toggled)
+        self.list_view.addAction(self._regex_action)
+
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
@@ -329,11 +334,18 @@ class LogView(LogViewCommon):
     def _on_filter_toggled(self, checked):
         self._apply_filter()
 
+    def _on_regex_toggled(self, checked):
+        if self.filter_button.isChecked():
+            self._apply_filter()
+
     def _apply_filter(self):
         text = self.filter_input.text()
         if self.filter_button.isChecked() and text:
             try:
-                hl_re = re.compile(re.escape(text), re.IGNORECASE)
+                if self._regex_action.isChecked():
+                    hl_re = re.compile(text, re.IGNORECASE)
+                else:
+                    hl_re = re.compile(re.escape(text), re.IGNORECASE)
             except re.error:
                 hl_re = None
         else:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -177,6 +177,7 @@ class LogViewCommon(LogViewDialog):
             self._update_timer.start()
 
     def _flush_updates(self):
+        self._update_timer.stop()
         self._model.append_from_tail()
         if self._following_tail:
             self._scroll_to_bottom()

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import logging
+import re
 
 from PyQt6 import (
     QtCore,
@@ -40,6 +41,7 @@ class LogItemModel(QtCore.QAbstractListModel):
     """Model storing log entries with level-based foreground colors."""
 
     _MAX_DISPLAY_CHARS = 500
+    _SOURCE_RE = re.compile(r'^[DWIE]: (\d{2}:\d{2}:\d{2},\d{3}) \S+:\d+: ')
 
     def __init__(self, log_tail, parent=None):
         super().__init__(parent)
@@ -47,7 +49,23 @@ class LogItemModel(QtCore.QAbstractListModel):
         self._log_tail = log_tail
         self._prev_pos = -1
         self._color_cache = {}
+        self._compact_view = False
         self.refresh_colors()
+
+    @property
+    def compact_view(self):
+        return self._compact_view
+
+    @compact_view.setter
+    def compact_view(self, value):
+        if value != self._compact_view:
+            self._compact_view = value
+            if self._items:
+                self.dataChanged.emit(
+                    self.index(0),
+                    self.index(len(self._items) - 1),
+                    [Qt.ItemDataRole.DisplayRole],
+                )
 
     def rowCount(self, parent=None):
         return len(self._items)
@@ -58,6 +76,8 @@ class LogItemModel(QtCore.QAbstractListModel):
         item = self._items[index.row()]
         if role == Qt.ItemDataRole.DisplayRole:
             msg = item.message
+            if self._compact_view:
+                msg = self._SOURCE_RE.sub(r'\1 ', msg)
             if len(msg) > self._MAX_DISPLAY_CHARS:
                 return msg[: self._MAX_DISPLAY_CHARS] + '…'
             return msg

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -199,16 +199,3 @@ class LogItemDelegate(QtWidgets.QStyledItemDelegate):
         painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter, text)
 
         painter.restore()
-
-    def sizeHint(self, option, index):
-        text = index.data(Qt.ItemDataRole.DisplayRole) or ''
-        widget = option.widget
-        if widget:
-            available_width = widget.viewport().width() - 4
-        else:
-            available_width = option.rect.width() - 4
-        layout = self._create_layout(text, option.font, available_width)
-        return QtCore.QSize(
-            int(layout.boundingRect().width()) + 4,
-            max(int(layout.boundingRect().height()), option.fontMetrics.height()),
-        )

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -39,6 +39,8 @@ FullTextRole = Qt.ItemDataRole.UserRole + 2
 class LogItemModel(QtCore.QAbstractListModel):
     """Model storing log entries with level-based foreground colors."""
 
+    _MAX_DISPLAY_CHARS = 500
+
     def __init__(self, log_tail, parent=None):
         super().__init__(parent)
         self._items = []
@@ -46,8 +48,6 @@ class LogItemModel(QtCore.QAbstractListModel):
         self._prev_pos = -1
         self._color_cache = {}
         self.refresh_colors()
-
-    _MAX_DISPLAY_CHARS = 500
 
     def rowCount(self, parent=None):
         return len(self._items)

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -33,6 +33,7 @@ from picard.ui.colors import interface_colors
 
 
 LevelRole = Qt.ItemDataRole.UserRole + 1
+FullTextRole = Qt.ItemDataRole.UserRole + 2
 
 
 class LogItemModel(QtCore.QAbstractListModel):
@@ -46,6 +47,8 @@ class LogItemModel(QtCore.QAbstractListModel):
         self._color_cache = {}
         self.refresh_colors()
 
+    _MAX_DISPLAY_CHARS = 500
+
     def rowCount(self, parent=None):
         return len(self._items)
 
@@ -54,11 +57,16 @@ class LogItemModel(QtCore.QAbstractListModel):
             return None
         item = self._items[index.row()]
         if role == Qt.ItemDataRole.DisplayRole:
-            return item.message
+            msg = item.message
+            if len(msg) > self._MAX_DISPLAY_CHARS:
+                return msg[: self._MAX_DISPLAY_CHARS] + '…'
+            return msg
         if role == Qt.ItemDataRole.ForegroundRole:
             return self._get_color(item.level)
         if role == LevelRole:
             return item.level
+        if role == FullTextRole:
+            return item.message
         return None
 
     def _get_color(self, level):
@@ -142,7 +150,7 @@ class LogFilterProxyModel(QtCore.QSortFilterProxyModel):
         if level < self._min_level:
             return False
         if self._text_re:
-            text = index.data(Qt.ItemDataRole.DisplayRole) or ''
+            text = index.data(FullTextRole) or ''
             if not self._text_re.search(text):
                 return False
         return True
@@ -199,3 +207,9 @@ class LogItemDelegate(QtWidgets.QStyledItemDelegate):
         painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter, text)
 
         painter.restore()
+
+    def sizeHint(self, option, index):
+        fm = option.fontMetrics
+        # Width based on max truncated length; height is single line
+        width = fm.horizontalAdvance('x') * LogItemModel._MAX_DISPLAY_CHARS + 4
+        return QtCore.QSize(width, fm.height())

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -196,21 +196,19 @@ class LogItemDelegate(QtWidgets.QStyledItemDelegate):
         # Draw text
         painter.setPen(text_color)
         painter.setFont(option.font)
-        painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.TextFlag.TextWordWrap, text)
+        painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter, text)
 
         painter.restore()
 
     def sizeHint(self, option, index):
         text = index.data(Qt.ItemDataRole.DisplayRole) or ''
-        fm = option.fontMetrics
-        # When word wrap is enabled, calculate height based on available width
         widget = option.widget
         if widget:
             available_width = widget.viewport().width() - 4
-            rect = fm.boundingRect(
-                QtCore.QRect(0, 0, available_width, 0),
-                Qt.TextFlag.TextWordWrap | Qt.AlignmentFlag.AlignLeft,
-                text,
-            )
-            return QtCore.QSize(available_width, max(rect.height(), fm.height()))
-        return QtCore.QSize(fm.horizontalAdvance(text) + 4, fm.height())
+        else:
+            available_width = option.rect.width() - 4
+        layout = self._create_layout(text, option.font, available_width)
+        return QtCore.QSize(
+            int(layout.boundingRect().width()) + 4,
+            max(int(layout.boundingRect().height()), option.fontMetrics.height()),
+        )

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -113,12 +113,6 @@ class LogItemModel(QtCore.QAbstractListModel):
         """Return all log messages as plain text for saving."""
         return '\n'.join(item.message for item in self._items)
 
-    def level_at(self, row):
-        """Return the log level for a given row."""
-        if 0 <= row < len(self._items):
-            return self._items[row].level
-        return logging.NOTSET
-
 
 class LogFilterProxyModel(QtCore.QSortFilterProxyModel):
     """Proxy model that filters log entries by minimum level and text pattern."""
@@ -137,10 +131,6 @@ class LogFilterProxyModel(QtCore.QSortFilterProxyModel):
         """Set compiled regex for text filtering, or None to show all."""
         self._text_re = pattern_re
         self.invalidateFilter()
-
-    @property
-    def min_level(self):
-        return self._min_level
 
     def filterAcceptsRow(self, source_row, source_parent):
         index = self.sourceModel().index(source_row, 0, source_parent)

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import logging
+
+from PyQt6 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+from PyQt6.QtCore import Qt
+
+from picard import log
+
+from picard.ui.colors import interface_colors
+
+
+LevelRole = Qt.ItemDataRole.UserRole + 1
+
+
+class LogItemModel(QtCore.QAbstractListModel):
+    """Model storing log entries with level-based foreground colors."""
+
+    def __init__(self, log_tail, parent=None):
+        super().__init__(parent)
+        self._items = []
+        self._log_tail = log_tail
+        self._prev_pos = -1
+        self._color_cache = {}
+        self.refresh_colors()
+
+    def rowCount(self, parent=None):
+        return len(self._items)
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if not index.isValid():
+            return None
+        item = self._items[index.row()]
+        if role == Qt.ItemDataRole.DisplayRole:
+            return item.message
+        if role == Qt.ItemDataRole.ForegroundRole:
+            return self._get_color(item.level)
+        if role == LevelRole:
+            return item.level
+        return None
+
+    def _get_color(self, level):
+        color = self._color_cache.get(level)
+        if color is None:
+            feat = log.levels_features.get(level)
+            if feat:
+                color = interface_colors.get_qcolor(feat.color_key)
+            else:
+                color = interface_colors.get_qcolor('log_info')
+            self._color_cache[level] = color
+        return color
+
+    def refresh_colors(self):
+        """Reload colors from config and repaint."""
+        interface_colors.load_from_config()
+        self._color_cache.clear()
+        if self._items:
+            self.dataChanged.emit(
+                self.index(0),
+                self.index(len(self._items) - 1),
+                [Qt.ItemDataRole.ForegroundRole],
+            )
+
+    def append_from_tail(self):
+        """Append new entries from the log tail since last read."""
+        new_items = list(self._log_tail.contents(self._prev_pos))
+        if not new_items:
+            return
+        start = len(self._items)
+        self.beginInsertRows(QtCore.QModelIndex(), start, start + len(new_items) - 1)
+        self._items.extend(new_items)
+        self._prev_pos = new_items[-1].pos
+        self.endInsertRows()
+
+    def clear_entries(self):
+        """Clear all entries and reset tail position."""
+        self.beginResetModel()
+        self._items.clear()
+        self._prev_pos = -1
+        self.endResetModel()
+
+    def get_all_text(self):
+        """Return all log messages as plain text for saving."""
+        return '\n'.join(item.message for item in self._items)
+
+    def level_at(self, row):
+        """Return the log level for a given row."""
+        if 0 <= row < len(self._items):
+            return self._items[row].level
+        return logging.NOTSET
+
+
+class LogFilterProxyModel(QtCore.QSortFilterProxyModel):
+    """Proxy model that filters log entries by minimum level and text pattern."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._min_level = logging.NOTSET
+        self._text_re = None
+
+    def set_min_level(self, level):
+        if level != self._min_level:
+            self._min_level = level
+            self.invalidateFilter()
+
+    def set_text_filter(self, pattern_re):
+        """Set compiled regex for text filtering, or None to show all."""
+        self._text_re = pattern_re
+        self.invalidateFilter()
+
+    @property
+    def min_level(self):
+        return self._min_level
+
+    def filterAcceptsRow(self, source_row, source_parent):
+        index = self.sourceModel().index(source_row, 0, source_parent)
+        level = index.data(LevelRole)
+        if level is None:
+            return False
+        if level < self._min_level:
+            return False
+        if self._text_re:
+            text = index.data(Qt.ItemDataRole.DisplayRole) or ''
+            if not self._text_re.search(text):
+                return False
+        return True
+
+
+class LogItemDelegate(QtWidgets.QStyledItemDelegate):
+    """Delegate that paints log entries with optional highlight spans."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._highlight_re = None
+
+    def set_highlight(self, pattern_re):
+        """Set compiled regex for highlight, or None to clear."""
+        self._highlight_re = pattern_re
+
+    def paint(self, painter, option, index):
+        self.initStyleOption(option, index)
+        painter.save()
+
+        # Let the style draw the background (handles theme, alternating rows, etc.)
+        style = option.widget.style() if option.widget else QtWidgets.QApplication.style()
+        style.drawPrimitive(QtWidgets.QStyle.PrimitiveElement.PE_PanelItemViewItem, option, painter, option.widget)
+
+        # Determine text color
+        if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
+            text_color = option.palette.highlightedText().color()
+        else:
+            fg = index.data(Qt.ItemDataRole.ForegroundRole)
+            text_color = fg if fg else option.palette.text().color()
+
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ''
+        rect = option.rect.adjusted(2, 0, -2, 0)
+        fm = option.fontMetrics
+
+        # Draw highlight borders around matches
+        if self._highlight_re and text:
+            hl_color = option.palette.highlight().color()
+            painter.setPen(QtGui.QPen(hl_color, 1.0))
+            for match in self._highlight_re.finditer(text):
+                start_x = fm.horizontalAdvance(text[: match.start()])
+                match_w = fm.horizontalAdvance(text[match.start() : match.end()])
+                hl_rect = QtCore.QRectF(
+                    rect.x() + start_x,
+                    rect.y() + 1,
+                    match_w,
+                    rect.height() - 2,
+                )
+                painter.drawRect(hl_rect)
+
+        # Draw text
+        painter.setPen(text_color)
+        painter.setFont(option.font)
+        painter.drawText(rect, Qt.AlignmentFlag.AlignLeft | Qt.TextFlag.TextWordWrap, text)
+
+        painter.restore()
+
+    def sizeHint(self, option, index):
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ''
+        fm = option.fontMetrics
+        # When word wrap is enabled, calculate height based on available width
+        widget = option.widget
+        if widget:
+            available_width = widget.viewport().width() - 4
+            rect = fm.boundingRect(
+                QtCore.QRect(0, 0, available_width, 0),
+                Qt.TextFlag.TextWordWrap | Qt.AlignmentFlag.AlignLeft,
+                text,
+            )
+            return QtCore.QSize(available_width, max(rect.height(), fm.height()))
+        return QtCore.QSize(fm.horizontalAdvance(text) + 4, fm.height())


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The Log View dialog uses QTextBrowser/QTextDocument which becomes slow with many log entries (rebuilds the entire document on verbosity change). The highlight feature is not intuitive for finding strings in thousands of lines — it highlights but does not filter.

* JIRA ticket: PICARD-3286
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

Rewrite using QListView with model/view architecture:

- `LogItemModel` + `LogFilterProxyModel` + `LogItemDelegate` in new `logviewmodel.py`
- Instant filtering by level and/or text regex (no document rebuild)
- Merged highlight and filter: matching rows shown with border highlight, non-matching hidden
- Filter UI: QLineEdit with embedded clear button + checkable toggle (Enter toggles on/off)
- No word wrap: `setUniformItemSizes(True)` for performance — word wrap forces Qt to measure every item on each insert (50s vs 9s for 1000 files). Long lines truncated at 500 chars; "View Detail…" in context menu opens scrollable dialog with full text
- 100ms batched updates: coalesces rapid log signals (~9.5s with log view open vs ~9s without)
- Context menu: View Detail, Copy, Select All, Clear Log (with icons)
- Plain substring filter by default (case-insensitive); optional regex mode via context menu toggle
- Debug Options menu stays open when toggling entries
- Compact View toggle in context menu (hides level prefix and source location)
- Regex Filter toggle in context menu for power users
- Clear Log moved from toolbar to context menu (declutters UI)
- Visible/total line count at bottom right
- Auto-scroll follows tail; scrolling up preserves position across filter/resize changes
- Explicit QueuedConnection for cross-thread log signal



<img width="1091" height="392" alt="image" src="https://github.com/user-attachments/assets/39174b1f-422d-4db8-8143-7efe222631e1" />
<img width="1145" height="706" alt="image" src="https://github.com/user-attachments/assets/67031145-31ed-4eb0-907a-4d39b22e8144" />
<img width="1102" height="375" alt="image" src="https://github.com/user-attachments/assets/f540faf1-0795-41dc-abbb-9e3f0447dca9" />
<img width="854" height="363" alt="image" src="https://github.com/user-attachments/assets/f9a0c21d-c5f1-4a24-bee0-72074941acaf" />

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->




