### PR TITLE
Add tagger_instance() function for type safe access to the Tagger instance

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -31,10 +31,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
 import sys
+from typing import TYPE_CHECKING
 
 from picard.version import Version
+
+
+if TYPE_CHECKING:
+    from picard.tagger import Tagger
 
 
 PICARD_ORG_NAME = "MusicBrainz"
@@ -61,6 +65,20 @@ if PICARD_BUILD_VERSION_STR:
 api_versions = ("3.0",)
 
 api_versions_tuple = tuple(Version.from_string(v) for v in api_versions)
+
+
+def tagger_instance() -> 'Tagger':
+    """Returns an instance of Tagger.
+
+    Tagger is the main application instance and a subclass of QApplication.
+    """
+    from PyQt6.QtCore import QCoreApplication  # avoid top level Qt import
+
+    from picard.tagger import Tagger  # avoid circular imports
+
+    instance = QCoreApplication.instance()
+    assert isinstance(instance, Tagger), 'Expected an instance of Tagger'
+    return instance
 
 
 def crash_handler(exc: Exception):

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -44,6 +44,7 @@ from picard.file import File
 from picard.i18n import N_
 from picard.util import (
     find_executable,
+    tagger_instance,
     win_prefix_longpath,
 )
 from picard.webservice.api_helpers import AcoustIdAPIHelper
@@ -82,7 +83,7 @@ AcoustIDTask = namedtuple('AcoustIDTask', ('file', 'next_func'))
 class AcoustIDClient(QtCore.QObject):
     def __init__(self, acoustid_api: AcoustIdAPIHelper):
         super().__init__()
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self._queue: deque = deque()
         self._running = 0
         self._acoustid_api = acoustid_api

--- a/picard/acoustid/__init__.py
+++ b/picard/acoustid/__init__.py
@@ -34,7 +34,10 @@ import json
 
 from PyQt6 import QtCore
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.acoustid.recordings import RecordingResolver
 from picard.config import get_config
 from picard.const import FPCALC_NAMES
@@ -44,7 +47,6 @@ from picard.file import File
 from picard.i18n import N_
 from picard.util import (
     find_executable,
-    tagger_instance,
     win_prefix_longpath,
 )
 from picard.webservice.api_helpers import AcoustIdAPIHelper

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -26,12 +26,12 @@
 
 from functools import partial
 
-from picard import log
-from picard.i18n import N_
-from picard.util import (
-    load_json,
+from picard import (
+    log,
     tagger_instance,
 )
+from picard.i18n import N_
+from picard.util import load_json
 
 from picard.ui.enums import MainAction
 

--- a/picard/acoustid/manager.py
+++ b/picard/acoustid/manager.py
@@ -26,11 +26,12 @@
 
 from functools import partial
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.i18n import N_
-from picard.util import load_json
+from picard.util import (
+    load_json,
+    tagger_instance,
+)
 
 from picard.ui.enums import MainAction
 
@@ -113,7 +114,7 @@ class AcoustIDManager:
     BATCH_SIZE_REDUCTION_FACTOR = 0.7
 
     def __init__(self, acoustid_api):
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self._submissions = {}
         self._acoustid_api = acoustid_api
 

--- a/picard/acoustid/recordings.py
+++ b/picard/acoustid/recordings.py
@@ -25,7 +25,10 @@ from collections import (
     deque,
     namedtuple,
 )
-from collections.abc import Callable, Iterable
+from collections.abc import (
+    Callable,
+    Iterable,
+)
 from functools import partial
 
 from PyQt6.QtNetwork import QNetworkReply

--- a/picard/browser/addrelease.py
+++ b/picard/browser/addrelease.py
@@ -28,9 +28,10 @@ import re
 from secrets import token_bytes
 from types import ModuleType
 
-from PyQt6.QtCore import QCoreApplication
-
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.const import BROWSER_INTEGRATION_LOCALHOST
 from picard.i18n import gettext as _
 from picard.util import format_time
@@ -79,7 +80,7 @@ def is_available():
 
 
 def is_enabled():
-    tagger = QCoreApplication.instance()
+    tagger = tagger_instance()
     return tagger.browser_integration.is_running
 
 
@@ -95,7 +96,7 @@ def serve_form(token):
     try:
         payload = jwt.decode(token, __key, algorithms=__algorithm)
         log.debug("received JWT token %r", payload)
-        tagger = QCoreApplication.instance()
+        tagger = tagger_instance()
         tport = tagger.browser_integration.port
         if 'cluster' in payload:
             cluster = _find_cluster(tagger, payload['cluster'])
@@ -125,7 +126,7 @@ def _generate_token(payload):
 
 def _open_url_with_token(payload):
     token = _generate_token(payload)
-    browser_integration = QCoreApplication.instance().browser_integration
+    browser_integration = tagger_instance().browser_integration
     url = f'http://{BROWSER_INTEGRATION_LOCALHOST}:{browser_integration.port}/add?token={token}'
     open(url)
 

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -32,14 +32,13 @@
 import os.path
 import re
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.config import get_config
 from picard.const import PICARD_URLS
 from picard.disc import Disc
 from picard.util import (
     build_qurl,
+    tagger_instance,
     webbrowser2,
 )
 
@@ -67,7 +66,7 @@ class FileLookup:
         self.server = server
         self.local_port = int(local_port)
         self.port = port
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
 
     def _url(self, path, params=None):
         if params is None:

--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -32,13 +32,15 @@
 import os.path
 import re
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.const import PICARD_URLS
 from picard.disc import Disc
 from picard.util import (
     build_qurl,
-    tagger_instance,
     webbrowser2,
 )
 

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -45,15 +45,13 @@ from picard import (
     PICARD_ORG_NAME,
     PICARD_VERSION_STR,
     log,
+    tagger_instance,
 )
 from picard.browser import addrelease
 from picard.config import get_config
 from picard.const import BROWSER_INTEGRATION_LOCALIP
 from picard.oauth import OAuthInvalidStateError
-from picard.util import (
-    mbid_validate,
-    tagger_instance,
-)
+from picard.util import mbid_validate
 from picard.util.thread import to_main
 
 

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -50,7 +50,10 @@ from picard.browser import addrelease
 from picard.config import get_config
 from picard.const import BROWSER_INTEGRATION_LOCALIP
 from picard.oauth import OAuthInvalidStateError
-from picard.util import mbid_validate
+from picard.util import (
+    mbid_validate,
+    tagger_instance,
+)
 from picard.util.thread import to_main
 
 
@@ -226,7 +229,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             if not mbid_validate(mbid):
                 self._response(400, '"id" is not a valid MBID.')
             else:
-                tagger = QtCore.QCoreApplication.instance()
+                tagger = tagger_instance()
                 to_main(tagger.load_mbid, type, mbid)
                 self._response(200, 'MBID "%s" loaded' % mbid)
         else:
@@ -246,7 +249,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def _auth(self, args):
         if 'code' in args and args['code']:
-            tagger = QtCore.QCoreApplication.instance()
+            tagger = tagger_instance()
             oauth_manager = tagger.webservice.oauth_manager
             try:
                 state = args.get('state', [''])[0]

--- a/picard/collection.py
+++ b/picard/collection.py
@@ -26,14 +26,13 @@
 
 from functools import partial
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.config import get_config
 from picard.i18n import (
     N_,
     ngettext,
 )
+from picard.util import tagger_instance
 from picard.webservice.api_helpers import MBAPIHelper
 
 
@@ -42,7 +41,7 @@ user_collections: dict[str, 'Collection'] = {}
 
 class Collection:
     def __init__(self, collection_id: str, mb_api: MBAPIHelper):
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.id = collection_id
         self.name = ''
         self.size = 0
@@ -132,13 +131,13 @@ class Collection:
 def get_user_collection(collection_id):
     collection = user_collections.get(collection_id)
     if collection is None:
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         collection = user_collections[collection_id] = Collection(collection_id, tagger.mb_api)
     return collection
 
 
 def load_user_collections(callback=None):
-    tagger = QtCore.QCoreApplication.instance()
+    tagger = tagger_instance()
 
     def request_finished(document, reply, error):
         if error:

--- a/picard/collection.py
+++ b/picard/collection.py
@@ -26,13 +26,15 @@
 
 from functools import partial
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.i18n import (
     N_,
     ngettext,
 )
-from picard.util import tagger_instance
 from picard.webservice.api_helpers import MBAPIHelper
 
 

--- a/picard/config.py
+++ b/picard/config.py
@@ -53,6 +53,7 @@ from picard import (
     log,
 )
 from picard.profile import profile_groups_all_settings
+from picard.util import tagger_instance
 from picard.version import Version
 
 
@@ -556,7 +557,7 @@ profiles = None
 
 def setup_config(app=None, filename=None):
     if app is None:
-        app = QtCore.QCoreApplication.instance()
+        app = tagger_instance()
     global config, setting, persist, profiles
     if filename is None:
         config = Config.from_app(app)

--- a/picard/config.py
+++ b/picard/config.py
@@ -51,9 +51,9 @@ from picard import (
     PICARD_ORG_NAME,
     PICARD_VERSION,
     log,
+    tagger_instance,
 )
 from picard.profile import profile_groups_all_settings
-from picard.util import tagger_instance
 from picard.version import Version
 
 

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -29,8 +29,6 @@ from collections.abc import Generator
 from functools import partial
 import traceback
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.album import Album
 from picard.album_requests import TaskType
@@ -58,6 +56,7 @@ from picard.i18n import N_
 from picard.metadata import Metadata
 from picard.util import (
     imageinfo,
+    tagger_instance,
     thread,
 )
 
@@ -346,7 +345,7 @@ class CoverArt:
 
     def _message(self, *args, **kwargs):
         """Display message to status bar"""
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         tagger.window.set_statusbar_message(*args, **kwargs)
 
 

--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -29,7 +29,10 @@ from collections.abc import Generator
 from functools import partial
 import traceback
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.album import Album
 from picard.album_requests import TaskType
 from picard.config import get_config
@@ -56,7 +59,6 @@ from picard.i18n import N_
 from picard.metadata import Metadata
 from picard.util import (
     imageinfo,
-    tagger_instance,
     thread,
 )
 

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -33,9 +33,8 @@ from functools import partial
 import traceback
 from types import ModuleType
 
-from PyQt6 import QtCore
-
 from picard import log
+from picard.util import tagger_instance
 from picard.util.mbserver import build_submission_url
 
 from picard.ui.cdlookup import CDLookupDialog
@@ -55,7 +54,7 @@ except ImportError:
 
 class Disc:
     def __init__(self, id=None):
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.id = id
         self.mcn = None
         self.tracks = 0

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -33,8 +33,10 @@ from functools import partial
 import traceback
 from types import ModuleType
 
-from picard import log
-from picard.util import tagger_instance
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.util.mbserver import build_submission_url
 
 from picard.ui.cdlookup import CDLookupDialog

--- a/picard/extension_points/item_actions.py
+++ b/picard/extension_points/item_actions.py
@@ -45,8 +45,8 @@
 
 from PyQt6 import QtGui
 
+from picard import tagger_instance
 from picard.plugin import ExtensionPoint
-from picard.util import tagger_instance
 from picard.util.display_title_base import HasDisplayTitle
 
 

--- a/picard/extension_points/item_actions.py
+++ b/picard/extension_points/item_actions.py
@@ -43,12 +43,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from PyQt6 import (
-    QtCore,
-    QtGui,
-)
+from PyQt6 import QtGui
 
 from picard.plugin import ExtensionPoint
+from picard.util import tagger_instance
 from picard.util.display_title_base import HasDisplayTitle
 
 
@@ -58,7 +56,7 @@ class BaseAction(QtGui.QAction, HasDisplayTitle):
 
     def __init__(self, api=None, parent=None):
         super().__init__(self.display_title(), parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.triggered.connect(self.__callback)
 
     def __callback(self):

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -40,8 +40,6 @@ import mutagen.oggspeex
 import mutagen.oggtheora
 import mutagen.oggvorbis
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.config import get_config
 from picard.coverart.image import (
@@ -55,6 +53,7 @@ from picard.metadata import Metadata
 from picard.util import (
     encode_filename,
     sanitize_date,
+    tagger_instance,
 )
 
 
@@ -524,5 +523,5 @@ OggContainerFile.supports_tag = VCommentFile.supports_tag
 
 
 def _guess_format(filename, options):
-    tagger = QtCore.QCoreApplication.instance()
+    tagger = tagger_instance()
     return tagger.format_registry.guess_format(filename, options)

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -40,7 +40,10 @@ import mutagen.oggspeex
 import mutagen.oggtheora
 import mutagen.oggvorbis
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImageError,
@@ -53,7 +56,6 @@ from picard.metadata import Metadata
 from picard.util import (
     encode_filename,
     sanitize_date,
-    tagger_instance,
 )
 
 

--- a/picard/item.py
+++ b/picard/item.py
@@ -39,14 +39,14 @@ import weakref
 
 from PyQt6 import QtCore
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.i18n import ngettext
 from picard.metadata import Metadata
-from picard.util import (
-    IgnoreUpdatesContext,
-    tagger_instance,
-)
+from picard.util import IgnoreUpdatesContext
 from picard.util.imagelist import ImageList
 
 

--- a/picard/item.py
+++ b/picard/item.py
@@ -43,7 +43,10 @@ from picard import log
 from picard.config import get_config
 from picard.i18n import ngettext
 from picard.metadata import Metadata
-from picard.util import IgnoreUpdatesContext
+from picard.util import (
+    IgnoreUpdatesContext,
+    tagger_instance,
+)
 from picard.util.imagelist import ImageList
 
 
@@ -184,12 +187,12 @@ class MetadataItem(QtCore.QObject, Item):
 
     @property
     def tagger(self):
-        return QtCore.QCoreApplication.instance()
+        return tagger_instance()
 
     @tagger.setter
     def tagger(self, value):
         # We used to set tagger property in subclasses, but that's not needed anymore
-        assert value == QtCore.QCoreApplication.instance()
+        assert value == tagger_instance()
         stack = inspect.stack()
         f = stack[1]
         log.warning("MetadataItem.tagger property set at %s:%d in %s", f.filename, f.lineno, f.function)

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -43,8 +43,6 @@ from typing import (
     TypeAlias,
 )
 
-from PyQt6 import QtCore
-
 from picard.config import Config, get_config
 from picard.mbjson import artist_credit_from_node, get_score
 from picard.similarity import similarity2
@@ -52,6 +50,7 @@ from picard.util import (
     compare_barcodes,
     extract_year_from_date,
     linear_combination_of_weights,
+    tagger_instance,
 )
 
 
@@ -211,7 +210,7 @@ def _compare_to_release_parts(
                 result.identifiers.append((score, id_w['catno']))
 
     if 'release-group' in release:
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         if tagger is not None:
             rg = tagger.get_release_group_by_id(release['release-group']['id'])  # type: ignore[attr-defined]
             if release['id'] in rg.loaded_albums:

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -37,7 +37,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import (
+    dataclass,
+    field,
+)
 from typing import (
     TYPE_CHECKING,
     TypeAlias,

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -43,6 +43,7 @@ from typing import (
     TypeAlias,
 )
 
+from picard import tagger_instance
 from picard.config import Config, get_config
 from picard.mbjson import artist_credit_from_node, get_score
 from picard.similarity import similarity2
@@ -50,7 +51,6 @@ from picard.util import (
     compare_barcodes,
     extract_year_from_date,
     linear_combination_of_weights,
-    tagger_instance,
 )
 
 

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -34,13 +34,13 @@ import traceback
 from types import SimpleNamespace
 
 from PyQt6 import QtCore
-from PyQt6.QtCore import QCoreApplication
 
 from picard import (
     PICARD_APP_NAME,
     PICARD_FANCY_VERSION_STR,
     PICARD_ORG_NAME,
     log,
+    tagger_instance,
 )
 from picard.config import (
     Option,
@@ -185,7 +185,7 @@ class PluginCLI:
 
         self._manager._registry.fetch_registry(callback=callback)
 
-        app = QCoreApplication.instance()
+        app = tagger_instance()
         while not result['done']:
             app.processEvents()
 
@@ -1746,7 +1746,7 @@ class PluginCLI:
             self._manager.refresh_registry_and_caches(callback=callback)
 
             # Process events until callback is called
-            app = QCoreApplication.instance()
+            app = tagger_instance()
             while not result['done']:
                 app.processEvents()
 

--- a/picard/plugin3/registry.py
+++ b/picard/plugin3/registry.py
@@ -33,7 +33,10 @@ from picard.git.utils import normalize_git_url
 from picard.i18n import sort_key
 from picard.plugin3.installable import InstallablePlugin
 from picard.plugin3.plugin import hash_string
-from picard.util import atomic_write
+from picard.util import (
+    atomic_write,
+    tagger_instance,
+)
 
 
 try:
@@ -254,7 +257,7 @@ class PluginRegistry:
             url: URL to fetch from
             callback: callback(success, error) called when complete
         """
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         if not tagger or not hasattr(tagger, 'webservice'):
             error = RegistryFetchError(url, Exception('WebService not available'))
             if callback:

--- a/picard/plugin3/registry.py
+++ b/picard/plugin3/registry.py
@@ -26,17 +26,17 @@ from PyQt6 import QtCore
 from PyQt6.QtCore import QUrl
 from PyQt6.QtNetwork import QNetworkRequest
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.const.defaults import DEFAULT_PLUGIN_REGISTRY_URLS
 from picard.git.utils import normalize_git_url
 from picard.i18n import sort_key
 from picard.plugin3.installable import InstallablePlugin
 from picard.plugin3.plugin import hash_string
-from picard.util import (
-    atomic_write,
-    tagger_instance,
-)
+from picard.util import atomic_write
 
 
 try:

--- a/picard/remotecommands/handlers.py
+++ b/picard/remotecommands/handlers.py
@@ -50,12 +50,13 @@ import re
 import time
 from urllib.parse import urlparse
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.const.sys import IS_WIN
 from picard.file import File
-from picard.util import thread
+from picard.util import (
+    tagger_instance,
+    thread,
+)
 from picard.util.cdrom import (
     DISCID_NOT_LOADED_MESSAGE,
     discid as _discid,
@@ -124,7 +125,7 @@ def remote_command(help_text, help_args=None):
 
 class RemoteCommandHandlers:
     def __init__(self, remotecommands_class):
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.remotecommands_class = remotecommands_class
 
     @remote_command("Clear the Picard logs")

--- a/picard/remotecommands/handlers.py
+++ b/picard/remotecommands/handlers.py
@@ -50,13 +50,13 @@ import re
 import time
 from urllib.parse import urlparse
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.const.sys import IS_WIN
 from picard.file import File
-from picard.util import (
-    tagger_instance,
-    thread,
-)
+from picard.util import thread
 from picard.util.cdrom import (
     DISCID_NOT_LOADED_MESSAGE,
     discid as _discid,

--- a/picard/track.py
+++ b/picard/track.py
@@ -53,7 +53,10 @@ import traceback
 from typing import TYPE_CHECKING
 import weakref
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.const import (
     DATA_TRACK_TITLE,
@@ -82,7 +85,6 @@ from picard.script import (
 )
 from picard.util import (
     pattern_as_regex,
-    tagger_instance,
     titlecase,
 )
 from picard.util.imagelist import ImageList

--- a/picard/track.py
+++ b/picard/track.py
@@ -53,8 +53,6 @@ import traceback
 from typing import TYPE_CHECKING
 import weakref
 
-from PyQt6 import QtCore
-
 from picard import log
 from picard.config import get_config
 from picard.const import (
@@ -84,6 +82,7 @@ from picard.script import (
 )
 from picard.util import (
     pattern_as_regex,
+    tagger_instance,
     titlecase,
 )
 from picard.util.imagelist import ImageList
@@ -421,7 +420,7 @@ class Track(FileListItem):
 
 class NonAlbumTrack(Track):
     def __init__(self, nat_id):
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         super().__init__(nat_id, tagger.nats)
         self.callback = None
         self.loaded = False

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -33,7 +33,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import (
     Option,
     get_config,
@@ -46,7 +49,6 @@ from picard.const.sys import (
 from picard.util import (
     get_url,
     restore_method,
-    tagger_instance,
     webbrowser2,
 )
 

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -46,6 +46,7 @@ from picard.const.sys import (
 from picard.util import (
     get_url,
     restore_method,
+    tagger_instance,
     webbrowser2,
 )
 
@@ -181,7 +182,7 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent, f=self.flags)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.__shown = False
         self.ready_for_display.connect(self.restore_geometry)
 

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -31,7 +31,10 @@ from PyQt6 import QtCore
 
 from picard.const import PICARD_URLS
 from picard.i18n import gettext as _
-from picard.util import versions
+from picard.util import (
+    tagger_instance,
+    versions,
+)
 
 from picard.ui import (
     PicardDialog,
@@ -61,7 +64,7 @@ class AboutDialog(PicardDialog, SingletonDialog):
             ]
         )
 
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         args['formats'] = ", ".join(map(lambda x: x[1:], tagger.format_registry.supported_extensions()))
         args['copyright_years'] = '2004-2024'
         args['authors_credits'] = ", ".join(

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -29,12 +29,10 @@
 
 from PyQt6 import QtCore
 
+from picard import tagger_instance
 from picard.const import PICARD_URLS
 from picard.i18n import gettext as _
-from picard.util import (
-    tagger_instance,
-    versions,
-)
+from picard.util import versions
 
 from picard.ui import (
     PicardDialog,

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -62,6 +62,7 @@ from picard.util import (
     bytes2human,
     imageinfo,
     normpath,
+    tagger_instance,
 )
 from picard.util.lrucache import LRUCache
 
@@ -79,7 +80,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         super().__init__("", parent=parent)
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.setSpacing(6)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         # Kills off any borders
         self.setStyleSheet('''QGroupBox{background-color:none;border:1px;}''')
         self.setFlat(True)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -47,7 +47,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImage,
@@ -62,7 +65,6 @@ from picard.util import (
     bytes2human,
     imageinfo,
     normpath,
-    tagger_instance,
 )
 from picard.util.lrucache import LRUCache
 

--- a/picard/ui/coverartbox/coverartthumbnail.py
+++ b/picard/ui/coverartbox/coverartthumbnail.py
@@ -44,6 +44,7 @@ from picard import log
 from picard.const import MAX_COVERS_TO_STACK
 from picard.coverart.image import CoverArtImageIOError
 from picard.i18n import gettext as _
+from picard.util import tagger_instance
 
 from picard.ui.colors import interface_colors
 from picard.ui.widgets import ActiveLabel
@@ -61,7 +62,7 @@ class CoverArtThumbnail(ActiveLabel):
         self.data = None
         self.has_common_images = None
         self.release = None
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         window_handle = self.window().windowHandle()
         if window_handle:
             self.pixel_ratio = window_handle.screen().devicePixelRatio()

--- a/picard/ui/coverartbox/coverartthumbnail.py
+++ b/picard/ui/coverartbox/coverartthumbnail.py
@@ -40,11 +40,13 @@ from PyQt6 import (
     QtGui,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.const import MAX_COVERS_TO_STACK
 from picard.coverart.image import CoverArtImageIOError
 from picard.i18n import gettext as _
-from picard.util import tagger_instance
 
 from picard.ui.colors import interface_colors
 from picard.ui.widgets import ActiveLabel

--- a/picard/ui/dialogs/cover_types_selector.py
+++ b/picard/ui/dialogs/cover_types_selector.py
@@ -17,7 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-from collections.abc import Generator, Iterable
+from collections.abc import (
+    Generator,
+    Iterable,
+)
 
 from PyQt6 import (
     QtCore,

--- a/picard/ui/dialogs/plugininfo.py
+++ b/picard/ui/dialogs/plugininfo.py
@@ -29,6 +29,7 @@ from PyQt6 import (
 from picard.i18n import gettext as _
 from picard.plugin3.categories import PluginCategorySet
 from picard.plugin3.installable import InstallablePlugin
+from picard.util import tagger_instance
 
 from picard.ui import PreserveGeometry
 from picard.ui.util import font_scaled_size
@@ -44,7 +45,7 @@ class PluginInfoDialog(QtWidgets.QDialog, PreserveGeometry):
         self._plugin_data = plugin_data
 
         # Cache plugin manager for performance
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         self.plugin_manager = tagger.get_plugin_manager()
 
         self.setWindowTitle(_("Plugin Information"))

--- a/picard/ui/dialogs/plugininfo.py
+++ b/picard/ui/dialogs/plugininfo.py
@@ -26,10 +26,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import tagger_instance
 from picard.i18n import gettext as _
 from picard.plugin3.categories import PluginCategorySet
 from picard.plugin3.installable import InstallablePlugin
-from picard.util import tagger_instance
 
 from picard.ui import PreserveGeometry
 from picard.ui.util import font_scaled_size

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -37,13 +37,11 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import tagger_instance
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
 from picard.i18n import gettext as _
-from picard.util import (
-    find_existing_path,
-    tagger_instance,
-)
+from picard.util import find_existing_path
 from picard.util.macos import (
     extend_root_volume_path,
     strip_root_volume_path,

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -40,7 +40,10 @@ from PyQt6 import (
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
 from picard.i18n import gettext as _
-from picard.util import find_existing_path
+from picard.util import (
+    find_existing_path,
+    tagger_instance,
+)
 from picard.util.macos import (
     extend_root_volume_path,
     strip_root_volume_path,
@@ -50,7 +53,7 @@ from picard.util.macos import (
 class FileBrowser(QtWidgets.QTreeView):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setDragEnabled(True)
         self.load_selected_files_action = QtGui.QAction(_("&Load selected files"), self)

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -66,7 +66,10 @@ from picard.i18n import (
     sort_key,
 )
 from picard.track import Track
-from picard.util import icontheme
+from picard.util import (
+    icontheme,
+    tagger_instance,
+)
 
 from picard.ui.colors import interface_colors
 from picard.ui.columns import (
@@ -95,7 +98,7 @@ def get_match_color(similarity, basecolor):
 class MainPanel(QtWidgets.QSplitter):
     def __init__(self, window, parent=None):
         super().__init__(parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.setChildrenCollapsible(False)
         self.window = window
         self.create_icons()
@@ -714,7 +717,7 @@ class FileItem(TreeItem):
     @staticmethod
     def decide_fingerprint_icon_info(file):
         if getattr(file, 'acoustid_fingerprint', None):
-            tagger = QtCore.QCoreApplication.instance()
+            tagger = tagger_instance()
             if tagger.acoustidmanager.is_submitted(file):
                 icon = FileItem.icon_fingerprint_gray
                 tooltip = _("Fingerprint has already been submitted")

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -52,7 +52,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.album import NatAlbum
 from picard.cluster import (
     Cluster,
@@ -66,10 +69,7 @@ from picard.i18n import (
     sort_key,
 )
 from picard.track import Track
-from picard.util import (
-    icontheme,
-    tagger_instance,
-)
+from picard.util import icontheme
 
 from picard.ui.colors import interface_colors
 from picard.ui.columns import (

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -55,7 +55,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.album import (
     Album,
     NatAlbum,
@@ -86,7 +89,6 @@ from picard.util import (
     iter_files_from_objects,
     normpath,
     restore_method,
-    tagger_instance,
 )
 
 from picard.ui.collectionmenu import CollectionMenu

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -86,6 +86,7 @@ from picard.util import (
     iter_files_from_objects,
     normpath,
     restore_method,
+    tagger_instance,
 )
 
 from picard.ui.collectionmenu import CollectionMenu
@@ -180,7 +181,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         self.columns = columns
         self.setAccessibleName(_(self.NAME))
         self.setAccessibleDescription(_(self.DESCRIPTION))
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.window = window
 
         # Subscribe to header update events
@@ -602,7 +603,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
     def drop_urls(urls, target, move_to_multi_tracks=True):
         files = []
         new_paths = []
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         for url in urls:
             log.debug("Dropped the URL: %r", url.toString(QtCore.QUrl.UrlFormattingOption.RemoveUserInfo))
             if url.scheme() == 'file' or not url.scheme():

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -104,9 +104,7 @@ from picard.ui.itemviews.events import header_events
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
 from picard.ui.util import menu_builder
-from picard.ui.widgets.configurablecolumnsheader import (
-    ConfigurableColumnsHeader,
-)
+from picard.ui.widgets.configurablecolumnsheader import ConfigurableColumnsHeader
 
 
 FILE_FILTERS = {'~filename', '~filepath'}

--- a/picard/ui/itemviews/custom_columns/registry.py
+++ b/picard/ui/itemviews/custom_columns/registry.py
@@ -25,9 +25,7 @@ from __future__ import annotations
 from PyQt6 import QtWidgets
 
 from picard.ui.itemviews.custom_columns.column import CustomColumn
-from picard.ui.itemviews.custom_columns.shared import (
-    get_recognized_view_columns,
-)
+from picard.ui.itemviews.custom_columns.shared import get_recognized_view_columns
 
 
 class CustomColumnsRegistry:

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -116,6 +116,7 @@ from picard.util import (
     reconnect,
     restore_method,
     sanitize_filename,
+    tagger_instance,
     thread,
     throttle,
     webbrowser2,
@@ -192,7 +193,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.action_map = {}
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_NativeWindow)
         self.__shown = False
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self._is_wayland = self.tagger.is_wayland
         self.selected_objects = []
         self.ignore_selection_changes = IgnoreUpdatesContext(on_exit=self.update_selection)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -65,6 +65,7 @@ from PyQt6 import (
 from picard import (
     PICARD_APP_ID,
     log,
+    tagger_instance,
 )
 from picard.album import Album
 from picard.browser import addrelease
@@ -116,7 +117,6 @@ from picard.util import (
     reconnect,
     restore_method,
     sanitize_filename,
-    tagger_instance,
     thread,
     throttle,
     webbrowser2,

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -41,7 +41,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.album import Album
 from picard.browser.filelookup import FileLookup
 from picard.cluster import Cluster
@@ -61,7 +64,6 @@ from picard.util import (
     IgnoreUpdatesContext,
     icontheme,
     restore_method,
-    tagger_instance,
     thread,
     throttle,
 )

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -61,6 +61,7 @@ from picard.util import (
     IgnoreUpdatesContext,
     icontheme,
     restore_method,
+    tagger_instance,
     thread,
     throttle,
 )
@@ -164,7 +165,7 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         config = get_config()
         config.setting.setting_changed.connect(self._on_setting_changed)
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -29,7 +29,10 @@ import re
 
 from PyQt6 import QtWidgets
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import (
     Option,
     get_config,
@@ -37,7 +40,6 @@ from picard.config import (
 )
 from picard.i18n import gettext as _
 from picard.profile import profile_groups_add_setting
-from picard.util import tagger_instance
 from picard.util.display_title_base import HasDisplayTitle
 
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -27,10 +27,7 @@
 from collections import defaultdict
 import re
 
-from PyQt6 import (
-    QtCore,
-    QtWidgets,
-)
+from PyQt6 import QtWidgets
 
 from picard import log
 from picard.config import (
@@ -40,6 +37,7 @@ from picard.config import (
 )
 from picard.i18n import gettext as _
 from picard.profile import profile_groups_add_setting
+from picard.util import tagger_instance
 from picard.util.display_title_base import HasDisplayTitle
 
 
@@ -66,7 +64,7 @@ class OptionsPage(QtWidgets.QWidget, HasDisplayTitle):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.setStyleSheet(self.STYLESHEET)
 
         # Keep track whether the options page has been destroyed to avoid

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -38,7 +38,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import (
     Option,
     OptionError,
@@ -57,7 +60,6 @@ from picard.profile import (
 from picard.util import (
     get_url,
     restore_method,
-    tagger_instance,
 )
 
 from picard.ui import (

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -57,6 +57,7 @@ from picard.profile import (
 from picard.util import (
     get_url,
     restore_method,
+    tagger_instance,
 )
 
 from picard.ui import (
@@ -311,7 +312,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)
 
         # Connect to plugin manager signals for dynamic updates
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         self.plugin_manager = tagger.get_plugin_manager()
         try:
             self.plugin_manager.plugin_ref_switched.connect(self.refresh_plugin_pages)

--- a/picard/ui/options/interface_quick_menu.py
+++ b/picard/ui/options/interface_quick_menu.py
@@ -36,9 +36,7 @@ from picard.i18n import (
     gettext as _,
 )
 
-from picard.ui.forms.ui_options_interface_quick_menu import (
-    Ui_InterfaceQuickMenuOptionsPage,
-)
+from picard.ui.forms.ui_options_interface_quick_menu import Ui_InterfaceQuickMenuOptionsPage
 from picard.ui.options import OptionsPage
 
 

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -49,9 +49,7 @@ from picard.util import icontheme
 
 from picard.ui import PicardDialog
 from picard.ui.enums import MainAction
-from picard.ui.forms.ui_options_interface_toolbar import (
-    Ui_InterfaceToolbarOptionsPage,
-)
+from picard.ui.forms.ui_options_interface_toolbar import Ui_InterfaceToolbarOptionsPage
 from picard.ui.moveable_list_view import MoveableListView
 from picard.ui.options import OptionsPage
 from picard.ui.util import (

--- a/picard/ui/options/interface_top_tags.py
+++ b/picard/ui/options/interface_top_tags.py
@@ -24,9 +24,7 @@ from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
 
-from picard.ui.forms.ui_options_interface_top_tags import (
-    Ui_InterfaceTopTagsOptionsPage,
-)
+from picard.ui.forms.ui_options_interface_top_tags import Ui_InterfaceTopTagsOptionsPage
 from picard.ui.options import OptionsPage
 
 

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -49,9 +49,7 @@ from picard.i18n import (
 )
 
 from picard.ui import PicardDialog
-from picard.ui.forms.ui_exception_script_selector import (
-    Ui_ExceptionScriptSelector,
-)
+from picard.ui.forms.ui_exception_script_selector import Ui_ExceptionScriptSelector
 from picard.ui.forms.ui_multi_locale_selector import Ui_MultiLocaleSelector
 from picard.ui.forms.ui_options_metadata import Ui_MetadataOptionsPage
 from picard.ui.moveable_list_view import MoveableListView

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -24,9 +24,7 @@
 
 from picard.config import get_config
 from picard.const import CACHE_SIZE_DISPLAY_UNIT
-from picard.const.defaults import (
-    DEFAULT_CACHE_SIZE_IN_BYTES,
-)
+from picard.const.defaults import DEFAULT_CACHE_SIZE_IN_BYTES
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
     N_,

--- a/picard/ui/options/player.py
+++ b/picard/ui/options/player.py
@@ -19,9 +19,7 @@
 
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
-from picard.i18n import (
-    N_,
-)
+from picard.i18n import N_
 
 from picard.ui.forms.ui_options_player import Ui_PlayerOptionsPage
 from picard.ui.options import OptionsPage

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -55,6 +55,7 @@ from picard.i18n import (
     pgettext_attributes,
     sort_key,
 )
+from picard.util import tagger_instance
 
 from picard.ui.forms.ui_options_releases import Ui_ReleasesOptionsPage
 from picard.ui.options import OptionsPage
@@ -80,7 +81,7 @@ class TipSlider(ClickableSlider):
         self.setSingleStep(self._step)
         self.setTickInterval(self._step)
         self.setPageStep(self._pagestep)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
 
     def showEvent(self, event):
         super().showEvent(event)

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -38,6 +38,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import tagger_instance
 from picard.config import get_config
 from picard.const import (
     RELEASE_FORMATS,
@@ -55,7 +56,6 @@ from picard.i18n import (
     pgettext_attributes,
     sort_key,
 )
-from picard.util import tagger_instance
 
 from picard.ui.forms.ui_options_releases import Ui_ReleasesOptionsPage
 from picard.ui.options import OptionsPage

--- a/picard/ui/options/renaming_compat.py
+++ b/picard/ui/options/renaming_compat.py
@@ -53,9 +53,7 @@ from picard.i18n import (
 from picard.util import system_supports_long_paths
 
 from picard.ui import PicardDialog
-from picard.ui.forms.ui_options_renaming_compat import (
-    Ui_RenamingCompatOptionsPage,
-)
+from picard.ui.forms.ui_options_renaming_compat import Ui_RenamingCompatOptionsPage
 from picard.ui.forms.ui_win_compat_dialog import Ui_WinCompatDialog
 from picard.ui.options import (
     OptionsCheckError,

--- a/picard/ui/options/tags_compatibility_ac3.py
+++ b/picard/ui/options/tags_compatibility_ac3.py
@@ -25,9 +25,7 @@ from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
 
-from picard.ui.forms.ui_options_tags_compatibility_ac3 import (
-    Ui_TagsCompatibilityOptionsPage,
-)
+from picard.ui.forms.ui_options_tags_compatibility_ac3 import Ui_TagsCompatibilityOptionsPage
 from picard.ui.options import OptionsPage
 
 

--- a/picard/ui/options/tags_compatibility_id3.py
+++ b/picard/ui/options/tags_compatibility_id3.py
@@ -27,9 +27,7 @@ from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
 
-from picard.ui.forms.ui_options_tags_compatibility_id3 import (
-    Ui_TagsCompatibilityOptionsPage,
-)
+from picard.ui.forms.ui_options_tags_compatibility_id3 import Ui_TagsCompatibilityOptionsPage
 from picard.ui.options import OptionsPage
 
 

--- a/picard/ui/options/tags_compatibility_wave.py
+++ b/picard/ui/options/tags_compatibility_wave.py
@@ -26,9 +26,7 @@ from picard.extension_points.options_pages import register_options_page
 from picard.formats.wav import WAVFile
 from picard.i18n import N_
 
-from picard.ui.forms.ui_options_tags_compatibility_wave import (
-    Ui_TagsCompatibilityOptionsPage,
-)
+from picard.ui.forms.ui_options_tags_compatibility_wave import Ui_TagsCompatibilityOptionsPage
 from picard.ui.options import OptionsPage
 
 

--- a/picard/ui/player/mpris.py
+++ b/picard/ui/player/mpris.py
@@ -20,7 +20,6 @@
 from enum import Enum
 
 from PyQt6.QtCore import (
-    QCoreApplication,
     QMetaType,
     QObject,
     QUrl,
@@ -40,6 +39,7 @@ from PyQt6.QtDBus import (
 from picard import (
     PICARD_APP_ID,
     PICARD_DISPLAY_NAME,
+    tagger_instance,
 )
 from picard.file import File
 
@@ -250,7 +250,7 @@ class MediaPlayer2Adaptor(QDBusAbstractAdaptor):
 
     @pyqtSlot()
     def Raise(self):
-        tagger = QCoreApplication.instance()
+        tagger = tagger_instance()
         tagger.bring_tagger_front()
 
     @pyqtSlot()

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -26,7 +26,10 @@ from functools import partial
 
 from PyQt6 import QtWidgets
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.album import Album
 from picard.cluster import (
     Cluster,
@@ -38,10 +41,7 @@ from picard.script import (
     ScriptParser,
 )
 from picard.track import Track
-from picard.util import (
-    iter_unique,
-    tagger_instance,
-)
+from picard.util import iter_unique
 
 
 class ScriptsMenu(QtWidgets.QMenu):

--- a/picard/ui/scriptsmenu.py
+++ b/picard/ui/scriptsmenu.py
@@ -24,10 +24,7 @@
 
 from functools import partial
 
-from PyQt6 import (
-    QtCore,
-    QtWidgets,
-)
+from PyQt6 import QtWidgets
 
 from picard import log
 from picard.album import Album
@@ -41,13 +38,16 @@ from picard.script import (
     ScriptParser,
 )
 from picard.track import Track
-from picard.util import iter_unique
+from picard.util import (
+    iter_unique,
+    tagger_instance,
+)
 
 
 class ScriptsMenu(QtWidgets.QMenu):
     def __init__(self, scripts, title, parent=None):
         super().__init__(title, parent=parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
 
         for script in scripts:
             action = self.addAction(script.name)

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -30,7 +30,10 @@ from PyQt6 import (
 )
 from PyQt6.QtCore import pyqtSignal
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.const import CAA_URL
 from picard.i18n import N_
@@ -41,10 +44,7 @@ from picard.mbjson import (
     release_to_metadata,
 )
 from picard.metadata import Metadata
-from picard.util import (
-    countries_shortlist,
-    tagger_instance,
-)
+from picard.util import countries_shortlist
 from picard.webservice.api_helpers import build_lucene_query
 
 from picard.ui.columns import (

--- a/picard/ui/searchdialog/album.py
+++ b/picard/ui/searchdialog/album.py
@@ -41,7 +41,10 @@ from picard.mbjson import (
     release_to_metadata,
 )
 from picard.metadata import Metadata
-from picard.util import countries_shortlist
+from picard.util import (
+    countries_shortlist,
+    tagger_instance,
+)
 from picard.webservice.api_helpers import build_lucene_query
 
 from picard.ui.columns import (
@@ -188,7 +191,7 @@ class AlbumSearchDialog(SearchDialog):
 
     @staticmethod
     def show_releasegroup_search(releasegroup_id, existing_album=None):
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         dialog = AlbumSearchDialog(
             tagger.window,
             force_advanced_search=True,

--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -27,7 +27,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard.util import tagger_instance
+from picard import tagger_instance
 
 
 class ElidedLabel(QtWidgets.QLabel):

--- a/picard/ui/widgets/__init__.py
+++ b/picard/ui/widgets/__init__.py
@@ -27,6 +27,8 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard.util import tagger_instance
+
 
 class ElidedLabel(QtWidgets.QLabel):
     """A QLabel that elides the displayed text with ellipsis when resized."""
@@ -101,9 +103,9 @@ class Popover(QtWidgets.QFrame):
         super().__init__(parent=parent)
         self.setWindowFlags(QtCore.Qt.WindowType.Popup | QtCore.Qt.WindowType.FramelessWindowHint)
         self.position = position
-        app = QtCore.QCoreApplication.instance()
-        self._is_wayland = app.is_wayland
-        self._main_window = app.window
+        tagger = tagger_instance()
+        self._is_wayland = tagger.is_wayland
+        self._main_window = tagger.window
 
     def show(self):
         super().show()  # show so that the geometry gets known

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -27,7 +27,10 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.config import get_config
 from picard.i18n import gettext as _
 from picard.metadata import (
@@ -37,10 +40,7 @@ from picard.metadata import (
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 from picard.plugin3.plugin import PluginState
 from picard.plugin3.ref_item import RefItem
-from picard.util import (
-    tagger_instance,
-    temporary_disconnect,
-)
+from picard.util import temporary_disconnect
 
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -37,7 +37,10 @@ from picard.metadata import (
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 from picard.plugin3.plugin import PluginState
 from picard.plugin3.ref_item import RefItem
-from picard.util import temporary_disconnect
+from picard.util import (
+    tagger_instance,
+    temporary_disconnect,
+)
 
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector
@@ -158,7 +161,7 @@ class PluginListWidget(QtWidgets.QWidget):
         self.tree_widget.customContextMenuRequested.connect(self._show_context_menu)
 
         # Cache tagger instance for performance
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.plugin_manager = self.tagger.get_plugin_manager()
         if not self.plugin_manager:
             raise RuntimeError("Plugin manager not available")
@@ -874,7 +877,7 @@ class SwitchRefDialog(QtWidgets.QDialog):
         self.plugin = plugin
         self.selected_ref = None
         # Cache tagger instance for performance
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.plugin_manager = self.tagger.get_plugin_manager()
         if not self.plugin_manager:
             raise RuntimeError("Plugin manager not available")

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -37,7 +37,10 @@ from picard.tags.docs import (
     display_plugin_tag_full_description,
     display_tag_full_description,
 )
-from picard.util import get_url
+from picard.util import (
+    get_url,
+    tagger_instance,
+)
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
@@ -118,7 +121,7 @@ class DocumentationPage(QtWidgets.QWidget):
 
 class FunctionsDocumentationPage(DocumentationPage):
     def generate_html(self):
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         manager = self.tagger.get_plugin_manager()
 
         def process_html(html, function):

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -29,6 +29,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import tagger_instance
 from picard.const.tags import ALL_TAGS
 from picard.extension_points.script_variables import ext_point_script_variables
 from picard.i18n import gettext as _
@@ -37,10 +38,7 @@ from picard.tags.docs import (
     display_plugin_tag_full_description,
     display_tag_full_description,
 )
-from picard.util import (
-    get_url,
-    tagger_instance,
-)
+from picard.util import get_url
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -42,22 +42,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-)
-
-from PyQt6.QtCore import QByteArray
-from PyQt6.QtNetwork import QNetworkReply
-
-
-try:
-    from charset_normalizer import detect  # type: ignore[unresolved-import]
-except ImportError:
-    try:
-        from chardet import detect  # type: ignore[unresolved-import,no-redef]
-    except ImportError:
-        detect = None  # type: ignore[assignment]
 from collections import (
     defaultdict,
     namedtuple,
@@ -85,12 +69,18 @@ import subprocess  # nosec: B404
 import sys
 import tempfile
 from time import monotonic
+from typing import Any
 import unicodedata
 
 from PyQt6 import QtCore
+from PyQt6.QtCore import QByteArray
 from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtNetwork import QNetworkReply
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 from picard.const import (
     MUSICBRAINZ_SERVERS,
     PICARD_DOCS_URLS,
@@ -108,12 +98,18 @@ from picard.i18n import (
 )
 
 
+try:
+    from charset_normalizer import detect  # type: ignore[unresolved-import]
+except ImportError:
+    try:
+        from chardet import detect  # type: ignore[unresolved-import,no-redef]
+    except ImportError:
+        detect = None  # type: ignore[assignment]
+
+
 winreg = None
 if IS_WIN:
     import winreg  # type: ignore[assignment]
-
-if TYPE_CHECKING:
-    from picard.tagger import Tagger
 
 # Windows path length constraints
 # See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
@@ -1505,11 +1501,3 @@ def atomic_write(path, data):
             with suppress(OSError, PermissionError):
                 temp_path.unlink()
         raise
-
-
-def tagger_instance() -> 'Tagger':
-    instance = QtCore.QCoreApplication.instance()
-    from picard.tagger import Tagger
-
-    assert isinstance(instance, Tagger), 'Expected an instance of Tagger'
-    return instance

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -42,7 +42,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from typing import Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 from PyQt6.QtCore import QByteArray
 from PyQt6.QtNetwork import QNetworkReply
@@ -103,12 +106,14 @@ from picard.i18n import (
     gettext as _,
     gettext_constants,
 )
-from picard.util.readthedocs import ReadTheDocs
 
 
 winreg = None
 if IS_WIN:
     import winreg  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from picard.tagger import Tagger
 
 # Windows path length constraints
 # See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
@@ -791,6 +796,8 @@ def get_url(url_key: str) -> str:
     Returns:
         str: Updated URL, or provided URL key if not matched.
     """
+    from picard.util.readthedocs import ReadTheDocs  # Local import to avoid circular import
+
     if url_key.startswith('/'):
         return (
             PICARD_DOCS_URLS['documentation'].format(
@@ -908,7 +915,7 @@ def parse_json(reply: QNetworkReply) -> Any:
 
 def restore_method(func):
     def func_wrapper(*args, **kwargs):
-        tagger = QtCore.QCoreApplication.instance()
+        tagger = tagger_instance()
         if not tagger._no_restore:
             return func(*args, **kwargs)
 
@@ -1498,3 +1505,11 @@ def atomic_write(path, data):
             with suppress(OSError, PermissionError):
                 temp_path.unlink()
         raise
+
+
+def tagger_instance() -> 'Tagger':
+    instance = QtCore.QCoreApplication.instance()
+    from picard.tagger import Tagger
+
+    assert isinstance(instance, Tagger), 'Expected an instance of Tagger'
+    return instance

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -40,7 +40,10 @@ from PyQt6.QtCore import (
     QRunnable,
 )
 
-from picard import log
+from picard import (
+    log,
+    tagger_instance,
+)
 
 
 class ProxyToMainEvent(QEvent):
@@ -122,7 +125,7 @@ def run_task(func, next_func=None, priority=0, thread_pool=None, task_counter=No
         task_counter.increment()
 
     if not thread_pool:
-        thread_pool = QCoreApplication.instance().thread_pool
+        thread_pool = tagger_instance().thread_pool
     thread_pool.start(Runnable(func, next_func, task_counter, traceback), priority)
 
 

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -73,6 +73,7 @@ from picard.util import (
     bytes2human,
     encoded_queryargs,
     parse_json,
+    tagger_instance,
 )
 from picard.util.xml import parse_xml
 from picard.webservice import ratecontrol
@@ -367,7 +368,7 @@ class WebService(QtCore.QObject):
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
-        self.tagger = QtCore.QCoreApplication.instance()
+        self.tagger = tagger_instance()
         self.manager = QtNetwork.QNetworkAccessManager()
         self.manager.sslErrors.connect(self.ssl_errors)
         self.oauth_manager = OAuthManager(self)

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -63,6 +63,7 @@ from picard import (
     PICARD_ORG_NAME,
     PICARD_VERSION_STR,
     log,
+    tagger_instance,
 )
 from picard.config import get_config
 from picard.const import appdirs
@@ -73,7 +74,6 @@ from picard.util import (
     bytes2human,
     encoded_queryargs,
     parse_json,
-    tagger_instance,
 )
 from picard.util.xml import parse_xml
 from picard.webservice import ratecontrol

--- a/picard/webservice/api_helpers/listenbrainz.py
+++ b/picard/webservice/api_helpers/listenbrainz.py
@@ -25,7 +25,10 @@ import enum
 import json
 from typing import Any
 
-from picard import PICARD_DISPLAY_NAME, PICARD_VERSION_STR
+from picard import (
+    PICARD_DISPLAY_NAME,
+    PICARD_VERSION_STR,
+)
 from picard.const import LISTENBRAINZ_API_URL
 from picard.metadata import Metadata
 from picard.webservice import (

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -21,7 +21,10 @@ Extending:
     - Add degradations: define a function(metadata, release) and add to DEGRADATIONS
 """
 
-from collections import Counter, defaultdict
+from collections import (
+    Counter,
+    defaultdict,
+)
 import json
 from pathlib import Path
 import random

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -47,6 +47,7 @@ from picard.formats import DEFAULT_FORMATS
 from picard.formats.registry import FormatRegistry
 from picard.i18n import setup_gettext
 from picard.releasegroup import ReleaseGroup
+from picard.tagger import Tagger
 
 
 class FakeThreadPool(QtCore.QObject):
@@ -54,32 +55,19 @@ class FakeThreadPool(QtCore.QObject):
         runnable.run()
 
 
-class FakeTagger(QtCore.QObject):
-    tagger_stats_changed = QtCore.pyqtSignal()
+cleanup_tasks = []
 
-    def __init__(self):
-        super().__init__()
-        self.tagger_stats_changed.connect(self.emit)
-        self.exit_cleanup = []
-        self.files = {}
-        self.stopping = False
-        self.thread_pool = FakeThreadPool()
-        self.priority_thread_pool = FakeThreadPool()
-        self.window = MagicMock()
-        self.webservice = MagicMock()
 
-    def register_cleanup(self, func):
-        self.exit_cleanup.append(func)
-
-    def run_cleanup(self):
-        for f in self.exit_cleanup:
-            f()
-
-    def emit(self, *args):
-        pass
-
-    def get_release_group_by_id(self, rg_id):  # pylint: disable=no-self-use
-        return ReleaseGroup(rg_id)
+def MockTagger():
+    tagger = MagicMock(spec=Tagger)
+    tagger.thread_pool = FakeThreadPool()
+    tagger.priority_thread_pool = FakeThreadPool()
+    tagger.get_release_group_by_id = MagicMock(side_effect=lambda rg_id: ReleaseGroup(rg_id))
+    tagger.stopping = False
+    tagger.files = {}
+    tagger.window = MagicMock()
+    tagger.webservice = MagicMock()
+    return tagger
 
 
 class PicardTestCase(unittest.TestCase):
@@ -87,7 +75,7 @@ class PicardTestCase(unittest.TestCase):
         super().setUp()
         log.set_verbosity(logging.DEBUG)
         setup_gettext(None, 'C')
-        self.tagger = FakeTagger()
+        self.tagger = MockTagger()
         QtCore.QCoreApplication.instance = lambda: self.tagger
         self.addCleanup(self.tagger.run_cleanup)
         self.init_config()

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -55,9 +55,6 @@ class FakeThreadPool(QtCore.QObject):
         runnable.run()
 
 
-cleanup_tasks = []
-
-
 def MockTagger():
     tagger = MagicMock(spec=Tagger)
     tagger.thread_pool = FakeThreadPool()
@@ -77,7 +74,6 @@ class PicardTestCase(unittest.TestCase):
         setup_gettext(None, 'C')
         self.tagger = MockTagger()
         QtCore.QCoreApplication.instance = lambda: self.tagger
-        self.addCleanup(self.tagger.run_cleanup)
         self.init_config()
 
     @staticmethod

--- a/test/plugins3/test_api.py
+++ b/test/plugins3/test_api.py
@@ -30,10 +30,7 @@ from unittest.mock import (
 from PyQt6.QtCore import QSettings
 
 from test.picardtestcase import PicardTestCase
-from test.plugins3.helpers import (
-    MockTagger,
-    load_plugin_manifest,
-)
+from test.plugins3.helpers import load_plugin_manifest
 
 from picard import log
 from picard.config import (
@@ -90,18 +87,17 @@ class TestPluginApiMethods(PicardTestCase):
     def test_register_format(self):
         """Test file format registration."""
         manifest = load_plugin_manifest('example')
-        mock_tagger = Mock()
-        api = PluginApi(manifest, mock_tagger)
+        api = PluginApi(manifest, self.tagger)
 
         mock_format = Mock()
+        self.tagger.format_registry = Mock()
 
         api.register_format(mock_format)
-        mock_tagger.format_registry.register.assert_called_once_with(mock_format)
+        self.tagger.format_registry.register.assert_called_once_with(mock_format)
 
     def test_manifest(self):
         manifest = load_plugin_manifest('example')
-        mock_tagger = Mock()
-        api = PluginApi(manifest, mock_tagger)
+        api = PluginApi(manifest, self.tagger)
 
         self.assertEqual(api.manifest, manifest)
         with self.assertRaises(AttributeError):
@@ -175,11 +171,10 @@ class TestPluginApiMethods(PicardTestCase):
     def test_get_plugin_version(self):
         """Test get_plugin_version method."""
         manifest = load_plugin_manifest('example')
-        mock_tagger = Mock()
         mock_plugin_manager = Mock()
-        mock_tagger.get_plugin_manager.return_value = mock_plugin_manager
+        self.tagger.get_plugin_manager.return_value = mock_plugin_manager
 
-        api = PluginApi(manifest, mock_tagger)
+        api = PluginApi(manifest, self.tagger)
 
         # Test with git metadata
         mock_metadata = Mock()
@@ -196,7 +191,7 @@ class TestPluginApiMethods(PicardTestCase):
         self.assertEqual(result, str(manifest.version))
 
         # Test no plugin manager
-        mock_tagger.get_plugin_manager.return_value = None
+        self.tagger.get_plugin_manager.return_value = None
         result = api.get_plugin_version()
         self.assertEqual(result, "Unknown")
 
@@ -215,11 +210,8 @@ class TestPluginApi(PicardTestCase):
     def test_init(self):
         manifest = load_plugin_manifest('example')
 
-        mock_tagger = MockTagger()
-        mock_ws = mock_tagger.webservice = Mock()
-
-        api = PluginApi(manifest, mock_tagger)
-        self.assertEqual(api.web_service, mock_ws)
+        api = PluginApi(manifest, self.tagger)
+        self.assertEqual(api.web_service, self.tagger.webservice)
         self.assertEqual(api.logger.name, 'main.plugin.example')
         self.assertEqual(api.global_config, get_config())
         self.assertIsInstance(api.plugin_config, ConfigSection)
@@ -228,13 +220,10 @@ class TestPluginApi(PicardTestCase):
         """Test PluginApi property accessors."""
         manifest = load_plugin_manifest('example')
 
-        mock_tagger = MockTagger()
-        mock_ws = mock_tagger.webservice = Mock()
-
-        api = PluginApi(manifest, mock_tagger)
+        api = PluginApi(manifest, self.tagger)
 
         # Test property accessors
-        self.assertEqual(api.web_service, mock_ws)
+        self.assertEqual(api.web_service, self.tagger.webservice)
         self.assertIsNotNone(api.mb_api)
         self.assertIsNotNone(api.logger)
         self.assertEqual(api.plugin_id, 'example')
@@ -248,7 +237,7 @@ class TestPluginApi(PicardTestCase):
         logging.disable(logging.NOTSET)
 
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, MockTagger())
+        api = PluginApi(manifest, self.tagger)
 
         # Verify logger name is correct
         self.assertEqual(api.logger.name, 'main.plugin.example')
@@ -299,11 +288,8 @@ class TestPluginApi(PicardTestCase):
             # Create a real QSettings instance
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
 
-            # Create mock tagger with real config
-            mock_tagger = MockTagger()
-
             # Create API with the test config
-            api = PluginApi(manifest, mock_tagger)
+            api = PluginApi(manifest, self.tagger)
             api._api_config._ConfigSection__qt_config = settings
 
             # Set some config values
@@ -328,7 +314,7 @@ class TestPluginApi(PicardTestCase):
             self.assertEqual(settings2.value(f'plugin.{test_uuid}/test_bool'), True)
 
             # Verify raw_value can read them back
-            api2 = PluginApi(manifest, mock_tagger)
+            api2 = PluginApi(manifest, self.tagger)
             api2._api_config._ConfigSection__qt_config = settings2
             self.assertEqual(api2.plugin_config.raw_value('test_string'), 'hello')
             self.assertEqual(api2.plugin_config.raw_value('test_int'), 42)
@@ -346,8 +332,7 @@ class TestPluginApi(PicardTestCase):
 
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
-            mock_tagger = MockTagger()
-            api = PluginApi(manifest, mock_tagger)
+            api = PluginApi(manifest, self.tagger)
             api._api_config._ConfigSection__qt_config = settings
 
             # Test registering options
@@ -395,7 +380,7 @@ class TestPluginApi(PicardTestCase):
             # Verify persistence of complex types
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, mock_tagger)
+            api2 = PluginApi(manifest, self.tagger)
             api2._api_config._ConfigSection__qt_config = settings2
 
             self.assertEqual(api2.plugin_config['list'], [1, 2, 3])
@@ -413,8 +398,7 @@ class TestPluginApi(PicardTestCase):
 
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
-            mock_tagger = MockTagger()
-            api = PluginApi(manifest, mock_tagger)
+            api = PluginApi(manifest, self.tagger)
             api._api_config._ConfigSection__qt_config = settings
 
             # Register options
@@ -438,7 +422,7 @@ class TestPluginApi(PicardTestCase):
 
             # Load in new QSettings instance (same process)
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, mock_tagger)
+            api2 = PluginApi(manifest, self.tagger)
             api2._api_config._ConfigSection__qt_config = settings2
 
             # Types are preserved due to QSettings in-memory cache
@@ -471,11 +455,8 @@ class TestPluginApi(PicardTestCase):
             # Create a real QSettings instance
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
 
-            # Create mock tagger
-            mock_tagger = MockTagger()
-
             # Create API
-            api = PluginApi(manifest, mock_tagger)
+            api = PluginApi(manifest, self.tagger)
             api._api_config._ConfigSection__qt_config = settings
 
             # Register options for the plugin
@@ -496,7 +477,7 @@ class TestPluginApi(PicardTestCase):
             # Verify persistence
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, mock_tagger)
+            api2 = PluginApi(manifest, self.tagger)
             api2._api_config._ConfigSection__qt_config = settings2
 
             # Values should persist and be properly typed

--- a/test/plugins3/test_registry.py
+++ b/test/plugins3/test_registry.py
@@ -70,9 +70,7 @@ def mock_webservice_fetch(response_data, error=None):
 class TestPluginRegistry(PicardTestCase):
     def _fetch_registry(self, registry, response_data, error=None):
         """Fetch registry with mocked webservice, return (success, error) result."""
-        mock_tagger = Mock()
-        mock_tagger.webservice = Mock()
-        mock_tagger.webservice.get_url = mock_webservice_fetch(response_data, error)
+        self.tagger.webservice.get_url = mock_webservice_fetch(response_data, error)
 
         result = {}
 
@@ -80,7 +78,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = err
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
         return result
@@ -499,16 +497,14 @@ class TestPluginRegistry(PicardTestCase):
 
             mock_response_data = b'[[blacklist]]\nurl = "test"'
 
-            mock_tagger = Mock()
-            mock_tagger.webservice = Mock()
-            mock_tagger.webservice.get_url = mock_webservice_fetch(mock_response_data)
+            self.tagger.webservice.get_url = mock_webservice_fetch(mock_response_data)
 
             result = {}
 
             def callback(success, error):
                 result['success'] = success
 
-            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
                 # Fetch and save to cache
                 registry.fetch_registry(use_cache=False, callback=callback)
 
@@ -549,9 +545,6 @@ class TestPluginRegistry(PicardTestCase):
         url2 = 'https://second.example.com/registry.toml'
         registry = PluginRegistry(registry_url=[url1, url2])
 
-        mock_tagger = Mock()
-        mock_tagger.webservice = Mock()
-
         calls = []
 
         def get_url_mock(url, handler, **kwargs):
@@ -562,7 +555,7 @@ class TestPluginRegistry(PicardTestCase):
             else:
                 handler(b'plugins = []\nblacklist = []', Mock(), None)
 
-        mock_tagger.webservice.get_url = get_url_mock
+        self.tagger.webservice.get_url = get_url_mock
 
         result = {}
 
@@ -570,7 +563,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertTrue(result['success'])
@@ -585,16 +578,13 @@ class TestPluginRegistry(PicardTestCase):
         url2 = 'https://second.example.com/registry.toml'
         registry = PluginRegistry(registry_url=[url1, url2])
 
-        mock_tagger = Mock()
-        mock_tagger.webservice = Mock()
-
         calls = []
 
         def get_url_mock(url, handler, **kwargs):
             calls.append(url.toString())
             handler(b'', Mock(), Exception('Network error'))
 
-        mock_tagger.webservice.get_url = get_url_mock
+        self.tagger.webservice.get_url = get_url_mock
 
         result = {}
 
@@ -602,7 +592,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertFalse(result['success'])
@@ -616,9 +606,6 @@ class TestPluginRegistry(PicardTestCase):
         url2 = 'https://second.example.com/registry.toml'
         registry = PluginRegistry(registry_url=[url1, url2])
 
-        mock_tagger = Mock()
-        mock_tagger.webservice = Mock()
-
         calls = []
 
         def get_url_mock(url, handler, **kwargs):
@@ -626,7 +613,7 @@ class TestPluginRegistry(PicardTestCase):
             # First URL returns invalid TOML
             handler(b'invalid toml [', Mock(), None)
 
-        mock_tagger.webservice.get_url = get_url_mock
+        self.tagger.webservice.get_url = get_url_mock
 
         result = {}
 
@@ -634,7 +621,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertFalse(result['success'])

--- a/test/plugins3/test_registry.py
+++ b/test/plugins3/test_registry.py
@@ -78,7 +78,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = err
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+        with patch('picard.tagger_instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
         return result
@@ -504,7 +504,7 @@ class TestPluginRegistry(PicardTestCase):
             def callback(success, error):
                 result['success'] = success
 
-            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+            with patch('picard.tagger_instance', return_value=self.tagger):
                 # Fetch and save to cache
                 registry.fetch_registry(use_cache=False, callback=callback)
 
@@ -563,7 +563,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+        with patch('picard.tagger_instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertTrue(result['success'])
@@ -592,7 +592,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+        with patch('picard.tagger_instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertFalse(result['success'])
@@ -621,7 +621,7 @@ class TestPluginRegistry(PicardTestCase):
             result['success'] = success
             result['error'] = error
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+        with patch('picard.tagger_instance', return_value=self.tagger):
             registry.fetch_registry(use_cache=False, callback=callback)
 
             self.assertFalse(result['success'])
@@ -655,11 +655,9 @@ class TestPluginRegistry(PicardTestCase):
         """Test that blacklist check doesn't fail if registry fetch fails."""
         registry = PluginRegistry()
 
-        mock_tagger = Mock()
-        mock_tagger.webservice = Mock()
-        mock_tagger.webservice.get_url = mock_webservice_fetch(b'', error=Exception('Network error'))
+        self.tagger.webservice.get_url = mock_webservice_fetch(b'', error=Exception('Network error'))
 
-        with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+        with patch('picard.tagger_instance', return_value=self.tagger):
             # Should not raise, just return False (not blacklisted)
             is_blacklisted, reason = registry.is_blacklisted('https://example.com/plugin')
 

--- a/test/plugins3/test_registry_advanced.py
+++ b/test/plugins3/test_registry_advanced.py
@@ -92,7 +92,7 @@ class TestRegistryAdvanced(PicardTestCase):
             def callback(success, error):
                 result['success'] = success
 
-            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+            with patch('picard.tagger_instance', return_value=self.tagger):
                 registry = PluginRegistry(registry_url=test_url, cache_dir=tmpdir)
                 registry.fetch_registry(callback=callback)
                 # Should have fetched and created data
@@ -138,7 +138,7 @@ class TestRegistryAdvanced(PicardTestCase):
                 result['success'] = success
 
             try:
-                with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
+                with patch('picard.tagger_instance', return_value=self.tagger):
                     registry.fetch_registry(use_cache=False, callback=callback)
                     # Should not raise, just log warning
                     self.assertTrue(result['success'])

--- a/test/plugins3/test_registry_advanced.py
+++ b/test/plugins3/test_registry_advanced.py
@@ -85,16 +85,14 @@ class TestRegistryAdvanced(PicardTestCase):
             cache_file.write_text('invalid toml{{{')
 
             # Mock WebService to return valid TOML data
-            mock_tagger = Mock()
-            mock_tagger.webservice = Mock()
-            mock_tagger.webservice.get_url = mock_webservice_fetch(b'plugins = []\nblacklist = []')
+            self.tagger.webservice.get_url = mock_webservice_fetch(b'plugins = []\nblacklist = []')
 
             result = {}
 
             def callback(success, error):
                 result['success'] = success
 
-            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+            with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
                 registry = PluginRegistry(registry_url=test_url, cache_dir=tmpdir)
                 registry.fetch_registry(callback=callback)
                 # Should have fetched and created data
@@ -132,9 +130,7 @@ class TestRegistryAdvanced(PicardTestCase):
             # Make cache dir read-only after registry init
             cache_dir.chmod(0o444)
 
-            mock_tagger = Mock()
-            mock_tagger.webservice = Mock()
-            mock_tagger.webservice.get_url = mock_webservice_fetch(b'plugins = []\nblacklist = []')
+            self.tagger.webservice.get_url = mock_webservice_fetch(b'plugins = []\nblacklist = []')
 
             result = {}
 
@@ -142,7 +138,7 @@ class TestRegistryAdvanced(PicardTestCase):
                 result['success'] = success
 
             try:
-                with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=mock_tagger):
+                with patch('picard.plugin3.registry.QtCore.QCoreApplication.instance', return_value=self.tagger):
                     registry.fetch_registry(use_cache=False, callback=callback)
                     # Should not raise, just log warning
                     self.assertTrue(result['success'])

--- a/test/plugins3/test_update.py
+++ b/test/plugins3/test_update.py
@@ -27,9 +27,7 @@ from picard.plugin3.manager.update import (
     PluginUpdater,
     UpdateCheck,
 )
-from picard.plugin3.plugin import (
-    Plugin,
-)
+from picard.plugin3.plugin import Plugin
 from picard.plugin3.plugin_metadata import PluginMetadata
 from picard.plugin3.ref_item import RefItem
 

--- a/test/test_date_sanitization_setting.py
+++ b/test/test_date_sanitization_setting.py
@@ -33,9 +33,7 @@ from picard.formats.apev2 import APEv2File
 from picard.formats.registry import FormatRegistry
 from picard.formats.util import date_sanitization_format_entries
 from picard.formats.vorbis import OggVorbisFile
-from picard.util import (
-    sanitize_date,
-)
+from picard.util import sanitize_date
 
 import pytest
 

--- a/test/test_util_thread.py
+++ b/test/test_util_thread.py
@@ -64,6 +64,7 @@ class ThreadTest(PicardTestCase):
 
     def setUp(self):
         super().setUp()
+        self.tagger = self.app
         self.tagger.installEventFilter(self.event_interceptor)
         self.result_queue = Queue()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The code needs access to the main application `Tagger` instance at many cases. Currently this means we have calls to `QtCore.QCoreApplication.instance()` scattered over the codebase. This has some issues:

1. Accessing the main tagger instance requires using a Qt specific function. If something changes in how this class is represented, we need to change all places where this gets accessed.
2. This approach does not work well with type checking. The returned instance is assumed to be of type `QCoreApplication`. But what is usually expected is `Tagger`, as the code needs access to the specific methods of that class. We know, that in our code the main application is always of type `Tagger`. We could cast or assert in all places where it is needed, but this increases code duplication.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add a util function `tagger_instance()` that wraps QCoreApplication.instance(). Assert the expected type to catch wrong app instance errors early in development.

Adjust some failing tests to pass the `isinstance` assertion.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
