### PR TITLE
Add clarification to number of lines displayed

### DIFF
--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -40,7 +40,10 @@ from PyQt6 import (
 
 from picard import log
 from picard.debug_opts import DebugOpt
-from picard.i18n import gettext as _
+from picard.i18n import (
+    gettext as _,
+    ngettext,
+)
 from picard.util import reconnect
 
 from picard.ui import (
@@ -329,10 +332,11 @@ class LogView(LogViewCommon):
             return
         visible = self._proxy_model.rowCount()
         total = self._model.rowCount()
+        total_str = ngettext("{count} line", "{count:,} lines", total).format(count=total)
         if visible == total:
-            self._status_label.setText(str(total))
+            self._status_label.setText(total_str)
         else:
-            self._status_label.setText(f"{visible}/{total}")
+            self._status_label.setText(f"{visible:,}/{total_str}")
 
     def _on_filter_changed(self, text):
         if self.filter_button.isChecked():


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The line count in the log viewer shows a number only, and does not indicate that it is actually the number of lines in the log.

* JIRA ticket (_optional_): PICARD-XXX


## Solution

Add clarification that this is the number of lines.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
