### PR TITLE
Don't log error message on None argument to menu_builder()

### DIFF
--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -291,6 +291,8 @@ def show_session_not_found_dialog(parent, path: str) -> None:
 def menu_builder(menu, main_actions, *args):
     """Adds each argument to menu, depending on their type"""
     for arg in args:
+        if arg is None:
+            continue
         if arg == '-':
             menu.addSeparator()
         elif isinstance(arg, QtWidgets.QMenu):


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Each time Picard starts it logs an error as:

<img width="647" height="180" alt="image" src="https://github.com/user-attachments/assets/d4671b08-5bdf-4c50-ae31-4a97411ace5d" />

This can be caused from the following code in `picard/ui/mainwindow/actions.py`:

```python
@add_action(MainAction.CHECK_UPDATE)
def _create_check_update_action(parent):
    if parent.tagger.autoupdate_enabled:
        action = QtGui.QAction(_("&Check for Update…"), parent)
        action.setMenuRole(QtGui.QAction.MenuRole.ApplicationSpecificRole)
        action.triggered.connect(parent.do_update_check)
    else:
        action = None
    return action
```

* JIRA ticket (_optional_): PICARD-XXX


## Solution

Skip a `None` argument when processing `menu_builder()`  so that there is no error logged.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
