### PR TITLE
PICARD-3291: Aggregate file metadata in cluster for release lookup

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -207,6 +207,68 @@ class Cluster(FileList):
         if signal and self.ui_item:
             self.ui_item.update()
 
+    _AGGREGATE_TAGS = ('barcode', 'catalognumber', 'date', 'label')
+    _MULTI_VALUED_TAGS = ('catalognumber', 'label')
+
+    def _aggregate_metadata(self):
+        """Populate cluster metadata with album-level tags from files.
+
+        Called once before lookup to provide barcode, catalognumber, date,
+        and label for the search query and release scoring.
+
+        A tag is set on the cluster only when:
+          1. More than half the files carry a non-empty value for it.
+          2. All those values agree.
+
+        For single-valued tags (barcode, date), agreement means all
+        raw strings are identical.
+
+        For multi-valued tags (catalognumber, label), agreement is
+        based on the intersection of values across files. For example,
+        if 5 files have "L1; L2" and 5 have "L1", the common value
+        "L1" is used. If the intersection is empty, the tag is not set.
+
+        Tags that don't meet the conditions are removed from cluster
+        metadata, ensuring stale values from a previous aggregation
+        are not reused.
+        """
+        result = self._compute_aggregate_tags()
+        for tag in self._AGGREGATE_TAGS:
+            if tag in result:
+                self.metadata[tag] = result[tag]
+            elif tag in self.metadata:
+                del self.metadata[tag]
+
+    def _compute_aggregate_tags(self):
+        """Compute aggregated tag values from files.
+
+        Returns a dict of tag -> value for tags that meet the
+        consensus criteria.
+        """
+        result = {}
+        threshold = len(self.files) / 2
+        for tag in self._AGGREGATE_TAGS:
+            values = []
+            for f in self.files:
+                v = f.metadata.get(tag, '')
+                if v:
+                    values.append(v)
+            if not values or len(values) <= threshold:
+                continue
+            # Fast path: all raw strings identical (common case).
+            unique = set(values)
+            if len(unique) == 1:
+                result[tag] = values[0]
+                continue
+            # For multi-valued tags, find the intersection of values
+            # across all files that have the tag.
+            if tag in self._MULTI_VALUED_TAGS:
+                sets = [set(v.split(MULTI_VALUED_JOINER)) for v in unique]
+                common = sets[0].intersection(*sets[1:])
+                if common:
+                    result[tag] = MULTI_VALUED_JOINER.join(sorted(common))
+        return result
+
     def get_num_files(self):
         return len(self.files)
 
@@ -361,6 +423,7 @@ class Cluster(FileList):
         """Try to identify the cluster using the existing metadata."""
         if self._lookup_task:
             return
+        self._aggregate_metadata()
         self.tagger.window.set_statusbar_message(
             N_("Looking up the metadata for cluster %(album)s…"),
             {'album': self.metadata['album']},

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -247,12 +247,18 @@ class Cluster(FileList):
         """
         result = {}
         threshold = len(self.files) / 2
-        for tag in self._AGGREGATE_TAGS:
-            values = []
-            for f in self.files:
+        if not threshold:
+            return result
+
+        # Single pass over files: collect non-empty values for all tags
+        tag_values: dict[str, list[str]] = {tag: [] for tag in self._AGGREGATE_TAGS}
+        for f in self.files:
+            for tag, values in tag_values.items():
                 v = f.metadata.get(tag, '')
                 if v:
                     values.append(v)
+
+        for tag, values in tag_values.items():
             if not values or len(values) <= threshold:
                 continue
             # Fast path: all raw strings identical (common case).

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -62,7 +62,6 @@ from picard.matching import (
     SimMatchRelease,
     compare_to_release,
 )
-from picard.metadata import MULTI_VALUED_JOINER
 from picard.track import Track
 from picard.util import (
     album_artist_from_path,
@@ -252,31 +251,27 @@ class Cluster(FileList):
             return result
 
         # Single pass over files: collect non-empty values for all tags
-        tag_values: defaultdict[str, list[str]] = defaultdict(list)
+        tag_values: defaultdict[str, list[list[str]]] = defaultdict(list)
         for f in self.files:
             for tag in self._AGGREGATE_TAGS:
-                v = f.metadata.get(tag, '')
-                if v:
-                    tag_values[tag].append(v)
+                values = f.metadata.getall(tag)
+                if values:
+                    tag_values[tag].append(values)
 
-        for tag, values in tag_values.items():
-            if not values or len(values) <= threshold:
+        for tag, all_values in tag_values.items():
+            if not all_values or len(all_values) <= threshold:
                 continue
-            # Fast path: all raw strings identical (common case).
-            unique = set(values)
-            if len(unique) == 1:
-                if tag in self._MULTI_VALUED_TAGS:
-                    result[tag] = sorted(values[0].split(MULTI_VALUED_JOINER))
-                else:
-                    result[tag] = values[0]
-                continue
-            # For multi-valued tags, find the intersection of values
-            # across all files that have the tag.
             if tag in self._MULTI_VALUED_TAGS:
-                sets = [set(v.split(MULTI_VALUED_JOINER)) for v in unique]
+                # Find the intersection of values across all files
+                sets = [set(v) for v in all_values]
                 common = sets[0].intersection(*sets[1:])
                 if common:
                     result[tag] = sorted(common)
+            else:
+                # For single-valued tags, use the value if all agree
+                unique = set(v[0] for v in all_values)
+                if len(unique) == 1:
+                    result[tag] = all_values[0][0]
         return result
 
     def _most_frequent_values(self, tags: Iterable[str]) -> dict[str, str]:
@@ -289,9 +284,9 @@ class Cluster(FileList):
         counts: dict[str, Counter[str]] = {tag: Counter() for tag in tags}
         for f in self.files:
             for tag in tags:
-                v = f.metadata.get(tag, '')
-                if v:
-                    for part in set(v.split(MULTI_VALUED_JOINER)):
+                values = f.metadata.getall(tag)
+                if values:
+                    for part in set(values):
                         counts[tag][part] += 1
         result = {}
         for tag, counter in counts.items():

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -240,7 +240,7 @@ class Cluster(FileList):
             elif tag in self.metadata:
                 del self.metadata[tag]
 
-    def _compute_aggregate_tags(self):
+    def _compute_aggregate_tags(self) -> dict[str, str | list[str]]:
         """Compute aggregated tag values from files.
 
         Returns a dict of tag -> value for tags that meet the
@@ -277,6 +277,28 @@ class Cluster(FileList):
                 common = sets[0].intersection(*sets[1:])
                 if common:
                     result[tag] = sorted(common)
+        return result
+
+    def _most_frequent_values(self, tags: Iterable[str]) -> dict[str, str]:
+        """Return the most frequent individual value for each given tag.
+
+        Single pass over all files. Only returns a value for a tag if it
+        meets the quorum (more than half the files).
+        """
+        threshold = len(self.files) / 2
+        counts: dict[str, Counter[str]] = {tag: Counter() for tag in tags}
+        for f in self.files:
+            for tag in tags:
+                v = f.metadata.get(tag, '')
+                if v:
+                    for part in set(v.split(MULTI_VALUED_JOINER)):
+                        counts[tag][part] += 1
+        result = {}
+        for tag, counter in counts.items():
+            if counter:
+                value, count = counter.most_common(1)[0]
+                if count > threshold:
+                    result[tag] = value
         return result
 
     def get_num_files(self):
@@ -438,17 +460,16 @@ class Cluster(FileList):
             {'album': self.metadata['album']},
         )
         config = get_config()
-        catno = self.metadata.get('catalognumber', '')
-        if catno:
-            catno = catno.split(MULTI_VALUED_JOINER)[0]
+        freq = self._most_frequent_values(('catalognumber', 'label'))
         self._lookup_task = self.tagger.mb_api.find_releases(
             self._lookup_finished,
             artist=self.metadata['albumartist'],
             release=self.metadata['album'],
             tracks=str(len(self.files)),
             barcode=self.metadata.get('barcode', ''),
-            catno=catno,
+            catno=freq.get('catalognumber', ''),
             date=self.metadata.get('date', ''),
+            label=freq.get('label', ''),
             limit=config.setting['query_limit'],
         )
 

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -251,12 +251,12 @@ class Cluster(FileList):
             return result
 
         # Single pass over files: collect non-empty values for all tags
-        tag_values: dict[str, list[str]] = {tag: [] for tag in self._AGGREGATE_TAGS}
+        tag_values: defaultdict[str, list[str]] = defaultdict(list)
         for f in self.files:
-            for tag, values in tag_values.items():
+            for tag in self._AGGREGATE_TAGS:
                 v = f.metadata.get(tag, '')
                 if v:
-                    values.append(v)
+                    tag_values[tag].append(v)
 
         for tag, values in tag_values.items():
             if not values or len(values) <= threshold:

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -265,7 +265,10 @@ class Cluster(FileList):
             # Fast path: all raw strings identical (common case).
             unique = set(values)
             if len(unique) == 1:
-                result[tag] = values[0]
+                if tag in self._MULTI_VALUED_TAGS:
+                    result[tag] = sorted(values[0].split(MULTI_VALUED_JOINER))
+                else:
+                    result[tag] = values[0]
                 continue
             # For multi-valued tags, find the intersection of values
             # across all files that have the tag.
@@ -273,7 +276,7 @@ class Cluster(FileList):
                 sets = [set(v.split(MULTI_VALUED_JOINER)) for v in unique]
                 common = sets[0].intersection(*sets[1:])
                 if common:
-                    result[tag] = MULTI_VALUED_JOINER.join(sorted(common))
+                    result[tag] = sorted(common)
         return result
 
     def get_num_files(self):

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -204,6 +204,7 @@ class Cluster(FileList):
 
     def update(self, signal=True):
         self.metadata['~totalalbumtracks'] = self.metadata['totaltracks'] = len(self.files)
+        self._aggregate_metadata()
         if signal and self.ui_item:
             self.ui_item.update()
 
@@ -213,7 +214,7 @@ class Cluster(FileList):
     def _aggregate_metadata(self):
         """Populate cluster metadata with album-level tags from files.
 
-        Called once before lookup to provide barcode, catalognumber, date,
+        Called on cluster update to provide barcode, catalognumber, date,
         and label for the search query and release scoring.
 
         A tag is set on the cluster only when:
@@ -429,7 +430,6 @@ class Cluster(FileList):
         """Try to identify the cluster using the existing metadata."""
         if self._lookup_task:
             return
-        self._aggregate_metadata()
         self.tagger.window.set_statusbar_message(
             N_("Looking up the metadata for cluster %(album)s…"),
             {'album': self.metadata['album']},

--- a/scripts/eval_matching/README.md
+++ b/scripts/eval_matching/README.md
@@ -48,6 +48,10 @@ Two matching levels are tested:
 
 - **Cluster-level** (`compare_to_release`): uses album, artist, date, barcode,
   track count — what Picard uses when matching a cluster of files to a release.
+- **Cluster-aggregated** (`--cluster-aggregated`): simulates the full pipeline —
+  per-file metadata is degraded, then aggregated via `_compute_aggregate_tags()`
+  (majority consensus), then scored. Tests that the aggregation preserves enough
+  signal for correct matching.
 - **File-level** (`compare_to_track`): adds track title, artist, and duration —
   what Picard uses when matching individual files to tracks.
 
@@ -60,6 +64,7 @@ Two matching levels are tested:
 | `-d`, `--degradation` | Filter to degradations matching a substring |
 | `-p`, `--profile` | Run only one config profile (neutral, prefer_us_cd, etc.) |
 | `--cluster-only` | Skip file-level evaluation |
+| `--cluster-aggregated` | Include cluster-aggregated evaluation (aggregation + scoring pipeline) |
 | `--file-only` | Skip cluster-level evaluation |
 | `--save FILE` | Save results snapshot for later comparison |
 | `--compare FILE` | Compare current results against a previous snapshot |
@@ -124,6 +129,7 @@ tied candidates:
 | `classical_same_composition` | Beethoven 5th — Karajan vs Szell |
 | `non_latin_editions` | 椎名林檎 三毒史 — digital vs CD, identical metadata |
 | `live_vs_studio` | Nirvana Nevermind vs MTV Unplugged |
+| `same_compilation_different_country` | Black Sabbath Dio Years — DE vs AU, only barcode differs |
 
 ## Degradation Patterns
 

--- a/scripts/eval_matching/corpus/eval_release_9764a202.json
+++ b/scripts/eval_matching/corpus/eval_release_9764a202.json
@@ -1,0 +1,907 @@
+{
+  "label-info": [
+    {
+      "catalog-number": "8122-79992-4",
+      "label": {
+        "name": "Rhino",
+        "disambiguation": "reissue label",
+        "type": "Imprint",
+        "label-code": 2982,
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
+        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4",
+        "sort-name": "Rhino"
+      }
+    }
+  ],
+  "text-representation": {
+    "script": "Latn",
+    "language": "eng"
+  },
+  "date": "2007-03-30",
+  "artist-credit": [
+    {
+      "joinphrase": "",
+      "name": "Black Sabbath",
+      "artist": {
+        "sort-name": "Black Sabbath",
+        "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+        "type": "Group",
+        "country": "GB",
+        "name": "Black Sabbath",
+        "disambiguation": "English heavy metal band",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      }
+    }
+  ],
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "barcode": "081227999247",
+  "id": "9764a202-87e6-4bd1-9cf9-147a5d089f77",
+  "packaging": "Jewel Case",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "release-group": {
+    "title": "The Dio Years",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "first-release-date": "2007-03-30",
+    "secondary-types": [
+      "Compilation"
+    ],
+    "disambiguation": "",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
+    "artist-credit": [
+      {
+        "joinphrase": "",
+        "name": "Black Sabbath",
+        "artist": {
+          "type": "Group",
+          "name": "Black Sabbath",
+          "country": "GB",
+          "disambiguation": "English heavy metal band",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+          "sort-name": "Black Sabbath",
+          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+        }
+      }
+    ],
+    "primary-type": "Album",
+    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48"
+  },
+  "release-events": [
+    {
+      "area": {
+        "name": "Germany",
+        "disambiguation": "",
+        "type": null,
+        "iso-3166-1-codes": [
+          "DE"
+        ],
+        "type-id": null,
+        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
+        "sort-name": "Germany"
+      },
+      "date": "2007-03-30"
+    }
+  ],
+  "country": "DE",
+  "disambiguation": "",
+  "quality": "normal",
+  "cover-art-archive": {
+    "front": true,
+    "darkened": false,
+    "back": true,
+    "artwork": true,
+    "count": 6
+  },
+  "media": [
+    {
+      "position": 1,
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "title": "",
+      "track-offset": 0,
+      "id": "59807c60-1295-3cf3-b707-9d598d975cef",
+      "tracks": [
+        {
+          "title": "Neon Knights",
+          "length": 232293,
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "type": "Group",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath"
+              }
+            }
+          ],
+          "number": "1",
+          "position": 1,
+          "id": "d60fa285-8544-317f-972b-1916ba9a70c9",
+          "recording": {
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group"
+                },
+                "name": "Black Sabbath",
+                "joinphrase": ""
+              }
+            ],
+            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
+            "video": false,
+            "length": 232293,
+            "title": "Neon Knights",
+            "isrcs": [
+              "GBUM70900395",
+              "USRH12003566",
+              "USWB10700217",
+              "USWB10800510"
+            ],
+            "first-release-date": "1980-04-25"
+          }
+        },
+        {
+          "recording": {
+            "first-release-date": "1980-04-25",
+            "isrcs": [
+              "GBUM70900393",
+              "USRH12003568",
+              "USWB10700218",
+              "USWB10800512"
+            ],
+            "title": "Lady Evil",
+            "length": 264493,
+            "video": false,
+            "id": "4325e6d2-8231-4ceb-ba22-3ff8bb5f5fa0",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ],
+            "disambiguation": ""
+          },
+          "id": "af2ac9de-d440-323b-95cd-ac956e144cbf",
+          "position": 2,
+          "number": "2",
+          "title": "Lady Evil",
+          "length": 264493,
+          "artist-credit": [
+            {
+              "artist": {
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "type": "Group",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "disambiguation": "English heavy metal band",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "name": "Black Sabbath",
+              "joinphrase": ""
+            }
+          ]
+        },
+        {
+          "number": "3",
+          "title": "Heaven and Hell",
+          "length": 418973,
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              }
+            }
+          ],
+          "recording": {
+            "first-release-date": "1980-04-25",
+            "length": 417240,
+            "title": "Heaven and Hell",
+            "isrcs": [
+              "GBUM70900392",
+              "USRH12003569",
+              "USWB10700219",
+              "USWB10800513"
+            ],
+            "video": false,
+            "id": "9ea011c9-d2ba-4e2a-adee-5ad2331f57e9",
+            "artist-credit": [
+              {
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "type": "Group",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": ""
+          },
+          "position": 3,
+          "id": "a3faf4b2-ccbb-38bb-96c9-a1104110422a"
+        },
+        {
+          "recording": {
+            "first-release-date": "1980-04-25",
+            "isrcs": [
+              "GBUM70900391",
+              "USRH12003571",
+              "USWB10700220",
+              "USWB10800515"
+            ],
+            "title": "Die Young",
+            "length": 284866,
+            "video": false,
+            "id": "cbe61838-9184-4b59-bbde-862ca30682c5",
+            "artist-credit": [
+              {
+                "artist": {
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": ""
+          },
+          "position": 4,
+          "id": "017559b5-68d5-3cf4-9753-3bedd4cc44fb",
+          "number": "4",
+          "length": 284866,
+          "title": "Die Young",
+          "artist-credit": [
+            {
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "disambiguation": "English heavy metal band",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ]
+        },
+        {
+          "number": "5",
+          "length": 351106,
+          "title": "Lonely Is the Word",
+          "artist-credit": [
+            {
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "name": "Black Sabbath",
+              "joinphrase": ""
+            }
+          ],
+          "recording": {
+            "length": 350000,
+            "title": "Lonely Is the Word",
+            "isrcs": [
+              "GBUM70900394",
+              "USRH12003573",
+              "USWB10700221",
+              "USWB10800517"
+            ],
+            "first-release-date": "1980-04-25",
+            "artist-credit": [
+              {
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "video": false,
+            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8"
+          },
+          "id": "4fed0a54-6818-3f09-ad69-353991223291",
+          "position": 5
+        },
+        {
+          "number": "6",
+          "length": 195986,
+          "title": "The Mob Rules",
+          "artist-credit": [
+            {
+              "artist": {
+                "type": "Group",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "recording": {
+            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
+            "video": false,
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ],
+            "first-release-date": "1981-11-04",
+            "length": 195346,
+            "title": "The Mob Rules",
+            "isrcs": [
+              "GBUM70900389",
+              "USRH12003578",
+              "USWB10000515",
+              "USWB10700222"
+            ]
+          },
+          "id": "246d6d49-bd0e-3913-96b0-a12170fe1daf",
+          "position": 6
+        },
+        {
+          "recording": {
+            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
+            "video": false,
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "type": "Group",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                },
+                "name": "Black Sabbath",
+                "joinphrase": ""
+              }
+            ],
+            "first-release-date": "1981-11-04",
+            "isrcs": [
+              "GBUM70900381",
+              "USRH12003574",
+              "USWB10700223"
+            ],
+            "length": 222360,
+            "title": "Turn Up the Night"
+          },
+          "id": "3b27dad5-b6a3-3450-82b9-fe71d3281f3b",
+          "position": 7,
+          "number": "7",
+          "artist-credit": [
+            {
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "name": "Black Sabbath",
+              "joinphrase": ""
+            }
+          ],
+          "title": "Turn Up the Night",
+          "length": 222360
+        },
+        {
+          "number": "8",
+          "artist-credit": [
+            {
+              "joinphrase": "",
+              "name": "Black Sabbath",
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              }
+            }
+          ],
+          "title": "Voodoo",
+          "length": 274653,
+          "recording": {
+            "first-release-date": "1981-11-04",
+            "isrcs": [
+              "GBUM70900382",
+              "USRH12003575",
+              "USWB10700224"
+            ],
+            "length": 273000,
+            "title": "Voodoo",
+            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548",
+            "video": false,
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "id": "de440ef4-39c7-304c-92f2-8f0c1f33b3f8",
+          "position": 8
+        },
+        {
+          "recording": {
+            "first-release-date": "1981-11-04",
+            "isrcs": [
+              "GBUM70900388",
+              "USRH12003581",
+              "USWB10700225"
+            ],
+            "title": "Falling off the Edge of the World",
+            "length": 303853,
+            "video": false,
+            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
+            "artist-credit": [
+              {
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type": "Group",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": ""
+          },
+          "position": 9,
+          "id": "054eb327-e90d-364a-8c8c-bf2d70f36131",
+          "number": "9",
+          "title": "Falling off the Edge of the World",
+          "length": 304960,
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "disambiguation": "English heavy metal band",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath"
+              }
+            }
+          ]
+        },
+        {
+          "position": 10,
+          "id": "3b4ba360-13db-3ef3-bba0-23416769a1d5",
+          "recording": {
+            "first-release-date": "1992-06-22",
+            "isrcs": [
+              "USCA21003160",
+              "USRE10700051"
+            ],
+            "title": "After All (The Dead)",
+            "length": 341626,
+            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
+            "video": false,
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "artist-credit": [
+            {
+              "artist": {
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "title": "After All (The Dead)",
+          "length": 342253,
+          "number": "10"
+        },
+        {
+          "position": 11,
+          "id": "9646f132-4de4-3a37-896b-928179b8970b",
+          "recording": {
+            "length": 242000,
+            "title": "TV Crimes",
+            "isrcs": [
+              "USCA21003161",
+              "USRE10700052"
+            ],
+            "first-release-date": "1992-06-01",
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "type": "Group",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b",
+            "video": false
+          },
+          "title": "TV Crimes",
+          "length": 242160,
+          "artist-credit": [
+            {
+              "artist": {
+                "type": "Group",
+                "disambiguation": "English heavy metal band",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "number": "11"
+        },
+        {
+          "recording": {
+            "first-release-date": "1992-06-22",
+            "isrcs": [
+              "USCA21003167",
+              "USRE10700053"
+            ],
+            "length": 313000,
+            "title": "I",
+            "video": false,
+            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
+            "artist-credit": [
+              {
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": ""
+          },
+          "position": 12,
+          "id": "297938ec-a80f-3632-9f58-82472d1495fc",
+          "number": "12",
+          "length": 313506,
+          "title": "I",
+          "artist-credit": [
+            {
+              "artist": {
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath"
+              },
+              "name": "Black Sabbath",
+              "joinphrase": ""
+            }
+          ]
+        },
+        {
+          "recording": {
+            "video": false,
+            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "name": "Black Sabbath",
+                  "type": "Group"
+                }
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-30",
+            "isrcs": [
+              "USWB10700226"
+            ],
+            "title": "Children of the Sea (live)",
+            "length": 374013
+          },
+          "position": 13,
+          "id": "3f9cc9dd-1bd1-3ed3-a31e-e49ca91ced76",
+          "number": "13",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath"
+              }
+            }
+          ],
+          "length": 374013,
+          "title": "Children of the Sea (live)"
+        },
+        {
+          "id": "df99baba-5501-340a-87c5-28ad921acffc",
+          "position": 14,
+          "recording": {
+            "first-release-date": "2007-03-13",
+            "length": 361066,
+            "title": "The Devil Cried",
+            "isrcs": [
+              "USRH10720699"
+            ],
+            "video": false,
+            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "name": "Black Sabbath",
+                "artist": {
+                  "type": "Group",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "sort-name": "Black Sabbath",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                }
+              }
+            ],
+            "disambiguation": ""
+          },
+          "length": 361066,
+          "title": "The Devil Cried",
+          "artist-credit": [
+            {
+              "artist": {
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "type": "Group"
+              },
+              "name": "Black Sabbath",
+              "joinphrase": ""
+            }
+          ],
+          "number": "14"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "type": "Group",
+                "disambiguation": "English heavy metal band",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "length": 340360,
+          "title": "Shadow of the Wind",
+          "number": "15",
+          "position": 15,
+          "id": "13668a48-b263-3337-aa36-2bf3ac6a690a",
+          "recording": {
+            "title": "Shadow of the Wind",
+            "length": 340360,
+            "isrcs": [
+              "USRH10720700"
+            ],
+            "first-release-date": "2007-03-27",
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ],
+            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
+            "video": false
+          }
+        },
+        {
+          "number": "16",
+          "artist-credit": [
+            {
+              "joinphrase": "",
+              "name": "Black Sabbath",
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "name": "Black Sabbath",
+                "type": "Group",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath"
+              }
+            }
+          ],
+          "length": 244853,
+          "title": "Ear in the Wall",
+          "recording": {
+            "id": "dc8d14c0-51ae-4409-85c0-05ae27e60363",
+            "video": false,
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "first-release-date": "2007-03-30",
+            "isrcs": [
+              "USRH10720701"
+            ],
+            "title": "Ear in the Wall",
+            "length": 244853
+          },
+          "id": "bbb17464-aac7-3c75-a464-475de6df496d",
+          "position": 16
+        }
+      ],
+      "format": "CD",
+      "track-count": 16
+    }
+  ],
+  "status": "Official",
+  "asin": "B000NA77YO",
+  "title": "The Dio Years"
+}

--- a/scripts/eval_matching/corpus/eval_release_c5192d47.json
+++ b/scripts/eval_matching/corpus/eval_release_c5192d47.json
@@ -1,0 +1,919 @@
+{
+  "packaging": "Jewel Case",
+  "text-representation": {
+    "script": "Latn",
+    "language": "eng"
+  },
+  "barcode": "9325583042089",
+  "quality": "normal",
+  "country": "AU",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "cover-art-archive": {
+    "front": true,
+    "darkened": false,
+    "back": false,
+    "count": 1,
+    "artwork": true
+  },
+  "label-info": [
+    {
+      "catalog-number": "8122799924",
+      "label": {
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "type": "Imprint",
+        "sort-name": "Warner Bros. Records",
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71"
+      }
+    },
+    {
+      "label": {
+        "type": "Imprint",
+        "disambiguation": "reissue label",
+        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4",
+        "sort-name": "Rhino",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
+        "name": "Rhino",
+        "label-code": 2982
+      },
+      "catalog-number": null
+    }
+  ],
+  "date": "2007",
+  "title": "The Dio Years",
+  "media": [
+    {
+      "title": "",
+      "position": 1,
+      "id": "996b1b68-b483-381c-bee0-94d268b8c613",
+      "format": "CD",
+      "track-offset": 0,
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "tracks": [
+        {
+          "title": "Neon Knights",
+          "position": 1,
+          "recording": {
+            "length": 232293,
+            "video": false,
+            "first-release-date": "1980-04-25",
+            "isrcs": [
+              "GBUM70900395",
+              "USRH12003566",
+              "USWB10700217",
+              "USWB10800510"
+            ],
+            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
+            "disambiguation": "",
+            "title": "Neon Knights",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type": "Group",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": ""
+              }
+            ]
+          },
+          "id": "d92d6f10-5462-4395-9f57-67d0fc3f36b5",
+          "length": 232293,
+          "number": "1",
+          "artist-credit": [
+            {
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath",
+                "type": "Group",
+                "country": "GB",
+                "sort-name": "Black Sabbath",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ]
+        },
+        {
+          "length": 264493,
+          "id": "0612d2f6-f0e8-4277-8ca0-c95767d02acb",
+          "title": "Lady Evil",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "name": "Black Sabbath"
+              }
+            ],
+            "length": 264493,
+            "first-release-date": "1980-04-25",
+            "video": false,
+            "id": "4325e6d2-8231-4ceb-ba22-3ff8bb5f5fa0",
+            "isrcs": [
+              "GBUM70900393",
+              "USRH12003568",
+              "USWB10700218",
+              "USWB10800512"
+            ],
+            "disambiguation": "",
+            "title": "Lady Evil"
+          },
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              }
+            }
+          ],
+          "number": "2"
+        },
+        {
+          "number": "3",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "country": "GB",
+                "type": "Group",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              }
+            }
+          ],
+          "title": "Heaven and Hell",
+          "position": 3,
+          "recording": {
+            "length": 417240,
+            "video": false,
+            "first-release-date": "1980-04-25",
+            "disambiguation": "",
+            "id": "9ea011c9-d2ba-4e2a-adee-5ad2331f57e9",
+            "isrcs": [
+              "GBUM70900392",
+              "USRH12003569",
+              "USWB10700219",
+              "USWB10800513"
+            ],
+            "title": "Heaven and Hell",
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath"
+                },
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "id": "737d876d-98e5-4733-a600-a696bb225150",
+          "length": 418973
+        },
+        {
+          "number": "4",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "artist": {
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": ""
+            }
+          ],
+          "position": 4,
+          "recording": {
+            "id": "cbe61838-9184-4b59-bbde-862ca30682c5",
+            "isrcs": [
+              "GBUM70900391",
+              "USRH12003571",
+              "USWB10700220",
+              "USWB10800515"
+            ],
+            "disambiguation": "",
+            "title": "Die Young",
+            "length": 284866,
+            "video": false,
+            "first-release-date": "1980-04-25",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "country": "GB",
+                  "type": "Group",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath"
+                }
+              }
+            ]
+          },
+          "title": "Die Young",
+          "id": "69cb9ba3-5de0-491e-a982-b601cbbe58b5",
+          "length": 284866
+        },
+        {
+          "id": "cd7fbbf0-1fab-4956-8700-5827d81bc931",
+          "position": 5,
+          "title": "Lonely Is the Word",
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "type": "Group",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "title": "Lonely Is the Word",
+            "disambiguation": "",
+            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8",
+            "isrcs": [
+              "GBUM70900394",
+              "USRH12003573",
+              "USWB10700221",
+              "USWB10800517"
+            ],
+            "length": 350000,
+            "video": false,
+            "first-release-date": "1980-04-25"
+          },
+          "length": 351106,
+          "number": "5",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "artist": {
+                "country": "GB",
+                "type": "Group",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              },
+              "joinphrase": ""
+            }
+          ]
+        },
+        {
+          "number": "6",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "type": "Group",
+                "country": "GB",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              }
+            }
+          ],
+          "id": "e319fc3e-5ae0-4258-ad88-3c5dd0def9b3",
+          "recording": {
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath"
+                },
+                "name": "Black Sabbath"
+              }
+            ],
+            "first-release-date": "1981-11-04",
+            "video": false,
+            "length": 195346,
+            "isrcs": [
+              "GBUM70900389",
+              "USRH12003578",
+              "USWB10000515",
+              "USWB10700222"
+            ],
+            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
+            "disambiguation": "",
+            "title": "The Mob Rules"
+          },
+          "title": "The Mob Rules",
+          "position": 6,
+          "length": 195986
+        },
+        {
+          "id": "b3d4b94c-722c-483f-b992-fde821846de3",
+          "position": 7,
+          "title": "Turn Up the Night",
+          "recording": {
+            "length": 222360,
+            "video": false,
+            "first-release-date": "1981-11-04",
+            "title": "Turn Up the Night",
+            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
+            "isrcs": [
+              "GBUM70900381",
+              "USRH12003574",
+              "USWB10700223"
+            ],
+            "disambiguation": "",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "country": "GB",
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                },
+                "joinphrase": ""
+              }
+            ]
+          },
+          "length": 222360,
+          "number": "7",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "type": "Group",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ]
+        },
+        {
+          "length": 274653,
+          "position": 8,
+          "title": "Voodoo",
+          "recording": {
+            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548",
+            "isrcs": [
+              "GBUM70900382",
+              "USRH12003575",
+              "USWB10700224"
+            ],
+            "disambiguation": "",
+            "title": "Voodoo",
+            "video": false,
+            "first-release-date": "1981-11-04",
+            "length": 273000,
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "type": "Group",
+                  "country": "GB",
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                },
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "id": "9ac4bea6-2a9a-48f3-9a01-0785287b0471",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group"
+              }
+            }
+          ],
+          "number": "8"
+        },
+        {
+          "recording": {
+            "first-release-date": "1981-11-04",
+            "video": false,
+            "length": 303853,
+            "isrcs": [
+              "GBUM70900388",
+              "USRH12003581",
+              "USWB10700225"
+            ],
+            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
+            "disambiguation": "",
+            "title": "Falling off the Edge of the World",
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "title": "Falling off the Edge of the World",
+          "position": 9,
+          "id": "5a4f05e2-5a80-45a1-a629-de3a076bcc36",
+          "length": 304960,
+          "number": "9",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "type": "Group",
+                "country": "GB",
+                "sort-name": "Black Sabbath",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              }
+            }
+          ]
+        },
+        {
+          "length": 342253,
+          "id": "266decef-da96-43a5-86ad-251e6fc90a77",
+          "position": 10,
+          "title": "After All (The Dead)",
+          "recording": {
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "sort-name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ],
+            "disambiguation": "",
+            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
+            "isrcs": [
+              "USCA21003160",
+              "USRE10700051"
+            ],
+            "title": "After All (The Dead)",
+            "length": 341626,
+            "first-release-date": "1992-06-22",
+            "video": false
+          },
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "type": "Group",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              }
+            }
+          ],
+          "number": "10"
+        },
+        {
+          "artist-credit": [
+            {
+              "joinphrase": "",
+              "artist": {
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath"
+              },
+              "name": "Black Sabbath"
+            }
+          ],
+          "number": "11",
+          "length": 242160,
+          "id": "1acc5ce5-1aeb-4019-a4fe-9ce36195afac",
+          "position": 11,
+          "title": "TV Crimes",
+          "recording": {
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type": "Group",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ],
+            "first-release-date": "1992-06-01",
+            "video": false,
+            "length": 242000,
+            "title": "TV Crimes",
+            "isrcs": [
+              "USCA21003161",
+              "USRE10700052"
+            ],
+            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b",
+            "disambiguation": ""
+          }
+        },
+        {
+          "id": "107b4f1b-ba32-4b02-a9b2-383f87e10f59",
+          "recording": {
+            "artist-credit": [
+              {
+                "joinphrase": "",
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type": "Group",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "name": "Black Sabbath"
+              }
+            ],
+            "title": "I",
+            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
+            "disambiguation": "",
+            "isrcs": [
+              "USCA21003167",
+              "USRE10700053"
+            ],
+            "length": 313000,
+            "first-release-date": "1992-06-22",
+            "video": false
+          },
+          "title": "I",
+          "position": 12,
+          "length": 313506,
+          "number": "12",
+          "artist-credit": [
+            {
+              "joinphrase": "",
+              "artist": {
+                "country": "GB",
+                "type": "Group",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "name": "Black Sabbath"
+              },
+              "name": "Black Sabbath"
+            }
+          ]
+        },
+        {
+          "id": "38471643-b220-4ad4-868d-0893ed2497e1",
+          "title": "Children of the Sea (live)",
+          "position": 13,
+          "recording": {
+            "first-release-date": "2007-03-30",
+            "video": false,
+            "length": 374013,
+            "isrcs": [
+              "USWB10700226"
+            ],
+            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
+            "disambiguation": "",
+            "title": "Children of the Sea (live)",
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "sort-name": "Black Sabbath",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "type": "Group",
+                  "country": "GB",
+                  "name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                }
+              }
+            ]
+          },
+          "length": 374013,
+          "number": "13",
+          "artist-credit": [
+            {
+              "joinphrase": "",
+              "artist": {
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "name": "Black Sabbath"
+            }
+          ]
+        },
+        {
+          "length": 361066,
+          "recording": {
+            "title": "The Devil Cried",
+            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
+            "isrcs": [
+              "USRH10720699"
+            ],
+            "disambiguation": "",
+            "length": 361066,
+            "first-release-date": "2007-03-13",
+            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath",
+                  "country": "GB",
+                  "type": "Group",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ]
+          },
+          "position": 14,
+          "title": "The Devil Cried",
+          "id": "7eefbe3a-cae0-4cb0-8446-ca9776a9fdbf",
+          "artist-credit": [
+            {
+              "artist": {
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "sort-name": "Black Sabbath",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "disambiguation": "English heavy metal band",
+                "type": "Group",
+                "country": "GB"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "number": "14"
+        },
+        {
+          "id": "d5aee5fc-9a65-4152-8867-6d2e96f81ee8",
+          "title": "Shadow of the Wind",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "joinphrase": "",
+                "artist": {
+                  "country": "GB",
+                  "type": "Group",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath"
+                }
+              }
+            ],
+            "video": false,
+            "first-release-date": "2007-03-27",
+            "length": 340360,
+            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
+            "isrcs": [
+              "USRH10720700"
+            ],
+            "disambiguation": "",
+            "title": "Shadow of the Wind"
+          },
+          "length": 340360,
+          "number": "15",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "sort-name": "Black Sabbath",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "type": "Group",
+                "country": "GB",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              }
+            }
+          ]
+        },
+        {
+          "number": "16",
+          "artist-credit": [
+            {
+              "name": "Black Sabbath",
+              "joinphrase": "",
+              "artist": {
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "sort-name": "Black Sabbath",
+                "country": "GB",
+                "type": "Group",
+                "name": "Black Sabbath",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              }
+            }
+          ],
+          "position": 16,
+          "title": "Ear in the Wall",
+          "recording": {
+            "artist-credit": [
+              {
+                "name": "Black Sabbath",
+                "artist": {
+                  "country": "GB",
+                  "type": "Group",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "disambiguation": "English heavy metal band",
+                  "sort-name": "Black Sabbath",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "name": "Black Sabbath"
+                },
+                "joinphrase": ""
+              }
+            ],
+            "length": 244853,
+            "video": false,
+            "first-release-date": "2007-03-30",
+            "title": "Ear in the Wall",
+            "id": "dc8d14c0-51ae-4409-85c0-05ae27e60363",
+            "isrcs": [
+              "USRH10720701"
+            ],
+            "disambiguation": ""
+          },
+          "id": "8e12b275-e5dc-412a-b069-c35d3ea7d4c1",
+          "length": 244853
+        }
+      ],
+      "track-count": 16
+    }
+  ],
+  "id": "c5192d47-f0e2-4f1b-81dc-fc61549d20e2",
+  "release-events": [
+    {
+      "area": {
+        "type-id": null,
+        "name": "Australia",
+        "type": null,
+        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+        "disambiguation": "",
+        "iso-3166-1-codes": [
+          "AU"
+        ],
+        "sort-name": "Australia"
+      },
+      "date": "2007"
+    }
+  ],
+  "disambiguation": "",
+  "artist-credit": [
+    {
+      "name": "Black Sabbath",
+      "artist": {
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+        "name": "Black Sabbath",
+        "type": "Group",
+        "country": "GB",
+        "sort-name": "Black Sabbath",
+        "disambiguation": "English heavy metal band",
+        "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+      },
+      "joinphrase": ""
+    }
+  ],
+  "status": "Official",
+  "release-group": {
+    "secondary-types": [
+      "Compilation"
+    ],
+    "primary-type": "Album",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
+    "artist-credit": [
+      {
+        "name": "Black Sabbath",
+        "artist": {
+          "country": "GB",
+          "type": "Group",
+          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+          "disambiguation": "English heavy metal band",
+          "sort-name": "Black Sabbath",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+          "name": "Black Sabbath"
+        },
+        "joinphrase": ""
+      }
+    ],
+    "disambiguation": "",
+    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48",
+    "title": "The Dio Years",
+    "first-release-date": "2007-03-30",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc"
+  },
+  "asin": null
+}

--- a/scripts/eval_matching/corpus/releases.tsv
+++ b/scripts/eval_matching/corpus/releases.tsv
@@ -29,3 +29,5 @@ ea92a194-2d60-35c7-9d56-0e1dba20cd45	Radiohead - In Rainbows 2007-12-03 GB (28 t
 cba282c5-dd83-3157-afb6-9af6a5af7709	Radiohead - In Rainbows 2008-01-01 US (10 tracks)
 2529f558-970b-33d2-a42c-41ab15a970c6	Metallica - Metallica 1991-08-12 CA (12 tracks)
 7c07f9a1-381f-4c00-8d17-2acc537597f8	Beyoncé - BEYONCÉ 2013-12-20 US (32 tracks)
+9764a202-87e6-4bd1-9cf9-147a5d089f77	Black Sabbath - The Dio Years 2007-03-30 DE (16 tracks)
+c5192d47-f0e2-4f1b-81dc-fc61549d20e2	Black Sabbath - The Dio Years 2007 AU (16 tracks)

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -536,6 +536,85 @@ def generate_corpus():
     return corpus
 
 
+def _aggregate_file_metadata(file_metadata_list):
+    """Simulate Cluster._compute_aggregate_tags on a list of Metadata objects.
+
+    Replicates the cluster aggregation logic: majority threshold,
+    single-value consensus, multi-valued intersection.
+    """
+    from picard.cluster import Cluster
+
+    # Create a minimal cluster with mock files
+    cluster = Cluster.__new__(Cluster)
+    cluster.files = []
+    for m in file_metadata_list:
+        mock_file = MagicMock()
+        mock_file.metadata = m
+        cluster.files.append(mock_file)
+    return cluster._compute_aggregate_tags()
+
+
+def generate_cluster_corpus():
+    """Build cluster-level corpus that exercises the aggregation path.
+
+    Simulates the real Picard flow:
+      1. Each file in the cluster has per-file metadata (with barcode, etc.)
+      2. Degradation is applied to each file's metadata
+      3. _compute_aggregate_tags() aggregates across files → cluster metadata
+      4. compare_to_release scores against the aggregated metadata
+
+    This tests whether the aggregation + scoring pipeline correctly
+    identifies the target release when file metadata is degraded.
+    """
+    corpus = []
+    for scenario in SCENARIOS:
+        target = load_release(scenario["target"])
+        distractors = [load_release(f) for f in scenario["distractors"]]
+        candidates = [target] + distractors
+
+        # Get track count to simulate N files in the cluster
+        all_tracks = []
+        for media in target.get("media", []):
+            all_tracks.extend(media.get("tracks", []))
+        if not all_tracks:
+            continue
+
+        for deg_name, deg_fn in DEGRADATIONS:
+            # Create per-file metadata for each track, then degrade each
+            file_metadata_list = []
+            for track in all_tracks:
+                m = metadata_from_track(track, target)
+                deg_fn(m, target)
+                file_metadata_list.append(m)
+
+            # Aggregate across files (like Cluster._compute_aggregate_tags)
+            aggregated = _aggregate_file_metadata(file_metadata_list)
+
+            # Build cluster-level metadata from first file as base,
+            # then override with aggregated values
+            cluster_meta = metadata_from_release(target)
+            deg_fn(cluster_meta, target)
+            for tag, value in aggregated.items():
+                cluster_meta[tag] = value
+            # Clear tags that didn't survive aggregation
+            for tag in ('barcode', 'catalognumber', 'date', 'label'):
+                if tag not in aggregated and tag in cluster_meta:
+                    del cluster_meta[tag]
+
+            corpus.append(
+                {
+                    "degradation": deg_name,
+                    "scenario": scenario["scenario"],
+                    "release_title": target["title"],
+                    "metadata": cluster_meta,
+                    "correct_id": target["id"],
+                    "candidates": candidates,
+                    "expectations": scenario.get("expectations"),
+                }
+            )
+    return corpus
+
+
 def metadata_from_track(track, release):
     """Convert a track + its release to Metadata, simulating a tagged file.
 
@@ -1006,6 +1085,23 @@ def _run_with_config(profile_name, weights):
         return evaluate(corpus, weights, config_profile=profile_name)
 
 
+def _run_cluster_aggregated_with_config(profile_name, weights):
+    """Generate cluster-aggregated corpus and evaluate.
+
+    Unlike _run_with_config which feeds metadata directly to scoring,
+    this simulates the real flow: per-file metadata → aggregation → scoring.
+    """
+    mock_config = _make_config(profile_name)
+    with (
+        patch("picard.config.get_config", return_value=mock_config),
+        patch("picard.mbjson.get_config", return_value=mock_config),
+        patch("picard.matching.get_config", return_value=mock_config),
+        patch("picard.matching.tagger_instance", return_value=None),
+    ):
+        corpus = generate_cluster_corpus()
+        return evaluate(corpus, weights, config_profile=profile_name)
+
+
 def print_comparison(all_results):
     """Print a side-by-side comparison of all config profiles."""
     print(f"\n{'=' * 70}")
@@ -1174,6 +1270,11 @@ def main():
         help="Run only cluster-level evaluation",
     )
     parser.add_argument(
+        "--cluster-aggregated",
+        action="store_true",
+        help="Include cluster-aggregated evaluation (tests aggregation + scoring pipeline)",
+    )
+    parser.add_argument(
         "--save",
         metavar="FILE",
         help="Save results snapshot to FILE for later comparison",
@@ -1210,6 +1311,13 @@ def main():
 
         if len(profiles) > 1:
             print_comparison(all_results)
+
+        if args.cluster_aggregated:
+            for profile_name in profiles:
+                random.seed(42)
+                agg_results = _run_cluster_aggregated_with_config(profile_name, CLUSTER_COMPARISON_WEIGHTS)
+                agg_results = _filter_results(agg_results, args.scenario, args.degradation)
+                print_report(agg_results, f"CLUSTER_AGGREGATED [{profile_name}]", verbose=args.verbose)
 
     if not args.cluster_only:
         random.seed(42)

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -293,6 +293,21 @@ SCENARIOS = [
         ],
         "scenario": "self_titled_albums",
     },
+    # --- Same compilation, different country: identical tracks/recordings, only barcode differs ---
+    {
+        "target": "eval_release_9764a202.json",  # Black Sabbath - The Dio Years DE (barcode 081227999247)
+        "distractors": [
+            "eval_release_c5192d47.json",  # Black Sabbath - The Dio Years AU (barcode 9325583042089)
+        ],
+        "scenario": "same_compilation_different_country",
+    },
+    {
+        "target": "eval_release_c5192d47.json",  # Black Sabbath - The Dio Years AU (barcode 9325583042089)
+        "distractors": [
+            "eval_release_9764a202.json",  # Black Sabbath - The Dio Years DE (barcode 081227999247)
+        ],
+        "scenario": "same_compilation_different_country",
+    },
 ]
 
 

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -985,6 +985,7 @@ def _run_with_config(profile_name, weights):
         patch("picard.config.get_config", return_value=mock_config),
         patch("picard.mbjson.get_config", return_value=mock_config),
         patch("picard.matching.get_config", return_value=mock_config),
+        patch("picard.matching.tagger_instance", return_value=None),
     ):
         corpus = generate_corpus()
         return evaluate(corpus, weights, config_profile=profile_name)
@@ -1203,6 +1204,7 @@ def main():
             patch("picard.config.get_config", return_value=mock_config),
             patch("picard.mbjson.get_config", return_value=mock_config),
             patch("picard.matching.get_config", return_value=mock_config),
+            patch("picard.matching.tagger_instance", return_value=None),
         ):
             file_corpus = generate_file_corpus()
             file_results = evaluate_file_corpus(file_corpus, FILE_COMPARISON_WEIGHTS, config_profile=file_profile)

--- a/scripts/eval_matching/eval_recording_lookup.py
+++ b/scripts/eval_matching/eval_recording_lookup.py
@@ -401,6 +401,7 @@ def main():
         patch("picard.config.get_config", return_value=mock_config),
         patch("picard.mbjson.get_config", return_value=mock_config),
         patch("picard.matching.get_config", return_value=mock_config),
+        patch("picard.matching.tagger_instance", return_value=None),
     ):
         corpus = generate_corpus() + generate_synthetic_corpus()
 

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -301,12 +301,14 @@ class ComputeAggregateTagsTest(PicardTestCase):
         self.assertEqual(result, {})
 
     def test_multi_valued_identical(self):
-        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino; Warner'])
+        rhino_warner = ['Rhino', 'Warner']
+        self._add_files('label', [rhino_warner, rhino_warner, rhino_warner])
         result = self.cluster._compute_aggregate_tags()
         self.assertEqual(result['label'], ['Rhino', 'Warner'])
 
     def test_multi_valued_intersection(self):
-        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino'])
+        rhino_warner = ['Rhino', 'Warner']
+        self._add_files('label', [rhino_warner, rhino_warner, ['Rhino']])
         result = self.cluster._compute_aggregate_tags()
         self.assertEqual(result['label'], ['Rhino'])
 
@@ -316,7 +318,9 @@ class ComputeAggregateTagsTest(PicardTestCase):
         self.assertNotIn('label', result)
 
     def test_multi_valued_different_order(self):
-        self._add_files('label', ['Rhino; Warner', 'Warner; Rhino', 'Rhino; Warner'])
+        rhino_warner = ['Rhino', 'Warner']
+        warner_rhino = ['Warner', 'Rhino']
+        self._add_files('label', [rhino_warner, warner_rhino, rhino_warner])
         result = self.cluster._compute_aggregate_tags()
         # All have same components, intersection is {Rhino, Warner}
         self.assertEqual(result['label'], ['Rhino', 'Warner'])
@@ -332,7 +336,8 @@ class ComputeAggregateTagsTest(PicardTestCase):
         self.assertNotIn('date', result)
 
     def test_catno_intersection(self):
-        self._add_files('catalognumber', ['ABC-123; DEF-456', 'ABC-123; DEF-456', 'ABC-123'])
+        abc_def = ['ABC-123', 'DEF-456']
+        self._add_files('catalognumber', [abc_def, abc_def, ['ABC-123']])
         result = self.cluster._compute_aggregate_tags()
         self.assertEqual(result['catalognumber'], ['ABC-123'])
 
@@ -342,7 +347,8 @@ class ComputeAggregateTagsTest(PicardTestCase):
         self.assertEqual(result, {'label': 'Rhino'})
 
     def test_most_frequent_values_multi(self):
-        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino'])
+        rhino_warner = ['Rhino', 'Warner']
+        self._add_files('label', [rhino_warner, rhino_warner, ['Rhino']])
         result = self.cluster._most_frequent_values(('label',))
         self.assertEqual(result, {'label': 'Rhino'})
 

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -261,3 +261,79 @@ class FileClusterTest(PicardTestCase):
         self.assertEqual('Album 1', fc.title)
         self.assertEqual('Artist 1', fc.artist)
         self.assertEqual(files, list(fc.files))
+
+
+class ComputeAggregateTagsTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+        self.cluster = Cluster("Test")
+
+    def _add_files(self, tag, values):
+        for v in values:
+            f = File('test.flac')
+            if v:
+                f.metadata[tag] = v
+            self.cluster.files.append(f)
+
+    def test_all_agree(self):
+        self._add_files('barcode', ['123', '123', '123'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['barcode'], '123')
+
+    def test_majority_agree(self):
+        self._add_files('barcode', ['123', '123', '123', '', ''])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['barcode'], '123')
+
+    def test_below_majority(self):
+        self._add_files('barcode', ['123', '', '', '', ''])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertNotIn('barcode', result)
+
+    def test_disagreement(self):
+        self._add_files('barcode', ['123', '456', '123', '456', '123'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertNotIn('barcode', result)
+
+    def test_no_files(self):
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result, {})
+
+    def test_multi_valued_identical(self):
+        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino; Warner'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['label'], 'Rhino; Warner')
+
+    def test_multi_valued_intersection(self):
+        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['label'], 'Rhino')
+
+    def test_multi_valued_no_common(self):
+        self._add_files('label', ['Rhino', 'Rhino', 'Warner'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertNotIn('label', result)
+
+    def test_multi_valued_different_order(self):
+        self._add_files('label', ['Rhino; Warner', 'Warner; Rhino', 'Rhino; Warner'])
+        result = self.cluster._compute_aggregate_tags()
+        # All have same components, fast path catches identical strings for 2/3,
+        # slow path finds intersection {Rhino, Warner}
+        self.assertIn('Rhino', result['label'])
+        self.assertIn('Warner', result['label'])
+
+    def test_date_all_agree(self):
+        self._add_files('date', ['2007-03-30', '2007-03-30', '2007-03-30'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['date'], '2007-03-30')
+
+    def test_date_disagree(self):
+        self._add_files('date', ['2007-03-30', '2007-03-30', '2007'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertNotIn('date', result)
+
+    def test_catno_intersection(self):
+        self._add_files('catalognumber', ['ABC-123; DEF-456', 'ABC-123; DEF-456', 'ABC-123'])
+        result = self.cluster._compute_aggregate_tags()
+        self.assertEqual(result['catalognumber'], 'ABC-123')

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -335,3 +335,27 @@ class ComputeAggregateTagsTest(PicardTestCase):
         self._add_files('catalognumber', ['ABC-123; DEF-456', 'ABC-123; DEF-456', 'ABC-123'])
         result = self.cluster._compute_aggregate_tags()
         self.assertEqual(result['catalognumber'], ['ABC-123'])
+
+    def test_most_frequent_values_single(self):
+        self._add_files('label', ['Rhino', 'Rhino', 'Rhino'])
+        result = self.cluster._most_frequent_values(('label',))
+        self.assertEqual(result, {'label': 'Rhino'})
+
+    def test_most_frequent_values_multi(self):
+        self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino'])
+        result = self.cluster._most_frequent_values(('label',))
+        self.assertEqual(result, {'label': 'Rhino'})
+
+    def test_most_frequent_values_below_quorum(self):
+        self._add_files('label', ['Rhino', 'Warner', 'Atlantic'])
+        result = self.cluster._most_frequent_values(('label',))
+        self.assertEqual(result, {})
+
+    def test_most_frequent_values_multiple_tags(self):
+        for _ in range(3):
+            f = File('test.flac')
+            f.metadata['label'] = 'Rhino'
+            f.metadata['catalognumber'] = 'ABC'
+            self.cluster.files.append(f)
+        result = self.cluster._most_frequent_values(('label', 'catalognumber'))
+        self.assertEqual(result, {'label': 'Rhino', 'catalognumber': 'ABC'})

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -303,12 +303,12 @@ class ComputeAggregateTagsTest(PicardTestCase):
     def test_multi_valued_identical(self):
         self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino; Warner'])
         result = self.cluster._compute_aggregate_tags()
-        self.assertEqual(result['label'], 'Rhino; Warner')
+        self.assertEqual(result['label'], ['Rhino', 'Warner'])
 
     def test_multi_valued_intersection(self):
         self._add_files('label', ['Rhino; Warner', 'Rhino; Warner', 'Rhino'])
         result = self.cluster._compute_aggregate_tags()
-        self.assertEqual(result['label'], 'Rhino')
+        self.assertEqual(result['label'], ['Rhino'])
 
     def test_multi_valued_no_common(self):
         self._add_files('label', ['Rhino', 'Rhino', 'Warner'])
@@ -318,10 +318,8 @@ class ComputeAggregateTagsTest(PicardTestCase):
     def test_multi_valued_different_order(self):
         self._add_files('label', ['Rhino; Warner', 'Warner; Rhino', 'Rhino; Warner'])
         result = self.cluster._compute_aggregate_tags()
-        # All have same components, fast path catches identical strings for 2/3,
-        # slow path finds intersection {Rhino, Warner}
-        self.assertIn('Rhino', result['label'])
-        self.assertIn('Warner', result['label'])
+        # All have same components, intersection is {Rhino, Warner}
+        self.assertEqual(result['label'], ['Rhino', 'Warner'])
 
     def test_date_all_agree(self):
         self._add_files('date', ['2007-03-30', '2007-03-30', '2007-03-30'])
@@ -336,4 +334,4 @@ class ComputeAggregateTagsTest(PicardTestCase):
     def test_catno_intersection(self):
         self._add_files('catalognumber', ['ABC-123; DEF-456', 'ABC-123; DEF-456', 'ABC-123'])
         result = self.cluster._compute_aggregate_tags()
-        self.assertEqual(result['catalognumber'], 'ABC-123')
+        self.assertEqual(result['catalognumber'], ['ABC-123'])


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Loading already-tagged files (e.g. Black Sabbath "The Dio Years" tagged from the DE release) and performing a cluster lookup would pick an arbitrary release  among tied candidates (e.g. the AU edition) because:

1. The barcode was not included in the MusicBrainz search query
2. The barcode-based scoring in compare_to_release was skipped (no barcode in cluster metadata)

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PICARD-3291](https://tickets.metabrainz.org/browse/PICARD-3291)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

When looking up a cluster, Picard now aggregates barcode, catalog number, date, and label from the files in the cluster. Previously these fields were never  propagated to the cluster metadata, so the lookup query and release scoring could not distinguish between releases that differ only by barcode/country.

`picard/cluster.py`: Add `_compute_aggregate_tags()` and `_aggregate_metadata()` to extract consensus values from files before lookup. Uses majority threshold and multi-valued intersection for safety.
`test/test_clustering.py`: Unit tests for the aggregation logic.
`scripts/eval_matching/`: Fix tagger_instance mocking, add corpus scenario reproducing the issue, add `--cluster-aggregated` mode testing the full aggregation→scoring pipeline.

Tag is set only when >50% of files have it AND all agree on the same value
Multi-valued tags (catalognumber, label): uses intersection across files (e.g. "Rhino; Warner" / "Rhino" = "Rhino")
If files disagree, the tag is not set (safer than guessing wrong)
  
Before: 5 candidates tied at 0.9106, result "ambiguous", arbitrary pick
After: correct release scores 0.9750, next best 0.5782, result "identified!"

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
