### PR TITLE
PICARD-3290: Fix file write access blocked by locked files on Windows

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -463,6 +463,10 @@ class File(MetadataItem):
     def save(self):
         self.set_pending()
         run_file_pre_save_processors(self)
+        # On Windows, ask the internal player to release this file before
+        # writing or moving it (PICARD-3290).
+        if IS_WIN:
+            self._release_file_from_player(self.filename)
         metadata = Metadata()
         metadata.copy(self.metadata)
         thread.run_task(
@@ -490,6 +494,16 @@ class File(MetadataItem):
             errmsg = "Couldn't preserve timestamps for %r: %s" % (filename, why)
             raise self.PreserveTimesUtimeError(errmsg) from None
         return (st.st_atime_ns, st.st_mtime_ns)
+
+    def _release_file_from_player(self, filename):
+        """Ask the internal player to release the file handle if it holds it.
+
+        Must be called from the main thread (e.g. from save()).
+        """
+        window = getattr(self.tagger, 'window', None)
+        player = getattr(window, 'player', None) if window else None
+        if player and hasattr(player, 'release_file'):
+            player.release_file(filename)
 
     def _save_and_rename(self, old_filename, metadata):
         """Save the metadata."""

--- a/picard/file.py
+++ b/picard/file.py
@@ -123,6 +123,8 @@ from picard.ui.filter import Filter
 
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from picard.cluster import Cluster
     from picard.track import Track
 
@@ -495,7 +497,32 @@ class File(MetadataItem):
             raise self.PreserveTimesUtimeError(errmsg) from None
         return (st.st_atime_ns, st.st_mtime_ns)
 
-    def _release_file_from_player(self, filename):
+    _PERMISSION_ERROR_RETRIES = 3
+    _PERMISSION_ERROR_RETRY_DELAY = 1.0  # seconds
+
+    def _retry_on_permission_error(self, func: 'Callable') -> None:
+        """Call func, retrying on PermissionError (Windows file locking).
+
+        This is safe to call from a worker thread.  On non-Windows platforms
+        or when retries are exhausted, the exception propagates normally.
+        """
+        if not IS_WIN:
+            return func()
+        for attempt in range(1, self._PERMISSION_ERROR_RETRIES + 1):
+            try:
+                return func()
+            except PermissionError:
+                if attempt >= self._PERMISSION_ERROR_RETRIES:
+                    raise
+                log.warning(
+                    "Permission denied on %r, retrying (%d/%d)…",
+                    self.filename,
+                    attempt,
+                    self._PERMISSION_ERROR_RETRIES,
+                )
+                time.sleep(self._PERMISSION_ERROR_RETRY_DELAY)
+
+    def _release_file_from_player(self, filename: str) -> None:
         """Ask the internal player to release the file handle if it holds it.
 
         Must be called from the main thread (e.g. from save()).
@@ -527,11 +554,11 @@ class File(MetadataItem):
             save = partial(self._save, old_filename, metadata)
             if config.setting['preserve_timestamps']:
                 try:
-                    self._preserve_times(old_filename, save)
+                    self._retry_on_permission_error(partial(self._preserve_times, old_filename, save))
                 except self.PreserveTimesUtimeError as why:
                     log.warning(why)
             else:
-                save()
+                self._retry_on_permission_error(save)
         # Rename files
         if config.setting['rename_files'] or config.setting['move_files']:
             new_filename = self._rename(old_filename, metadata, config.setting)
@@ -703,8 +730,36 @@ class File(MetadataItem):
         if not settings['move_overwrite_existing_files']:
             new_filename = get_available_filename(new_filename, old_filename)
         log.debug("Moving file %r => %r", old_filename, new_filename)
-        move_ensure_casing(old_filename, new_filename)
+        self._move_with_retry(old_filename, new_filename)
         return new_filename
+
+    def _move_with_retry(self, old_filename: str, new_filename: str) -> None:
+        """Move a file, retrying on PermissionError (Windows).
+
+        On cross-drive moves, shutil.move copies then deletes. If the delete
+        fails (source locked), a copy is left at the destination. Clean it up
+        before retrying.
+        """
+        if not IS_WIN:
+            move_ensure_casing(old_filename, new_filename)
+            return
+        for attempt in range(1, self._PERMISSION_ERROR_RETRIES + 1):
+            try:
+                move_ensure_casing(old_filename, new_filename)
+                return
+            except PermissionError:
+                if attempt >= self._PERMISSION_ERROR_RETRIES:
+                    raise
+                # Clean up partial copy at destination from failed cross-drive move
+                if os.path.exists(new_filename) and os.path.exists(old_filename):
+                    os.remove(new_filename)
+                log.warning(
+                    "Permission denied on %r, retrying (%d/%d)…",
+                    old_filename,
+                    attempt,
+                    self._PERMISSION_ERROR_RETRIES,
+                )
+                time.sleep(self._PERMISSION_ERROR_RETRY_DELAY)
 
     def _save_images(self, dirname, metadata):
         """Save the cover images to disk."""

--- a/picard/file.py
+++ b/picard/file.py
@@ -108,6 +108,7 @@ from picard.util import (
     format_time,
     is_absolute_path,
     normpath,
+    samefile,
     thread,
     tracknum_and_title_from_filename,
 )
@@ -751,7 +752,11 @@ class File(MetadataItem):
                 if attempt >= self._PERMISSION_ERROR_RETRIES:
                     raise
                 # Clean up partial copy at destination from failed cross-drive move
-                if os.path.exists(new_filename) and os.path.exists(old_filename):
+                if (
+                    os.path.exists(new_filename)
+                    and os.path.exists(old_filename)
+                    and not samefile(old_filename, new_filename)
+                ):
                     os.remove(new_filename)
                 log.warning(
                     "Permission denied on %r, retrying (%d/%d)…",

--- a/picard/file.py
+++ b/picard/file.py
@@ -528,9 +528,8 @@ class File(MetadataItem):
 
         Must be called from the main thread (e.g. from save()).
         """
-        window = getattr(self.tagger, 'window', None)
-        player = getattr(window, 'player', None) if window else None
-        if player and hasattr(player, 'release_file'):
+        player = self.tagger.window.player
+        if player:
             player.release_file(filename)
 
     def _save_and_rename(self, old_filename, metadata):

--- a/picard/ui/player/player.py
+++ b/picard/ui/player/player.py
@@ -223,7 +223,19 @@ class Player(QtCore.QObject):
         # hard stop, not just end of track
         self._playback_state = Player.PlaybackState.STOPPED
         self._player.stop()
+        self._player.setSource(QtCore.QUrl())
         self.playback_state_changed.emit(self._playback_state)
+
+    @QtCore.pyqtSlot(str)
+    def release_file(self, filename: str):
+        """Release the file handle if the player is currently holding the given file.
+
+        This stops playback and clears the media source so the file can be
+        written to or moved.  Must be called from the main thread.
+        """
+        if self._current_file and self._current_file.filename == filename:
+            log.debug("Internal player: releasing file %r for save/move", filename)
+            self.stop()
 
     def play_next(self):
         if self.is_playing:

--- a/picard/ui/player/player.py
+++ b/picard/ui/player/player.py
@@ -223,7 +223,6 @@ class Player(QtCore.QObject):
         # hard stop, not just end of track
         self._playback_state = Player.PlaybackState.STOPPED
         self._player.stop()
-        self._player.setSource(QtCore.QUrl())
         self.playback_state_changed.emit(self._playback_state)
 
     @QtCore.pyqtSlot(str)
@@ -267,6 +266,7 @@ class Player(QtCore.QObject):
             self._play_next()
         else:
             if state == QMediaPlayer.PlaybackState.StoppedState:
+                self._player.setSource(QtCore.QUrl())
                 new_state = Player.PlaybackState.STOPPED
             elif state == QMediaPlayer.PlaybackState.PlayingState:
                 new_state = Player.PlaybackState.PLAYING

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -28,6 +28,7 @@ import unittest
 from unittest.mock import (
     MagicMock,
     Mock,
+    patch,
 )
 
 from test.picardtestcase import PicardTestCase
@@ -847,3 +848,80 @@ class FileCopyMetadataTest(PicardTestCase):
 
         score = MyFormat.score('/somepath/somefile.ogg', Mock(), b"abc")
         self.assertEqual(score, 0)
+
+
+class RetryOnPermissionErrorTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+        self.file = File('somepath/somefile.mp3')
+
+    @patch('picard.file.IS_WIN', False)
+    def test_no_retry_on_non_windows(self):
+        """On non-Windows, PermissionError propagates immediately."""
+        func = Mock(side_effect=PermissionError("locked"))
+        with self.assertRaises(PermissionError):
+            self.file._retry_on_permission_error(func)
+        func.assert_called_once()
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    def test_succeeds_first_try(self, mock_sleep):
+        func = Mock(return_value='result')
+        result = self.file._retry_on_permission_error(func)
+        self.assertEqual('result', result)
+        func.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    def test_succeeds_after_retry(self, mock_sleep):
+        """Succeeds on second attempt after one PermissionError."""
+        func = Mock(side_effect=[PermissionError("locked"), 'result'])
+        result = self.file._retry_on_permission_error(func)
+        self.assertEqual('result', result)
+        self.assertEqual(2, func.call_count)
+        mock_sleep.assert_called_once_with(self.file._PERMISSION_ERROR_RETRY_DELAY)
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    def test_raises_after_max_retries(self, mock_sleep):
+        """Raises PermissionError after exhausting all retries."""
+        func = Mock(side_effect=PermissionError("locked"))
+        with self.assertRaises(PermissionError):
+            self.file._retry_on_permission_error(func)
+        self.assertEqual(self.file._PERMISSION_ERROR_RETRIES, func.call_count)
+        self.assertEqual(self.file._PERMISSION_ERROR_RETRIES - 1, mock_sleep.call_count)
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    def test_non_permission_error_not_retried(self, mock_sleep):
+        """Other exceptions propagate immediately without retry."""
+        func = Mock(side_effect=OSError("other error"))
+        with self.assertRaises(OSError):
+            self.file._retry_on_permission_error(func)
+        func.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    @patch('picard.file.move_ensure_casing')
+    def test_move_with_retry_cleans_partial_copy(self, mock_move, mock_sleep):
+        """On failed cross-drive move, partial copy at destination is removed before retry."""
+        # First call: simulate cross-drive failure (copy exists at dest, source still there)
+        # Second call: succeeds
+        mock_move.side_effect = [PermissionError("locked"), None]
+        with patch('os.path.exists', return_value=True), patch('os.remove') as mock_remove:
+            self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
+        mock_remove.assert_called_once_with('/dst/file.mp3')
+        self.assertEqual(2, mock_move.call_count)
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    @patch('picard.file.move_ensure_casing')
+    def test_move_with_retry_no_cleanup_if_no_partial_copy(self, mock_move, mock_sleep):
+        """No cleanup if destination doesn't exist (same-drive move failure)."""
+        mock_move.side_effect = [PermissionError("locked"), None]
+        with patch('os.path.exists', return_value=False), patch('os.remove') as mock_remove:
+            self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
+        mock_remove.assert_not_called()

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -911,7 +911,11 @@ class RetryOnPermissionErrorTest(PicardTestCase):
         # First call: simulate cross-drive failure (copy exists at dest, source still there)
         # Second call: succeeds
         mock_move.side_effect = [PermissionError("locked"), None]
-        with patch('os.path.exists', return_value=True), patch('os.remove') as mock_remove:
+        with (
+            patch('os.path.exists', return_value=True),
+            patch('picard.file.samefile', return_value=False),
+            patch('os.remove') as mock_remove,
+        ):
             self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
         mock_remove.assert_called_once_with('/dst/file.mp3')
         self.assertEqual(2, mock_move.call_count)
@@ -923,5 +927,19 @@ class RetryOnPermissionErrorTest(PicardTestCase):
         """No cleanup if destination doesn't exist (same-drive move failure)."""
         mock_move.side_effect = [PermissionError("locked"), None]
         with patch('os.path.exists', return_value=False), patch('os.remove') as mock_remove:
+            self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
+        mock_remove.assert_not_called()
+
+    @patch('picard.file.IS_WIN', True)
+    @patch('picard.file.time.sleep')
+    @patch('picard.file.move_ensure_casing')
+    def test_move_with_retry_no_cleanup_if_samefile(self, mock_move, mock_sleep):
+        """No cleanup if source and destination resolve to the same file."""
+        mock_move.side_effect = [PermissionError("locked"), None]
+        with (
+            patch('os.path.exists', return_value=True),
+            patch('picard.file.samefile', return_value=True),
+            patch('os.remove') as mock_remove,
+        ):
             self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
         mock_remove.assert_not_called()


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: On Windows, files cannot be saved or moved when held open by the internal player or an external application. This PR fixes both cases: releasing the player's file handle before save/move, and retrying on transient PermissionError from external locks.

## Problem

* JIRA ticket: [PICARD-3290](https://tickets.metabrainz.org/browse/PICARD-3290)

On Windows, when a file is being played by Picard's built-in player, `QMediaPlayer` keeps the file handle open even after `stop()` is called. This prevents Picard from writing tags or moving the file, resulting in `PermissionError: [WinError 32]`. Since there is no "stop" button (only pause), the user has no way to release the file short of restarting Picard.

Additionally, external applications (antivirus scanners, file indexers, other media players) can temporarily hold file locks on Windows, causing the same PermissionError during save/move operations.

## Solution

Two separate fixes (one commit each):

**1. Internal player releases file handle before save/move**

- `Player.stop()` now calls `setSource(QUrl())` to fully release the file handle (previously it only called `stop()` which keeps the source open on Windows).
- Added `Player.release_file(filename)` slot that stops playback if the player currently holds the given file.
- `File.save()` (which runs on the main thread) calls `_release_file_from_player()` before dispatching the save task to the worker thread. Since both `save()` and the player live on the main thread, this is a simple direct call with no cross-thread complexity.

**2. Retry mechanism for externally locked files**

- Added `File._retry_on_permission_error(func)` that retries a callable up to 3 times with a 1-second delay on `PermissionError`. On non-Windows platforms it is a no-op (calls func directly).
- Wrapped the save and rename operations in `_save_and_rename()` with this retry.
- Runs in the save worker thread so it does not block the UI.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed with AI assistance (Kiro CLI), with human review and direction.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
