### PR TITLE
PICARD-3297: Fix cover art 'Show more details' failing after clustering

### DIFF
--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -126,7 +126,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.show_details_button.clicked.connect(self.show_cover_art_info)
 
     def show_cover_art_info(self):
-        self.tagger.window.view_info(default_tab=1)
+        self.tagger.window.view_info(default_tab=1, item=self.item)
 
     def update_display(self, force=False):
         if self.isHidden():

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -96,6 +96,7 @@ from picard.i18n import (
     gettext as _,
     ngettext,
 )
+from picard.item import Item
 from picard.options import (
     Option,
     get_option_title,
@@ -1682,7 +1683,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 return None
             return (FileInfoDialog, file)
 
-    def view_info(self, default_tab: int = 0, item: object | None = None) -> None:
+    def view_info(self, default_tab: int = 0, item: Item | None = None) -> None:
         """Open the info dialog for the given item or the current selection.
 
         Args:

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1663,23 +1663,47 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if obj and obj.release_group:
             AlbumSearchDialog.show_releasegroup_search(obj.release_group.id, obj)
 
-    def view_info(self, default_tab=0):
-        try:
-            selected = self.selected_objects[0]
-        except IndexError:
-            return
-        if isinstance(selected, Album):
-            dialog_class = AlbumInfoDialog
-        elif isinstance(selected, Cluster):
-            dialog_class = ClusterInfoDialog
-        elif isinstance(selected, Track):
-            dialog_class = TrackInfoDialog
+    @staticmethod
+    def _get_info_dialog(item: object) -> tuple[type, object] | None:
+        """Resolve an item to the appropriate info dialog class and target object.
+
+        Returns a (dialog_class, item) tuple, or None if no dialog can be shown.
+        """
+        if isinstance(item, Album):
+            return (AlbumInfoDialog, item)
+        elif isinstance(item, Cluster):
+            return (ClusterInfoDialog, item)
+        elif isinstance(item, Track):
+            return (TrackInfoDialog, item)
         else:
             try:
-                selected = next(iter_files_from_objects(self.selected_objects))
+                file = next(iter_files_from_objects([item]))
             except StopIteration:
+                return None
+            return (FileInfoDialog, file)
+
+    def view_info(self, default_tab: int = 0, item: object | None = None) -> None:
+        """Open the info dialog for the given item or the current selection.
+
+        Args:
+            default_tab: Index of the tab to show initially.
+            item: Item to show info for.  If None, uses the first item
+                from selected_objects.
+        """
+        if item:
+            if not getattr(item, 'can_view_info', True):
                 return
-            dialog_class = FileInfoDialog
+            selected = item
+        else:
+            try:
+                selected = self.selected_objects[0]
+            except IndexError:
+                log.debug("view_info: no item selected")
+                return
+        result = self._get_info_dialog(selected)
+        if not result:
+            return
+        dialog_class, selected = result
         dialog = dialog_class(selected, self)
         dialog.ui.tabWidget.setCurrentIndex(default_tab)
         dialog.exec()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1692,7 +1692,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 from selected_objects.
         """
         if item:
-            if not getattr(item, 'can_view_info', True):
+            if not item.can_view_info:
                 return
             selected = item
         else:

--- a/test/test_get_info_dialog.py
+++ b/test/test_get_info_dialog.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+from test.picardtestcase import PicardTestCase
+
+from picard.album import (
+    Album,
+    NatAlbum,
+)
+from picard.cluster import (
+    Cluster,
+    UnclusteredFiles,
+)
+from picard.file import File
+from picard.track import Track
+
+from picard.ui.infodialog import (
+    AlbumInfoDialog,
+    ClusterInfoDialog,
+    FileInfoDialog,
+    TrackInfoDialog,
+)
+from picard.ui.mainwindow import MainWindow
+
+
+class GetInfoDialogTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+
+    def test_album(self):
+        album = MagicMock(spec=Album)
+        result = MainWindow._get_info_dialog(album)
+        self.assertEqual((AlbumInfoDialog, album), result)
+
+    def test_nat_album(self):
+        """NatAlbum is an Album subclass, should resolve to AlbumInfoDialog."""
+        nat = MagicMock(spec=NatAlbum)
+        result = MainWindow._get_info_dialog(nat)
+        self.assertEqual((AlbumInfoDialog, nat), result)
+
+    def test_cluster(self):
+        cluster = MagicMock(spec=Cluster)
+        result = MainWindow._get_info_dialog(cluster)
+        self.assertEqual((ClusterInfoDialog, cluster), result)
+
+    def test_unclustered_files(self):
+        """UnclusteredFiles is a Cluster subclass, should resolve to ClusterInfoDialog."""
+        unclustered = MagicMock(spec=UnclusteredFiles)
+        result = MainWindow._get_info_dialog(unclustered)
+        self.assertEqual((ClusterInfoDialog, unclustered), result)
+
+    def test_track(self):
+        track = MagicMock(spec=Track)
+        result = MainWindow._get_info_dialog(track)
+        self.assertEqual((TrackInfoDialog, track), result)
+
+    def test_file(self):
+        file = MagicMock(spec=File)
+        with patch('picard.ui.mainwindow.iter_files_from_objects', return_value=iter([file])):
+            result = MainWindow._get_info_dialog(file)
+        self.assertEqual((FileInfoDialog, file), result)
+
+    def test_file_list_with_files(self):
+        """A FileList (or any non-standard object) extracts the first file."""
+        file = MagicMock(spec=File)
+        file_list = MagicMock()
+        with patch('picard.ui.mainwindow.iter_files_from_objects', return_value=iter([file])):
+            result = MainWindow._get_info_dialog(file_list)
+        self.assertEqual((FileInfoDialog, file), result)
+
+    def test_object_with_no_files(self):
+        """Returns None for an object that yields no files."""
+        obj = MagicMock()
+        with patch('picard.ui.mainwindow.iter_files_from_objects', return_value=iter([])):
+            result = MainWindow._get_info_dialog(obj)
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix the cover art "Show more details" button failing to open the info dialog after clustering and lookup.

## Problem

* JIRA ticket: PICARD-3297

After clustering and looking up an album, clicking "Show more details" in the cover art box does nothing. Two issues:

1. `show_cover_art_info()` called `view_info()` without passing the item, relying on `selected_objects` which can be empty or stale after operations that move items in the tree (clustering, lookup).

2. `view_info()` had no `isinstance` check for `File` objects. When the cover art box's `self.item` was a File (common after lookup), it fell into the `else` branch which tried to extract a file from `selected_objects` instead of using the passed item — silently failing when `selected_objects` was empty.

## Solution

- `show_cover_art_info()` now passes `self.item` directly to `view_info()`, so the dialog always opens for the item the cover art box is displaying.
- `view_info()` accepts an optional `item` parameter. When provided, it uses that item directly instead of reading from `selected_objects`.
- Extracted `_get_info_dialog(item)` static method that resolves any item to the appropriate dialog class. The `else` branch now uses `iter_files_from_objects([selected])` (the resolved item) instead of falling back to `selected_objects`.
- Added debug log when `view_info()` is called with no selection.
- Added unit tests for `_get_info_dialog` covering all object types: Album, NatAlbum, Cluster, UnclusteredFiles, Track, File, FileList, and unknown objects.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed with AI assistance (Kiro CLI), with human review and direction.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
