### PR TITLE
PICARD-3281: Reduce UI blocking when loading many files

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -822,9 +822,16 @@ class Tagger(QtWidgets.QApplication):
         else:
             self.browser_integration.stop()
 
+    _CALLBACK_BATCH_SIZE = 25
+    _callback_queue: list = []
+    _callback_timer_running: bool = False
+
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):
-            event.run()
+            self._callback_queue.append(event)
+            if not self._callback_timer_running:
+                self._callback_timer_running = True
+                QtCore.QTimer.singleShot(0, self._process_callback_batch)
         elif event.type() == QtCore.QEvent.Type.FileOpen:
             file = event.file()
             self.add_paths([file])
@@ -835,6 +842,16 @@ class Tagger(QtWidgets.QApplication):
             # apparently there's some magic inside QFileOpenEvent...
             return 1
         return super().event(event)
+
+    def _process_callback_batch(self) -> None:
+        """Process a batch of queued callbacks, then yield to the event loop."""
+        count = min(self._CALLBACK_BATCH_SIZE, len(self._callback_queue))
+        for _i in range(count):
+            self._callback_queue.pop(0).run()
+        if self._callback_queue:
+            QtCore.QTimer.singleShot(0, self._process_callback_batch)
+        else:
+            self._callback_timer_running = False
 
     def _file_loaded(self, file, target=None, remove_file=False, unmatched_files=None):
         config = get_config()
@@ -984,7 +1001,7 @@ class Tagger(QtWidgets.QApplication):
 
     _FILE_LOAD_BATCH_SIZE = 25
 
-    def _load_files_batch(self, files, offset, target, unmatched_files):
+    def _load_files_batch(self, files: list, offset: int, target: object, unmatched_files: list) -> None:
         """Dispatch a batch of file loads, then yield to the event loop."""
         end = min(offset + self._FILE_LOAD_BATCH_SIZE, len(files))
         for i in range(offset, end):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -980,15 +980,17 @@ class Tagger(QtWidgets.QApplication):
             self.window.suspend_while_loading_enter()
             self._pending_files_count += len(new_files)
             unmatched_files = []
-            for i, file in enumerate(new_files):
-                file.load(partial(self._file_loaded, target=target, unmatched_files=unmatched_files))
-                # Calling processEvents helps processing the _file_loaded
-                # callbacks in between, which keeps the UI more responsive.
-                # Avoid calling it to often to not slow down the loading to much
-                # Using an uneven number to have the unclustered file counter
-                # not look stuck in certain digits.
-                if i % 17 == 0:
-                    QtCore.QCoreApplication.processEvents()
+            self._load_files_batch(new_files, 0, target, unmatched_files)
+
+    _FILE_LOAD_BATCH_SIZE = 25
+
+    def _load_files_batch(self, files, offset, target, unmatched_files):
+        """Dispatch a batch of file loads, then yield to the event loop."""
+        end = min(offset + self._FILE_LOAD_BATCH_SIZE, len(files))
+        for i in range(offset, end):
+            files[i].load(partial(self._file_loaded, target=target, unmatched_files=unmatched_files))
+        if end < len(files):
+            QtCore.QTimer.singleShot(0, partial(self._load_files_batch, files, end, target, unmatched_files))
 
     @staticmethod
     def _scan_paths_recursive(paths, recursive, ignore_hidden):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Reduce UI blocking when loading many files by throttling both file load dispatching and background task callback processing.

## Problem

* JIRA ticket: [PICARD-3281](https://tickets.metabrainz.org/browse/PICARD-3281)

When loading many files (e.g. 2000 singletons), the UI becomes completely unresponsive — users cannot scroll, click menus, or interact with the application until all files are loaded. This is reported on Windows 10/11 but also reproducible on Linux.

**Root cause analysis:**

1. All `file.load()` calls were dispatched to the thread pool at once. With 8+ threads completing in parallel, hundreds of completion callbacks (`ProxyToMainEvent`) queue up on the main thread.

2. `Tagger.event()` processed each `ProxyToMainEvent` immediately and synchronously. Qt delivers all queued events of the same type sequentially, so the main thread executes hundreds of callbacks back-to-back without ever yielding to process paint or input events.

3. Calling `processEvents()` from inside the event handler doesn't help — it recursively processes more `ProxyToMainEvent`s, making the problem worse.

**Testing methodology:**

- Tested with ~2000 audio files on Linux/SSD
- Added timing instrumentation showing the main thread was blocked for up to 2+ seconds between event loop yields
- Verified that `processEvents()` inside callbacks causes recursion (processes more callbacks, not paint events)
- Tested batch sizes of 20, 25, and 50 — settled on 25 as a good balance between responsiveness and loading speed

## Solution

Two complementary changes:

**1. Batch file load dispatching** (commit 1)

Instead of dispatching all file loads at once, dispatch them in batches of 25 using `QTimer.singleShot(0)` between batches. This naturally limits how many completion callbacks can arrive in a burst.

**2. Throttle callback processing** (commit 2)

Instead of running each `ProxyToMainEvent` immediately in `Tagger.event()`, queue them internally and process 25 at a time. Between batches, `QTimer.singleShot(0)` yields to the event loop, allowing Qt to process paint and input events.

This second change is generic — it benefits all background task callbacks (file loading, AcoustID lookups, album loading, cover art downloads), not just file loading.

**Result:** The UI remains responsive during bulk file loading. Users can scroll, open menus, and interact with the application while files load in the background. There is a minor increase in total loading time due to the yielding, but the perceived performance is dramatically better.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Code was developed with AI assistance (Kiro CLI), with human review, direction, and manual testing.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

**Requesting feedback:** This is a draft for discussion. The batch size (25) may need tuning based on testing on Windows with large collections. The callback throttling approach changes how all background task results are delivered to the main thread, so thorough testing across different workflows is recommended.
