### PR TITLE
Document Metadata access patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,23 @@ metadata['artist'] = 'New Artist'
 file.metadata_updated.emit()
 ```
 
+### Metadata Access
+```python
+# Metadata is always stored internally as a list of strings.
+
+# ❌ Don't use get() + split on MULTI_VALUED_JOINER to get individual values
+values = metadata.get('artist', '').split(MULTI_VALUED_JOINER)
+
+# ✅ Use getall() to get individual values as a list
+values = metadata.getall('artist')  # Returns: ['Artist 1', 'Artist 2']
+
+# ✅ Use get() or [] only for display (returns joined string)
+display = metadata['artist']  # Returns: 'Artist 1; Artist 2'
+
+# ✅ Set multiple values by passing a list (don't join them)
+metadata['artist'] = ['Artist 1', 'Artist 2']
+```
+
 ### Configuration Access
 ```python
 # ✅ Always use config.setting

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -213,14 +213,27 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         return name.rstrip(':')
 
     def getall(self, name: str) -> list[str]:
+        """Return all values for a tag as a list.
+
+        Metadata is always stored internally as a list of strings.
+        Use this method when you need the individual values (e.g., multiple
+        artists or labels). Returns an empty list if the tag is not set.
+        """
         with self._lock.lock_for_read():
             return self._store.get(self.normalize_tag(name), [])
 
     def getraw(self, name: str):
+        """Return the raw stored list for a tag, raising KeyError if missing."""
         with self._lock.lock_for_read():
             return self._store[self.normalize_tag(name)]
 
     def get(self, name: str, default=None) -> str | None:
+        """Return all values joined into a single string.
+
+        Multiple values are joined with `multi_valued_joiner` (default: "; ").
+        Use `getall()` instead when you need the individual values as a list.
+        Returns `default` if the tag is not set.
+        """
         with self._lock.lock_for_read():
             values = self._store.get(self.normalize_tag(name), None)
             if values:
@@ -229,9 +242,20 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
                 return default
 
     def __getitem__(self, name: str) -> str:
+        """Return all values joined as a string, or empty string if unset.
+
+        Equivalent to `self.get(name) or ''`. Use `getall()` when you need
+        individual values as a list.
+        """
         return self.get(name) or ''
 
     def _set(self, name, values):
+        """Store values for a tag.
+
+        Values are always stored as a list internally. A single string is
+        wrapped in a list. To store multiple values, pass a list of strings
+        (do NOT join them with MULTI_VALUED_JOINER).
+        """
         name = self.normalize_tag(name)
         if isinstance(values, str) or not isinstance(values, Iterable):
             values = [values]


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add docstrings to Metadata accessor methods and document the correct access patterns in AGENTS.md.

## Problem

The Metadata class stores values internally as lists, but the accessor methods lacked documentation explaining this. This leads to incorrect usage patterns like `metadata.get(tag).split(MULTI_VALUED_JOINER)` instead of simply using `metadata.getall(tag)`.

## Solution

- Added docstrings to `getall()`, `getraw()`, `get()`, `__getitem__()`, and `_set()` explaining the internal storage model and when to use each method.
- Added a "Metadata Access" section to AGENTS.md with clear do/don't examples.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Docstrings and AGENTS.md section drafted by AI, reviewed and approved by human.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)