### PR TITLE
PICARD-3294: Move 'never replace' cover art filters to file assignment time

### DIFF
--- a/picard/coverart/processing/filters.py
+++ b/picard/coverart/processing/filters.py
@@ -65,49 +65,70 @@ def size_metadata_filter(metadata):
     return _check_threshold_size(metadata['width'], metadata['height'])
 
 
-def bigger_previous_image_filter(data, image_info, album, coverartimage):
+def bigger_previous_image_filter(coverartimage, previous_images):
+    """Return False if previous_images contains a bigger image of the same type.
+
+    Used to prevent replacing embedded images with smaller downloaded ones.
+    """
     config = get_config()
-    if config.setting['dont_replace_with_smaller_cover'] and config.setting['save_images_to_tags']:
-        downloaded_types = coverartimage.normalized_types()
-        previous_images = album.orig_metadata.images.get_types_dict()
-        if downloaded_types in previous_images:
-            previous_image = previous_images[downloaded_types]
-            log.debug_if(
-                DebugOpt.COVERART,
-                "Bigger image filter: new %d x %d vs existing %d x %d",
-                image_info.width,
-                image_info.height,
-                previous_image.width,
-                previous_image.height,
-            )
-            if image_info.width < previous_image.width or image_info.height < previous_image.height:
-                log.debug("Discarding cover art. A bigger image with the same types is already embedded.")
-                return False
+    if not config.setting['dont_replace_with_smaller_cover']:
+        return True
+    downloaded_types = coverartimage.normalized_types()
+    previous_images_dict = previous_images.get_types_dict()
+    if downloaded_types in previous_images_dict:
+        previous_image = previous_images_dict[downloaded_types]
+        log.debug_if(
+            DebugOpt.COVERART,
+            "Bigger image filter: new %d x %d vs existing %d x %d",
+            coverartimage.width,
+            coverartimage.height,
+            previous_image.width,
+            previous_image.height,
+        )
+        if coverartimage.width < previous_image.width or coverartimage.height < previous_image.height:
+            log.debug("Discarding cover art. A bigger image with the same types is already embedded.")
+            return False
     return True
 
 
-def image_types_filter(data, image_info, album, coverartimage):
+def image_types_filter(coverartimage, previous_images):
+    """Return False if previous_images contains an image of a "never replace" type.
+
+    Used to prevent replacing embedded images of specific types (e.g. front, back).
+    """
     config = get_config()
-    if config.setting['dont_replace_cover_of_types'] and config.setting['save_images_to_tags']:
-        downloaded_types = set(coverartimage.normalized_types())
-        never_replace_types = config.setting['dont_replace_included_types']
-        log.debug_if(
-            DebugOpt.COVERART,
-            "Image types filter: downloaded types %r, never replace types %r",
-            downloaded_types,
-            never_replace_types,
-        )
-        previous_image_types = album.orig_metadata.images.get_types_dict()
-        for previous_image_type in previous_image_types:
-            type_already_embedded = downloaded_types.intersection(previous_image_type)
-            should_not_replace = downloaded_types.intersection(never_replace_types)
-            if type_already_embedded and should_not_replace:
-                log.debug("Discarding cover art. An image with the same type is already embedded.")
-                return False
+    if not config.setting['dont_replace_cover_of_types']:
+        return True
+    downloaded_types = set(coverartimage.normalized_types())
+    never_replace_types = config.setting['dont_replace_included_types']
+    log.debug_if(
+        DebugOpt.COVERART,
+        "Image types filter: downloaded types %r, never replace types %r",
+        downloaded_types,
+        never_replace_types,
+    )
+    previous_image_types = previous_images.get_types_dict()
+    for previous_image_type in previous_image_types:
+        type_already_embedded = downloaded_types.intersection(previous_image_type)
+        should_not_replace = downloaded_types.intersection(never_replace_types)
+        if type_already_embedded and should_not_replace:
+            log.debug("Discarding cover art. An image with the same type is already embedded.")
+            return False
+    return True
+
+
+def filter_image_for_file(coverartimage, previous_images):
+    """Run per-file "never replace" filters on a single image.
+
+    Returns True if the image should be assigned to the file,
+    False if it should be skipped.
+    """
+    if not bigger_previous_image_filter(coverartimage, previous_images):
+        return False
+    if not image_types_filter(coverartimage, previous_images):
+        return False
     return True
 
 
 register_cover_art_filter(size_filter)
 register_cover_art_metadata_filter(size_metadata_filter)
-register_cover_art_filter(bigger_previous_image_filter)
-register_cover_art_filter(image_types_filter)

--- a/picard/coverart/setters/__init__.py
+++ b/picard/coverart/setters/__init__.py
@@ -38,7 +38,11 @@
 from enum import IntEnum
 
 from picard import log
+from picard.config import get_config
 from picard.coverart.image import CoverArtImage
+from picard.coverart.processing.filters import filter_image_for_file
+from picard.debug_opts import DebugOpt
+from picard.file import File
 from picard.item import MetadataItem
 
 from .handlers import _set_coverart_dispatch
@@ -82,15 +86,39 @@ class CoverArtSetter:
         """
         return _set_coverart_dispatch(self.source_obj, self)
 
-    def _set_image(self, obj: MetadataItem) -> None:
+    def _set_image(self, obj: MetadataItem) -> bool:
         """
         Set the cover art image on an object based on the current mode.
+
+        For File objects, applies per-file "never replace" filters when
+        save_images_to_tags is enabled.
 
         Parameters
         ----------
         obj
             The object to set the image on
+
+        Returns
+        -------
+        bool
+            True if the image was set, False if filtered out
         """
+        if isinstance(obj, File) and get_config().setting['save_images_to_tags']:
+            if not filter_image_for_file(self.coverartimage, obj.orig_metadata.images):
+                log.debug_if(
+                    DebugOpt.COVERART,
+                    "Per-file filter rejected %r for %r",
+                    self.coverartimage,
+                    obj,
+                )
+                return False
+            log.debug_if(
+                DebugOpt.COVERART,
+                "Per-file filter accepted %r for %r",
+                self.coverartimage,
+                obj,
+            )
+
         if self.mode == CoverArtSetterMode.REPLACE and self.coverartimage.is_front_image():
             obj.metadata.images.strip_front_images()
             log.debug("Replacing images with %r in %r", self.coverartimage, obj)
@@ -99,3 +127,4 @@ class CoverArtSetter:
 
         obj.metadata.images.append(self.coverartimage)
         obj.metadata_images_changed.emit()
+        return True

--- a/picard/coverart/setters/handlers.py
+++ b/picard/coverart/setters/handlers.py
@@ -26,8 +26,6 @@ from functools import singledispatch
 from picard import log
 from picard.album import Album
 from picard.cluster import Cluster
-from picard.config import get_config
-from picard.coverart.processing.filters import filter_image_for_file
 from picard.file import File
 from picard.item import (
     FileListItem,
@@ -88,11 +86,8 @@ def _handle_album(album: Album, setter) -> bool:
             setter._set_image(track)
 
         for file in album.iterfiles():
-            if get_config().setting['save_images_to_tags']:
-                if not filter_image_for_file(setter.coverartimage, file.orig_metadata.images):
-                    continue
-            setter._set_image(file)
-            file.update(signal=False)
+            if setter._set_image(file):
+                file.update(signal=False)
 
     album.update(update_tracks=True)
     return True
@@ -129,8 +124,8 @@ def _handle_filelist(filelist: FileListItem, setter) -> bool:
                 stack.enter_context(parent.suspend_metadata_images_update)
                 parents.add(parent)
 
-            setter._set_image(file)
-            file.update(signal=False)
+            if setter._set_image(file):
+                file.update(signal=False)
 
         for parent in parents:
             if isinstance(parent, Album):
@@ -163,8 +158,8 @@ def _handle_file(file: File, setter) -> bool:
     """
     log.debug("set_coverart_file %r", file)
 
-    setter._set_image(file)
-    file.update()
+    if setter._set_image(file):
+        file.update()
     return True
 
 

--- a/picard/coverart/setters/handlers.py
+++ b/picard/coverart/setters/handlers.py
@@ -26,6 +26,8 @@ from functools import singledispatch
 from picard import log
 from picard.album import Album
 from picard.cluster import Cluster
+from picard.config import get_config
+from picard.coverart.processing.filters import filter_image_for_file
 from picard.file import File
 from picard.item import (
     FileListItem,
@@ -86,6 +88,9 @@ def _handle_album(album: Album, setter) -> bool:
             setter._set_image(track)
 
         for file in album.iterfiles():
+            if get_config().setting['save_images_to_tags']:
+                if not filter_image_for_file(setter.coverartimage, file.orig_metadata.images):
+                    continue
             setter._set_image(file)
             file.update(signal=False)
 

--- a/picard/track.py
+++ b/picard/track.py
@@ -211,7 +211,17 @@ class Track(FileListItem):
         meta_diff = self.metadata.diff(self.scripted_metadata)
         metadata.update(meta_diff)
         # Images are not affected by scripting, always use the tracks current images
-        metadata.images = self.metadata.images
+        # Apply per-file "never replace" filters against the file's original embedded images
+        if config.setting['save_images_to_tags']:
+            # import here to avoid circular imports
+            from picard.coverart.processing.filters import filter_image_for_file
+
+            metadata.images = self.metadata.images.copy()
+            for image in list(metadata.images):
+                if not filter_image_for_file(image, file.orig_metadata.images):
+                    metadata.images.remove(image)
+        else:
+            metadata.images = self.metadata.images
         file.copy_metadata(metadata)
         file.update(signal=False)
         self.update()

--- a/picard/track.py
+++ b/picard/track.py
@@ -63,6 +63,7 @@ from picard.const import (
     SILENCE_TRACK_TITLE,
     VARIOUS_ARTISTS_ID,
 )
+from picard.debug_opts import DebugOpt
 from picard.file import (
     run_file_post_addition_to_track_processors,
     run_file_post_removal_from_track_processors,
@@ -219,6 +220,12 @@ class Track(FileListItem):
             metadata.images = self.metadata.images.copy()
             for image in list(metadata.images):
                 if not filter_image_for_file(image, file.orig_metadata.images):
+                    log.debug_if(
+                        DebugOpt.COVERART,
+                        "update_file_metadata: filtered out %r for %r",
+                        image,
+                        file,
+                    )
                     metadata.images.remove(image)
         else:
             metadata.images = self.metadata.images

--- a/picard/ui/infodialog/dialog.py
+++ b/picard/ui/infodialog/dialog.py
@@ -42,7 +42,9 @@ from picard import log
 from picard.album import Album
 from picard.config import get_config
 from picard.coverart.image import CoverArtImageIOError
+from picard.coverart.processing.filters import filter_image_for_file
 from picard.coverart.utils import translated_types_as_string
+from picard.debug_opts import DebugOpt
 from picard.file import File
 from picard.i18n import gettext as _
 from picard.track import Track
@@ -91,8 +93,13 @@ class InfoDialog(PicardDialog):
         self.has_new_external_images = any(image.external_file_coverart for image in self.new_images)
         has_orig_images = hasattr(obj, 'orig_metadata') and obj.orig_metadata.images
         if has_orig_images:
+            # Apply per-file "never replace" filters to show what will actually be saved
+            if get_config().setting['save_images_to_tags']:
+                self.new_images = [
+                    image for image in self.new_images if filter_image_for_file(image, obj.orig_metadata.images)
+                ]
             artworktable_class = ArtworkTableOriginal
-            has_new_different_images = obj.orig_metadata.images != obj.metadata.images
+            has_new_different_images = sorted(obj.orig_metadata.images) != self.new_images
             if has_new_different_images or self.has_new_external_images:
                 is_track = isinstance(obj, Track)
                 is_linked_file = isinstance(obj, File) and isinstance(obj.parent_item, Track)
@@ -104,6 +111,15 @@ class InfoDialog(PicardDialog):
         self.ui.setupUi(self)
         self.ui.buttonBox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Close)
         self.ui.buttonBox.rejected.connect(self.close)
+
+        log.debug_if(
+            DebugOpt.COVERART,
+            "Cover art info dialog for %r: orig_images=%r, new_images=%r, table=%s",
+            obj,
+            self.orig_images,
+            self.new_images,
+            artworktable_class.__name__,
+        )
 
         # Add the ArtworkTable to the ui
         self.ui.artwork_table = artworktable_class(parent=self)

--- a/test/test_coverart_processing.py
+++ b/test/test_coverart_processing.py
@@ -116,27 +116,33 @@ class ImageFiltersTest(PicardTestCase):
 
     def test_filter_by_previous_image_size(self):
         album = self._create_fake_album()
-        image1, info1 = create_fake_image(500, 500, 'jpg')
-        image2, info2 = create_fake_image(2000, 2000, 'jpg')
+        previous_images = album.orig_metadata.images
         coverartimage = CoverArtImage(types=['front'], support_types=True)
-        self.assertFalse(bigger_previous_image_filter(image1, info1, album, coverartimage))
-        self.assertTrue(bigger_previous_image_filter(image2, info2, album, coverartimage))
+        coverartimage.width = 500
+        coverartimage.height = 500
+        self.assertFalse(bigger_previous_image_filter(coverartimage, previous_images))
+        coverartimage = CoverArtImage(types=['front'], support_types=True)
+        coverartimage.width = 2000
+        coverartimage.height = 2000
+        self.assertTrue(bigger_previous_image_filter(coverartimage, previous_images))
         coverartimage = CoverArtImage(types=['back'], support_types=True)
-        self.assertTrue(bigger_previous_image_filter(image1, info1, album, coverartimage))
+        coverartimage.width = 500
+        coverartimage.height = 500
+        self.assertTrue(bigger_previous_image_filter(coverartimage, previous_images))
 
     def test_filter_by_image_type(self):
         album = self._create_fake_album()
-        image, info = create_fake_image(1000, 1000, 'jpg')
+        previous_images = album.orig_metadata.images
         coverartimage1 = CoverArtImage(types=['front'], support_types=True)
         coverartimage2 = CoverArtImage(types=['back'], support_types=True)
         coverartimage3 = CoverArtImage(types=['front', 'back'], support_types=True)
         coverartimage4 = CoverArtImage(types=['spine'], support_types=True)
         coverartimage5 = CoverArtImage(types=['booklet', 'spine'], support_types=True)
-        self.assertFalse(image_types_filter(image, info, album, coverartimage1))
-        self.assertTrue(image_types_filter(image, info, album, coverartimage2))
-        self.assertFalse(image_types_filter(image, info, album, coverartimage3))
-        self.assertTrue(image_types_filter(image, info, album, coverartimage4))
-        self.assertTrue(image_types_filter(image, info, album, coverartimage5))
+        self.assertFalse(image_types_filter(coverartimage1, previous_images))
+        self.assertTrue(image_types_filter(coverartimage2, previous_images))
+        self.assertFalse(image_types_filter(coverartimage3, previous_images))
+        self.assertTrue(image_types_filter(coverartimage4, previous_images))
+        self.assertTrue(image_types_filter(coverartimage5, previous_images))
 
 
 class ImageProcessorsTest(PicardTestCase):

--- a/test/test_coverart_setter.py
+++ b/test/test_coverart_setter.py
@@ -103,6 +103,8 @@ def mock_file() -> Mock:
     file.metadata = Mock()
     file.metadata.images = Mock()
     file.metadata_images_changed = Mock()
+    file.orig_metadata = Mock()
+    file.orig_metadata.images = []
     file.update = Mock()
     return file
 


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Move the "Never replace cover images with smaller ones" and "Never replace selected cover image types" filters from download time to file assignment time, so they work regardless of whether files are matched before or after cover art is loaded.

## Problem

* JIRA ticket: PICARD-3294

The "never replace" filters ran at download time comparing against `album.orig_metadata.images`. This only worked if files were already matched to the album when cover art was downloaded. If files were matched later, the filters had already passed (since `album.orig_metadata.images` was empty), and images were assigned to files without filtering.

## Solution

- Remove `bigger_previous_image_filter` and `image_types_filter` from the download-time filter chain
- Refactor both filters to accept `(coverartimage, previous_images)` — comparing against a specific file's embedded images rather than the album aggregate
- Apply per-file filtering in `CoverArtSetter._set_image` so it covers all code paths (`_handle_album`, `_handle_filelist`, `_handle_file`)
- Apply per-file filtering in `track.update_file_metadata()` for files matched after cover art is loaded
- Apply the same filter in the cover art info dialog so "New Embedded" accurately shows what will be saved
- Filters only apply when `save_images_to_tags` is enabled (nothing to protect if not embedding)
- Add `DebugOpt.COVERART` logging for filter accept/reject decisions


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI investigated the codebase, proposed the fix approach, and implemented the changes. Human reviewed, tested manually with real files (Black Sabbath - The Dio Years), and validated the debug log output.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
