### PR TITLE
ci: Remove pip cache from package-pypi workflow

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: '3.14'
-        cache: 'pip'
     - name: Install dependencies (Linux)
       if: runner.os == 'linux'
       run: |
@@ -93,7 +92,6 @@ jobs:
       id: setup
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
     - name: Install gettext (Windows)
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Remove `cache: 'pip'` from the package-pypi workflow to reduce GitHub Actions cache usage.

## Problem

The repository's Actions cache was at 99.8% capacity (10,220 / 10,240 MB), preventing CI from running. The main culprit was pip caches from the `package-pypi` workflow: ~400 MB per OS/Python combination × 10 entries = ~4 GB.

## Solution

Remove `cache: 'pip'` from both jobs in `package-pypi.yml`. The pip cache saves ~30 seconds per job but costs 400+ MB of cache space per entry. The tradeoff is not worth it given the 10 GB limit shared across all workflows.

Also manually deleted existing stale pip caches, bringing usage from 10.2 GB down to 2 GB.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)