### PR TITLE
Plugin UI quality-of-life improvements

### DIFF
--- a/picard/options.py
+++ b/picard/options.py
@@ -158,6 +158,7 @@ TextOption('persist', 'session_autosave_path', '')
 ListOption('persist', 'tutorial_steps_shown', [])
 BoolOption('persist', 'tutorial_disabled', False)
 BoolOption('persist', 'setup_wizard_completed', False)
+BoolOption('persist', 'show_plugin_install_warning', True)
 
 # picard/ui/metadatabox.py
 #

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -23,6 +23,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard.config import get_config
 from picard.i18n import gettext as _
 
 from picard.ui import PicardDialog
@@ -57,6 +58,38 @@ class InstallConfirmDialog(PicardDialog):
         """Setup the dialog UI."""
         layout = QtWidgets.QVBoxLayout(self)
 
+        # General security warning (with "don't show again")
+        config = get_config()
+        if config.persist['show_plugin_install_warning']:
+            warning_content = QtWidgets.QHBoxLayout()
+
+            icon_label = QtWidgets.QLabel()
+            icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning)
+            icon_label.setPixmap(icon.pixmap(24, 24))
+            icon_label.setFixedSize(28, 28)
+            icon_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
+            warning_content.addWidget(icon_label)
+
+            text_layout = QtWidgets.QVBoxLayout()
+            general_warning = QtWidgets.QLabel(
+                _("Plugins run with full access to your system. Only install plugins from sources you trust.")
+            )
+            general_warning.setWordWrap(True)
+            font = general_warning.font()
+            font.setPointSizeF(font.pointSizeF() * 1.1)
+            font.setBold(True)
+            general_warning.setFont(font)
+            text_layout.addWidget(general_warning)
+
+            self._dont_show_checkbox = QtWidgets.QCheckBox(_("Don't show this warning again"))
+            text_layout.addWidget(self._dont_show_checkbox)
+            warning_content.addLayout(text_layout)
+
+            layout.addLayout(warning_content)
+            layout.addWidget(self._create_separator())
+        else:
+            self._dont_show_checkbox = None
+
         # Plugin name and URL
         info_label = QtWidgets.QLabel(_("Install plugin: {name}").format(name=self.plugin_name))
         info_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
@@ -67,9 +100,8 @@ class InstallConfirmDialog(PicardDialog):
         url_label.setWordWrap(True)
         layout.addWidget(url_label)
 
-        # Warning area
+        # Trust/blacklist warning area (shown conditionally)
         self.warning_label = QtWidgets.QLabel()
-        self.warning_label.setStyleSheet("color: orange; font-weight: bold;")
         self.warning_label.setWordWrap(True)
         self.warning_label.hide()
         layout.addWidget(self.warning_label)
@@ -92,6 +124,12 @@ class InstallConfirmDialog(PicardDialog):
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
+    def _create_separator(self):
+        separator = QtWidgets.QFrame()
+        separator.setFrameShape(QtWidgets.QFrame.Shape.HLine)
+        separator.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
+        return separator
+
     def check_trust_and_blacklist(self):
         """Check trust level and blacklist status."""
         try:
@@ -100,8 +138,9 @@ class InstallConfirmDialog(PicardDialog):
             # Check blacklist first
             is_blacklisted, reason = registry.is_blacklisted(self.url, self.plugin_uuid)
             if is_blacklisted:
-                self.warning_label.setText(_("ERROR: This plugin is blacklisted: {reason}").format(reason=reason))
-                self.warning_label.setStyleSheet("color: red; font-weight: bold;")
+                self.warning_label.setText(
+                    "<b>" + _("This plugin is blacklisted: {reason}").format(reason=reason) + "</b>"
+                )
                 self.warning_label.show()
                 self.install_button.setEnabled(False)
                 return
@@ -111,17 +150,14 @@ class InstallConfirmDialog(PicardDialog):
             if trust_level in ("community", "unregistered"):
                 if trust_level == "community":
                     warning_text = _(
-                        "Warning: This is a community plugin. "
-                        "Community plugins are not reviewed by the Picard team. "
-                        "Only install plugins from sources you trust."
+                        "This is a community plugin. Community plugins are not reviewed by the Picard team."
                     )
                 else:  # unregistered
                     warning_text = _(
-                        "Warning: This plugin is not in the official registry. "
-                        "Installing unregistered plugins may pose security risks. "
-                        "Only install plugins from sources you trust."
+                        "This plugin is not in the official registry. "
+                        "Installing unregistered plugins may pose security risks."
                     )
-                self.warning_label.setText(warning_text)
+                self.warning_label.setText("<b>" + warning_text + "</b>")
                 self.warning_label.show()
         except Exception:
             pass
@@ -144,5 +180,8 @@ class InstallConfirmDialog(PicardDialog):
 
     def _confirm_install(self):
         """Handle install button click."""
+        if self._dont_show_checkbox and self._dont_show_checkbox.isChecked():
+            config = get_config()
+            config.persist['show_plugin_install_warning'] = False
         self.selected_ref = self.ref_selector.get_selected_ref()
         self.accept()

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -91,12 +91,19 @@ class InstallConfirmDialog(PicardDialog):
             self._dont_show_checkbox = None
 
         # Plugin name and URL
-        info_label = QtWidgets.QLabel(_("Install plugin: {name}").format(name=self.plugin_name))
+        info_label = QtWidgets.QLabel(_("Install plugin: {name}").format(name=f"<b>{self.plugin_name}</b>"))
         info_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
         layout.addWidget(info_label)
 
-        url_label = QtWidgets.QLabel(_("Repository: {url}").format(url=self.url))
-        url_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
+        if self.url.startswith(('http://', 'https://')):
+            url_display = f'<a href="{self.url}">{self.url}</a>'
+        else:
+            url_display = self.url
+        url_label = QtWidgets.QLabel(_("Repository: {url}").format(url=url_display))
+        url_label.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse | QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse
+        )
+        url_label.setOpenExternalLinks(True)
         url_label.setWordWrap(True)
         layout.addWidget(url_label)
 

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -58,6 +58,7 @@ class Plugins3OptionsPage(OptionsPage):
 
         # Cache plugin manager for performance
         self.plugin_manager = self.tagger.get_plugin_manager()
+        self._last_plugin_count = 0
 
         self.setup_ui()
         if self.plugin_manager:
@@ -160,27 +161,28 @@ class Plugins3OptionsPage(OptionsPage):
         layout.addWidget(self.splitter, 1)  # Give most space to splitter
 
         # Status mini-log (shows last 3 messages)
-        self.status_log = QtWidgets.QTextEdit()
-        self.status_log.setMaximumHeight(60)  # About 3 lines
+        self.status_log = QtWidgets.QPlainTextEdit()
         self.status_log.setReadOnly(True)
         self.status_log.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        self.status_messages = []  # Keep track of last 3 messages
-        layout.addWidget(self.status_log, 0)  # Minimal space for status
+        # Show ~3 lines based on actual font metrics
+        line_height = self.status_log.fontMetrics().lineSpacing()
+        margins = self.status_log.contentsMargins()
+        self.status_log.setFixedHeight(line_height * 3 + margins.top() + margins.bottom() + 8)
+        self.status_messages = []
+        layout.addWidget(self.status_log, 0)
 
     def _show_status(self, message, clear_after_ms=None):
-        """Add message to status log (keeps last 3 messages)."""
+        """Add message to status log."""
         timestamp = datetime.now().strftime("%H:%M:%S")
         formatted_message = f"[{timestamp}] {message}"
 
-        # Add to messages list and keep only last 3
         self.status_messages.append(formatted_message)
-        if len(self.status_messages) > 3:
-            self.status_messages.pop(0)
 
         # Update display
         self.status_log.setPlainText("\n".join(self.status_messages))
         # Scroll to bottom to show latest message
-        self.status_log.verticalScrollBar().setValue(self.status_log.verticalScrollBar().maximum())
+        sb = self.status_log.verticalScrollBar()
+        sb.setValue(sb.maximum())
         QtWidgets.QApplication.processEvents()
 
     def load(self):
@@ -188,8 +190,6 @@ class Plugins3OptionsPage(OptionsPage):
             return
 
         # Load plugins from plugin manager.
-        self._show_status(_("Loading plugins…"))
-        # Load plugins immediately when page is loaded
         try:
             # Validate persisted updates against current plugin state
             config = get_config()
@@ -208,13 +208,15 @@ class Plugins3OptionsPage(OptionsPage):
             self.plugin_list.set_updates(valid_updates)
             self._filter_plugins()
             plugin_count = len(self.plugin_manager.plugins)
-            self._show_status(
-                ngettext(
-                    "Loaded {plugin_count:,d} plugin",
-                    "Loaded {plugin_count:,d} plugins",
-                    plugin_count,
-                ).format(plugin_count=plugin_count)
-            )
+            if plugin_count != self._last_plugin_count:
+                self._last_plugin_count = plugin_count
+                self._show_status(
+                    ngettext(
+                        "{plugin_count:,d} plugin installed",
+                        "{plugin_count:,d} plugins installed",
+                        plugin_count,
+                    ).format(plugin_count=plugin_count)
+                )
             self._show_enabled_state()
             self._update_details_button_text()  # Update button state based on plugin availability
         except Exception as e:

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -87,15 +87,18 @@ class Plugins3OptionsPage(OptionsPage):
         # Check whether plugins are available
         available, unavailable_reason = self.tagger.get_plugins_available()
         if not available:
-            no_plugins_box = QtWidgets.QFrame(self)
-            no_plugins_box.setStyleSheet("QFrame { background-color: #ffc107; color: black }")
-            no_plugins_box.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-            no_plugins_box_layout = QtWidgets.QVBoxLayout(no_plugins_box)
+            no_plugins_box = QtWidgets.QHBoxLayout()
+            icon_label = QtWidgets.QLabel()
+            icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning)
+            icon_label.setPixmap(icon.pixmap(24, 24))
+            icon_label.setFixedSize(28, 28)
+            no_plugins_box.addWidget(icon_label)
             no_plugins_label = QtWidgets.QLabel(
-                _("Plugins unavailable: {reason}.").format(reason=unavailable_reason), parent=no_plugins_box
+                "<b>" + _("Plugins unavailable: {reason}.").format(reason=unavailable_reason) + "</b>"
             )
-            no_plugins_box_layout.addWidget(no_plugins_label)
-            layout.addWidget(no_plugins_box)
+            no_plugins_label.setWordWrap(True)
+            no_plugins_box.addWidget(no_plugins_label)
+            layout.addLayout(no_plugins_box)
             layout.addStretch()
             return
 

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -182,7 +182,7 @@ class Plugins3OptionsPage(OptionsPage):
         self.status_log.setPlainText("\n".join(self.status_messages))
         # Scroll to bottom to show latest message
         sb = self.status_log.verticalScrollBar()
-        sb.setValue(sb.maximum())
+        sb.setValue(sb.maximum() - 1)
         QtWidgets.QApplication.processEvents()
 
     def load(self):

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -39,6 +39,7 @@ from picard.metadata import (
 )
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 from picard.plugin3.plugin import PluginState
+from picard.plugin3.ref_item import RefItem
 from picard.util import temporary_disconnect
 
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
@@ -296,8 +297,31 @@ class PluginListWidget(QtWidgets.QWidget):
             return False
 
     def _format_update_version(self, update):
-        """Format update version info for display (matching git info format)."""
-        return update.new_ref_item.format() or _("Available")
+        """Format update version info for display.
+
+        Handles both UpdateCheck (from update checking, has new_ref/new_commit)
+        and UpdateResult (from actual updates, has new_ref_item).
+        """
+        # UpdateResult has new_ref_item
+        new_ref_item = getattr(update, 'new_ref_item', None)
+        if new_ref_item:
+            return new_ref_item.format() or _("Available")
+
+        # UpdateCheck has new_ref and new_commit
+        ref = getattr(update, 'new_ref', None) or getattr(update, 'old_ref', 'main')
+        commit = getattr(update, 'new_commit', None)
+
+        if ref:
+            if ref.startswith('v') or '.' in ref:
+                ref_type = RefItem.Type.TAG
+            else:
+                ref_type = RefItem.Type.BRANCH
+        else:
+            ref = commit
+            ref_type = RefItem.Type.COMMIT
+
+        ref_item = RefItem(shortname=ref, ref_type=ref_type, commit=commit)
+        return ref_item.format() or _("Available")
 
     def _get_new_version(self, plugin):
         """Get the new version available for update."""

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -550,8 +550,6 @@ class PluginListWidget(QtWidgets.QWidget):
 
         menu.addSeparator()
 
-        menu.addSeparator()
-
         # Information action
         info_action = menu.addAction(_("Information"))
         info_action.triggered.connect(lambda: self._show_plugin_info(plugin))

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -158,6 +158,7 @@ class PluginListWidget(QtWidgets.QWidget):
         self.tree_widget.itemSelectionChanged.connect(self._on_selection_changed)
         self.tree_widget.itemClicked.connect(self._on_item_clicked)
         self.tree_widget.customContextMenuRequested.connect(self._show_context_menu)
+        self.tree_widget.installEventFilter(self)
 
         # Cache tagger instance for performance
         self.tagger = tagger_instance()
@@ -486,6 +487,16 @@ class PluginListWidget(QtWidgets.QWidget):
 
             # Update panel when update checkboxes change
             self._update_panel_state()
+
+    def eventFilter(self, obj, event):
+        """Handle Space key to toggle plugin enabled state."""
+        if obj is self.tree_widget and event.type() == QtCore.QEvent.Type.KeyPress:
+            if event.key() == QtCore.Qt.Key.Key_Space:
+                item = self.tree_widget.currentItem()
+                if item:
+                    self._on_item_clicked(item, COLUMN_ENABLED)
+                    return True
+        return super().eventFilter(obj, event)
 
     def _refresh_plugin_list(self):
         """Refresh the plugin list to reflect current state."""

--- a/picard/ui/widgets/refselector.py
+++ b/picard/ui/widgets/refselector.py
@@ -45,7 +45,9 @@ class RefSelectorWidget(QtWidgets.QWidget):
         if self.include_default:
             default_widget = QtWidgets.QWidget()
             default_layout = QtWidgets.QVBoxLayout(default_widget)
-            self.default_label = QtWidgets.QLabel(_("Use the default ref (usually main/master branch)"))
+            self.default_label = QtWidgets.QLabel()
+            self.default_label.setWordWrap(True)
+            self._set_default_label_text(None, None)
             default_layout.addWidget(self.default_label)
             default_layout.addStretch()
             self.tab_widget.addTab(default_widget, _("Default"))
@@ -106,12 +108,19 @@ class RefSelectorWidget(QtWidgets.QWidget):
             list_item.setData(QtWidgets.QListWidgetItem.ItemType.UserType, ref_item)
             self.branches_list.addItem(list_item)
 
+    def _set_default_label_text(self, ref_name, description):
+        """Update the default tab label text."""
+        if ref_name:
+            self.default_label.setText(
+                _("Recommended: <b>{ref}</b> ({description})").format(ref=ref_name, description=description)
+            )
+        else:
+            self.default_label.setText(_("Use the default ref (usually main/master branch)"))
+
     def set_default_ref_info(self, default_ref_name, description):
         """Update the default tab with specific ref information."""
         if self.include_default and hasattr(self, 'default_label') and default_ref_name:
-            self.default_label.setText(
-                _("Use default ref: {ref} ({description})").format(ref=default_ref_name, description=description)
-            )
+            self._set_default_label_text(default_ref_name, description)
 
     def get_selected_ref(self):
         """Get the currently selected ref."""


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

A collection of small plugin UI improvements: security warning on install, better visual feedback, bug fixes, and keyboard accessibility.

## Problem

Several small UX issues in the plugin management UI:
- No general security warning when installing plugins
- Hardcoded colors breaking dark themes
- Double separator in context menu
- No keyboard shortcut for enable/disable
- "New Version" column showing "Available" instead of actual version info
- Status log limited to 3 messages with fixed pixel height

## Solution

1. **Security warning** on plugin install dialog with "don't show again" checkbox
2. **Bold plugin name** and clickable repository URL in install confirm dialog
3. **Default ref** shown more prominently in ref selector (bold "Recommended:" prefix)
4. **Fix double separator** in plugin list context menu
5. **Replace hardcoded color** in "plugins unavailable" warning with theme-aware icon + bold text
6. **Space key shortcut** to toggle plugin enabled/disabled state
7. **Fix update version display** for UpdateCheck objects (regression from c9a616f0f)
8. **Improve status log**: font-scaled height, full history with scroll, show plugin count only on change

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI proposed changes; human reviewed, tested interactively, and directed design decisions.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)