### PR TITLE
Improve plugin version display and tooltips

### DIFF
--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -740,30 +740,6 @@ class PluginManager(QObject):
             pass
         return None
 
-    def get_plugin_version_display(self, plugin):
-        """Get version display text for plugin."""
-        version_text = ""
-
-        try:
-            # Try to get version from git metadata first (prioritize git ref)
-            if plugin.uuid:
-                metadata = self._metadata.get_plugin_metadata(plugin.uuid)
-                if metadata:
-                    git_info = self.get_plugin_git_info(metadata)
-                    if git_info:
-                        version_text = git_info
-        except Exception:
-            pass
-
-        # Fallback to manifest version if no git metadata
-        if not version_text:
-            if plugin.manifest:
-                version = plugin.manifest._data.get('version')
-                if version:
-                    version_text = version
-
-        return version_text or "Unknown"
-
     def get_plugin_git_info(self, metadata):
         """Format git information for display."""
         if not metadata:

--- a/picard/plugin3/manager/update.py
+++ b/picard/plugin3/manager/update.py
@@ -65,6 +65,7 @@ class UpdateCheck(NamedTuple):
     commit_date: int
     old_ref: str
     new_ref: str
+    new_ref_type: str | None = None
 
 
 class UpdateAllResult(NamedTuple):
@@ -471,7 +472,15 @@ class PluginUpdater:
         else:
             display_old_ref = old_ref
 
-        display_new_ref = new_ref if new_ref else (short_commit_id(latest_commit) if is_detached else None)
+        if new_ref:
+            display_new_ref = new_ref
+            new_ref_type = 'tag'
+        elif is_detached:
+            display_new_ref = short_commit_id(latest_commit)
+            new_ref_type = 'commit'
+        else:
+            display_new_ref = None
+            new_ref_type = 'branch'
 
         return UpdateCheck(
             plugin_id=plugin.plugin_id,
@@ -480,6 +489,7 @@ class PluginUpdater:
             commit_date=latest_commit_date,
             old_ref=display_old_ref,
             new_ref=display_new_ref,
+            new_ref_type=new_ref_type,
         )
 
     def _check_single_plugin_update(self, plugin, metadata, skip_fetch):

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -673,6 +673,18 @@ class Plugin:
         except Exception:
             return None
 
+    def get_current_commit_date(self):
+        """Get the commit date of the current HEAD as a unix timestamp."""
+        if not self.local_path or not (self.local_path / '.git').exists():
+            return None
+        try:
+            backend = git_backend()
+            with backend.create_repository(self.local_path) as repo:
+                commit_id = repo.get_head_target()
+                return repo.get_commit_date(commit_id)
+        except Exception:
+            return None
+
     def load_module(self):
         """Load corresponding module from source path"""
         if self.state == PluginState.LOADED:

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -663,17 +663,12 @@ class Plugin:
 
     def get_current_commit_id(self, short=False):
         """Get the current commit ID of the plugin if it's a git repository."""
-        if not self.local_path:
+        if not self.local_path or not (self.local_path / '.git').exists():
             return None
-        git_dir = self.local_path / '.git'
-        if not git_dir.exists():
-            return None
-
         try:
             backend = git_backend()
-            repo = backend.create_repository(self.local_path)
-            commit_id = repo.get_head_target()
-            repo.free()
+            with backend.create_repository(self.local_path) as repo:
+                commit_id = repo.get_head_target()
             return short_commit_id(commit_id) if short else commit_id
         except Exception:
             return None

--- a/picard/ui/formattedtextdelegate.py
+++ b/picard/ui/formattedtextdelegate.py
@@ -33,6 +33,7 @@ from PyQt6.QtGui import (
     QTextOption,
 )
 from PyQt6.QtWidgets import (
+    QApplication,
     QStyle,
     QStyledItemDelegate,
     QStyleOptionViewItem,
@@ -64,20 +65,45 @@ class FormattedTextDelegate(QStyledItemDelegate):
             fill_brush = option.backgroundBrush
             text_color_role = QPalette.ColorRole.Text
 
+        painter.save()
+        painter.setClipRect(option.rect)
+        painter.fillRect(option.rect, fill_brush)
+
+        # Draw checkbox if the item has one
+        text_rect = option.rect
+        if option.features & QStyleOptionViewItem.ViewItemFeature.HasCheckIndicator:
+            style = option.widget.style() if option.widget else QApplication.style()
+            check_rect = style.subElementRect(QStyle.SubElement.SE_ItemViewItemCheckIndicator, option, option.widget)
+            if option.checkState == Qt.CheckState.Checked:
+                state = QStyle.StateFlag.State_On
+            elif option.checkState == Qt.CheckState.PartiallyChecked:
+                state = QStyle.StateFlag.State_NoChange
+            else:
+                state = QStyle.StateFlag.State_Off
+            opt = QStyleOptionViewItem(option)
+            opt.rect = check_rect
+            opt.state = opt.state | state
+            style.drawPrimitive(QStyle.PrimitiveElement.PE_IndicatorItemViewItemCheck, opt, painter, option.widget)
+            # Offset text rect past the checkbox
+            text_rect = option.rect.adjusted(check_rect.width() + 4, 0, 0, 0)
+
         # Get the formatted text from the model
         text = index.data(Qt.ItemDataRole.DisplayRole)
         if not text:
+            painter.restore()
             return
 
         # Create a QTextDocument to render the formatted text
         doc = self._create_doc(text, option)
+        doc.setTextWidth(text_rect.width())
         layout = doc.documentLayout()
         if not layout:
+            painter.restore()
             return
 
         # A layout context for rendering the text
         context = QAbstractTextDocumentLayout.PaintContext()
-        context.clip = QRectF(0, 0, float(option.rect.width()), float(option.rect.height()))
+        context.clip = QRectF(0, 0, float(text_rect.width()), float(text_rect.height()))
 
         # Set the text color based on the current palette
         text_color = option.palette.color(text_color_role)
@@ -85,18 +111,16 @@ class FormattedTextDelegate(QStyledItemDelegate):
 
         # Calculate top margin to center the text vertically
         text_size = layout.documentSize()
-        top_margin = option.rect.top() + (option.rect.height() - text_size.height()) / 2
+        top_margin = text_rect.top() + (text_rect.height() - text_size.height()) / 2
 
         # Draw the text
-        painter.save()
-        painter.setClipRect(option.rect)
-        painter.fillRect(option.rect, fill_brush)
-        painter.translate(option.rect.left(), top_margin)
+        painter.translate(text_rect.left(), top_margin)
         layout.draw(painter, context)
         painter.restore()
 
     def sizeHint(self, option, index):
         # Provide a size hint based on the QTextDocument's size
+        self.initStyleOption(option, index)
         text = index.data(Qt.ItemDataRole.DisplayRole)
         if not text:
             return super().sizeHint(option, index)
@@ -104,7 +128,13 @@ class FormattedTextDelegate(QStyledItemDelegate):
         # Create a QTextDocument to render the formatted text
         doc = self._create_doc(text, option)
 
-        return QSize(math.ceil(doc.idealWidth()), math.ceil(doc.size().height()))
+        width = math.ceil(doc.idealWidth())
+        if option.features & QStyleOptionViewItem.ViewItemFeature.HasCheckIndicator:
+            style = option.widget.style() if option.widget else QApplication.style()
+            check_rect = style.subElementRect(QStyle.SubElement.SE_ItemViewItemCheckIndicator, option, option.widget)
+            width += check_rect.width() + 4
+
+        return QSize(width, math.ceil(doc.size().height()))
 
     def _create_doc(self, text, option) -> QTextDocument:
         doc = QTextDocument()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -350,12 +350,13 @@ class Plugins3OptionsPage(OptionsPage):
     def _on_plugin_selected(self, plugin):
         """Handle plugin selection."""
         # Get cached update status to avoid network call
-        has_update = None
+        update = None
         if plugin:
             config = get_config()
-            has_update = plugin.plugin_id in config.persist['plugins3_updates']
+            updates = config.persist['plugins3_updates']
+            update = updates.get(plugin.plugin_id) if updates else None
 
-        self.plugin_details.show_plugin(plugin, has_update)
+        self.plugin_details.show_plugin(plugin, update)
         # Update button text since details are now shown
         self._update_details_button_text()
 

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -29,14 +29,18 @@ from PyQt6 import (
 from picard.config import get_config
 from picard.i18n import gettext as _
 from picard.plugin3.asyncops.manager import AsyncPluginManager
+from picard.plugin3.ref_item import RefItem
 
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.util import font_scaled_size
+from picard.ui.widgets.pluginformat import (
+    commit_date_display,
+    html_ref_format,
+)
 from picard.ui.widgets.pluginlistwidget import (
     PluginListWidget,
     UninstallPluginDialog,
 )
-from picard.ui.widgets.pluginformat import commit_date_display
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):
@@ -83,6 +87,7 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         self.details_layout = QtWidgets.QFormLayout(details_widget)
 
         self.git_ref_label = QtWidgets.QLabel()
+        self.git_ref_label.setTextFormat(QtCore.Qt.TextFormat.RichText)
         self.git_ref_label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
         self.details_layout.addRow(_("Version:"), self.git_ref_label)
 
@@ -247,19 +252,17 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         """Get plugin remote URL from metadata."""
         return self.plugin_manager.get_plugin_remote_url(plugin)
 
-    def _format_git_info(self, metadata):
-        """Format git information for display."""
-        return self.plugin_manager.get_plugin_git_info(metadata)
-
     def _get_git_ref_display(self, plugin):
-        """Get git ref display text."""
+        """Get git ref display text (HTML)."""
         try:
             if plugin.uuid:
                 metadata = self.plugin_manager._get_plugin_metadata(plugin.uuid)
                 if metadata:
-                    git_info = self._format_git_info(metadata)
-                    if git_info:
-                        return git_info
+                    git_ref = metadata.get_git_ref()
+                    ref_item = RefItem.from_git_ref(git_ref)
+                    result = html_ref_format(ref_item)
+                    if result:
+                        return result
         except Exception:
             pass
         return _("N/A")

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -32,7 +32,11 @@ from picard.plugin3.asyncops.manager import AsyncPluginManager
 
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.util import font_scaled_size
-from picard.ui.widgets.pluginlistwidget import UninstallPluginDialog
+from picard.ui.widgets.pluginlistwidget import (
+    PluginListWidget,
+    UninstallPluginDialog,
+)
+from picard.ui.widgets.pluginformat import commit_date_display
 
 
 class PluginDetailsWidget(QtWidgets.QWidget):
@@ -125,12 +129,12 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         # Initially hide everything
         self.setVisible(False)
 
-    def show_plugin(self, plugin, has_update=None):
+    def show_plugin(self, plugin, update=None):
         """Show details for the given plugin.
 
         Args:
             plugin: Plugin to show
-            has_update: Optional cached update status to avoid network call
+            update: Optional UpdateCheck object with update info
         """
         self.current_plugin = plugin
 
@@ -155,6 +159,13 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         if git_ref:
             self.git_ref_label.setText(git_ref)
 
+        # Set version tooltip with commit date
+        commit_date = plugin.get_current_commit_date()
+        if commit_date:
+            self.git_ref_label.setToolTip(commit_date_display(commit_date))
+        else:
+            self.git_ref_label.setToolTip("")
+
         authors = self._get_authors_display(plugin)
         self.details_layout.setRowVisible(self.authors_label, bool(authors))
         if authors:
@@ -170,12 +181,13 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         if git_url:
             self.git_url_label.setText(git_url)
 
-        # Check if update is available - use cached value if provided, otherwise disable button
-        if has_update is not None:
-            self.update_button.setEnabled(has_update)
+        # Update button state and tooltip
+        if update:
+            self.update_button.setEnabled(True)
+            self._set_update_button_tooltip(update)
         else:
-            # Don't check for updates during normal display to avoid network calls
             self.update_button.setEnabled(False)
+            self.update_button.setToolTip("")
 
         # Always enable description button since PluginInfoDialog shows comprehensive info
         self.description_button.setEnabled(True)
@@ -260,6 +272,14 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         elif remote_url:
             return remote_url
         return ""
+
+    def _set_update_button_tooltip(self, update):
+        """Set tooltip on update button with target version and date."""
+        version = PluginListWidget._format_update_version(update)
+        parts = [_("Update to {version}").format(version=version)]
+        if update.commit_date:
+            parts.append(commit_date_display(update.commit_date))
+        self.update_button.setToolTip('\n'.join(parts))
 
     def _update_plugin(self):
         """Update the current plugin."""
@@ -352,7 +372,7 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             if hasattr(self.parent(), 'plugin_state_changed'):
                 self.parent().plugin_state_changed.emit(plugin, "updated")
             # Refresh the display - plugin should no longer have update available
-            self.show_plugin(plugin, False)
+            self.show_plugin(plugin)
         else:
             self.update_button.setEnabled(True)
             error_msg = str(result.error) if result.error else _("Unknown error")

--- a/picard/ui/widgets/pluginformat.py
+++ b/picard/ui/widgets/pluginformat.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import time
+
+from picard.const.defaults import DEFAULT_TIME_FORMAT
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
+
+
+_COMMIT_DATE_LABEL = N_("Commit date: {date}")
+
+
+def format_commit_date(timestamp):
+    """Format a unix timestamp for display."""
+    return time.strftime(DEFAULT_TIME_FORMAT, time.localtime(timestamp))
+
+
+def commit_date_display(timestamp):
+    """Format a commit date timestamp as a translatable display string."""
+    return _(_COMMIT_DATE_LABEL).format(date=format_commit_date(timestamp))

--- a/picard/ui/widgets/pluginformat.py
+++ b/picard/ui/widgets/pluginformat.py
@@ -18,6 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+import html
 import time
 
 from picard.const.defaults import DEFAULT_TIME_FORMAT
@@ -25,16 +26,28 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
+from picard.plugin3.ref_item import RefItem
 
 
+_CURRENT_LABEL = N_("current")
 _COMMIT_DATE_LABEL = N_("Commit date: {date}")
 
 
-def format_commit_date(timestamp):
+def format_commit_date(timestamp: int) -> str:
     """Format a unix timestamp for display."""
     return time.strftime(DEFAULT_TIME_FORMAT, time.localtime(timestamp))
 
 
-def commit_date_display(timestamp):
+def commit_date_display(timestamp: int) -> str:
     """Format a commit date timestamp as a translatable display string."""
     return _(_COMMIT_DATE_LABEL).format(date=format_commit_date(timestamp))
+
+
+def html_ref_format(ref_item: RefItem, **kwargs) -> str:
+    """Format a RefItem as HTML with bold ref name and italic commit."""
+    return ref_item.format(
+        ref_formatter=lambda t: f'<b>{html.escape(t)}</b>',
+        commit_formatter=lambda t: f'<i>{html.escape(t)}</i>',
+        current_formatter=lambda t: f'{t} <i>({html.escape(_(_CURRENT_LABEL))})</i>',
+        **kwargs,
+    )

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -215,6 +215,7 @@ class PluginListWidget(QtWidgets.QWidget):
 
             # Column 2: Version (without update suffix)
             item.setText(COLUMN_VERSION, self._get_clean_version_display(plugin))
+            self._set_version_tooltip(item, plugin)
 
             # Column 3: Update checkbox and new version
             if self._setup_update_column(item, plugin):
@@ -254,6 +255,12 @@ class PluginListWidget(QtWidgets.QWidget):
     def _get_clean_version_display(self, plugin):
         """Get display text for plugin version without update suffix."""
         return self.plugin_manager.get_plugin_version_display(plugin)
+
+    def _set_version_tooltip(self, item, plugin):
+        """Set tooltip on Version column with commit date if available."""
+        commit_date = plugin.get_current_commit_date()
+        if commit_date:
+            item.setToolTip(COLUMN_VERSION, commit_date_display(commit_date))
 
     def _set_update_checkbox_tooltip(self, item, is_checked, plugin):
         """Set tooltip for update checkbox based on its state."""

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -297,30 +297,19 @@ class PluginListWidget(QtWidgets.QWidget):
             return False
 
     def _format_update_version(self, update):
-        """Format update version info for display.
-
-        Handles both UpdateCheck (from update checking, has new_ref/new_commit)
-        and UpdateResult (from actual updates, has new_ref_item).
-        """
-        # UpdateResult has new_ref_item
-        new_ref_item = getattr(update, 'new_ref_item', None)
-        if new_ref_item:
-            return new_ref_item.format() or _("Available")
-
-        # UpdateCheck has new_ref and new_commit
-        ref = getattr(update, 'new_ref', None) or getattr(update, 'old_ref', 'main')
-        commit = getattr(update, 'new_commit', None)
-
-        if ref:
-            if ref.startswith('v') or '.' in ref:
-                ref_type = RefItem.Type.TAG
-            else:
-                ref_type = RefItem.Type.BRANCH
-        else:
-            ref = commit
+        """Format update version info for display."""
+        if update.new_ref_type == 'tag':
+            ref_type = RefItem.Type.TAG
+        elif update.new_ref_type == 'commit':
             ref_type = RefItem.Type.COMMIT
+        else:
+            ref_type = RefItem.Type.BRANCH
 
-        ref_item = RefItem(shortname=ref, ref_type=ref_type, commit=commit)
+        ref = update.new_ref or update.new_commit
+        if not ref:
+            return _("Available")
+
+        ref_item = RefItem(shortname=ref, ref_type=ref_type, commit=update.new_commit)
         return ref_item.format() or _("Available")
 
     def _get_new_version(self, plugin):

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -46,6 +46,7 @@ from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.util import font_scaled_size
+from picard.ui.widgets.pluginformat import commit_date_display
 from picard.ui.widgets.refselector import RefSelectorWidget
 
 
@@ -254,12 +255,19 @@ class PluginListWidget(QtWidgets.QWidget):
         """Get display text for plugin version without update suffix."""
         return self.plugin_manager.get_plugin_version_display(plugin)
 
-    def _set_update_checkbox_tooltip(self, item, is_checked):
+    def _set_update_checkbox_tooltip(self, item, is_checked, plugin):
         """Set tooltip for update checkbox based on its state."""
+        parts = []
         if is_checked:
-            item.setToolTip(COLUMN_NEW_VERSION, _("This plugin is included in updates"))
+            parts.append(_("This plugin is included in updates"))
         else:
-            item.setToolTip(COLUMN_NEW_VERSION, _("This plugin is excluded from updates"))
+            parts.append(_("This plugin is excluded from updates"))
+
+        update = self._updates.get(plugin.plugin_id)
+        if update and update.commit_date:
+            parts.append(commit_date_display(update.commit_date))
+
+        item.setToolTip(COLUMN_NEW_VERSION, '\n'.join(parts))
 
     def _setup_update_column(self, item, plugin):
         """Setup update column with checkbox and new version. Returns True if plugin has updates."""
@@ -285,10 +293,10 @@ class PluginListWidget(QtWidgets.QWidget):
 
             if plugin.plugin_id in do_not_update:
                 item.setCheckState(COLUMN_NEW_VERSION, QtCore.Qt.CheckState.Unchecked)
-                self._set_update_checkbox_tooltip(item, False)
+                self._set_update_checkbox_tooltip(item, False, plugin)
             else:
                 item.setCheckState(COLUMN_NEW_VERSION, QtCore.Qt.CheckState.Checked)
-                self._set_update_checkbox_tooltip(item, True)
+                self._set_update_checkbox_tooltip(item, True, plugin)
             return True
         else:
             # No update available - no text, no checkbox
@@ -487,7 +495,7 @@ class PluginListWidget(QtWidgets.QWidget):
                 is_checked = item.checkState(COLUMN_NEW_VERSION) == QtCore.Qt.CheckState.Checked
 
                 # Update tooltip based on new state
-                self._set_update_checkbox_tooltip(item, is_checked)
+                self._set_update_checkbox_tooltip(item, is_checked, plugin)
 
                 if not is_checked and plugin.plugin_id not in do_not_update:
                     # User unchecked - add to do not update list

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -45,8 +45,12 @@ from picard.util import temporary_disconnect
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
+from picard.ui.formattedtextdelegate import FormattedTextDelegate
 from picard.ui.util import font_scaled_size
-from picard.ui.widgets.pluginformat import commit_date_display
+from picard.ui.widgets.pluginformat import (
+    commit_date_display,
+    html_ref_format,
+)
 from picard.ui.widgets.refselector import RefSelectorWidget
 
 
@@ -148,6 +152,11 @@ class PluginListWidget(QtWidgets.QWidget):
         header.setSectionResizeMode(COLUMN_VERSION, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         header.setSectionResizeMode(COLUMN_NEW_VERSION, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
         header.setStretchLastSection(False)
+
+        # Use rich text delegate for version columns
+        version_delegate = FormattedTextDelegate(self.tree_widget)
+        self.tree_widget.setItemDelegateForColumn(COLUMN_VERSION, version_delegate)
+        self.tree_widget.setItemDelegateForColumn(COLUMN_NEW_VERSION, version_delegate)
 
         # Create update panel
         self.update_panel = UpdatePanel()
@@ -253,8 +262,23 @@ class PluginListWidget(QtWidgets.QWidget):
         return self.plugin_manager.get_plugin_remote_url(plugin)
 
     def _get_clean_version_display(self, plugin):
-        """Get display text for plugin version without update suffix."""
-        return self.plugin_manager.get_plugin_version_display(plugin)
+        """Get HTML display text for plugin version."""
+        try:
+            if plugin.uuid:
+                metadata = self.plugin_manager._metadata.get_plugin_metadata(plugin.uuid)
+                if metadata:
+                    git_ref = metadata.get_git_ref()
+                    ref_item = RefItem.from_git_ref(git_ref)
+                    result = html_ref_format(ref_item)
+                    if result:
+                        return result
+        except Exception:
+            pass
+        if plugin.manifest:
+            version = plugin.manifest._data.get('version')
+            if version:
+                return version
+        return _("Unknown")
 
     def _set_version_tooltip(self, item, plugin):
         """Set tooltip on Version column with commit date if available."""
@@ -313,7 +337,7 @@ class PluginListWidget(QtWidgets.QWidget):
 
     @staticmethod
     def _format_update_version(update):
-        """Format update version info for display."""
+        """Format update version info for display (HTML)."""
         if update.new_ref_type == 'tag':
             ref_type = RefItem.Type.TAG
         elif update.new_ref_type == 'commit':
@@ -326,7 +350,7 @@ class PluginListWidget(QtWidgets.QWidget):
             return _("Available")
 
         ref_item = RefItem(shortname=ref, ref_type=ref_type, commit=update.new_commit)
-        return ref_item.format() or _("Available")
+        return html_ref_format(ref_item) or _("Available")
 
     def _get_new_version(self, plugin):
         """Get the new version available for update."""

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -311,7 +311,8 @@ class PluginListWidget(QtWidgets.QWidget):
             item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsUserCheckable)
             return False
 
-    def _format_update_version(self, update):
+    @staticmethod
+    def _format_update_version(update):
         """Format update version info for display."""
         if update.new_ref_type == 'tag':
             ref_type = RefItem.Type.TAG

--- a/picard/ui/widgets/refselector.py
+++ b/picard/ui/widgets/refselector.py
@@ -24,6 +24,9 @@ from PyQt6 import QtWidgets
 from picard.i18n import gettext as _
 from picard.plugin3.ref_item import RefItem
 
+from picard.ui.formattedtextdelegate import FormattedTextDelegate
+from picard.ui.widgets.pluginformat import html_ref_format
+
 
 class RefSelectorWidget(QtWidgets.QWidget):
     """Widget for selecting git refs (tags, branches, or custom input)."""
@@ -56,12 +59,14 @@ class RefSelectorWidget(QtWidgets.QWidget):
 
         # Tags tab
         self.tags_list = QtWidgets.QListWidget()
+        self.tags_list.setItemDelegate(FormattedTextDelegate(self.tags_list))
         self.tab_widget.addTab(self.tags_list, _("Tags"))
         self.tags_tab_index = tab_index
         tab_index += 1
 
         # Branches tab
         self.branches_list = QtWidgets.QListWidget()
+        self.branches_list.setItemDelegate(FormattedTextDelegate(self.branches_list))
         self.tab_widget.addTab(self.branches_list, _("Branches"))
         self.branches_tab_index = tab_index
         tab_index += 1
@@ -91,7 +96,7 @@ class RefSelectorWidget(QtWidgets.QWidget):
                 commit=ref.get('commit', ''),
             )
             is_current = current_ref and ref['name'] == current_ref
-            list_item = QtWidgets.QListWidgetItem(ref_item.format(is_current=is_current))
+            list_item = QtWidgets.QListWidgetItem(html_ref_format(ref_item, is_current=is_current))
             list_item.setData(QtWidgets.QListWidgetItem.ItemType.UserType, ref_item)
             self.tags_list.addItem(list_item)
 
@@ -104,7 +109,7 @@ class RefSelectorWidget(QtWidgets.QWidget):
                 commit=ref.get('commit', ''),
             )
             is_current = current_ref and ref['name'] == current_ref
-            list_item = QtWidgets.QListWidgetItem(ref_item.format(is_current=is_current))
+            list_item = QtWidgets.QListWidgetItem(html_ref_format(ref_item, is_current=is_current))
             list_item.setData(QtWidgets.QListWidgetItem.ItemType.UserType, ref_item)
             self.branches_list.addItem(list_item)
 

--- a/test/plugins3/test_plugin.py
+++ b/test/plugins3/test_plugin.py
@@ -242,6 +242,32 @@ class TestPluginGetCurrentCommitId(PicardTestCase):
         self.assertIsNone(plugin.get_current_commit_id())
 
 
+class TestPluginGetCurrentCommitDate(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        skip_if_no_git_backend()
+        self.tmpdir = self.mktmpdir()
+
+    def test_returns_timestamp(self):
+        repo_path = Path(self.tmpdir) / 'test-plugin'
+        create_git_repo_with_backend(repo_path, {'__init__.py': ''})
+        plugin = Plugin(Path(self.tmpdir), 'test-plugin')
+        result = plugin.get_current_commit_date()
+        self.assertIsInstance(result, int)
+        self.assertGreater(result, 0)
+
+    def test_returns_none_no_local_path(self):
+        plugin = Plugin(Path(self.tmpdir), 'test-plugin')
+        plugin.local_path = None
+        self.assertIsNone(plugin.get_current_commit_date())
+
+    def test_returns_none_no_git_dir(self):
+        repo_path = Path(self.tmpdir) / 'test-plugin'
+        repo_path.mkdir()
+        plugin = Plugin(Path(self.tmpdir), 'test-plugin')
+        self.assertIsNone(plugin.get_current_commit_date())
+
+
 class TestPluginNameAndStr(PicardTestCase):
     def test_str_returns_plugin_id(self):
         plugin = Plugin(Path('/tmp'), 'my-plugin')

--- a/test/plugins3/test_update.py
+++ b/test/plugins3/test_update.py
@@ -485,6 +485,7 @@ class TestCreateUpdateCheck(PicardTestCase):
         self.assertIsInstance(result, UpdateCheck)
         self.assertEqual(result.old_ref, 'v1.0')
         self.assertEqual(result.new_ref, 'v2.0')
+        self.assertEqual(result.new_ref_type, 'tag')
         self.assertEqual(result.old_commit, 'aaa')
         self.assertEqual(result.new_commit, 'bbb')
 
@@ -506,6 +507,7 @@ class TestCreateUpdateCheck(PicardTestCase):
 
         # Detached head should show short commit IDs
         self.assertEqual(result.old_ref, 'aabbccd')
+        self.assertEqual(result.new_ref_type, 'commit')
 
     def test_branch_based_update(self):
         plugin = Mock()
@@ -525,6 +527,85 @@ class TestCreateUpdateCheck(PicardTestCase):
 
         self.assertEqual(result.old_ref, 'main')
         self.assertIsNone(result.new_ref)
+        self.assertEqual(result.new_ref_type, 'branch')
+
+
+class TestFormatUpdateVersion(PicardTestCase):
+    """Test PluginListWidget._format_update_version() logic."""
+
+    def _format(self, update):
+        """Call the formatting logic directly without instantiating the widget."""
+        from picard.ui.widgets.pluginlistwidget import PluginListWidget
+
+        return PluginListWidget._format_update_version(None, update)
+
+    def test_tag_update(self):
+        update = UpdateCheck(
+            plugin_id='test',
+            old_commit='aaa',
+            new_commit='bbb1234',
+            commit_date=0,
+            old_ref='v1.0',
+            new_ref='v2.0',
+            new_ref_type='tag',
+        )
+        result = self._format(update)
+        self.assertIn('v2.0', result)
+
+    def test_commit_update(self):
+        update = UpdateCheck(
+            plugin_id='test',
+            old_commit='aaa1234',
+            new_commit='bbb1234',
+            commit_date=0,
+            old_ref='aaa1234',
+            new_ref='bbb1234',
+            new_ref_type='commit',
+        )
+        result = self._format(update)
+        self.assertIn('bbb1234', result)
+
+    def test_branch_update_no_new_ref(self):
+        update = UpdateCheck(
+            plugin_id='test',
+            old_commit='aaa',
+            new_commit='bbb1234',
+            commit_date=0,
+            old_ref='main',
+            new_ref=None,
+            new_ref_type='branch',
+        )
+        result = self._format(update)
+        # Falls back to new_commit
+        self.assertIn('bbb1234', result)
+
+    def test_no_ref_no_commit(self):
+        update = UpdateCheck(
+            plugin_id='test',
+            old_commit='aaa',
+            new_commit='',
+            commit_date=0,
+            old_ref='main',
+            new_ref=None,
+            new_ref_type='branch',
+        )
+        result = self._format(update)
+        self.assertEqual(result, 'Available')
+
+    def test_legacy_update_check_without_new_ref_type(self):
+        """Test backward compat with persisted UpdateCheck missing new_ref_type."""
+        update = UpdateCheck(
+            plugin_id='test',
+            old_commit='aaa',
+            new_commit='bbb1234',
+            commit_date=0,
+            old_ref='main',
+            new_ref='v2.0',
+        )
+        self.assertIsNone(update.new_ref_type)
+        result = self._format(update)
+        # Falls through to BRANCH type since new_ref_type is None
+        self.assertIn('v2.0', result)
 
 
 class TestCheckSinglePluginUpdate(PicardTestCase):

--- a/test/plugins3/test_update.py
+++ b/test/plugins3/test_update.py
@@ -537,7 +537,7 @@ class TestFormatUpdateVersion(PicardTestCase):
         """Call the formatting logic directly without instantiating the widget."""
         from picard.ui.widgets.pluginlistwidget import PluginListWidget
 
-        return PluginListWidget._format_update_version(None, update)
+        return PluginListWidget._format_update_version(update)
 
     def test_tag_update(self):
         update = UpdateCheck(


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix `_format_update_version()` to use explicit ref types instead of a fragile heuristic, add commit date tooltips to the plugin list and details pane, and use rich text (bold ref / italic commit) for version display across the plugin UI.

## Problem

- `_format_update_version()` used a fragile heuristic (`startswith('v') or '.' in ref`) to guess whether a ref was a tag or branch, leading to misclassification of commit hashes and branch names containing dots.
- Plugin version display was plain text with no visual distinction between ref names and commit IDs.
- No commit date information was shown anywhere in the plugin UI.

## Solution

1. Add `new_ref_type` field to `UpdateCheck` so the ref type is determined at creation time rather than guessed at display time.
2. Add `Plugin.get_current_commit_date()` to read the HEAD commit date from the git repo.
3. Show commit date as tooltips on Version and New Version columns, and on the details pane version label and update button.
4. Create `picard/ui/widgets/pluginformat.py` as the single place for plugin UI formatting (commit date display and HTML ref formatting).
5. Use `FormattedTextDelegate` with HTML formatters (bold ref, italic commit) on version columns, details pane, and ref selector lists.
6. Fix `FormattedTextDelegate` to properly render checkboxes alongside rich text.

<img width="982" height="328" alt="image" src="https://github.com/user-attachments/assets/a8031f0d-7d66-49ff-9b9d-f0d619b6acd3" />


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Code was developed through iterative AI-human collaboration with continuous manual testing and review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
