### PR TITLE
PICARD-3281: Time-budgeted batch processing for UI responsiveness

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -174,7 +174,8 @@ class Cluster(FileList):
         if self.can_show_coverart:
             self.add_metadata_images_from_children(added_files)
         if self.ui_item:
-            self.ui_item.add_files(added_files)
+            with DebugOpt.TIMINGS.timing("Cluster.add_files: %d items to tree", len(added_files)):
+                self.ui_item.add_files(added_files)
         if new_album:
             self._update_related_album(added_files=added_files)
 

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -19,8 +19,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import (
+    Callable,
+    Generator,
+)
+from contextlib import contextmanager
 from enum import Enum
 import sys
+import time
 
 from picard.i18n import N_
 
@@ -57,6 +63,50 @@ class DebugOptEnum(int, Enum):
     def opt_names(cls):
         """Returns a comma-separated list of all possible debug options"""
         return ','.join(sorted(o.optname for o in cls))
+
+    @contextmanager
+    def timing(
+        self,
+        msg: str = '',
+        *args: object,
+        msg_func: Callable[[], str] | None = None,
+    ) -> Generator[None]:
+        """Context manager that logs elapsed time if this debug option is enabled.
+
+        When disabled, this is effectively a no-op with minimal overhead
+        (just a boolean check).
+
+        Args:
+            msg: Format string for the log message.
+            *args: Arguments for the format string.
+            msg_func: A callable returning the message string. Called only
+                after the timed block completes and only if the option is
+                enabled. Use for expensive message construction.
+                Mutually exclusive with msg/args.
+
+        Usage:
+            with DebugOpt.TIMINGS.timing("Batch: %d items", count):
+                do_work()
+            # logs: "Batch: 25 items in 12.3 ms"
+
+            with DebugOpt.TIMINGS.timing(msg_func=lambda: f"Heavy {obj!r}"):
+                do_work()
+        """
+        if not self.enabled:
+            yield
+            return
+        from picard import log
+
+        t0 = time.perf_counter_ns()
+        yield
+        elapsed_ms = (time.perf_counter_ns() - t0) / 1_000_000
+        if msg_func is not None:
+            formatted = msg_func()
+        elif args:
+            formatted = msg % args
+        else:
+            formatted = msg
+        log.debug("%s in %.1f ms", formatted, elapsed_ms)
 
     @classmethod
     def help_text(cls):
@@ -118,3 +168,4 @@ class DebugOpt(DebugOptEnum):
     COVERART = 7, N_('Cover Art'), N_('Log cover art filter, resize and convert operations')
     MATCHING = 8, N_('Matching'), N_('Log similarity scores and match decisions')
     PLUGIN_DEVELOPMENT = 9, N_('Plugin Development'), N_('Log plugin details typically only used during development')
+    TIMINGS = 10, N_('Timings'), N_('Log timing information for operations affecting UI responsiveness')

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -832,7 +832,9 @@ class Tagger(QtWidgets.QApplication):
     _callback_queue: list = []
     _callback_timer_running: bool = False
 
-    def _process_in_batches(self, items: list, process_func, label: str, time_budget: float | None = None) -> None:
+    def _process_in_batches(
+        self, items: list, process_func, label: str, time_budget: float | None = None, on_complete=None
+    ) -> None:
         """Process items with a time budget, yielding to the event loop between batches.
 
         Args:
@@ -840,6 +842,7 @@ class Tagger(QtWidgets.QApplication):
             process_func: Callable that processes a single item.
             label: Label for debug timing output.
             time_budget: Max seconds per batch. Defaults to _BATCH_TIME_BUDGET.
+            on_complete: Optional callable invoked when all items are processed.
         """
         if time_budget is None:
             time_budget = self._BATCH_TIME_BUDGET
@@ -850,7 +853,11 @@ class Tagger(QtWidgets.QApplication):
             count += 1
         log.debug_if(DebugOpt.TIMINGS, "%s: %d items, %d remaining", label, count, len(items))
         if items:
-            QtCore.QTimer.singleShot(0, partial(self._process_in_batches, items, process_func, label, time_budget))
+            QtCore.QTimer.singleShot(
+                0, partial(self._process_in_batches, items, process_func, label, time_budget, on_complete)
+            )
+        elif on_complete:
+            on_complete()
 
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):
@@ -1473,17 +1480,23 @@ class Tagger(QtWidgets.QApplication):
             log.error("Error while clustering: %r", error)
             return
 
-        with self.window.suspend_while_loading:
-            for file_cluster in process_events_iter(result):
-                files = set(file_cluster.files)
-                if len(files) > 1:
-                    cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
-                else:
-                    cluster = self.unclustered_files
-                cluster.add_files(files)
+        clusters = list(result)
+        self.window.suspend_while_loading_enter()
 
-        if callback:
-            callback()
+        def on_complete():
+            self.window.suspend_while_loading_exit()
+            if callback:
+                callback()
+
+        self._process_in_batches(clusters, self._apply_cluster, "Clustering", on_complete=on_complete)
+
+    def _apply_cluster(self, file_cluster):
+        files = set(file_cluster.files)
+        if len(files) > 1:
+            cluster = self.load_cluster(file_cluster.title, file_cluster.artist)
+        else:
+            cluster = self.unclustered_files
+        cluster.add_files(files)
 
     def load_cluster(self, name, artist):
         for cluster in self.clusters:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -828,9 +828,29 @@ class Tagger(QtWidgets.QApplication):
         else:
             self.browser_integration.stop()
 
-    _CALLBACK_BATCH_SIZE = 25
+    _BATCH_TIME_BUDGET = 0.050  # 50ms per batch (~20 yields/sec)
     _callback_queue: list = []
     _callback_timer_running: bool = False
+
+    def _process_in_batches(self, items: list, process_func, label: str, time_budget: float | None = None) -> None:
+        """Process items with a time budget, yielding to the event loop between batches.
+
+        Args:
+            items: List of items to process. Items are popped from the front.
+            process_func: Callable that processes a single item.
+            label: Label for debug timing output.
+            time_budget: Max seconds per batch. Defaults to _BATCH_TIME_BUDGET.
+        """
+        if time_budget is None:
+            time_budget = self._BATCH_TIME_BUDGET
+        deadline = time.perf_counter() + time_budget
+        count = 0
+        while items and time.perf_counter() < deadline:
+            process_func(items.pop(0))
+            count += 1
+        log.debug_if(DebugOpt.TIMINGS, "%s: %d items, %d remaining", label, count, len(items))
+        if items:
+            QtCore.QTimer.singleShot(0, partial(self._process_in_batches, items, process_func, label, time_budget))
 
     def event(self, event):
         if isinstance(event, thread.ProxyToMainEvent):
@@ -850,11 +870,13 @@ class Tagger(QtWidgets.QApplication):
         return super().event(event)
 
     def _process_callback_batch(self) -> None:
-        """Process a batch of queued callbacks, then yield to the event loop."""
-        count = min(self._CALLBACK_BATCH_SIZE, len(self._callback_queue))
-        with DebugOpt.TIMINGS.timing("Callback batch: %d items, %d queued", count, len(self._callback_queue) - count):
-            for _i in range(count):
-                self._callback_queue.pop(0).run()
+        """Process queued callbacks until the time budget is exhausted, then yield."""
+        deadline = time.perf_counter() + self._BATCH_TIME_BUDGET
+        count = 0
+        while self._callback_queue and time.perf_counter() < deadline:
+            self._callback_queue.pop(0).run()
+            count += 1
+        log.debug_if(DebugOpt.TIMINGS, "Callback batch: %d items, %d queued", count, len(self._callback_queue))
         if self._callback_queue:
             QtCore.QTimer.singleShot(0, self._process_callback_batch)
         else:
@@ -1000,18 +1022,12 @@ class Tagger(QtWidgets.QApplication):
             self.window.suspend_while_loading_enter()
             self._pending_files_count += len(new_files)
             unmatched_files = []
-            self._load_files_batch(new_files, 0, target, unmatched_files)
+            self._load_files_batch(new_files, target, unmatched_files)
 
-    _FILE_LOAD_BATCH_SIZE = 25
-
-    def _load_files_batch(self, files: list, offset: int, target: object, unmatched_files: list) -> None:
-        """Dispatch a batch of file loads, then yield to the event loop."""
-        end = min(offset + self._FILE_LOAD_BATCH_SIZE, len(files))
-        with DebugOpt.TIMINGS.timing("File load dispatch: %d files (offset %d/%d)", end - offset, offset, len(files)):
-            for i in range(offset, end):
-                files[i].load(partial(self._file_loaded, target=target, unmatched_files=unmatched_files))
-        if end < len(files):
-            QtCore.QTimer.singleShot(0, partial(self._load_files_batch, files, end, target, unmatched_files))
+    def _load_files_batch(self, files: list, target: object, unmatched_files: list) -> None:
+        """Dispatch file loads using time-budgeted batching."""
+        callback = partial(self._file_loaded, target=target, unmatched_files=unmatched_files)
+        self._process_in_batches(files, lambda f: f.load(callback), "File load dispatch")
 
     @staticmethod
     def _scan_paths_recursive(paths, recursive, ignore_hidden):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -728,9 +728,15 @@ class Tagger(QtWidgets.QApplication):
                     save_session_to_path(self, path)
 
         log.debug("Picard stopping")
-        self.run_cleanup()
-        DataHash.remove_all_files()
+        with DebugOpt.TIMINGS.timing("run_cleanup"):
+            self.run_cleanup()
+        with DebugOpt.TIMINGS.timing("DataHash.remove_all_files"):
+            DataHash.remove_all_files()
         QtCore.QCoreApplication.processEvents()
+        if sys.stdout:
+            sys.stdout.flush()
+        if sys.stderr:
+            sys.stderr.flush()
 
     def _run_init(self):
         config = get_config()
@@ -846,8 +852,9 @@ class Tagger(QtWidgets.QApplication):
     def _process_callback_batch(self) -> None:
         """Process a batch of queued callbacks, then yield to the event loop."""
         count = min(self._CALLBACK_BATCH_SIZE, len(self._callback_queue))
-        for _i in range(count):
-            self._callback_queue.pop(0).run()
+        with DebugOpt.TIMINGS.timing("Callback batch: %d items, %d queued", count, len(self._callback_queue) - count):
+            for _i in range(count):
+                self._callback_queue.pop(0).run()
         if self._callback_queue:
             QtCore.QTimer.singleShot(0, self._process_callback_batch)
         else:
@@ -857,7 +864,8 @@ class Tagger(QtWidgets.QApplication):
         config = get_config()
         self._pending_files_count -= 1
         if self._pending_files_count == 0:
-            self.window.suspend_while_loading_exit()
+            with DebugOpt.TIMINGS.timing("suspend_while_loading_exit"):
+                self.window.suspend_while_loading_exit()
 
         if remove_file:
             file.remove()
@@ -999,8 +1007,9 @@ class Tagger(QtWidgets.QApplication):
     def _load_files_batch(self, files: list, offset: int, target: object, unmatched_files: list) -> None:
         """Dispatch a batch of file loads, then yield to the event loop."""
         end = min(offset + self._FILE_LOAD_BATCH_SIZE, len(files))
-        for i in range(offset, end):
-            files[i].load(partial(self._file_loaded, target=target, unmatched_files=unmatched_files))
+        with DebugOpt.TIMINGS.timing("File load dispatch: %d files (offset %d/%d)", end - offset, offset, len(files)):
+            for i in range(offset, end):
+                files[i].load(partial(self._file_loaded, target=target, unmatched_files=unmatched_files))
         if end < len(files):
             QtCore.QTimer.singleShot(0, partial(self._load_files_batch, files, end, target, unmatched_files))
 

--- a/test/test_debug_opt.py
+++ b/test/test_debug_opt.py
@@ -108,3 +108,66 @@ class TestDebugOpt(PicardTestCase):
 
             class BuggyOpt(DebugOptEnum):
                 C = 1, "x"
+
+
+class TestDebugOptTiming(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        DebugOptTestCase.set_registry(set())
+
+    def test_timing_disabled_no_logging(self):
+        """When disabled, timing should not log anything."""
+        self.assertFalse(DebugOptTestCase.A.enabled)
+        with DebugOptTestCase.A.timing("should not appear"):
+            pass
+        # No exception means it worked as a no-op
+
+    def test_timing_disabled_body_executes(self):
+        """The wrapped code must still execute when timing is disabled."""
+        result = []
+        with DebugOptTestCase.A.timing("test"):
+            result.append(1)
+        self.assertEqual(result, [1])
+
+    def test_timing_enabled_body_executes(self):
+        """The wrapped code must execute when timing is enabled."""
+        DebugOptTestCase.A.enabled = True
+        result = []
+        with DebugOptTestCase.A.timing("test"):
+            result.append(1)
+        self.assertEqual(result, [1])
+
+    def test_timing_enabled_logs_message(self):
+        """When enabled, timing should log the formatted message with elapsed time."""
+        from unittest.mock import patch
+
+        DebugOptTestCase.A.enabled = True
+        with patch('picard.log.debug') as mock_debug:
+            with DebugOptTestCase.A.timing("Batch: %d items", 25):
+                pass
+            mock_debug.assert_called_once()
+            fmt, msg, elapsed = mock_debug.call_args[0]
+            self.assertEqual(fmt, "%s in %.1f ms")
+            self.assertEqual(msg, "Batch: 25 items")
+            self.assertIsInstance(elapsed, float)
+            self.assertGreaterEqual(elapsed, 0.0)
+
+    def test_timing_msg_func(self):
+        """msg_func should be called lazily only when enabled."""
+        from unittest.mock import patch
+
+        DebugOptTestCase.A.enabled = True
+        called = []
+        with patch('picard.log.debug') as mock_debug:
+            with DebugOptTestCase.A.timing(msg_func=lambda: (called.append(1), "Lazy msg")[1]):
+                pass
+            self.assertEqual(called, [1])
+            fmt, msg, _elapsed = mock_debug.call_args[0]
+            self.assertEqual(msg, "Lazy msg")
+
+    def test_timing_msg_func_not_called_when_disabled(self):
+        """msg_func must not be called when the option is disabled."""
+        called = []
+        with DebugOptTestCase.A.timing(msg_func=lambda: (called.append(1), "nope")[1]):
+            pass
+        self.assertEqual(called, [])


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Replace fixed-size batch processing with a time-budgeted approach (50ms per batch) for callback processing, file load dispatching, and clustering. Also adds a TIMINGS debug option for diagnosing UI responsiveness issues.

## Problem

* JIRA ticket: PICARD-3281

The previous fix (#3188) batched callbacks in groups of 25, but each batch could still block the main thread for 100-330ms on fast machines (and likely 500ms+ on slower Windows machines). The user reported the fix didn't help.

Root cause: with 2000+ pre-tagged files, each callback does tree widget operations (~2-4ms each). A fixed batch of 25 means 50-100ms of blocking per batch. Additionally, clustering was running synchronously without yielding at all.

## Solution

**1. Time-budgeted batch processing** (replaces fixed batch size)

Instead of processing a fixed number of items per batch, process items until a 50ms time budget is exhausted, then yield to the event loop. This adapts to both fast and slow machines:
- Light callbacks (API responses): many per batch
- Heavy callbacks (tree updates): fewer per batch
- Guarantees ~20 yields/sec regardless of per-item cost

**2. Generic `_process_in_batches()` utility**

Reusable method for any list that needs time-budgeted processing with event loop yielding. Supports an `on_complete` callback for post-processing.

**3. Time-budgeted clustering**

`_clustering_finished` now uses the same approach instead of processing all clusters synchronously.

**4. TIMINGS debug option**

New `--debug-opts=timings` option with a `timing()` context manager on `DebugOptEnum`. Logs elapsed time for instrumented code blocks. Used to measure callback batch duration, file load dispatch, clustering, and exit cleanup.

**Testing results (2025 files, Linux/SSD):**

| Metric | Old (fixed 25) | New (50ms budget) |
|--------|---------------|-------------------|
| Items/batch during load | 25 | 4-14 (adaptive) |
| Batch blocking time | 100-330ms | ≤50ms |
| UI yields/sec | ~4-8 | ~20 |
| Total load time | ~10-12s | ~18s |
| UI responsive | No | Yes |

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed with AI assistance (Kiro CLI), with human direction, testing, and review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

**Requesting feedback:** The 50ms time budget may need tuning. Testing on Windows with large collections of singletons (the reporter's scenario) would be valuable.
