### PR TITLE
PICARD-3295: Fix track losing cover art when file is removed

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -288,7 +288,7 @@ class CoverArt:
     def _set_metadata(self, image: CoverArtImage):
         if image.can_be_saved_to_metadata:
             log.debug("Storing to metadata: %r", image)
-            setter = CoverArtSetter(CoverArtSetterMode.REPLACE, image, self.album)
+            setter = CoverArtSetter(CoverArtSetterMode.REPLACE, image, self.album, update_orig=True)
             setter.set_coverart()
             # If the image already was a front image,
             # there might still be some other non-CAA front

--- a/picard/coverart/setters/__init__.py
+++ b/picard/coverart/setters/__init__.py
@@ -58,7 +58,13 @@ class CoverArtSetterMode(IntEnum):
 class CoverArtSetter:
     """Handles setting cover art on different types of objects using single dispatch pattern."""
 
-    def __init__(self, mode: CoverArtSetterMode, coverartimage: CoverArtImage, source_obj: MetadataItem) -> None:
+    def __init__(
+        self,
+        mode: CoverArtSetterMode,
+        coverartimage: CoverArtImage,
+        source_obj: MetadataItem,
+        update_orig: bool = False,
+    ) -> None:
         """
         Initialize the CoverArtSetter.
 
@@ -74,6 +80,7 @@ class CoverArtSetter:
         self.mode = mode
         self.coverartimage = coverartimage
         self.source_obj = source_obj
+        self.update_orig = update_orig
 
     def set_coverart(self) -> bool:
         """
@@ -119,12 +126,24 @@ class CoverArtSetter:
                 obj,
             )
 
-        if self.mode == CoverArtSetterMode.REPLACE and self.coverartimage.is_front_image():
-            obj.metadata.images.strip_front_images()
-            log.debug("Replacing images with %r in %r", self.coverartimage, obj)
-        else:
-            log.debug("Appending image %r to %r", self.coverartimage, obj)
+        attrs_to_update = ['metadata']
+        # Update original metadata, if requested, but not for files unless they
+        # are the source object.
+        if self.update_orig and (obj == self.source_obj or not isinstance(obj, File)):
+            attrs_to_update.append('orig_metadata')
 
-        obj.metadata.images.append(self.coverartimage)
+        for attr in attrs_to_update:
+            metadata = getattr(obj, attr, None)
+            if not metadata:
+                continue
+
+            if self.mode == CoverArtSetterMode.REPLACE and self.coverartimage.is_front_image():
+                metadata.images.strip_front_images()
+                log.debug("Replacing images with %r in %r", self.coverartimage, obj)
+            else:
+                log.debug("Appending image %r to %r", self.coverartimage, obj)
+
+            metadata.images.append(self.coverartimage)
+
         obj.metadata_images_changed.emit()
         return True

--- a/picard/track.py
+++ b/picard/track.py
@@ -242,7 +242,10 @@ class Track(FileListItem):
         if self.album:
             self.album.remove_file(self, file, new_album=new_album)
         self.remove_metadata_images_from_children([file])
-        if not self.files and self._orig_images:
+        if not self.files and self.album:
+            self.orig_metadata.images = self.album.orig_metadata.images.copy()
+            self.metadata.images = self.album.metadata.images.copy()
+        elif not self.files and self._orig_images:
             self.orig_metadata.images = self._orig_images
             self.metadata.images = self._orig_images.copy()
         run_file_post_removal_from_track_processors(self, file)

--- a/test/test_coverart_setter.py
+++ b/test/test_coverart_setter.py
@@ -202,6 +202,34 @@ class TestCoverArtSetter:
             mock_obj.metadata.images.strip_front_images.assert_not_called()
 
         mock_obj.metadata.images.append.assert_called_once_with(mock_image)
+        mock_obj.orig_metadata.images.append.assert_not_called()
+        mock_obj.orig_metadata.images.strip_front_images.assert_not_called()
+        mock_obj.metadata_images_changed.emit.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ('mode', 'should_strip', 'mock_image'),
+        [
+            (CoverArtSetterMode.REPLACE, True, CoverArtImage(types=['front'])),
+            (CoverArtSetterMode.APPEND, False, CoverArtImage(types=['front'])),
+            (CoverArtSetterMode.REPLACE, False, CoverArtImage(types=['medium'], support_types=True)),
+        ],
+    )
+    def test_set_orig_metadata(
+        self, mode: CoverArtSetterMode, should_strip: bool, mock_image: Mock, mock_obj: Mock
+    ) -> None:
+        """Test _set_image method in different modes."""
+        setter = CoverArtSetter(mode, mock_image, mock_obj, update_orig=True)
+        setter._set_image(mock_obj)
+
+        if should_strip:
+            mock_obj.metadata.images.strip_front_images.assert_called_once()
+            mock_obj.orig_metadata.images.strip_front_images.assert_called_once()
+        else:
+            mock_obj.metadata.images.strip_front_images.assert_not_called()
+            mock_obj.orig_metadata.images.strip_front_images.assert_not_called()
+
+        mock_obj.metadata.images.append.assert_called_once_with(mock_image)
+        mock_obj.orig_metadata.images.append.assert_called_once_with(mock_image)
         mock_obj.metadata_images_changed.emit.assert_called_once()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix tracks losing cover art when files are removed, including the case where files are already attached when cover art downloads.

## Problem

* JIRA ticket: PICARD-3295

When a file is removed from a track, the cover art is lost. Two scenarios:

1. Load release with cover art, attach file, remove file → cover art gone
2. Load release with files already matched, cover art downloads, remove file → cover art gone

Scenario 1 was caused by `orig_metadata` not receiving cover art from the setter.

Scenario 2 was caused by `_orig_images` being saved before cover art arrived (empty), and `remove_metadata_images_from_children` clearing `orig_metadata.images` before restoration.

## Solution

**Commit 1** (by @phw): Pass `update_orig=True` when setting cover art from CAA, so `orig_metadata` on tracks receives the images.

**Commit 2**: When restoring images after file removal, use the album's current cover art as the source of truth instead of `_orig_images` (which may be stale). The album always has the correct cover art state. Falls back to `_orig_images` for edge cases without an album.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Code developed with AI assistance (Kiro CLI), with human direction and testing.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other: Needs review from @phw regarding interaction with cover art setter changes.
