### PR TITLE
PICARD-3304: Fix picard-plugins CLI crash on startup

### DIFF
--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -40,7 +40,6 @@ from picard import (
     PICARD_FANCY_VERSION_STR,
     PICARD_ORG_NAME,
     log,
-    tagger_instance,
 )
 from picard.config import (
     Option,
@@ -185,7 +184,7 @@ class PluginCLI:
 
         self._manager._registry.fetch_registry(callback=callback)
 
-        app = tagger_instance()
+        app = QtCore.QCoreApplication.instance()
         while not result['done']:
             app.processEvents()
 
@@ -1746,7 +1745,7 @@ class PluginCLI:
             self._manager.refresh_registry_and_caches(callback=callback)
 
             # Process events until callback is called
-            app = tagger_instance()
+            app = QtCore.QCoreApplication.instance()
             while not result['done']:
                 app.processEvents()
 

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -63,7 +63,6 @@ from picard import (
     PICARD_ORG_NAME,
     PICARD_VERSION_STR,
     log,
-    tagger_instance,
 )
 from picard.config import get_config
 from picard.const import appdirs
@@ -368,7 +367,6 @@ class WebService(QtCore.QObject):
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
-        self.tagger = tagger_instance()
         self.manager = QtNetwork.QNetworkAccessManager()
         self.manager.sslErrors.connect(self.ssl_errors)
         self.oauth_manager = OAuthManager(self)

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -102,7 +102,6 @@ def _make_cli(manager, args, **kwargs):
 class TestPluginCLI(PicardTestCase):
     def setUp(self):
         super().setUp()
-        self.patch_tagger_instance('picard.plugin3.cli')
 
     def test_list_plugins_empty(self):
         """Test listing plugins when none are installed."""

--- a/test/plugins3/test_cli_integration.py
+++ b/test/plugins3/test_cli_integration.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import subprocess
+import sys
+import unittest
+
+from picard.git.factory import has_git_backend
+
+
+class TestCliIntegration(unittest.TestCase):
+    """Integration tests that run picard-plugins in a subprocess.
+
+    These tests verify the actual startup path works end-to-end,
+    without mocking, to catch regressions like PICARD-3300.
+    """
+
+    def test_cli_starts_without_crash(self):
+        """picard-plugins -V must not crash during minimal_init (PICARD-3300)."""
+        result = subprocess.run(
+            [sys.executable, '-m', 'picard.plugin3.cli', '-V'],
+            capture_output=True,
+            timeout=10,
+        )
+        expected_code = 0 if has_git_backend() else 1
+        self.assertEqual(result.returncode, expected_code, msg=result.stderr.decode())

--- a/test/test_webservice.py
+++ b/test/test_webservice.py
@@ -71,7 +71,6 @@ def dummy_handler(*args, **kwargs):
 class WebServiceTest(PicardTestCase):
     def setUp(self):
         super().setUp()
-        self.patch_tagger_instance('picard.webservice')
         # Isolate the network cache folder to a temporary directory to avoid
         # modifying the user's actual network cache during WebService initialization
         self.tmpdir = self.mktmpdir()
@@ -137,7 +136,6 @@ class WebServiceTest(PicardTestCase):
 class WebServiceTaskTest(PicardTestCase):
     def setUp(self):
         super().setUp()
-        self.patch_tagger_instance('picard.webservice')
         self.set_config_values(
             {
                 'use_proxy': False,
@@ -384,7 +382,6 @@ class RequestPriorityQueueTest(PicardTestCase):
 class WebServiceProxyTest(PicardTestCase):
     def setUp(self):
         super().setUp()
-        self.patch_tagger_instance('picard.webservice')
         self.set_config_values(PROXY_SETTINGS)
 
     def test_proxy_setup(self):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The picard-plugins CLI crashed with 'Expected an instance of Tagger' on every command since commit 3f188e0c2 (2026-05-21), which replaced `QCoreApplication.instance() `with `tagger_instance()` in `WebService.__init__`.

The CLI's `minimal_init()` creates a plain `QCoreApplication` (not a Tagger), so the assertion in `tagger_instance()` always fails in the CLI context.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3300, PICARD-3304
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

- Remove `self.tagger` from `WebService.__init__`: it became dead code when commit 9bf514b82 replaced self.tagger.tagger_stats_changed.emit()` with the dedicated `WebService.pending_requests_changed` signal.
- Replace `tagger_instance() `calls in cli.py with `QtCore.QCoreApplication.instance()`, since the CLI only needs `processEvents()` and never requires a full Tagger.
- Add a subprocess integration test that catches this class of regression by running `picard-plugins` in a real process without mocking.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
