### PR TITLE
PICARD-3301: Fix visual glitch for multi-line log entries

### DIFF
--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -73,6 +73,7 @@ class LogViewDialog(PicardDialog):
         self.list_view.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.list_view.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.list_view.customContextMenuRequested.connect(self._show_context_menu)
+        self.list_view.activated.connect(self._show_detail)
         self.vbox.addWidget(self.list_view)
 
         view_detail_action = QtGui.QAction(

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -42,6 +42,7 @@ class LogItemModel(QtCore.QAbstractListModel):
 
     _MAX_DISPLAY_CHARS = 500
     _SOURCE_RE = re.compile(r'^[DWIE]: (\d{2}:\d{2}:\d{2},\d{3}) \S+:\d+: ')
+    _CONTROL_CHAR_MAP = str.maketrans({chr(c): chr(0x2400 + c) for c in range(32)} | {'\x7f': '\u2421'})
 
     def __init__(self, log_tail, parent=None):
         super().__init__(parent)
@@ -79,8 +80,9 @@ class LogItemModel(QtCore.QAbstractListModel):
             if self._compact_view:
                 msg = self._SOURCE_RE.sub(r'\1 ', msg)
             if len(msg) > self._MAX_DISPLAY_CHARS:
-                return msg[: self._MAX_DISPLAY_CHARS] + '…'
-            return msg
+                remaining = len(msg) - self._MAX_DISPLAY_CHARS
+                msg = f"{msg[: self._MAX_DISPLAY_CHARS]}… (+{remaining} chars)"
+            return msg.translate(self._CONTROL_CHAR_MAP)
         if role == Qt.ItemDataRole.ForegroundRole:
             return self._get_color(item.level)
         if role == LevelRole:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Multi-line log messages (e.g. tracebacks) were rendered with `AlignVCenter` in a single-line-height row, causing text to appear centered/overlapping.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3301
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

Fix by replacing all C0 control characters (0x00-0x1F) and DEL (0x7F) with their Unicode Control Pictures equivalents (U+2400 block) in the `DisplayRole`. This makes newlines, tabs, and any other invisible control characters visible as single glyphs.

It actually flattens multi-lines to a single line, avoid performance degradation and complexity linked to multi-line display.
The full unmodified text remains available via the **View Detail** dialog (`FullTextRole`).

Also:
- Improve the truncation indicator to show how many characters were cut: '… (+N chars)' instead of just '…'.
- Open **View Detail** on double-click or Enter (activated signal).

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
