### PR TITLE
PICARD-3303: Add syntax highlighting to Log Detail dialog

### DIFF
--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -47,6 +47,7 @@ from picard.ui import (
     FONT_FAMILY_MONOSPACE,
     PicardDialog,
 )
+from picard.ui.colors import interface_colors
 from picard.ui.logviewmodel import (
     FullTextRole,
     LogFilterProxyModel,
@@ -54,6 +55,89 @@ from picard.ui.logviewmodel import (
     LogItemModel,
 )
 from picard.ui.util import FileDialog
+
+
+class LogHighlighter(QtGui.QSyntaxHighlighter):
+    """Syntax highlighter for Picard log output in the detail view."""
+
+    _PATTERNS = None
+
+    @classmethod
+    def _build_patterns(cls):
+        opt_names = '|'.join(re.escape(opt.optname) for opt in DebugOpt)
+        cls._PATTERNS = [
+            (re.compile(r'^E: '), 'error'),
+            (re.compile(r'^W: '), 'warning'),
+            (re.compile(r'^I: '), 'info'),
+            (re.compile(r'^D: '), 'debug'),
+            (re.compile(r'^[DWIE]: \d{2}:\d{2}:\d{2},\d{3} (\S+:\d+:)'), 'source'),
+            (re.compile(rf'\[({opt_names})\]'), 'debug_opt'),
+            (re.compile(r'^Traceback \(most recent call last\):$'), 'traceback'),
+            (re.compile(r'^\s+File ".+", line \d+'), 'path'),
+            (re.compile(r'^(?:\w+\.)*\w*(?:Error|Exception|Warning|Exit): .+$'), 'error'),
+            (re.compile(r'^\s+\^+\s*$'), 'error'),
+        ]
+
+    def __init__(self, document):
+        super().__init__(document)
+        self._formats = self._build_formats()
+
+    def _build_formats(self):
+        error_color = interface_colors.get_qcolor('log_error')
+        warning_color = interface_colors.get_qcolor('log_warning')
+        debug_color = interface_colors.get_qcolor('log_debug')
+        info_color = interface_colors.get_qcolor('log_info')
+
+        bold = QtGui.QTextCharFormat()
+        bold.setFontWeight(QtGui.QFont.Weight.Bold)
+
+        error_fmt = QtGui.QTextCharFormat()
+        error_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
+        error_fmt.setForeground(error_color)
+
+        warning_fmt = QtGui.QTextCharFormat()
+        warning_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
+        warning_fmt.setForeground(warning_color)
+
+        info_fmt = QtGui.QTextCharFormat()
+        info_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
+        info_fmt.setForeground(info_color)
+
+        debug_fmt = QtGui.QTextCharFormat()
+        debug_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
+        debug_fmt.setForeground(debug_color)
+
+        source_fmt = QtGui.QTextCharFormat()
+        source_fmt.setForeground(debug_color)
+
+        debug_opt_fmt = QtGui.QTextCharFormat()
+        debug_opt_fmt.setFontWeight(QtGui.QFont.Weight.Bold)
+        debug_opt_fmt.setForeground(debug_color)
+
+        path_fmt = QtGui.QTextCharFormat()
+        path_fmt.setForeground(debug_color)
+
+        return {
+            'error': error_fmt,
+            'warning': warning_fmt,
+            'info': info_fmt,
+            'debug': debug_fmt,
+            'source': source_fmt,
+            'debug_opt': debug_opt_fmt,
+            'traceback': bold,
+            'path': path_fmt,
+        }
+
+    def highlightBlock(self, text):
+        if self._PATTERNS is None:
+            self._build_patterns()
+        for pattern, key in self._PATTERNS:
+            fmt = self._formats[key]
+            for match in pattern.finditer(text):
+                if match.lastindex:
+                    self.setFormat(match.start(1), match.end(1) - match.start(1), fmt)
+                else:
+                    self.setFormat(match.start(), match.end() - match.start(), fmt)
 
 
 class LogViewDialog(PicardDialog):
@@ -125,6 +209,7 @@ class LogViewDialog(PicardDialog):
         text_edit.setLineWrapMode(QtWidgets.QPlainTextEdit.LineWrapMode.WidgetWidth)
         text_edit.setFont(self.list_view.font())
         text_edit.setPlainText(text)
+        dlg._highlighter = LogHighlighter(text_edit.document())
         layout.addWidget(text_edit)
         dlg.show()
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The Log Detail dialog (opened via double-click or Enter on a log entry) now displays plain monospace text with no visual structure, making tracebacks and long debug output hard to read.

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3303
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Add a theme-aware QSyntaxHighlighter for the Log Detail view that highlights:
- Log level prefixes (D:/I:/W:/E:) using existing log level colors
- Source locations (module.function:line:)
- Debug option names ([plugin_updates], [timings], etc.)
- Python traceback elements (File references, exception lines, carets)

Colors are sourced from interface_colors (log_error, log_warning, log_debug, log_info) so they adapt to light/dark themes automatically.

<img width="1295" height="693" alt="Capture d’écran du 2026-05-30 00-02-41" src="https://github.com/user-attachments/assets/ad35eef6-483a-4aef-901a-c848b7997c71" />

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
