### PR TITLE
PICARD-3300: Exclude picard-plugins CLI from macOS app bundle

### DIFF
--- a/picard.spec
+++ b/picard.spec
@@ -148,56 +148,48 @@ else:
         strip=False,
         upx=False,
         icon='picard.ico',
-        version='win-version-info.txt',
         console=False,
-        # macOS specific
-        target_arch=os.environ.get('TARGET_ARCH', None),
-        codesign_identity=os.environ.get('CODESIGN_IDENTITY', None),
-        entitlements_file='./scripts/package/entitlements.plist',
-    )
-
-    # The picard-plugins CLI tool
-    a_plugins = Analysis(
-        ['picard/plugin3/cli.py'],
-        pathex=['picard'],
-        binaries=[],
-        datas=[],
-        hiddenimports=['cffi'],
-        hookspath=None,
-        runtime_hooks=[],
-        excludes=excludes,
-    )
-    pyz_plugins = PYZ(a_plugins.pure, a_plugins.zipped_data)
-    exe_plugins = EXE(
-        pyz_plugins,
-        a_plugins.scripts,
-        exclude_binaries=True,
-        name='picard-plugins',
-        debug=False,
-        strip=False,
-        upx=False,
-        icon='picard.ico',
+        # Windows specific
         version='win-version-info.txt',
-        console=False if os_name == 'Darwin' else True,
         # macOS specific
         target_arch=os.environ.get('TARGET_ARCH', None),
         codesign_identity=os.environ.get('CODESIGN_IDENTITY', None),
         entitlements_file='./scripts/package/entitlements.plist',
     )
 
-    coll = COLLECT(
-        exe,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        exe_plugins,
-        a_plugins.binaries,
-        a_plugins.zipfiles,
-        a_plugins.datas,
-        strip=False,
-        upx=False,
-        name='picard',
-    )
+    collect_items = [exe, a.binaries, a.zipfiles, a.datas]
+
+    # The picard-plugins CLI tool.
+    # Do not include on macOS, since macOS does not support multiple targets
+    # in the app bundle and mixing windowed and console executables.
+    if os_name != 'Darwin':
+        a_plugins = Analysis(
+            ['picard/plugin3/cli.py'],
+            pathex=['picard'],
+            binaries=[],
+            datas=[],
+            hiddenimports=['cffi'],
+            hookspath=None,
+            runtime_hooks=[],
+            excludes=excludes,
+        )
+        pyz_plugins = PYZ(a_plugins.pure, a_plugins.zipped_data)
+        exe_plugins = EXE(
+            pyz_plugins,
+            a_plugins.scripts,
+            exclude_binaries=True,
+            name='picard-plugins',
+            debug=False,
+            strip=False,
+            upx=False,
+            icon='picard.ico',
+            console=True,
+            # Windows specific
+            version='win-version-info.txt',
+        )
+        collect_items.extend([exe_plugins, a_plugins.binaries, a_plugins.zipfiles, a_plugins.datas])
+
+    coll = COLLECT(*collect_items, strip=False, upx=False, name='picard')
 
     if os_name == 'Darwin':
         info_plist = {

--- a/picard.spec
+++ b/picard.spec
@@ -6,6 +6,14 @@ import os
 import platform
 import sys
 
+from PyInstaller.building.api import (
+    COLLECT,
+    EXE,
+    PYZ,
+)
+from PyInstaller.building.build_main import Analysis
+from PyInstaller.building.osx import BUNDLE
+
 
 sys.path.insert(0, '.')
 from picard import (
@@ -134,7 +142,6 @@ else:
         pyz,
         a.scripts,
         exclude_binaries=True,
-        target_arch=os.environ.get('TARGET_ARCH', None),
         # Avoid name clash between picard executable and picard module folder
         name='picard' if os_name == 'Windows' else 'picard-run',
         debug=False,
@@ -143,7 +150,8 @@ else:
         icon='picard.ico',
         version='win-version-info.txt',
         console=False,
-        # macOS code signing
+        # macOS specific
+        target_arch=os.environ.get('TARGET_ARCH', None),
         codesign_identity=os.environ.get('CODESIGN_IDENTITY', None),
         entitlements_file='./scripts/package/entitlements.plist',
     )
@@ -164,7 +172,6 @@ else:
         pyz_plugins,
         a_plugins.scripts,
         exclude_binaries=True,
-        target_arch=os.environ.get('TARGET_ARCH', None),
         name='picard-plugins',
         debug=False,
         strip=False,
@@ -172,7 +179,8 @@ else:
         icon='picard.ico',
         version='win-version-info.txt',
         console=False if os_name == 'Darwin' else True,
-        # macOS code signing
+        # macOS specific
+        target_arch=os.environ.get('TARGET_ARCH', None),
         codesign_identity=os.environ.get('CODESIGN_IDENTITY', None),
         entitlements_file='./scripts/package/entitlements.plist',
     )


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3300
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

macOS does not support multiple binary targets in the same app bundle. Previously we had the picard-plugins marked as `console=True`, which made macOS launch even the GUI program in console mode without window. Now it runs both the GUI and CLI on every app start.

Given that the CLI is hidden in the app folder anyway and hard to access, completely exclude it from the bundle. Users wanting the CLI can install Picard via pypi.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
