### PR TITLE
PICARD-3302: Allow focusing Log View dialog while Options dialog is open

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -238,6 +238,7 @@ class Tagger(QtWidgets.QApplication):
         self._bootstrap()
         super().__init__(sys.argv)
         self.__class__.__instance = self
+        self._setup_app_icon()
         self._init_properties_from_args_or_env(cmdline_args)
         init_options()
         setup_config(app=self, filename=self._config_file)
@@ -278,6 +279,15 @@ class Tagger(QtWidgets.QApplication):
         # shutdown.
         self.exit_cleanup = []
         self.stopping = False
+
+    def _setup_app_icon(self):
+        icon = QtGui.QIcon()
+        for size in (16, 24, 32, 48, 128, 256):
+            icon.addFile(
+                ":/images/{size}x{size}/{app_id}.png".format(size=size, app_id=PICARD_APP_ID),
+                QtCore.QSize(size, size),
+            )
+        self.setWindowIcon(icon)
 
     def _init_properties_from_args_or_env(self, cmdline_args):
         """Initialize properties from command line arguments or environment"""

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -199,6 +199,21 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
             self.setWindowModality(self.modality)
         elif parent is not None:
             self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        if parent is None:
+            self._register_parentless()
+
+    _parentless_instances: list['PicardDialog'] = []
+
+    def _register_parentless(self):
+        self._parentless_instances.append(self)
+
+    @classmethod
+    def close_all_parentless(cls):
+        """Close all parentless dialogs. Called on application quit."""
+        for dialog in cls._parentless_instances:
+            log.debug("Closing parentless dialog %s on quit", type(dialog).__name__)
+            dialog.close()
+        cls._parentless_instances.clear()
 
     def keyPressEvent(self, event):
         if event.matches(QtGui.QKeySequence.StandardKey.Close):

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -180,6 +180,13 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
         | QtCore.Qt.WindowType.WindowTitleHint
         | QtCore.Qt.WindowType.WindowCloseButtonHint
     )
+    # Default modality: WindowModal when a parent is given, NonModal otherwise.
+    # Subclasses can override this with an explicit Qt.WindowModality value to
+    # opt out of the automatic behaviour, e.g.:
+    #   modality = QtCore.Qt.WindowModality.NonModal   # keep non-modal despite having a parent
+    #   modality = QtCore.Qt.WindowModality.ApplicationModal  # force app-modal (rare)
+    # Set to None to use the automatic parent-based logic (the default).
+    modality = None
     ready_for_display = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
@@ -187,6 +194,10 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
         self.tagger = tagger_instance()
         self.__shown = False
         self.ready_for_display.connect(self.restore_geometry)
+        if self.modality is not None:
+            self.setWindowModality(self.modality)
+        elif parent is not None:
+            self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
 
     def keyPressEvent(self, event):
         if event.matches(QtGui.QKeySequence.StandardKey.Close):

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -90,6 +90,7 @@ class PreserveGeometry:
     def __init__(self, *args, **kwargs):
         Option.add_if_missing('persist', self.opt_name(), QtCore.QByteArray())
         Option.add_if_missing('persist', self.splitters_name(), {})
+        self._geometry_initialized = False
         if getattr(self, 'finished', None):
             self.finished.connect(self.save_geometry)
 
@@ -136,6 +137,7 @@ class PreserveGeometry:
 
     @restore_method
     def restore_geometry(self):
+        self._geometry_initialized = True
         config = get_config()
         geometry = config.persist[self.opt_name()]
         if not geometry.isNull():
@@ -153,8 +155,13 @@ class PreserveGeometry:
             del config.persist[self.splitters_name()][name]
 
     def save_geometry(self):
+        if not self._geometry_initialized:
+            return
+        geometry = self.saveGeometry()
+        if not geometry:
+            return
         config = get_config()
-        config.persist[self.opt_name()] = self.saveGeometry()
+        config.persist[self.opt_name()] = geometry
         config.persist[self.splitters_name()] = {
             name: bytearray(splitter.saveState()) for name, splitter in self._get_splitters.items()
         }

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -163,9 +163,7 @@ class SingletonDialog:
         # Update parent if changed
         if 'parent' in kwargs and parent != kwargs['parent']:
             instance.setParent(kwargs['parent'])
-        instance.show()
-        instance.raise_()
-        instance.activateWindow()
+        instance.show_nonmodal()
         return instance
 
     @classmethod
@@ -212,6 +210,32 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
             self.ready_for_display.emit()
             self.__shown = True
         return super().showEvent(event)
+
+    def _show_with_modality(self, modality):
+        self.setWindowModality(modality)
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    def show_modal(self):
+        """Show this dialog as window-modal and bring it to the front.
+
+        Sets WindowModal modality (blocking only the parent window), then
+        shows, raises, and activates the dialog. Use this instead of exec()
+        when you want non-blocking modal behaviour, or instead of a bare
+        show() when the dialog must block its parent.
+        """
+        self._show_with_modality(QtCore.Qt.WindowModality.WindowModal)
+
+    def show_nonmodal(self):
+        """Show this dialog as non-modal and bring it to the front.
+
+        Clears any modality so the dialog does not block any window, then
+        shows, raises, and activates it. Use this for persistent utility
+        windows (log viewer, documentation, etc.) that should stay open
+        alongside the rest of the UI.
+        """
+        self._show_with_modality(QtCore.Qt.WindowModality.NonModal)
 
     def show_help(self, help_url=None):
         url = help_url or self.help_url

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -25,6 +25,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+import os
 import uuid
 
 from PyQt6 import (
@@ -62,6 +63,25 @@ elif IS_HAIKU:
     FONT_FAMILY_MONOSPACE = 'Noto Sans Mono'
 else:
     FONT_FAMILY_MONOSPACE = 'Monospace'
+
+
+def modal_options():
+    """Whether the Options dialog should use modal behavior.
+
+    On macOS, Options must be WindowModal because NonModal dialogs can get
+    lost behind the main window with no way to recover. On other platforms,
+    Options uses NonModal + disabled MainWindow, which allows utility windows
+    (LogView, Script Editor) to remain interactive.
+
+    Can be overridden with the PICARD_MODAL_OPTIONS environment variable
+    (set to '1' to force modal, '0' to force non-modal).
+
+    Returns True for modal behavior, False for non-modal + disabled parent.
+    """
+    override = os.environ.get('PICARD_MODAL_OPTIONS')
+    if override is not None:
+        return override == '1'
+    return IS_MACOS
 
 
 class PreserveGeometry:

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -163,7 +163,9 @@ class SingletonDialog:
         # Update parent if changed
         if 'parent' in kwargs and parent != kwargs['parent']:
             instance.setParent(kwargs['parent'])
-        instance.show_nonmodal()
+        instance.show()
+        instance.raise_()
+        instance.activateWindow()
         return instance
 
     @classmethod

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -233,6 +233,11 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
 
     def _register_parentless(self):
         self._parentless_instances.append(self)
+        self.destroyed.connect(self._unregister_parentless)
+
+    def _unregister_parentless(self):
+        if self in self._parentless_instances:
+            self._parentless_instances.remove(self)
 
     @classmethod
     def close_all_parentless(cls):

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -46,6 +46,7 @@ from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
+from picard.i18n import gettext as _
 from picard.util import (
     get_url,
     restore_method,
@@ -238,6 +239,17 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
         alongside the rest of the UI.
         """
         self._show_with_modality(QtCore.Qt.WindowModality.NonModal)
+
+    def set_window_title(self, title: str) -> None:
+        """Set window title, appending the app name for parentless windows.
+
+        Parentless windows appear as separate entries in the taskbar, so the
+        app name suffix helps identify them. Parented dialogs are already
+        visually associated with their parent and don't need it.
+        """
+        if not self.parent():
+            title = _("%s — MusicBrainz Picard") % title
+        self.setWindowTitle(title)
 
     def show_help(self, help_url=None):
         url = help_url or self.help_url

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -42,6 +42,8 @@ from picard.ui.forms.ui_aboutdialog import Ui_AboutDialog
 
 
 class AboutDialog(PicardDialog, SingletonDialog):
+    modality = QtCore.Qt.WindowModality.NonModal
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -42,8 +42,6 @@ from picard.ui.forms.ui_aboutdialog import Ui_AboutDialog
 
 
 class AboutDialog(PicardDialog, SingletonDialog):
-    modality = QtCore.Qt.WindowModality.NonModal
-
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)

--- a/picard/ui/allowrtdupdatesdialog.py
+++ b/picard/ui/allowrtdupdatesdialog.py
@@ -50,7 +50,7 @@ class AllowRtdUpdatesDialog:
         self.msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         self.msg.setText(dialog_text)
         self.msg.setWindowTitle(_("ReadTheDocs Updates"))
-        self.msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
 
         self.cb = QtWidgets.QCheckBox(show_again_text)
         self.cb.setChecked(self.show_again)

--- a/picard/ui/caa_types_selector.py
+++ b/picard/ui/caa_types_selector.py
@@ -185,7 +185,6 @@ class CAATypesSelectorDialog(PicardDialog):
         self._known_types = {t['name']: translate_caa_type(t['name']) for t in CAA_TYPES}
 
         self.setWindowTitle(_("Cover art types"))
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.setSizeConstraint(QtWidgets.QLayout.SizeConstraint.SetFixedSize)
 

--- a/picard/ui/coverartbox/imageurldialog.py
+++ b/picard/ui/coverartbox/imageurldialog.py
@@ -49,7 +49,6 @@ class ImageURLDialog(PicardDialog):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setWindowTitle(_("Enter URL"))
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.layout = QtWidgets.QVBoxLayout(self)
         self.label = QtWidgets.QLabel(_("Cover art URL:"))
         self.url = QtWidgets.QLineEdit(self)

--- a/picard/ui/dialogs/cover_types_selector.py
+++ b/picard/ui/dialogs/cover_types_selector.py
@@ -43,7 +43,6 @@ class CoverTypesSelectorDialog(PicardDialog):
     def __init__(self, selected_types: Iterable[str] | None = None, parent=None):
         super().__init__(parent)
         self.setWindowTitle(_("Cover art types"))
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self._layout = QtWidgets.QVBoxLayout(self)
 
         self._types_list = QtWidgets.QListWidget(self)

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -48,7 +48,6 @@ class InstallConfirmDialog(PicardDialog):
         self.plugin_manager = self.tagger.get_plugin_manager()
 
         self.setWindowTitle(_("Confirm Plugin Installation"))
-        self.setModal(True)
         self.setMinimumSize(font_scaled_size(self, 60, 20))
         self.setup_ui()
         self.check_trust_and_blacklist()

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -69,7 +69,6 @@ class InstallPluginDialog(PicardDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(_("Install Plugin"))
-        self.setModal(True)
         self.setMinimumSize(font_scaled_size(self, 60, 20))
 
         # Cache frequently accessed objects

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -538,19 +538,26 @@ class InstallPluginDialog(PicardDialog):
         # Disable UI before showing confirmation dialog to prevent interaction
         self._disable_ui_for_installation()
 
-        ref = None
         if getattr(plugin, 'ref', None) is None:
             # Show confirmation dialog
             plugin_name = plugin.get_display_name()
             plugin_uuid = plugin.plugin_uuid
             confirm_dialog = InstallConfirmDialog(plugin_name, url, self, plugin_uuid, None)
-            if confirm_dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
-                # Re-enable UI if user cancels
-                self._enable_ui_after_installation()
-                return
-            if confirm_dialog.selected_ref:
-                ref = confirm_dialog.selected_ref.shortname
+            confirm_dialog.finished.connect(
+                lambda result: self._on_install_confirm_finished(result, confirm_dialog, url, plugin, current_tab)
+            )
+            confirm_dialog.open()
+        else:
+            self._proceed_with_install(url, plugin.ref, plugin, current_tab)
 
+    def _on_install_confirm_finished(self, result, confirm_dialog, url, plugin, current_tab):
+        if result != QtWidgets.QDialog.DialogCode.Accepted:
+            self._enable_ui_after_installation()
+            return
+        ref = confirm_dialog.selected_ref.shortname if confirm_dialog.selected_ref else None
+        self._proceed_with_install(url, ref, plugin, current_tab)
+
+    def _proceed_with_install(self, url, ref, plugin, current_tab):
         # Use versioning scheme for registry plugins when no ref specified
         if current_tab == TAB_REGISTRY and ref is None:
             # Get original plugin data for versioning scheme

--- a/picard/ui/dialogs/plugin_order_selector.py
+++ b/picard/ui/dialogs/plugin_order_selector.py
@@ -60,7 +60,6 @@ class PluginOrderSelectorDialog(PicardDialog):
         self._make_plugin_list()
 
         self.setWindowTitle(_("Plugin Execution Order"))
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setMinimumSize(font_scaled_size(self, 80, 25))
         self._layout = QtWidgets.QVBoxLayout(self)
 

--- a/picard/ui/dialogs/plugininfo.py
+++ b/picard/ui/dialogs/plugininfo.py
@@ -26,16 +26,15 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import tagger_instance
 from picard.i18n import gettext as _
 from picard.plugin3.categories import PluginCategorySet
 from picard.plugin3.installable import InstallablePlugin
 
-from picard.ui import PreserveGeometry
+from picard.ui import PicardDialog
 from picard.ui.util import font_scaled_size
 
 
-class PluginInfoDialog(QtWidgets.QDialog, PreserveGeometry):
+class PluginInfoDialog(PicardDialog):
     """Dialog showing detailed plugin information for both registry and installed plugins."""
 
     defaultsize = QtCore.QSize(600, 500)
@@ -45,17 +44,11 @@ class PluginInfoDialog(QtWidgets.QDialog, PreserveGeometry):
         self._plugin_data = plugin_data
 
         # Cache plugin manager for performance
-        tagger = tagger_instance()
-        self.plugin_manager = tagger.get_plugin_manager()
+        self.plugin_manager = self.tagger.get_plugin_manager()
 
         self.setWindowTitle(_("Plugin Information"))
-        self.setModal(True)
         self.setMinimumSize(font_scaled_size(self, 60, 20))
         self.setup_ui()
-
-    def showEvent(self, event):
-        super().showEvent(event)
-        self.restore_geometry()
 
     @property
     def plugin_data(self):

--- a/picard/ui/forms/ui_edittagdialog.py
+++ b/picard/ui/forms/ui_edittagdialog.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/edittagdialog.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -17,10 +17,9 @@ from picard.i18n import gettext as _
 class Ui_EditTagDialog(object):
     def setupUi(self, EditTagDialog):
         EditTagDialog.setObjectName("EditTagDialog")
-        EditTagDialog.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        EditTagDialog.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         EditTagDialog.resize(400, 250)
         EditTagDialog.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
-        EditTagDialog.setModal(True)
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(EditTagDialog)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.tag_names = QtWidgets.QComboBox(parent=EditTagDialog)
@@ -68,7 +67,9 @@ class Ui_EditTagDialog(object):
         self.remove_value.setAutoDefault(False)
         self.remove_value.setObjectName("remove_value")
         self.verticalLayout.addWidget(self.remove_value)
-        spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Maximum)
+        spacerItem = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Maximum
+        )
         self.verticalLayout.addItem(spacerItem)
         self.move_value_up = QtWidgets.QPushButton(parent=EditTagDialog)
         self.move_value_up.setText("")
@@ -82,7 +83,9 @@ class Ui_EditTagDialog(object):
         self.move_value_down.setIcon(icon)
         self.move_value_down.setObjectName("move_value_down")
         self.verticalLayout.addWidget(self.move_value_down)
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem1)
         self.horizontalLayout.addLayout(self.verticalLayout)
         self.verticalLayout_2.addLayout(self.horizontalLayout)
@@ -94,22 +97,24 @@ class Ui_EditTagDialog(object):
         self.buttonbox.setSizePolicy(sizePolicy)
         self.buttonbox.setMinimumSize(QtCore.QSize(150, 0))
         self.buttonbox.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.buttonbox.setStandardButtons(QtWidgets.QDialogButtonBox.StandardButton.Cancel|QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        self.buttonbox.setStandardButtons(
+            QtWidgets.QDialogButtonBox.StandardButton.Cancel | QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
         self.buttonbox.setObjectName("buttonbox")
         self.verticalLayout_2.addWidget(self.buttonbox)
 
         self.retranslateUi(EditTagDialog)
-        self.buttonbox.accepted.connect(EditTagDialog.accept)
-        self.buttonbox.rejected.connect(EditTagDialog.reject)
-        self.move_value_up.clicked.connect(EditTagDialog.move_row_up)
-        self.move_value_down.clicked.connect(EditTagDialog.move_row_down)
-        self.edit_value.clicked.connect(EditTagDialog.edit_value)
-        self.add_value.clicked.connect(EditTagDialog.add_value)
-        self.value_list.itemChanged['QListWidgetItem*'].connect(EditTagDialog.value_edited)
-        self.remove_value.clicked.connect(EditTagDialog.remove_value)
-        self.value_list.itemSelectionChanged.connect(EditTagDialog.value_selection_changed)
-        self.tag_names.editTextChanged['QString'].connect(EditTagDialog.tag_changed)
-        self.tag_names.activated['int'].connect(EditTagDialog.tag_selected)
+        self.buttonbox.accepted.connect(EditTagDialog.accept)  # type: ignore
+        self.buttonbox.rejected.connect(EditTagDialog.reject)  # type: ignore
+        self.move_value_up.clicked.connect(EditTagDialog.move_row_up)  # type: ignore
+        self.move_value_down.clicked.connect(EditTagDialog.move_row_down)  # type: ignore
+        self.edit_value.clicked.connect(EditTagDialog.edit_value)  # type: ignore
+        self.add_value.clicked.connect(EditTagDialog.add_value)  # type: ignore
+        self.value_list.itemChanged['QListWidgetItem*'].connect(EditTagDialog.value_edited)  # type: ignore
+        self.remove_value.clicked.connect(EditTagDialog.remove_value)  # type: ignore
+        self.value_list.itemSelectionChanged.connect(EditTagDialog.value_selection_changed)  # type: ignore
+        self.tag_names.editTextChanged['QString'].connect(EditTagDialog.tag_changed)  # type: ignore
+        self.tag_names.activated['int'].connect(EditTagDialog.tag_selected)  # type: ignore
         QtCore.QMetaObject.connectSlotsByName(EditTagDialog)
         EditTagDialog.setTabOrder(self.tag_names, self.value_list)
         EditTagDialog.setTabOrder(self.value_list, self.edit_value)

--- a/picard/ui/forms/ui_passworddialog.py
+++ b/picard/ui/forms/ui_passworddialog.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/passworddialog.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -19,7 +19,9 @@ class Ui_PasswordDialog(object):
         PasswordDialog.setObjectName("PasswordDialog")
         PasswordDialog.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         PasswordDialog.resize(378, 246)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(PasswordDialog.sizePolicy().hasHeightForWidth())
@@ -31,13 +33,14 @@ class Ui_PasswordDialog(object):
         self.info_text.setWordWrap(True)
         self.info_text.setObjectName("info_text")
         self.verticalLayout.addWidget(self.info_text)
-        spacerItem = QtWidgets.QSpacerItem(20, 60, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem = QtWidgets.QSpacerItem(
+            20, 60, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem)
         self.label = QtWidgets.QLabel(parent=PasswordDialog)
         self.label.setObjectName("label")
         self.verticalLayout.addWidget(self.label)
         self.username = QtWidgets.QLineEdit(parent=PasswordDialog)
-        self.username.setWindowModality(QtCore.Qt.WindowModality.NonModal)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -52,16 +55,20 @@ class Ui_PasswordDialog(object):
         self.password.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
         self.password.setObjectName("password")
         self.verticalLayout.addWidget(self.password)
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem1)
         self.buttonbox = QtWidgets.QDialogButtonBox(parent=PasswordDialog)
         self.buttonbox.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.buttonbox.setStandardButtons(QtWidgets.QDialogButtonBox.StandardButton.Cancel|QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        self.buttonbox.setStandardButtons(
+            QtWidgets.QDialogButtonBox.StandardButton.Cancel | QtWidgets.QDialogButtonBox.StandardButton.Ok
+        )
         self.buttonbox.setObjectName("buttonbox")
         self.verticalLayout.addWidget(self.buttonbox)
 
         self.retranslateUi(PasswordDialog)
-        self.buttonbox.rejected.connect(PasswordDialog.reject)
+        self.buttonbox.rejected.connect(PasswordDialog.reject)  # type: ignore
         QtCore.QMetaObject.connectSlotsByName(PasswordDialog)
 
     def retranslateUi(self, PasswordDialog):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -331,7 +331,7 @@ class DebugOptsMenu(QtWidgets.QMenu):
 
 class LogView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.main_tail, _("Log"), parent=parent)
+        super().__init__(log.main_tail, _("Log View — MusicBrainz Picard"), parent=parent)
         self.verbosity = log.get_effective_level()
         self._status_label = None
         self.help_url = '/appendices/log_viewer.html'
@@ -546,4 +546,4 @@ class LogView(LogViewCommon):
 
 class HistoryView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.history_tail, _("Activity History"), parent=parent)
+        super().__init__(log.history_tail, _("Activity History — MusicBrainz Picard"), parent=parent)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -142,6 +142,7 @@ class LogHighlighter(QtGui.QSyntaxHighlighter):
 
 class LogViewDialog(PicardDialog):
     defaultsize = QtCore.QSize(570, 400)
+    modality = QtCore.Qt.WindowModality.NonModal
 
     def __init__(self, title, parent=None):
         super().__init__(parent=parent)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -147,7 +147,7 @@ class LogViewDialog(PicardDialog):
     def __init__(self, title, parent=None):
         super().__init__(parent=parent)
         self.setWindowFlags(QtCore.Qt.WindowType.Window)
-        self.setWindowTitle(title)
+        self.set_window_title(title)
         self.vbox = QtWidgets.QVBoxLayout()
         self.setLayout(self.vbox)
         self.list_view = QtWidgets.QListView()
@@ -331,7 +331,7 @@ class DebugOptsMenu(QtWidgets.QMenu):
 
 class LogView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.main_tail, _("Log View — MusicBrainz Picard"), parent=parent)
+        super().__init__(log.main_tail, _("Log View"), parent=parent)
         self.verbosity = log.get_effective_level()
         self._status_label = None
         self.help_url = '/appendices/log_viewer.html'
@@ -546,4 +546,4 @@ class LogView(LogViewCommon):
 
 class HistoryView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.history_tail, _("Activity History — MusicBrainz Picard"), parent=parent)
+        super().__init__(log.history_tail, _("Activity History"), parent=parent)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1311,14 +1311,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         options_dialog = OptionsDialog.show_instance(page, self)
         options_dialog.finished.connect(self._options_closed)
         if not modal_options():
-            self.setEnabled(False)
-            options_dialog.setEnabled(True)
+            self._disable_while_dialog_shown(options_dialog)
 
         return options_dialog
 
     def _options_closed(self):
-        if not modal_options():
-            self.setEnabled(True)
         if self.script_editor_dialog is not None:
             self.open_file_naming_script_editor()
             self.script_editor_dialog.show()
@@ -1327,6 +1324,24 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._make_profile_selector_menu()
         self._make_script_selector_menu()
         self._make_settings_selector_menu()
+
+    def _disable_while_dialog_shown(self, dialog):
+        """Disable MainWindow while dialog is shown, re-enable when it closes.
+
+        Connects to both `finished` (normal close path) and `destroyed`
+        (safety net if the dialog is destroyed without emitting `finished`,
+        e.g. via deleteLater or parent destruction). The isEnabled() guard
+        prevents double-action when both signals fire in sequence.
+        """
+
+        def re_enable():
+            if not self.isEnabled():
+                self.setEnabled(True)
+
+        dialog.destroyed.connect(re_enable)
+        dialog.finished.connect(re_enable)
+        self.setEnabled(False)
+        dialog.setEnabled(True)
 
     def show_help(self):
         webbrowser2.open('documentation')

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -264,6 +264,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 ":/images/{size}x{size}/{app_id}.png".format(size=size, app_id=PICARD_APP_ID), QtCore.QSize(size, size)
             )
         self.setWindowIcon(icon)
+        QtWidgets.QApplication.instance().setWindowIcon(icon)
 
         self.show_close_window = IS_MACOS
 
@@ -287,8 +288,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.file_browser.hide()
         self.panel.insertWidget(0, self.file_browser)
 
-        self.log_dialog = LogView(self)
-        self.history_dialog = HistoryView(self)
+        self.log_dialog = LogView()
+        self.history_dialog = HistoryView()
 
         self.metadata_box = MetadataBox(parent=self)
         self.cover_art_box = CoverArtBox(parent=self)
@@ -432,6 +433,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 # Silently close the script editor without displaying the confirmation a second time.
                 self.script_editor_dialog.loading = True
         event.accept()
+        self.log_dialog.close()
+        self.history_dialog.close()
 
     def _setup_desktop_status_indicator(self):
         if DesktopStatusIndicator:

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1303,12 +1303,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def show_options(self, page=None):
         ReadTheDocs.update_documentation_items()  # Retry updates if required
-        options_dialog = OptionsDialog.show_instance(page, self)
-        options_dialog.finished.connect(self._options_closed)
         if self.script_editor_dialog is not None:
             # Disable signal processing to avoid saving changes not processed with "Make It So!"
             for signal in self.script_editor_signals:
                 signal.disconnect()
+        options_dialog = OptionsDialog.show_instance(page, self)
+        options_dialog.finished.connect(self._options_closed)
 
         return options_dialog
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -429,6 +429,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.history_dialog.close()
         if self.script_editor_dialog:
             ScriptEditorDialog.get_instance().close()
+        if AboutDialog._instance:
+            AboutDialog._instance.close()
 
     def _setup_desktop_status_indicator(self):
         if DesktopStatusIndicator:
@@ -1299,7 +1301,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.tagger.activeWindow().close()
 
     def show_about(self):
-        return AboutDialog.show_instance(self)
+        return AboutDialog.show_instance()
 
     def show_options(self, page=None):
         ReadTheDocs.update_documentation_items()  # Retry updates if required

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1329,9 +1329,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         webbrowser2.open('documentation')
 
     def _show_log_dialog(self, dialog):
-        dialog.show()
-        dialog.raise_()
-        dialog.activateWindow()
+        dialog.show_nonmodal()
 
     def show_log(self):
         self._show_log_dialog(self.log_dialog)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1309,10 +1309,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 signal.disconnect()
         options_dialog = OptionsDialog.show_instance(page, self)
         options_dialog.finished.connect(self._options_closed)
+        self.setEnabled(False)
+        options_dialog.setEnabled(True)
 
         return options_dialog
 
     def _options_closed(self):
+        self.setEnabled(True)
         if self.script_editor_dialog is not None:
             self.open_file_naming_script_editor()
             self.script_editor_dialog.show()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -127,7 +127,10 @@ from picard.util.cdrom import (
 )
 from picard.util.readthedocs import ReadTheDocs
 
-from picard.ui import PreserveGeometry
+from picard.ui import (
+    PicardDialog,
+    PreserveGeometry,
+)
 from picard.ui.aboutdialog import AboutDialog
 from picard.ui.allowrtdupdatesdialog import AllowRtdUpdatesDialog
 from picard.ui.coverartbox import CoverArtBox
@@ -425,12 +428,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 # Silently close the script editor without displaying the confirmation a second time.
                 self.script_editor_dialog.loading = True
         event.accept()
-        self.log_dialog.close()
-        self.history_dialog.close()
-        if self.script_editor_dialog:
-            ScriptEditorDialog.get_instance().close()
-        if AboutDialog._instance:
-            AboutDialog._instance.close()
+        PicardDialog.close_all_parentless()
 
     def _setup_desktop_status_indicator(self):
         if DesktopStatusIndicator:

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -63,7 +63,6 @@ from PyQt6 import (
 )
 
 from picard import (
-    PICARD_APP_ID,
     log,
     tagger_instance,
 )
@@ -258,13 +257,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def setupUi(self):
         self.setWindowTitle(_("MusicBrainz Picard"))
-        icon = QtGui.QIcon()
-        for size in (16, 24, 32, 48, 128, 256):
-            icon.addFile(
-                ":/images/{size}x{size}/{app_id}.png".format(size=size, app_id=PICARD_APP_ID), QtCore.QSize(size, size)
-            )
-        self.setWindowIcon(icon)
-        QtWidgets.QApplication.instance().setWindowIcon(icon)
 
         self.show_close_window = IS_MACOS
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1300,7 +1300,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.tagger.activeWindow().close()
 
     def show_about(self):
-        return AboutDialog.show_instance()
+        return AboutDialog.show_instance(self)
 
     def show_options(self, page=None):
         ReadTheDocs.update_documentation_items()  # Retry updates if required

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -130,6 +130,7 @@ from picard.util.readthedocs import ReadTheDocs
 from picard.ui import (
     PicardDialog,
     PreserveGeometry,
+    modal_options,
 )
 from picard.ui.aboutdialog import AboutDialog
 from picard.ui.allowrtdupdatesdialog import AllowRtdUpdatesDialog
@@ -1309,13 +1310,15 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 signal.disconnect()
         options_dialog = OptionsDialog.show_instance(page, self)
         options_dialog.finished.connect(self._options_closed)
-        self.setEnabled(False)
-        options_dialog.setEnabled(True)
+        if not modal_options():
+            self.setEnabled(False)
+            options_dialog.setEnabled(True)
 
         return options_dialog
 
     def _options_closed(self):
-        self.setEnabled(True)
+        if not modal_options():
+            self.setEnabled(True)
         if self.script_editor_dialog is not None:
             self.open_file_naming_script_editor()
             self.script_editor_dialog.show()
@@ -2162,7 +2165,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """Open the file naming script editor / manager in a new window."""
         ReadTheDocs.update_documentation_items()  # Retry updates if required
         examples = ScriptEditorExamples(tagger=self.tagger)
-        self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=examples)
+        if modal_options():
+            self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=examples)
+        else:
+            self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=examples)
         self.script_editor_dialog.signal_save.connect(self._script_editor_save)
         self.script_editor_dialog.signal_selection_changed.connect(self._update_selector_from_script_editor)
         self.script_editor_dialog.signal_index_changed.connect(self._script_editor_index_changed)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -435,6 +435,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         event.accept()
         self.log_dialog.close()
         self.history_dialog.close()
+        if self.script_editor_dialog:
+            ScriptEditorDialog.get_instance().close()
 
     def _setup_desktop_status_indicator(self):
         if DesktopStatusIndicator:
@@ -2165,7 +2167,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """Open the file naming script editor / manager in a new window."""
         ReadTheDocs.update_documentation_items()  # Retry updates if required
         examples = ScriptEditorExamples(tagger=self.tagger)
-        self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=examples)
+        self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=examples)
         self.script_editor_dialog.signal_save.connect(self._script_editor_save)
         self.script_editor_dialog.signal_selection_changed.connect(self._update_selector_from_script_editor)
         self.script_editor_dialog.signal_index_changed.connect(self._script_editor_index_changed)

--- a/picard/ui/newuserdialog.py
+++ b/picard/ui/newuserdialog.py
@@ -53,7 +53,7 @@ class NewUserDialog:
         self.msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         self.msg.setText(dialog_text)
         self.msg.setWindowTitle(_("New User Warning"))
-        self.msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
 
         self.cb = QtWidgets.QCheckBox(show_again_text)
         self.cb.setChecked(self.show_again)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -341,7 +341,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # If the script editor is already open (opened from main window),
         # reconnect it to the file renaming options page without raising it.
         if self.tagger and self.tagger.window.script_editor_dialog is not None:
-            self.get_page('filerenaming').show_script_editing_page()
+            self.get_page('filerenaming').show_script_editing_page(raise_window=False)
 
     @property
     def initialized_pages(self):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -773,7 +773,6 @@ class AttachedProfilesDialog(PicardDialog):
         self.populate_table()
 
         self.ui.buttonBox.setFocus()
-        self.setModal(True)
 
     def populate_table(self):
         model = QtGui.QStandardItemModel()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -157,6 +157,10 @@ class ErrorOptionsPage(OptionsPage):
 
 class OptionsDialog(PicardDialog, SingletonDialog):
     modality = QtCore.Qt.WindowModality.NonModal
+    # Stay above MainWindow since it is disabled while Options is open.
+    # Without this, the user could click MainWindow and hide Options behind it
+    # (especially problematic on macOS where there's no taskbar entry to recover).
+    flags = PicardDialog.flags | QtCore.Qt.WindowType.WindowStaysOnTopHint
     suspend_signals = False
 
     def add_pages(self, parent_pagename, default_pagename, parent_item):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -388,9 +388,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             override_profiles=override_profiles,
             override_settings=override_settings,
         )
-        profile_dialog.show()
-        profile_dialog.raise_()
-        profile_dialog.activateWindow()
+        profile_dialog.show_modal()
 
     def update_from_profile_changes(self):
         if not self.suspend_signals:

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -305,8 +305,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.finished.connect(self.saveWindowState)
 
         self.load_all_pages()
-        self.first_enter = True
-        self.installEventFilter(self)
 
         maintenance_page = self.get_page('maintenance')
         if maintenance_page.loaded:
@@ -339,6 +337,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Set initial selection after plugin refresh
         if self.default_item:
             self.ui.pages_tree.setCurrentItem(self.default_item)  # this will call switch_page
+
+        # If the script editor is already open (opened from main window),
+        # reconnect it to the file renaming options page without raising it.
+        if self.tagger and self.tagger.window.script_editor_dialog is not None:
+            self.get_page('filerenaming').show_script_editing_page()
 
     @property
     def initialized_pages(self):
@@ -448,17 +451,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                     except AttributeError:
                         pass
                     break
-
-    def eventFilter(self, object, event):
-        """Process selected events."""
-        evtype = event.type()
-        if evtype == QtCore.QEvent.Type.Enter:
-            if self.first_enter:
-                self.first_enter = False
-                if self.tagger and self.tagger.window.script_editor_dialog is not None:
-                    self.get_page('filerenaming').show_script_editing_page()
-                    self.activateWindow()
-        return False
 
     def get_page(self, pagename):
         return self.item_to_page[self.pagename_to_item[pagename]]

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -221,10 +221,15 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.Window)
         else:
             # On Linux/Windows: use NonModal + disabled MainWindow (set in
-            # show_options). Add WindowStaysOnTopHint to prevent Options from
-            # being hidden behind the disabled MainWindow.
+            # show_options). Use Tool type to stay above parent (MainWindow)
+            # without staying on top of other applications.
             self.setWindowModality(QtCore.Qt.WindowModality.NonModal)
-            self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.WindowStaysOnTopHint)
+            self.setWindowFlags(
+                QtCore.Qt.WindowType.Tool
+                | QtCore.Qt.WindowType.WindowTitleHint
+                | QtCore.Qt.WindowType.WindowSystemMenuHint
+                | QtCore.Qt.WindowType.WindowCloseButtonHint
+            )
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.ui = Ui_OptionsDialog()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -156,6 +156,7 @@ class ErrorOptionsPage(OptionsPage):
 
 
 class OptionsDialog(PicardDialog, SingletonDialog):
+    modality = QtCore.Qt.WindowModality.NonModal
     suspend_signals = False
 
     def add_pages(self, parent_pagename, default_pagename, parent_item):
@@ -341,7 +342,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # If the script editor is already open (opened from main window),
         # reconnect it to the file renaming options page without raising it.
         if self.tagger and self.tagger.window.script_editor_dialog is not None:
-            self.get_page('filerenaming').show_script_editing_page(raise_window=False)
+            self.get_page('filerenaming').show_script_editing_page()
 
     @property
     def initialized_pages(self):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -48,6 +48,7 @@ from picard.config import (
     SettingConfigSection,
     get_config,
 )
+from picard.const.sys import IS_MACOS
 from picard.extension_points.options_pages import ext_point_options_pages
 from picard.i18n import (
     N_,
@@ -213,7 +214,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def __init__(self, default_page=None, parent=None):
         super().__init__(parent=parent)
-        self.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        if IS_MACOS:
+            # Prevent macOS from rendering this as a sheet attached to the
+            # parent's title bar. On Linux/Windows, the Window flag would break
+            # WindowModal enforcement, so it is only set on macOS.
+            self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.Window)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.ui = Ui_OptionsDialog()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -48,7 +48,6 @@ from picard.config import (
     SettingConfigSection,
     get_config,
 )
-from picard.const.sys import IS_MACOS
 from picard.extension_points.options_pages import ext_point_options_pages
 from picard.i18n import (
     N_,
@@ -67,6 +66,7 @@ from picard.ui import (
     HashableTreeWidgetItem,
     PicardDialog,
     SingletonDialog,
+    modal_options,
 )
 from picard.ui.colors import interface_colors as _interface_colors
 from picard.ui.forms.ui_options import Ui_OptionsDialog
@@ -156,11 +156,6 @@ class ErrorOptionsPage(OptionsPage):
 
 
 class OptionsDialog(PicardDialog, SingletonDialog):
-    modality = QtCore.Qt.WindowModality.NonModal
-    # Stay above MainWindow since it is disabled while Options is open.
-    # Without this, the user could click MainWindow and hide Options behind it
-    # (especially problematic on macOS where there's no taskbar entry to recover).
-    flags = PicardDialog.flags | QtCore.Qt.WindowType.WindowStaysOnTopHint
     suspend_signals = False
 
     def add_pages(self, parent_pagename, default_pagename, parent_item):
@@ -219,11 +214,17 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def __init__(self, default_page=None, parent=None):
         super().__init__(parent=parent)
-        if IS_MACOS:
-            # Prevent macOS from rendering this as a sheet attached to the
-            # parent's title bar. On Linux/Windows, the Window flag would break
-            # WindowModal enforcement, so it is only set on macOS.
+        if modal_options():
+            # On macOS: use WindowModal (blocks MainWindow, allows child windows
+            # like Script Editor to be shown above). Add Window flag to prevent
+            # sheet rendering.
             self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.Window)
+        else:
+            # On Linux/Windows: use NonModal + disabled MainWindow (set in
+            # show_options). Add WindowStaysOnTopHint to prevent Options from
+            # being hidden behind the disabled MainWindow.
+            self.setWindowModality(QtCore.Qt.WindowModality.NonModal)
+            self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowType.WindowStaysOnTopHint)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.ui = Ui_OptionsDialog()

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -285,7 +285,6 @@ class AddActionDialog(PicardDialog):
         super().__init__(parent=parent)
         self.display_list = display_list
 
-        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setWindowTitle(_("Select an action"))
 
         layout = QtWidgets.QVBoxLayout(self)

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -177,16 +177,8 @@ class RenamingOptionsPage(OptionsPage):
             self.ui.example_filename_before,
         )
 
-    def show_script_editing_page(self, raise_window=True):
-        if raise_window:
-            # Opening from button click: use show_instance which handles
-            # parenting (allows WM to show it above the Options dialog)
-            self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=self.examples)
-        else:
-            # Reconnecting from Options __init__: don't raise or re-parent
-            self.script_editor_dialog = ScriptEditorDialog.get_instance(examples=self.examples)
-        self.script_editor_dialog.examples = self.examples
-        self.script_editor_dialog.update_examples()
+    def show_script_editing_page(self):
+        self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=self.examples)
 
         self.script_editor_dialog.signal_save.connect(self.save_from_editor)
         self.script_editor_dialog.signal_update.connect(self.display_examples)

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -177,12 +177,16 @@ class RenamingOptionsPage(OptionsPage):
             self.ui.example_filename_before,
         )
 
-    def show_script_editing_page(self):
-        self.script_editor_dialog = ScriptEditorDialog.get_instance(examples=self.examples)
-        if not self.script_editor_dialog.isVisible():
-            self.script_editor_dialog.show()
-            self.script_editor_dialog.raise_()
-            self.script_editor_dialog.activateWindow()
+    def show_script_editing_page(self, raise_window=True):
+        if raise_window:
+            # Opening from button click: use show_instance which handles
+            # parenting (allows WM to show it above the Options dialog)
+            self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=self.examples)
+        else:
+            # Reconnecting from Options __init__: don't raise or re-parent
+            self.script_editor_dialog = ScriptEditorDialog.get_instance(examples=self.examples)
+        self.script_editor_dialog.examples = self.examples
+        self.script_editor_dialog.update_examples()
 
         self.script_editor_dialog.signal_save.connect(self.save_from_editor)
         self.script_editor_dialog.signal_update.connect(self.display_examples)

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -46,6 +46,7 @@ from picard.i18n import (
 )
 from picard.script import ScriptParser
 
+from picard.ui import modal_options
 from picard.ui.forms.ui_options_renaming import Ui_RenamingOptionsPage
 from picard.ui.options import (
     OptionsCheckError,
@@ -178,7 +179,12 @@ class RenamingOptionsPage(OptionsPage):
         )
 
     def show_script_editing_page(self):
-        self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=self.examples)
+        if modal_options():
+            # On macOS Options is WindowModal; parent the Script Editor to this
+            # page so it's a child of the modal dialog (exempt from blocking).
+            self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=self.examples)
+        else:
+            self.script_editor_dialog = ScriptEditorDialog.show_instance(examples=self.examples)
 
         self.script_editor_dialog.signal_save.connect(self.save_from_editor)
         self.script_editor_dialog.signal_update.connect(self.display_examples)

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -178,7 +178,11 @@ class RenamingOptionsPage(OptionsPage):
         )
 
     def show_script_editing_page(self):
-        self.script_editor_dialog = ScriptEditorDialog.show_instance(parent=self, examples=self.examples)
+        self.script_editor_dialog = ScriptEditorDialog.get_instance(examples=self.examples)
+        if not self.script_editor_dialog.isVisible():
+            self.script_editor_dialog.show()
+            self.script_editor_dialog.raise_()
+            self.script_editor_dialog.activateWindow()
 
         self.script_editor_dialog.signal_save.connect(self.save_from_editor)
         self.script_editor_dialog.signal_update.connect(self.display_examples)

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -79,6 +79,7 @@ class ScriptFileError(OptionsCheckError):
 
 class ScriptingDocumentationDialog(PicardDialog, SingletonDialog):
     defaultsize = QtCore.QSize(570, 400)
+    modality = QtCore.Qt.WindowModality.NonModal
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)

--- a/picard/ui/savewarningdialog.py
+++ b/picard/ui/savewarningdialog.py
@@ -76,7 +76,7 @@ class SaveWarningDialog:
         self.msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         self.msg.setText(warning_text)
         self.msg.setWindowTitle(_("File Save Warning"))
-        self.msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+        self.msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
 
         self.cb = QtWidgets.QCheckBox(disable_text)
         self.cb.setChecked(False)

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -149,7 +149,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         super().__init__(parent=parent)
         self.examples = examples
 
-        self.setWindowTitle(self.display_title())
+        self.set_window_title(self.display_title())
         self.loading = True
         self.ui = Ui_ScriptEditor()
         self.ui.setupUi(self)

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -582,9 +582,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         self.current_item_dict = self.get_selected_item()
         details_page = ScriptDetailsEditor(self.current_item_dict, parent=self)
         details_page.signal_save.connect(self.update_from_details)
-        details_page.show()
-        details_page.raise_()
-        details_page.activateWindow()
+        details_page.show_modal()
 
     def update_from_details(self):
         """Update the script selection combo box and script list after updates from the script details dialog."""

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -1038,7 +1038,6 @@ class ScriptDetailsEditor(PicardDialog, HasDisplayTitle):
 
         self.ui.buttonBox.setFocus()
 
-        self.setModal(True)
         self.setWindowTitle(_(self.display_title()))
         self.skip_change_check = False
 

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -104,6 +104,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
 
     TITLE = N_("File naming script editor")
     STYLESHEET_ERROR = OptionsPage.STYLESHEET_ERROR
+    modality = QtCore.Qt.WindowModality.NonModal
 
     help_url = 'doc_naming_script_edit'
 

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -18,7 +18,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from PyQt6 import QtWidgets
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
 
 from picard.config import (
     Config,
@@ -190,6 +193,7 @@ class SetupWizard(QtWidgets.QWizard):
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setWindowTitle(_("Picard Setup"))
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.setMinimumSize(500, 350)
         self.setOption(QtWidgets.QWizard.WizardOption.NoBackButtonOnStartPage)
         if IS_WIN:

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -338,7 +338,10 @@ class PluginDetailsWidget(QtWidgets.QWidget):
     def _perform_uninstall(self):
         """Fallback uninstall method."""
         dialog = UninstallPluginDialog(self.current_plugin, self)
-        dialog.exec()
+        dialog.finished.connect(lambda: self._on_uninstall_dialog_finished(dialog))
+        dialog.open()
+
+    def _on_uninstall_dialog_finished(self, dialog):
         if dialog.uninstall_confirmed:
             try:
                 async_manager = AsyncPluginManager(self.plugin_manager)

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -861,7 +861,7 @@ class PluginListWidget(QtWidgets.QWidget):
             msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
             msg.setText(_("There were no installed metadata processing plugins found."))
             msg.setWindowTitle(_("No Data"))
-            msg.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
+            msg.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
             msg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
             msg.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
             msg.show()
@@ -921,7 +921,7 @@ class SwitchRefDialog(QtWidgets.QDialog):
         if not self.plugin_manager:
             raise RuntimeError("Plugin manager not available")
         self.setWindowTitle(_("Switch Git Ref"))
-        self.setModal(True)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         self.resize(font_scaled_size(self, 50, 20))
         self.setMinimumSize(font_scaled_size(self, 50, 20))
         self.setup_ui()

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -792,7 +792,11 @@ class PluginListWidget(QtWidgets.QWidget):
     def _switch_ref_from_menu(self, plugin):
         """Switch plugin ref from context menu."""
         dialog = SwitchRefDialog(plugin, self)
-        if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+        dialog.finished.connect(lambda result: self._on_switch_ref_dialog_finished(result, dialog, plugin))
+        dialog.open()
+
+    def _on_switch_ref_dialog_finished(self, result, dialog, plugin):
+        if result == QtWidgets.QDialog.DialogCode.Accepted:
             async_manager = AsyncPluginManager(self.plugin_manager)
             async_manager.switch_ref(
                 plugin=plugin,

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -753,13 +753,17 @@ class PluginListWidget(QtWidgets.QWidget):
 
             # Show confirmation dialog
             confirm_dialog = InstallConfirmDialog(plugin.name(), plugin_url, self, plugin.uuid, current_ref)
-            if confirm_dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
-                return
+            confirm_dialog.finished.connect(
+                lambda result: self._on_reinstall_confirm_finished(result, confirm_dialog, plugin, plugin_url)
+            )
+            confirm_dialog.open()
         except Exception as e:
             log.error("Failed to reinstall plugin %s: %s", plugin.plugin_id, e, exc_info=True)
             self._reinstall_error_dialog(plugin, str(e))
-            return
 
+    def _on_reinstall_confirm_finished(self, result, confirm_dialog, plugin, plugin_url):
+        if result != QtWidgets.QDialog.DialogCode.Accepted:
+            return
         async_manager = AsyncPluginManager(self.plugin_manager)
         async_manager.install_plugin(
             url=plugin_url,

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -704,7 +704,10 @@ class PluginListWidget(QtWidgets.QWidget):
     def _uninstall_plugin_from_menu(self, plugin):
         """Uninstall plugin from context menu."""
         dialog = UninstallPluginDialog(plugin, self)
-        dialog.exec()
+        dialog.finished.connect(lambda: self._on_uninstall_dialog_finished(dialog, plugin))
+        dialog.open()
+
+    def _on_uninstall_dialog_finished(self, dialog, plugin):
         if dialog.uninstall_confirmed:
             async_manager = AsyncPluginManager(self.plugin_manager)
             async_manager.uninstall_plugin(

--- a/ui/edittagdialog.ui
+++ b/ui/edittagdialog.ui
@@ -3,7 +3,7 @@
  <class>EditTagDialog</class>
  <widget class="QDialog" name="EditTagDialog">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -18,9 +18,6 @@
   </property>
   <property name="windowTitle">
    <string>Edit Tag</string>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/ui/passworddialog.ui
+++ b/ui/passworddialog.ui
@@ -54,9 +54,6 @@
    </item>
    <item>
     <widget class="QLineEdit" name="username" >
-     <property name="windowModality" >
-      <enum>Qt::NonModal</enum>
-     </property>
      <property name="sizePolicy" >
       <sizepolicy vsizetype="Fixed" hsizetype="Expanding" >
        <horstretch>0</horstretch>


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix dialog modality so that Log View and History View remain focusable and interactive while the Options dialog (or any other modal dialog) is open. Standardize modality handling across all dialogs.

## Problem

* JIRA ticket: PICARD-3302

When the Options dialog is open, the Log View dialog cannot receive focus. Clicking the Log View in the taskbar briefly highlights it but focus returns to the Options dialog. This happens because the Options dialog uses `ApplicationModal` modality, which blocks interaction with all other application windows, including independent top-level windows like the Log View.

## Solution

**Infrastructure changes:**
- `PicardDialog` now auto-applies `WindowModal` when a parent is given, `NonModal` otherwise. A class-level `modality` attribute allows subclasses to opt out.
- Added `show_modal()` / `show_nonmodal()` convenience methods to `PicardDialog`.
- Fixed `SingletonDialog.show_instance()` which was overriding modality with `NonModal`.
- Made `LogView` and `HistoryView` parentless windows so they are never in any modality chain. Set the app icon on `QApplication` so parentless windows inherit it, and explicitly close them on app quit.

**Per-dialog fixes:**
- Removed explicit `ApplicationModal` / `setModal(True)` from: `OptionsDialog`, `AttachedProfilesDialog`, `ScriptDetailsEditor`, `InstallPluginDialog`, `InstallConfirmDialog`, `PluginInfoDialog`, `SwitchRefDialog`, `UninstallPluginDialog`, `EditTagDialog`, `AllowRtdUpdatesDialog`, `NewUserDialog`, `SaveWarningDialog`.
- Added explicit `WindowModal` to `SetupWizard` (QWizard, not PicardDialog).
- On macOS only: `OptionsDialog` sets `Qt.WindowType.Window` flag to prevent sheet rendering (on Linux/Windows this flag breaks `WindowModal` enforcement).
- Cleaned up `.ui` file artifacts (removed `NonModal` on child widget in `passworddialog.ui`).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed collaboratively with an AI assistant (Kiro/Claude), with human review, testing, and direction at each step.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
