### PR TITLE
Remove api parameter from BaseAction.__init__

### DIFF
--- a/picard/extension_points/item_actions.py
+++ b/picard/extension_points/item_actions.py
@@ -54,7 +54,7 @@ class BaseAction(QtGui.QAction, HasDisplayTitle):
     TITLE = "Unknown"
     MENU: list = []
 
-    def __init__(self, api=None, parent=None):
+    def __init__(self, parent=None):
         super().__init__(self.display_title(), parent=parent)
         self.tagger = tagger_instance()
         self.triggered.connect(self.__callback)
@@ -67,7 +67,10 @@ class BaseAction(QtGui.QAction, HasDisplayTitle):
             # Avoid circular import: extension_points loaded early before picard.log is fully initialized
             from picard import log
 
-            plugin_id = getattr(self.api, 'plugin_id', 'unknown')
+            if hasattr(self, 'api'):
+                plugin_id = getattr(self.api, 'plugin_id', 'unknown')
+            else:
+                plugin_id = None
             log.error("Error in action %s (plugin: %s):", self.display_title(), plugin_id, exc_info=True)
 
     def callback(self, objs):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->


BaseAction is not supposed to have an api parameter, and it is currently unused. The api attribute is injected by the PluginApi. It is generally also possible that Picard provides a BaseAction independent of plugins, but this is currently unused.

This fixes a minor oversight when the plugin API got refactored.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
