### PR TITLE
Fix plugin UI bugs: duplicated categories and unknown versions

### DIFF
--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -242,7 +242,9 @@ class InstallPluginDialog(PicardDialog):
             registry = self.plugin_manager._registry
             plugins = registry.list_plugins()
 
-            # Populate categories
+            # Populate categories (clear existing entries first to avoid duplicates)
+            self.category_combo.clear()
+            self.category_combo.addItem(_("All Categories"), "")
             categories = PluginCategorySet()
             for plugin in plugins:
                 categories.update(plugin.get('categories', []))

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -272,6 +272,13 @@ class PluginListWidget(QtWidgets.QWidget):
                     result = html_ref_format(ref_item)
                     if result:
                         return result
+                # No metadata (e.g. fresh config), fall back to local git repo
+                ref_name, commit = self.plugin_manager._metadata._get_current_ref_info(plugin)
+                if ref_name:
+                    ref_item = RefItem(shortname=ref_name, commit=commit)
+                    result = html_ref_format(ref_item)
+                    if result:
+                        return result
         except Exception:
             pass
         if plugin.manifest:


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix two UI bugs in the plugin install/options dialogs: duplicated categories in the registry tab filter, and plugin versions showing as "Unknown" when starting with a fresh config.

## Problem

1. In the plugin install dialog, the registry tab's category filter combo box shows duplicated entries because `_load_registry_plugins()` is called multiple times without clearing existing items.
2. When starting with a fresh config but with plugins already installed, plugin versions are displayed as "Unknown" because `plugins3_metadata` is empty and the code had no fallback to determine the version from the local git repository.

## Solution

1. Clear the category combo box before repopulating it in `_load_registry_plugins()`.
2. Add a fallback in `_get_clean_version_display` that reads the current git ref directly from the plugin's local repository when metadata is unavailable.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Both fixes were developed with AI assistance (Kiro CLI).

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
