### PR TITLE
PICARD-3313: Support installing local non-git plugins

### DIFF
--- a/docs/PLUGINSV3/LOCAL_NON_GIT.md
+++ b/docs/PLUGINSV3/LOCAL_NON_GIT.md
@@ -1,0 +1,143 @@
+# Local Non-Git Plugins
+
+## Purpose
+
+Local non-git plugins allow developers and testers to load a plugin directly from a directory on disk **without requiring a git repository**. This is intended exclusively for **testing and development** workflows where setting up git is unnecessary overhead.
+
+> **Important:** A git repository is required to distribute a plugin and to have it added to the official Picard plugin registry. Without git, version management and automatic updates are not available.
+
+## When to Use
+
+- Rapid prototyping of a new plugin idea
+- Testing a plugin during development before initializing a git repository
+- Loading a plugin received as a plain directory (e.g., from a zip archive)
+
+For anything beyond personal testing, use `picard-plugins --init` to create a proper git-managed plugin project.
+
+## How It Works
+
+A local non-git plugin:
+
+- Lives in place on disk — nothing is copied, symlinked, or cloned.
+- Requires a valid `MANIFEST.toml` (same fields as any plugin: `uuid`, `name`, `description`, `api`) and an `__init__.py` with `enable(api)`.
+- Is registered via its metadata entry (`ref_type='local'`) in the existing `plugins3_metadata` config.
+- Is loaded on startup from its original path.
+- Is **automatically removed** from config if the directory disappears.
+
+## CLI Usage
+
+### Install
+
+```bash
+picard-plugins --install /path/to/my-plugin
+```
+
+A confirmation prompt warns about the absence of git:
+
+```text
+⚠ This plugin is not managed by git.
+⚠   A git repository is required to distribute a plugin and to have it
+    added to the official registry.
+⚠   Without git, version management and automatic updates are not available.
+Do you want to continue? [y/N]
+```
+
+Use `--yes` to skip the prompt.
+
+### List
+
+```bash
+picard-plugins --list
+```
+
+Local non-git plugins show a `[local]` marker:
+
+```text
+  My Plugin (enabled) [local]
+    Short description
+    UUID: ...
+    Source: /path/to/my-plugin
+    Path: /path/to/my-plugin
+```
+
+### Update (Reload)
+
+```bash
+picard-plugins --update my-plugin
+```
+
+For local non-git plugins, this performs a **reload**: disable → re-read manifest → enable. This picks up any code or manifest changes without restarting Picard.
+
+Output: `✓ my-plugin: Plugin reloaded`
+
+### Remove (Unregister)
+
+```bash
+picard-plugins --remove my-plugin
+```
+
+This **unregisters** the plugin from Picard's config. The files on disk are **not deleted**.
+
+### Unsupported Operations
+
+The following commands are not available for local non-git plugins:
+
+| Command | Behavior |
+|---------|----------|
+| `--switch-ref` | Error: "not managed by git" |
+| `--list-refs` | Error: "not managed by git" |
+| `--check-updates` | Silently skipped |
+
+## GUI Usage
+
+In the Install Plugin dialog → **Local** tab:
+
+1. Select a directory containing `MANIFEST.toml` and `__init__.py`.
+2. If the directory has no `.git`, a confirmation dialog appears with the same warning about git being required for distribution.
+3. Click **Yes** to proceed.
+
+Local non-git plugins appear in the plugin list with a visual indicator and support the same enable/disable/remove actions as git-managed plugins.
+
+## Metadata Storage
+
+Local non-git plugins use the same `plugins3_metadata` config dict as git-managed plugins, with:
+
+```python
+{
+    "uuid": "...",
+    "name": "plugin-dir-name",
+    "url": "/absolute/path/to/plugin",
+    "ref": "local",
+    "commit": "",
+    "ref_type": "local"
+}
+```
+
+On startup, entries with `ref_type='local'` are loaded directly from the stored path. If the path no longer exists, the entry is automatically removed.
+
+## Limitations
+
+- No version tracking — there is no commit history or tags.
+- No automatic updates — `--update` only reloads from disk.
+- Not distributable — cannot be shared via the plugin registry.
+- No ref switching — there are no branches or tags.
+- Plugin name collisions with git-managed plugins are rejected (UUID uniqueness is enforced).
+
+## Migrating to Git
+
+When ready to distribute your plugin:
+
+```bash
+cd /path/to/my-plugin
+git init
+git add -A
+git commit -m "Initial commit"
+```
+
+Then reinstall via git:
+
+```bash
+picard-plugins --install /path/to/my-plugin --reinstall
+```
+
+The plugin will now be managed by git with full update/ref support. Alternatively, use `picard-plugins --init` from the start for a proper project scaffold with git already configured.

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -518,7 +518,10 @@ class PluginCLI:
 
                     # Source URL if available
                     if metadata and metadata.url:
-                        self._out.info(f'  Source: {self._out.d_url(metadata.url)}')
+                        if is_local:
+                            self._out.info('  Source: local')
+                        else:
+                            self._out.info(f'  Source: {self._out.d_url(metadata.url)}')
 
                     self._out.info(f'  Path: {self._out.d_path(plugin.local_path)}')
                 self._out.print()
@@ -600,7 +603,10 @@ class PluginCLI:
 
         # Show source URL if available
         if metadata and metadata.url:
-            self._out.print(f'Source: {self._out.d_url(metadata.url)}')
+            if is_local:
+                self._out.print('Source: local')
+            else:
+                self._out.print(f'Source: {self._out.d_url(metadata.url)}')
 
         # Optional fields - only show if present
         if plugin.manifest.authors:

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -92,6 +92,7 @@ from picard.plugin3.plugin import (
     PluginSourceGit,
     short_commit_id,
 )
+from picard.plugin3.plugin_metadata import is_local_non_git_plugin
 from picard.plugin3.project_config import PluginProjectConfig
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import (
@@ -466,13 +467,18 @@ class PluginCLI:
                 # Show manifest name (human-readable) with localization
                 display_name = plugin.manifest.name(locale_str) if plugin.manifest else plugin.plugin_id
 
+                # Check if local non-git plugin
+                metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
+                is_local = is_local_non_git_plugin(metadata)
+
                 # Display with semantic methods
                 if is_enabled:
                     status = self._out.d_status_enabled()
                 else:
                     status = self._out.d_status_disabled()
 
-                self._out.print(f'  {self._out.d_name(display_name)} ({status})')
+                local_marker = ' [local]' if is_local else ''
+                self._out.print(f'  {self._out.d_name(display_name)} ({status}){local_marker}')
 
                 if getattr(plugin, 'manifest', None):
                     desc = plugin.manifest.description(locale_str)
@@ -548,8 +554,10 @@ class PluginCLI:
 
         is_enabled = plugin.uuid and plugin.uuid in self._manager._enabled_plugins
         metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else {}
+        is_local = is_local_non_git_plugin(metadata)
 
-        self._out.print(f'Plugin: {self._out.d_name(plugin.manifest.name())}')
+        local_marker = ' [local]' if is_local else ''
+        self._out.print(f'Plugin: {self._out.d_name(plugin.manifest.name())}{local_marker}')
 
         # Show short description on one line (required field)
         desc = plugin.manifest.description()
@@ -647,6 +655,14 @@ class PluginCLI:
         if not info:
             self._out.error(f'Plugin "{identifier}" not found (not installed and not in registry)')
             return ExitCode.NOT_FOUND
+
+        # Check if this is a local non-git plugin
+        plugin = info['plugin']
+        if plugin and plugin.uuid:
+            metadata = self._manager._get_plugin_metadata(plugin.uuid)
+            if is_local_non_git_plugin(metadata):
+                self._out.error(f'Plugin "{identifier}" is a local plugin and is not managed by git')
+                return ExitCode.ERROR
 
         url = info['url']
         current_ref = info['current_ref']
@@ -894,32 +910,49 @@ class PluginCLI:
                             return ExitCode.ERROR
 
                     # Check trust level and show appropriate warnings
-                    trust_level = self._manager._registry.get_trust_level(url)
-                    trust_community = getattr(self._args, 'trust_community', False)
-
-                    if trust_level == 'community' and not trust_community:
-                        self._out.warning(self._out.d_warning('WARNING: This is a community plugin'))
+                    # For local non-git directories, skip registry/trust checks
+                    local_non_git = Path(url).is_dir() and not (Path(url) / '.git').exists()
+                    if local_non_git:
+                        self._out.warning('This plugin is not managed by git.')
                         self._out.warning(
-                            self._out.d_warning('  Community plugins are not reviewed by the Picard team')
+                            '  A git repository is required to distribute a plugin'
+                            ' and to have it added to the official registry.'
                         )
-                        self._out.warning(self._out.d_warning('  Only install plugins from sources you trust'))
+                        self._out.warning('  Without git, version management and automatic updates are not available.')
 
                         if not yes:
                             if not self._out.yesno('Do you want to continue?'):
                                 self._out.print('Installation cancelled')
                                 return ExitCode.CANCELLED
+                    else:
+                        trust_level = self._manager._registry.get_trust_level(url)
+                        trust_community = getattr(self._args, 'trust_community', False)
 
-                    elif trust_level == 'unregistered':
-                        self._out.warning(self._out.d_warning('WARNING: This plugin is not in the official registry'))
-                        self._out.warning(
-                            self._out.d_warning('  Installing unregistered plugins may pose security risks')
-                        )
-                        self._out.warning(self._out.d_warning('  Only install plugins from sources you trust'))
+                        if trust_level == 'community' and not trust_community:
+                            self._out.warning(self._out.d_warning('WARNING: This is a community plugin'))
+                            self._out.warning(
+                                self._out.d_warning('  Community plugins are not reviewed by the Picard team')
+                            )
+                            self._out.warning(self._out.d_warning('  Only install plugins from sources you trust'))
 
-                        if not yes:
-                            if not self._out.yesno('Do you want to continue?'):
-                                self._out.print('Installation cancelled')
-                                return ExitCode.CANCELLED
+                            if not yes:
+                                if not self._out.yesno('Do you want to continue?'):
+                                    self._out.print('Installation cancelled')
+                                    return ExitCode.CANCELLED
+
+                        elif trust_level == 'unregistered':
+                            self._out.warning(
+                                self._out.d_warning('WARNING: This plugin is not in the official registry')
+                            )
+                            self._out.warning(
+                                self._out.d_warning('  Installing unregistered plugins may pose security risks')
+                            )
+                            self._out.warning(self._out.d_warning('  Only install plugins from sources you trust'))
+
+                            if not yes:
+                                if not self._out.yesno('Do you want to continue?'):
+                                    self._out.print('Installation cancelled')
+                                    return ExitCode.CANCELLED
 
                 if ref:
                     self._out.print(f'Installing plugin from {url} (ref: {ref})...')
@@ -1089,7 +1122,11 @@ class PluginCLI:
                 result = self._manager.update_plugin(plugin)
 
                 if result.old_commit == result.new_commit:
-                    if result.new_version:
+                    # Local non-git plugins: show "reloaded" instead of "up to date"
+                    metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
+                    if is_local_non_git_plugin(metadata):
+                        self._out.success(f'{self._out.d_name(plugin.plugin_id)}: Plugin reloaded')
+                    elif result.new_version:
                         self._out.info(
                             f'{self._out.d_name(plugin.plugin_id)}: Already up to date ({result.new_version})'
                         )
@@ -1151,11 +1188,19 @@ class PluginCLI:
                     self._out.info(f'{self._out.d_name(r.plugin_id)}: {r.error}')
                     unchanged += 1
                 elif r.result.old_commit == r.result.new_commit:
-                    if r.result.new_version:
+                    # Local non-git plugins: show "reloaded" instead of "up to date"
+                    plugin = self._manager.plugin_id_to_plugin(r.plugin_id)
+                    plugin_uuid = plugin.uuid if plugin else None
+                    metadata = self._manager._get_plugin_metadata(plugin_uuid) if plugin_uuid else None
+                    if is_local_non_git_plugin(metadata):
+                        self._out.success(f'{self._out.d_name(r.plugin_id)}: Plugin reloaded')
+                        updated += 1
+                    elif r.result.new_version:
                         self._out.info(f'{self._out.d_name(r.plugin_id)}: Already up to date ({r.result.new_version})')
+                        unchanged += 1
                     else:
                         self._out.info(f'{self._out.d_name(r.plugin_id)}: Already up to date')
-                    unchanged += 1
+                        unchanged += 1
                 else:
                     version_info = self._format_version_info(r.result)
                     self._out.success(f'{self._out.d_name(r.plugin_id)}: {version_info}')

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -37,6 +37,7 @@ from picard import log
 if TYPE_CHECKING:
     from picard.tagger import Tagger
 
+from picard.config import get_config
 from picard.const.appdirs import cache_folder
 from picard.git.backend import GitRefType
 from picard.git.factory import git_backend
@@ -55,6 +56,7 @@ from picard.plugin3.plugin import (
 from picard.plugin3.plugin_metadata import (
     PluginMetadata,
     PluginMetadataManager,
+    is_local_non_git_plugin,
 )
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import PluginRegistry
@@ -508,6 +510,42 @@ class PluginManager(QObject):
         self._plugin_dirs.append(plugin_dir)
         if primary:
             self._primary_plugin_dir = plugin_dir
+            self._load_local_plugins()
+
+    def _load_local_plugins(self):
+        """Load non-git local plugins from metadata and auto-remove stale entries."""
+        config = get_config()
+        if config is None:
+            return
+        metadata_dict = config.setting['plugins3_metadata']
+        if not metadata_dict:
+            return
+        to_remove = []
+        loaded_uuids = {p.uuid for p in self._plugins if p.uuid}
+
+        for uuid, entry in list(metadata_dict.items()):
+            if entry.get('ref_type') != 'local':
+                continue
+            # Skip if already loaded (e.g. symlink in plugin dir)
+            if uuid in loaded_uuids:
+                continue
+            path = Path(entry.get('url', ''))
+            if not path.is_dir():
+                log.warning('Local plugin path no longer exists, removing: %s', path)
+                to_remove.append(uuid)
+                continue
+            plugin = self._load_plugin(path.parent, path.name)
+            if plugin:
+                log.debug('Loaded local plugin %s from %s', plugin.plugin_id, path)
+                self._plugins.append(plugin)
+
+        # Auto-cleanup stale entries
+        if to_remove:
+            for uuid in to_remove:
+                metadata_dict.pop(uuid, None)
+                self._enabled_plugins.discard(uuid)
+            config.setting['plugins3_metadata'] = metadata_dict
+            self._save_config()
 
     def _preserve_original_ref_if_needed(self, url_or_path, ref, reinstall):
         """Preserve original ref if reinstalling and no ref specified.
@@ -695,6 +733,8 @@ class PluginManager(QObject):
     def _should_fetch_plugin_refs(self, plugin, metadata):
         """Check if a plugin should have its refs fetched."""
         if not plugin.uuid or not metadata or not metadata.url:
+            return False
+        if is_local_non_git_plugin(metadata):
             return False
 
         # Only fetch refs for plugins with remote URLs or local git repos

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -711,6 +711,11 @@ class PluginManager(QObject):
         # Use ref_type to reliably determine if plugin was installed as a commit
         return metadata.ref_type == 'commit'
 
+    def is_local_non_git(self, plugin):
+        """Check if a plugin is a local non-git plugin."""
+        metadata = self._metadata.get_plugin_metadata(plugin.uuid)
+        return is_local_non_git_plugin(metadata)
+
     def _get_current_ref_for_updates(self, repo, metadata):
         """Get the current ref to use for update checking.
 

--- a/picard/plugin3/manager/install.py
+++ b/picard/plugin3/manager/install.py
@@ -215,6 +215,13 @@ class PluginInstaller:
         # Validate manifest directly from source
         manifest = PluginValidation.read_and_validate_manifest(local_path, str(local_path))
 
+        # Check if already installed from this path
+        if not reinstall:
+            resolved_path = local_path.resolve()
+            for existing in self.manager._plugins:
+                if existing.local_path.resolve() == resolved_path:
+                    raise PluginAlreadyInstalledError(manifest.name(), str(local_path))
+
         # Blacklist + UUID conflict check
         if not force_blacklisted:
             self._check_blacklist(str(local_path), None, local_path, manifest.uuid)

--- a/picard/plugin3/manager/install.py
+++ b/picard/plugin3/manager/install.py
@@ -25,7 +25,10 @@ import tempfile
 
 from picard import log
 from picard.git.ops import GitOperations
-from picard.git.utils import get_local_repository_path
+from picard.git.utils import (
+    get_local_path,
+    get_local_repository_path,
+)
 from picard.plugin3.installable import (
     LocalInstallablePlugin,
     UrlInstallablePlugin,
@@ -75,8 +78,13 @@ class PluginInstaller:
         self, url, ref=None, reinstall=False, force_blacklisted=False, discard_changes=False, enable_after_install=False
     ):
         """Install a plugin from a git URL or local directory."""
-        # Check if url is a local directory
+        # Check if url is a local directory (git or plain)
         local_path = get_local_repository_path(url)
+        if not local_path:
+            # Also check for plain local directory (non-git)
+            plain_path = get_local_path(url)
+            if plain_path and plain_path.is_dir():
+                local_path = plain_path
 
         # For remote URLs, check if registry redirects to a different URL
         if not local_path:
@@ -202,6 +210,58 @@ class PluginInstaller:
                 raise PluginAlreadyInstalledError(plugin_name, source_url)
             self._handle_existing_plugin_reinstall(final_path, plugin_name, discard_changes)
 
+    def _install_local_non_git(self, local_path, reinstall, force_blacklisted, enable_after_install):
+        """Install a non-git local plugin loaded in-place."""
+        # Validate manifest directly from source
+        manifest = PluginValidation.read_and_validate_manifest(local_path, str(local_path))
+
+        # Blacklist + UUID conflict check
+        if not force_blacklisted:
+            self._check_blacklist(str(local_path), None, local_path, manifest.uuid)
+        self._check_uuid_conflict(manifest, str(local_path), reinstall)
+
+        # Handle reinstall: remove existing plugin from list
+        if reinstall:
+            for existing in list(self.manager._plugins):
+                if existing.uuid and existing.uuid == manifest.uuid:
+                    try:
+                        if existing.state != PluginState.DISABLED:
+                            existing.disable()
+                    except Exception:
+                        pass
+                    self.manager._enabled_plugins.discard(existing.uuid)
+                    self.manager._plugins.remove(existing)
+                    break
+
+        # Save metadata with ref_type='local'
+        self.manager._metadata.save_plugin_metadata(
+            PluginMetadata(
+                name=manifest.name(),
+                url=str(local_path),
+                ref='local',
+                commit='',
+                uuid=manifest.uuid,
+                ref_type='local',
+            )
+        )
+
+        # Create Plugin pointing directly at the local path
+        plugin = Plugin(local_path.parent, local_path.name, uuid=manifest.uuid)
+        plugin.read_manifest()
+        self.manager._plugins.append(plugin)
+        self.manager.plugin_installed.emit(plugin)
+
+        if enable_after_install:
+            try:
+                self.manager.enable_plugin(plugin)
+            except Exception as e:
+                log.error('Local plugin installation failed during enable: %s', e)
+                self.manager._plugins.remove(plugin)
+                raise
+
+        log.info('Local plugin %s installed from %s', plugin.plugin_id, local_path)
+        return plugin.plugin_id
+
     def _install_common(
         self, source_url, ref, reinstall, force_blacklisted, discard_changes, enable_after_install, is_local=False
     ):
@@ -212,11 +272,9 @@ class PluginInstaller:
         # Handle local-specific pre-sync operations
         if is_local:
             local_path = Path(source_url)
-            # All plugins must be git repositories
+            # Non-git local directory: install in-place
             if not (local_path / '.git').exists():
-                raise ValueError(
-                    f"Plugin directory {local_path} is not a git repository. All plugins must be git repositories."
-                )
+                return self._install_local_non_git(local_path, reinstall, force_blacklisted, enable_after_install)
 
             # Check source repository status and get current ref if needed
             try:

--- a/picard/plugin3/manager/lifecycle.py
+++ b/picard/plugin3/manager/lifecycle.py
@@ -42,6 +42,7 @@ from picard.plugin3.plugin import (
     Plugin,
     PluginState,
 )
+from picard.plugin3.plugin_metadata import is_local_non_git_plugin
 
 
 if TYPE_CHECKING:
@@ -56,6 +57,12 @@ class PluginLifecycleManager:
 
     def uninstall_plugin(self, plugin: Plugin, purge=False):
         """Uninstall a plugin."""
+        # Local non-git plugins: just unregister, don't delete files
+        if plugin.uuid:
+            metadata = self.manager._get_plugin_metadata(plugin.uuid)
+            if is_local_non_git_plugin(metadata):
+                return self._unregister_local_plugin(plugin, purge)
+
         try:
             self.manager.disable_plugin(plugin)
         except Exception:
@@ -98,6 +105,24 @@ class PluginLifecycleManager:
         if plugin in self.manager.plugins:
             self.manager.plugins.remove(plugin)
 
+        self.manager.plugin_uninstalled.emit(plugin)
+
+    def _unregister_local_plugin(self, plugin: Plugin, purge=False):
+        """Unregister a local non-git plugin without deleting files."""
+        try:
+            self.manager.disable_plugin(plugin)
+        except Exception:
+            log.warning("Failed to disable local plugin %s during uninstall", plugin.plugin_id, exc_info=True)
+        config = get_config()
+        if plugin.uuid:
+            metadata_dict = config.setting['plugins3_metadata']
+            metadata_dict.pop(plugin.uuid, None)
+            config.setting['plugins3_metadata'] = metadata_dict
+            unset_plugin_uuid(plugin.uuid)
+        if purge and plugin.uuid:
+            self.manager._clean_plugin_config(plugin.uuid)
+        if plugin in self.manager.plugins:
+            self.manager.plugins.remove(plugin)
         self.manager.plugin_uninstalled.emit(plugin)
 
     def enable_plugin(self, plugin: Plugin):

--- a/picard/plugin3/manager/update.py
+++ b/picard/plugin3/manager/update.py
@@ -34,13 +34,17 @@ from picard.plugin3.manager.errors import (
     PluginBlacklistedError,
     PluginCommitPinnedError,
     PluginDirtyError,
+    PluginNoSourceError,
 )
 from picard.plugin3.plugin import (
     PluginSourceGit,
     PluginState,
     short_commit_id,
 )
-from picard.plugin3.plugin_metadata import PluginMetadata
+from picard.plugin3.plugin_metadata import (
+    PluginMetadata,
+    is_local_non_git_plugin,
+)
 from picard.plugin3.ref_item import RefItem
 
 
@@ -111,6 +115,23 @@ class PluginUpdater:
             try_reenable()
             raise
 
+    def _reload_local_plugin(self, plugin):
+        """Reload a local non-git plugin (disable → re-read manifest → enable)."""
+
+        def perform_reload():
+            plugin.read_manifest()
+            return UpdateResult(
+                old_version='',
+                new_version='',
+                old_commit='',
+                new_commit='',
+                old_ref_item=RefItem('local'),
+                new_ref_item=RefItem('local'),
+                commit_date=0,
+            )
+
+        return self._with_plugin_state_management(plugin, perform_reload)
+
     def _check_dirty_working_dir(self, plugin, discard_changes):
         """Check for uncommitted changes if not discarding."""
         if not discard_changes:
@@ -137,8 +158,13 @@ class PluginUpdater:
 
     def update_plugin(self, plugin, discard_changes=False):
         """Update a single plugin to latest version."""
-        self.manager._ensure_plugin_url(plugin, 'update')
         uuid, metadata = self.manager._get_plugin_uuid_and_metadata(plugin)
+
+        # Local non-git plugins: reload instead of git update
+        if is_local_non_git_plugin(metadata):
+            return self._reload_local_plugin(plugin)
+
+        self.manager._ensure_plugin_url(plugin, 'update')
 
         # Check for uncommitted changes and commit pinning
         self._check_dirty_working_dir(plugin, discard_changes)
@@ -252,6 +278,11 @@ class PluginUpdater:
 
     def switch_ref(self, plugin, ref, discard_changes=False):
         """Switch plugin to a different git ref."""
+        # Local non-git plugins cannot switch refs
+        metadata = self.manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
+        if is_local_non_git_plugin(metadata):
+            raise PluginNoSourceError(plugin.plugin_id, 'switch ref')
+
         self.manager._ensure_plugin_url(plugin, 'switch ref')
 
         # Convert GitRef to string for GitOperations (which still expects strings)

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -122,6 +122,11 @@ class PluginMetadata:
         return GitRef(name='', target='')
 
 
+def is_local_non_git_plugin(metadata) -> bool:
+    """Check if metadata represents a local non-git plugin. Safe with None."""
+    return metadata is not None and getattr(metadata, 'ref_type', None) == 'local'
+
+
 class PluginMetadataManager:
     """Manages plugin metadata storage and retrieval."""
 

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -36,13 +36,14 @@ class InstallConfirmDialog(PicardDialog):
 
     defaultsize = QtCore.QSize(500, 400)
 
-    def __init__(self, plugin_name, url, parent=None, plugin_uuid=None, current_ref=None):
+    def __init__(self, plugin_name, url, parent=None, plugin_uuid=None, current_ref=None, show_ref_selector=True):
         super().__init__(parent)
         self.plugin_name = plugin_name
         self.url = url
         self.plugin_uuid = plugin_uuid
         self.current_ref = current_ref
         self.selected_ref = None
+        self._show_ref_selector = show_ref_selector
 
         # Cache plugin manager for performance
         self.plugin_manager = self.tagger.get_plugin_manager()
@@ -96,9 +97,11 @@ class InstallConfirmDialog(PicardDialog):
 
         if self.url.startswith(('http://', 'https://')):
             url_display = f'<a href="{self.url}">{self.url}</a>'
+            url_label = QtWidgets.QLabel(_("Repository: {url}").format(url=url_display))
+        elif self._show_ref_selector:
+            url_label = QtWidgets.QLabel(_("Repository: {url}").format(url=self.url))
         else:
-            url_display = self.url
-        url_label = QtWidgets.QLabel(_("Repository: {url}").format(url=url_display))
+            url_label = QtWidgets.QLabel(_("Path: {path}").format(path=self.url))
         url_label.setTextInteractionFlags(
             QtCore.Qt.TextInteractionFlag.TextSelectableByMouse | QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse
         )
@@ -112,7 +115,7 @@ class InstallConfirmDialog(PicardDialog):
         self.warning_label.hide()
         layout.addWidget(self.warning_label)
 
-        # Ref selection (optional)
+        # Ref selection (optional, hidden for non-git plugins)
         ref_group = QtWidgets.QGroupBox(_("Git Reference (Optional)"))
         ref_layout = QtWidgets.QVBoxLayout(ref_group)
 
@@ -120,6 +123,9 @@ class InstallConfirmDialog(PicardDialog):
         self.ref_selector = RefSelectorWidget(include_default=True)
         ref_layout.addWidget(self.ref_selector)
         layout.addWidget(ref_group)
+        if not self._show_ref_selector:
+            ref_group.hide()
+            layout.addStretch()
 
         # Buttons
         button_box = QtWidgets.QDialogButtonBox()
@@ -170,6 +176,8 @@ class InstallConfirmDialog(PicardDialog):
 
     def load_refs(self):
         """Load available refs from repository."""
+        if not self._show_ref_selector:
+            return
         try:
             refs = self.plugin_manager.fetch_all_git_refs(self.url)
             if refs:

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -41,6 +41,7 @@ from picard.plugin3.installable import (
 from picard.plugin3.registry import RegistryPlugin
 
 from picard.ui import PicardDialog
+from picard.ui.colors import interface_colors
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.util import font_scaled_size
@@ -73,6 +74,7 @@ class InstallPluginDialog(PicardDialog):
 
         # Cache frequently accessed objects
         self.plugin_manager = self.tagger.get_plugin_manager()
+        self._local_path_valid = False
 
         self.setup_ui()
 
@@ -189,7 +191,7 @@ class InstallPluginDialog(PicardDialog):
 
         # Warning label
         self.warning_label = QtWidgets.QLabel()
-        self.warning_label.setStyleSheet("color: orange; font-weight: bold;")
+        self.warning_label.setStyleSheet("color: %s; font-weight: bold;" % interface_colors.get_color('log_warning'))
         self.warning_label.setWordWrap(True)
         self.warning_label.hide()
         layout.addWidget(self.warning_label)
@@ -212,9 +214,15 @@ class InstallPluginDialog(PicardDialog):
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
+        # Local tab status label (shown below the group box)
+        self.local_status_label = QtWidgets.QLabel()
+        self.local_status_label.setWordWrap(True)
+        self.local_status_label.hide()
+        local_layout.insertWidget(1, self.local_status_label)
+
         # Connect input changes to validation
         self.url_edit.textChanged.connect(self._validate_input)
-        self.path_edit.textChanged.connect(self._validate_input)
+        self.path_edit.textChanged.connect(self._validate_local_path)
         self.local_ref_edit.textChanged.connect(self._validate_input)
         self.tab_widget.currentChanged.connect(self._validate_input)
         self._load_registry_plugins()
@@ -233,8 +241,44 @@ class InstallPluginDialog(PicardDialog):
             if url:
                 self._check_trust_level(url)
         else:  # TAB_LOCAL - Local directory tab
-            path = self.path_edit.text().strip()
-            self.install_button.setEnabled(bool(path))
+            self.install_button.setEnabled(self._local_path_valid)
+
+    def _validate_local_path(self):
+        """Validate local path and update Ref/Tag field and status."""
+        path = self.path_edit.text().strip()
+        self._local_path_valid = False
+
+        if not path:
+            self.local_ref_edit.setEnabled(True)
+            self.local_status_label.hide()
+        elif not os.path.isdir(path):
+            self.local_ref_edit.setEnabled(False)
+            self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_error'))
+            self.local_status_label.setText(_("The selected path is not a directory."))
+            self.local_status_label.show()
+        elif not os.path.isfile(os.path.join(path, "MANIFEST.toml")):
+            self.local_ref_edit.setEnabled(False)
+            self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_error'))
+            self.local_status_label.setText(_("The directory does not contain a MANIFEST.toml file."))
+            self.local_status_label.show()
+        elif not os.path.exists(os.path.join(path, ".git")):
+            self.local_ref_edit.setEnabled(False)
+            self.local_ref_edit.clear()
+            self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_warning'))
+            self.local_status_label.setText(
+                _(
+                    "This plugin is not managed by git. "
+                    "It will be installed as a local non-git plugin without version management or updates."
+                )
+            )
+            self.local_status_label.show()
+            self._local_path_valid = True
+        else:
+            self.local_ref_edit.setEnabled(True)
+            self.local_status_label.hide()
+            self._local_path_valid = True
+
+        self._validate_input()
 
     def _load_registry_plugins(self):
         """Load plugins from registry."""
@@ -561,7 +605,11 @@ class InstallPluginDialog(PicardDialog):
             # Show confirmation dialog
             plugin_name = plugin.get_display_name()
             plugin_uuid = plugin.plugin_uuid
-            confirm_dialog = InstallConfirmDialog(plugin_name, url, self, plugin_uuid, None)
+            # Hide ref selector for non-git local plugins
+            show_ref_selector = not (current_tab == TAB_LOCAL and not os.path.exists(os.path.join(url, ".git")))
+            confirm_dialog = InstallConfirmDialog(
+                plugin_name, url, self, plugin_uuid, None, show_ref_selector=show_ref_selector
+            )
             confirm_dialog.finished.connect(
                 lambda result: self._on_install_confirm_finished(result, confirm_dialog, url, plugin, current_tab)
             )

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -494,11 +494,30 @@ class InstallPluginDialog(PicardDialog):
             QtWidgets.QMessageBox.critical(
                 self,
                 _("Invalid Plugin Directory"),
-                _(
-                    "The selected directory does not contain a MANIFEST.toml file. A valid plugin requires both a git repository and a MANIFEST.toml file."
-                ),
+                _("The selected directory does not contain a MANIFEST.toml file."),
             )
             return None
+
+        # Warn if not a git repository
+        git_path = os.path.join(url, ".git")
+        if not os.path.exists(git_path):
+            result = QtWidgets.QMessageBox.warning(
+                self,
+                _("Plugin Not Managed by Git"),
+                _(
+                    "This plugin is not managed by git.\n\n"
+                    "A git repository is required to distribute a plugin"
+                    " and to have it added to the official registry."
+                    " Without git, version management and automatic updates"
+                    " are not available.\n\n"
+                    "Do you want to continue?"
+                ),
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+                QtWidgets.QMessageBox.StandardButton.No,
+            )
+            if result != QtWidgets.QMessageBox.StandardButton.Yes:
+                return None
+            ref = None  # No ref for non-git plugins
 
         return LocalInstallablePlugin(url, ref, self.plugin_manager._registry)
 

--- a/picard/ui/dialogs/plugininfo.py
+++ b/picard/ui/dialogs/plugininfo.py
@@ -302,6 +302,8 @@ class PluginInfoDialog(PicardDialog):
             return getattr(self.plugin_data, 'git_url', getattr(self.plugin_data, 'source_url', '')) or ''
         else:
             try:
+                if self.plugin_manager and self.plugin_manager.is_local_non_git(self.plugin_data):
+                    return ''
                 return self.plugin_manager.get_plugin_remote_url(self.plugin_data) or '' if self.plugin_manager else ''
             except (AttributeError, Exception):
                 return ''

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -388,7 +388,7 @@ class Plugins3OptionsPage(OptionsPage):
         config = get_config()
 
         # Update the updates dict based on the action
-        if action in ("updated", "reinstalled", "ref switched"):
+        if action in ("updated", "reloaded", "reinstalled", "ref switched"):
             self._check_plugin_update_after_action(plugin, action)
             # Update the plugin list widget with new updates dict
             self.plugin_list.set_updates(config.persist['plugins3_updates'])

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -181,7 +181,10 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         if maintainers:
             self.maintainers_label.setText(maintainers)
 
-        git_url = self._get_git_url_display(plugin)
+        if self.plugin_manager.is_local_non_git(plugin):
+            git_url = _("local")
+        else:
+            git_url = self._get_git_url_display(plugin)
         self.details_layout.setRowVisible(self.git_url_label, bool(git_url))
         if git_url:
             self.git_url_label.setText(git_url)

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -107,7 +107,8 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             QtCore.Qt.TextInteractionFlag.TextSelectableByMouse | QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse
         )
         self.git_url_label.setOpenExternalLinks(True)
-        self.details_layout.addRow(_("Repository:"), self.git_url_label)
+        self.git_url_row_label = QtWidgets.QLabel(_("Repository:"))
+        self.details_layout.addRow(self.git_url_row_label, self.git_url_label)
 
         layout.addWidget(details_widget)
 
@@ -182,18 +183,26 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             self.maintainers_label.setText(maintainers)
 
         if self.plugin_manager.is_local_non_git(plugin):
-            git_url = _("local")
+            self.git_url_row_label.setText(_("Path:"))
+            git_url = str(plugin.local_path)
         else:
+            self.git_url_row_label.setText(_("Repository:"))
             git_url = self._get_git_url_display(plugin)
         self.details_layout.setRowVisible(self.git_url_label, bool(git_url))
         if git_url:
             self.git_url_label.setText(git_url)
 
-        # Update button state and tooltip
-        if update:
+        # Update/Reload button state and tooltip
+        if self.plugin_manager.is_local_non_git(plugin):
+            self.update_button.setText(_("Reload"))
+            self.update_button.setEnabled(True)
+            self.update_button.setToolTip("")
+        elif update:
+            self.update_button.setText(_("Update"))
             self.update_button.setEnabled(True)
             self._set_update_button_tooltip(update)
         else:
+            self.update_button.setText(_("Update"))
             self.update_button.setEnabled(False)
             self.update_button.setToolTip("")
 
@@ -379,7 +388,8 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             self.plugin_updated.emit()  # Signal that plugin was updated
             # Emit the same signal as context menu for status updates
             if hasattr(self.parent(), 'plugin_state_changed'):
-                self.parent().plugin_state_changed.emit(plugin, "updated")
+                action = "reloaded" if self.plugin_manager.is_local_non_git(plugin) else "updated"
+                self.parent().plugin_state_changed.emit(plugin, action)
             # Refresh the display - plugin should no longer have update available
             self.show_plugin(plugin)
         else:

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -700,7 +700,8 @@ class PluginListWidget(QtWidgets.QWidget):
             # Refresh the plugin list
             self.populate_plugins(self.plugin_manager.plugins)
             # Emit signal for options dialog to refresh and update updates dict
-            self.plugin_state_changed.emit(plugin, "updated")
+            action = "reloaded" if self.plugin_manager.is_local_non_git(plugin) else "updated"
+            self.plugin_state_changed.emit(plugin, action)
         else:
             error_msg = str(result.error) if result.error else _("Unknown error")
             self._update_error_dialog(plugin, error_msg)

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -595,10 +595,17 @@ class PluginListWidget(QtWidgets.QWidget):
 
         menu.addSeparator()
 
-        # Update action
-        update_action = menu.addAction(_("Update"))
-        update_action.triggered.connect(lambda: self._update_plugin_from_menu(plugin))
-        update_action.setEnabled(self._has_update_available(plugin))
+        # Determine if this is a local non-git plugin
+        is_local = self.plugin_manager.is_local_non_git(plugin)
+
+        # Update/Reload action
+        if is_local:
+            reload_action = menu.addAction(_("Reload"))
+            reload_action.triggered.connect(lambda: self._update_plugin_from_menu(plugin))
+        else:
+            update_action = menu.addAction(_("Update"))
+            update_action.triggered.connect(lambda: self._update_plugin_from_menu(plugin))
+            update_action.setEnabled(self._has_update_available(plugin))
 
         # Uninstall action
         uninstall_action = menu.addAction(_("Uninstall"))
@@ -608,9 +615,10 @@ class PluginListWidget(QtWidgets.QWidget):
         reinstall_action = menu.addAction(_("Reinstall"))
         reinstall_action.triggered.connect(lambda: self._reinstall_plugin_from_menu(plugin))
 
-        # Switch ref action
-        switch_ref_action = menu.addAction(_("Switch Ref"))
-        switch_ref_action.triggered.connect(lambda: self._switch_ref_from_menu(plugin))
+        # Switch ref action (disabled for local non-git plugins)
+        if not is_local:
+            switch_ref_action = menu.addAction(_("Switch Ref"))
+            switch_ref_action.triggered.connect(lambda: self._switch_ref_from_menu(plugin))
 
         menu.addSeparator()
 
@@ -621,7 +629,10 @@ class PluginListWidget(QtWidgets.QWidget):
         # View repository action (if available)
         remote_url = self._get_plugin_remote_url(plugin)
         if remote_url:
-            view_repo_action = menu.addAction(_("View Repository"))
+            if is_local:
+                view_repo_action = menu.addAction(_("View Directory"))
+            else:
+                view_repo_action = menu.addAction(_("View Repository"))
             view_repo_action.triggered.connect(lambda: self._view_repository(plugin))
 
         # Report bug action (if available)
@@ -752,7 +763,10 @@ class PluginListWidget(QtWidgets.QWidget):
                 pass
 
             # Show confirmation dialog
-            confirm_dialog = InstallConfirmDialog(plugin.name(), plugin_url, self, plugin.uuid, current_ref)
+            show_ref_selector = not self.plugin_manager.is_local_non_git(plugin)
+            confirm_dialog = InstallConfirmDialog(
+                plugin.name(), plugin_url, self, plugin.uuid, current_ref, show_ref_selector=show_ref_selector
+            )
             confirm_dialog.finished.connect(
                 lambda result: self._on_reinstall_confirm_finished(result, confirm_dialog, plugin, plugin_url)
             )

--- a/test/plugins3/test_local_non_git_plugin.py
+++ b/test/plugins3/test_local_non_git_plugin.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from pathlib import Path
+import shutil
+import tempfile
+
+from test.picardtestcase import PicardTestCase
+from test.plugins3.helpers import (
+    MockTagger,
+    create_test_manifest_content,
+    run_cli,
+)
+
+from picard.plugin3.manager import (
+    PluginManager,
+    PluginManifestNotFoundError,
+)
+from picard.plugin3.validator import generate_uuid
+
+
+def _create_plugin_dir(base_dir, uuid):
+    """Create a local non-git plugin directory."""
+    plugin_name = f'test-lng-{uuid[:8]}'
+    plugin_dir = Path(base_dir) / plugin_name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / 'MANIFEST.toml').write_text(create_test_manifest_content(name='Test LNG Plugin', uuid=uuid))
+    (plugin_dir / '__init__.py').write_text('def enable(api): pass\ndef disable(): pass\n')
+    return plugin_dir, plugin_name
+
+
+def _create_manager(plugins_dir):
+    """Create a PluginManager without triggering _load_local_plugins."""
+    manager = PluginManager(MockTagger())
+    manager._primary_plugin_dir = Path(plugins_dir)
+    manager._plugin_dirs.append(manager._primary_plugin_dir)
+    return manager
+
+
+class TestLocalNonGitPlugin(PicardTestCase):
+    """Tests for non-git local plugin lifecycle."""
+
+    def test_install_and_metadata(self):
+        """Install a local non-git plugin and verify metadata."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            manager = _create_manager(plugins_dir)
+
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False)
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+
+            self.assertIsNotNone(plugin)
+            self.assertEqual(plugin.local_path, plugin_dir)
+            self.assertEqual(plugin_id, plugin_name)
+
+            metadata = manager._get_plugin_metadata(plugin.uuid)
+            self.assertIsNotNone(metadata)
+            self.assertEqual(metadata.ref_type, 'local')
+            self.assertEqual(metadata.url, str(plugin_dir))
+            self.assertEqual(metadata.commit, '')
+
+    def test_install_no_manifest_fails(self):
+        """Installing a dir without MANIFEST.toml raises error."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            empty_dir = Path(tmp_dir) / 'empty-plugin'
+            empty_dir.mkdir()
+            (empty_dir / '__init__.py').write_text('')
+            manager = _create_manager(plugins_dir)
+
+            with self.assertRaises(PluginManifestNotFoundError):
+                manager.install_plugin(str(empty_dir), enable_after_install=False)
+
+    def test_reinstall(self):
+        """Reinstalling a local non-git plugin replaces the existing one."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            manager = _create_manager(plugins_dir)
+
+            manager.install_plugin(str(plugin_dir), enable_after_install=False)
+            manager.install_plugin(str(plugin_dir), reinstall=True, enable_after_install=False)
+
+            count = sum(1 for p in manager.plugins if p.plugin_id == plugin_name)
+            self.assertEqual(count, 1)
+
+    def test_remove_keeps_files(self):
+        """Removing a local non-git plugin unregisters it but keeps files."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            manager = _create_manager(plugins_dir)
+
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False)
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+            manager.uninstall_plugin(plugin)
+
+            self.assertIsNone(manager.plugin_id_to_plugin(plugin_id))
+            self.assertIsNone(manager._get_plugin_metadata(uuid))
+            self.assertTrue(plugin_dir.exists())
+            self.assertTrue((plugin_dir / 'MANIFEST.toml').exists())
+
+    def test_update_reloads(self):
+        """Updating a local non-git plugin reloads it and re-reads manifest."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            manager = _create_manager(plugins_dir)
+
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False)
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+
+            (plugin_dir / 'MANIFEST.toml').write_text(create_test_manifest_content(name='Updated Name', uuid=uuid))
+
+            result = manager.update_plugin(plugin)
+            self.assertEqual(result.old_commit, '')
+            self.assertEqual(result.new_commit, '')
+            self.assertEqual(plugin.manifest.name(), 'Updated Name')
+
+    def test_stale_path_cleanup(self):
+        """Local plugin with missing path is auto-removed on startup."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+
+            manager = _create_manager(plugins_dir)
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False)
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+            actual_uuid = plugin.uuid
+            self.assertIsNotNone(manager._get_plugin_metadata(actual_uuid))
+
+            # Delete plugin directory
+            shutil.rmtree(plugin_dir)
+
+            # New manager simulates restart — _load_local_plugins should clean up
+            manager2 = PluginManager(MockTagger())
+            manager2.add_directory(plugins_dir, primary=True)
+
+            self.assertIsNone(manager2.plugin_id_to_plugin(plugin_name))
+            self.assertIsNone(manager2._get_plugin_metadata(actual_uuid))
+
+
+class TestLocalNonGitPluginCLI(PicardTestCase):
+    """Tests for CLI behavior with local non-git plugins."""
+
+    def test_cli_list_info_update_refs(self):
+        """CLI shows [local] marker, reloads on update, blocks list-refs."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            manager = _create_manager(plugins_dir)
+            manager.install_plugin(str(plugin_dir), enable_after_install=False)
+
+            # --list shows [local]
+            exit_code, stdout, _ = run_cli(manager, list=True)
+            self.assertEqual(exit_code, 0)
+            self.assertIn('[local]', stdout)
+
+            # --info shows [local]
+            exit_code, stdout, _ = run_cli(manager, info=plugin_name)
+            self.assertEqual(exit_code, 0)
+            self.assertIn('[local]', stdout)
+
+            # --update shows 'Plugin reloaded'
+            exit_code, stdout, _ = run_cli(manager, update=[plugin_name])
+            self.assertEqual(exit_code, 0)
+            self.assertIn('Plugin reloaded', stdout)
+
+            # --list-refs is blocked
+            exit_code, _, stderr = run_cli(manager, list_refs=plugin_name)
+            self.assertNotEqual(exit_code, 0)
+            self.assertIn('not managed by git', stderr)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Allow plugins to be installed from a local directory without requiring a git repository, for testing and development purposes.

## Problem

Currently, installing a plugin from a local directory requires it to be a git repository. This is unnecessary friction for developers who want to quickly test a plugin without setting up git first.

PICARD-3313

## Solution

When `--install /path/to/plugin` is given a directory without `.git`, the plugin is loaded in-place (no copy, no clone). It uses the same manifest validation, blacklist/UUID checks, and enable/disable lifecycle as git-managed plugins, but git-specific operations (update via pull, switch-ref, list-refs, check-updates) are either adapted (update = reload) or blocked with a clear message.

Key changes:
- `_install_local_non_git()` in installer for plain directories
- Load local plugins from metadata (`ref_type='local'`) on startup, auto-remove stale paths
- `--update` performs a reload (disable → re-read manifest → enable)
- `--remove` unregisters without deleting files
- CLI/GUI confirmation warns that git is required for distribution and registry inclusion
- `is_local_non_git_plugin()` helper for consistent metadata checks
- Documentation in `docs/PLUGINSV3/LOCAL_NON_GIT.md`
- 7 unit tests

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed interactively with AI (Kiro CLI), with human direction on design decisions, naming, architecture, and review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
