### PR TITLE
PICARD-3317, PICARD-3318: Fix and redesign Attached Profiles dialog

### DIFF
--- a/picard/ui/forms/ui_options_attached_profiles.py
+++ b/picard/ui/forms/ui_options_attached_profiles.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options_attached_profiles.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -17,17 +17,44 @@ from picard.i18n import gettext as _
 class Ui_AttachedProfilesDialog(object):
     def setupUi(self, AttachedProfilesDialog):
         AttachedProfilesDialog.setObjectName("AttachedProfilesDialog")
-        AttachedProfilesDialog.resize(800, 450)
+        AttachedProfilesDialog.resize(650, 400)
         self.vboxlayout = QtWidgets.QVBoxLayout(AttachedProfilesDialog)
         self.vboxlayout.setContentsMargins(9, 9, 9, 9)
         self.vboxlayout.setSpacing(6)
         self.vboxlayout.setObjectName("vboxlayout")
-        self.options_list = QtWidgets.QTableView(parent=AttachedProfilesDialog)
-        self.options_list.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.options_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
-        self.options_list.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
-        self.options_list.setObjectName("options_list")
-        self.vboxlayout.addWidget(self.options_list)
+        self.splitter = QtWidgets.QSplitter(parent=AttachedProfilesDialog)
+        self.splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
+        self.splitter.setObjectName("splitter")
+        self.left_panel = QtWidgets.QWidget(parent=self.splitter)
+        self.left_panel.setObjectName("left_panel")
+        self.left_layout = QtWidgets.QVBoxLayout(self.left_panel)
+        self.left_layout.setContentsMargins(0, 0, 0, 0)
+        self.left_layout.setObjectName("left_layout")
+        self.profiles_label = QtWidgets.QLabel(parent=self.left_panel)
+        self.profiles_label.setObjectName("profiles_label")
+        self.left_layout.addWidget(self.profiles_label)
+        self.profile_list = QtWidgets.QTreeWidget(parent=self.left_panel)
+        self.profile_list.setHeaderHidden(True)
+        self.profile_list.setRootIsDecorated(False)
+        self.profile_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.profile_list.setObjectName("profile_list")
+        self.profile_list.headerItem().setText(0, "1")
+        self.profile_list.headerItem().setText(1, "2")
+        self.left_layout.addWidget(self.profile_list)
+        self.right_panel = QtWidgets.QWidget(parent=self.splitter)
+        self.right_panel.setObjectName("right_panel")
+        self.right_layout = QtWidgets.QVBoxLayout(self.right_panel)
+        self.right_layout.setContentsMargins(0, 0, 0, 0)
+        self.right_layout.setObjectName("right_layout")
+        self.options_label = QtWidgets.QLabel(parent=self.right_panel)
+        self.options_label.setObjectName("options_label")
+        self.right_layout.addWidget(self.options_label)
+        self.settings_tree = QtWidgets.QTreeWidget(parent=self.right_panel)
+        self.settings_tree.setHeaderHidden(True)
+        self.settings_tree.setObjectName("settings_tree")
+        self.settings_tree.headerItem().setText(0, "1")
+        self.right_layout.addWidget(self.settings_tree)
+        self.vboxlayout.addWidget(self.splitter)
         self.buttonBox = QtWidgets.QDialogButtonBox(parent=AttachedProfilesDialog)
         self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.StandardButton.NoButton)
         self.buttonBox.setObjectName("buttonBox")
@@ -38,3 +65,5 @@ class Ui_AttachedProfilesDialog(object):
 
     def retranslateUi(self, AttachedProfilesDialog):
         AttachedProfilesDialog.setWindowTitle(_("Profiles Attached to Options"))
+        self.profiles_label.setText(_("Profiles"))
+        self.options_label.setText(_("Options in this section"))

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -45,7 +45,6 @@ from picard import (
 from picard.config import (
     Option,
     OptionError,
-    SettingConfigSection,
     get_config,
 )
 from picard.extension_points.options_pages import ext_point_options_pages
@@ -402,13 +401,10 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def display_attached_profiles(self, option_group):
         profile_page = self.get_page('profiles')
-        override_profiles = profile_page._clean_and_get_all_profiles()
-        override_settings = profile_page.profile_settings
         profile_dialog = AttachedProfilesDialog(
             option_group,
+            profile_page,
             parent=self,
-            override_profiles=override_profiles,
-            override_settings=override_settings,
         )
         profile_dialog.show_modal()
 
@@ -555,30 +551,13 @@ class OptionsDialog(PicardDialog, SingletonDialog):
     def get_page(self, pagename):
         return self.item_to_page[self.pagename_to_item[pagename]]
 
-    def page_has_attached_profiles(self, page, enabled_profiles_only=False):
-        if not page.loaded:
-            return False
-        profile_page = self.get_page('profiles')
-        if not profile_page.loaded:
-            return False
-        option_group = profile_groups_group_from_page(page)
-        if not option_group:
-            return False
-        working_profiles, working_settings = self.get_working_profile_data()
-        for opt in option_group['settings']:
-            for item in working_profiles:
-                if enabled_profiles_only and not item['enabled']:
-                    continue
-                profile_id = item['id']
-                if setting_profile_key(opt.name, opt.section) in working_settings[profile_id]:
-                    return True
-        return False
-
     def set_profiles_button_and_highlight(self, page):
-        if self.page_has_attached_profiles(page):
-            self.ui.attached_profiles_button.setDisabled(False)
-        else:
-            self.ui.attached_profiles_button.setDisabled(True)
+        option_group = profile_groups_group_from_page(page)
+        enabled = False
+        if option_group:
+            working_profiles, _ = self.get_working_profile_data()
+            enabled = any(p['enabled'] for p in working_profiles)
+        self.ui.attached_profiles_button.setEnabled(enabled)
         self.update_profile_save_warning(page)
 
     def update_profile_save_warning(self, page):
@@ -869,61 +848,192 @@ class AttachedProfilesDialog(PicardDialog):
     NAME = 'attachedprofiles'
     TITLE = N_("Attached Profiles")
 
-    def __init__(self, option_group, parent=None, override_profiles=None, override_settings=None):
+    def __init__(self, option_group, profile_page, parent=None):
         super().__init__(parent=parent)
         self.option_group = option_group
+        self.profile_page = profile_page
+        self._building_tree = False
+        self._highlighted_item = None
+
         self.ui = Ui_AttachedProfilesDialog()
         self.ui.setupUi(self)
         self.ui.buttonBox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Close)
         self.ui.buttonBox.rejected.connect(self.close_window)
+        self.ui.splitter.setStretchFactor(1, 1)
 
-        config = get_config()
-        if override_profiles is None or override_settings is None:
-            self.profiles = config.profiles[SettingConfigSection.PROFILES_KEY]
-            self.settings = config.profiles[SettingConfigSection.SETTINGS_KEY]
-        else:
-            self.profiles = override_profiles
-            self.settings = override_settings
+        self.setWindowTitle(_("Profiles Attached to Options in %s Section") % self.option_group['title'])
 
-        self.populate_table()
+        # Only show enabled profiles
+        self._enabled_profiles = [p for p in self.profile_page._clean_and_get_all_profiles() if p['enabled']]
 
-        self.ui.buttonBox.setFocus()
+        self._populate_profile_list()
+        self.ui.profile_list.itemSelectionChanged.connect(self._on_selection_changed)
+        self.ui.settings_tree.itemChanged.connect(self._on_item_changed)
+        self.ui.settings_tree.setMouseTracking(True)
+        self.ui.settings_tree.itemEntered.connect(self._on_item_hovered)
 
-    def populate_table(self):
-        model = QtGui.QStandardItemModel()
-        model.setColumnCount(2)
-        header_names = (_("Option"), _("Attached Profiles"))
-        model.setHorizontalHeaderLabels(header_names)
+        # Hide left pane if only one enabled profile
+        if len(self._enabled_profiles) <= 1:
+            self.ui.left_panel.hide()
 
-        window_title = _("Profiles Attached to Options in %s Section") % self.option_group['title']
-        self.setWindowTitle(window_title)
+        self._last_selection = []
+        if self.ui.profile_list.topLevelItemCount() > 0:
+            self.ui.profile_list.topLevelItem(0).setSelected(True)
 
+    # --- Profile list ---
+
+    def _populate_profile_list(self):
+        self.ui.profile_list.clear()
+        for profile in self._enabled_profiles:
+            item = QtWidgets.QTreeWidgetItem(["○", profile['title']])
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, profile['id'])
+            self.ui.profile_list.addTopLevelItem(item)
+        self.ui.profile_list.resizeColumnToContents(0)
+
+    def _selected_profile_ids(self):
+        return [item.data(0, QtCore.Qt.ItemDataRole.UserRole) for item in self.ui.profile_list.selectedItems()]
+
+    def _on_selection_changed(self):
+        if not self.ui.profile_list.selectedItems():
+            # Never allow empty selection
+            self.ui.profile_list.blockSignals(True)
+            if len(self._last_selection) == 1:
+                self._last_selection[0].setSelected(True)
+            else:
+                first = self.ui.profile_list.topLevelItem(0)
+                first.setSelected(True)
+                self._last_selection = [first]
+            self.ui.profile_list.blockSignals(False)
+            return
+        self._last_selection = list(self.ui.profile_list.selectedItems())
+        self._populate_settings_tree()
+
+    # --- Settings tree ---
+
+    def _populate_settings_tree(self):
+        self._building_tree = True
+        self._highlighted_item = None
+        self._check_states = {}
+        self.ui.settings_tree.clear()
+        selected_ids = self._selected_profile_ids()
         for setting in self.option_group['settings']:
             try:
                 title = Option.get_title(setting.section, setting.name)
             except OptionError as e:
                 log.debug(e)
                 continue
-            option_item = QtGui.QStandardItem(_(title))
-            option_item.setEditable(False)
-            attached = []
-            for profile in self.profiles:
-                if setting.name in self.settings[profile['id']]:
-                    if profile['enabled']:
-                        display_title = _('{profile} [Enabled]').format(profile=profile['title'])
-                    else:
-                        display_title = profile['title']
-                    attached.append(display_title)
-            attached_profiles = "\n".join(attached) or _("None")
-            profile_item = QtGui.QStandardItem(attached_profiles)
-            profile_item.setEditable(False)
-            model.appendRow((option_item, profile_item))
+            if title is None:
+                title = setting.name
+            pkey = setting_profile_key(setting.name, setting.section)
+            item = QtWidgets.QTreeWidgetItem([_(title)])
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, pkey)
+            item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+            state = self._compute_check_state(pkey, selected_ids)
+            self._check_states[pkey] = state
+            item.setCheckState(0, state)
+            item.setToolTip(0, self._build_tooltip(pkey))
+            self.ui.settings_tree.addTopLevelItem(item)
+        self._building_tree = False
 
-        self.ui.options_list.setModel(model)
-        self.ui.options_list.resizeColumnsToContents()
-        self.ui.options_list.resizeRowsToContents()
-        self.ui.options_list.horizontalHeader().setStretchLastSection(True)
+    def _compute_check_state(self, pkey, selected_ids):
+        """Determine check state for an option given selected profiles."""
+        in_selected = selected_ids and all(
+            pkey in self.profile_page.get_settings_for_profile(pid) for pid in selected_ids
+        )
+        if in_selected:
+            return QtCore.Qt.CheckState.Checked
+        # Check if any other enabled profile has it
+        selected_set = set(selected_ids)
+        for profile in self._enabled_profiles:
+            if profile['id'] in selected_set:
+                continue
+            if pkey in self.profile_page.profile_settings.get(profile['id'], {}):
+                return QtCore.Qt.CheckState.PartiallyChecked
+        return QtCore.Qt.CheckState.Unchecked
+
+    def _build_tooltip(self, pkey):
+        """Build tooltip explaining which profile this option will be saved to."""
+        for profile in self._enabled_profiles:
+            psettings = self.profile_page.profile_settings.get(profile['id'], {})
+            if pkey in psettings:
+                return _("This option will be saved to profile: %s") % profile['title']
+        return _("Not in any profile")
+
+    def _on_item_changed(self, item, column):
+        if self._building_tree:
+            return
+        # Only react to actual check state changes
+        pkey = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        new_state = item.checkState(0)
+        if self._check_states.get(pkey) == new_state:
+            return
+        selected_ids = self._selected_profile_ids()
+        if not selected_ids:
+            return
+        # User clicked: partial or unchecked → add to selected profiles
+        # checked → remove from selected profiles
+        if new_state != QtCore.Qt.CheckState.Unchecked:
+            # Any click from partial/unchecked means "add"
+            for pid in selected_ids:
+                settings = self.profile_page.get_settings_for_profile(pid)
+                if pkey not in settings:
+                    settings[pkey] = None
+        else:
+            # Unchecked means "remove from selected profiles"
+            for pid in selected_ids:
+                settings = self.profile_page.get_settings_for_profile(pid)
+                settings.pop(pkey, None)
+        # Recompute correct state (may become partial if other profiles have it)
+        correct_state = self._compute_check_state(pkey, selected_ids)
+        self._check_states[pkey] = correct_state
+        if item.checkState(0) != correct_state:
+            self.ui.settings_tree.blockSignals(True)
+            item.setCheckState(0, correct_state)
+            self.ui.settings_tree.blockSignals(False)
+        item.setToolTip(0, self._build_tooltip(pkey))
+        self._update_profile_markers(pkey)
+        self.profile_page.update_config_overrides()
+        self.profile_page.profile_selected(update_settings=True)
+        self.profile_page.reload_all_page_settings()
+
+    def _on_item_hovered(self, item, column):
+        """Show filled circle on profile list items that contain the hovered option."""
+        if self._highlighted_item is item:
+            return
+        # Highlight the option row
+        self._clear_option_highlight()
+        bg = QtGui.QColor(_interface_colors.get_color('profile_hl_bg'))
+        bg.setAlpha(80)
+        item.setBackground(0, QtGui.QBrush(bg))
+        self._highlighted_item = item
+        # Update markers
+        pkey = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        self._update_profile_markers(pkey)
+
+    def _update_profile_markers(self, pkey):
+        for i in range(self.ui.profile_list.topLevelItemCount()):
+            list_item = self.ui.profile_list.topLevelItem(i)
+            pid = list_item.data(0, QtCore.Qt.ItemDataRole.UserRole)
+            psettings = self.profile_page.profile_settings.get(pid, {})
+            marker = "●" if pkey in psettings else "○"
+            if list_item.text(0) != marker:
+                list_item.setText(0, marker)
+
+    def _clear_profile_highlights(self):
+        for i in range(self.ui.profile_list.topLevelItemCount()):
+            list_item = self.ui.profile_list.topLevelItem(i)
+            if list_item.text(0) != "○":
+                list_item.setText(0, "○")
+        self._clear_option_highlight()
+
+    def _clear_option_highlight(self):
+        if self._highlighted_item:
+            self._highlighted_item.setBackground(0, QtGui.QBrush())
+            self._highlighted_item = None
+
+    def leaveEvent(self, event):
+        self._clear_profile_highlights()
+        super().leaveEvent(event)
 
     def close_window(self):
-        """Close the script metadata editor window."""
         self.close()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -32,6 +32,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import TYPE_CHECKING
+
 from PyQt6 import (
     QtCore,
     QtGui,
@@ -110,6 +112,10 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     tags_compatibility_id3,
     tags_compatibility_wave,
 )
+
+
+if TYPE_CHECKING:
+    from picard.ui.options.profiles import ProfilesOptionsPage
 
 
 class ErrorOptionsPage(OptionsPage):
@@ -399,7 +405,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         message_box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
         message_box.exec()
 
-    def display_attached_profiles(self, option_group):
+    def display_attached_profiles(self, option_group: dict) -> None:
         profile_page = self.get_page('profiles')
         profile_dialog = AttachedProfilesDialog(
             option_group,
@@ -848,12 +854,12 @@ class AttachedProfilesDialog(PicardDialog):
     NAME = 'attachedprofiles'
     TITLE = N_("Attached Profiles")
 
-    def __init__(self, option_group, profile_page, parent=None):
+    def __init__(self, option_group: dict, profile_page: 'ProfilesOptionsPage', parent=None) -> None:
         super().__init__(parent=parent)
         self.option_group = option_group
         self.profile_page = profile_page
-        self._building_tree = False
-        self._highlighted_item = None
+        self._building_tree: bool = False
+        self._highlighted_item: QtWidgets.QTreeWidgetItem | None = None
 
         self.ui = Ui_AttachedProfilesDialog()
         self.ui.setupUi(self)
@@ -882,7 +888,7 @@ class AttachedProfilesDialog(PicardDialog):
 
     # --- Profile list ---
 
-    def _populate_profile_list(self):
+    def _populate_profile_list(self) -> None:
         self.ui.profile_list.clear()
         for profile in self._enabled_profiles:
             item = QtWidgets.QTreeWidgetItem(["○", profile['title']])
@@ -890,10 +896,10 @@ class AttachedProfilesDialog(PicardDialog):
             self.ui.profile_list.addTopLevelItem(item)
         self.ui.profile_list.resizeColumnToContents(0)
 
-    def _selected_profile_ids(self):
+    def _selected_profile_ids(self) -> list[str]:
         return [item.data(0, QtCore.Qt.ItemDataRole.UserRole) for item in self.ui.profile_list.selectedItems()]
 
-    def _on_selection_changed(self):
+    def _on_selection_changed(self) -> None:
         if not self.ui.profile_list.selectedItems():
             # Never allow empty selection
             self.ui.profile_list.blockSignals(True)
@@ -910,7 +916,7 @@ class AttachedProfilesDialog(PicardDialog):
 
     # --- Settings tree ---
 
-    def _populate_settings_tree(self):
+    def _populate_settings_tree(self) -> None:
         self._building_tree = True
         self._highlighted_item = None
         self._check_states = {}
@@ -935,7 +941,7 @@ class AttachedProfilesDialog(PicardDialog):
             self.ui.settings_tree.addTopLevelItem(item)
         self._building_tree = False
 
-    def _compute_check_state(self, pkey, selected_ids):
+    def _compute_check_state(self, pkey: str, selected_ids: list[str]) -> QtCore.Qt.CheckState:
         """Determine check state for an option given selected profiles."""
         in_selected = selected_ids and all(
             pkey in self.profile_page.get_settings_for_profile(pid) for pid in selected_ids
@@ -951,7 +957,7 @@ class AttachedProfilesDialog(PicardDialog):
                 return QtCore.Qt.CheckState.PartiallyChecked
         return QtCore.Qt.CheckState.Unchecked
 
-    def _build_tooltip(self, pkey):
+    def _build_tooltip(self, pkey: str) -> str:
         """Build tooltip explaining which profile this option will be saved to."""
         for profile in self._enabled_profiles:
             psettings = self.profile_page.profile_settings.get(profile['id'], {})
@@ -959,7 +965,7 @@ class AttachedProfilesDialog(PicardDialog):
                 return _("This option will be saved to profile: %s") % profile['title']
         return _("Not in any profile")
 
-    def _on_item_changed(self, item, column):
+    def _on_item_changed(self, item: QtWidgets.QTreeWidgetItem, column: int) -> None:
         if self._building_tree:
             return
         # Only react to actual check state changes
@@ -996,7 +1002,7 @@ class AttachedProfilesDialog(PicardDialog):
         self.profile_page.profile_selected(update_settings=True)
         self.profile_page.reload_all_page_settings()
 
-    def _on_item_hovered(self, item, column):
+    def _on_item_hovered(self, item: QtWidgets.QTreeWidgetItem, column: int) -> None:
         """Show filled circle on profile list items that contain the hovered option."""
         if self._highlighted_item is item:
             return
@@ -1010,7 +1016,7 @@ class AttachedProfilesDialog(PicardDialog):
         pkey = item.data(0, QtCore.Qt.ItemDataRole.UserRole)
         self._update_profile_markers(pkey)
 
-    def _update_profile_markers(self, pkey):
+    def _update_profile_markers(self, pkey: str) -> None:
         for i in range(self.ui.profile_list.topLevelItemCount()):
             list_item = self.ui.profile_list.topLevelItem(i)
             pid = list_item.data(0, QtCore.Qt.ItemDataRole.UserRole)
@@ -1019,14 +1025,14 @@ class AttachedProfilesDialog(PicardDialog):
             if list_item.text(0) != marker:
                 list_item.setText(0, marker)
 
-    def _clear_profile_highlights(self):
+    def _clear_profile_highlights(self) -> None:
         for i in range(self.ui.profile_list.topLevelItemCount()):
             list_item = self.ui.profile_list.topLevelItem(i)
             if list_item.text(0) != "○":
                 list_item.setText(0, "○")
         self._clear_option_highlight()
 
-    def _clear_option_highlight(self):
+    def _clear_option_highlight(self) -> None:
         if self._highlighted_item:
             self._highlighted_item.setBackground(0, QtGui.QBrush())
             self._highlighted_item = None
@@ -1035,5 +1041,5 @@ class AttachedProfilesDialog(PicardDialog):
         self._clear_profile_highlights()
         super().leaveEvent(event)
 
-    def close_window(self):
+    def close_window(self) -> None:
         self.close()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -900,7 +900,7 @@ class AttachedProfilesDialog(PicardDialog):
 
         for setting in self.option_group['settings']:
             try:
-                title = Option.get_title('setting', setting.name)
+                title = Option.get_title(setting.section, setting.name)
             except OptionError as e:
                 log.debug(e)
                 continue

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -850,9 +850,19 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             function()
 
 
+class _NoSelectionDelegate(QtWidgets.QStyledItemDelegate):
+    """Delegate that paints items without selection highlight."""
+
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        option.state &= ~QtWidgets.QStyle.StateFlag.State_Selected
+
+
 class AttachedProfilesDialog(PicardDialog):
     NAME = 'attachedprofiles'
     TITLE = N_("Attached Profiles")
+    MARKER_ACTIVE = "★"
+    MARKER_INACTIVE = "☆"
 
     def __init__(self, option_group: dict, profile_page: 'ProfilesOptionsPage', parent=None) -> None:
         super().__init__(parent=parent)
@@ -873,31 +883,54 @@ class AttachedProfilesDialog(PicardDialog):
         self._enabled_profiles = [p for p in self.profile_page._clean_and_get_all_profiles() if p['enabled']]
 
         self._populate_profile_list()
+        self.ui.profile_list.setIndentation(0)
+        self.ui.profile_list.setItemDelegateForColumn(0, _NoSelectionDelegate(self.ui.profile_list))
         self.ui.profile_list.itemSelectionChanged.connect(self._on_selection_changed)
         self.ui.settings_tree.itemChanged.connect(self._on_item_changed)
         self.ui.settings_tree.setMouseTracking(True)
+        self.ui.settings_tree.setIndentation(0)
         self.ui.settings_tree.itemEntered.connect(self._on_item_hovered)
 
         # Hide left pane if only one enabled profile
         if len(self._enabled_profiles) <= 1:
-            self.ui.left_panel.hide()
+            self.ui.profile_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.NoSelection)
 
         self._last_selection = []
-        if self.ui.profile_list.topLevelItemCount() > 0:
+        if len(self._enabled_profiles) > 1 and self.ui.profile_list.topLevelItemCount() > 0:
             self.ui.profile_list.topLevelItem(0).setSelected(True)
+        elif len(self._enabled_profiles) == 1:
+            self._populate_settings_tree()
 
     # --- Profile list ---
 
     def _populate_profile_list(self) -> None:
         self.ui.profile_list.clear()
+        self.ui.profile_list.setToolTip(
+            _(
+                "Hover an option to see which profiles contain it.\n"
+                "%s = option is in this profile, %s = option is not in this profile"
+            )
+            % (self.MARKER_ACTIVE, self.MARKER_INACTIVE)
+        )
+        fm = self.ui.profile_list.fontMetrics()
+        marker_width = fm.horizontalAdvance(self.MARKER_ACTIVE) + 4
+        marker_height = fm.boundingRect(self.MARKER_ACTIVE).height()
+        marker_size = QtCore.QSize(marker_width, marker_height)
         for profile in self._enabled_profiles:
-            item = QtWidgets.QTreeWidgetItem(["○", profile['title']])
+            item = QtWidgets.QTreeWidgetItem([self.MARKER_INACTIVE, profile['title']])
             item.setData(0, QtCore.Qt.ItemDataRole.UserRole, profile['id'])
+            item.setSizeHint(0, marker_size)
             self.ui.profile_list.addTopLevelItem(item)
-        self.ui.profile_list.resizeColumnToContents(0)
+        self.ui.profile_list.header().setMinimumSectionSize(marker_width)
+        self.ui.profile_list.header().resizeSection(0, marker_width)
+        self.ui.profile_list.header().setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Fixed)
 
     def _selected_profile_ids(self) -> list[str]:
-        return [item.data(0, QtCore.Qt.ItemDataRole.UserRole) for item in self.ui.profile_list.selectedItems()]
+        ids = [item.data(0, QtCore.Qt.ItemDataRole.UserRole) for item in self.ui.profile_list.selectedItems()]
+        if not ids:
+            # No selection (single profile mode) — use all enabled profiles
+            ids = [p['id'] for p in self._enabled_profiles]
+        return ids
 
     def _on_selection_changed(self) -> None:
         if not self.ui.profile_list.selectedItems():
@@ -943,11 +976,12 @@ class AttachedProfilesDialog(PicardDialog):
 
     def _compute_check_state(self, pkey: str, selected_ids: list[str]) -> QtCore.Qt.CheckState:
         """Determine check state for an option given selected profiles."""
-        in_selected = selected_ids and all(
-            pkey in self.profile_page.get_settings_for_profile(pid) for pid in selected_ids
-        )
-        if in_selected:
-            return QtCore.Qt.CheckState.Checked
+        if selected_ids:
+            in_count = sum(1 for pid in selected_ids if pkey in self.profile_page.get_settings_for_profile(pid))
+            if in_count == len(selected_ids):
+                return QtCore.Qt.CheckState.Checked
+            if in_count > 0:
+                return QtCore.Qt.CheckState.PartiallyChecked
         # Check if any other enabled profile has it
         selected_set = set(selected_ids)
         for profile in self._enabled_profiles:
@@ -958,12 +992,21 @@ class AttachedProfilesDialog(PicardDialog):
         return QtCore.Qt.CheckState.Unchecked
 
     def _build_tooltip(self, pkey: str) -> str:
-        """Build tooltip explaining which profile this option will be saved to."""
-        for profile in self._enabled_profiles:
-            psettings = self.profile_page.profile_settings.get(profile['id'], {})
-            if pkey in psettings:
-                return _("This option will be saved to profile: %s") % profile['title']
-        return _("Not in any profile")
+        """Build tooltip explaining current state and what clicking will do."""
+        selected_ids = self._selected_profile_ids()
+        state = self._compute_check_state(pkey, selected_ids)
+        if state == QtCore.Qt.CheckState.Checked:
+            tooltip = _("This option is in the selected profile(s).\nClick to remove it from them.")
+        elif state == QtCore.Qt.CheckState.PartiallyChecked:
+            # Find which profile(s) have it
+            profiles_with = []
+            for profile in self._enabled_profiles:
+                if pkey in self.profile_page.profile_settings.get(profile['id'], {}):
+                    profiles_with.append(profile['title'])
+            tooltip = _("This option is in: %s\nClick to add it to the selected profile(s).") % ", ".join(profiles_with)
+        else:
+            tooltip = _("This option is not in any profile.\nClick to add it to the selected profile(s).")
+        return tooltip
 
     def _on_item_changed(self, item: QtWidgets.QTreeWidgetItem, column: int) -> None:
         if self._building_tree:
@@ -1021,15 +1064,15 @@ class AttachedProfilesDialog(PicardDialog):
             list_item = self.ui.profile_list.topLevelItem(i)
             pid = list_item.data(0, QtCore.Qt.ItemDataRole.UserRole)
             psettings = self.profile_page.profile_settings.get(pid, {})
-            marker = "●" if pkey in psettings else "○"
+            marker = self.MARKER_ACTIVE if pkey in psettings else self.MARKER_INACTIVE
             if list_item.text(0) != marker:
                 list_item.setText(0, marker)
 
     def _clear_profile_highlights(self) -> None:
         for i in range(self.ui.profile_list.topLevelItemCount()):
             list_item = self.ui.profile_list.topLevelItem(i)
-            if list_item.text(0) != "○":
-                list_item.setText(0, "○")
+            if list_item.text(0) != self.MARKER_INACTIVE:
+                list_item.setText(0, self.MARKER_INACTIVE)
         self._clear_option_highlight()
 
     def _clear_option_highlight(self) -> None:

--- a/ui/options_attached_profiles.ui
+++ b/ui/options_attached_profiles.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>450</height>
+    <width>650</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Profiles Attached to Options</string>
   </property>
-  <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="vboxlayout">
    <property name="spacing">
     <number>6</number>
    </property>
@@ -30,16 +30,91 @@
     <number>9</number>
    </property>
    <item>
-    <widget class="QTableView" name="options_list">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
+     <widget class="QWidget" name="left_panel">
+      <layout class="QVBoxLayout" name="left_layout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="profiles_label">
+         <property name="text">
+          <string>Profiles</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="profile_list">
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+         <column>
+          <property name="text">
+           <string notr="true">1</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string notr="true">2</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="right_panel">
+      <layout class="QVBoxLayout" name="right_layout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="options_label">
+         <property name="text">
+          <string>Options in this section</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="settings_tree">
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string notr="true">1</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix plugin options not showing in the Attached Profiles dialog, and redesign the dialog to allow interactive editing of profile-option assignments.

## Problem

* JIRA ticket: PICARD-3317, PICARD-3318

The Attached Profiles dialog had two issues:
1. Plugin options never appeared because `Option.get_title()` was called with hardcoded `'setting'` section instead of the actual plugin section (`plugin.<uuid>`).
2. The dialog was read-only — it only showed which profiles contained which options but didn't allow editing.

## Solution

**PICARD-3317 fix:** Use `setting.section` instead of hardcoded `'setting'` in `Option.get_title()` call.

**PICARD-3318 redesign:** Replace the read-only table with an interactive split-pane dialog:
- Left pane: enabled profiles list with multi-select (hidden if single profile). ●/○ markers show which profiles contain the hovered option.
- Right pane: option checklist scoped to the current page with tristate checkboxes:
  - ☑ Checked = option is in the selected profile(s)
  - ◪ Partially checked = option is in another (lower priority) profile
  - ☐ Unchecked = option is not in any enabled profile
- Tooltips explain which profile the option will be saved to
- Hovered option row highlighted with profile highlight color
- Changes propagate immediately to the Profiles page and highlights
- Button disabled when no enabled profiles exist

<img width="874" height="610" alt="image" src="https://github.com/user-attachments/assets/610754e6-c984-4ba6-8ee9-03739dfc232c" />


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed iteratively with AI assistance through design discussion, implementation, debugging, and performance optimization.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
