### PR TITLE
Add `--no-git` option when creating a plugin scaffold from CLI

### DIFF
--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -1161,7 +1161,8 @@ appear in order:
 5. Short description
 6. Categories — comma-separated numbers for multiple (e.g. `1,3`)
 7. License — defaults to last used value or GPL-2.0-or-later
-8. Create initial git commit? — yes/no (default: yes)
+8. Initialize git repository? — yes/no (default: yes)
+9. Create initial git commit? — yes/no (default: yes) — only if "Initialize git repository?" is yes.
 
 Author name, email, and license are persisted across runs.
 
@@ -1174,6 +1175,7 @@ Author name, email, and license are persisted across runs.
 | `--author NAME` | Author name for MANIFEST.toml |
 | `--category CATEGORY` | Plugin category (metadata, coverart, ui, etc.) |
 | `--with-translations` | Include translation support (locale files and examples) |
+| `--no-git` | Skip initialization of the git repository (works in both interactive and non-interactive modes) |
 | `--no-commit` | Skip initial git commit (works in both interactive and non-interactive modes) |
 
 **Examples:**
@@ -1199,6 +1201,9 @@ picard-plugins --init "My Cool Plugin" --parent-dir ~/dev --target-dir my-plugin
 
 # With translation support
 picard-plugins --init "My Cool Plugin" --with-translations
+
+# Skip initializing the git repository
+picard-plugins --init "My Cool Plugin" --no-git
 
 # Skip initial git commit
 picard-plugins --init "My Cool Plugin" --no-commit

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -2054,7 +2054,7 @@ class PluginCLI:
         if not project.report_bugs_to and author_email:
             project.report_bugs_to = f'mailto:{author_email}'
         try:
-            filenames = write_plugin_project(target, project)
+            filenames = write_plugin_project(target, project, git_initialization)
         except OSError as e:
             self._out.error(f'Failed to create plugin project: {e}')
             return ExitCode.ERROR

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -1949,6 +1949,17 @@ class PluginCLI:
             if locale_input:
                 source_locale = locale_input
 
+        git_initialization = not getattr(self._args, 'no_git', False) and self._out.yesno(
+            'Initialize git repository?', default='Y'
+        )
+
+        if git_initialization:
+            git_commit = not getattr(self._args, 'no_commit', False) and self._out.yesno(
+                'Create initial git commit?', default='Y'
+            )
+        else:
+            git_commit = False
+
         return self.create_plugin_project(
             PluginProjectConfig(
                 name=name,
@@ -1962,8 +1973,8 @@ class PluginCLI:
             ),
             author_email=author_email,
             target=target,
-            git_commit=not getattr(self._args, 'no_commit', False)
-            and self._out.yesno('Create initial git commit?', default='Y'),
+            git_initialization=git_initialization,
+            git_commit=git_commit,
         )
 
     def create_plugin_project(
@@ -1972,6 +1983,7 @@ class PluginCLI:
         *,
         author_email='',
         target=None,
+        git_initialization=True,
         git_commit=True,
     ):
         """Create the plugin project directory and files.
@@ -1980,6 +1992,7 @@ class PluginCLI:
             project: Plugin project configuration
             author_email: Author email for git commit
             target: Explicit target directory (overrides --parent-dir/--target-dir)
+            git_initialization: Whether to initialize a git repository
             git_commit: Whether to create an initial git commit
 
         Returns:
@@ -2008,6 +2021,10 @@ class PluginCLI:
         # Check --source-locale flag
         if project.source_locale == DEFAULT_SOURCE_LOCALE:
             project.source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
+
+        # Check --no-git flag
+        if git_initialization:
+            git_initialization = not getattr(self._args, 'no_git', False)
 
         # Check --no-commit flag
         if git_commit:
@@ -2047,26 +2064,27 @@ class PluginCLI:
             self._out.info(filename)
 
         # Initialize git repository
-        try:
-            backend = git_backend()
-            repo = backend.init_repository(target)
+        if git_initialization:
             try:
-                if git_commit:
-                    commit_message = project.commit_message.strip() or 'Initial plugin scaffold'
-                    author_name, commit_email = get_git_author(project.authors or None, author_email)
-                    backend.add_and_commit_files(
-                        repo,
-                        commit_message,
-                        author_name=author_name,
-                        author_email=commit_email,
-                    )
-                    self._out.success('Git repository initialized with initial commit')
-                else:
-                    self._out.success('Git repository initialized')
-            finally:
-                repo.free()
-        except Exception as e:
-            self._out.warning(f'Git initialization failed: {e}')
+                backend = git_backend()
+                repo = backend.init_repository(target)
+                try:
+                    if git_commit:
+                        commit_message = project.commit_message.strip() or 'Initial plugin scaffold'
+                        author_name, commit_email = get_git_author(project.authors or None, author_email)
+                        backend.add_and_commit_files(
+                            repo,
+                            commit_message,
+                            author_name=author_name,
+                            author_email=commit_email,
+                        )
+                        self._out.success('Git repository initialized with initial commit')
+                    else:
+                        self._out.success('Git repository initialized')
+                finally:
+                    repo.free()
+            except Exception as e:
+                self._out.warning(f'Git initialization failed: {e}')
 
         self._out.nl()
         self._out.print('Next steps:')
@@ -2074,7 +2092,7 @@ class PluginCLI:
         self._out.info(f'Edit {self._out.d_path("__init__.py")} to add your plugin code')
         self._out.info(f'Edit {self._out.d_path("MANIFEST.toml")} to update metadata')
         self._out.info(f'Run {self._out.d_command("picard-plugins --validate .")} to check your plugin')
-        if not git_commit:
+        if git_initialization and not git_commit:
             commit_cmd = 'git add -A && git commit -m "Initial plugin scaffold"'
             self._out.info(f'Run {self._out.d_command(commit_cmd)} to commit')
 
@@ -2234,7 +2252,8 @@ def process_cmdline_args():
     group_advanced.add_argument(
         '--with-translations', action='store_true', help="include translation support (locale files and examples)"
     )
-    group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit with --init")
+    group_advanced.add_argument('--no-git', action='store_true', help="skip initializing git repository")
+    group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit")
     group_advanced.add_argument(
         '--source-locale',
         metavar='LOCALE',

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -272,6 +272,7 @@ def generate_source_locale_toml() -> str:
 def write_plugin_project(
     target: Path,
     project: PluginProjectConfig,
+    git_initialization: bool = True,
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -280,7 +281,7 @@ def write_plugin_project(
     Args:
         target: Path to the plugin directory
         project: Plugin project configuration
-
+        git_initialization: Whether to write a .gitignore file (default: True)
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
@@ -296,8 +297,10 @@ def write_plugin_project(
     )
     (target / '__init__.py').write_text(init_py_content, encoding='utf-8')
     (target / 'README.md').write_text(generate_readme(project.name, project.long_description), encoding='utf-8')
-    (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
-    filenames = ['MANIFEST.toml', '__init__.py', 'README.md', '.gitignore']
+    filenames = ['MANIFEST.toml', '__init__.py', 'README.md']
+    if git_initialization:
+        (target / '.gitignore').write_text(generate_gitignore(), encoding='utf-8')
+        filenames.append('.gitignore')
     if project.with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -193,6 +193,7 @@ class MockCliArgs(Mock):
             'trust': None,
             'locale': 'en',
             'with_translations': False,
+            'no_git': False,
             'no_commit': False,
             'source_locale': DEFAULT_SOURCE_LOCALE,
         }

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -1473,6 +1473,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         category='',
         license='',
         with_i18n='n',
+        git_initialization='y',
         git_commit='y',
     ):
         """Build input side_effect list for _cmd_init_interactive prompts.
@@ -1483,7 +1484,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         inputs = [name, target_path, author]
         if author:
             inputs.append(email)
-        inputs.extend([description, category, license, with_i18n, git_commit])
+        inputs.extend([description, category, license, with_i18n, git_initialization, git_commit])
         return inputs
 
     def test_interactive_full(self):
@@ -1513,6 +1514,16 @@ class TestPluginCLIInitInteractive(PicardTestCase):
             exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'MANIFEST.toml').exists())
+
+    def test_interactive_no_git(self):
+        """Interactive mode with only name provided and no git initialization."""
+        target = self.tmpdir / 'picard-plugin-my-plugin'
+        inputs = self._init_inputs(name='My Plugin', git_initialization='n')
+        with patch('builtins.input', side_effect=inputs):
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        self.assertTrue((target / 'MANIFEST.toml').exists())
+        self.assertFalse((target / '.git').is_dir())
 
     def test_interactive_empty_name_fails(self):
         """Interactive mode fails if name is empty."""
@@ -1593,6 +1604,13 @@ class TestPluginCLIInitGit(PicardTestCase):
     def tearDown(self):
         super().tearDown()
         shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_no_git_does_not_create_git_repo(self):
+        """--no-git does not create a git repository."""
+        target = self.tmpdir / 'test-plugin'
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), no_git=True)
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        self.assertFalse((target / '.git').is_dir())
 
     def test_init_creates_git_repo(self):
         """--init creates a git repository."""


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Recent changes to the plugin system now allow the use of local plugins without them being a git repository, but the CLI tool for creating a local plugin scaffold always initialized the git repo for the plugin.

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

Add a new `--no-git` option to the CLI for creating a new local plugin scaffold.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
