### PR TITLE
PICARD-3308: allow setting collation algorithm used

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -26,6 +26,7 @@ import gettext as module_gettext
 import locale
 import os
 import re
+from typing import Protocol
 
 from PyQt6.QtCore import (
     QCollator,
@@ -197,9 +198,13 @@ def setup_gettext(localedir, ui_language=None, logger=None):
 
     _logger("Using locale: %r", current_locale)
     QLocale.setDefault(QLocale(current_locale))
-    _qcollator = QCollator()
-    _qcollator_numeric = QCollator()
-    _qcollator_numeric.setNumericMode(True)
+
+    # Setup collator
+    _logger("Collator: %s", ACTIVE_COLLATOR)
+    if ACTIVE_COLLATOR == 'qt':
+        _qcollator = QCollator()
+        _qcollator_numeric = QCollator()
+        _qcollator_numeric.setNumericMode(True)
 
     global _translation
     _translation = {
@@ -250,20 +255,10 @@ def gettext_constants(message: str) -> str:
     return _translation['constants'].gettext(message)
 
 
-def sort_key(string, numeric=False):
-    """Transforms a string to one that can be used in locale-aware comparisons.
+class Comparable(Protocol):
+    """Protocol for annotating comparable types."""
 
-    Args:
-        string: The string to convert
-        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
-
-    Returns: An object that can be compared locale-aware
-    """
-    # QCollator.sortKey is broken, see https://bugreports.qt.io/browse/QTBUG-128170
-    if IS_WIN:
-        return _sort_key_strxfrm(string, numeric)
-    else:
-        return _sort_key_qt(string, numeric)
+    def __lt__(self, other, /) -> bool: ...
 
 
 RE_NUMBER = re.compile(r'(\d+)')
@@ -274,7 +269,15 @@ def _digits_replace(matchobj):
     return str(int(s)) if s.isdecimal() else s
 
 
-def _sort_key_qt(string, numeric=False):
+def _sort_key_qt(string: str, numeric: bool = False) -> Comparable:
+    """Transforms a string to one that can be used in locale-aware comparisons.
+
+    Args:
+        string: The string to convert
+        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
+
+    Returns: An object that can be compared locale-aware
+    """
     collator = _qcollator_numeric if numeric else _qcollator
 
     # Null bytes can cause crashes in OS collation functions.
@@ -297,15 +300,36 @@ def _sort_key_qt(string, numeric=False):
     return collator.sortKey(string)
 
 
-def _sort_key_strxfrm(string, numeric=False):
+def _sort_key_strxfrm(string: str, numeric: bool = False) -> Comparable:
+    """Transforms a string to one that can be used in locale-aware comparisons.
+
+    Args:
+        string: The string to convert
+        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
+
+    Returns: An object that can be compared locale-aware
+    """
     if numeric:
         return [int(s) if s.isdecimal() else _strxfrm(s) for s in RE_NUMBER.split(str(string).replace('\0', ''))]
     else:
         return _strxfrm(string)
 
 
-def _strxfrm(string):
+def _strxfrm(string: str) -> str:
     try:
         return locale.strxfrm(string)
     except (OSError, ValueError):
         return string.lower()
+
+
+AVAILABLE_COLLATORS = {
+    'strxfrm': _sort_key_strxfrm,
+    'qt': _sort_key_qt,
+}
+
+DEFAULT_COLLATOR = 'strxfrm' if IS_WIN else 'qt'
+ACTIVE_COLLATOR = os.environ.get('PICARD_COLLATOR', DEFAULT_COLLATOR)
+if ACTIVE_COLLATOR not in AVAILABLE_COLLATORS:
+    ACTIVE_COLLATOR = DEFAULT_COLLATOR
+
+sort_key = AVAILABLE_COLLATORS.get(ACTIVE_COLLATOR)

--- a/picard/i18n/__init__.py
+++ b/picard/i18n/__init__.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2012 Frederik “Freso” S. Olesen
+# Copyright (C) 2013-2014, 2018-2024 Laurent Monin
+# Copyright (C) 2017 Sambhav Kothari
+# Copyright (C) 2017-2024 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections.abc import Callable
+
+from picard.i18n.collate import (
+    setup_collator,
+    sort_key,
+)
+from picard.i18n.gettext import (
+    N_,
+    _,
+    gettext,
+    gettext_attributes,
+    gettext_constants,
+    gettext_countries,
+    ngettext,
+    pgettext_attributes,
+    setup_gettext,
+)
+
+
+__all__ = [
+    'N_',
+    '_',
+    'gettext',
+    'gettext_attributes',
+    'gettext_constants',
+    'gettext_countries',
+    'ngettext',
+    'pgettext_attributes',
+    'setup_i18n',
+    'sort_key',
+]
+
+
+def setup_i18n(localedir: str | None, ui_language: str | None = None, logger: Callable | None = None):
+    logger = _init_logger(logger)
+
+    # Setup gettext translations
+    setup_gettext(localedir, ui_language, logger)
+
+    # Setup collator
+    setup_collator(logger)
+
+
+def _init_logger(logger: Callable | None) -> Callable:
+    if not logger:
+        logger = lambda *a, **b: None  # noqa: E731
+    return logger

--- a/picard/i18n/collate.py
+++ b/picard/i18n/collate.py
@@ -114,9 +114,14 @@ def _strxfrm(string: str) -> str:
         return string.lower()
 
 
+def _sort_key_string(string: str, numeric: bool = False) -> Comparable:
+    return string
+
+
 AVAILABLE_COLLATORS = {
     'strxfrm': _sort_key_strxfrm,
     'qt': _sort_key_qt,
+    'string': _sort_key_string,
 }
 
 # QCollator.sortKey is broken on Windows in some Qt builds,

--- a/picard/i18n/collate.py
+++ b/picard/i18n/collate.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2024, 2026 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from collections.abc import Callable
+import locale
+import os
+import re
+from typing import Protocol
+
+from PyQt6.QtCore import QCollator
+
+from picard.const.sys import (
+    IS_MACOS,
+    IS_WIN,
+)
+
+
+_qcollator = QCollator()
+_qcollator_numeric = QCollator()
+_qcollator_numeric.setNumericMode(True)
+
+
+def setup_collator(logger: Callable):
+    global _qcollator, _qcollator_numeric
+
+    logger("Collator: %s", ACTIVE_COLLATOR)
+    if ACTIVE_COLLATOR == 'qt':
+        _qcollator = QCollator()
+        _qcollator_numeric = QCollator()
+        _qcollator_numeric.setNumericMode(True)
+
+
+class Comparable(Protocol):
+    """Protocol for annotating comparable types."""
+
+    def __lt__(self, other, /) -> bool: ...
+
+
+RE_NUMBER = re.compile(r'(\d+)')
+
+
+def _digits_replace(matchobj):
+    s = matchobj.group(0)
+    return str(int(s)) if s.isdecimal() else s
+
+
+def _sort_key_qt(string: str, numeric: bool = False) -> Comparable:
+    """Transforms a string to one that can be used in locale-aware comparisons.
+
+    Args:
+        string: The string to convert
+        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
+
+    Returns: An object that can be compared locale-aware
+    """
+    collator = _qcollator_numeric if numeric else _qcollator
+
+    # Null bytes can cause crashes in OS collation functions.
+    string = string.replace('\0', '')
+
+    # On macOS / Windows the numeric sorting does not work reliable with non-latin
+    # scripts. Replace numbers in the sort string with their latin equivalent.
+    if numeric and (IS_MACOS or IS_WIN):
+        string = RE_NUMBER.sub(_digits_replace, string)
+
+    if IS_MACOS:
+        # macOS does not sort the empty string before other values correctly
+        if not string:
+            string = ' '
+        # On macOS numeric sorting of strings entirely consisting of numeric
+        # characters fails and always sorts alphabetically (002 < 1). Always
+        # prefix with an alphabetic character to work around that.
+        string = 'a' + string
+
+    return collator.sortKey(string)
+
+
+def _sort_key_strxfrm(string: str, numeric: bool = False) -> Comparable:
+    """Transforms a string to one that can be used in locale-aware comparisons.
+
+    Args:
+        string: The string to convert
+        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
+
+    Returns: An object that can be compared locale-aware
+    """
+    if numeric:
+        return [int(s) if s.isdecimal() else _strxfrm(s) for s in RE_NUMBER.split(str(string).replace('\0', ''))]
+    else:
+        return _strxfrm(string)
+
+
+def _strxfrm(string: str) -> str:
+    try:
+        return locale.strxfrm(string)
+    except (OSError, ValueError):
+        return string.lower()
+
+
+AVAILABLE_COLLATORS = {
+    'strxfrm': _sort_key_strxfrm,
+    'qt': _sort_key_qt,
+}
+
+# QCollator.sortKey is broken on Windows in some Qt builds,
+# see https://qt-project.atlassian.net/browse/QTBUG-88704
+DEFAULT_COLLATOR = 'strxfrm' if IS_WIN else 'qt'
+ACTIVE_COLLATOR = os.environ.get('PICARD_COLLATOR', DEFAULT_COLLATOR)
+if ACTIVE_COLLATOR not in AVAILABLE_COLLATORS:
+    ACTIVE_COLLATOR = DEFAULT_COLLATOR
+
+sort_key = AVAILABLE_COLLATORS[ACTIVE_COLLATOR]

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Frederik “Freso” S. Olesen
 # Copyright (C) 2013-2014, 2018-2024 Laurent Monin
 # Copyright (C) 2017 Sambhav Kothari
-# Copyright (C) 2017-2024 Philipp Wolfer
+# Copyright (C) 2017-2024, 2026 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -21,28 +21,18 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-
+from collections.abc import Callable
 import gettext as module_gettext
 import locale
 import os
-import re
-from typing import Protocol
 
-from PyQt6.QtCore import (
-    QCollator,
-    QLocale,
-)
+from PyQt6.QtCore import QLocale
 
 from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
 
-
-_logger = None
-_qcollator = QCollator()
-_qcollator_numeric = QCollator()
-_qcollator_numeric.setNumericMode(True)
 
 _null_translations = module_gettext.NullTranslations()
 _translation = {
@@ -104,23 +94,28 @@ def set_locale_from_env():
 if IS_WIN:
     from ctypes import windll  # type: ignore[attr-defined]
 
-    def _get_default_locale():
+    def _get_default_locale_win():
         try:
             return locale.windows_locale[windll.kernel32.GetUserDefaultUILanguage()]
         except KeyError:
             return None
 
+    _get_default_locale = _get_default_locale_win
+
 elif IS_MACOS:
     import Foundation
 
-    def _get_default_locale():
+    def _get_default_locale_mac():
         defaults = Foundation.NSUserDefaults.standardUserDefaults()
         return defaults.objectForKey_('AppleLanguages')[0].replace('-', '_')
 
+    _get_default_locale = _get_default_locale_mac
 else:
 
-    def _get_default_locale():
+    def _get_default_locale_none():
         return None
+
+    _get_default_locale = _get_default_locale_none
 
 
 def _try_encodings():
@@ -158,13 +153,10 @@ def _log_lang_env_vars():
     _logger("Env vars: %s", ' '.join(env_vars))
 
 
-def setup_gettext(localedir, ui_language=None, logger=None):
+def setup_gettext(localedir: str | None, ui_language: str | None, logger: Callable):
     """Setup locales, load translations, install gettext functions."""
-    global _logger, _qcollator, _qcollator_numeric
-    if not logger:
-        _logger = lambda *a, **b: None  # noqa: E731
-    else:
-        _logger = logger
+    global _logger
+    _logger = logger
 
     if ui_language:
         _logger("UI language: %r", ui_language)
@@ -198,13 +190,6 @@ def setup_gettext(localedir, ui_language=None, logger=None):
 
     _logger("Using locale: %r", current_locale)
     QLocale.setDefault(QLocale(current_locale))
-
-    # Setup collator
-    _logger("Collator: %s", ACTIVE_COLLATOR)
-    if ACTIVE_COLLATOR == 'qt':
-        _qcollator = QCollator()
-        _qcollator_numeric = QCollator()
-        _qcollator_numeric.setNumericMode(True)
 
     global _translation
     _translation = {
@@ -253,83 +238,3 @@ def gettext_countries(message: str) -> str:
 
 def gettext_constants(message: str) -> str:
     return _translation['constants'].gettext(message)
-
-
-class Comparable(Protocol):
-    """Protocol for annotating comparable types."""
-
-    def __lt__(self, other, /) -> bool: ...
-
-
-RE_NUMBER = re.compile(r'(\d+)')
-
-
-def _digits_replace(matchobj):
-    s = matchobj.group(0)
-    return str(int(s)) if s.isdecimal() else s
-
-
-def _sort_key_qt(string: str, numeric: bool = False) -> Comparable:
-    """Transforms a string to one that can be used in locale-aware comparisons.
-
-    Args:
-        string: The string to convert
-        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
-
-    Returns: An object that can be compared locale-aware
-    """
-    collator = _qcollator_numeric if numeric else _qcollator
-
-    # Null bytes can cause crashes in OS collation functions.
-    string = string.replace('\0', '')
-
-    # On macOS / Windows the numeric sorting does not work reliable with non-latin
-    # scripts. Replace numbers in the sort string with their latin equivalent.
-    if numeric and (IS_MACOS or IS_WIN):
-        string = RE_NUMBER.sub(_digits_replace, string)
-
-    if IS_MACOS:
-        # macOS does not sort the empty string before other values correctly
-        if not string:
-            string = ' '
-        # On macOS numeric sorting of strings entirely consisting of numeric
-        # characters fails and always sorts alphabetically (002 < 1). Always
-        # prefix with an alphabetic character to work around that.
-        string = 'a' + string
-
-    return collator.sortKey(string)
-
-
-def _sort_key_strxfrm(string: str, numeric: bool = False) -> Comparable:
-    """Transforms a string to one that can be used in locale-aware comparisons.
-
-    Args:
-        string: The string to convert
-        numeric: Boolean indicating whether to use number aware sorting (natural sorting)
-
-    Returns: An object that can be compared locale-aware
-    """
-    if numeric:
-        return [int(s) if s.isdecimal() else _strxfrm(s) for s in RE_NUMBER.split(str(string).replace('\0', ''))]
-    else:
-        return _strxfrm(string)
-
-
-def _strxfrm(string: str) -> str:
-    try:
-        return locale.strxfrm(string)
-    except (OSError, ValueError):
-        return string.lower()
-
-
-AVAILABLE_COLLATORS = {
-    'strxfrm': _sort_key_strxfrm,
-    'qt': _sort_key_qt,
-}
-
-DEFAULT_COLLATOR = 'strxfrm' if IS_WIN else 'qt'
-ACTIVE_COLLATOR = os.environ.get('PICARD_COLLATOR', DEFAULT_COLLATOR)
-if ACTIVE_COLLATOR not in AVAILABLE_COLLATORS:
-    ACTIVE_COLLATOR = DEFAULT_COLLATOR
-
-sort_key = AVAILABLE_COLLATORS.get(ACTIVE_COLLATOR)

--- a/picard/i18n/qt.py
+++ b/picard/i18n/qt.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2025-2026 Laurent Monin
+# Copyright (C) 2026 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import TYPE_CHECKING
+
+from PyQt6 import QtCore
+
+from picard import log
+
+
+if TYPE_CHECKING:
+    from picard.tagger import Tagger
+
+
+# Translator priority constants (higher = installed later = searched first)
+TRANSLATOR_PRIORITY_QT_BASE = 100  # Qt base translations (highest priority)
+TRANSLATOR_PRIORITY_PLUGIN = 0  # Plugin translations (lower priority)
+
+
+@dataclass(init=True, order=True, kw_only=True)
+class Translator:
+    sort_index: int = TRANSLATOR_PRIORITY_QT_BASE
+    installed: bool = field(default=False, compare=False)
+    instance: QtCore.QTranslator = field(compare=False)
+    comment: str = field(default='', compare=False)
+
+    def __str__(self):
+        if self.sort_index == TRANSLATOR_PRIORITY_QT_BASE:
+            prefix = "Picard"
+        elif self.sort_index == TRANSLATOR_PRIORITY_PLUGIN:
+            prefix = "plugin"
+        else:
+            prefix = "unknown"
+        return f"{prefix} {self.comment}"
+
+
+class Translators:
+    def __init__(self, tagger: 'Tagger'):
+        self.tagger = tagger
+        self.tagger._qt_translators_updated.connect(self.reinstall)
+        self._translators = []
+        self._changed = False
+        self.add_default_translators()
+
+    def add_default_translators(self) -> None:
+        translator = QtCore.QTranslator(self.tagger)
+        locale = QtCore.QLocale()
+        translation_path = QtCore.QLibraryInfo.path(QtCore.QLibraryInfo.LibraryPath.TranslationsPath)
+        log.debug("Looking for Qt locale %s in %s", locale.name(), translation_path)
+        if translator.load(locale, 'qtbase_', directory=translation_path):
+            t = Translator(sort_index=TRANSLATOR_PRIORITY_QT_BASE, instance=translator, comment='Qt Base')
+            self._translators.append(t)
+            self._changed = True
+        else:
+            log.debug("Qt locale %s not available", locale.name())
+
+    def add_translator(self, translator: QtCore.QTranslator) -> None:
+        plugin_id = getattr(translator, 'plugin_id', '')
+        comment = plugin_id if plugin_id else repr(translator)
+        if translator.isEmpty():
+            # this shouldn't happen with plugins, but safer
+            log.debug("Not adding empty translator for %s", comment)
+            return
+        t = Translator(sort_index=TRANSLATOR_PRIORITY_PLUGIN, instance=translator, comment=comment)
+        self._translators.append(t)
+        self._changed = True
+
+    def remove_translator(self, translator: QtCore.QTranslator) -> None:
+        for t in self._translators[:]:
+            if t.instance == translator:
+                if t.installed:
+                    log.debug("Remove translator: %s", t)
+                    self.tagger.removeTranslator(t.instance)
+                self._translators.remove(t)
+                self._changed = True
+                break
+
+    def reinstall(self) -> None:
+        if not self._changed:
+            return
+        self._changed = False
+
+        # Translations are searched for in the reverse order in which they were installed,
+        # so the most recently installed translation file is searched for translations first
+        # and the earliest translation file is searched last.
+        # The search stops as soon as a translation containing a matching string is found.
+
+        # First, remove installed translators
+        for t in self._translators:
+            if t.installed:
+                self.tagger.removeTranslator(t.instance)
+                t.installed = False
+
+        # Now install new ones (higher sort_index installed last, used first)
+        installed_count = 0
+        for t in sorted(self._translators):
+            t.installed = self.tagger.installTranslator(t.instance)
+            if t.installed:
+                installed_count += 1
+
+        log.debug("%d/%d Qt Translators installed", installed_count, len(self._translators))
+        installed_index = 0
+        last = installed_count - 1
+        prefix = "Qt Translator"
+        # Iterate in reverse order, since "the most recently installed translation file is searched for translations first"
+        for t in sorted(self._translators, reverse=True):
+            if not t.installed:
+                log.debug("%s: %s failed to install", prefix, t)
+                continue
+            if installed_count > 1 and installed_index == 0:
+                log.debug("%s: %s installed (searched first)", prefix, t)
+            elif installed_count > 1 and installed_index == last:
+                log.debug("%s: %s installed (searched last)", prefix, t)
+            else:
+                log.debug("%s: %s installed", prefix, t)
+            installed_index += 1

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -49,10 +49,6 @@
 import argparse
 from collections import namedtuple
 import contextlib
-from dataclasses import (
-    dataclass,
-    field,
-)
 from functools import partial
 from hashlib import blake2b
 from io import StringIO
@@ -137,6 +133,7 @@ from picard.i18n import (
     gettext as _,
     setup_i18n,
 )
+from picard.i18n.qt import Translators
 from picard.options import init_options
 
 
@@ -1782,110 +1779,6 @@ def setup_dbus():
         dbus.registerService(PICARD_APP_ID)
     except ImportError:
         pass
-
-
-# Translator priority constants (higher = installed later = searched first)
-TRANSLATOR_PRIORITY_QT_BASE = 100  # Qt base translations (highest priority)
-TRANSLATOR_PRIORITY_PLUGIN = 0  # Plugin translations (lower priority)
-
-
-@dataclass(init=True, order=True, kw_only=True)
-class Translator:
-    sort_index: int = TRANSLATOR_PRIORITY_QT_BASE
-    installed: bool = field(default=False, compare=False)
-    instance: QtCore.QTranslator = field(default=None, compare=False)
-    comment: str = field(default='', compare=False)
-
-    def __str__(self):
-        if self.sort_index == TRANSLATOR_PRIORITY_QT_BASE:
-            prefix = "Picard"
-        elif self.sort_index == TRANSLATOR_PRIORITY_PLUGIN:
-            prefix = "plugin"
-        else:
-            prefix = "unknown"
-        return f"{prefix} {self.comment}"
-
-
-class Translators:
-    def __init__(self, tagger):
-        self.tagger = tagger
-        self.tagger._qt_translators_updated.connect(self.reinstall)
-        self._translators = []
-        self._changed = False
-        self.add_default_translators()
-
-    def add_default_translators(self):
-        translator = QtCore.QTranslator(self.tagger)
-        locale = QtCore.QLocale()
-        translation_path = QtCore.QLibraryInfo.path(QtCore.QLibraryInfo.LibraryPath.TranslationsPath)
-        log.debug("Looking for Qt locale %s in %s", locale.name(), translation_path)
-        if translator.load(locale, 'qtbase_', directory=translation_path):
-            t = Translator(sort_index=TRANSLATOR_PRIORITY_QT_BASE, instance=translator, comment='Qt Base')
-            self._translators.append(t)
-            self._changed = True
-        else:
-            log.debug("Qt locale %s not available", locale.name())
-
-    def add_translator(self, translator):
-        plugin_id = getattr(translator, 'plugin_id', '')
-        comment = plugin_id if plugin_id else repr(translator)
-        if translator.isEmpty():
-            # this shouldn't happen with plugins, but safer
-            log.debug("Not adding empty translator for %s", comment)
-            return
-        t = Translator(sort_index=TRANSLATOR_PRIORITY_PLUGIN, instance=translator, comment=comment)
-        self._translators.append(t)
-        self._changed = True
-
-    def remove_translator(self, translator):
-        for t in self._translators[:]:
-            if t.instance == translator:
-                if t.installed:
-                    log.debug("Remove translator: %s", t)
-                    self.tagger.removeTranslator(t.instance)
-                self._translators.remove(t)
-                self._changed = True
-                break
-
-    def reinstall(self):
-        if not self._changed:
-            return
-        self._changed = False
-
-        # Translations are searched for in the reverse order in which they were installed,
-        # so the most recently installed translation file is searched for translations first
-        # and the earliest translation file is searched last.
-        # The search stops as soon as a translation containing a matching string is found.
-
-        # First, remove installed translators
-        for t in self._translators:
-            if t.installed:
-                self.tagger.removeTranslator(t.instance)
-                t.installed = False
-
-        # Now install new ones (higher sort_index installed last, used first)
-        installed_count = 0
-        for t in sorted(self._translators):
-            t.installed = self.tagger.installTranslator(t.instance)
-            if t.installed:
-                installed_count += 1
-
-        log.debug("%d/%d Qt Translators installed", installed_count, len(self._translators))
-        installed_index = 0
-        last = installed_count - 1
-        prefix = "Qt Translator"
-        # Iterate in reverse order, since "the most recently installed translation file is searched for translations first"
-        for t in sorted(self._translators, reverse=True):
-            if not t.installed:
-                log.debug("%s: %s failed to install", prefix, t)
-                continue
-            if installed_count > 1 and installed_index == 0:
-                log.debug("%s: %s installed (searched first)", prefix, t)
-            elif installed_count > 1 and installed_index == last:
-                log.debug("%s: %s installed (searched last)", prefix, t)
-            else:
-                log.debug("%s: %s installed", prefix, t)
-            installed_index += 1
 
 
 def main(localedir=None, autoupdate=True):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -135,7 +135,7 @@ from picard.formats.registry import FormatRegistry
 from picard.i18n import (
     N_,
     gettext as _,
-    setup_gettext,
+    setup_i18n,
 )
 from picard.options import init_options
 
@@ -391,7 +391,7 @@ class Tagger(QtWidgets.QApplication):
             basedir = FROZEN_TEMP_PATH if IS_FROZEN else os.path.dirname(__file__)
             localedir = os.path.join(basedir, 'locale')
         # Must be before config upgrade because upgrade dialogs need to be translated.
-        setup_gettext(localedir, config.setting['ui_language'], log.debug)
+        setup_i18n(localedir, config.setting['ui_language'], log.debug)
 
     def _init_webservice(self):
         """Initialize web service/API"""

--- a/picard/ui/itemviews/custom_columns/protocols.py
+++ b/picard/ui/itemviews/custom_columns/protocols.py
@@ -27,6 +27,7 @@ from typing import (
 
 from PyQt6 import QtGui
 
+from picard.i18n.collate import Comparable
 from picard.item import Item
 
 
@@ -64,7 +65,7 @@ class ColumnValueProvider(Protocol):
 
 @runtime_checkable
 class SortKeyProvider(Protocol):
-    def sort_key(self, obj: Item):  # pragma: no cover - optional
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - optional
         """Return sort key for item.
 
         Parameters

--- a/picard/ui/itemviews/custom_columns/sorting_adapters.py
+++ b/picard/ui/itemviews/custom_columns/sorting_adapters.py
@@ -23,7 +23,10 @@
 from collections.abc import Callable
 from weakref import WeakKeyDictionary
 
-from picard.i18n import sort_key as _sort_key
+from picard.i18n.collate import (
+    Comparable,
+    sort_key as _sort_key,
+)
 from picard.item import Item
 
 from picard.ui.itemviews.custom_columns.protocols import (
@@ -81,7 +84,7 @@ class _AdapterBase(SortKeyProvider):
 class LocaleAwareSortAdapter(_AdapterBase):
     """Provide case-insensitive sort using `str.casefold()` on evaluated value."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return case-insensitive sort key for item."""
         return _sort_key(self._base.evaluate(obj) or "")
 
@@ -89,7 +92,7 @@ class LocaleAwareSortAdapter(_AdapterBase):
 class CasefoldSortAdapter(_AdapterBase):
     """Provide case-insensitive sort using `str.casefold()` on evaluated value."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return case-insensitive sort key for item."""
         return _sort_key((self._base.evaluate(obj) or "").casefold())
 
@@ -105,7 +108,7 @@ class NumericSortAdapter(_AdapterBase):
         parser_name = getattr(self._parser, "__name__", repr(self._parser))
         return f"{self.__class__.__name__}(base={self._base!r}, parser={parser_name})"
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return numeric-first composite sort key for item.
 
         Returns a tuple to avoid cross-type comparisons:
@@ -124,7 +127,7 @@ class NumericSortAdapter(_AdapterBase):
 class LengthSortAdapter(_AdapterBase):
     """Provide sort by string length of evaluated value."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return length-based sort key for item."""
         return len(self._base.evaluate(obj) or "")
 
@@ -148,7 +151,7 @@ class ArticleInsensitiveAdapter(_AdapterBase):
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return f"{self.__class__.__name__}(base={self._base!r}, articles={self._articles!r})"
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return article-insensitive sort key for item.
 
         Returns a tuple (tail, original_lower) so items compare by the tail
@@ -169,7 +172,7 @@ class CompositeSortAdapter(_AdapterBase):
     Each key function takes the item and returns a comparable value.
     """
 
-    def __init__(self, base: ColumnValueProvider, key_funcs: list[Callable[[Item], object]]):
+    def __init__(self, base: ColumnValueProvider, key_funcs: list[Callable[[Item], Comparable]]):
         """Initialize adapter.
 
         Parameters
@@ -186,7 +189,7 @@ class CompositeSortAdapter(_AdapterBase):
         funcs = [getattr(f, "__name__", repr(f)) for f in self._key_funcs]
         return f"{self.__class__.__name__}(base={self._base!r}, key_funcs={funcs})"
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return composite tuple sort key for item.
 
         Normalize each component to ensure cross-item comparability and avoid
@@ -207,7 +210,7 @@ class CompositeSortAdapter(_AdapterBase):
 class NullsLastAdapter(_AdapterBase):
     """Provide sort with empty values ordered last."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return sort key that pushes empty values to the end."""
         v = self._base.evaluate(obj)
         cleaned = _clean_invisible_and_whitespace(v)
@@ -219,7 +222,7 @@ class NullsLastAdapter(_AdapterBase):
 class NullsFirstAdapter(_AdapterBase):
     """Provide sort with empty values ordered first."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return sort key that pulls empty values to the front."""
         v = self._base.evaluate(obj)
         cleaned = _clean_invisible_and_whitespace(v)
@@ -232,7 +235,7 @@ class CachedSortAdapter(_AdapterBase):
     """Provide cached sort keys for an underlying provider (value or sort_key)."""
 
     def __init__(
-        self, base: ColumnValueProvider, key_func: Callable[[Item, ColumnValueProvider], object] | None = None
+        self, base: ColumnValueProvider, key_func: Callable[[Item, ColumnValueProvider], Comparable] | None = None
     ):
         """Initialize adapter.
 
@@ -245,10 +248,10 @@ class CachedSortAdapter(_AdapterBase):
             use provider.sort_key if available, otherwise use casefolded evaluate.
         """
         super().__init__(base)
-        self._cache: WeakKeyDictionary[Item, object] = WeakKeyDictionary()
+        self._cache: WeakKeyDictionary[Item, Comparable] = WeakKeyDictionary()
         self._key_func = key_func
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return cached sort key for item.
 
         If a custom key_func is provided normalize the result to avoid
@@ -299,7 +302,7 @@ class CachedSortAdapter(_AdapterBase):
 class NaturalSortAdapter(_AdapterBase):
     """Provide natural (alphanumeric) sort using locale-aware natural ordering."""
 
-    def sort_key(self, obj: Item):  # pragma: no cover - thin wrapper
+    def sort_key(self, obj: Item) -> Comparable:  # pragma: no cover - thin wrapper
         """Return natural sort key for item.
 
         Uses natural sorting to handle mixed text/numbers intelligently.

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -48,7 +48,7 @@ from picard import (
 )
 from picard.formats import DEFAULT_FORMATS
 from picard.formats.registry import FormatRegistry
-from picard.i18n import setup_gettext
+from picard.i18n import setup_i18n
 from picard.releasegroup import ReleaseGroup
 from picard.tagger import Tagger
 
@@ -74,7 +74,7 @@ class PicardTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
         log.set_verbosity(logging.DEBUG)
-        setup_gettext(None, 'C')
+        setup_i18n(None, 'C')
         self.tagger = MockTagger()
         self.init_config()
 

--- a/test/plugins3/test_plugin.py
+++ b/test/plugins3/test_plugin.py
@@ -286,19 +286,16 @@ class TestPluginNameAndStr(PicardTestCase):
         self.assertEqual(plugin.name(), 'my-plugin')
 
     def test_lt_compares_by_name(self):
-        import picard.i18n
-
         QLocale.setDefault(QLocale('en'))
-        picard.i18n._qcollator = QCollator()
-
-        p1 = Plugin(Path('/tmp'), 'alpha')
-        p1.manifest = Mock()
-        p1.manifest.name_i18n.return_value = 'Alpha'
-        p2 = Plugin(Path('/tmp'), 'beta')
-        p2.manifest = Mock()
-        p2.manifest.name_i18n.return_value = 'Beta'
-        self.assertTrue(p1 < p2)
-        self.assertFalse(p2 < p1)
+        with patch('picard.i18n.collate._qcollator', new=QCollator()):
+            p1 = Plugin(Path('/tmp'), 'alpha')
+            p1.manifest = Mock()
+            p1.manifest.name_i18n.return_value = 'Alpha'
+            p2 = Plugin(Path('/tmp'), 'beta')
+            p2.manifest = Mock()
+            p2.manifest.name_i18n.return_value = 'Beta'
+            self.assertTrue(p1 < p2)
+            self.assertFalse(p2 < p1)
 
 
 class TestPluginDisable(PicardTestCase):

--- a/test/plugins3/test_qt_translator.py
+++ b/test/plugins3/test_qt_translator.py
@@ -27,10 +27,10 @@ from PyQt6 import QtCore
 
 from test.picardtestcase import PicardTestCase
 
+from picard.i18n.qt import Translators
 from picard.plugin3.api import PluginApi
 from picard.plugin3.i18n import PluginTranslator
 from picard.plugin3.manifest import PluginManifest
-from picard.tagger import Translators
 
 
 class TestPluginTranslator(PicardTestCase):

--- a/test/test_coverart_details_option.py
+++ b/test/test_coverart_details_option.py
@@ -12,7 +12,7 @@ from picard.config import (
     Option,
     get_config,
 )
-from picard.i18n import setup_gettext
+from picard.i18n import setup_i18n
 
 import pytest
 
@@ -22,7 +22,7 @@ from picard.ui.coverartbox import CoverArtBox
 @pytest.fixture(autouse=True)
 def i18n_c_locale() -> None:
     # Ensure deterministic number formatting
-    setup_gettext(None, 'C')
+    setup_i18n(None, 'C')
 
 
 @dataclass

--- a/test/test_coverartbox_info.py
+++ b/test/test_coverartbox_info.py
@@ -21,7 +21,7 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from picard.i18n import setup_gettext
+from picard.i18n import setup_i18n
 
 import pytest
 
@@ -135,7 +135,7 @@ def lightweight_box() -> type[CoverArtBox]:
 @pytest.fixture(autouse=True)
 def i18n_c_locale() -> None:
     # Ensure deterministic number formatting for bytes2human
-    setup_gettext(None, 'C')
+    setup_i18n(None, 'C')
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_custom_columns_sorting_adapters.py
+++ b/test/test_custom_columns_sorting_adapters.py
@@ -183,7 +183,7 @@ def test_nulls_first_adapter(values: list[str], expected: list[str]) -> None:
 def test_cached_sort_adapter() -> None:
     calls: dict[str, int] = {}
 
-    def key_func(it: _ValueItem, provider) -> object:
+    def key_func(it, provider) -> str:
         s = provider.evaluate(it)
         calls[s] = calls.get(s, 0) + 1
         return s.casefold()

--- a/test/test_custom_columns_sorting_adapters.py
+++ b/test/test_custom_columns_sorting_adapters.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 import dataclasses
 
 from picard.const.sys import IS_WIN
-from picard.i18n import setup_gettext
+from picard.i18n import setup_i18n
 
 import pytest
 
@@ -85,7 +85,7 @@ def _sorted_values(adapter_factory: Callable[[object], object], values: list[str
     ],
 )
 def test_casefold_sort_adapter(values: list[str], expected: list[str]) -> None:
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     result = _sorted_values(CasefoldSortAdapter, values)
     assert result == expected
 
@@ -130,7 +130,7 @@ def test_length_sort_adapter() -> None:
 
 @pytest.mark.skipif(IS_WIN, reason="QCollator not used on Windows")
 def test_article_insensitive_adapter() -> None:
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     values = ["The Beatles", "Beatles", "An Artist", "Artist"]
     expected = ["An Artist", "Artist", "The Beatles", "Beatles"]
     result = _sorted_values(ArticleInsensitiveAdapter, values)
@@ -159,7 +159,7 @@ def test_composite_sort_adapter() -> None:
     ],
 )
 def test_nulls_last_adapter(values: list[str], expected: list[str]) -> None:
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     result = _sorted_values(NullsLastAdapter, values)
     assert result == expected
 
@@ -175,7 +175,7 @@ def test_nulls_last_adapter(values: list[str], expected: list[str]) -> None:
     ],
 )
 def test_nulls_first_adapter(values: list[str], expected: list[str]) -> None:
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     result = _sorted_values(NullsFirstAdapter, values)
     assert result == expected
 
@@ -218,14 +218,14 @@ def test_cached_sort_adapter() -> None:
     ],
 )
 def test_natural_sort_adapter(values: list[str], expected: list[str]) -> None:
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     result = _sorted_values(NaturalSortAdapter, values)
     assert result == expected
 
 
 def test_natural_sort_adapter_basic_functionality() -> None:
     """Test that natural sorting works for basic cases."""
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     values = ["item1", "item10", "item2"]
     result = _sorted_values(NaturalSortAdapter, values)
     expected = ["item1", "item2", "item10"]
@@ -234,7 +234,7 @@ def test_natural_sort_adapter_basic_functionality() -> None:
 
 def test_natural_sort_adapter_vs_regular_sorting() -> None:
     """Test that natural sorting differs from regular text sorting for numeric content."""
-    setup_gettext(None, 'en')
+    setup_i18n(None, 'en')
     values = ["file1.txt", "file10.txt", "file2.txt", "file20.txt"]
 
     # Regular casefold sorting (lexicographic)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -33,15 +33,17 @@ from test.picardtestcase import PicardTestCase
 
 from picard.i18n import (
     N_,
-    _try_encodings,
-    _try_locales,
     gettext as _,
     gettext_constants,
     gettext_countries,
     ngettext,
     pgettext_attributes,
-    setup_gettext,
+    setup_i18n,
     sort_key,
+)
+from picard.i18n.gettext import (
+    _try_encodings,
+    _try_locales,
 )
 
 
@@ -50,7 +52,7 @@ localedir = os.path.join(os.path.dirname(__file__), '..', 'locale')
 
 class TestI18n(PicardTestCase):
     def tearDown(self):
-        setup_gettext(None, 'C')
+        setup_i18n(None, 'C')
 
     def test_missing_locales(self):
         tmplocaledir = tempfile.mkdtemp()
@@ -61,7 +63,7 @@ class TestI18n(PicardTestCase):
         self.addCleanup(cleanup_tmplocale)
         locale_de = os.path.join(tmplocaledir, 'de', 'LC_MESSAGES', 'picard.mo')
         self.assertFalse(os.path.exists(locale_de), 'unexpected file %s' % locale_de)
-        setup_gettext(tmplocaledir, 'de')
+        setup_i18n(tmplocaledir, 'de')
         self.assertEqual('foo', _('foo'))
         self.assertEqual('Country', _('Country'))
         self.assertEqual('Country', N_('Country'))
@@ -79,7 +81,7 @@ class TestI18n(PicardTestCase):
         locale_de = os.path.join(localedir, 'de', 'LC_MESSAGES', 'picard.mo')
         self.assertTrue(os.path.exists(locale_de), 'expected file %s' % locale_de)
 
-        setup_gettext(localedir, 'de')
+        setup_i18n(localedir, 'de')
 
         self.assertEqual('foo', _('foo'))
         self.assertEqual('Land', _('Country'))
@@ -91,11 +93,11 @@ class TestI18n(PicardTestCase):
         self.assertEqual('Frankreich', gettext_countries('France'))
 
     def test_gettext_handles_empty_string(self):
-        setup_gettext(localedir, 'fr')
+        setup_i18n(localedir, 'fr')
         self.assertEqual('', _(''))
 
     def test_sort_key(self):
-        setup_gettext(localedir, 'de')
+        setup_i18n(localedir, 'de')
         self.assertLess(sort_key('äb'), sort_key('ac'))
         self.assertLess(sort_key('foo002'), sort_key('foo1'))
         self.assertLess(sort_key('002 foo'), sort_key('1 foo'))
@@ -110,7 +112,7 @@ class TestI18n(PicardTestCase):
         self.assertLess(sort_key('99', numeric=True), sort_key('100', numeric=True))
 
     def test_sort_key_numbers_different_scripts(self):
-        setup_gettext(localedir, 'en')
+        setup_i18n(localedir, 'en')
         for four in ('4', '𝟜', '٤', '๔'):
             self.assertLess(
                 sort_key('3', numeric=True),

--- a/test/test_sorting_adapters_key_stabilisation.py
+++ b/test/test_sorting_adapters_key_stabilisation.py
@@ -107,7 +107,7 @@ def test_composite_sort_adapter_mixed_component_types_no_typeerror() -> None:
             super().__init__()
             self.value = s
 
-    def key_primary(obj: Dummy) -> object:
+    def key_primary(obj) -> str | float:
         # Return number if numeric, else original string (mixed types)
         s = obj.value
         try:
@@ -115,7 +115,7 @@ def test_composite_sort_adapter_mixed_component_types_no_typeerror() -> None:
         except Exception:
             return s
 
-    def key_secondary(obj: Dummy) -> object:
+    def key_secondary(obj) -> str:
         return obj.value.casefold()
 
     adapter = CompositeSortAdapter(base=StubProvider(""), key_funcs=[key_primary, key_secondary])
@@ -131,7 +131,7 @@ def test_composite_sort_adapter_mixed_component_types_no_typeerror() -> None:
 
 
 def test_cached_sort_adapter_key_func_mixed_types_normalized() -> None:
-    def key_func(_obj, provider: ColumnValueProvider) -> object:
+    def key_func(_obj, provider: ColumnValueProvider) -> str:
         s = provider.evaluate(_obj)
         return int(s) if s.isdigit() else s
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3308
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is a preparation for debugging PICARD-3308 (sorting broken on macOS), but does not in itself resolve the issue.

Due to various bugs with sorting on different platforms Picard currently implement two different collation algorithms for locale aware sorting. It can either use `locale.strxfrm` or Qt's `QCollator`.

`strxfrm` is the current default on Windows, since QCollator used to be broken in the Windows build (see PICARD-2953 and https://qt-project.atlassian.net/browse/QTBUG-88704).

On the other hand we had issues with `strxfrm` causing crashes on macOS for some locales (PICARD-2914) and also on Haiku (fixed on the OS side since then) and some other sorting issues. So currently the default for all other platforms is using `QCollator`.

Right now sorting does not work at all on macOS, at least not on ARM builds, this is PICARD-3308.

In order to be able to test the various implementations with a binary build and to give users some workaround if sorting is broken this PR introduces support for a `PICARD_COLLATOR` environment variable, which can be set to one of three values:

- `strxfrm`: Use `locale.strxfrm`
- `qt`: Use `QCollator`
- `string`: No locale aware collation, just sort by normal string comparison

Without `PICARD_COLLATOR` being set or set to an unknown value the platform specific default will be used as before.

This PR also refactors the previous `i18n.py` into a `i18n` package. 


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Add support for defining the collation algorithm to use by setting the `PICARD_COLLATOR` environment variable
- Refactor the previous `i18n.py` into a `i18n` package, separate the gettext and collation code into separate files
- Move the `Transators` and `Translator` classes, that handle setting up `QTranslator` instances, from `tagger.py` to `i18n/qt.py`.



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
