### PR TITLE
PICARD-3320: Fix profiles disappearing when plugins change options pages

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -720,10 +720,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
         log.debug("refresh_plugin_pages: Refresh complete")
 
-        # Reload profiles settings tree to reflect plugin option changes
+        # Rebuild the profile settings tree to reflect plugin option changes.
+        # Use profile_selected() instead of load() to preserve unsaved
+        # in-memory profile data (new profiles, settings changes).
         profile_page = self.get_page('profiles')
         if profile_page and profile_page.loaded:
-            profile_page.load()
+            profile_page.profile_selected()
+            profile_page.update_config_overrides()
+            self.highlight_enabled_profile_options()
 
     def enable_page(self, pagename):
         """Enable a page in the options tree."""

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -242,6 +242,9 @@ class ProfilesOptionsPage(OptionsPage):
                     log.debug("Missing title for option: %s", setting.name)
                 pkey = setting_profile_key(setting.name, setting.section)
                 widget_item.addChild(self._make_child_item(settings, pkey, opt_title))
+            # Skip groups that have settings defined but none are visible
+            if group_settings and widget_item.childCount() == 0:
+                continue
             added = False
             if parent:
                 # Find parent item
@@ -257,6 +260,11 @@ class ProfilesOptionsPage(OptionsPage):
                 self.ui.settings_tree.addTopLevelItem(widget_item)
             if title in self.expanded_sections:
                 widget_item.setExpanded(True)
+        # Remove top-level items that are empty parent containers
+        for i in range(self.ui.settings_tree.topLevelItemCount() - 1, -1, -1):
+            tl_item = self.ui.settings_tree.topLevelItem(i)
+            if tl_item.childCount() == 0:
+                self.ui.settings_tree.takeTopLevelItem(i)
         self.building_tree = False
 
     def _make_child_item(self, settings, name, title):


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix profiles disappearing and stale highlights when plugins are enabled/disabled during an active Options dialog session. Also fix empty "Plugins" branch appearing in the profile settings tree.

## Problem

* JIRA ticket: PICARD-3320

When a plugin is enabled or disabled while the Options dialog is open:

1. Newly created (unsaved) profiles disappear from the profile list.
2. Profile highlights remain on option widgets for profiles that are no longer shown, leaving the UI in an inconsistent state.
3. An empty "Plugins" branch appears in the profile settings tree after all plugin groups have been removed.

## Solution

**Issues 1 & 2:** `refresh_plugin_pages()` was calling `profile_page.load()`, which reloads profiles from the persisted config and discards any unsaved in-memory changes. Replaced with `profile_page.profile_selected()` which rebuilds the settings tree from the current in-memory state, followed by `update_config_overrides()` and `highlight_enabled_profile_options()` to keep overrides and highlights consistent.

**Issue 3:** In `make_setting_tree()`, skip groups whose settings all failed to resolve (producing no visible children), and after building the tree remove any top-level parent containers that ended up with no children.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
