### PR TITLE
PICARD-3321: Fix highlighting for option profile

### DIFF
--- a/picard/ui/options/renaming_compat.py
+++ b/picard/ui/options/renaming_compat.py
@@ -73,7 +73,7 @@ class RenamingCompatOptionsPage(OptionsPage):
     OPTIONS: PageOptionConfigs = {
         'ascii_filenames': {'widgets': ['ascii_filenames']},
         'windows_compatibility': {'widgets': ['windows_compatibility']},
-        'win_compat_replacements': {'widgets': ['windows_compatibility', 'btn_windows_compatibility_change']},
+        'win_compat_replacements': {'widgets': ['btn_windows_compatibility_change']},
         'windows_long_paths': {'widgets': ['windows_long_paths']},
         'replace_spaces_with_underscores': {'widgets': ['replace_spaces_with_underscores']},
         'replace_dir_separator': {'widgets': ['replace_dir_separator']},


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

If the 'windows_compatibility' option was selected in an option profile but the 'win_compat_replacements' option was not selected, the 'windows_compatibility' option was not highlighted on the File Naming >> Compatibility settings page.  This was due to the 'windows_compatibility' widget being included for highlighting on both options, and the later option ('win_compat_replacements') overrode the highlighting for the 'windows_compatibility' option.

* JIRA ticket (_optional_): PICARD-3321

## Solution

Remove the 'windows_compatibility' widget from the highlighting list for the 'win_compat_replacements' setting.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
