### PR TITLE
PICARD-3322: Display all profiles in the Attached Profiles dialog

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -988,13 +988,6 @@ class AttachedProfilesDialog(PicardDialog):
                 return QtCore.Qt.CheckState.Checked
             if in_count > 0:
                 return QtCore.Qt.CheckState.PartiallyChecked
-        # Check if any other enabled profile has it
-        selected_set = set(selected_ids)
-        for profile in self._enabled_profiles:
-            if profile['id'] in selected_set:
-                continue
-            if pkey in self.profile_page.profile_settings.get(profile['id'], {}):
-                return QtCore.Qt.CheckState.PartiallyChecked
         return QtCore.Qt.CheckState.Unchecked
 
     def _build_tooltip(self, pkey: str) -> str:

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -559,11 +559,9 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def set_profiles_button_and_highlight(self, page):
         option_group = profile_groups_group_from_page(page)
-        enabled = False
-        if option_group:
-            working_profiles, _ = self.get_working_profile_data()
-            enabled = any(p['enabled'] for p in working_profiles)
-        self.ui.attached_profiles_button.setEnabled(enabled)
+        defined_profiles = self.get_page('profiles')._clean_and_get_all_profiles()
+        # Only enable the dialog button if there are profiles defined and an option group on the page
+        self.ui.attached_profiles_button.setEnabled(bool(option_group) and bool(defined_profiles))
         self.update_profile_save_warning(page)
 
     def update_profile_save_warning(self, page):
@@ -883,8 +881,8 @@ class AttachedProfilesDialog(PicardDialog):
 
         self.setWindowTitle(_("Profiles Attached to Options in %s Section") % self.option_group['title'])
 
-        # Only show enabled profiles
-        self._enabled_profiles = [p for p in self.profile_page._clean_and_get_all_profiles() if p['enabled']]
+        # Show all profiles because even disabled profiles can be attached to options
+        self._enabled_profiles = self.profile_page._clean_and_get_all_profiles()
 
         self._populate_profile_list()
         self.ui.profile_list.setIndentation(0)
@@ -921,7 +919,11 @@ class AttachedProfilesDialog(PicardDialog):
         marker_height = fm.boundingRect(self.MARKER_ACTIVE).height()
         marker_size = QtCore.QSize(marker_width, marker_height)
         for profile in self._enabled_profiles:
-            item = QtWidgets.QTreeWidgetItem([self.MARKER_INACTIVE, profile['title']])
+            # Identify profiles that are disabled but still attached to options with the "(disabled)" suffix,
+            # but keep them selectable so users can manage their attached options from the page.
+            item = QtWidgets.QTreeWidgetItem(
+                [self.MARKER_INACTIVE, profile['title'] + (_(" (disabled)") if not profile['enabled'] else "")]
+            )
             item.setData(0, QtCore.Qt.ItemDataRole.UserRole, profile['id'])
             item.setSizeHint(0, marker_size)
             self.ui.profile_list.addTopLevelItem(item)


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The title on the Attached Profiles dialog displayed from the options pages shows as "Profiles Attached to Options in {page title} Section".  This is incorrect because the dialog displays only the currectly active profiles, regardless of whether or not they are actually attached to any settings on the page.  If a profile that is attached to settings on the page isn't currently set as active, it will not be displayed in the dialog.

* JIRA ticket (_optional_): PICARD-3322

## Solution

Rather than trying to find an appropriate title, because the Attached Profiles dialog now allows settings on the page to be added to or removed from profiles, the dialog was modified to display all profiles (regardless of whether or not they are currently active).  In addition, ensure that the dialog is disabled if there are no profiles defined.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
