### PR TITLE
PICARD-3308: fix macOS locale detection

### DIFF
--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -92,6 +92,33 @@ def set_locale_from_env():
     return current_locale
 
 
+def _bcp47_to_locale(tag: str) -> str:
+    """Convert a BCP 47 language tag to a POSIX locale identifier.
+
+    Extracts the language and region components, skipping script subtags.
+    If no region is found, uses locale.normalize() to infer a default region
+    for the language.
+
+    Examples:
+        'en-US' -> 'en_US'
+        'zh-Hans-CN' -> 'zh_CN'
+        'en' -> 'en_US' (via locale.normalize)
+        'fr' -> 'fr_FR' (via locale.normalize)
+    """
+    parts = tag.split('-')
+    language = parts[0]
+    for part in parts[1:]:
+        # Region designator: 2 uppercase ASCII letters or 3 digits
+        if (len(part) == 2 and part.isascii() and part.isupper()) or (len(part) == 3 and part.isdigit()):
+            return f'{language}_{part}'
+    # No region found — use locale.normalize to infer a default region
+    normalized = locale.normalize(language)
+    if normalized != language:
+        # Strip encoding suffix (e.g. 'en_US.ISO8859-1' -> 'en_US')
+        return normalized.split('.')[0]
+    return language
+
+
 if IS_WIN:
     from ctypes import windll  # type: ignore[attr-defined]
 
@@ -106,14 +133,31 @@ if IS_WIN:
 elif IS_MACOS:
     import Foundation
 
-    def _get_default_locale_mac():
-        defaults = Foundation.NSUserDefaults.standardUserDefaults()
-        if 'AppleLocale' in defaults:
-            return defaults['AppleLocale']
-        elif 'AppleLanguages' in defaults:
-            # Note: In newer macOS versions AppleLanguages no longer contains the full
-            # locale name with region, so this might be unusable.
-            return defaults['AppleLanguages'][0].replace('-', '_')
+    def _get_default_locale_mac() -> str | None:
+        """Read the user's locale from macOS user defaults.
+
+        Prefers AppleLocale (full locale with region, e.g. 'en_US') and falls
+        back to AppleLanguages (BCP 47 language tags, e.g. 'en-US').
+
+        Handles known quirks:
+        - AppleLocale may contain ICU keyword suffixes (e.g. '@currency=GBP')
+          when the user has customized regional settings; these are stripped.
+        - AppleLocale may be absent on some macOS 10.13/10.14 configurations.
+        - AppleLanguages on newer macOS may contain script subtags
+          (e.g. 'zh-Hans-CN') or lack region entirely (e.g. 'en').
+        """
+        try:
+            defaults = Foundation.NSUserDefaults.standardUserDefaults()
+            if 'AppleLocale' in defaults:
+                locale_str = defaults['AppleLocale']
+                # Strip ICU keyword suffixes like @currency=USD or @calendar=gregorian
+                return locale_str.split('@')[0] if locale_str else None
+            elif 'AppleLanguages' in defaults:
+                # Note: In newer macOS versions AppleLanguages no longer contains the full
+                # locale name with region, so this might return only a language code.
+                return _bcp47_to_locale(defaults['AppleLanguages'][0])
+        except Exception as e:
+            _logger("Failed to read macOS locale defaults: %s", e)
         return None
 
     _get_default_locale = _get_default_locale_mac

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -108,7 +108,13 @@ elif IS_MACOS:
 
     def _get_default_locale_mac():
         defaults = Foundation.NSUserDefaults.standardUserDefaults()
-        return defaults.objectForKey_('AppleLanguages')[0].replace('-', '_')
+        if 'AppleLocale' in defaults:
+            return defaults['AppleLocale']
+        elif 'AppleLanguages' in defaults:
+            # Note: In newer macOS versions AppleLanguages no longer contains the full
+            # locale name with region, so this might be unusable.
+            return defaults['AppleLanguages'][0].replace('-', '_')
+        return None
 
     _get_default_locale = _get_default_locale_mac
 else:

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -42,6 +42,7 @@ from picard.i18n import (
     sort_key,
 )
 from picard.i18n.gettext import (
+    _bcp47_to_locale,
     _try_encodings,
     _try_locales,
 )
@@ -163,3 +164,31 @@ class TestTryEncodingsLocales(PicardTestCase):
         locale_getpreferredencoding_mock.assert_called_once()
         calls = [call('EN.ISO-8859-1'), call('EN.UTF-8')]
         locale_nomalize_mock.assert_has_calls(calls)
+
+
+class TestBcp47ToLocale(PicardTestCase):
+    def test_language_with_region(self):
+        self.assertEqual('en_US', _bcp47_to_locale('en-US'))
+        self.assertEqual('en_GB', _bcp47_to_locale('en-GB'))
+        self.assertEqual('pt_BR', _bcp47_to_locale('pt-BR'))
+
+    def test_language_with_script_and_region(self):
+        self.assertEqual('zh_CN', _bcp47_to_locale('zh-Hans-CN'))
+        self.assertEqual('zh_TW', _bcp47_to_locale('zh-Hant-TW'))
+
+    @patch('locale.normalize', autospec=True)
+    def test_bare_language_normalizes(self, locale_normalize_mock):
+        locale_normalize_mock.return_value = 'en_US.ISO8859-1'
+        self.assertEqual('en_US', _bcp47_to_locale('en'))
+        locale_normalize_mock.assert_called_once_with('en')
+
+    @patch('locale.normalize', autospec=True)
+    def test_bare_language_no_mapping(self, locale_normalize_mock):
+        # locale.normalize returns input unchanged if no mapping exists
+        locale_normalize_mock.return_value = 'xx'
+        self.assertEqual('xx', _bcp47_to_locale('xx'))
+        locale_normalize_mock.assert_called_once_with('xx')
+
+    def test_numeric_region(self):
+        # UN M.49 numeric region codes (3 digits)
+        self.assertEqual('es_419', _bcp47_to_locale('es-419'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3308
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The method to detect the user's defined locale from the OS does not work on newer macOS version. Querying `AppleLanguages` from `NSUserDefaults` yields only a list of language codes ("en", "de"), but not full locales with region ("en_US", "de_DE"). But using just the language fails when trying to set a locale.

This breaks both showing the proper UI language and the collator.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

On macOS, first check `AppleLocale`. This is set to a proper locale string, e.g. `en_US`. I kept checking `AppleLanguages` as a fallback. I just don't know whether this is needed for older macOS versions or not, nor do I know with which macOS version it happened that `AppleLanguages` no longer contains the region.

Without the changes the logs show:

```
D: 07:16:04,412 picard/i18n/gettext.setup_gettext:166: UI language: system
D: 07:16:04,412 picard/i18n/gettext._log_lang_env_vars:154: Env vars: 
D: 07:16:04,412 picard/i18n/gettext.setup_gettext:174: Trying locales: ['en']
D: 07:16:04,412 picard/i18n/gettext.setup_gettext:184: Failed to set locale: 'en'
D: 07:16:04,412 picard/i18n/gettext.set_locale_from_env:91: Setting locale from env: 'C'
D: 07:16:04,412 picard/i18n/gettext.setup_gettext:192: Using locale: 'C'
```

With the changes the `en_US` locale is detected properly:

```
D: 09:17:24,736 picard/i18n/gettext.setup_gettext:172: UI language: system
D: 09:17:24,736 picard/i18n/gettext._log_lang_env_vars:160: Env vars: 
D: 09:17:24,736 picard/i18n/gettext.setup_gettext:180: Trying locales: ['en_US']
D: 09:17:24,737 picard/i18n/gettext.setup_gettext:187: Set locale to: 'en_US.ISO8859-1'
D: 09:17:24,737 picard/i18n/gettext.setup_gettext:198: Using locale: 'en_US.ISO8859-1'
```

Tested with macOS Tahoe 26.2.

This PR also simplifies the code a bit. pyobjc exposes a dict like interface for `NSUserDefaults`. `defaults['key']` or `defaults.get('key')` is the same as `defaults.objectForKey_('key')`, but more Python like.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
