### PR TITLE
PICARD-3327: fix auto match with restored session

### DIFF
--- a/picard/session/session_loader.py
+++ b/picard/session/session_loader.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 import gzip
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Protocol,
 )
@@ -53,6 +54,10 @@ from picard.session.session_data import (
     GroupedItems,
 )
 from picard.session.track_mover import TrackMover
+
+
+if TYPE_CHECKING:
+    from picard.tagger import Tagger
 
 
 class ProgressReporter(Protocol):
@@ -111,6 +116,7 @@ class TaggerProgressReporter:
             'preload_cache': msg_preload,
             'load_items': msg_load_items,
             'finalize': msg_finalize,
+            'restored': _("Session restored"),
         }
 
         entry = dispatch.get(stage)
@@ -553,10 +559,10 @@ class OverrideApplicator:
         album.run_when_loaded(run)
 
 
-class SessionLoader:
+class SessionLoader(QtCore.QObject):
     """Orchestrate loading and restoring Picard sessions."""
 
-    def __init__(self, tagger: Any) -> None:
+    def __init__(self, tagger: 'Tagger') -> None:
         """Initialize the session loader.
 
         Parameters
@@ -564,6 +570,7 @@ class SessionLoader:
         tagger : Any
             The Picard tagger instance.
         """
+        super().__init__(tagger)
         self.tagger = tagger
         self._progress: ProgressReporter = TaggerProgressReporter(tagger)
         self._file_reader = SessionFileReader()
@@ -743,10 +750,12 @@ class SessionLoader:
         before unsetting the session restoring flag.
         """
         if not get_config().setting['session_safe_restore']:
+            self._progress.emit('restored')
             return
 
         if self.tagger._pending_files_count == 0 and not self.tagger.webservice.num_pending_web_requests:
             self.tagger._restoring_session = False
+            self._progress.emit('restored')
         else:
             QtCore.QTimer.singleShot(SessionConstants.DEFAULT_RETRY_DELAY_MS, self._unset_restoring_flag_when_idle)
 

--- a/picard/session/session_loader.py
+++ b/picard/session/session_loader.py
@@ -749,10 +749,6 @@ class SessionLoader(QtCore.QObject):
         This method checks if all file loads and web requests are finished
         before unsetting the session restoring flag.
         """
-        if not get_config().setting['session_safe_restore']:
-            self._progress.emit('restored')
-            return
-
         if self.tagger._pending_files_count == 0 and not self.tagger.webservice.num_pending_web_requests:
             self.tagger._restoring_session = False
             self._progress.emit('restored')

--- a/test/session/test_session_loader.py
+++ b/test/session/test_session_loader.py
@@ -28,6 +28,8 @@ from unittest.mock import (
 
 import yaml
 
+import PyQt6.QtCore
+
 import picard.config as picard_config
 from picard.metadata import Metadata
 from picard.session.session_loader import SessionLoader
@@ -35,11 +37,20 @@ from picard.session.session_loader import SessionLoader
 import pytest
 
 
+class MockQtTagger(PyQt6.QtCore.QObject):
+    def __init__(self) -> None:
+        super().__init__()
+        self.albums = {}
+        self.clear_session = Mock()
+        self.load_album = Mock()
+        self.webservice = Mock()
+
+
 @pytest.fixture
 def session_loader() -> SessionLoader:
     """Provide a SessionLoader instance."""
-    tagger_mock = Mock()
-    return SessionLoader(tagger_mock)
+    tagger_mock = MockQtTagger()
+    return SessionLoader(tagger_mock)  # type: ignore
 
 
 def test_session_loader_schedule_metadata_application(session_loader: SessionLoader, mock_single_shot) -> None:
@@ -137,8 +148,8 @@ def test_session_loader_finalize_loading(session_loader: SessionLoader, mock_sin
 
 def test_session_loader_initialization() -> None:
     """Test SessionLoader initialization."""
-    tagger_mock = Mock()
-    loader = SessionLoader(tagger_mock)
+    tagger_mock = MockQtTagger()
+    loader = SessionLoader(tagger_mock)  # type: ignore
 
     assert loader.tagger == tagger_mock
     assert loader.loaded_albums == {}
@@ -157,10 +168,8 @@ def test_session_loader_requests_allowed(tmp_path: Path, mock_single_shot, cfg_o
     cfg.setting['session_no_mb_requests_on_load'] = False
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
-    tagger.albums = {}
-
-    loader = SessionLoader(tagger)
+    tagger = MockQtTagger()
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,
@@ -187,10 +196,8 @@ def test_session_loader_requests_suppressed(tmp_path: Path, mock_single_shot, cf
     cfg.setting['session_no_mb_requests_on_load'] = True
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
-    tagger.albums = {}
-
-    loader = SessionLoader(tagger)
+    tagger = MockQtTagger()
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,
@@ -211,13 +218,13 @@ def test_session_loader_cached_album_refresh_allowed(tmp_path: Path, mock_single
     cfg.setting['session_no_mb_requests_on_load'] = False
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
+    tagger = MockQtTagger()
     album_mock = Mock()
     album_mock.unmatched_files = Mock()
     album_mock.run_when_loaded = Mock(side_effect=lambda cb: cb())
     tagger.albums = {"album-123": album_mock}
 
-    loader = SessionLoader(tagger)
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,
@@ -240,13 +247,13 @@ def test_session_loader_cached_album_no_refresh_when_suppressed(tmp_path: Path, 
     cfg.setting['session_no_mb_requests_on_load'] = True
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
+    tagger = MockQtTagger()
     album_mock = Mock()
     album_mock.unmatched_files = Mock()
     album_mock.run_when_loaded = Mock(side_effect=lambda cb: cb())
     tagger.albums = {"album-123": album_mock}
 
-    loader = SessionLoader(tagger)
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,
@@ -279,10 +286,8 @@ def test_session_loader_request_suppression_matrix_unmatched(
     cfg.setting['session_no_mb_requests_on_load'] = no_requests
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
-    tagger.albums = {}
-
-    loader = SessionLoader(tagger)
+    tagger = MockQtTagger()
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,
@@ -320,13 +325,13 @@ def test_session_loader_request_suppression_matrix_cached(
     cfg.setting['session_no_mb_requests_on_load'] = no_requests
     cfg.setting['session_safe_restore'] = False
 
-    tagger = Mock()
+    tagger = MockQtTagger()
     album_mock = Mock()
     album_mock.unmatched_files = Mock()
     album_mock.run_when_loaded = Mock(side_effect=lambda cb: cb())
     tagger.albums = {"album-xyz": album_mock}
 
-    loader = SessionLoader(tagger)
+    loader = SessionLoader(tagger)  # type: ignore
 
     data = {
         'version': 1,

--- a/test/session/test_session_loader.py
+++ b/test/session/test_session_loader.py
@@ -73,20 +73,6 @@ def test_session_loader_schedule_metadata_application_empty_map(
     mock_single_shot.assert_called_once()
 
 
-def test_session_loader_unset_restoring_flag_when_idle_safe_restore_disabled(
-    session_loader: SessionLoader, cfg_options
-) -> None:
-    """Test unsetting restoring flag when safe restore is disabled."""
-    # Set the config value for this test
-    cfg = picard_config.get_config()
-    cfg.setting['session_safe_restore'] = False
-
-    session_loader._unset_restoring_flag_when_idle()
-
-    # Should not check pending files or web requests when safe restore is disabled
-    # The method should return early without checking attributes
-
-
 def test_session_loader_unset_restoring_flag_when_idle_pending_files(
     session_loader: SessionLoader, mock_single_shot, cfg_options
 ) -> None:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3327
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If the option "No auto-matching on load" is enabled in session options auto-matching files with MBIDs or auto-analyzing added files does not work for the entire session.

These get disabled during the session restoring process, but never get enabled after the session was restored.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The root cause was that `SessionLoader` is not a `QObject` and hence can not have Qt slots, but when passing a method to `singleShot` a slot is expected, otherwise it is not called.

Turning  `SessionLoader` into a proper `QObject` ensures `_unset_restoring_flag_when_idle` gets called. Also removed the condition to only unset `tagger._restoring_session` if the `session_safe_restore` option is enabled. The option is not guaranteed to stay unchanged during session restore, so there is a chance of it getting disabled during session restore, which would cause `_restoring_session` to be stuck. There is also no harm setting it to `False` regardless.

This PR also contains a small change to always emit a message after session restore ended. Otherwise progress report was stuck with the last message when finalization was pending.

Note: Instead of turning `SessionLoader` into a `QObject` the callback could also have been defined as an inline function. But this complicates testing.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
