### PR TITLE
PICARD-3313: Add --no-git support for local plugin install

### DIFF
--- a/docs/PLUGINSV3/LOCAL_NON_GIT.md
+++ b/docs/PLUGINSV3/LOCAL_NON_GIT.md
@@ -11,6 +11,7 @@ Local non-git plugins allow developers and testers to load a plugin directly fro
 - Rapid prototyping of a new plugin idea
 - Testing a plugin during development before initializing a git repository
 - Loading a plugin received as a plain directory (e.g., from a zip archive)
+- Developing a plugin in a git repository but wanting Picard to load it directly from the working tree (use `--no-git`)
 
 For anything beyond personal testing, use `picard-plugins --init` to create a proper git-managed plugin project.
 
@@ -44,13 +45,42 @@ Do you want to continue? [y/N]
 
 Use `--yes` to skip the prompt.
 
+### Install with `--no-git` (git directory present)
+
+If a plugin directory contains a `.git` repository but you want to load it in-place
+(e.g., for active development), use `--no-git`:
+
+```bash
+picard-plugins --install /path/to/my-git-plugin --no-git
+```
+
+A confirmation prompt warns about disabling git features:
+
+```text
+⚠ This plugin has a git repository.
+⚠   Git features (updates, refs) will be disabled in local mode.
+⚠   Use --reinstall without --no-git to restore them.
+Do you want to continue? [y/N]
+```
+
+Use `--yes` to skip the prompt.
+
+Plugins installed this way show a `[local-dev]` marker in `--list` output to
+distinguish them from plugins without git at all.
+
+To restore git-managed mode later:
+
+```bash
+picard-plugins --install /path/to/my-git-plugin --reinstall
+```
+
 ### List
 
 ```bash
 picard-plugins --list
 ```
 
-Local non-git plugins show a `[local]` marker:
+Local non-git plugins show a `[local]` or `[local-dev]` marker:
 
 ```text
   My Plugin (enabled) [local]
@@ -58,6 +88,12 @@ Local non-git plugins show a `[local]` marker:
     UUID: ...
     Source: /path/to/my-plugin
     Path: /path/to/my-plugin
+
+  My Dev Plugin (enabled) [local-dev]
+    Short description
+    UUID: ...
+    Source: /path/to/my-git-plugin
+    Path: /path/to/my-git-plugin
 ```
 
 ### Update (Reload)
@@ -113,6 +149,19 @@ Local non-git plugins use the same `plugins3_metadata` config dict as git-manage
 }
 ```
 
+When installed with `--no-git` from a directory containing `.git`, the entry uses
+`ref_type` value `"local-dev"` instead of `"local"`:
+
+```python
+{
+    ...
+    "ref_type": "local-dev"
+}
+```
+
+The `"local-dev"` ref type indicates the plugin has a git repository but was explicitly
+installed in local mode. This is used to display the `[local-dev]` marker in list output.
+
 On startup, entries with `ref_type='local'` are loaded directly from the stored path. If the path no longer exists, the entry is automatically removed.
 
 ## Limitations
@@ -141,3 +190,9 @@ picard-plugins --install /path/to/my-plugin --reinstall
 ```
 
 The plugin will now be managed by git with full update/ref support. Alternatively, use `picard-plugins --init` from the start for a proper project scaffold with git already configured.
+
+If the plugin was installed with `--no-git` (already has git), simply reinstall without the flag:
+
+```bash
+picard-plugins --install /path/to/my-plugin --reinstall
+```

--- a/picard/plugin3/asyncops/manager.py
+++ b/picard/plugin3/asyncops/manager.py
@@ -33,13 +33,14 @@ class AsyncPluginManager:
     def __init__(self, manager: PluginManager):
         self._manager = manager
 
-    def install_plugin(self, url, ref=None, reinstall=False, progress_callback=None, callback=None):
+    def install_plugin(self, url, ref=None, reinstall=False, no_git=False, progress_callback=None, callback=None):
         """Install plugin asynchronously.
 
         Args:
             url: Plugin URL or registry ID
             ref: Optional git ref
             reinstall: Whether to reinstall if exists
+            no_git: If True, treat a git directory as a local non-git plugin
             progress_callback: Optional callback for progress updates
             callback: Called with OperationResult on completion
         """
@@ -51,7 +52,7 @@ class AsyncPluginManager:
                     ProgressUpdate(operation='install', message=f'Installing from {url}...', percent=0),
                 )
 
-            plugin_id = self._manager.install_plugin(url, ref, reinstall, enable_after_install=True)
+            plugin_id = self._manager.install_plugin(url, ref, reinstall, enable_after_install=True, no_git=no_git)
 
             if progress_callback:
                 to_main(

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -96,7 +96,7 @@ from picard.plugin3.plugin_metadata import (
     LOCAL_DEV_MARKER,
     LOCAL_MARKER,
     REF_TYPE_LOCAL_DEV,
-    is_local_non_git_plugin,
+    is_local_plugin,
 )
 from picard.plugin3.project_config import PluginProjectConfig
 from picard.plugin3.ref_item import RefItem
@@ -448,7 +448,7 @@ class PluginCLI:
 
     def _local_marker(self, metadata) -> str:
         """Return display marker for local non-git plugins."""
-        if is_local_non_git_plugin(metadata):
+        if is_local_plugin(metadata):
             label = LOCAL_DEV_MARKER if metadata.ref_type == REF_TYPE_LOCAL_DEV else LOCAL_MARKER
             return f' [{label}]'
         return ''
@@ -481,7 +481,7 @@ class PluginCLI:
 
                 # Check if local non-git plugin
                 metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
-                is_local = is_local_non_git_plugin(metadata)
+                is_local = is_local_plugin(metadata)
 
                 # Display with semantic methods
                 if is_enabled:
@@ -569,7 +569,7 @@ class PluginCLI:
 
         is_enabled = plugin.uuid and plugin.uuid in self._manager._enabled_plugins
         metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else {}
-        is_local = is_local_non_git_plugin(metadata)
+        is_local = is_local_plugin(metadata)
 
         local_marker = self._local_marker(metadata)
         self._out.print(f'Plugin: {self._out.d_name(plugin.manifest.name())}{local_marker}')
@@ -678,7 +678,7 @@ class PluginCLI:
         plugin = info['plugin']
         if plugin and plugin.uuid:
             metadata = self._manager._get_plugin_metadata(plugin.uuid)
-            if is_local_non_git_plugin(metadata):
+            if is_local_plugin(metadata):
                 self._out.error(f'Plugin "{identifier}" is a local plugin and is not managed by git')
                 return ExitCode.ERROR
 
@@ -1153,7 +1153,7 @@ class PluginCLI:
                 if result.old_commit == result.new_commit:
                     # Local non-git plugins: show "reloaded" instead of "up to date"
                     metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
-                    if is_local_non_git_plugin(metadata):
+                    if is_local_plugin(metadata):
                         self._out.success(f'{self._out.d_name(plugin.plugin_id)}: Plugin reloaded')
                     elif result.new_version:
                         self._out.info(
@@ -1221,7 +1221,7 @@ class PluginCLI:
                     plugin = self._manager.plugin_id_to_plugin(r.plugin_id)
                     plugin_uuid = plugin.uuid if plugin else None
                     metadata = self._manager._get_plugin_metadata(plugin_uuid) if plugin_uuid else None
-                    if is_local_non_git_plugin(metadata):
+                    if is_local_plugin(metadata):
                         self._out.success(f'{self._out.d_name(r.plugin_id)}: Plugin reloaded')
                         updated += 1
                     elif r.result.new_version:

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -92,7 +92,12 @@ from picard.plugin3.plugin import (
     PluginSourceGit,
     short_commit_id,
 )
-from picard.plugin3.plugin_metadata import is_local_non_git_plugin
+from picard.plugin3.plugin_metadata import (
+    LOCAL_DEV_MARKER,
+    LOCAL_MARKER,
+    REF_TYPE_LOCAL_DEV,
+    is_local_non_git_plugin,
+)
 from picard.plugin3.project_config import PluginProjectConfig
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import (
@@ -441,6 +446,13 @@ class PluginCLI:
         """
         return self._manager.select_ref_for_plugin(plugin)
 
+    def _local_marker(self, metadata) -> str:
+        """Return display marker for local non-git plugins."""
+        if is_local_non_git_plugin(metadata):
+            label = LOCAL_DEV_MARKER if metadata.ref_type == REF_TYPE_LOCAL_DEV else LOCAL_MARKER
+            return f' [{label}]'
+        return ''
+
     def _cmd_list(self):
         """List all installed plugins with details."""
         if not self._manager.plugins:
@@ -477,7 +489,7 @@ class PluginCLI:
                 else:
                     status = self._out.d_status_disabled()
 
-                local_marker = ' [local]' if is_local else ''
+                local_marker = self._local_marker(metadata)
                 self._out.print(f'  {self._out.d_name(display_name)} ({status}){local_marker}')
 
                 if getattr(plugin, 'manifest', None):
@@ -559,7 +571,7 @@ class PluginCLI:
         metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else {}
         is_local = is_local_non_git_plugin(metadata)
 
-        local_marker = ' [local]' if is_local else ''
+        local_marker = self._local_marker(metadata)
         self._out.print(f'Plugin: {self._out.d_name(plugin.manifest.name())}{local_marker}')
 
         # Show short description on one line (required field)
@@ -793,6 +805,7 @@ class PluginCLI:
         explicit_ref = getattr(self._args, 'ref', None)
         reinstall = getattr(self._args, 'reinstall', False)
         force_blacklisted = getattr(self._args, 'force_blacklisted', False)
+        no_git = getattr(self._args, 'no_git', False)
         yes = getattr(self._args, 'yes', False)
 
         if force_blacklisted:
@@ -918,6 +931,7 @@ class PluginCLI:
                     # Check trust level and show appropriate warnings
                     # For local non-git directories, skip registry/trust checks
                     local_non_git = Path(url).is_dir() and not (Path(url) / '.git').exists()
+                    local_no_git_override = no_git and Path(url).is_dir() and (Path(url) / '.git').exists()
                     if local_non_git:
                         self._out.warning('This plugin is not managed by git.')
                         self._out.warning(
@@ -925,6 +939,15 @@ class PluginCLI:
                             ' and to have it added to the official registry.'
                         )
                         self._out.warning('  Without git, version management and automatic updates are not available.')
+
+                        if not yes:
+                            if not self._out.yesno('Do you want to continue?'):
+                                self._out.print('Installation cancelled')
+                                return ExitCode.CANCELLED
+                    elif local_no_git_override:
+                        self._out.warning('This plugin has a git repository.')
+                        self._out.warning('  Git features (updates, refs) will be disabled in local mode.')
+                        self._out.warning('  Use --reinstall without --no-git to restore them.')
 
                         if not yes:
                             if not self._out.yesno('Do you want to continue?'):
@@ -970,7 +993,7 @@ class PluginCLI:
                     self._out.warning('Local repository has uncommitted changes')
 
                 plugin_id = self._manager.install_plugin(
-                    url, ref, reinstall, force_blacklisted, enable_after_install=True
+                    url, ref, reinstall, force_blacklisted, enable_after_install=True, no_git=no_git
                 )
                 self._out.success(f'Plugin {self._out.d_id(plugin_id)} installed successfully')
                 self._out.info('Restart Picard to load the plugin')
@@ -986,7 +1009,7 @@ class PluginCLI:
                     success, result = self._handle_dirty_error(
                         e,
                         lambda **kw: self._manager.install_plugin(
-                            url, ref, reinstall, force_blacklisted, enable_after_install=True, **kw
+                            url, ref, reinstall, force_blacklisted, enable_after_install=True, no_git=no_git, **kw
                         ),
                     )
                     if not success:
@@ -2252,7 +2275,11 @@ def process_cmdline_args():
     group_advanced.add_argument(
         '--with-translations', action='store_true', help="include translation support (locale files and examples)"
     )
-    group_advanced.add_argument('--no-git', action='store_true', help="skip initializing git repository")
+    group_advanced.add_argument(
+        '--no-git',
+        action='store_true',
+        help="for --init: skip git init; for --install: load git plugin in local mode (no updates/refs)",
+    )
     group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit")
     group_advanced.add_argument(
         '--source-locale',

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -58,7 +58,7 @@ from picard.plugin3.plugin_metadata import (
     REF_TYPE_LOCAL_DEV,
     PluginMetadata,
     PluginMetadataManager,
-    is_local_non_git_plugin,
+    is_local_plugin,
 )
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import PluginRegistry
@@ -721,10 +721,10 @@ class PluginManager(QObject):
         # Use ref_type to reliably determine if plugin was installed as a commit
         return metadata.ref_type == 'commit'
 
-    def is_local_non_git(self, plugin):
+    def is_local_plugin(self, plugin):
         """Check if a plugin is a local non-git plugin."""
         metadata = self._metadata.get_plugin_metadata(plugin.uuid)
-        return is_local_non_git_plugin(metadata)
+        return is_local_plugin(metadata)
 
     def _get_current_ref_for_updates(self, repo, metadata):
         """Get the current ref to use for update checking.
@@ -749,7 +749,7 @@ class PluginManager(QObject):
         """Check if a plugin should have its refs fetched."""
         if not plugin.uuid or not metadata or not metadata.url:
             return False
-        if is_local_non_git_plugin(metadata):
+        if is_local_plugin(metadata):
             return False
 
         # Only fetch refs for plugins with remote URLs or local git repos

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -54,6 +54,8 @@ from picard.plugin3.plugin import (
     short_commit_id,
 )
 from picard.plugin3.plugin_metadata import (
+    REF_TYPE_LOCAL,
+    REF_TYPE_LOCAL_DEV,
     PluginMetadata,
     PluginMetadataManager,
     is_local_non_git_plugin,
@@ -524,7 +526,7 @@ class PluginManager(QObject):
         loaded_uuids = {p.uuid for p in self._plugins if p.uuid}
 
         for uuid, entry in list(metadata_dict.items()):
-            if entry.get('ref_type') != 'local':
+            if entry.get('ref_type') not in (REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV):
                 continue
             # Skip if already loaded (e.g. symlink in plugin dir)
             if uuid in loaded_uuids:
@@ -667,7 +669,14 @@ class PluginManager(QObject):
         return self._validation_manager._validate_manifest_or_rollback(plugin, old_commit)
 
     def install_plugin(
-        self, url, ref=None, reinstall=False, force_blacklisted=False, discard_changes=False, enable_after_install=False
+        self,
+        url,
+        ref=None,
+        reinstall=False,
+        force_blacklisted=False,
+        discard_changes=False,
+        enable_after_install=False,
+        no_git=False,
     ):
         """Install a plugin from a git URL or local directory.
 
@@ -678,12 +687,13 @@ class PluginManager(QObject):
             force_blacklisted: If True, bypass blacklist check (dangerous!)
             discard_changes: If True, discard uncommitted changes on reinstall
             enable_after_install: If True, enable the plugin after successful installation
+            no_git: If True, treat a git directory as a local non-git plugin
 
         Raises:
             PluginDirtyError: If reinstalling and plugin has uncommitted changes
         """
         return self._installer.install_plugin(
-            url, ref, reinstall, force_blacklisted, discard_changes, enable_after_install
+            url, ref, reinstall, force_blacklisted, discard_changes, enable_after_install, no_git=no_git
         )
 
     def _find_newer_version_tag(self, url, current_tag, versioning_scheme):

--- a/picard/plugin3/manager/install.py
+++ b/picard/plugin3/manager/install.py
@@ -45,7 +45,11 @@ from picard.plugin3.plugin import (
     PluginState,
     hash_string,
 )
-from picard.plugin3.plugin_metadata import PluginMetadata
+from picard.plugin3.plugin_metadata import (
+    REF_TYPE_LOCAL,
+    REF_TYPE_LOCAL_DEV,
+    PluginMetadata,
+)
 from picard.plugin3.validation import PluginValidation
 
 
@@ -75,7 +79,14 @@ class PluginInstaller:
         self.manager = manager
 
     def install_plugin(
-        self, url, ref=None, reinstall=False, force_blacklisted=False, discard_changes=False, enable_after_install=False
+        self,
+        url,
+        ref=None,
+        reinstall=False,
+        force_blacklisted=False,
+        discard_changes=False,
+        enable_after_install=False,
+        no_git=False,
     ):
         """Install a plugin from a git URL or local directory."""
         # Check if url is a local directory (git or plain)
@@ -97,7 +108,7 @@ class PluginInstaller:
         # Install from local directory or remote URL
         if local_path:
             return self._install_from_local_directory(
-                local_path, reinstall, force_blacklisted, ref, discard_changes, enable_after_install
+                local_path, reinstall, force_blacklisted, ref, discard_changes, enable_after_install, no_git=no_git
             )
 
         return self._install_from_remote_url(
@@ -210,7 +221,9 @@ class PluginInstaller:
                 raise PluginAlreadyInstalledError(plugin_name, source_url)
             self._handle_existing_plugin_reinstall(final_path, plugin_name, discard_changes)
 
-    def _install_local_non_git(self, local_path, reinstall, force_blacklisted, enable_after_install):
+    def _install_local_non_git(
+        self, local_path, reinstall, force_blacklisted, enable_after_install, ref_type=REF_TYPE_LOCAL
+    ):
         """Install a non-git local plugin loaded in-place."""
         # Validate manifest directly from source
         manifest = PluginValidation.read_and_validate_manifest(local_path, str(local_path))
@@ -240,15 +253,15 @@ class PluginInstaller:
                     self.manager._plugins.remove(existing)
                     break
 
-        # Save metadata with ref_type='local'
+        # Save metadata with ref_type
         self.manager._metadata.save_plugin_metadata(
             PluginMetadata(
                 name=manifest.name(),
                 url=str(local_path),
-                ref='local',
+                ref=REF_TYPE_LOCAL,
                 commit='',
                 uuid=manifest.uuid,
-                ref_type='local',
+                ref_type=ref_type,
             )
         )
 
@@ -270,7 +283,15 @@ class PluginInstaller:
         return plugin.plugin_id
 
     def _install_common(
-        self, source_url, ref, reinstall, force_blacklisted, discard_changes, enable_after_install, is_local=False
+        self,
+        source_url,
+        ref,
+        reinstall,
+        force_blacklisted,
+        discard_changes,
+        enable_after_install,
+        is_local=False,
+        no_git=False,
     ):
         """Common installation logic for both remote and local sources."""
         # Preserve original ref if reinstalling and no ref specified
@@ -279,9 +300,13 @@ class PluginInstaller:
         # Handle local-specific pre-sync operations
         if is_local:
             local_path = Path(source_url)
-            # Non-git local directory: install in-place
-            if not (local_path / '.git').exists():
-                return self._install_local_non_git(local_path, reinstall, force_blacklisted, enable_after_install)
+            has_git = (local_path / '.git').exists()
+            # --no-git flag or no .git directory: install in-place
+            if no_git or not has_git:
+                ref_type = REF_TYPE_LOCAL_DEV if no_git and has_git else REF_TYPE_LOCAL
+                return self._install_local_non_git(
+                    local_path, reinstall, force_blacklisted, enable_after_install, ref_type=ref_type
+                )
 
             # Check source repository status and get current ref if needed
             try:
@@ -348,10 +373,18 @@ class PluginInstaller:
         ref=None,
         discard_changes=False,
         enable_after_install=False,
+        no_git=False,
     ):
         """Install a plugin from a local directory."""
         return self._install_common(
-            local_path, ref, reinstall, force_blacklisted, discard_changes, enable_after_install, is_local=True
+            local_path,
+            ref,
+            reinstall,
+            force_blacklisted,
+            discard_changes,
+            enable_after_install,
+            is_local=True,
+            no_git=no_git,
         )
 
     def _handle_existing_plugin_reinstall(self, final_path, plugin_name, discard_changes):

--- a/picard/plugin3/manager/lifecycle.py
+++ b/picard/plugin3/manager/lifecycle.py
@@ -42,7 +42,7 @@ from picard.plugin3.plugin import (
     Plugin,
     PluginState,
 )
-from picard.plugin3.plugin_metadata import is_local_non_git_plugin
+from picard.plugin3.plugin_metadata import is_local_plugin
 
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class PluginLifecycleManager:
         # Local non-git plugins: just unregister, don't delete files
         if plugin.uuid:
             metadata = self.manager._get_plugin_metadata(plugin.uuid)
-            if is_local_non_git_plugin(metadata):
+            if is_local_plugin(metadata):
                 return self._unregister_local_plugin(plugin, purge)
 
         try:

--- a/picard/plugin3/manager/update.py
+++ b/picard/plugin3/manager/update.py
@@ -43,7 +43,7 @@ from picard.plugin3.plugin import (
 )
 from picard.plugin3.plugin_metadata import (
     PluginMetadata,
-    is_local_non_git_plugin,
+    is_local_plugin,
 )
 from picard.plugin3.ref_item import RefItem
 
@@ -161,7 +161,7 @@ class PluginUpdater:
         uuid, metadata = self.manager._get_plugin_uuid_and_metadata(plugin)
 
         # Local non-git plugins: reload instead of git update
-        if is_local_non_git_plugin(metadata):
+        if is_local_plugin(metadata):
             return self._reload_local_plugin(plugin)
 
         self.manager._ensure_plugin_url(plugin, 'update')
@@ -280,7 +280,7 @@ class PluginUpdater:
         """Switch plugin to a different git ref."""
         # Local non-git plugins cannot switch refs
         metadata = self.manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
-        if is_local_non_git_plugin(metadata):
+        if is_local_plugin(metadata):
             raise PluginNoSourceError(plugin.plugin_id, 'switch ref')
 
         self.manager._ensure_plugin_url(plugin, 'switch ref')

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -129,7 +129,7 @@ LOCAL_MARKER = N_('local')
 LOCAL_DEV_MARKER = N_('local-dev')
 
 
-def is_local_non_git_plugin(metadata) -> bool:
+def is_local_plugin(metadata) -> bool:
     """Check if metadata represents a local plugin. Safe with None."""
     return metadata is not None and getattr(metadata, 'ref_type', None) in (REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV)
 

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -34,6 +34,7 @@ from picard.git.backend import (
 )
 from picard.git.factory import git_backend
 from picard.git.utils import normalize_git_url
+from picard.i18n import N_
 
 
 if TYPE_CHECKING:
@@ -55,7 +56,7 @@ class PluginMetadata:
     git_ref: GitRef | None = None  # New GitRef object (preferred over ref/ref_type)
 
     def to_dict(self):
-        """Convert to dict for config storage, excluding None values."""
+        """Convert to dict for config storage, excluding None values and defaults."""
         data = {k: v for k, v in asdict(self).items() if v is not None}
         # Serialize git_ref to tuple for storage
         if self.git_ref:
@@ -122,9 +123,15 @@ class PluginMetadata:
         return GitRef(name='', target='')
 
 
+REF_TYPE_LOCAL = 'local'
+REF_TYPE_LOCAL_DEV = 'local-dev'
+LOCAL_MARKER = N_('local')
+LOCAL_DEV_MARKER = N_('local-dev')
+
+
 def is_local_non_git_plugin(metadata) -> bool:
-    """Check if metadata represents a local non-git plugin. Safe with None."""
-    return metadata is not None and getattr(metadata, 'ref_type', None) == 'local'
+    """Check if metadata represents a local plugin. Safe with None."""
+    return metadata is not None and getattr(metadata, 'ref_type', None) in (REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV)
 
 
 class PluginMetadataManager:

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -185,6 +185,17 @@ class InstallPluginDialog(PicardDialog):
         self.local_ref_edit.setPlaceholderText(_("main"))
         local_form.addRow(_("Ref/Tag:"), self.local_ref_edit)
 
+        self.no_git_checkbox = QtWidgets.QCheckBox(_("Load in-place (ignore git)"))
+        self.no_git_checkbox.setToolTip(
+            _(
+                "If checked, the plugin will be loaded directly from disk without git features "
+                "(no updates, no ref switching). Useful for active development."
+            )
+        )
+        self.no_git_checkbox.setEnabled(False)
+        self.no_git_checkbox.toggled.connect(self._validate_local_path)
+        local_form.addRow("", self.no_git_checkbox)
+
         local_layout.addWidget(local_group)
         local_layout.addStretch()
         self.tab_widget.addTab(local_widget, _("Local"))
@@ -243,27 +254,46 @@ class InstallPluginDialog(PicardDialog):
         else:  # TAB_LOCAL - Local directory tab
             self.install_button.setEnabled(self._local_path_valid)
 
-    def _validate_local_path(self):
+    def _validate_local_path(self, *args):
         """Validate local path and update Ref/Tag field and status."""
+        if getattr(self, '_validating_local_path', False):
+            return
+        self._validating_local_path = True
+        try:
+            self._do_validate_local_path()
+        finally:
+            self._validating_local_path = False
+
+    def _do_validate_local_path(self):
+        """Internal validation logic for local path."""
         path = self.path_edit.text().strip()
         self._local_path_valid = False
+        no_git = self.no_git_checkbox.isChecked()
 
         if not path:
             self.local_ref_edit.setEnabled(True)
+            self.no_git_checkbox.setEnabled(False)
             self.local_status_label.hide()
         elif not os.path.isdir(path):
             self.local_ref_edit.setEnabled(False)
+            self.no_git_checkbox.setEnabled(False)
             self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_error'))
             self.local_status_label.setText(_("The selected path is not a directory."))
             self.local_status_label.show()
         elif not os.path.isfile(os.path.join(path, "MANIFEST.toml")):
             self.local_ref_edit.setEnabled(False)
+            self.no_git_checkbox.setEnabled(False)
             self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_error'))
             self.local_status_label.setText(_("The directory does not contain a MANIFEST.toml file."))
             self.local_status_label.show()
         elif not os.path.exists(os.path.join(path, ".git")):
             self.local_ref_edit.setEnabled(False)
             self.local_ref_edit.clear()
+            self.no_git_checkbox.setEnabled(False)
+            # Block signals to avoid re-triggering _validate_local_path
+            self.no_git_checkbox.blockSignals(True)
+            self.no_git_checkbox.setChecked(False)
+            self.no_git_checkbox.blockSignals(False)
             self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_warning'))
             self.local_status_label.setText(
                 _(
@@ -273,8 +303,23 @@ class InstallPluginDialog(PicardDialog):
             )
             self.local_status_label.show()
             self._local_path_valid = True
+        elif no_git:
+            self.local_ref_edit.setEnabled(False)
+            if self.local_ref_edit.text():
+                self.local_ref_edit.clear()
+            self.no_git_checkbox.setEnabled(True)
+            self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_warning'))
+            self.local_status_label.setText(
+                _(
+                    "Git features (updates, refs) will be disabled. "
+                    "The plugin will be loaded directly from this directory."
+                )
+            )
+            self.local_status_label.show()
+            self._local_path_valid = True
         else:
             self.local_ref_edit.setEnabled(True)
+            self.no_git_checkbox.setEnabled(True)
             self.local_status_label.hide()
             self._local_path_valid = True
 
@@ -523,6 +568,7 @@ class InstallPluginDialog(PicardDialog):
         """Create LocalInstallablePlugin from local path input."""
         url = self.path_edit.text().strip()
         ref = self.local_ref_edit.text().strip() or None
+        no_git = self.no_git_checkbox.isChecked()
         if not url:
             QtWidgets.QMessageBox.warning(
                 self, _("No Directory Selected"), _("Please select a local plugin directory.")
@@ -544,9 +590,11 @@ class InstallPluginDialog(PicardDialog):
             )
             return None
 
-        # Warn if not a git repository
         git_path = os.path.join(url, ".git")
-        if not os.path.exists(git_path):
+        has_git = os.path.exists(git_path)
+
+        if not has_git:
+            # No .git: warn about non-git limitations
             result = QtWidgets.QMessageBox.warning(
                 self,
                 _("Plugin Not Managed by Git"),
@@ -563,7 +611,10 @@ class InstallPluginDialog(PicardDialog):
             )
             if result != QtWidgets.QMessageBox.StandardButton.Yes:
                 return None
-            ref = None  # No ref for non-git plugins
+            ref = None
+        elif no_git:
+            # .git exists but user wants local mode
+            ref = None
 
         return LocalInstallablePlugin(url, ref, self.plugin_manager._registry)
 
@@ -600,6 +651,9 @@ class InstallPluginDialog(PicardDialog):
             QtWidgets.QMessageBox.critical(self, _("Error"), _("Plugin has no repository URL"))
             return
 
+        # Determine no_git flag for local tab
+        no_git = current_tab == TAB_LOCAL and self.no_git_checkbox.isChecked()
+
         # Disable UI before showing confirmation dialog to prevent interaction
         self._disable_ui_for_installation()
 
@@ -608,25 +662,29 @@ class InstallPluginDialog(PicardDialog):
             plugin_name = plugin.get_display_name()
             plugin_uuid = plugin.plugin_uuid
             # Hide ref selector for non-git local plugins
-            show_ref_selector = not (current_tab == TAB_LOCAL and not os.path.exists(os.path.join(url, ".git")))
+            show_ref_selector = not (
+                current_tab == TAB_LOCAL and (not os.path.exists(os.path.join(url, ".git")) or no_git)
+            )
             confirm_dialog = InstallConfirmDialog(
                 plugin_name, url, self, plugin_uuid, None, show_ref_selector=show_ref_selector
             )
             confirm_dialog.finished.connect(
-                lambda result: self._on_install_confirm_finished(result, confirm_dialog, url, plugin, current_tab)
+                lambda result: self._on_install_confirm_finished(
+                    result, confirm_dialog, url, plugin, current_tab, no_git
+                )
             )
             confirm_dialog.open()
         else:
-            self._proceed_with_install(url, plugin.ref, plugin, current_tab)
+            self._proceed_with_install(url, plugin.ref, plugin, current_tab, no_git=no_git)
 
-    def _on_install_confirm_finished(self, result, confirm_dialog, url, plugin, current_tab):
+    def _on_install_confirm_finished(self, result, confirm_dialog, url, plugin, current_tab, no_git=False):
         if result != QtWidgets.QDialog.DialogCode.Accepted:
             self._enable_ui_after_installation()
             return
         ref = confirm_dialog.selected_ref.shortname if confirm_dialog.selected_ref else None
-        self._proceed_with_install(url, ref, plugin, current_tab)
+        self._proceed_with_install(url, ref, plugin, current_tab, no_git=no_git)
 
-    def _proceed_with_install(self, url, ref, plugin, current_tab):
+    def _proceed_with_install(self, url, ref, plugin, current_tab, no_git=False):
         # Use versioning scheme for registry plugins when no ref specified
         if current_tab == TAB_REGISTRY and ref is None:
             # Get original plugin data for versioning scheme
@@ -643,7 +701,9 @@ class InstallPluginDialog(PicardDialog):
 
         # Start async installation
         async_manager = AsyncPluginManager(self.plugin_manager)
-        async_manager.install_plugin(url=url, ref=ref, progress_callback=self._on_progress, callback=self._on_complete)
+        async_manager.install_plugin(
+            url=url, ref=ref, no_git=no_git, progress_callback=self._on_progress, callback=self._on_complete
+        )
 
     def _on_progress(self, update):
         """Handle installation progress."""

--- a/picard/ui/dialogs/plugininfo.py
+++ b/picard/ui/dialogs/plugininfo.py
@@ -302,7 +302,7 @@ class PluginInfoDialog(PicardDialog):
             return getattr(self.plugin_data, 'git_url', getattr(self.plugin_data, 'source_url', '')) or ''
         else:
             try:
-                if self.plugin_manager and self.plugin_manager.is_local_non_git(self.plugin_data):
+                if self.plugin_manager and self.plugin_manager.is_local_plugin(self.plugin_data):
                     return ''
                 return self.plugin_manager.get_plugin_remote_url(self.plugin_data) or '' if self.plugin_manager else ''
             except (AttributeError, Exception):

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -182,7 +182,7 @@ class PluginDetailsWidget(QtWidgets.QWidget):
         if maintainers:
             self.maintainers_label.setText(maintainers)
 
-        if self.plugin_manager.is_local_non_git(plugin):
+        if self.plugin_manager.is_local_plugin(plugin):
             self.git_url_row_label.setText(_("Path:"))
             git_url = str(plugin.local_path)
         else:
@@ -193,7 +193,7 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             self.git_url_label.setText(git_url)
 
         # Update/Reload button state and tooltip
-        if self.plugin_manager.is_local_non_git(plugin):
+        if self.plugin_manager.is_local_plugin(plugin):
             self.update_button.setText(_("Reload"))
             self.update_button.setEnabled(True)
             self.update_button.setToolTip("")
@@ -388,7 +388,7 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             self.plugin_updated.emit()  # Signal that plugin was updated
             # Emit the same signal as context menu for status updates
             if hasattr(self.parent(), 'plugin_state_changed'):
-                action = "reloaded" if self.plugin_manager.is_local_non_git(plugin) else "updated"
+                action = "reloaded" if self.plugin_manager.is_local_plugin(plugin) else "updated"
                 self.parent().plugin_state_changed.emit(plugin, action)
             # Refresh the display - plugin should no longer have update available
             self.show_plugin(plugin)

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from functools import partial
+import html
 
 from PyQt6 import (
     QtCore,
@@ -39,6 +40,12 @@ from picard.metadata import (
 )
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 from picard.plugin3.plugin import PluginState
+from picard.plugin3.plugin_metadata import (
+    LOCAL_DEV_MARKER,
+    LOCAL_MARKER,
+    REF_TYPE_LOCAL_DEV,
+    is_local_non_git_plugin,
+)
 from picard.plugin3.ref_item import RefItem
 from picard.util import temporary_disconnect
 
@@ -267,6 +274,10 @@ class PluginListWidget(QtWidgets.QWidget):
             if plugin.uuid:
                 metadata = self.plugin_manager._metadata.get_plugin_metadata(plugin.uuid)
                 if metadata:
+                    # For local plugins, show translated 'local' or 'local-dev'
+                    if is_local_non_git_plugin(metadata):
+                        label = LOCAL_DEV_MARKER if metadata.ref_type == REF_TYPE_LOCAL_DEV else LOCAL_MARKER
+                        return f'<b>{html.escape(_(label))}</b>'
                     git_ref = metadata.get_git_ref()
                     ref_item = RefItem.from_git_ref(git_ref)
                     result = html_ref_format(ref_item)
@@ -288,7 +299,10 @@ class PluginListWidget(QtWidgets.QWidget):
         return _("Unknown")
 
     def _set_version_tooltip(self, item, plugin):
-        """Set tooltip on Version column with commit date if available."""
+        """Set tooltip on Version column with source path or commit date."""
+        if self.plugin_manager.is_local_non_git(plugin):
+            item.setToolTip(COLUMN_VERSION, str(plugin.local_path))
+            return
         commit_date = plugin.get_current_commit_date()
         if commit_date:
             item.setToolTip(COLUMN_VERSION, commit_date_display(commit_date))
@@ -761,6 +775,30 @@ class PluginListWidget(QtWidgets.QWidget):
                 return
             plugin_url = metadata.url
 
+            # For local-dev plugins, warn that reinstall will switch to git-managed mode
+            no_git = False
+            if metadata.ref_type == REF_TYPE_LOCAL_DEV:
+                msgbox = QtWidgets.QMessageBox(self)
+                msgbox.setWindowTitle(_("Reinstall Local Plugin"))
+                msgbox.setText(
+                    _(
+                        "This plugin is loaded in local mode (git ignored).\n\n"
+                        "Do you want to keep it in local mode, or switch to "
+                        "git-managed mode (cloned to plugin directory)?"
+                    )
+                )
+                keep_local_btn = msgbox.addButton(_("Keep local"), QtWidgets.QMessageBox.ButtonRole.YesRole)
+                switch_git_btn = msgbox.addButton(_("Switch to git"), QtWidgets.QMessageBox.ButtonRole.NoRole)
+                msgbox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+                msgbox.exec()
+                clicked = msgbox.clickedButton()
+                if clicked == keep_local_btn:
+                    no_git = True
+                elif clicked == switch_git_btn:
+                    no_git = False
+                else:
+                    return
+
             # Get current ref for reinstall
             current_ref = None
             try:
@@ -776,14 +814,14 @@ class PluginListWidget(QtWidgets.QWidget):
                 plugin.name(), plugin_url, self, plugin.uuid, current_ref, show_ref_selector=show_ref_selector
             )
             confirm_dialog.finished.connect(
-                lambda result: self._on_reinstall_confirm_finished(result, confirm_dialog, plugin, plugin_url)
+                lambda result: self._on_reinstall_confirm_finished(result, confirm_dialog, plugin, plugin_url, no_git)
             )
             confirm_dialog.open()
         except Exception as e:
             log.error("Failed to reinstall plugin %s: %s", plugin.plugin_id, e, exc_info=True)
             self._reinstall_error_dialog(plugin, str(e))
 
-    def _on_reinstall_confirm_finished(self, result, confirm_dialog, plugin, plugin_url):
+    def _on_reinstall_confirm_finished(self, result, confirm_dialog, plugin, plugin_url, no_git=False):
         if result != QtWidgets.QDialog.DialogCode.Accepted:
             return
         async_manager = AsyncPluginManager(self.plugin_manager)
@@ -791,6 +829,7 @@ class PluginListWidget(QtWidgets.QWidget):
             url=plugin_url,
             ref=confirm_dialog.selected_ref.shortname if confirm_dialog.selected_ref else None,
             reinstall=True,
+            no_git=no_git,
             callback=partial(self._on_reinstall_complete, plugin),
         )
 

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -44,7 +44,7 @@ from picard.plugin3.plugin_metadata import (
     LOCAL_DEV_MARKER,
     LOCAL_MARKER,
     REF_TYPE_LOCAL_DEV,
-    is_local_non_git_plugin,
+    is_local_plugin,
 )
 from picard.plugin3.ref_item import RefItem
 from picard.util import temporary_disconnect
@@ -275,7 +275,7 @@ class PluginListWidget(QtWidgets.QWidget):
                 metadata = self.plugin_manager._metadata.get_plugin_metadata(plugin.uuid)
                 if metadata:
                     # For local plugins, show translated 'local' or 'local-dev'
-                    if is_local_non_git_plugin(metadata):
+                    if is_local_plugin(metadata):
                         label = LOCAL_DEV_MARKER if metadata.ref_type == REF_TYPE_LOCAL_DEV else LOCAL_MARKER
                         return f'<b>{html.escape(_(label))}</b>'
                     git_ref = metadata.get_git_ref()
@@ -300,7 +300,7 @@ class PluginListWidget(QtWidgets.QWidget):
 
     def _set_version_tooltip(self, item, plugin):
         """Set tooltip on Version column with source path or commit date."""
-        if self.plugin_manager.is_local_non_git(plugin):
+        if self.plugin_manager.is_local_plugin(plugin):
             item.setToolTip(COLUMN_VERSION, str(plugin.local_path))
             return
         commit_date = plugin.get_current_commit_date()
@@ -617,7 +617,7 @@ class PluginListWidget(QtWidgets.QWidget):
         menu.addSeparator()
 
         # Determine if this is a local non-git plugin
-        is_local = self.plugin_manager.is_local_non_git(plugin)
+        is_local = self.plugin_manager.is_local_plugin(plugin)
 
         # Update/Reload action
         if is_local:
@@ -721,7 +721,7 @@ class PluginListWidget(QtWidgets.QWidget):
             # Refresh the plugin list
             self.populate_plugins(self.plugin_manager.plugins)
             # Emit signal for options dialog to refresh and update updates dict
-            action = "reloaded" if self.plugin_manager.is_local_non_git(plugin) else "updated"
+            action = "reloaded" if self.plugin_manager.is_local_plugin(plugin) else "updated"
             self.plugin_state_changed.emit(plugin, action)
         else:
             error_msg = str(result.error) if result.error else _("Unknown error")
@@ -809,7 +809,7 @@ class PluginListWidget(QtWidgets.QWidget):
                 pass
 
             # Show confirmation dialog
-            show_ref_selector = not self.plugin_manager.is_local_non_git(plugin)
+            show_ref_selector = not self.plugin_manager.is_local_plugin(plugin)
             confirm_dialog = InstallConfirmDialog(
                 plugin.name(), plugin_url, self, plugin.uuid, current_ref, show_ref_selector=show_ref_selector
             )

--- a/test/plugins3/test_local_non_git_plugin.py
+++ b/test/plugins3/test_local_non_git_plugin.py
@@ -29,6 +29,7 @@ from test.plugins3.helpers import (
     run_cli,
 )
 
+from picard.config import get_config
 from picard.plugin3.manager import (
     PluginManager,
     PluginManifestNotFoundError,
@@ -157,6 +158,83 @@ class TestLocalNonGitPlugin(PicardTestCase):
             self.assertIsNone(manager2._get_plugin_metadata(actual_uuid))
 
 
+class TestNoGitInstall(PicardTestCase):
+    """Tests for installing a git-tracked plugin with no_git=True."""
+
+    def test_install_with_no_git_sets_local_dev_ref_type(self):
+        """Install with no_git=True on a .git directory sets ref_type to local-dev."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            # Create a fake .git directory
+            (plugin_dir / '.git').mkdir()
+
+            manager = _create_manager(plugins_dir)
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
+
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+            metadata = manager._get_plugin_metadata(plugin.uuid)
+            self.assertEqual(metadata.ref_type, 'local-dev')
+            self.assertEqual(plugin.local_path, plugin_dir)
+
+    def test_install_without_no_git_has_local_ref_type(self):
+        """Normal local install (no .git) has ref_type='local'."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+
+            manager = _create_manager(plugins_dir)
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False)
+
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+            metadata = manager._get_plugin_metadata(plugin.uuid)
+            self.assertEqual(metadata.ref_type, 'local')
+
+    def test_no_git_on_dir_without_git_still_works(self):
+        """no_git=True on a dir without .git installs normally as local."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+
+            manager = _create_manager(plugins_dir)
+            plugin_id = manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
+
+            plugin = manager.plugin_id_to_plugin(plugin_id)
+            metadata = manager._get_plugin_metadata(plugin.uuid)
+            self.assertEqual(metadata.ref_type, 'local')
+
+    def test_local_dev_ref_type_persists_in_metadata_dict(self):
+        """ref_type='local-dev' is stored in the config dict."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            (plugin_dir / '.git').mkdir()
+
+            manager = _create_manager(plugins_dir)
+            manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
+
+            config = get_config()
+            raw = config.setting['plugins3_metadata']
+            # Find the entry by looking for our path
+            entry = next(v for v in raw.values() if v.get('url') == str(plugin_dir))
+            self.assertEqual(entry.get('ref_type'), 'local-dev')
+
+    def test_local_ref_type_has_no_has_git_field(self):
+        """Local install has no has_git field and ref_type='local' in config dict."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+
+            manager = _create_manager(plugins_dir)
+            manager.install_plugin(str(plugin_dir), enable_after_install=False)
+
+            config = get_config()
+            raw = config.setting['plugins3_metadata']
+            entry = next(v for v in raw.values() if v.get('url') == str(plugin_dir))
+            self.assertNotIn('has_git', entry)
+            self.assertEqual(entry.get('ref_type'), 'local')
+
+
 class TestLocalNonGitPluginCLI(PicardTestCase):
     """Tests for CLI behavior with local non-git plugins."""
 
@@ -187,3 +265,31 @@ class TestLocalNonGitPluginCLI(PicardTestCase):
             exit_code, _, stderr = run_cli(manager, list_refs=plugin_name)
             self.assertNotEqual(exit_code, 0)
             self.assertIn('not managed by git', stderr)
+
+    def test_cli_list_shows_local_dev_marker(self):
+        """CLI --list shows [local-dev] for plugins installed with --no-git."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            (plugin_dir / '.git').mkdir()
+
+            manager = _create_manager(plugins_dir)
+            manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
+
+            exit_code, stdout, _ = run_cli(manager, list=True)
+            self.assertEqual(exit_code, 0)
+            self.assertIn('[local-dev]', stdout)
+
+    def test_cli_info_shows_local_dev_marker(self):
+        """CLI --info shows [local-dev] for plugins installed with --no-git."""
+        with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as plugins_dir:
+            uuid = generate_uuid()
+            plugin_dir, plugin_name = _create_plugin_dir(tmp_dir, uuid)
+            (plugin_dir / '.git').mkdir()
+
+            manager = _create_manager(plugins_dir)
+            manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
+
+            exit_code, stdout, _ = run_cli(manager, info=plugin_name)
+            self.assertEqual(exit_code, 0)
+            self.assertIn('[local-dev]', stdout)


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Allow `--no-git` flag with `--install` to load a git-tracked plugin directory in local mode (in-place, no clone, no git operations). Uses `ref_type='local-dev'` to distinguish from plain local plugins. Includes GUI checkbox equivalent, reinstall mode choice dialog, and consistent `[local-dev]` display markers.

## Problem

* JIRA ticket: PICARD-3313

Developers working on plugins in a git repository currently must either:
1. Have Picard clone the plugin to the plugins directory (losing live editing), or
2. Remove `.git` to use the local non-git install (losing version control).

There's no way to load a git-tracked plugin directory directly from its working tree for rapid development iteration.

## Solution

Reuse the existing `--no-git` CLI flag (already used for `--init`) in the `--install` context. When a local directory has `.git` but `--no-git` is passed, it's installed in-place with `ref_type='local-dev'` in metadata (vs `ref_type='local'` for plain non-git directories).

Key changes:

**Core:**
- `REF_TYPE_LOCAL_DEV = 'local-dev'` constant for the new ref_type value
- `is_local_plugin()` (renamed from `is_local_non_git_plugin`) covers both `'local'` and `'local-dev'`
- `no_git` parameter threaded through `install_plugin` → `_install_common` → `_install_local_non_git`
- No new dataclass fields — uses existing `ref_type` to carry the distinction

**CLI:**
- `--no-git` flag read in `_cmd_install`, specific warning/confirmation
- `_local_marker()` helper for consistent `[local]`/`[local-dev]` display
- Updated `--no-git` help text for dual purpose

**GUI:**
- "Load in-place (ignore git)" checkbox in Local install tab (enabled only when `.git` detected)
- Reinstall dialog for `local-dev` plugins: "Keep local" / "Switch to git" / Cancel
- Version column shows bold "local-dev" with source path as tooltip
- Re-entrancy guard in path validation

**Other:**
- `REF_TYPE_LOCAL`, `LOCAL_MARKER`, `LOCAL_DEV_MARKER` constants
- Documentation in `docs/PLUGINSV3/LOCAL_NON_GIT.md`
- 7 unit tests (5 manager + 2 CLI)

Restoring git-managed mode: `--reinstall` without `--no-git` (CLI) or "Switch to git" button (GUI).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed interactively with AI (Kiro CLI), with human direction on design decisions, naming, architecture, and review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
