### PR TITLE
PICARD-3330: Fix config upgrade hooks to also update profile overrides

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -64,6 +64,39 @@ def temp_option(option_type: type[Option], section: str, name: str, default: Con
     opt.unregister()
 
 
+def _rename_option_in_settings(
+    settings: dict,
+    old_name: str,
+    new_name: str,
+    reverse: bool = False,
+) -> None:
+    """Rename an option key in a settings dict (profile override or imported settings).
+
+    If reverse is True, the boolean value is also inverted.
+    Settings with None value (tracked but not overridden) are renamed without transformation.
+    """
+    if old_name in settings:
+        value = settings[old_name]
+        if reverse and value is not None:
+            value = not value
+        settings[new_name] = value
+        del settings[old_name]
+
+
+def _upgrade_option_value_in_settings(
+    settings: dict,
+    name: str,
+    transform: Callable,
+) -> None:
+    """Apply a value transform to an option in a settings dict (profile override or imported settings).
+
+    The transform function receives the current value and must return the new value.
+    Settings with None value (tracked but not overridden) are left unchanged.
+    """
+    if name in settings and settings[name] is not None:
+        settings[name] = transform(settings[name])
+
+
 def rename_option(
     config: Config,
     old_opt: str,
@@ -85,12 +118,38 @@ def rename_option(
         all_settings = _p['user_profile_settings']
         for profile in _p['user_profiles']:
             id = profile['id']
-            if id in all_settings and old_opt in all_settings[id]:
-                all_settings[id][new_opt] = all_settings[id][old_opt]
-                if reverse:
-                    all_settings[id][new_opt] = not all_settings[id][new_opt]
-                all_settings[id].pop(old_opt)
+            if id in all_settings:
+                _rename_option_in_settings(all_settings[id], old_opt, new_opt, reverse)
         _p['user_profile_settings'] = all_settings
+
+
+def upgrade_option_value(
+    config: Config,
+    name: str,
+    transform: Callable,
+) -> None:
+    """Apply a value transform to an option in base config and all profile overrides.
+
+    Use this in upgrade hooks when an option's value format changes but the key
+    stays the same. The transform function receives the current raw value and
+    must return the new value. Reads bypass profile overrides and Option.convert()
+    to access the actual stored value.
+    """
+    _s = config.setting
+    if name in _s:
+        value = _s.raw_value(name)
+        if value is not None:
+            with _s.no_profile():
+                _s[name] = transform(value)
+
+    _p = config.profiles
+    _s.init_profile_options()
+    all_settings = _p['user_profile_settings']
+    for profile in _p['user_profiles']:
+        id = profile['id']
+        if id in all_settings:
+            _upgrade_option_value_in_settings(all_settings[id], name, transform)
+    _p['user_profile_settings'] = all_settings
 
 
 class UpgradeHooksAutodetectError(Exception):

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -48,6 +48,7 @@ from picard.config import (
 from picard.config_upgrade import (
     rename_option,
     temp_option,
+    upgrade_option_value,
 )
 from picard.const.defaults import (
     DEFAULT_FILE_NAMING_FORMAT,
@@ -382,8 +383,11 @@ def upgrade_to_v2_4_0beta3(config):
 
 def upgrade_to_v2_5_0dev1(config):
     """Rename whitelist cover art provider"""
-    _s = config.setting
-    _s['ca_providers'] = [('UrlRelationships' if n == 'Whitelist' else n, s) for n, s in _s['ca_providers']]
+    upgrade_option_value(
+        config,
+        'ca_providers',
+        lambda providers: [('UrlRelationships' if n == 'Whitelist' else n, s) for n, s in providers],
+    )
 
 
 def upgrade_to_v2_5_0dev2(config):
@@ -632,11 +636,12 @@ def upgrade_to_v3_0_0dev9(config):
 
 def upgrade_to_v3_0_0dev10(config):
     """Update cover art processing format options"""
-    # Use raw values to ensure that we get a string to process
     for setting_key in ('cover_tags_convert_to_format', 'cover_file_convert_to_format'):
-        value = config.setting.raw_value(setting_key, qtype='QString')
-        if value and isinstance(value, str):
-            config.setting[setting_key] = value.lower()
+        upgrade_option_value(
+            config,
+            setting_key,
+            lambda value: value.lower() if isinstance(value, str) else value,
+        )
 
 
 def upgrade_to_v3_0_0a2(config):
@@ -647,15 +652,15 @@ def upgrade_to_v3_0_0a2(config):
     def fix_matchedtracks(script):
         return matched_tracks_regex.sub('$matchedtracks()', script)
 
+    def fix_tagger_scripts(scripts):
+        return [(pos, name, enabled, fix_matchedtracks(script)) for pos, name, enabled, script in scripts]
+
     renaming_scripts = config.setting.raw_value('file_renaming_scripts') or {}
     for script_item in renaming_scripts.values():
         script_item['script'] = fix_matchedtracks(script_item['script'])
     config.setting['file_renaming_scripts'] = renaming_scripts
 
-    tagger_scripts = config.setting.raw_value('list_of_scripts') or []
-    for i, (pos, name, enabled, script) in enumerate(tagger_scripts):
-        tagger_scripts[i] = (pos, name, enabled, fix_matchedtracks(script))
-    config.setting['list_of_scripts'] = tagger_scripts
+    upgrade_option_value(config, 'list_of_scripts', fix_tagger_scripts)
 
 
 def upgrade_to_v3_0_0a3(config):
@@ -692,8 +697,11 @@ def upgrade_to_v3_0_0b5(config):
     rename_option(config, 'selected_file_naming_script_id', 'active_file_naming_script_id', TextOption, '')
 
     new_items = ['rename_files', 'move_files', 'enable_tag_saving']
-    quick_menu_items = config.setting['quick_menu_items']
-    for item in reversed(new_items):
-        if item not in quick_menu_items:
-            quick_menu_items.insert(0, item)
-    config.setting['quick_menu_items'] = quick_menu_items
+
+    def add_quick_menu_items(items):
+        for item in reversed(new_items):
+            if item not in items:
+                items.insert(0, item)
+        return items
+
+    upgrade_option_value(config, 'quick_menu_items', add_quick_menu_items)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -25,6 +25,8 @@ from test.picardtestcase import PicardTestCase
 
 from picard.config_upgrade import (
     UpgradeHooksAutodetectError,
+    _rename_option_in_settings,
+    _upgrade_option_value_in_settings,
     autodetect_upgrade_hooks,
 )
 from picard.version import Version
@@ -102,3 +104,58 @@ class TestPicardConfigUpgradesAutodetect(PicardTestCase):
             Version(major=2, minor=0, patch=0, identifier='final', revision=0),
         )
         self.assertEqual(tuple(hooks), expected_keys)
+
+
+class TestRenameOptionInSettings(PicardTestCase):
+    def test_rename_existing_key(self):
+        settings = {'old_name': 'value', 'other': 42}
+        _rename_option_in_settings(settings, 'old_name', 'new_name')
+        self.assertEqual({'new_name': 'value', 'other': 42}, settings)
+
+    def test_rename_with_reverse(self):
+        settings = {'old_name': True}
+        _rename_option_in_settings(settings, 'old_name', 'new_name', reverse=True)
+        self.assertEqual({'new_name': False}, settings)
+
+    def test_rename_missing_key(self):
+        settings = {'other': 'value'}
+        _rename_option_in_settings(settings, 'old_name', 'new_name')
+        self.assertEqual({'other': 'value'}, settings)
+
+    def test_rename_none_value(self):
+        settings = {'old_name': None}
+        _rename_option_in_settings(settings, 'old_name', 'new_name')
+        self.assertEqual({'new_name': None}, settings)
+
+    def test_rename_none_value_reverse(self):
+        settings = {'old_name': None}
+        _rename_option_in_settings(settings, 'old_name', 'new_name', reverse=True)
+        # None values are not transformed, just moved
+        self.assertEqual({'new_name': None}, settings)
+
+
+class TestUpgradeOptionValueInSettings(PicardTestCase):
+    def test_transform_existing_key(self):
+        settings = {'my_opt': 'HELLO', 'other': 42}
+        _upgrade_option_value_in_settings(settings, 'my_opt', str.lower)
+        self.assertEqual({'my_opt': 'hello', 'other': 42}, settings)
+
+    def test_transform_missing_key(self):
+        settings = {'other': 42}
+        _upgrade_option_value_in_settings(settings, 'my_opt', str.lower)
+        self.assertEqual({'other': 42}, settings)
+
+    def test_transform_none_value_unchanged(self):
+        settings = {'my_opt': None}
+        _upgrade_option_value_in_settings(settings, 'my_opt', str.lower)
+        # None values (tracked but not overridden) are not transformed
+        self.assertEqual({'my_opt': None}, settings)
+
+    def test_transform_list(self):
+        settings = {'items': [('Whitelist', True), ('Other', False)]}
+        _upgrade_option_value_in_settings(
+            settings,
+            'items',
+            lambda providers: [('UrlRelationships' if n == 'Whitelist' else n, s) for n, s in providers],
+        )
+        self.assertEqual({'items': [('UrlRelationships', True), ('Other', False)]}, settings)

--- a/test/test_config_upgrade_hooks.py
+++ b/test/test_config_upgrade_hooks.py
@@ -298,6 +298,43 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         hooks.upgrade_to_v2_5_0dev1(self.config)
         self.assertEqual(expected, self.config.setting['ca_providers'])
 
+    def test_upgrade_to_v2_5_0dev1_profiles(self):
+        ListOption('setting', 'ca_providers', [], in_profile=True)
+        ListOption.add_if_missing('profiles', 'user_profiles', [])
+        Option.add_if_missing('profiles', 'user_profile_settings', {})
+
+        self.config.setting['ca_providers'] = [
+            ('Cover Art Archive', True),
+            ('Whitelist', True),
+        ]
+        self.config.profiles['user_profiles'] = [
+            {'id': 'p1', 'enabled': True, 'position': 0, 'title': 'Test'},
+        ]
+        self.config.profiles['user_profile_settings'] = {
+            'p1': {
+                'ca_providers': [
+                    ('Cover Art Archive', False),
+                    ('Whitelist', False),
+                    ('Local', True),
+                ],
+            },
+        }
+
+        hooks.upgrade_to_v2_5_0dev1(self.config)
+
+        # Base config updated
+        with self.config.setting.no_profile():
+            self.assertEqual(
+                [('Cover Art Archive', True), ('UrlRelationships', True)],
+                self.config.setting['ca_providers'],
+            )
+        # Profile updated
+        profile_settings = self.config.profiles['user_profile_settings']['p1']
+        self.assertEqual(
+            [('Cover Art Archive', False), ('UrlRelationships', False), ('Local', True)],
+            profile_settings['ca_providers'],
+        )
+
     def test_upgrade_to_v2_5_0dev2(self):
         Option("persist", "splitter_state", QByteArray())
         Option("persist", "bottom_splitter_state", QByteArray())
@@ -570,6 +607,35 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual(ImageFormat.WEBP, self.config.setting['cover_tags_convert_to_format'])
         self.assertEqual(ImageFormat.PNG, self.config.setting['cover_file_convert_to_format'])
 
+    def test_upgrade_to_v3_0_0dev10_profiles(self):
+        Option('setting', 'cover_tags_convert_to_format', 'jpeg', in_profile=True)
+        Option('setting', 'cover_file_convert_to_format', 'jpeg', in_profile=True)
+        ListOption.add_if_missing('profiles', 'user_profiles', [])
+        Option.add_if_missing('profiles', 'user_profile_settings', {})
+
+        self.config.setting['cover_tags_convert_to_format'] = 'WebP'
+        self.config.setting['cover_file_convert_to_format'] = 'PNG'
+        self.config.profiles['user_profiles'] = [
+            {'id': 'p1', 'enabled': True, 'position': 0, 'title': 'Test'},
+        ]
+        self.config.profiles['user_profile_settings'] = {
+            'p1': {
+                'cover_tags_convert_to_format': 'TIFF',
+                'cover_file_convert_to_format': 'JPEG',
+            },
+        }
+
+        hooks.upgrade_to_v3_0_0dev10(self.config)
+
+        # Base config updated
+        with self.config.setting.no_profile():
+            self.assertEqual('webp', self.config.setting['cover_tags_convert_to_format'])
+            self.assertEqual('png', self.config.setting['cover_file_convert_to_format'])
+        # Profile updated
+        profile_settings = self.config.profiles['user_profile_settings']['p1']
+        self.assertEqual('tiff', profile_settings['cover_tags_convert_to_format'])
+        self.assertEqual('jpeg', profile_settings['cover_file_convert_to_format'])
+
     def test_upgrade_to_v3_0_0a2(self):
         Option('setting', 'file_renaming_scripts', {})
         ListOption('setting', 'list_of_scripts', [])
@@ -602,6 +668,44 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
             expected_script,
             result_tagger_script[3],
         )
+
+    def test_upgrade_to_v3_0_0a2_profiles(self):
+        Option('setting', 'file_renaming_scripts', {})
+        ListOption('setting', 'list_of_scripts', [], in_profile=True)
+        ListOption.add_if_missing('profiles', 'user_profiles', [])
+        Option.add_if_missing('profiles', 'user_profile_settings', {})
+
+        test_script = r'$set(foo,$matchedtracks(baz))'
+        expected_script = '$set(foo,$matchedtracks())'
+
+        self.config.setting['file_renaming_scripts'] = {
+            'test-id': {'id': 'test-id', 'title': 'Test', 'script': test_script},
+        }
+        self.config.setting['list_of_scripts'] = [
+            (0, 'Base Script', True, test_script),
+        ]
+        self.config.profiles['user_profiles'] = [
+            {'id': 'p1', 'enabled': True, 'position': 0, 'title': 'Test'},
+        ]
+        self.config.profiles['user_profile_settings'] = {
+            'p1': {
+                'list_of_scripts': [
+                    (0, 'Profile Script', True, test_script),
+                ],
+            },
+        }
+
+        hooks.upgrade_to_v3_0_0a2(self.config)
+
+        # Base config updated
+        self.assertEqual(expected_script, self.config.setting['list_of_scripts'][0][3])
+        self.assertEqual(
+            expected_script,
+            self.config.setting['file_renaming_scripts']['test-id']['script'],
+        )
+        # Profile updated
+        profile_settings = self.config.profiles['user_profile_settings']['p1']
+        self.assertEqual(expected_script, profile_settings['list_of_scripts'][0][3])
 
     def test_upgrade_to_v3_0_0a3(self):
         Option('persist', 'album_view_header_state', PyQt6.QtCore.QByteArray())
@@ -647,3 +751,38 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual(items[:3], ['rename_files', 'move_files', 'enable_tag_saving'])
         self.assertIn('save_images_to_tags', items)
         self.assertIn('save_images_to_files', items)
+
+    def test_upgrade_to_v3_0_0b5_profiles(self):
+        ListOption('setting', 'quick_menu_items', [], in_profile=True)
+        TextOption('setting', 'selected_file_naming_script_id', '')
+        TextOption('setting', 'active_file_naming_script_id', '')
+        ListOption.add_if_missing('profiles', 'user_profiles', [])
+        Option.add_if_missing('profiles', 'user_profile_settings', {})
+
+        self.config.setting['selected_file_naming_script_id'] = 'test-id'
+        self.config.setting['quick_menu_items'] = ['save_images_to_tags']
+        self.config.profiles['user_profiles'] = [
+            {'id': 'p1', 'enabled': True, 'position': 0, 'title': 'Test'},
+        ]
+        self.config.profiles['user_profile_settings'] = {
+            'p1': {
+                'selected_file_naming_script_id': 'profile-script-id',
+                'quick_menu_items': ['embed_only_one_front_image'],
+            },
+        }
+
+        hooks.upgrade_to_v3_0_0b5(self.config)
+
+        # Base config: key renamed, items added
+        self.assertEqual('test-id', self.config.setting['active_file_naming_script_id'])
+        self.assertNotIn('selected_file_naming_script_id', self.config.setting)
+        items = self.config.setting['quick_menu_items']
+        self.assertEqual(items[:3], ['rename_files', 'move_files', 'enable_tag_saving'])
+
+        # Profile: key renamed, items added
+        profile_settings = self.config.profiles['user_profile_settings']['p1']
+        self.assertEqual('profile-script-id', profile_settings['active_file_naming_script_id'])
+        self.assertNotIn('selected_file_naming_script_id', profile_settings)
+        profile_items = profile_settings['quick_menu_items']
+        self.assertEqual(profile_items[:3], ['rename_files', 'move_files', 'enable_tag_saving'])
+        self.assertIn('embed_only_one_front_image', profile_items)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Config upgrade hooks that transform option values (not just rename keys) now also update those values in user profile overrides. Previously, profile overrides were left with stale/broken values after upgrade.

## Problem

* JIRA ticket: PICARD-3330

Several config upgrade hooks modify `in_profile=True` option values in the base config but do not update the same options when overridden in user profiles. This means profile overrides retain stale/broken values after upgrade.

Affected hooks:
- `v2_5_0dev1`: `ca_providers` — "Whitelist" never renamed to "UrlRelationships" in profiles
- `v3_0_0dev10`: `cover_tags/file_convert_to_format` — never lowercased in profiles
- `v3_0_0a2`: `list_of_scripts` — broken `$matchedtracks()` never fixed in profiles
- `v3_0_0b5`: `quick_menu_items` — new default items never added in profiles

The existing `rename_option()` helper already handles profiles correctly, but there was no equivalent for value transforms.

## Solution

1. Add `upgrade_option_value(config, name, transform)` helper that applies a transform function to both the base config and all profile overrides (analogous to `rename_option()`).

2. Add reusable `rename_option_in_settings()` and `upgrade_option_value_in_settings()` that operate on plain settings dicts. `rename_option()` is refactored to use the former internally. These helpers are also designed for reuse by future profile import functionality.

3. Fix the 4 affected hooks to use `upgrade_option_value()`.

4. Add unit tests for the new helpers and profile-aware integration tests for each fixed hook.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code, tests, and analysis were developed with AI assistance (Kiro CLI). The bug was identified during design analysis of the shareable profiles feature, and the fix was implemented and tested with AI guidance.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
