### PR TITLE
PICARD-3331: Fix encoding error saving file metadata (NFC/NFD normalization)

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -59,6 +59,7 @@ from picard.i18n import N_
 from picard.metadata import Metadata
 from picard.util import (
     imageinfo,
+    resolve_fs_path,
     thread,
 )
 
@@ -216,7 +217,7 @@ class CoverArt:
         # local files, load image data from filesystem
         elif image.url and image.url.scheme() == 'file':
             try:
-                path = image.url.toLocalFile()
+                path = resolve_fs_path(image.url.toLocalFile())
                 with open(path, 'rb') as file:
                     data = file.read()
                     image_info = imageinfo.identify(data)

--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -56,8 +56,6 @@ from picard.coverart.utils import (
 )
 from picard.metadata import Metadata
 from picard.util import (
-    decode_filename,
-    encode_filename,
     imageinfo,
     is_absolute_path,
     periodictouch,
@@ -461,7 +459,7 @@ class CoverArtImage:
         relpath = make_short_filename(basedir, relpath, win_shorten_path=win_shorten_path)
         filename = os.path.join(basedir, relpath)
         filename = make_save_path(filename, win_compat=win_compat, mac_compat=IS_MACOS)
-        return encode_filename(filename)
+        return filename
 
     def save(self, dirname: str, metadata: Metadata, counters: dict[str, int]):
         """Saves this image.
@@ -488,7 +486,7 @@ class CoverArtImage:
         filename = self._make_image_filename(filename, dirname, metadata, win_compat, win_shorten_path)
 
         overwrite = config.setting['save_images_overwrite']
-        ext = encode_filename(self.extension)
+        ext = self.extension
         image_filename = self._next_filename(filename, counters)
         while os.path.exists(image_filename + ext) and not overwrite:
             if not self._is_write_needed(image_filename + ext):
@@ -512,11 +510,11 @@ class CoverArtImage:
     @staticmethod
     def _next_filename(filename, counters):
         if counters[filename]:
-            new_filename = "%s (%d)" % (decode_filename(filename), counters[filename])
+            new_filename = "%s (%d)" % (filename, counters[filename])
         else:
             new_filename = filename
         counters[filename] += 1
-        return encode_filename(new_filename)
+        return new_filename
 
     def _is_write_needed(self, filename):
         if os.path.exists(filename) and os.path.getsize(filename) == self.datalength:

--- a/picard/file.py
+++ b/picard/file.py
@@ -106,6 +106,7 @@ from picard.util import (
     format_time,
     is_absolute_path,
     normpath,
+    resolve_fs_path,
     samefile,
     thread,
     tracknum_and_title_from_filename,
@@ -592,7 +593,7 @@ class File(MetadataItem):
         if error is not None:
             self._set_error(error)
         else:
-            self.filename = new_filename = result
+            self.filename = new_filename = resolve_fs_path(result)
             self.base_filename = os.path.basename(new_filename)
             length = self.orig_metadata.length
             temp_info = {}

--- a/picard/file.py
+++ b/picard/file.py
@@ -102,7 +102,6 @@ from picard.tags.preserved import UserPreservedTags
 from picard.util import (
     any_exception_isinstance,
     bytes2human,
-    decode_filename,
     emptydir,
     format_time,
     is_absolute_path,
@@ -818,7 +817,7 @@ class File(MetadataItem):
     def _apply_additional_files_moves(self, moves, overwrite_existing_files=False):
         for old_file_path, new_file_path in moves:
             # FIXME we shouldn't do this from a thread!
-            if self.tagger.files.get(decode_filename(old_file_path)):
+            if self.tagger.files.get(old_file_path):
                 log.debug("File loaded in the tagger, not moving %r", old_file_path)
                 continue
             if not overwrite_existing_files and os.path.exists(new_file_path):

--- a/picard/file.py
+++ b/picard/file.py
@@ -104,7 +104,6 @@ from picard.util import (
     bytes2human,
     decode_filename,
     emptydir,
-    encode_filename,
     format_time,
     is_absolute_path,
     normpath,
@@ -1031,7 +1030,7 @@ class File(MetadataItem):
         metadata['~filename'] = filename_no_ext
         metadata['~extension'] = extension.lower()[1:]
 
-        filename_encoded = encode_filename(self.filename)
+        filename_encoded = self.filename
         try:
             metadata['~filesize'] = os.path.getsize(filename_encoded)
 

--- a/picard/formats/ac3.py
+++ b/picard/formats/ac3.py
@@ -26,7 +26,6 @@ import mutagen.apev2
 from picard import log
 from picard.config import get_config
 from picard.formats.apev2 import APEv2File
-from picard.util import encode_filename
 
 from .mutagenext import ac3
 
@@ -54,7 +53,7 @@ class AC3File(APEv2File):
             super()._save(filename, metadata)
         elif config.setting['remove_ape_from_ac3']:
             try:
-                mutagen.apev2.delete(encode_filename(filename))
+                mutagen.apev2.delete(filename)
             except BaseException:
                 log.exception('Error removing APEv2 tags from %s', filename)
 

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -48,7 +48,6 @@ from picard.file import File
 from picard.i18n import N_
 from picard.metadata import Metadata
 from picard.util import (
-    encode_filename,
     sanitize_date,
 )
 from picard.util.filenaming import (
@@ -140,7 +139,7 @@ class APEv2File(File):
         assert self._File, f"_File not defined for {self.__class__.__name__}"
         log.debug("Loading file %r", filename)
         self.__casemap = {}
-        file = self._File(encode_filename(filename))
+        file = self._File(filename)
         metadata = Metadata()
         if file.tags:
             for origname, values in file.tags.items():
@@ -198,7 +197,7 @@ class APEv2File(File):
         log.debug("Saving file %r", filename)
         config = get_config()
         try:
-            tags = mutagen.apev2.APEv2(encode_filename(filename))
+            tags = mutagen.apev2.APEv2(filename)
         except mutagen.apev2.APENoHeaderError:
             tags = mutagen.apev2.APEv2()
         images_to_save = list(metadata.images.to_be_saved_to_tags())
@@ -246,7 +245,7 @@ class APEv2File(File):
             # (mp3tags does this, but it's against the specs)
 
         self._remove_deleted_tags(metadata, tags)
-        tags.save(encode_filename(filename))
+        tags.save(filename)
 
     def _remove_deleted_tags(self, metadata, tags):
         """Remove the tags from the file that were deleted in the UI"""
@@ -396,7 +395,7 @@ class AACFile(APEv2File):
             super()._save(filename, metadata)
         elif config.setting['remove_ape_from_aac']:
             try:
-                mutagen.apev2.delete(encode_filename(filename))
+                mutagen.apev2.delete(filename)
             except BaseException:
                 log.exception("Error removing APEv2 tags from %s", filename)
 

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -43,7 +43,6 @@ from picard.coverart.utils import types_from_id3
 from picard.file import File
 from picard.formats.mutagenext import delall_ci
 from picard.metadata import Metadata
-from picard.util import encode_filename
 
 
 def unpack_image(data):
@@ -209,7 +208,7 @@ class ASFFile(File):
         log.debug("Loading file %r", filename)
         config = get_config()
         self.__casemap = {}
-        file = ASF(encode_filename(filename))
+        file = ASF(filename)
         metadata = Metadata()
         if not file.tags:
             return metadata
@@ -263,7 +262,7 @@ class ASFFile(File):
     def _save(self, filename, metadata):
         log.debug("Saving file %r", filename)
         config = get_config()
-        file = ASF(encode_filename(filename))
+        file = ASF(filename)
         tags = file.tags
         if not tags:
             return

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -524,8 +524,6 @@ class ID3File(File):
         """Save metadata to the file."""
         log.debug("Saving file %r", filename)
 
-        # TODO: check _get_tags vs encode_filename(), not sure if we can pass it directly using
-        # encoded_filename below
         tags = self._get_tags(filename)
         config = get_config()
         self._initialize_tags_for_saving(tags, config)

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -71,7 +71,6 @@ from picard.tags import (
     parse_subtag,
 )
 from picard.util import (
-    encode_filename,
     sanitize_date,
 )
 
@@ -334,7 +333,7 @@ class ID3File(File):
     def _init_load(self, filename):
         """Initialize loading process and return necessary parameters."""
         self.__casemap = {}
-        file = self._get_file(encode_filename(filename))
+        file = self._get_file(filename)
         tags = file.tags or {}
         config = get_config()
 
@@ -590,12 +589,11 @@ class ID3File(File):
         self._save_people_frames(tags, people_frames)
         self._remove_deleted_tags(tags, metadata, config_params)
 
-        encoded_filename = encode_filename(filename)
-        self._save_tags(tags, encoded_filename)
+        self._save_tags(tags, filename)
 
         if self._IsMP3 and config.setting['remove_ape_from_mp3']:
             try:
-                mutagen.apev2.delete(encoded_filename)
+                mutagen.apev2.delete(filename)
             except BaseException:
                 pass
 
@@ -636,7 +634,7 @@ class ID3File(File):
 
     def _get_tags(self, filename):
         try:
-            return compatid3.CompatID3(encode_filename(filename))
+            return compatid3.CompatID3(filename)
         except mutagen.id3.ID3NoHeaderError:
             return compatid3.CompatID3()
 

--- a/picard/formats/midi.py
+++ b/picard/formats/midi.py
@@ -25,7 +25,6 @@ from mutagen.smf import SMF
 from picard import log
 from picard.file import File
 from picard.metadata import Metadata
-from picard.util import encode_filename
 
 
 class MIDIFile(File):
@@ -36,7 +35,7 @@ class MIDIFile(File):
     def _load(self, filename):
         log.debug("Loading file %r", filename)
         metadata = Metadata()
-        file = self._File(encode_filename(filename))
+        file = self._File(filename)
         self._info(metadata, file)
         return metadata
 

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -48,7 +48,6 @@ from picard.coverart.image import (
 from picard.file import File
 from picard.formats.mutagenext import delall_ci
 from picard.metadata import Metadata
-from picard.util import encode_filename
 
 
 def _add_text_values_to_metadata(metadata, name, values):
@@ -182,7 +181,7 @@ class MP4File(File):
     def _load(self, filename):
         log.debug("Loading file %r", filename)
         self.__casemap = {}
-        file = MP4(encode_filename(filename))
+        file = MP4(filename)
         tags = file.tags or {}
         metadata = Metadata()
         for name, values in tags.items():
@@ -257,7 +256,7 @@ class MP4File(File):
     def _save(self, filename, metadata):
         log.debug("Saving file %r", filename)
         config = get_config()
-        file = MP4(encode_filename(self.filename))
+        file = MP4(self.filename)
         if file.tags is None:
             file.add_tags()
         tags = file.tags

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -54,10 +54,7 @@ from picard.coverart.utils import types_from_id3
 from picard.file import File
 from picard.i18n import N_
 from picard.metadata import Metadata
-from picard.util import (
-    encode_filename,
-    sanitize_date,
-)
+from picard.util import sanitize_date
 
 
 FLAC_MAX_BLOCK_SIZE = 2**24 - 1  # FLAC block size is limited to a 24 bit integer
@@ -145,7 +142,7 @@ class VCommentFile(File):
         assert self._File, f"_File not defined for {self.__class__.__name__}"
         log.debug("Loading file %r", filename)
         config = get_config()
-        file = self._File(encode_filename(filename))
+        file = self._File(filename)
         file.tags = file.tags or {}
         metadata = Metadata()
         for origname, values in file.tags.items():
@@ -268,7 +265,7 @@ class VCommentFile(File):
         config = get_config()
         is_flac = self._File == mutagen.flac.FLAC
         is_opus = self._File == mutagen.oggopus.OggOpus
-        file = self._File(encode_filename(filename))
+        file = self._File(filename)
         if file.tags is None:
             file.add_tags()
         assert file.tags is not None

--- a/picard/script/serializer.py
+++ b/picard/script/serializer.py
@@ -45,7 +45,10 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
-from picard.util import make_filename_from_title
+from picard.util import (
+    make_filename_from_title,
+    resolve_fs_path,
+)
 
 from picard.ui.util import FileDialog
 
@@ -276,6 +279,7 @@ class ScriptSerializer:
         )
         if not filename:
             return None
+        filename = resolve_fs_path(filename)
         log.debug("Importing script file: %s", filename)
         try:
             with open(filename, 'r', encoding='utf-8') as i_file:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -176,6 +176,7 @@ from picard.util import (
     periodictouch,
     pipe,
     process_events_iter,
+    resolve_filename,
     system_supports_long_paths,
     thread,
     versions,
@@ -1014,6 +1015,7 @@ class Tagger(QtWidgets.QApplication):
         new_files = []
         for filename in filenames:
             filename = normpath(filename)
+            filename = resolve_filename(filename)
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r", filename)
                 continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -175,7 +175,7 @@ from picard.util import (
     periodictouch,
     pipe,
     process_events_iter,
-    resolve_filename,
+    resolve_fs_path,
     system_supports_long_paths,
     thread,
     versions,
@@ -1014,7 +1014,7 @@ class Tagger(QtWidgets.QApplication):
         new_files = []
         for filename in filenames:
             filename = normpath(filename)
-            filename = resolve_filename(filename)
+            filename = resolve_fs_path(filename)
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r", filename)
                 continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1013,8 +1013,8 @@ class Tagger(QtWidgets.QApplication):
         ignore_hidden = config.setting["ignore_hidden_files"]
         new_files = []
         for filename in filenames:
-            filename = normpath(filename)
             filename = resolve_fs_path(filename)
+            filename = normpath(filename)
             if ignore_hidden and is_hidden(filename):
                 log.debug("File ignored (hidden): %r", filename)
                 continue

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -168,7 +168,6 @@ from picard.track import (
 from picard.util import (
     check_io_encoding,
     cli,
-    encode_filename,
     is_hidden,
     iter_files_from_objects,
     mbid_validate,
@@ -1307,9 +1306,7 @@ class Tagger(QtWidgets.QApplication):
     def run_lookup_cd(self, device):
         disc = Disc()
         self.set_wait_cursor()
-        thread.run_task(
-            partial(disc.read, encode_filename(device)), partial(self._lookup_disc, disc), traceback=log.is_debug()
-        )
+        thread.run_task(partial(disc.read, device), partial(self._lookup_disc, disc), traceback=log.is_debug())
 
     def lookup_discid_from_logfile(self):
         file_chooser = FileDialog(parent=self.window)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -65,6 +65,7 @@ from picard.util import (
     bytes2human,
     imageinfo,
     normpath,
+    resolve_fs_path,
 )
 from picard.util.lrucache import LRUCache
 
@@ -288,7 +289,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 important=True,
             )
         elif url.scheme() == 'file':
-            path = normpath(url.toLocalFile().rstrip("\0"))
+            path = resolve_fs_path(normpath(url.toLocalFile().rstrip("\0")))
             if path and os.path.exists(path):
                 with open(path, 'rb') as f:
                     data = f.read()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -116,6 +116,7 @@ from picard.util import (
     iter_unique,
     open_local_path,
     reconnect,
+    resolve_fs_path,
     restore_method,
     sanitize_filename,
     thread,
@@ -1489,6 +1490,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             ),
         )
         if path:
+            path = resolve_fs_path(path)
             # Initial progress feedback before heavy load
             self.set_statusbar_message(N_('Loading session from "%(path)s" …'), {'path': path})
             try:

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -39,7 +39,10 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
-from picard.util import webbrowser2
+from picard.util import (
+    resolve_fs_path,
+    webbrowser2,
+)
 
 from picard.ui.forms.ui_options_fingerprinting import (
     Ui_FingerprintingOptionsPage,
@@ -137,7 +140,7 @@ class FingerprintingOptionsPage(OptionsPage):
             directory=self.ui.acoustid_fpcalc.text(),
         )
         if path:
-            path = os.path.normpath(path)
+            path = resolve_fs_path(os.path.normpath(path))
             self.ui.acoustid_fpcalc.setText(path)
 
     def acoustid_fpcalc_download(self):

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -43,7 +43,10 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
-from picard.util import open_local_path
+from picard.util import (
+    open_local_path,
+    resolve_fs_path,
+)
 
 from picard.ui.forms.ui_options_maintenance import Ui_MaintenanceOptionsPage
 from picard.ui.options import (
@@ -316,7 +319,7 @@ class MaintenanceOptionsPage(OptionsPage):
             directory=directory,
             filter=self._get_dialog_filetypes(ext),
         )
-        return filename
+        return resolve_fs_path(filename) if filename else filename
 
     def load_backup(self):
         directory = self.get_current_autobackup_dir()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -214,7 +214,7 @@ Translation: Picard will have problems with non-english characters
 """)
 
 
-def resolve_filename(filename: str | bytes | Path) -> str:
+def resolve_fs_path(filename: str | bytes | Path) -> str:
     """Resolve a filename to its actual on-disk representation.
 
     Call this once when a path enters the file handling pipeline. After

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -500,14 +500,13 @@ def translate_from_sortname(name: str, sortname: str) -> str:
     return name
 
 
-def find_existing_path(path: str | bytes) -> str:
-    path = encode_filename(path)
+def find_existing_path(path: str) -> str:
     while path and not os.path.isdir(path):
         head, tail = os.path.split(path)
         if head == path:
             break
         path = head
-    return decode_filename(path)
+    return path
 
 
 def _add_windows_executable_extension(*executables: str) -> tuple[str, ...]:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -233,6 +233,45 @@ def decode_filename(filename: str | bytes) -> str:
         return filename.decode(_io_encoding)
 
 
+def resolve_filename(filename: str | bytes | Path) -> str:
+    """Resolve a filename to its actual on-disk representation.
+
+    Call this once when a path enters the file handling pipeline. After
+    resolution, all downstream code can use the result directly without
+    further normalization or encoding.
+
+    Handles Unicode normalization mismatches (NFC vs NFD) that occur when
+    files are accessed across different OS/filesystem combinations (e.g.
+    macOS SMB client → Linux ext4 server).  See PICARD-3331.
+
+    Args:
+        filename: A file path as str, bytes, or Path.
+
+    Returns:
+        A str path that exists on disk (if any normalization variant matches),
+        or the original path as str if no match is found.
+    """
+    if isinstance(filename, (bytes, bytearray)):
+        filename = os.fsdecode(filename)
+    elif isinstance(filename, Path):
+        filename = str(filename)
+
+    if os.path.exists(filename):
+        return filename
+
+    nfc = unicodedata.normalize('NFC', filename)
+    if nfc != filename and os.path.exists(nfc):
+        log.debug("Resolved filename via NFC normalization: %r", filename)
+        return nfc
+
+    nfd = unicodedata.normalize('NFD', filename)
+    if nfd != filename and os.path.exists(nfd):
+        log.debug("Resolved filename via NFD normalization: %r", filename)
+        return nfd
+
+    return filename
+
+
 def _check_windows_min_version(major: int, build: int) -> bool:
     try:
         v = sys.getwindowsversion()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -214,25 +214,6 @@ Translation: Picard will have problems with non-english characters
 """)
 
 
-def encode_filename(filename: str | bytes) -> str | bytes:
-    """Encode unicode strings to filesystem encoding."""
-    if isinstance(filename, str):
-        if os.path.supports_unicode_filenames and not IS_MACOS:
-            return filename
-        else:
-            return filename.encode(_io_encoding, 'replace')
-    else:
-        return filename
-
-
-def decode_filename(filename: str | bytes) -> str:
-    """Decode strings from filesystem encoding to unicode."""
-    if isinstance(filename, str):
-        return filename
-    else:
-        return filename.decode(_io_encoding)
-
-
 def resolve_filename(filename: str | bytes | Path) -> str:
     """Resolve a filename to its actual on-disk representation.
 

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -122,7 +122,7 @@ def _shorten_to_bytes_length(text: str, length: int) -> str:
     when encoded in the "filesystem encoding".
     """
     assert isinstance(text, str), "This function only works on unicode"
-    raw = text.encode(_io_encoding, 'replace')
+    raw = os.fsencode(text)
     # maybe there's no need to truncate anything
     if len(raw) <= length:
         return text
@@ -137,12 +137,12 @@ def _shorten_to_bytes_length(text: str, length: int) -> str:
         # so ord(char) & 0b11000000 = 0b10000000
         while i > 0 and (raw[i] & 0xC0) == 0x80:
             i -= 1
-        return raw[:i].decode(_io_encoding)
+        return os.fsdecode(raw[:i])
     # finally, a brute force approach
     i = length
     while i > 0:
         try:
-            return raw[:i].decode(_io_encoding)
+            return os.fsdecode(raw[:i])
         except UnicodeDecodeError:
             pass
         i -= 1

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -48,8 +48,6 @@ from picard.util import (
     WIN_MAX_FILEPATH_LEN,
     WIN_MAX_NODE_LEN,
     _io_encoding,
-    decode_filename,
-    encode_filename,
     is_unc_path,
     samefile,
 )
@@ -124,7 +122,7 @@ def _shorten_to_bytes_length(text: str, length: int) -> str:
     when encoded in the "filesystem encoding".
     """
     assert isinstance(text, str), "This function only works on unicode"
-    raw = encode_filename(text)
+    raw = text.encode(_io_encoding, 'replace')
     # maybe there's no need to truncate anything
     if len(raw) <= length:
         return text
@@ -139,12 +137,12 @@ def _shorten_to_bytes_length(text: str, length: int) -> str:
         # so ord(char) & 0b11000000 = 0b10000000
         while i > 0 and (raw[i] & 0xC0) == 0x80:
             i -= 1
-        return decode_filename(raw[:i])
+        return raw[:i].decode(_io_encoding)
     # finally, a brute force approach
     i = length
     while i > 0:
         try:
-            return decode_filename(raw[:i])
+            return raw[:i].decode(_io_encoding)
         except UnicodeDecodeError:
             pass
         i -= 1

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -45,7 +45,6 @@ from picard.coverart.utils import (
 )
 from picard.file import File
 from picard.metadata import Metadata
-from picard.util import encode_filename
 from picard.util.filenaming import WinPathTooLong
 
 
@@ -332,7 +331,7 @@ class CoverArtImageTest(PicardTestCase):
         with TemporaryDirectory() as d:
             image1 = create_image(b'a', types=['back'], support_types=True)
             expected_filename = os.path.join(d, 'back.png')
-            counter_filename = encode_filename(os.path.join(d, 'back'))
+            counter_filename = os.path.join(d, 'back')
             image1.save(d, metadata, counters)
             self.assertTrue(os.path.exists(expected_filename))
             self.assertEqual(len(image1.data), os.path.getsize(expected_filename))
@@ -416,8 +415,8 @@ class CoverArtImageMakeFilenameTest(PicardTestCase):
 
     def compare_paths(self, path1, path2):
         self.assertEqual(
-            encode_filename(os.path.normpath(path1)),
-            encode_filename(os.path.normpath(path2)),
+            os.path.normpath(path1),
+            os.path.normpath(path2),
         )
 
     def test_make_image_filename(self):

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -354,18 +354,8 @@ class ShortenFilenameTest(PicardTestCase):
         with self.assertRaises(ValueError):
             shorten_filename('a' * 11, 10, None)
 
-    @unittest.skipUnless(
-        os.path.supports_unicode_filenames and not IS_MACOS,
-        'for filesystem with Unicode support',
-    )
-    def test_shorten_bytes_fs_unicode_support(self):
-        self.assertEqual('ä' * 10, shorten_filename('ä' * 11, 10, ShortenMode.BYTES))
-
-    @unittest.skipIf(
-        os.path.supports_unicode_filenames and not IS_MACOS,
-        'for filesystem without Unicode support',
-    )
-    def test_shorten_bytes_fs_no_unicode_support(self):
+    def test_shorten_bytes_multibyte(self):
+        # 'ä' is 2 bytes in UTF-8, so 10 bytes fits 5 'ä' characters
         self.assertEqual('ä' * 5, shorten_filename('ä' * 11, 10, ShortenMode.BYTES))
         self.assertEqual('ä' * 2, shorten_filename('ä' * 6, 5, ShortenMode.BYTES))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -765,6 +765,7 @@ class ResolveFsPathTest(PicardTestCase):
             self.assertIsInstance(result, str)
             self.assertEqual(f.name, result)
 
+    @unittest.skipUnless(_io_encoding.lower() == 'utf-8', 'utf-8 only test')
     def test_bytes_existing_file(self):
         """Decodes bytes path and returns str."""
         with NamedTemporaryFile(suffix='.flac') as f:
@@ -808,7 +809,13 @@ class ResolveFsPathTest(PicardTestCase):
             # Try resolving via NFC path
             nfc_path = os.path.join(d, nfc_name)
             result = resolve_fs_path(nfc_path)
-            self.assertTrue(os.path.exists(result))
+            # On byte-exact filesystems (ext4), result is the NFD path.
+            # On normalization-insensitive filesystems (ZFS, APFS), the NFC
+            # path already exists so it's returned unchanged.
+            if os.path.exists(nfc_path):
+                self.assertEqual(nfc_path, result)
+            else:
+                self.assertEqual(nfd_path, result)
 
     @unittest.skipUnless(_io_encoding.lower() == 'utf-8', 'utf-8 only test')
     def test_nfd_resolves_to_nfc_file(self):
@@ -825,13 +832,13 @@ class ResolveFsPathTest(PicardTestCase):
             # Try resolving via NFD path
             nfd_path = os.path.join(d, nfd_name)
             result = resolve_fs_path(nfd_path)
-            self.assertTrue(os.path.exists(result))
-
-    def test_ascii_path_no_normalization_needed(self):
-        """ASCII-only paths are returned unchanged (fast path)."""
-        with NamedTemporaryFile(suffix='.flac', prefix='test_ascii_') as f:
-            result = resolve_fs_path(f.name)
-            self.assertEqual(f.name, result)
+            # On byte-exact filesystems (ext4), result is the NFC path.
+            # On normalization-insensitive filesystems (ZFS, APFS), the NFD
+            # path already exists so it's returned unchanged.
+            if os.path.exists(nfd_path):
+                self.assertEqual(nfd_path, result)
+            else:
+                self.assertEqual(nfc_path, result)
 
 
 class NormpathTest(PicardTestCase):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -84,7 +84,7 @@ from picard.util import (
     normpath,
     parse_date,
     pattern_as_regex,
-    resolve_filename,
+    resolve_fs_path,
     system_supports_long_paths,
     temporary_disconnect,
     titlecase,
@@ -761,14 +761,14 @@ class ResolveFsPathTest(PicardTestCase):
     def test_str_existing_file(self):
         """Returns existing str path unchanged."""
         with NamedTemporaryFile(suffix='.flac') as f:
-            result = resolve_filename(f.name)
+            result = resolve_fs_path(f.name)
             self.assertIsInstance(result, str)
             self.assertEqual(f.name, result)
 
     def test_bytes_existing_file(self):
         """Decodes bytes path and returns str."""
         with NamedTemporaryFile(suffix='.flac') as f:
-            result = resolve_filename(f.name.encode('utf-8'))
+            result = resolve_fs_path(f.name.encode('utf-8'))
             self.assertIsInstance(result, str)
             self.assertEqual(f.name, result)
 
@@ -777,19 +777,19 @@ class ResolveFsPathTest(PicardTestCase):
         import pathlib
 
         with NamedTemporaryFile(suffix='.flac') as f:
-            result = resolve_filename(pathlib.Path(f.name))
+            result = resolve_fs_path(pathlib.Path(f.name))
             self.assertIsInstance(result, str)
             self.assertEqual(f.name, result)
 
     def test_nonexistent_returns_str(self):
         """Non-existent path is returned as str without error."""
-        result = resolve_filename('/nonexistent/path/file.flac')
+        result = resolve_fs_path('/nonexistent/path/file.flac')
         self.assertIsInstance(result, str)
         self.assertEqual('/nonexistent/path/file.flac', result)
 
     def test_nonexistent_bytes_returns_str(self):
         """Non-existent bytes path is decoded and returned as str."""
-        result = resolve_filename(b'/nonexistent/path/file.flac')
+        result = resolve_fs_path(b'/nonexistent/path/file.flac')
         self.assertIsInstance(result, str)
         self.assertEqual('/nonexistent/path/file.flac', result)
 
@@ -807,7 +807,7 @@ class ResolveFsPathTest(PicardTestCase):
                 f.write('test')
             # Try resolving via NFC path
             nfc_path = os.path.join(d, nfc_name)
-            result = resolve_filename(nfc_path)
+            result = resolve_fs_path(nfc_path)
             self.assertTrue(os.path.exists(result))
 
     @unittest.skipUnless(_io_encoding.lower() == 'utf-8', 'utf-8 only test')
@@ -824,13 +824,13 @@ class ResolveFsPathTest(PicardTestCase):
                 f.write('test')
             # Try resolving via NFD path
             nfd_path = os.path.join(d, nfd_name)
-            result = resolve_filename(nfd_path)
+            result = resolve_fs_path(nfd_path)
             self.assertTrue(os.path.exists(result))
 
     def test_ascii_path_no_normalization_needed(self):
         """ASCII-only paths are returned unchanged (fast path)."""
         with NamedTemporaryFile(suffix='.flac', prefix='test_ascii_') as f:
-            result = resolve_filename(f.name)
+            result = resolve_fs_path(f.name)
             self.assertEqual(f.name, result)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -69,10 +69,8 @@ from picard.util import (
     album_artist_from_path,
     any_exception_isinstance,
     build_qurl,
-    decode_filename,
     detect as charset_detect,
     detect_file_encoding,
-    encode_filename,
     encoded_queryargs,
     extract_year_from_date,
     get_url,
@@ -759,41 +757,7 @@ class BuildQUrlTest(PicardTestCase):
         self.assertEqual(expected, result)
 
 
-class EncodeFilenameTest(PicardTestCase):
-    def test_encode_fs_unicode_support(self):
-        path = '/some/file-ä.ext'
-        with patch('os.path.supports_unicode_filenames', True):
-            with patch('picard.util.IS_MACOS', False):
-                self.assertEqual(path, encode_filename(path))
-
-    def test_encode_fs_no_unicode_support(self):
-        path = '/some/file-ä.ext'
-        with patch('os.path.supports_unicode_filenames', False):
-            with patch('picard.util._io_encoding', 'latin-1') as _io_encoding:
-                self.assertEqual(path.encode(_io_encoding), encode_filename(path))
-
-    def test_encode_path_as_bytes(self):
-        path = '/some/file-ä.ext'.encode('latin-1')
-        self.assertEqual(path, encode_filename(path))
-
-
-class DecodeFilenameTest(PicardTestCase):
-    def test_decode_string(self):
-        path = '/some/file-ä.ext'
-        self.assertEqual(path, decode_filename(path))
-
-    def test_decode_bytes(self):
-        path = '/some/file-ä.ext'
-        self.assertEqual(path, decode_filename(path.encode(_io_encoding)))
-
-    def test_decode_bytes_invalid_encoding(self):
-        path = '/some/file-ä.ext'.encode('latin-1')
-        with patch('picard.util._io_encoding', 'utf-8'):
-            with self.assertRaises(UnicodeDecodeError):
-                decode_filename(path)
-
-
-class ResolveFilenameTest(PicardTestCase):
+class ResolveFsPathTest(PicardTestCase):
     def test_str_existing_file(self):
         """Returns existing str path unchanged."""
         with NamedTemporaryFile(suffix='.flac') as f:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -40,6 +40,7 @@ from datetime import (
 import os
 import re
 import subprocess  # nosec: B404
+import tempfile
 from tempfile import NamedTemporaryFile
 import unittest
 from unittest.mock import (
@@ -85,6 +86,7 @@ from picard.util import (
     normpath,
     parse_date,
     pattern_as_regex,
+    resolve_filename,
     system_supports_long_paths,
     temporary_disconnect,
     titlecase,
@@ -789,6 +791,83 @@ class DecodeFilenameTest(PicardTestCase):
         with patch('picard.util._io_encoding', 'utf-8'):
             with self.assertRaises(UnicodeDecodeError):
                 decode_filename(path)
+
+
+class ResolveFilenameTest(PicardTestCase):
+    def test_str_existing_file(self):
+        """Returns existing str path unchanged."""
+        with NamedTemporaryFile(suffix='.flac') as f:
+            result = resolve_filename(f.name)
+            self.assertIsInstance(result, str)
+            self.assertEqual(f.name, result)
+
+    def test_bytes_existing_file(self):
+        """Decodes bytes path and returns str."""
+        with NamedTemporaryFile(suffix='.flac') as f:
+            result = resolve_filename(f.name.encode('utf-8'))
+            self.assertIsInstance(result, str)
+            self.assertEqual(f.name, result)
+
+    def test_path_existing_file(self):
+        """Converts Path to str."""
+        import pathlib
+
+        with NamedTemporaryFile(suffix='.flac') as f:
+            result = resolve_filename(pathlib.Path(f.name))
+            self.assertIsInstance(result, str)
+            self.assertEqual(f.name, result)
+
+    def test_nonexistent_returns_str(self):
+        """Non-existent path is returned as str without error."""
+        result = resolve_filename('/nonexistent/path/file.flac')
+        self.assertIsInstance(result, str)
+        self.assertEqual('/nonexistent/path/file.flac', result)
+
+    def test_nonexistent_bytes_returns_str(self):
+        """Non-existent bytes path is decoded and returned as str."""
+        result = resolve_filename(b'/nonexistent/path/file.flac')
+        self.assertIsInstance(result, str)
+        self.assertEqual('/nonexistent/path/file.flac', result)
+
+    @unittest.skipUnless(_io_encoding.lower() == 'utf-8', 'utf-8 only test')
+    def test_nfc_resolves_to_nfd_file(self):
+        """NFC path resolves to existing NFD file on byte-exact filesystem."""
+        import unicodedata
+
+        nfc_name = 'Voilà.flac'
+        nfd_name = unicodedata.normalize('NFD', nfc_name)
+        with tempfile.TemporaryDirectory() as d:
+            # Create file with NFD name
+            nfd_path = os.path.join(d, nfd_name)
+            with open(nfd_path, 'w') as f:
+                f.write('test')
+            # Try resolving via NFC path
+            nfc_path = os.path.join(d, nfc_name)
+            result = resolve_filename(nfc_path)
+            self.assertTrue(os.path.exists(result))
+
+    @unittest.skipUnless(_io_encoding.lower() == 'utf-8', 'utf-8 only test')
+    def test_nfd_resolves_to_nfc_file(self):
+        """NFD path resolves to existing NFC file on byte-exact filesystem."""
+        import unicodedata
+
+        nfc_name = 'Voilà.flac'
+        nfd_name = unicodedata.normalize('NFD', nfc_name)
+        with tempfile.TemporaryDirectory() as d:
+            # Create file with NFC name
+            nfc_path = os.path.join(d, nfc_name)
+            with open(nfc_path, 'w') as f:
+                f.write('test')
+            # Try resolving via NFD path
+            nfd_path = os.path.join(d, nfd_name)
+            result = resolve_filename(nfd_path)
+            self.assertTrue(os.path.exists(result))
+
+    def test_ascii_path_no_normalization_needed(self):
+        """ASCII-only paths are returned unchanged (fast path)."""
+        with NamedTemporaryFile(suffix='.flac', prefix='test_ascii_') as f:
+            result = resolve_filename(f.name)
+            self.assertEqual(f.name, result)
 
 
 class NormpathTest(PicardTestCase):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Replace `encode_filename()` with `resolve_fs_path()` — a new function that resolves file paths against the filesystem using Unicode NFC/NFD normalization fallback. This fixes the `MutagenError: [Errno 2] No such file or directory` when saving files with accented characters on byte-exact filesystems (macOS → SMB → Linux ext4).

## Problem

* JIRA ticket: PICARD-3331 (also related: PICARD-644, PICARD-2055)

On macOS, `encode_filename()` always converted file paths from Python `str` to `bytes` before passing them to Mutagen. When files reside on a byte-exact filesystem (e.g. SMB mount backed by Linux ext4), and the stored filename uses a different Unicode normalization (NFC vs NFD) than what the filesystem has, the bytes don't match and the file cannot be found.

Example: A file stored as NFD `Franc\xcc\xa7oise` (decomposed ç) on the server fails to open when Picard produces NFC bytes `Fran\xc3\xa7oise` (composed ç).

This also affects Linux where `os.path.supports_unicode_filenames` is `False`, causing `encode_filename` to return bytes there as well.

## Solution

1. **Add `resolve_fs_path(filename: str | bytes | Path) -> str`** — resolves a path against the filesystem, trying NFC and NFD normalization alternatives if the file isn't found. Zero overhead in the common case (file exists → immediate return).

2. **Call `resolve_fs_path` at external path entry points** — where paths come from Qt (drag & drop, file dialogs, URLs) or CLI arguments. Called once before `normpath`. Also called after file save/rename to ensure `self.filename` matches the on-disk representation.

3. **Remove `encode_filename()` from all format handlers** — Mutagen receives `str` paths directly, which the OS handles correctly on all platforms.

4. **Remove `encode_filename()` and `decode_filename()`** entirely — they have no remaining callers. The root cause of the bug (forcing bytes) is eliminated.

5. **Fix `_shorten_to_bytes_length`** — uses `os.fsencode()` / `os.fsdecode()` for byte-length calculation.

### Convention established

- `resolve_fs_path()` is called **once** when a path enters the pipeline from an external source (Qt dialogs, drag & drop, CLI). Not needed for paths from `os.scandir`/`os.listdir` or files we just created.
- All downstream code (format handlers, stat calls, cover art) receives an already-resolved `str`
- No more `str` → `bytes` → `str` round-trips for file I/O

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Analysis, reproduction, implementation, and tests were developed with AI assistance (Kiro CLI). Design decisions were made collaboratively with the maintainer.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other: This is a draft — needs testing on macOS with actual SMB mounts to confirm the fix works end-to-end in the real scenario.
