### PR TITLE
Fixes for plugin options and option profiles

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -381,6 +381,8 @@ class ProfileConfigSection(ConfigSection):
             return False
         pkey = self._profile_key(name)
         is_override = self._is_settings_override_active()
+        if isinstance(value, Enum):
+            value = value.value
         for profile_id in self._get_active_profile_ids():
             settings = all_settings.get(profile_id)
             if settings and pkey in settings:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1016,6 +1016,7 @@ class PluginApi:
         self._set_class_name_and_title(provider_class)
         if getattr(provider_class, 'OPTIONS', None):
             provider_class.OPTIONS.api = self  # type: ignore[attr-defined]
+            provider_class.OPTIONS.OPTION_SECTION = self._api_config.section_name
         return register_cover_art_provider(provider_class)
 
     def register_cover_art_filter(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3332, PICARD-3333
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This fixes two distinct, but related options. I tried to enable `in_profile` for the `use_cdart` option of https://git.sr.ht/~phw/picard-plugin-fanarttv

This had two issues:

1.  PICARD-3332: The option is an enum. In setting the underlying `value` (str or int) of the enum value is stored, but in profile the actual enum value got stored. Which causes Qt to store it as a QVariant with a reference to the enum type. This causes issues restoring the data when the plugin is unavailable. Which it isn't early during start.
2. PICARD-3333: The plugin registers a `CoverArtProvider`, which brings it's own `OptionPage`. This did not have `.OPTION_SECTION` set, which causes registering the option highlights to fail.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- In profiles, store the base value for enum types.
- PluginAPI sets `OPTION_SECTION` also for cover art option pages



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
