### PR TITLE
PICARD-3334: Fix track title translation

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -98,7 +98,6 @@ _ARTIST_REL_TYPES = {
 _TRACK_TO_METADATA = {
     'number': '~musicbrainz_tracknumber',
     'position': 'tracknumber',
-    'title': 'title',
 }
 
 _MEDIUM_TO_METADATA = {
@@ -110,7 +109,6 @@ _MEDIUM_TO_METADATA = {
 _RECORDING_TO_METADATA = {
     'disambiguation': '~recordingcomment',
     'first-release-date': '~recording_firstreleasedate',
-    'title': 'title',
 }
 
 _RELEASE_TO_METADATA = {
@@ -761,16 +759,11 @@ def _node_skip_empty_iter(node: Node) -> Iterator[tuple[str, Any]]:
 
 def track_to_metadata(node: Node, track: 'Track') -> None:
     m = track.metadata
-    recording_to_metadata(node['recording'], m, track)
-    config = get_config()
+    recording_to_metadata(node['recording'], m, track, node.get('title'))
     m.add_unique('musicbrainz_trackid', node['id'])
     # overwrite with data we have on the track
     for key, value in _node_skip_empty_iter(node):
-        if key == 'title':
-            # If translating track titles, keep the title potentially set from recording aliases
-            if not config.setting['translate_track_titles']:
-                m['title'] = value
-        elif key in _TRACK_TO_METADATA:
+        if key in _TRACK_TO_METADATA:
             m[_TRACK_TO_METADATA[key]] = value
         elif key == 'length' and value:
             m.length = value
@@ -780,7 +773,9 @@ def track_to_metadata(node: Node, track: 'Track') -> None:
         m['~length'] = format_time(m.length)
 
 
-def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = None) -> None:
+def recording_to_metadata(
+    node: Node, m: 'Metadata', track: 'Track | None' = None, track_title: str | None = None
+) -> None:
     m.length = 0
     m.add_unique('musicbrainz_recordingid', node['id'])
     config = get_config()
@@ -806,14 +801,19 @@ def recording_to_metadata(node: Node, m: 'Metadata', track: 'Track | None' = Non
         elif key == 'video' and value:
             m['~video'] = '1'
     add_genres_from_node(node, track)
-    # Translate track title from recording aliases if enabled, unless script exception applies
+    # Translate recording title from recording aliases if enabled, unless script exception applies
+    recording_title = node.get('title')
     if config.setting['translate_track_titles']:
-        if not _should_skip_translation_due_to_scripts(node.get('title'), config=config):
-            alias = _find_localized_alias_name(node.get('aliases'), config.setting['translation_locales'])
-            if alias:
-                m['title'] = alias.name
-    if m['title']:
-        m['~recordingtitle'] = m['title']
+        alias = _find_localized_alias_name(node.get('aliases'), config.setting['translation_locales'])
+        if alias:
+            if not _should_skip_translation_due_to_scripts(recording_title, config=config):
+                recording_title = alias.name
+            if track_title and not _should_skip_translation_due_to_scripts(track_title, config=config):
+                track_title = alias.name
+
+    m['title'] = track_title or recording_title
+    if recording_title:
+        m['~recordingtitle'] = recording_title
     if m.length:
         m['~length'] = format_time(m.length)
 

--- a/test/test_mbjson_translations.py
+++ b/test/test_mbjson_translations.py
@@ -300,6 +300,99 @@ def test_release_to_metadata_translation_toggle(
 
 
 @pytest.mark.parametrize('toggle', [False, True])
+def test_track_to_metadata_translation_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+    config: Any,
+    mock_get_config: Callable[[], Any],
+    toggle: bool,
+) -> None:
+    config.setting['translate_track_titles'] = toggle
+    config.setting['translation_locales'] = ['en']
+    config.setting['translate_artist_names_script_exception'] = False
+
+    node = {
+        'id': 'track-1',
+        'title': 'Track Title',
+        'recording': {
+            'id': 'rec-1',
+            'title': '蜷局',
+            'aliases': [
+                {'locale': 'en', 'name': 'Recording Title EN', 'sort-name': 'Recording Title EN', 'primary': True},
+            ],
+        },
+    }
+    m = Metadata()
+    t = Track('1')
+    t.metadata = m
+    mbjson.track_to_metadata(node, track=t)
+
+    if toggle:
+        assert m['title'] == 'Recording Title EN'
+    else:
+        assert m['title'] == 'Track Title'
+
+
+@pytest.mark.parametrize('toggle', [False, True])
+def test_track_to_metadata_translation_honor_script_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    config: Any,
+    mock_get_config: Callable[[], Any],
+    toggle: bool,
+) -> None:
+    config.setting['translate_track_titles'] = True
+    config.setting['translation_locales'] = ['en']
+    config.setting['translate_artist_names_script_exception'] = toggle
+    monkeypatch.setattr(mbjson, '_should_skip_translation_due_to_scripts', lambda _text, config=None: toggle)
+
+    node = {
+        'id': 'track-1',
+        'title': 'Track Title',
+        'recording': {
+            'id': 'rec-1',
+            'title': '蜷局',
+            'aliases': [
+                {'locale': 'en', 'name': 'Recording Title EN', 'sort-name': 'Recording Title EN', 'primary': True},
+            ],
+        },
+    }
+    m = Metadata()
+    t = Track('1')
+    t.metadata = m
+    mbjson.track_to_metadata(node, track=t)
+
+    if toggle:
+        assert m['title'] == 'Track Title'
+    else:
+        assert m['title'] == 'Recording Title EN'
+
+
+def test_track_to_metadata_translation_do_not_use_recording_title_as_translation(
+    monkeypatch: pytest.MonkeyPatch,
+    config: Any,
+    mock_get_config: Callable[[], Any],
+) -> None:
+    config.setting['translate_track_titles'] = True
+    config.setting['translation_locales'] = ['en']
+    config.setting['translate_artist_names_script_exception'] = False
+
+    node = {
+        'id': 'track-1',
+        'title': 'Track Title',
+        'recording': {
+            'id': 'rec-1',
+            'title': 'Recording Title',
+            'aliases': [],  # no aliases, should fall use track title
+        },
+    }
+    m = Metadata()
+    t = Track('1')
+    t.metadata = m
+    mbjson.track_to_metadata(node, track=t)
+
+    assert m['title'] == 'Track Title'
+
+
+@pytest.mark.parametrize('toggle', [False, True])
 def test_recording_to_metadata_translation_toggle(
     monkeypatch: pytest.MonkeyPatch,
     config: Any,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3334
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

With enabled track title translation track titles where always replaced by the recording title, even if the track title matched script exceptions.



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Optionally pass the track title to `recording_to_metadata`. If given, it will be used as metadata 'title', unless translations are enabled and there is no script exception and there is a suitable translation.

Recording title gets used and translated separately. It's set as `~recordingtitle` or used if there is no track_title given (standalone recordings).

Added tests for the cases that fail without the patch. No existing test captured this case, but all existing tests still pass.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
