### PR TITLE
Columns util cleanup

### DIFF
--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -65,7 +65,6 @@ from picard.ui.itemviews.custom_columns.providers import LazyHeaderIconProvider
 from picard.ui.itemviews.custom_columns.sorting_adapters import NumericSortAdapter
 from picard.ui.itemviews.custom_columns.utils import (
     parse_bitrate,
-    parse_file_size,
     parse_time_format,
 )
 from picard.ui.itemviews.match_quality_column import MatchQualityProvider
@@ -183,7 +182,6 @@ def create_common_columns() -> tuple[Column, ...]:
     size_col = make_numeric_field_column(
         N_("Size"),
         '~filesize',
-        parse_file_size,
         align=ColumnAlign.RIGHT,
         column_group=ColumnGroup.FILE,
     )

--- a/picard/ui/itemviews/columns.py
+++ b/picard/ui/itemviews/columns.py
@@ -55,18 +55,16 @@ from picard.ui.columns import (
     Columns,
     ColumnSortType,
 )
-from picard.ui.itemviews.custom_columns import (
+from picard.ui.itemviews.custom_columns.factory import (
     make_delegate_column,
+    make_duration_field_column,
     make_field_column,
+    make_icon_header_column,
     make_numeric_field_column,
 )
-from picard.ui.itemviews.custom_columns.factory import make_icon_header_column
 from picard.ui.itemviews.custom_columns.providers import LazyHeaderIconProvider
 from picard.ui.itemviews.custom_columns.sorting_adapters import NumericSortAdapter
-from picard.ui.itemviews.custom_columns.utils import (
-    parse_bitrate,
-    parse_time_format,
-)
+from picard.ui.itemviews.custom_columns.utils import parse_bitrate
 from picard.ui.itemviews.match_quality_column import MatchQualityProvider
 
 
@@ -136,12 +134,10 @@ def create_common_columns() -> tuple[Column, ...]:
     )
 
     # Length with numeric sort key from metadata.length
-    length_col = make_numeric_field_column(
+    length_col = make_duration_field_column(
         N_("Length"),
         '~length',
-        parse_time_format,
         width=50,
-        align=ColumnAlign.RIGHT,
         is_default=True,
         column_group=ColumnGroup.TRACK,
     )

--- a/picard/ui/itemviews/custom_columns/factory.py
+++ b/picard/ui/itemviews/custom_columns/factory.py
@@ -49,7 +49,10 @@ from picard.ui.itemviews.custom_columns.providers import (
     TransformProvider,
 )
 from picard.ui.itemviews.custom_columns.script_provider import ChainedValueProvider
-from picard.ui.itemviews.custom_columns.sorting_adapters import NumericSortAdapter
+from picard.ui.itemviews.custom_columns.sorting_adapters import (
+    MetadataDurationSortAdapter,
+    NumericSortAdapter,
+)
 
 
 def _infer_sort_type(provider: ColumnValueProvider, sort_type: ColumnSortType | None) -> ColumnSortType:
@@ -222,6 +225,46 @@ def make_numeric_field_column(
         always_visible=always_visible,
         sort_type=ColumnSortType.SORTKEY,
         status_icon=status_icon,
+        is_default=is_default,
+        column_group=column_group,
+    )
+
+
+def make_duration_field_column(
+    title: str,
+    key: str,
+    *,
+    width: int | None = None,
+    is_default: bool = False,
+    column_group: ColumnGroup | None = None,
+) -> CustomColumn:
+    """Create a field column for metadata length sorting.
+
+    Parameters
+    ----------
+    title : str
+        Display title of the column.
+    key : str
+        Internal key used to identify the column and field source.
+    width : int | None, optional
+        Fixed width in pixels. If ``None``, uses default behavior.
+    is_default : bool, default ``False``
+        If ``True``, marks this column as visible by default.
+
+    Returns
+    -------
+    CustomColumn
+        The configured duration field column with proper sorting.
+    """
+    base_provider = FieldReferenceProvider(key)
+    numeric_provider = MetadataDurationSortAdapter(base_provider)
+    return _create_custom_column(
+        title,
+        key,
+        numeric_provider,
+        width=width,
+        align=ColumnAlign.RIGHT,
+        sort_type=ColumnSortType.SORTKEY,
         is_default=is_default,
         column_group=column_group,
     )

--- a/picard/ui/itemviews/custom_columns/sorting_adapters.py
+++ b/picard/ui/itemviews/custom_columns/sorting_adapters.py
@@ -102,7 +102,7 @@ class NumericSortAdapter(_AdapterBase):
 
     def __init__(self, base: ColumnValueProvider, parser: Callable[[str], float] | None = None):
         super().__init__(base)
-        self._parser = parser or (lambda s: float(s))
+        self._parser = parser or float
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         parser_name = getattr(self._parser, "__name__", repr(self._parser))

--- a/picard/ui/itemviews/custom_columns/sorting_adapters.py
+++ b/picard/ui/itemviews/custom_columns/sorting_adapters.py
@@ -98,7 +98,10 @@ class CasefoldSortAdapter(_AdapterBase):
 
 
 class NumericSortAdapter(_AdapterBase):
-    """Provide numeric sort using a parser (default: float) on evaluated value."""
+    """Provide numeric sort using a parser (default: float) on value.
+    Sorting will happen on the raw metadata value, if set. Otherwise falls back
+    to base provider evaluate.
+    """
 
     def __init__(self, base: ColumnValueProvider, parser: Callable[[str], float] | None = None):
         super().__init__(base)
@@ -115,7 +118,12 @@ class NumericSortAdapter(_AdapterBase):
         - (0, number) when the value parses as numeric (numbers first)
         - (1, natural_key) when non-numeric (fallback, sorted naturally)
         """
-        value_str: str = self._base.evaluate(obj) or ""
+        value_str = ""
+        if key := getattr(self._base, 'key', None):
+            if metadata := getattr(obj, 'metadata', None):
+                value_str = metadata[key]
+        if not value_str:
+            value_str = self._base.evaluate(obj) or ""
         try:
             parsed_value = self._parser(value_str)
         except (ValueError, TypeError):

--- a/picard/ui/itemviews/custom_columns/sorting_adapters.py
+++ b/picard/ui/itemviews/custom_columns/sorting_adapters.py
@@ -124,6 +124,22 @@ class NumericSortAdapter(_AdapterBase):
             return (0, parsed_value)
 
 
+class MetadataDurationSortAdapter(NumericSortAdapter):
+    """Sort items by their metadata.length (audio duration).
+
+    Fall back to numeric sort adapter of the field value.
+    """
+
+    def sort_key(self, obj: Item) -> Comparable:
+        """Return length-based sort key for item."""
+        metadata = getattr(obj, 'metadata', None)
+        if metadata:
+            # Return a tuple for consistency with NumericSortAdapter
+            return (0, metadata.length)
+        else:
+            return super().sort_key(obj)
+
+
 class LengthSortAdapter(_AdapterBase):
     """Provide sort by string length of evaluated value."""
 

--- a/picard/ui/itemviews/custom_columns/utils.py
+++ b/picard/ui/itemviews/custom_columns/utils.py
@@ -54,43 +54,6 @@ def parse_time_format(time_str: str) -> float:
         raise ValueError(f"Invalid time format: {time_str}")
 
 
-def parse_file_size(size_str: str) -> float:
-    """Parse file size format (e.g., '1.0 MB', '1.0 MiB') to bytes.
-
-    Parameters
-    ----------
-    size_str : str
-        File size string with optional unit (B, KB, MB, GB, TB).
-
-    Returns
-    -------
-    float
-        Size in bytes.
-
-    Raises
-    ------
-    ValueError
-        If the size format is invalid.
-    """
-    if not size_str:
-        return 0.0
-    # Remove any parentheses content like "(1.0 MiB)"
-    size_str = size_str.split('(')[0].strip()
-    size_str = size_str.upper()
-
-    # Extract number and unit
-    match = re.match(r'^([\d.]+)\s*([KMGT]?B?)$', size_str)
-    if not match:
-        raise ValueError(f"Invalid size format: {size_str}")
-
-    number, unit = match.groups()
-    number = float(number)
-
-    # Convert to bytes
-    multipliers = {'B': 1, 'KB': 1024, 'MB': 1024**2, 'GB': 1024**3, 'TB': 1024**4}
-    return number * multipliers.get(unit, 1)
-
-
 def parse_bitrate(bitrate_str: str) -> float:
     """Parse bitrate format (e.g., '320 kbps', '128 kbps') to kbps.
 

--- a/picard/ui/itemviews/custom_columns/utils.py
+++ b/picard/ui/itemviews/custom_columns/utils.py
@@ -23,37 +23,6 @@
 import re
 
 
-def parse_time_format(time_str: str) -> float:
-    """Parse time format (e.g., '3:00', '1:02:59') to seconds.
-
-    Parameters
-    ----------
-    time_str : str
-        Time string in format MM:SS or HH:MM:SS.
-
-    Returns
-    -------
-    float
-        Time in seconds.
-
-    Raises
-    ------
-    ValueError
-        If the time format is invalid.
-    """
-    if not time_str or time_str == "?:??":
-        return 0.0
-    parts = time_str.split(':')
-    if len(parts) == 2:  # MM:SS
-        minutes, seconds = map(float, parts)
-        return minutes * 60 + seconds
-    elif len(parts) == 3:  # HH:MM:SS
-        hours, minutes, seconds = map(float, parts)
-        return hours * 3600 + minutes * 60 + seconds
-    else:
-        raise ValueError(f"Invalid time format: {time_str}")
-
-
 def parse_bitrate(bitrate_str: str) -> float:
     """Parse bitrate format (e.g., '320 kbps', '128 kbps') to kbps.
 

--- a/test/test_custom_columns_sorting_adapters.py
+++ b/test/test_custom_columns_sorting_adapters.py
@@ -20,6 +20,7 @@
 
 from collections.abc import Callable
 import dataclasses
+from unittest.mock import MagicMock
 
 from picard.const.sys import IS_WIN
 from picard.i18n import setup_i18n
@@ -43,6 +44,11 @@ from picard.ui.itemviews.custom_columns import (
     NumericSortAdapter,
     make_callable_column,
 )
+from picard.ui.itemviews.custom_columns.protocols import ColumnValueProvider
+from picard.ui.itemviews.custom_columns.sorting_adapters import (
+    MetadataDurationSortAdapter,
+    _AdapterBase,
+)
 
 
 @dataclasses.dataclass
@@ -50,7 +56,7 @@ class _ValueItem:
     value: str
 
 
-def _build_sorted_column(adapter_factory: Callable[[object], object]) -> CustomColumn:
+def _build_sorted_column(adapter_factory: type[_AdapterBase] | Callable[[object], ColumnValueProvider]) -> CustomColumn:
     base_col = make_callable_column(
         title="Value",
         key="test_value_key",
@@ -69,7 +75,9 @@ def _build_sorted_column(adapter_factory: Callable[[object], object]) -> CustomC
     )
 
 
-def _sorted_values(adapter_factory: Callable[[object], object], values: list[str]) -> list[str]:
+def _sorted_values(
+    adapter_factory: type[_AdapterBase] | Callable[[object], ColumnValueProvider], values: list[str]
+) -> list[str]:
     col = _build_sorted_column(adapter_factory)
     items = [_ValueItem(v) for v in values]
     # type: ignore[operator]
@@ -118,6 +126,22 @@ def test_numeric_sort_adapter_custom_parser() -> None:
     # "x" is non-numeric and sorts after numeric values
     expected = ["1:00", "2:05", "3:30", "x"]
     result = _sorted_values(adapter, values)
+    assert result == expected
+
+
+def test_metadata_duration_sort_adapter() -> None:
+    obj1 = MagicMock()
+    obj1.metadata.length = 100
+    obj2 = MagicMock()
+    obj2.metadata.length = 200
+    # Mixin an object without metadata to test mixed content sorting
+    obj3 = _ValueItem(value='300')
+    obj4 = MagicMock()
+    obj4.metadata.length = 400
+    values = [obj2, obj1, obj4, obj3]
+    expected = [obj1, obj2, obj3, obj4]
+    col = _build_sorted_column(MetadataDurationSortAdapter)
+    result = sorted(values, key=lambda it: col.sortkey(it))
     assert result == expected
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This is a refactoring for the length and filesize custom columns sorting. Both used custom sort key parsing with some wrong assumptions.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The `NumericSortAdapter` would always call `_base.evaluate` to get a columns value. This returns the display value. For numeric values this usually involves a call to formatting the numeric value, which `NumericSortAdapter` then has to parse again.

Hence `NumericSortAdapter` got changed to use the raw value from metadata first, if available. While always being a string, the value is usually already numeric, hence the default parser of using `float` might already work.

The filesize column used a helper `parse_file_size`. This had several issues:
- The column `~filesize` already contains the size in bytes. So the default conversion in `NumericSortAdapter` of using `float` already is enough
- `parse_file_size` did not handle `MiB` (as used by bytes2human and hence by the display value) nor localized decimal separators. Hence it always failed.
- The fallback of using natural number sorting already works reasonable well

Hence remove the `parse_file_size` helper and rely on parsing the raw metadata value as float.

The length column again used unnecessary parsing. Specifically the length aka audio duration has an efficient way of sorting, as `Metadata.length` already is an integer value of the duration in milliseconds. Add a new `MetadataDurationSortAdapter` with tests.R


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
