### PR TITLE
PICARD-3336: Make the about window non-modal

### DIFF
--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -42,6 +42,8 @@ from picard.ui.forms.ui_aboutdialog import Ui_AboutDialog
 
 
 class AboutDialog(PicardDialog, SingletonDialog):
+    modality = QtCore.Qt.WindowModality.NonModal
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3336
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The about dialog is shown on macOS as a modal sheet, with no window controls and hence no UI element to close it.

I did some research how other applications on different platforms handle about / info dialogs, see https://tickets.metabrainz.org/browse/PICARD-3336?focusedId=81318&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-81318. This varies highly from application to application, there is not really a "right way" to do it.

But very common is the model where the about dialog is non-modal, so other windows still can get focus. But also the about dialog is shown on top, so it does not easily get lost. This is typical for all KDE applications and several other Linux applications, but also many applications on Windows.

On macOS the about dialogs of Apple's own software is also non-modal, but allows getting hidden by the main window (even thought macOS makes it rather difficult to reach hidden windows).

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make the about dialog `WindowModality.NonModal`, but still set a parent. This makes the Window on most platforms stay on top, but not prevent other windows to gain focus. This matches behavior of many other applications across different platforms (see above).

It also fixes the dialog on macOS being shown as a sheet without a window close button.

<img width="1775" height="1013" alt="grafik" src="https://github.com/user-attachments/assets/342d2a61-1774-484b-b32a-ddef0bad0eb5" />

On macOS the dialog does not stay on top, though. But again this matches behavior of Apple's own software, so I think is fine.

This also is now the same behavior as on Picard 2.x again.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
