### PR TITLE
Remove entry point for old picard-plugins CLI, update PluginCLI to use new args structure directly

### DIFF
--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -906,13 +906,10 @@ picard-cli plugins check-blacklist --uuid a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d
 # Refresh registry cache
 picard-cli plugins refresh-registry
 
-# Combine with other commands (recommended when switching registries)
-picard-cli plugins refresh-registry --browse
-picard-cli plugins refresh-registry --install view-script-variables
-
 # After changing PICARD_PLUGIN_REGISTRY_URL
 export PICARD_PLUGIN_REGISTRY_URL="https://example.com/custom-registry.toml"
-picard-cli plugins refresh-registry --browse
+picard-cli plugins refresh-registry
+picard-cli plugins browse
 ```
 
 **Use cases:**
@@ -921,7 +918,7 @@ picard-cli plugins refresh-registry --browse
 - Forcing immediate update of registry data
 - Clearing stale cache
 
-**Note:** The registry is cached locally. Use `--refresh-registry` to bypass the cache and fetch the latest version immediately. It can be combined with any other command that uses the registry (--browse, --search, --install, etc.).
+**Note:** The registry is cached locally. Use `refresh-registry` to bypass the cache and fetch the latest version immediately. Run it before other registry commands (`browse`, `search`, `install`) if you need fresh data.
 
 ---
 

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -322,7 +322,7 @@ picard-cli plugins install view-script-variables
 picard-cli plugins install listenbrainz discogs acoustid
 ```
 
-**Note:** The registry ID is shown in `--browse` and `--search` output. It's different from the internal plugin_id that gets created after installation.
+**Note:** The registry ID is shown in `browse` and `search` output. It's different from the internal plugin_id that gets created after installation.
 
 **Versioning behavior:**
 - If plugin has `versioning_scheme` in registry and no `--ref` specified:
@@ -410,19 +410,19 @@ picard-cli plugins update view-script-variables
 # Update one plugin (using plugin ID)
 picard-cli plugins update listenbrainz_a1b2c3d4-e5f6-...
 
-# Update to specific ref
-picard-cli plugins update view-script-variables --ref v2.0.0
-
 # Update all plugins
 picard-cli plugins update --all
 
 # Check for updates without installing
 picard-cli plugins check-updates
+
+# To switch to a specific ref, use switch-ref
+picard-cli plugins switch-ref view-script-variables v2.0.0
 ```
 
 **Note on registry ID:** If you installed a plugin from the registry (e.g., `picard-cli plugins install view-script-variables`), you can use the short registry ID for updates instead of the long plugin_id with UUID suffix.
 
-**Note on `--check-updates`:** This command checks for updates within the currently installed git ref (branch/tag). If a plugin is installed from a specific branch (e.g., `dev`), it will only check for updates on that branch, not on other branches like `main`. To switch to a different branch, use `--switch-ref` instead.
+**Note on `check-updates`:** This command checks for updates within the currently installed git ref (branch/tag). If a plugin is installed from a specific branch (e.g., `dev`), it will only check for updates on that branch, not on other branches like `main`. To switch to a different branch, use `switch-ref` instead.
 
 **Versioning behavior:**
 - If plugin has `versioning_scheme` in registry:
@@ -443,7 +443,7 @@ picard-cli plugins update my-plugin
 # Updates to latest commit on current branch
 ```
 
-**Note on tags:** If a plugin is installed with a version tag (e.g., `v1.0.0`, `1.2.3`), `--update` will automatically find and switch to the latest version tag. Non-version tags (e.g., `stable`, `latest`) are treated as immutable.
+**Note on tags:** If a plugin is installed with a version tag (e.g., `v1.0.0`, `1.2.3`), `update` will automatically find and switch to the latest version tag. Non-version tags (e.g., `stable`, `latest`) are treated as immutable.
 
 ```bash
 # Plugin installed with version tag v1.0.0
@@ -461,7 +461,7 @@ picard-cli plugins switch-ref myplugin v2.0.0
 picard-cli plugins switch-ref myplugin main
 ```
 
-**Note on commits:** If a plugin was installed with a specific commit hash, `--update` will report "Already up to date" because commit hashes are immutable. Use `--switch-ref` to change to a different commit, tag, or branch.
+**Note on commits:** If a plugin was installed with a specific commit hash, `update` will report "Already up to date" because commit hashes are immutable. Use `switch-ref` to change to a different commit, tag, or branch.
 
 **Example:**
 ```bash
@@ -550,16 +550,15 @@ Last Updated: 2025-11-20 14:15:00
 - `picard-cli plugins refs <name|url>` - List available refs for plugin
 - `picard-cli plugins install <url> --ref <ref>` - Install specific ref
 - `picard-cli plugins switch-ref <name> <ref>` - Switch to different ref
-- `picard-cli plugins update <name> --ref <ref>` - Update to specific ref
 - `picard-cli plugins info <name>` - Show available refs for registered plugins
 
 **Description:** Manage git branches, tags, and commits
 
 **Understanding refs:**
-- **Branches** (e.g., `main`, `dev`): Mutable - `--update` pulls latest commits
-- **Version tags** (e.g., `v1.0.0`, `2.1.3`): `--update` automatically finds and switches to latest version tag
-- **Non-version tags** (e.g., `stable`, `latest`): Immutable - use `--switch-ref` to change
-- **Commits** (e.g., `abc1234`): Immutable - cannot be updated, use `--switch-ref` to change
+- **Branches** (e.g., `main`, `dev`): Mutable - `update` pulls latest commits
+- **Version tags** (e.g., `v1.0.0`, `2.1.3`): `update` automatically finds and switches to latest version tag
+- **Non-version tags** (e.g., `stable`, `latest`): Immutable - use `switch-ref` to change
+- **Commits** (e.g., `abc1234`): Immutable - cannot be updated, use `switch-ref` to change
 
 **Registry refs:**
 Plugins in the official registry can specify multiple refs (branches/tags) that are available for installation:
@@ -572,9 +571,9 @@ When installing a registered plugin without specifying `--ref`, Picard automatic
 - Picard 3.x users get the `picard-v3` branch
 - Picard 4.x users get the `main` branch
 
-**When to use `--update` vs `--switch-ref`:**
-- Use `--update` to get the latest version (works for both branches and tags)
-- Use `--switch-ref` to change to a different branch/tag, or to switch from commit to branch/tag
+**When to use `update` vs `switch-ref`:**
+- Use `update` to get the latest version (works for both branches and tags)
+- Use `switch-ref` to change to a different branch/tag, or to switch from commit to branch/tag
 
 **Examples:**
 ```bash
@@ -610,7 +609,7 @@ picard-cli plugins switch-ref myplugin v1.1.0
 
 **Ref validation:**
 
-When using `--switch-ref`, Picard validates the ref exists:
+When using `switch-ref`, Picard validates the ref exists:
 
 - **With `versioning_scheme`**: Validates tag matches pattern and exists
   ```bash

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -111,9 +111,9 @@ picard-cli plugins manifest ~/dev/my-plugin    # From local directory
 picard-cli plugins browse
 picard-cli plugins search "cover art"
 
-# Disable colored output
-picard-cli plugins list --no-color
-picard-cli plugins validate ~/dev/my-plugin --no-color
+# Disable colored output (--no-color and --yes are top-level picard-cli options)
+picard-cli --no-color plugins list
+picard-cli --no-color plugins validate ~/dev/my-plugin
 ```
 
 ---
@@ -151,13 +151,12 @@ picard -e "PLUGIN_ENABLE listenbrainz"
 ### Help Output
 
 ```text
-usage: picard-cli plugins [-h] [--yes] [--locale LOCALE] <command> ...
+usage: picard-cli plugins [-h] [--locale LOCALE] <command> ...
 
 Install, update, enable, and manage Picard plugins.
 
 options:
   -h, --help        show this help message and exit
-  --yes, -y         skip confirmation prompts
   --locale LOCALE   locale for displaying plugin info (e.g., 'fr', 'de', 'en')
 
 plugin commands:

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -1253,12 +1253,7 @@ Clean with: picard-cli plugins clean-config <uuid>
 | 0 | Success |
 | 1 | General error |
 | 2 | Plugin not found |
-| 3 | Network error |
-| 4 | Git error |
-| 5 | Blacklisted plugin |
-| 6 | Incompatible API version |
-| 7 | Invalid manifest |
-| 8 | User cancelled |
+| 130 | Operation cancelled (SIGINT) |
 
 ---
 

--- a/picard/cli/plugins.py
+++ b/picard/cli/plugins.py
@@ -201,118 +201,6 @@ def register_subcommand(subparsers):
     plugins_parser.set_defaults(run_command=_run_plugins)
 
 
-def _adapt_args(args):
-    """Adapt subcommand-style args to the format PluginCLI expects.
-
-    Translates the verb-based namespace into the flat --flag namespace
-    that PluginCLI.run() dispatches on.
-    """
-    verb = getattr(args, 'verb', None)
-
-    # Map verb-style args to the flat PluginCLI args namespace
-    # These are the attributes that PluginCLI.run() checks via if/elif
-    args.list = verb == 'list'
-    args.install = getattr(args, 'source', None) if verb == 'install' else None
-    args.remove = getattr(args, 'plugin', None) if verb in ('remove', 'uninstall') else None
-    args.enable = getattr(args, 'plugin', None) if verb == 'enable' else None
-    args.disable = getattr(args, 'plugin', None) if verb == 'disable' else None
-
-    # Update: either specific plugins or --all
-    if verb == 'update':
-        plugins = getattr(args, 'plugin', None)
-        if getattr(args, 'update_all', False) or not plugins:
-            args.update = None
-            args.update_all = True
-        else:
-            args.update = plugins
-            args.update_all = False
-    else:
-        args.update = None
-        args.update_all = getattr(args, 'update_all', False)
-
-    args.info = getattr(args, 'plugin', None) if verb == 'info' else None
-    args.list_refs = getattr(args, 'plugin', None) if verb == 'refs' else None
-
-    if verb == 'switch-ref':
-        args.switch_ref = [args.plugin, args.ref]
-    else:
-        args.switch_ref = None
-
-    args.browse = verb == 'browse'
-    args.search = getattr(args, 'query', None) if verb == 'search' else None
-
-    if verb == 'check-blacklist':
-        args.check_blacklist = getattr(args, 'url', '') or ''
-    else:
-        args.check_blacklist = None
-
-    args.refresh_registry = verb == 'refresh-registry'
-    args.check_updates = verb == 'check-updates'
-
-    if verb == 'validate':
-        args.validate = getattr(args, 'source', None)
-    else:
-        args.validate = None
-
-    if verb == 'manifest':
-        args.manifest = getattr(args, 'target', '')
-    else:
-        # Use sentinel to distinguish "not given" from "given with no arg"
-        args.manifest = None
-
-    if verb == 'init':
-        args.init = getattr(args, 'name', '')
-    else:
-        args.init = None
-
-    if verb == 'clean-config':
-        args.clean_config = getattr(args, 'plugin', '')
-    else:
-        args.clean_config = None
-
-    # Ensure common attributes exist
-    if not hasattr(args, 'ref'):
-        args.ref = None
-    if not hasattr(args, 'reinstall'):
-        args.reinstall = False
-    if not hasattr(args, 'force_blacklisted'):
-        args.force_blacklisted = False
-    if not hasattr(args, 'trust_community'):
-        args.trust_community = False
-    if not hasattr(args, 'trust'):
-        args.trust = None
-    if not hasattr(args, 'category'):
-        args.category = None
-    if not hasattr(args, 'purge'):
-        args.purge = False
-    if not hasattr(args, 'target_dir'):
-        args.target_dir = None
-    if not hasattr(args, 'parent_dir'):
-        args.parent_dir = None
-    if not hasattr(args, 'author'):
-        args.author = None
-    if not hasattr(args, 'with_translations'):
-        args.with_translations = False
-    if not hasattr(args, 'no_git'):
-        args.no_git = False
-    if not hasattr(args, 'no_commit'):
-        args.no_commit = False
-    if not hasattr(args, 'source_locale'):
-        args.source_locale = DEFAULT_SOURCE_LOCALE
-    if not hasattr(args, 'locale'):
-        args.locale = 'en'
-    if not hasattr(args, 'uuid'):
-        args.uuid = None
-    if not hasattr(args, 'yes'):
-        args.yes = False
-    if not hasattr(args, 'no_color'):
-        args.no_color = False
-
-    args.remote_commands_help = False
-
-    return args
-
-
 def _run_plugins(args):
     """Initialize and run the plugin CLI with subcommand args."""
     from picard.cli._bootstrap import (
@@ -344,9 +232,6 @@ def _run_plugins(args):
     # Bootstrap app, logging, and debug options
     app = init_cli(args, with_webservice=True)  # noqa: F841
 
-    # Adapt args for PluginCLI
-    adapted_args = _adapt_args(args)
-
     # Create plugin manager
     manager = PluginManager()
     manager.add_directory(USER_PLUGIN_DIR, primary=True)
@@ -354,7 +239,7 @@ def _run_plugins(args):
     # Create output
     output = PluginOutput(color=False if is_color_disabled(args) else None)
 
-    return PluginCLI(manager, adapted_args, output=output).run()
+    return PluginCLI(manager, args, output=output).run()
 
 
 def _argparse():

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -133,10 +133,9 @@ Option('persist', 'cli_plugins_init', {})
 class PluginCLI(BaseCLI):
     """Command line interface for managing plugins."""
 
-    def __init__(self, manager, args, output=None, parser=None):
+    def __init__(self, manager, args, output=None):
         super().__init__(args, output or PluginOutput())
         self._manager = manager
-        self._parser = parser
 
     def _ensure_registry(self):
         """Ensure registry is loaded, fetching from remote if needed.
@@ -267,73 +266,55 @@ class PluginCLI(BaseCLI):
 
     def _dispatch(self):
         """Dispatch to the appropriate plugin command."""
-        # Handle refresh-registry first if specified
-        if getattr(self._args, 'refresh_registry', None):
-            result = self._cmd_refresh_registry()
-            # If refresh failed, return error
-            if result != ExitCode.SUCCESS:
-                return result
-            # Continue to execute other command if specified
+        cmd = self._args.verb
 
-        # Validate that --ref is only used with install or validate commands
-        ref = getattr(self._args, 'ref', None)
-        if ref:
-            valid_with_ref = self._args.install or (hasattr(self._args, 'validate') and self._args.validate)
-            if not valid_with_ref:
-                self._out.error('--ref can only be used with install or validate')
-                return ExitCode.ERROR
-
-        if self._args.list:
+        if cmd == 'list':
             return self._cmd_list()
-        elif self._args.info:
-            return self._cmd_info(self._args.info)
-        elif self._args.list_refs:
-            return self._cmd_list_refs(self._args.list_refs)
-        elif self._args.enable:
-            return self._cmd_enable(self._args.enable)
-        elif self._args.disable:
-            return self._cmd_disable(self._args.disable)
-        elif self._args.install:
-            return self._cmd_install(self._args.install)
-        elif self._args.remove:
-            return self._cmd_remove(self._args.remove)
-        elif self._args.update:
-            return self._cmd_update(self._args.update)
-        elif self._args.update_all:
-            return self._cmd_update_all()
-        elif self._args.check_updates:
+        elif cmd == 'info':
+            return self._cmd_info(self._args.plugin)
+        elif cmd == 'refs':
+            return self._cmd_list_refs(self._args.plugin)
+        elif cmd == 'enable':
+            return self._cmd_enable(self._args.plugin)
+        elif cmd == 'disable':
+            return self._cmd_disable(self._args.plugin)
+        elif cmd == 'install':
+            return self._cmd_install(self._args.source)
+        elif cmd == 'remove':
+            return self._cmd_remove(self._args.plugin)
+        elif cmd == 'update':
+            if self._args.update_all or not self._args.plugin:
+                return self._cmd_update_all()
+            else:
+                return self._cmd_update(self._args.plugin)
+        elif cmd == 'check-updates':
             return self._cmd_check_updates()
-        elif getattr(self._args, 'browse', None):
+        elif cmd == 'browse':
             return self._cmd_browse()
-        elif getattr(self._args, 'search', None):
-            return self._cmd_search(self._args.search)
-        elif getattr(self._args, 'check_blacklist', None) is not None or getattr(self._args, 'uuid', None):
-            url = getattr(self._args, 'check_blacklist', None) or None
-            uuid = getattr(self._args, 'uuid', None)
+        elif cmd == 'search':
+            return self._cmd_search(self._args.query)
+        elif cmd == 'check-blacklist':
+            url = self._args.url or None
+            uuid = self._args.uuid
             if not url and not uuid:
                 self._out.error('check-blacklist requires a URL or --uuid (or both)')
                 return ExitCode.ERROR
             return self._cmd_check_blacklist(url, uuid)
-        elif getattr(self._args, 'refresh_registry', None):
-            # Already handled at the start, just return success
-            return ExitCode.SUCCESS
-        elif getattr(self._args, 'switch_ref', None):
-            return self._cmd_switch_ref(self._args.switch_ref[0], self._args.switch_ref[1])
-        elif hasattr(self._args, 'clean_config') and self._args.clean_config is not None:
-            return self._cmd_clean_config(self._args.clean_config)
-        elif getattr(self._args, 'validate', None):
-            return self._cmd_validate(self._args.validate, ref)
-        elif hasattr(self._args, 'manifest') and self._args.manifest is not None:
-            return self._cmd_manifest(self._args.manifest)
-        elif hasattr(self._args, 'init') and self._args.init is not None:
-            return self._cmd_init(self._args.init)
+        elif cmd == 'refresh-registry':
+            return self._cmd_refresh_registry()
+        elif cmd == 'switch-ref':
+            return self._cmd_switch_ref(self._args.plugin, self._args.ref)
+        elif cmd == 'clean-config':
+            return self._cmd_clean_config(self._args.plugin)
+        elif cmd == 'validate':
+            return self._cmd_validate(self._args.source, self._args.ref)
+        elif cmd == 'manifest':
+            return self._cmd_manifest(self._args.target)
+        elif cmd == 'init':
+            return self._cmd_init(self._args.name)
         else:
-            if self._parser:
-                self._parser.print_help()
-                return ExitCode.SUCCESS
-            else:
-                self._out.error('No action specified')
-                return ExitCode.ERROR
+            self._out.error('No action specified')
+            return ExitCode.ERROR
 
     def _get_registry_plugin_version(self, plugin_data):
         """Get latest version tag for a registry plugin.

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -19,27 +19,17 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import argparse
 from datetime import datetime
-import logging
-import os
 from pathlib import Path
 import shutil
 
 # Additional imports for CLI operations
-import sys
 import tempfile
 import traceback
 from types import SimpleNamespace
 
 from PyQt6 import QtCore
 
-from picard import (
-    PICARD_APP_NAME,
-    PICARD_FANCY_VERSION_STR,
-    PICARD_ORG_NAME,
-    log,
-)
 from picard.cli.base import (
     BaseCLI,
     ExitCode,
@@ -47,19 +37,12 @@ from picard.cli.base import (
 from picard.config import (
     Option,
     get_config,
-    setup_config,
 )
-from picard.const import USER_PLUGIN_DIR
-from picard.debug_opts import DebugOpt
-from picard.git.factory import (
-    git_backend,
-    has_git_backend,
-)
+from picard.git.factory import git_backend
 from picard.git.utils import (
     check_local_repo_dirty,
     get_local_repository_path,
 )
-from picard.options import init_options
 from picard.plugin3.constants import (
     CATEGORIES as VALID_CATEGORIES,
     DEFAULT_SOURCE_LOCALE,
@@ -78,7 +61,6 @@ from picard.plugin3.manager import (
     PluginBlacklistedError,
     PluginCommitPinnedError,
     PluginDirtyError,
-    PluginManager,
     PluginManifestError,
     PluginManifestInvalidError,
     PluginManifestNotFoundError,
@@ -108,11 +90,6 @@ from picard.plugin3.registry import (
     RegistryParseError,
 )
 from picard.plugin3.validator import MAX_NAME_LENGTH
-from picard.util import (
-    cli,
-    versions,
-)
-from picard.webservice import WebService
 
 
 def get_display_locale(args):
@@ -2149,196 +2126,3 @@ class PluginCLI(BaseCLI):
             'unregistered': '🔓',
         }
         return badges.get(trust_level, '?')
-
-
-def process_cmdline_args():
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
-
-    # Picard specific arguments
-    parser.add_argument('-c', '--config-file', action='store', default=None, help="location of the configuration file")
-    parser.add_argument('--debug', action='store_true', help="enable debug-level logging")
-    parser.add_argument('-v', '--version', action='store_true', help="display version information and exit")
-    parser.add_argument('-V', '--long-version', action='store_true', help="display long version information and exit")
-    parser.add_argument(
-        '--debug-opts',
-        action='store',
-        default=None,
-        nargs='?',
-        const='',
-        metavar='OPTIONS',
-        help="comma-separated list of debug options. Use --debug-opts without value to list available options",
-    )
-    parser.add_argument('--yes', '-y', action='store_true', help="skip confirmation prompts")
-    parser.add_argument('--no-color', action='store_true', help="disable colored output")
-
-    group_management = parser.add_argument_group("Plugin Management")
-    group_management.add_argument('-l', '--list', action='store_true', help="list all installed plugins with details")
-    group_management.add_argument(
-        '-i', '--install', nargs='+', metavar='URL', help="install plugin(s) from git URL(s) or by name"
-    )
-    group_management.add_argument('-r', '--remove', nargs='+', metavar='PLUGIN', help="uninstall plugin(s)")
-    group_management.add_argument('-e', '--enable', nargs='+', metavar='PLUGIN', help="enable plugin(s)")
-    group_management.add_argument('-d', '--disable', nargs='+', metavar='PLUGIN', help="disable plugin(s)")
-    group_management.add_argument(
-        '-u', '--update', nargs='+', metavar='PLUGIN', help="update plugin(s) to latest version"
-    )
-    group_management.add_argument('--update-all', action='store_true', help="update all installed plugins")
-    group_management.add_argument('--info', metavar='PLUGIN', help="show detailed plugin information")
-    group_management.add_argument('--validate', metavar='URL', help="validate plugin MANIFEST from git URL")
-    group_management.add_argument(
-        '--clean-config',
-        nargs='?',
-        const='',
-        metavar='PLUGIN',
-        help="delete saved options for a plugin (list orphaned configs if no plugin specified)",
-    )
-    group_management.add_argument(
-        '--manifest', nargs='?', const='', metavar='PLUGIN', help="show MANIFEST.toml (template if no argument)"
-    )
-    group_management.add_argument(
-        '--init', nargs='?', const='', metavar='NAME', help="create a new plugin project (interactive if no name given)"
-    )
-
-    group_git = parser.add_argument_group("Git Version Control")
-    group_git.add_argument('--list-refs', metavar='PLUGIN', help="list available git refs (branches/tags) for plugin")
-    group_git.add_argument(
-        '--ref', metavar='REF', help="git ref (branch/tag/commit) to use with --install or --validate"
-    )
-    group_git.add_argument(
-        '--switch-ref', nargs=2, metavar=('PLUGIN', 'REF'), help="switch plugin to different git ref"
-    )
-
-    group_discover = parser.add_argument_group("Plugin Discovery")
-    group_discover.add_argument('--browse', action='store_true', help="browse plugins from registry")
-    group_discover.add_argument('--search', metavar='QUERY', help="search plugins in registry")
-    group_discover.add_argument(
-        '--check-blacklist',
-        nargs='?',
-        const='',
-        metavar='URL',
-        help="check if URL and/or UUID is blacklisted",
-    )
-    group_discover.add_argument('--uuid', metavar='UUID', help="plugin UUID to use with --check-blacklist")
-
-    group_registry = parser.add_argument_group("Registry")
-    group_registry.add_argument(
-        '--refresh-registry', action='store_true', help="force refresh of plugin registry cache"
-    )
-    group_registry.add_argument('--check-updates', action='store_true', help="check for available updates")
-
-    group_advanced = parser.add_argument_group("Advanced Options")
-    group_advanced.add_argument('--reinstall', action='store_true', help="force reinstall when used with --install")
-    group_advanced.add_argument('--force-blacklisted', action='store_true', help="bypass blacklist check (dangerous!)")
-    group_advanced.add_argument('--trust-community', action='store_true', help="skip warnings for community plugins")
-    group_advanced.add_argument('--trust', metavar='LEVEL', help="filter by trust level (official, trusted, community)")
-    group_advanced.add_argument(
-        '--category', metavar='CATEGORY', help="filter by category (metadata, coverart, ui, etc.)"
-    )
-    group_advanced.add_argument('--purge', action='store_true', help="delete plugin saved options on uninstall")
-    group_advanced.add_argument('--target-dir', metavar='DIR', help="override directory name for --init")
-    group_advanced.add_argument(
-        '--parent-dir', metavar='DIR', help="parent directory for --init (default: current directory)"
-    )
-    group_advanced.add_argument('--author', metavar='NAME', help="author name for --init")
-    group_advanced.add_argument(
-        '--with-translations', action='store_true', help="include translation support (locale files and examples)"
-    )
-    group_advanced.add_argument(
-        '--no-git',
-        action='store_true',
-        help="for --init: skip git init; for --install: load git plugin in local mode (no updates/refs)",
-    )
-    group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit")
-    group_advanced.add_argument(
-        '--source-locale',
-        metavar='LOCALE',
-        default=DEFAULT_SOURCE_LOCALE,
-        help=f"source locale for --init with --with-translations (default: {DEFAULT_SOURCE_LOCALE})",
-    )
-    group_advanced.add_argument(
-        '--locale', metavar='LOCALE', default='en', help="locale for displaying plugin info (e.g., 'fr', 'de', 'en')"
-    )
-
-    # Additional information
-    parser.description = "Manage Picard plugins (install, update, enable, disable)"
-    parser.epilog = (
-        "Trust Levels:\n"
-        "  🛡️ official: Reviewed by Picard team (highest trust)\n"
-        "  ✓ trusted: Known authors, not reviewed (high trust)\n"
-        "  ⚠️ community: Other authors, not reviewed (use caution)\n"
-        "  🔓 unregistered: Not in registry (local/unknown source - lowest trust)\n"
-        "\nFor more information, visit: https://picard.musicbrainz.org/docs/plugins/"
-    )
-
-    args = parser.parse_args()
-    args.remote_commands_help = False
-
-    # Handle debug-opts help request
-    if args.debug_opts is not None and not args.debug_opts.strip():
-        DebugOpt.print_help_and_exit()
-
-    return args, parser
-
-
-def minimal_init(config_file=None):
-    """Minimal initialization for CLI commands without GUI.
-
-    Returns a QCoreApplication instance with config initialized.
-    """
-    QtCore.QCoreApplication.setApplicationName(PICARD_APP_NAME)
-    QtCore.QCoreApplication.setOrganizationName(PICARD_ORG_NAME)
-
-    app = QtCore.QCoreApplication(sys.argv)
-
-    init_options()
-    setup_config(app=app, filename=config_file)
-
-    # Initialize WebService for network operations (needed for registry fetching)
-    app.webservice = WebService()
-
-    return app
-
-
-def main():
-    try:
-        if not has_git_backend():
-            cli.print_message_and_exit("git backend not available", status=1)
-    except ImportError as err:
-        cli.print_message_and_exit("failed importing git backend", str(err), status=1)
-
-    cmdline_args, parser = process_cmdline_args()
-
-    app = minimal_init(cmdline_args.config_file)  # noqa: F841 - app must stay alive for QCoreApplication
-
-    if cmdline_args.long_version:
-        cli.print_message_and_exit(versions.as_string())
-    if cmdline_args.version:
-        cli.print_message_and_exit(f"{PICARD_ORG_NAME} {PICARD_APP_NAME} {PICARD_FANCY_VERSION_STR}")
-
-    log.enable_console_handler()
-
-    # Suppress INFO logs for cleaner CLI output unless in debug mode or debug options are enabled
-    if not cmdline_args.debug and not cmdline_args.debug_opts:
-        log.set_verbosity(logging.WARNING)
-    elif cmdline_args.debug or cmdline_args.debug_opts:
-        # Ensure DEBUG level is enabled when requested or debug options are used
-        log.set_verbosity(logging.DEBUG)
-
-    # Initialize debug options for CLI
-    if cmdline_args.debug_opts:
-        DebugOpt.from_string(cmdline_args.debug_opts)
-
-    manager = PluginManager()
-    manager.add_directory(USER_PLUGIN_DIR, primary=True)
-
-    # Create output with color setting from args
-    # None = auto-detect (isatty), False = explicitly disabled
-    no_color = getattr(cmdline_args, 'no_color', False) or 'NO_COLOR' in os.environ
-    output = PluginOutput(color=False if no_color else None)
-
-    exit_code = PluginCLI(manager, cmdline_args, output=output, parser=parser).run()
-    sys.exit(exit_code)
-
-
-if __name__ == "__main__":
-    main()

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -158,30 +158,15 @@ class MockCliArgs(Mock):
     """Mock CLI args with sensible defaults."""
 
     def __init__(self, **kwargs):
+        # Name has special meaning in Mock
+        name = kwargs.get('name', None)
+        if name is not None:
+            del kwargs['name']
         defaults = {
+            'verb': None,
             'ref': None,
-            'list': False,
-            'info': None,
-            'list_refs': None,
-            'enable': None,
-            'disable': None,
-            'install': None,
-            'uninstall': None,
-            'remove': None,
-            'status': None,
-            'update': None,
             'update_all': False,
-            'check_updates': False,
-            'browse': False,
-            'search': None,
-            'check_blacklist': None,
             'uuid': None,
-            'refresh_registry': False,
-            'switch_ref': None,
-            'clean_config': None,
-            'validate': None,
-            'manifest': None,
-            'init': None,
             'target_dir': None,
             'parent_dir': None,
             'author': None,
@@ -196,9 +181,14 @@ class MockCliArgs(Mock):
             'no_git': False,
             'no_commit': False,
             'source_locale': DEFAULT_SOURCE_LOCALE,
+            'query': None,
+            'plugin': None,
+            'source': None,
+            'url': None,
         }
         defaults.update(kwargs)
         super().__init__(**defaults)
+        self.name = name
 
 
 def run_cli(manager, **args_kwargs):

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -106,7 +106,7 @@ class TestPluginCLI(PicardTestCase):
     def test_list_plugins_empty(self):
         """Test listing plugins when none are installed."""
         manager = MockPluginManager(plugins=[])
-        exit_code, stdout, _ = run_cli(manager, list=True)
+        exit_code, stdout, _ = run_cli(manager, verb='list')
 
         self.assertEqual(exit_code, 0)
         self.assertIn('No plugins installed', stdout)
@@ -121,7 +121,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager(plugins=[mock_plugin], _enabled_plugins={test_uuid})
         manager._get_plugin_metadata = Mock(return_value={})
 
-        exit_code, stdout, _ = run_cli(manager, list=True)
+        exit_code, stdout, _ = run_cli(manager, verb='list')
 
         self.assertEqual(exit_code, 0)
         self.assertIn('Example plugin', stdout)
@@ -142,7 +142,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager(plugins=[plugin1, plugin2, plugin3])
         manager._get_plugin_metadata = Mock(return_value={})
 
-        exit_code, stdout, _ = run_cli(manager, list=True)
+        exit_code, stdout, _ = run_cli(manager, verb='list')
 
         self.assertEqual(exit_code, 0)
         # Check that plugins appear in alphabetical order
@@ -157,7 +157,7 @@ class TestPluginCLI(PicardTestCase):
         """Test info command for non-existent plugin."""
         manager = MockPluginManager(plugins=[])
         manager.find_plugin = Mock(return_value=None)
-        exit_code, _, stderr = run_cli(manager, info='nonexistent')
+        exit_code, _, stderr = run_cli(manager, verb='info', plugin='nonexistent')
 
         self.assertEqual(exit_code, 2)
         self.assertIn('not found', stderr)
@@ -193,7 +193,7 @@ class TestPluginCLI(PicardTestCase):
             plugin_dir = create_test_plugin_dir(tmpdir, 'test-plugin', manifest_content, add_git=True)
 
             manager = create_mock_manager_with_manifest_validation()
-            exit_code, stdout, stderr = run_cli(manager, validate=str(plugin_dir))
+            exit_code, stdout, stderr = run_cli(manager, verb='validate', source=str(plugin_dir))
 
             if exit_code != 0:
                 print(f"STDOUT: {stdout}")
@@ -223,13 +223,13 @@ class TestPluginCLI(PicardTestCase):
         manager.check_updates = Mock(return_value={})
         manager.update_all_plugins = Mock(return_value=[])
 
-        # Test --check-updates
-        exit_code, _, _ = run_cli(manager, check_updates=True)
+        # Test check-updates
+        exit_code, _, _ = run_cli(manager, verb='check-updates')
         self.assertEqual(exit_code, 0)
         manager.check_updates.assert_called_once()
 
-        # Test --update-all
-        exit_code, _, _ = run_cli(manager, update_all=True)
+        # Test update --all
+        exit_code, _, _ = run_cli(manager, verb='update', update_all=True)
         self.assertEqual(exit_code, 0)
         manager.update_all_plugins.assert_called_once()
 
@@ -237,7 +237,7 @@ class TestPluginCLI(PicardTestCase):
         """Test update command for non-existent plugin."""
         manager = MockPluginManager(plugins=[])
         manager.find_plugin = Mock(return_value=None)
-        exit_code, _, stderr = run_cli(manager, update=['nonexistent'])
+        exit_code, _, stderr = run_cli(manager, verb='update', plugin='nonexistent')
 
         self.assertEqual(exit_code, 2)
         self.assertIn('not found', stderr)
@@ -262,7 +262,7 @@ class TestPluginCLI(PicardTestCase):
             )
         )
 
-        exit_code, stdout, _ = run_cli(manager, update=['test-plugin'])
+        exit_code, stdout, _ = run_cli(manager, verb='update', plugin=['test-plugin'])
 
         self.assertEqual(exit_code, 0)
         self.assertIn('1.0.0', stdout)
@@ -302,7 +302,7 @@ class TestPluginCLI(PicardTestCase):
                 patch('picard.plugin3.manager.clean.get_config', return_value=test_config),
                 patch('picard.plugin3.cli.get_config', return_value=test_config),
             ):
-                exit_code, stdout, _ = run_cli(manager, clean_config=test_uuid, yes=True)
+                exit_code, stdout, _ = run_cli(manager, verb='clean-config', plugin=test_uuid, yes=True)
 
             self.assertEqual(exit_code, 0)
             self.assertIn('deleted', stdout.lower())
@@ -318,7 +318,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager(plugins=[mock_plugin], enable_plugin=Mock())
         manager.find_plugin = Mock(return_value=mock_plugin)
 
-        exit_code, _, _ = run_cli(manager, enable=['test-plugin'])
+        exit_code, _, _ = run_cli(manager, verb='enable', plugin=['test-plugin'])
 
         self.assertEqual(exit_code, 0)
         manager.enable_plugin.assert_called_once_with(mock_plugin)
@@ -329,7 +329,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager(plugins=[mock_plugin], disable_plugin=Mock())
         manager.find_plugin = Mock(return_value=mock_plugin)
 
-        exit_code, _, _ = run_cli(manager, disable=['test-plugin'])
+        exit_code, _, _ = run_cli(manager, verb='disable', plugin=['test-plugin'])
 
         self.assertEqual(exit_code, 0)
         manager.disable_plugin.assert_called_once_with(mock_plugin)
@@ -340,7 +340,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager(plugins=[mock_plugin])
         manager.check_updates = Mock(side_effect=KeyboardInterrupt())
 
-        exit_code, _, stderr = run_cli(manager, check_updates=True)
+        exit_code, _, stderr = run_cli(manager, verb='check-updates')
 
         self.assertEqual(exit_code, 130)
         self.assertIn('cancelled', stderr.lower())
@@ -369,7 +369,7 @@ class TestPluginCLI(PicardTestCase):
             ),
         ]
 
-        exit_code, _, _ = run_cli(manager, browse=True)
+        exit_code, _, _ = run_cli(manager, verb='browse')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager._registry.list_plugins.assert_called_once_with(category=None, trust_level=None)
@@ -389,7 +389,7 @@ class TestPluginCLI(PicardTestCase):
             ),
         ]
 
-        exit_code, _, _ = run_cli(manager, browse=True, category='metadata', trust='official')
+        exit_code, _, _ = run_cli(manager, verb='browse', category='metadata', trust='official')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager._registry.list_plugins.assert_called_once_with(category='metadata', trust_level='official')
@@ -411,7 +411,7 @@ class TestPluginCLI(PicardTestCase):
             ),
         ]
 
-        exit_code, _, _ = run_cli(manager, search='listen')
+        exit_code, _, _ = run_cli(manager, verb='search', query='listen')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
 
@@ -429,7 +429,7 @@ class TestPluginCLI(PicardTestCase):
         manager._find_plugin_by_url.return_value = None  # Not already installed
         manager.install_plugin.return_value = 'test-plugin'
 
-        exit_code, _, _ = run_cli(manager, install=['test-plugin'])
+        exit_code, _, _ = run_cli(manager, verb='install', source=['test-plugin'])
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager._registry.find_plugin.assert_called_once_with(plugin_id='test-plugin')
@@ -441,7 +441,7 @@ class TestPluginCLI(PicardTestCase):
         manager._registry.find_plugin.return_value = None
         manager._registry.list_plugins.return_value = []
 
-        exit_code, _, stderr = run_cli(manager, install=['nonexistent'])
+        exit_code, _, stderr = run_cli(manager, verb='install', source=['nonexistent'])
 
         self.assertEqual(exit_code, ExitCode.NOT_FOUND)
         self.assertIn('not found in registry', stderr)
@@ -451,7 +451,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager()
         manager._registry.is_blacklisted.return_value = (False, None)
 
-        exit_code, stdout, _ = run_cli(manager, check_blacklist='https://github.com/test/plugin')
+        exit_code, stdout, _ = run_cli(manager, verb='check-blacklist', url='https://github.com/test/plugin')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         self.assertIn('Not blacklisted', stdout)
@@ -462,7 +462,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager()
         manager._registry.is_blacklisted.return_value = (True, 'Security vulnerability')
 
-        exit_code, stdout, stderr = run_cli(manager, check_blacklist='https://github.com/bad/plugin')
+        exit_code, stdout, stderr = run_cli(manager, verb='check-blacklist', url='https://github.com/bad/plugin')
 
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Blacklisted', stderr)
@@ -475,7 +475,8 @@ class TestPluginCLI(PicardTestCase):
 
         exit_code, stdout, stderr = run_cli(
             manager,
-            check_blacklist='https://github.com/test/plugin',
+            verb='check-blacklist',
+            url='https://github.com/test/plugin',
             uuid='blacklisted-uuid-1234',
         )
 
@@ -492,7 +493,7 @@ class TestPluginCLI(PicardTestCase):
 
         exit_code, stdout, stderr = run_cli(
             manager,
-            check_blacklist='',
+            verb='check-blacklist',
             uuid='blacklisted-uuid-1234',
         )
 
@@ -518,7 +519,7 @@ class TestPluginCLI(PicardTestCase):
             ),
         ]
 
-        exit_code, _, _ = run_cli(manager, search='test', category='metadata')
+        exit_code, _, _ = run_cli(manager, verb='search', query='test', category='metadata')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager._registry.list_plugins.assert_called_once_with(category='metadata', trust_level=None)
@@ -528,7 +529,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager()
         manager._registry.list_plugins.return_value = []
 
-        exit_code, _, _ = run_cli(manager, search='test', trust='official')
+        exit_code, _, _ = run_cli(manager, verb='search', query='test', trust='official')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager._registry.list_plugins.assert_called_once_with(category=None, trust_level='official')
@@ -549,7 +550,7 @@ class TestPluginCLI(PicardTestCase):
             'registry_url': 'https://test.example.com/registry.toml',
         }
 
-        exit_code, stdout, _ = run_cli(manager, refresh_registry=True)
+        exit_code, stdout, _ = run_cli(manager, verb='refresh-registry')
 
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         manager.refresh_registry_and_caches.assert_called_once()
@@ -562,7 +563,7 @@ class TestPluginCLI(PicardTestCase):
         manager = MockPluginManager()
         manager.refresh_registry_and_caches.side_effect = Exception('Network error')
 
-        exit_code, _, stderr = run_cli(manager, refresh_registry=True)
+        exit_code, _, stderr = run_cli(manager, verb='refresh-registry')
 
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Failed to refresh registry', stderr)
@@ -575,7 +576,7 @@ class TestPluginCLI(PicardTestCase):
             'https://test.example.com/registry.toml', Exception('Connection timeout')
         )
 
-        exit_code, _, stderr = run_cli(manager, refresh_registry=True)
+        exit_code, _, stderr = run_cli(manager, verb='refresh-registry')
 
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Failed to fetch registry', stderr)
@@ -589,7 +590,7 @@ class TestPluginCLI(PicardTestCase):
             'https://test.example.com/registry.toml', Exception('Invalid JSON')
         )
 
-        exit_code, _, stderr = run_cli(manager, refresh_registry=True)
+        exit_code, _, stderr = run_cli(manager, verb='refresh-registry')
 
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Failed to parse registry', stderr)
@@ -608,7 +609,7 @@ class TestPluginCLI(PicardTestCase):
         # Mock update_plugin to raise PluginCommitPinnedError
         manager.update_plugin.side_effect = PluginCommitPinnedError('test-plugin', 'abc1234')
 
-        exit_code, stdout, stderr = run_cli(manager, update=['test-plugin'])
+        exit_code, stdout, stderr = run_cli(manager, verb='update', plugin=['test-plugin'])
 
         self.assertEqual(exit_code, 0)
         self.assertIn('pinned to commit', stderr)
@@ -618,93 +619,24 @@ class TestPluginCLI(PicardTestCase):
 
 
 class TestPluginCLIErrors(PicardTestCase):
-    def test_ref_without_install_or_validate(self):
-        """Test --ref without --install or --validate returns error."""
+    def test_no_action(self):
+        """Test no action specified returns error."""
         manager = MockPluginManager()
         args = MockCliArgs()
-        args.ref = 'main'
-        args.install = None
-        args.validate = False
-        args.list = False
+        args.verb = None
 
-        stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
-
-        cli = PluginCLI(manager, args, output=output)
-        result = cli.run()
-
-        self.assertEqual(result, ExitCode.ERROR)
-        self.assertIn('--ref can only be used with install or validate', stderr.getvalue())
-
-    def test_no_action_without_parser(self):
-        """Test no action specified without parser returns error."""
-        manager = MockPluginManager()
-        args = MockCliArgs()
-        args.ref = None
-        args.list = False
-        args.info = None
-        args.status = None
-        args.enable = None
-        args.disable = None
-        args.install = None
-        args.uninstall = None
-        args.update = None
-        args.update_all = False
-        args.check_updates = False
-        args.browse = False
-        args.search = None
-        args.check_blacklist = None
-        args.refresh_registry = False
-        args.switch_ref = None
-        args.clean_config = None
-        args.validate = None
-        args.manifest = None
-
-        cli, stderr = _make_cli(manager, args, parser=None)
+        cli, stderr = _make_cli(manager, args)
         result = cli.run()
 
         self.assertEqual(result, ExitCode.ERROR)
         self.assertIn('No action specified', stderr.getvalue())
 
-    def test_no_action_with_parser(self):
-        """Test no action specified with parser prints help."""
-        manager = MockPluginManager()
-        args = MockCliArgs()
-        args.ref = None
-        args.list = False
-        args.info = None
-        args.status = None
-        args.enable = None
-        args.disable = None
-        args.install = None
-        args.uninstall = None
-        args.update = None
-        args.update_all = False
-        args.check_updates = False
-        args.browse = False
-        args.search = None
-        args.check_blacklist = None
-        args.refresh_registry = False
-        args.switch_ref = None
-        args.clean_config = None
-        args.validate = None
-        args.manifest = None
-
-        parser = Mock()
-        output = PluginOutput(stdout=StringIO(), stderr=StringIO(), color=False)
-
-        cli = PluginCLI(manager, args, output=output, parser=parser)
-        result = cli.run()
-
-        self.assertEqual(result, ExitCode.SUCCESS)
-        parser.print_help.assert_called_once()
-
     def test_keyboard_interrupt(self):
         """Test KeyboardInterrupt returns CANCELLED."""
         manager = MockPluginManager()
         args = MockCliArgs()
+        args.verb = 'list'
         args.ref = None
-        args.list = True
 
         # Make _cmd_list raise KeyboardInterrupt
         cli, stderr = _make_cli(manager, args)
@@ -719,8 +651,8 @@ class TestPluginCLIErrors(PicardTestCase):
         """Test generic exception returns ERROR."""
         manager = MockPluginManager()
         args = MockCliArgs()
+        args.verb = 'list'
         args.ref = None
-        args.list = True
 
         # Make _cmd_list raise exception
         cli, stderr = _make_cli(manager, args)
@@ -1207,14 +1139,18 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_creates_directory(self):
         """--init NAME creates picard-plugin-<slug> directory."""
         target = self.tmpdir / 'picard-plugin-my-cool-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='My Cool Plugin', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='My Cool Plugin', target_dir=str(target)
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue(target.exists())
 
     def test_init_creates_manifest(self):
         """--init creates MANIFEST.toml with correct name."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test Plugin', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test Plugin', target_dir=str(target)
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('name = "Test Plugin"', manifest)
@@ -1223,7 +1159,7 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_creates_init_py(self):
         """--init creates __init__.py with enable/disable stubs."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         init_py = (target / '__init__.py').read_text(encoding='utf-8')
         self.assertIn('def enable(api: PluginApi)', init_py)
@@ -1232,7 +1168,7 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_creates_readme(self):
         """--init creates README.md with plugin name."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='My Plugin', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='My Plugin', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         readme = (target / 'README.md').read_text(encoding='utf-8')
         self.assertIn('# My Plugin', readme)
@@ -1262,7 +1198,7 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_creates_gitignore(self):
         """--init creates .gitignore."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         gitignore = (target / '.gitignore').read_text(encoding='utf-8')
         self.assertIn('__pycache__/', gitignore)
@@ -1270,7 +1206,9 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_with_author(self):
         """--init --author sets authors in MANIFEST."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), author='Jane Doe')
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), author='Jane Doe'
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('authors = ["Jane Doe"]', manifest)
@@ -1279,7 +1217,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --author 'Name <email>' parses name for MANIFEST and email for git."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), author='Jane Doe <jane@example.com>'
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), author='Jane Doe <jane@example.com>'
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
@@ -1289,7 +1227,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --author 'Name <email>' sets report_bugs_to mailto in MANIFEST."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), author='Jane Doe <jane@example.com>'
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), author='Jane Doe <jane@example.com>'
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
@@ -1298,7 +1236,7 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_no_email_has_report_bugs_to_comment(self):
         """--init without email has commented report_bugs_to in MANIFEST."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('# report_bugs_to =', manifest)
@@ -1307,7 +1245,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --category sets categories in MANIFEST."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), category='metadata'
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), category='metadata'
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
@@ -1316,7 +1254,10 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_default_directory_name(self):
         """--init without --target-dir uses picard-plugin-<slug> in cwd."""
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test Plugin', target_dir=str(self.tmpdir / 'picard-plugin-test-plugin')
+            MockPluginManager(),
+            verb='init',
+            name='Test Plugin',
+            target_dir=str(self.tmpdir / 'picard-plugin-test-plugin'),
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((self.tmpdir / 'picard-plugin-test-plugin').exists())
@@ -1326,7 +1267,7 @@ class TestPluginCLIInit(PicardTestCase):
         target = self.tmpdir / 'existing'
         target.mkdir()
         (target / 'somefile').write_text('content')
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.ERROR, exit_code)
         self.assertIn('not empty', stderr)
 
@@ -1334,20 +1275,20 @@ class TestPluginCLIInit(PicardTestCase):
         """--init succeeds if target directory exists but is empty."""
         target = self.tmpdir / 'empty'
         target.mkdir()
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'MANIFEST.toml').exists())
 
     def test_init_no_name_with_yes_fails(self):
         """--init --yes without name fails."""
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', yes=True)
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', yes=True)
         self.assertEqual(ExitCode.ERROR, exit_code)
         self.assertIn('required', stderr)
 
     def test_init_prints_summary(self):
         """--init prints created files summary."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertIn('MANIFEST.toml', stdout)
         self.assertIn('__init__.py', stdout)
@@ -1357,7 +1298,9 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_name_too_long(self):
         """--init fails if name exceeds MAX_NAME_LENGTH."""
         long_name = 'A' * (MAX_NAME_LENGTH + 1)
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init=long_name, target_dir=str(self.tmpdir / 'test'))
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name=long_name, target_dir=str(self.tmpdir / 'test')
+        )
         self.assertEqual(ExitCode.ERROR, exit_code)
         self.assertIn('maximum length', stderr)
 
@@ -1365,7 +1308,9 @@ class TestPluginCLIInit(PicardTestCase):
         """--parent-dir sets the parent directory."""
         parent = self.tmpdir / 'projects'
         parent.mkdir()
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test Plugin', parent_dir=str(parent))
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test Plugin', parent_dir=str(parent)
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((parent / 'picard-plugin-test-plugin').exists())
 
@@ -1374,14 +1319,14 @@ class TestPluginCLIInit(PicardTestCase):
         parent = self.tmpdir / 'projects'
         parent.mkdir()
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', parent_dir=str(parent), target_dir='custom-name'
+            MockPluginManager(), verb='init', name='Test', parent_dir=str(parent), target_dir='custom-name'
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((parent / 'custom-name').exists())
 
     def test_init_empty_slug_no_target_dir_fails(self):
         """--init with a name that produces an empty slug and no --target-dir fails."""
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='!!!')
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='!!!')
         self.assertEqual(ExitCode.ERROR, exit_code)
         self.assertIn('--target-dir', stderr)
 
@@ -1389,7 +1334,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --with-translations adds source_locale and i18n comments to MANIFEST."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), with_translations=True
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
@@ -1401,7 +1346,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --with-translations generates __init__.py with t_ and api.tr usage."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), with_translations=True
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         init_py = (target / '__init__.py').read_text(encoding='utf-8')
@@ -1413,7 +1358,7 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --with-translations creates locale/ directory with source locale file."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), with_translations=True
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'locale').is_dir())
@@ -1424,14 +1369,14 @@ class TestPluginCLIInit(PicardTestCase):
     def test_init_without_i18n_no_locale_dir(self):
         """--init without --with-translations does not create locale/ directory."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertFalse((target / 'locale').exists())
 
     def test_init_without_i18n_no_source_locale(self):
         """--init without --with-translations does not add source_locale to MANIFEST."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertNotIn('source_locale', manifest)
@@ -1440,7 +1385,12 @@ class TestPluginCLIInit(PicardTestCase):
         """--init --with-translations --source-locale creates correct locale file and manifest."""
         target = self.tmpdir / 'test-plugin'
         exit_code, stdout, stderr = run_cli(
-            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True, source_locale='fr'
+            MockPluginManager(),
+            verb='init',
+            name='Test',
+            target_dir=str(target),
+            with_translations=True,
+            source_locale='fr',
         )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
@@ -1498,7 +1448,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
             category='1',
         )
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('name = "My Plugin"', manifest)
@@ -1511,7 +1461,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'picard-plugin-my-plugin'
         inputs = self._init_inputs(name='My Plugin')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'MANIFEST.toml').exists())
 
@@ -1520,7 +1470,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'picard-plugin-my-plugin'
         inputs = self._init_inputs(name='My Plugin', git_initialization='n')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'MANIFEST.toml').exists())
         self.assertFalse((target / '.git').is_dir())
@@ -1529,7 +1479,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         """Interactive mode fails if name is empty."""
         inputs = self._init_inputs(name='')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='')
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init')
         self.assertEqual(ExitCode.ERROR, exit_code)
         self.assertIn('required', stderr)
 
@@ -1538,7 +1488,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'test'
         inputs = self._init_inputs(license='MIT')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('license = "MIT"', manifest)
@@ -1548,7 +1498,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'test'
         inputs = self._init_inputs()
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('license = "GPL-2.0-or-later"', manifest)
@@ -1559,7 +1509,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'test'
         inputs = self._init_inputs(category='invalid')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertNotIn('categories', manifest)
@@ -1569,7 +1519,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'test'
         inputs = self._init_inputs(category='1,3')
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', target_dir=str(target))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertIn('categories = ["metadata", "ui"]', manifest)
@@ -1579,7 +1529,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         target = self.tmpdir / 'picard-plugin-test'
         inputs = self._init_inputs()
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='', parent_dir=str(self.tmpdir))
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', parent_dir=str(self.tmpdir))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / 'MANIFEST.toml').exists())
 
@@ -1588,7 +1538,7 @@ class TestPluginCLIInitInteractive(PicardTestCase):
         custom_target = self.tmpdir / 'custom-dir'
         inputs = self._init_inputs(target_path=str(custom_target))
         with patch('builtins.input', side_effect=inputs):
-            exit_code, stdout, stderr = run_cli(MockPluginManager(), init='')
+            exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init')
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((custom_target / 'MANIFEST.toml').exists())
 
@@ -1608,21 +1558,23 @@ class TestPluginCLIInitGit(PicardTestCase):
     def test_no_git_does_not_create_git_repo(self):
         """--no-git does not create a git repository."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), no_git=True)
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), no_git=True
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertFalse((target / '.git').is_dir())
 
     def test_init_creates_git_repo(self):
         """--init creates a git repository."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / '.git').is_dir())
 
     def test_init_creates_initial_commit(self):
         """--init creates an initial commit with all files."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         repo = get_backend_repo(target)
         # Should have a HEAD pointing to a commit
@@ -1633,14 +1585,14 @@ class TestPluginCLIInitGit(PicardTestCase):
     def test_init_git_message_in_output(self):
         """--init prints git initialization message."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertIn('Git repository initialized', stdout)
 
     def test_init_all_files_committed(self):
         """--init commits all generated files (clean working tree)."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target))
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', name='Test', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         repo = get_backend_repo(target)
         status = repo.get_status()
@@ -1652,7 +1604,9 @@ class TestPluginCLIInitGit(PicardTestCase):
     def test_init_commit_uses_provided_author(self):
         """--init --author uses the provided name for the git commit."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), author='Jane Doe')
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), author='Jane Doe'
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         repo = get_backend_repo(target)
         commit_id = repo.get_head_target()
@@ -1663,7 +1617,9 @@ class TestPluginCLIInitGit(PicardTestCase):
     def test_init_no_commit_skips_initial_commit(self):
         """--init --no-commit creates git repo but no commit."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), no_commit=True)
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), no_commit=True
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertTrue((target / '.git').is_dir())
         repo = get_backend_repo(target)
@@ -1673,7 +1629,9 @@ class TestPluginCLIInitGit(PicardTestCase):
     def test_init_no_commit_output_message(self):
         """--init --no-commit shows 'initialized' without 'initial commit'."""
         target = self.tmpdir / 'test-plugin'
-        exit_code, stdout, stderr = run_cli(MockPluginManager(), init='Test', target_dir=str(target), no_commit=True)
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), verb='init', name='Test', target_dir=str(target), no_commit=True
+        )
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertIn('Git repository initialized', stdout)
         self.assertNotIn('initial commit', stdout)

--- a/test/plugins3/test_cli_integration.py
+++ b/test/plugins3/test_cli_integration.py
@@ -22,8 +22,6 @@ import subprocess
 import sys
 import unittest
 
-from picard.git.factory import has_git_backend
-
 
 class TestCliIntegration(unittest.TestCase):
     """Integration tests that run picard-cli in a subprocess.
@@ -39,5 +37,4 @@ class TestCliIntegration(unittest.TestCase):
             capture_output=True,
             timeout=10,
         )
-        expected_code = 0 if has_git_backend() else 1
-        self.assertEqual(result.returncode, expected_code, msg=result.stderr.decode())
+        self.assertEqual(result.returncode, 0, msg=result.stderr.decode())

--- a/test/plugins3/test_install.py
+++ b/test/plugins3/test_install.py
@@ -194,7 +194,7 @@ class TestPluginInstall(PicardTestCase):
         new_git_ref = GitRef('refs/tags/v1.0.0', ref_type=GitRefType.TAG)
         mock_manager.switch_ref = Mock(return_value=(old_git_ref, new_git_ref, 'abc1234', 'def5678'))
 
-        exit_code, stdout, _ = run_cli(mock_manager, switch_ref=['test-plugin', 'v1.0.0'])
+        exit_code, stdout, _ = run_cli(mock_manager, verb='switch-ref', plugin='test-plugin', ref='v1.0.0')
 
         self.assertEqual(exit_code, 0)
         mock_manager.switch_ref.assert_called_once_with(mock_plugin, 'v1.0.0')
@@ -207,7 +207,7 @@ class TestPluginInstall(PicardTestCase):
         """Test switch-ref for non-existent plugin."""
         mock_manager = MockPluginManager(plugins=[])
         mock_manager.find_plugin = Mock(return_value=None)
-        exit_code, _, stderr = run_cli(mock_manager, switch_ref=['nonexistent', 'v1.0.0'])
+        exit_code, _, stderr = run_cli(mock_manager, verb='switch-ref', plugin='nonexistent', ref='v1.0.0')
 
         self.assertEqual(exit_code, 2)
         self.assertIn('not found', stderr)
@@ -410,7 +410,7 @@ class TestPluginInstall(PicardTestCase):
         mock_manager._registry.get_trust_level = Mock(return_value='unregistered')
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(install=['https://example.com/plugin.git'], yes=True)
+        args = MockCliArgs(verb='install', source=['https://example.com/plugin.git'], yes=True)
 
         stdout = StringIO()
         output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
@@ -435,7 +435,7 @@ class TestPluginInstall(PicardTestCase):
         mock_manager._registry.get_trust_level = Mock(return_value='unregistered')
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(install=['https://example.com/plugin.git'])
+        args = MockCliArgs(verb='install', source=['https://example.com/plugin.git'])
 
         stderr = StringIO()
         output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
@@ -457,7 +457,7 @@ class TestPluginInstall(PicardTestCase):
         mock_manager.uninstall_plugin = Mock()
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(remove=['test-plugin'], yes=True)
+        args = MockCliArgs(verb='remove', plugin=['test-plugin'], yes=True)
 
         stdout = StringIO()
         output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
@@ -485,7 +485,7 @@ class TestPluginInstall(PicardTestCase):
         )
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(update=['test-plugin'])
+        args = MockCliArgs(verb='update', plugin=['test-plugin'])
 
         stdout = StringIO()
         output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
@@ -513,7 +513,7 @@ class TestPluginInstall(PicardTestCase):
         )
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(update=['test-plugin'])
+        args = MockCliArgs(verb='update', plugin=['test-plugin'])
 
         stdout = StringIO()
         output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
@@ -552,7 +552,7 @@ class TestPluginInstall(PicardTestCase):
         )
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(update_all=True)
+        args = MockCliArgs(verb='update', update_all=True)
 
         stdout = StringIO()
         output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
@@ -572,7 +572,7 @@ class TestPluginInstall(PicardTestCase):
         mock_manager = MockPluginManager()
         mock_tagger._pluginmanager3 = mock_manager
 
-        args = MockCliArgs(install=['plugin1', 'plugin2'], ref='v1.0.0', yes=False)
+        args = MockCliArgs(verb='install', source=['plugin1', 'plugin2'], ref='v1.0.0', yes=False)
 
         stdout = StringIO()
         stderr = StringIO()

--- a/test/plugins3/test_local_non_git_plugin.py
+++ b/test/plugins3/test_local_non_git_plugin.py
@@ -246,23 +246,23 @@ class TestLocalNonGitPluginCLI(PicardTestCase):
             manager = _create_manager(plugins_dir)
             manager.install_plugin(str(plugin_dir), enable_after_install=False)
 
-            # --list shows [local]
-            exit_code, stdout, _ = run_cli(manager, list=True)
+            # list shows [local]
+            exit_code, stdout, _ = run_cli(manager, verb='list')
             self.assertEqual(exit_code, 0)
             self.assertIn('[local]', stdout)
 
-            # --info shows [local]
-            exit_code, stdout, _ = run_cli(manager, info=plugin_name)
+            # info shows [local]
+            exit_code, stdout, _ = run_cli(manager, verb='info', plugin=plugin_name)
             self.assertEqual(exit_code, 0)
             self.assertIn('[local]', stdout)
 
-            # --update shows 'Plugin reloaded'
-            exit_code, stdout, _ = run_cli(manager, update=[plugin_name])
+            # update shows 'Plugin reloaded'
+            exit_code, stdout, _ = run_cli(manager, verb='update', plugin=[plugin_name])
             self.assertEqual(exit_code, 0)
             self.assertIn('Plugin reloaded', stdout)
 
-            # --list-refs is blocked
-            exit_code, _, stderr = run_cli(manager, list_refs=plugin_name)
+            # list-refs is blocked
+            exit_code, _, stderr = run_cli(manager, verb='refs', plugin=plugin_name)
             self.assertNotEqual(exit_code, 0)
             self.assertIn('not managed by git', stderr)
 
@@ -276,7 +276,7 @@ class TestLocalNonGitPluginCLI(PicardTestCase):
             manager = _create_manager(plugins_dir)
             manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
 
-            exit_code, stdout, _ = run_cli(manager, list=True)
+            exit_code, stdout, _ = run_cli(manager, verb='list')
             self.assertEqual(exit_code, 0)
             self.assertIn('[local-dev]', stdout)
 
@@ -290,6 +290,6 @@ class TestLocalNonGitPluginCLI(PicardTestCase):
             manager = _create_manager(plugins_dir)
             manager.install_plugin(str(plugin_dir), enable_after_install=False, no_git=True)
 
-            exit_code, stdout, _ = run_cli(manager, info=plugin_name)
+            exit_code, stdout, _ = run_cli(manager, verb='info', plugin=plugin_name)
             self.assertEqual(exit_code, 0)
             self.assertIn('[local-dev]', stdout)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This continues the refactoring started in #3248 by completely removing the entry point for old picard-plugins CLI and update `PluginCLI` to use new args structure directly.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Remove entry point for old picard-plugins CLI, update PluginCLI to use new args structure directly, which allows removing `_adapt_args`.

This avoids the compatibility conversion of args and makes it simplifies the code. E.g. checking parameters that are allowed only by certain commands is now handled by argparse already.

It also makes it now easier to extend with new commands, as one can focus on the new command structure and does not need to consider also the conversion in  `_adapt_args`.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
