### PR TITLE
PICARD-3337: Add a "picard-cli plugins compile-ui" command

### DIFF
--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -183,6 +183,7 @@ development commands:
     init            create a new plugin project
     validate        validate a plugin MANIFEST
     manifest        show MANIFEST.toml (template if no argument)
+    compile-ui      compile the UI for a plugin
 
 Trust Levels:
   🛡️ official: Reviewed by Picard team (highest trust)
@@ -225,6 +226,7 @@ For more information, visit: https://picard.musicbrainz.org/docs/plugins/
 | `init [name]` | Create a new plugin project |
 | `validate <path-or-url>` | Validate plugin MANIFEST |
 | `manifest [target]` | Show MANIFEST.toml (template or from plugin) |
+| `compile-ui [path]` | Compile a .ui file to .py |
 
 ---
 
@@ -1180,6 +1182,28 @@ Next steps:
   Edit MANIFEST.toml to update metadata
   Run picard-cli plugins validate . to check your plugin
 ```
+
+
+### Compile UI
+
+**Command:** `picard-cli plugins compile-ui [path]`
+
+**Description:** Compiles a .ui file created with Qt Designer into a .py file
+
+**Use cases:**
+- Design a UI for your plugin using Qt Designer and compile it into a .py file
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Force compilation even if up-to-date |
+
+**Examples:**
+```bash
+picard-cli plugins compile-ui path/to/myplugin.ui
+```
+
 
 ### Testing Workflow
 ```bash

--- a/picard/cli/plugins.py
+++ b/picard/cli/plugins.py
@@ -205,6 +205,12 @@ def register_subcommand(subparsers):
     )
     p_manifest.set_defaults(run_command=_run_plugins)
 
+    # --- compile-ui ---
+    p_compile_ui = verb_parsers.add_parser('compile-ui', help='compile the UI for a plugin')
+    p_compile_ui.add_argument('ui_file', metavar='PATH', help="Path to a .ui file")
+    p_compile_ui.add_argument('--force', '-f', action='store_true', help='Force compilation even if up-to-date')
+    p_compile_ui.set_defaults(run_command=_run_plugins)
+
     # Default handler when no verb is given
     plugins_parser.set_defaults(run_command=_run_plugins)
 

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -20,6 +20,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from datetime import datetime
+from io import StringIO
+import os.path
 from pathlib import Path
 import shutil
 
@@ -122,6 +124,24 @@ def get_localized_registry_field(plugin, field, locale='en'):
     else:
         # For other fields, return the base field
         return getattr(plugin, field, '')
+
+
+def newer(file1: Path, file2: Path) -> bool:
+    """Returns True, if file1 has been modified after file2"""
+    if not file2.exists():
+        return True
+    return os.path.getmtime(file1) > os.path.getmtime(file2)
+
+
+def compile_ui(ui_file: Path, py_file: Path) -> None:
+    # import locally in case PyQt6 stops shipping uic (happened in the past)
+    from PyQt6 import uic
+
+    tmp_out = StringIO()
+    uic.compileUi(str(ui_file), tmp_out)
+    output = tmp_out.getvalue()
+    with open(py_file, "w") as f:
+        f.write(output)
 
 
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
@@ -312,6 +332,8 @@ class PluginCLI(BaseCLI):
             return self._cmd_manifest(self._args.target)
         elif cmd == 'init':
             return self._cmd_init(self._args.name)
+        elif cmd == 'compile-ui':
+            return self._cmd_compile_ui(self._args.ui_file, self._args.force)
         else:
             self._out.error('No action specified')
             return ExitCode.ERROR
@@ -1791,6 +1813,29 @@ class PluginCLI(BaseCLI):
             return self._cmd_init_interactive()
 
         return self.create_plugin_project(PluginProjectConfig(name=name))
+
+    def _cmd_compile_ui(self, ui_file, force):
+        """Compile the UI for a plugin."""
+
+        ui_file = Path(ui_file)
+        py_file = ui_file.parent.joinpath(os.path.splitext(ui_file)[0] + '.py')
+
+        if not ui_file.exists():
+            self._out.error(f"File {self._out.bold(ui_file.name)} does not exist.")
+            return ExitCode.NOT_FOUND
+
+        self._out.print(f"Compiling {self._out.bold(ui_file.name)} -> {self._out.bold(py_file.name)}...")
+        if newer(ui_file, py_file) or force:
+            try:
+                compile_ui(ui_file, py_file)
+                self._out.success(f"Compiled {self._out.bold(py_file.name)}")
+            except Exception as e:
+                self._handle_exception(e, f"Failed to compile {self._out.bold(ui_file.name)}")
+                return ExitCode.ERROR
+        else:
+            self._out.info(f"Skipping, {self._out.bold(py_file.name)} is up to date")
+
+        return ExitCode.SUCCESS
 
     def _cmd_init_interactive(self):
         """Run interactive plugin project creation."""

--- a/test/data/widget.ui
+++ b/test/data/widget.ui
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -140,8 +140,8 @@ class PicardTestCase(unittest.TestCase):
         else:
             shutil.rmtree(tmpdir, ignore_errors=ignore_errors, onerror=_remove_readonly)
 
-    def copy_file_tmp(self, filepath, ext):
-        fd, copy = mkstemp(suffix=ext)
+    def copy_file_tmp(self, filepath, ext, dir=None):
+        fd, copy = mkstemp(suffix=ext, dir=dir)
         os.close(fd)
         self.addCleanup(self.remove_file_tmp, copy)
         shutil.copy(filepath, copy)

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -185,6 +185,7 @@ class MockCliArgs(Mock):
             'plugin': None,
             'source': None,
             'url': None,
+            'force': False,
         }
         defaults.update(kwargs)
         super().__init__(**defaults)

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -1635,3 +1635,40 @@ class TestPluginCLIInitGit(PicardTestCase):
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         self.assertIn('Git repository initialized', stdout)
         self.assertNotIn('initial commit', stdout)
+
+
+class TestPluginCLICompileUI(PicardTestCase):
+    """Tests for compile-ui command."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmpdir = Path(self.mktmpdir())
+
+    def test_compile_ui(self):
+        """Test compile-ui succeeds"""
+        ui_file = self.tmpdir / 'widget.ui'
+        py_file = self.tmpdir / 'widget.py'
+        shutil.copy('test/data/widget.ui', ui_file)
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='compile-ui', ui_file=ui_file)
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        self.assertTrue(py_file.is_file())
+
+    def test_compile_ui_skips_up_to_date(self):
+        """Test compile-ui skips compilation for up-to-date file"""
+        ui_file = self.tmpdir / 'widget.ui'
+        shutil.copy('test/data/widget.ui', ui_file)
+        run_cli(MockPluginManager(), verb='compile-ui', ui_file=ui_file)
+        # Compiling again skips the file
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='compile-ui', ui_file=ui_file)
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        self.assertIn('Skipping', stdout)
+        # Compiling with --force recompiles the file
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='compile-ui', ui_file=ui_file, force=True)
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        self.assertIn('Compiled', stdout)
+
+    def test_compile_ui_no_file(self):
+        """Test compile-ui fails with non-existent file"""
+        ui_file = '/invalid/file.ui'
+        exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='compile-ui', ui_file=ui_file)
+        self.assertEqual(ExitCode.NOT_FOUND, exit_code)


### PR DESCRIPTION
Plugin authors can use this to compile Qt Designer .ui files into Python code.

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3337
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->


Advanced plugins might ship their own UI as a Qt Designer .ui file. This is supported, but compiling those files into Python is not straight forward.

Also while currently no extra transfroms are needed for the resulting Python, we might need to do so in the future.

It would be good if the picard-cli would provide a "compile-ui" command.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add a `compile-ui` command with tests.

```
usage: picard-cli plugins compile-ui [-h] [--force] PATH

positional arguments:
  PATH         Path to a .ui file

options:
  -h, --help   show this help message and exit
  --force, -f  Force compilation even if up-to-date
```

Example:

```
uv run picard-cli plugins compile-ui ../picard-plugin-fanarttv/*.ui --force
Compiling ui_options.ui -> ui_options.py...
✓ Compiled ui_options.py
```

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
