### PR TITLE
PICARD-3338: Fix PICARD_PLUGIN_REGISTRY_URL being ignored due to cache fallback

### DIFF
--- a/picard/plugin3/registry.py
+++ b/picard/plugin3/registry.py
@@ -86,8 +86,8 @@ class PluginRegistry:
         else:
             env_url = os.environ.get('PICARD_PLUGIN_REGISTRY_URL')
             if env_url:
-                # Environment variable takes precedence, try it first then fallback to defaults
-                self.registry_urls = [env_url] + DEFAULT_PLUGIN_REGISTRY_URLS
+                # Environment variable overrides defaults entirely
+                self.registry_urls = [env_url]
             else:
                 self.registry_urls = DEFAULT_PLUGIN_REGISTRY_URLS
 


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: When `PICARD_PLUGIN_REGISTRY_URL` is set, the registry now uses exclusively that URL instead of falling back to the official registry cache.

## Problem

* JIRA ticket: PICARD-3338

When `PICARD_PLUGIN_REGISTRY_URL` is set to a custom/local registry, CLI commands like `install` and `browse` still use the official registry data if its cache file exists on disk.

The env var URL was prepended to the default URL list (`[env_url] + DEFAULT_PLUGIN_REGISTRY_URLS`), causing `_load_from_cache()` to iterate over all URLs and load the official registry's cached file when the custom URL's cache didn't exist yet.

**Steps to reproduce:**
1. Run `picard-cli plugins browse` (caches the official registry)
2. Set `PICARD_PLUGIN_REGISTRY_URL=/path/to/local/registry.toml`
3. Run `picard-cli plugins refresh-registry` (succeeds, reports local file loaded)
4. Run `picard-cli plugins install my-local-plugin` → "not found in registry"

## Solution

When `PICARD_PLUGIN_REGISTRY_URL` is set, use only that URL without appending the default URLs as fallbacks. The env var is an explicit override, not a "try first" preference. Cache iteration in `_load_from_cache()` still works correctly for the normal case (multiple default fallback URLs).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Bug was identified and fix was developed with AI assistance (Kiro CLI).

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)