### PR TITLE
Update plugin test scripts to new subcommand-style CLI syntax

### DIFF
--- a/scripts/test_plugin_commands.sh
+++ b/scripts/test_plugin_commands.sh
@@ -4,7 +4,8 @@
 
 set -e
 
-PICARD_PLUGINS="picard-cli plugins"
+PICARD_CLI="picard-cli"
+PICARD_PLUGINS="$PICARD_CLI plugins"
 TEST_PLUGIN_ID="additional-artists-variables"
 TEST_PLUGIN_UUID="2eae631a-1696-4bdc-841f-f75aaa3ae294"
 TEST_PLUGIN_URL="https://github.com/rdswift/picard-plugin-additional-artists-variables"
@@ -14,162 +15,162 @@ echo
 
 # Test 1: Browse all plugins from registry
 echo "1. Browse all plugins from registry"
-$PICARD_PLUGINS --browse
+$PICARD_PLUGINS browse
 echo
 
 # Test 2: Search plugins
 echo "2. Search for 'artist' in plugins"
-$PICARD_PLUGINS --search artist
+$PICARD_PLUGINS search artist
 echo
 
 # Test 3: Search with category filter
 echo "3. Browse with category filter (metadata)"
-$PICARD_PLUGINS --browse --category metadata
+$PICARD_PLUGINS browse --category metadata
 echo
 
 # Test 4: Browse with trust level filter
 echo "4. Browse with trust level filter (official)"
-$PICARD_PLUGINS --browse --trust official
+$PICARD_PLUGINS browse --trust official
 echo
 
 # Test 5: Refresh registry cache
 echo "5. Refresh registry cache"
-$PICARD_PLUGINS --refresh-registry
+$PICARD_PLUGINS refresh-registry
 echo
 
 # Test 6: Show manifest template
 echo "6. Show manifest template"
-$PICARD_PLUGINS --manifest
+$PICARD_PLUGINS manifest
 echo
 
 # Test 7: Validate plugin from URL
 echo "7. Validate plugin from URL"
-$PICARD_PLUGINS --validate $TEST_PLUGIN_URL
+$PICARD_PLUGINS validate $TEST_PLUGIN_URL
 echo
 
 # Test 8: Check blacklist for URL (not blacklisted)
 echo "8. Check blacklist for URL (should not be blacklisted)"
-$PICARD_PLUGINS --check-blacklist $TEST_PLUGIN_URL
+$PICARD_PLUGINS check-blacklist $TEST_PLUGIN_URL
 echo
 
 # Test 9: Check blacklist with --uuid (not blacklisted)
 echo "9. Check blacklist with --uuid (should not be blacklisted)"
-$PICARD_PLUGINS --check-blacklist $TEST_PLUGIN_URL --uuid $TEST_PLUGIN_UUID
+$PICARD_PLUGINS check-blacklist $TEST_PLUGIN_URL --uuid $TEST_PLUGIN_UUID
 echo
 
 # Test 10: Install a plugin
 echo "10. Install $TEST_PLUGIN_ID"
-$PICARD_PLUGINS --install $TEST_PLUGIN_ID --yes
+$PICARD_CLI --yes plugins install $TEST_PLUGIN_ID
 echo
 
 # Test 11: List installed plugins
 echo "11. List installed plugins"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 # Test 12: Show plugin info by ID
 echo "12. Show plugin info for $TEST_PLUGIN_ID"
-$PICARD_PLUGINS --info $TEST_PLUGIN_ID
+$PICARD_PLUGINS info $TEST_PLUGIN_ID
 echo
 
 # Test 13: Show plugin info by UUID
 echo "13. Show plugin info by UUID"
-$PICARD_PLUGINS --info $TEST_PLUGIN_UUID
+$PICARD_PLUGINS info $TEST_PLUGIN_UUID
 echo
 
 # Test 14: Show plugin manifest
 echo "14. Show plugin manifest"
-$PICARD_PLUGINS --manifest $TEST_PLUGIN_ID
+$PICARD_PLUGINS manifest $TEST_PLUGIN_ID
 echo
 
 # Test 15: List refs for plugin
 echo "15. List refs for $TEST_PLUGIN_ID"
-$PICARD_PLUGINS --list-refs $TEST_PLUGIN_ID
+$PICARD_PLUGINS refs $TEST_PLUGIN_ID
 echo
 
 # Test 16: Enable plugin
 echo "16. Enable plugin"
-$PICARD_PLUGINS --enable $TEST_PLUGIN_ID
+$PICARD_PLUGINS enable $TEST_PLUGIN_ID
 echo
 
 # Test 17: Disable plugin
 echo "17. Disable plugin"
-$PICARD_PLUGINS --disable $TEST_PLUGIN_ID
+$PICARD_PLUGINS disable $TEST_PLUGIN_ID
 echo
 
 # Test 18: Check for updates
 echo "18. Check for updates"
-$PICARD_PLUGINS --check-updates
+$PICARD_PLUGINS check-updates
 echo
 
 # Test 19: Update plugin
 echo "19. Update plugin"
-$PICARD_PLUGINS --update $TEST_PLUGIN_ID --yes
+$PICARD_CLI --yes plugins update $TEST_PLUGIN_ID
 echo
 
 # Test 20: Switch to specific ref
 echo "20. Switch to specific ref (v1.0.0)"
-$PICARD_PLUGINS --switch-ref $TEST_PLUGIN_ID v1.0.0 --yes
+$PICARD_CLI --yes plugins switch-ref $TEST_PLUGIN_ID v1.0.0
 echo
 
 # Test 21: Verify switch
 echo "21. Verify ref switch"
-$PICARD_PLUGINS --info $TEST_PLUGIN_ID
+$PICARD_PLUGINS info $TEST_PLUGIN_ID
 echo
 
 # Test 22: Update all plugins
 echo "22. Update all plugins"
-$PICARD_PLUGINS --update-all --yes
+$PICARD_CLI --yes plugins update --all
 echo
 
 # Test 23: Test with --no-color flag
 echo "23. List plugins with --no-color"
-$PICARD_PLUGINS --list --no-color
+$PICARD_CLI --no-color plugins list
 echo
 
 # Test 24: Clean plugin config
 echo "24. Clean plugin config"
-$PICARD_PLUGINS --clean-config $TEST_PLUGIN_ID --yes
+$PICARD_CLI --yes plugins clean-config $TEST_PLUGIN_ID
 echo
 
 # Test 25: Uninstall plugin
 echo "25. Uninstall $TEST_PLUGIN_ID"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_ID --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_ID
 echo
 
 # Test 26: Verify uninstall
 echo "26. Verify uninstall"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 # Test 27: Install with specific ref
 echo "27. Install with specific ref (v1.0.0)"
-$PICARD_PLUGINS --install $TEST_PLUGIN_ID --ref v1.0.0 --yes
+$PICARD_CLI --yes plugins install $TEST_PLUGIN_ID --ref v1.0.0
 echo
 
 # Test 28: Verify installation
 echo "28. Verify installation"
-$PICARD_PLUGINS --info $TEST_PLUGIN_ID
+$PICARD_PLUGINS info $TEST_PLUGIN_ID
 echo
 
 # Test 29: Validate plugin with specific ref
 echo "29. Validate plugin with specific ref"
-$PICARD_PLUGINS --validate $TEST_PLUGIN_URL --ref v1.0.0
+$PICARD_PLUGINS validate $TEST_PLUGIN_URL --ref v1.0.0
 echo
 
 # Test 30: Reinstall plugin
 echo "30. Reinstall plugin"
-$PICARD_PLUGINS --install $TEST_PLUGIN_ID --reinstall --yes
+$PICARD_CLI --yes plugins install $TEST_PLUGIN_ID --reinstall
 echo
 
 # Test 31: Uninstall with purge
 echo "31. Uninstall with purge (delete config)"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_ID --purge --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_ID --purge
 echo
 
 # Test 32: Verify final cleanup
 echo "32. Verify final cleanup"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 echo "=== All Tests Completed Successfully ==="

--- a/scripts/test_plugin_commands_local.sh
+++ b/scripts/test_plugin_commands_local.sh
@@ -11,7 +11,8 @@ TEST_PLUGIN_UUID="12345678-1234-4678-9234-123456789abc"
 
 # Use local registry (direct path, no file:// prefix)
 export PICARD_PLUGIN_REGISTRY_URL="$REGISTRY_FILE"
-PICARD_PLUGINS="picard-cli plugins"
+PICARD_CLI="picard-cli"
+PICARD_PLUGINS="$PICARD_CLI plugins"
 
 BLACKLISTED_UUID="deadbeef-dead-4bad-beef-deadbeefcafe"
 BLACKLISTED_URL="https://github.com/badactor/malicious-plugin"
@@ -23,14 +24,14 @@ echo "Registry file: $REGISTRY_FILE"
 cleanup() {
     echo "Cleanup: Removing test directory and plugin"
     rm -rf "$TEST_DIR"
-    $PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>/dev/null || true
+    $PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>/dev/null || true
     echo "✓ Cleanup complete"
 }
 trap cleanup EXIT
 
 # Clean up any existing test plugins from previous runs
 echo "Cleaning up any existing test plugins..."
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>/dev/null || true
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>/dev/null || true
 echo
 
 # Setup: Create a dummy plugin with git repository
@@ -124,87 +125,87 @@ echo
 
 # Test 1: Refresh registry
 echo "1. Refresh registry"
-$PICARD_PLUGINS --refresh-registry
+$PICARD_PLUGINS refresh-registry
 echo
 
 # Test 2: Install plugin from registry
 echo "2. Install plugin from registry (should auto-select latest version)"
-$PICARD_PLUGINS --install test-plugin --yes
+$PICARD_CLI --yes plugins install test-plugin
 echo
 
 # Test 3: List installed plugins
 echo "3. List installed plugins"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 # Test 4: Show plugin info by UUID
 echo "4. Show plugin info by UUID"
-$PICARD_PLUGINS --info $TEST_PLUGIN_UUID
+$PICARD_PLUGINS info $TEST_PLUGIN_UUID
 echo
 
 # Test 5: Show plugin manifest
 echo "5. Show plugin manifest"
-$PICARD_PLUGINS --manifest $TEST_PLUGIN_UUID
+$PICARD_PLUGINS manifest $TEST_PLUGIN_UUID
 echo
 
 # Test 6: Enable plugin
 echo "6. Enable plugin"
-$PICARD_PLUGINS --enable $TEST_PLUGIN_UUID
+$PICARD_PLUGINS enable $TEST_PLUGIN_UUID
 echo
 
 # Test 7: Disable plugin
 echo "7. Disable plugin"
-$PICARD_PLUGINS --disable $TEST_PLUGIN_UUID
+$PICARD_PLUGINS disable $TEST_PLUGIN_UUID
 echo
 
 # Test 9: Clean plugin config
 echo "9. Clean plugin config"
-$PICARD_PLUGINS --clean-config $TEST_PLUGIN_UUID --yes
+$PICARD_CLI --yes plugins clean-config $TEST_PLUGIN_UUID
 echo
 
 # Test 10: Uninstall plugin
 echo "10. Uninstall plugin"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID
 echo
 
 # Test 11: Verify uninstall
 echo "11. Verify uninstall"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 # Test 12: Install with specific ref
 echo "12. Install with specific ref (v1.0.0)"
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --ref v1.0.0 --yes
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref v1.0.0
 echo
 
 # Test 13: Verify installation
 echo "13. Verify installation (should show v1.0.0)"
-$PICARD_PLUGINS --info $TEST_PLUGIN_UUID | grep -i version
+$PICARD_PLUGINS info $TEST_PLUGIN_UUID | grep -i version
 echo
 
 # Test 14: Reinstall plugin
 echo "14. Reinstall plugin"
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --reinstall --yes
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --reinstall
 echo
 
 # Test 15: Uninstall with purge
 echo "15. Uninstall with purge (delete config)"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge
 echo
 
 # Test 16: Verify final cleanup
 echo "16. Verify final cleanup"
-$PICARD_PLUGINS --list
+$PICARD_PLUGINS list
 echo
 
 # Test 17: Install with lightweight tag (v1.0.0)
 echo "17. Install with lightweight tag (v1.0.0)"
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --ref v1.0.0 --yes
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref v1.0.0
 echo
 
 # Test 18: Verify lightweight tag resolves to commit
 echo "18. Verify lightweight tag resolves to commit"
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
 echo "Stored commit: $STORED_COMMIT"
 echo "Expected commit: ${COMMIT_V1_0_0:0:7}"
 if [ "$STORED_COMMIT" = "${COMMIT_V1_0_0:0:7}" ]; then
@@ -217,12 +218,12 @@ echo
 
 # Test 19: Switch to annotated tag (v1.1.0)
 echo "19. Switch to annotated tag (v1.1.0)"
-$PICARD_PLUGINS --switch-ref $TEST_PLUGIN_UUID v1.1.0
+$PICARD_PLUGINS switch-ref $TEST_PLUGIN_UUID v1.1.0
 echo
 
 # Test 20: Verify annotated tag resolves to commit (not tag object)
 echo "20. Verify annotated tag resolves to commit (not tag object)"
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
 echo "Stored commit: $STORED_COMMIT"
 echo "Expected commit: ${COMMIT_V1_1_0:0:7}"
 if [ "$STORED_COMMIT" = "${COMMIT_V1_1_0:0:7}" ]; then
@@ -235,12 +236,12 @@ echo
 
 # Test 21: Update plugin (should update to v1.2.0 if versioning detected)
 echo "21. Update plugin (may update to newer tag if available)"
-$PICARD_PLUGINS --update $TEST_PLUGIN_UUID --yes
+$PICARD_CLI --yes plugins update $TEST_PLUGIN_UUID
 echo
 
 # Test 22: Verify commit after update
 echo "22. Verify commit after update"
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
 echo "Stored commit after update: $STORED_COMMIT"
 # Should be either v1.1.0 or v1.2.0 depending on versioning detection
 echo "✓ Update completed"
@@ -248,12 +249,12 @@ echo
 
 # Test 23: Switch to another annotated tag (v1.2.0)
 echo "23. Switch to another annotated tag (v1.2.0)"
-$PICARD_PLUGINS --switch-ref $TEST_PLUGIN_UUID v1.2.0
+$PICARD_PLUGINS switch-ref $TEST_PLUGIN_UUID v1.2.0
 echo
 
 # Test 24: Verify new annotated tag resolves correctly
 echo "24. Verify new annotated tag resolves correctly"
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
 echo "Stored commit: $STORED_COMMIT"
 echo "Expected commit: ${COMMIT_V1_2_0:0:7}"
 if [ "$STORED_COMMIT" = "${COMMIT_V1_2_0:0:7}" ]; then
@@ -270,16 +271,16 @@ echo
 
 # Test 25: List refs
 echo "25. List refs"
-$PICARD_PLUGINS --list-refs $TEST_PLUGIN_UUID
+$PICARD_PLUGINS refs $TEST_PLUGIN_UUID
 echo
 
 # Note: Cache invalidation test would require remote git URL
 # Local file paths bypass version tag caching and fetch directly from repo
-# The --refresh-registry cache clearing works correctly for remote registry plugins
+# The refresh-registry cache clearing works correctly for remote registry plugins
 
 # Test 26: Final uninstall
 echo "26. Final uninstall"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge
 echo
 
 # Test 27: Test invalid manifest (missing uuid) - should rollback
@@ -294,12 +295,12 @@ git tag invalid-manifest
 cd - > /dev/null
 
 # Install valid version first
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --ref v1.2.0 --yes
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref v1.2.0
 echo "✓ Installed valid version"
 
 # Try to switch to invalid manifest - should fail and rollback
 echo "Attempting to switch to invalid manifest (should rollback)..."
-if $PICARD_PLUGINS --switch-ref $TEST_PLUGIN_UUID invalid-manifest 2>/dev/null; then
+if $PICARD_PLUGINS switch-ref $TEST_PLUGIN_UUID invalid-manifest 2>/dev/null; then
     echo "✗ ERROR: Switch to invalid manifest should have failed"
     exit 1
 else
@@ -307,8 +308,8 @@ else
 fi
 
 # Verify plugin is still functional on original version
-if $PICARD_PLUGINS --info $TEST_PLUGIN_UUID >/dev/null 2>&1; then
-    STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+if $PICARD_PLUGINS info $TEST_PLUGIN_UUID >/dev/null 2>&1; then
+    STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
     if [ "$STORED_COMMIT" = "${COMMIT_V1_2_0:0:7}" ]; then
         echo "✓ Plugin correctly rolled back to previous version"
     else
@@ -337,13 +338,13 @@ git tag invalid-toml-syntax
 cd - > /dev/null
 
 # Install valid version first
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --yes 2>/dev/null || true
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --ref v1.2.0 --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID 2>/dev/null || true
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref v1.2.0
 echo "✓ Installed valid version"
 
 # Try to switch to invalid TOML - should fail and rollback
 echo "Attempting to switch to invalid TOML syntax (should rollback)..."
-if $PICARD_PLUGINS --switch-ref $TEST_PLUGIN_UUID invalid-toml-syntax 2>/dev/null; then
+if $PICARD_PLUGINS switch-ref $TEST_PLUGIN_UUID invalid-toml-syntax 2>/dev/null; then
     echo "✗ ERROR: Switch to invalid TOML should have failed"
     exit 1
 else
@@ -351,8 +352,8 @@ else
 fi
 
 # Verify plugin is still functional on original version
-if $PICARD_PLUGINS --info $TEST_PLUGIN_UUID >/dev/null 2>&1; then
-    STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+if $PICARD_PLUGINS info $TEST_PLUGIN_UUID >/dev/null 2>&1; then
+    STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
     if [ "$STORED_COMMIT" = "${COMMIT_V1_2_0:0:7}" ]; then
         echo "✓ Plugin correctly rolled back to previous version after TOML error"
     else
@@ -366,9 +367,9 @@ echo
 
 # Test 29: Test install with invalid manifest - should cleanup
 echo "29. Test install with invalid manifest - should cleanup"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --yes 2>/dev/null || true
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID 2>/dev/null || true
 echo "Attempting to install invalid manifest (should fail and cleanup)..."
-if $PICARD_PLUGINS --install "$PLUGIN_REPO" --ref invalid-manifest --yes 2>/dev/null; then
+if $PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref invalid-manifest 2>/dev/null; then
     echo "✗ ERROR: Install of invalid manifest should have failed"
     exit 1
 else
@@ -376,7 +377,7 @@ else
 fi
 
 # Verify no broken plugin left behind
-PLUGIN_COUNT=$($PICARD_PLUGINS --list 2>/dev/null | grep -c "$TEST_PLUGIN_UUID" || true)
+PLUGIN_COUNT=$($PICARD_PLUGINS list 2>/dev/null | grep -c "$TEST_PLUGIN_UUID" || true)
 if [ "$PLUGIN_COUNT" -eq 0 ]; then
     echo "✓ No broken plugin left after failed install"
 else
@@ -403,7 +404,7 @@ cd - > /dev/null
 echo "Attempting to install with broken UUID..."
 echo "Note: This test demonstrates the rollback protection is in place,"
 echo "      but the actual failure occurs during manifest validation, not enable."
-if $PICARD_PLUGINS --install "$PLUGIN_REPO" --ref broken-uuid-enable --yes 2>/dev/null; then
+if $PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref broken-uuid-enable 2>/dev/null; then
     echo "✗ ERROR: Install with broken UUID should have failed"
     exit 1
 else
@@ -411,7 +412,7 @@ else
 fi
 
 # Verify no broken plugin left behind
-PLUGIN_COUNT=$($PICARD_PLUGINS --list 2>/dev/null | grep -c "$TEST_PLUGIN_UUID" || true)
+PLUGIN_COUNT=$($PICARD_PLUGINS list 2>/dev/null | grep -c "$TEST_PLUGIN_UUID" || true)
 if [ "$PLUGIN_COUNT" -eq 0 ]; then
     echo "✓ No broken plugin left after failed local install"
     echo "  (Rollback protection is in place for edge cases where enable could fail)"
@@ -430,12 +431,12 @@ echo
 
 # Test 31: Check blacklist - non-blacklisted URL
 echo "31. Check blacklist - non-blacklisted URL (should pass)"
-$PICARD_PLUGINS --check-blacklist https://github.com/safe/plugin
+$PICARD_PLUGINS check-blacklist https://github.com/safe/plugin
 echo
 
 # Test 32: Check blacklist - blacklisted URL (exact match)
 echo "32. Check blacklist - blacklisted URL (should fail)"
-if $PICARD_PLUGINS --check-blacklist "$BLACKLISTED_URL" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist "$BLACKLISTED_URL" 2>/dev/null; then
     echo "✗ ERROR: Blacklisted URL should have been detected"
     exit 1
 else
@@ -445,7 +446,7 @@ echo
 
 # Test 33: Check blacklist - blacklisted UUID via --uuid
 echo "33. Check blacklist - blacklisted UUID via --uuid (should fail)"
-if $PICARD_PLUGINS --check-blacklist https://example.com/any-url --uuid "$BLACKLISTED_UUID" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist https://example.com/any-url --uuid "$BLACKLISTED_UUID" 2>/dev/null; then
     echo "✗ ERROR: Blacklisted UUID should have been detected"
     exit 1
 else
@@ -455,12 +456,12 @@ echo
 
 # Test 34: Check blacklist - non-blacklisted UUID via --uuid
 echo "34. Check blacklist - non-blacklisted UUID via --uuid (should pass)"
-$PICARD_PLUGINS --check-blacklist https://example.com/any-url --uuid "safe-uuid-1234"
+$PICARD_PLUGINS check-blacklist https://example.com/any-url --uuid "safe-uuid-1234"
 echo
 
 # Test 34b: Check blacklist - UUID only, no URL (should fail)
 echo "34b. Check blacklist - blacklisted UUID only, no URL (should fail)"
-if $PICARD_PLUGINS --check-blacklist --uuid "$BLACKLISTED_UUID" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist --uuid "$BLACKLISTED_UUID" 2>/dev/null; then
     echo "✗ ERROR: Blacklisted UUID should have been detected"
     exit 1
 else
@@ -470,12 +471,12 @@ echo
 
 # Test 34c: Check blacklist - non-blacklisted UUID only, no URL (should pass)
 echo "34c. Check blacklist - non-blacklisted UUID only, no URL (should pass)"
-$PICARD_PLUGINS --check-blacklist --uuid "safe-uuid-1234"
+$PICARD_PLUGINS check-blacklist --uuid "safe-uuid-1234"
 echo
 
 # Test 35: Check blacklist - URL matching regex pattern
 echo "35. Check blacklist - URL matching regex pattern (should fail)"
-if $PICARD_PLUGINS --check-blacklist "https://evilorg.com/some-plugin" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist "https://evilorg.com/some-plugin" 2>/dev/null; then
     echo "✗ ERROR: URL matching blacklist regex should have been detected"
     exit 1
 else
@@ -485,12 +486,12 @@ echo
 
 # Test 36: Check blacklist - URL not matching regex pattern
 echo "36. Check blacklist - URL not matching regex (should pass)"
-$PICARD_PLUGINS --check-blacklist "https://evilorg.org/different-domain"
+$PICARD_PLUGINS check-blacklist "https://evilorg.org/different-domain"
 echo
 
 # Test 37: Install blacklisted URL (should be blocked)
 echo "37. Install blacklisted URL (should be blocked)"
-OUTPUT=$($PICARD_PLUGINS --install "$BLACKLISTED_URL" --yes 2>&1 || true)
+OUTPUT=$($PICARD_CLI --yes plugins install "$BLACKLISTED_URL" 2>&1 || true)
 if echo "$OUTPUT" | grep -qi "blacklisted"; then
     echo "✓ Installing blacklisted URL correctly blocked"
 else
@@ -503,7 +504,7 @@ echo
 # Test 38: Install blacklisted URL with --force-blacklisted
 echo "38. Install blacklisted URL with --force-blacklisted (should bypass blacklist)"
 echo "Note: Will fail at git clone (URL doesn't exist), but should get past blacklist check"
-OUTPUT=$($PICARD_PLUGINS --install "$BLACKLISTED_URL" --force-blacklisted --yes 2>&1 || true)
+OUTPUT=$($PICARD_CLI --yes plugins install "$BLACKLISTED_URL" --force-blacklisted 2>&1 || true)
 if echo "$OUTPUT" | grep -qi "bypassing blacklist"; then
     echo "✓ Force-blacklisted correctly bypassed blacklist check"
 else
@@ -515,7 +516,7 @@ echo
 
 # Test 39: Install URL matching blacklist regex (should be blocked)
 echo "39. Install URL matching blacklist regex (should be blocked)"
-OUTPUT=$($PICARD_PLUGINS --install "https://evilorg.com/sneaky-plugin" --yes 2>&1 || true)
+OUTPUT=$($PICARD_CLI --yes plugins install "https://evilorg.com/sneaky-plugin" 2>&1 || true)
 if echo "$OUTPUT" | grep -qi "blacklisted"; then
     echo "✓ Installing URL matching blacklist regex correctly blocked"
 else
@@ -550,24 +551,24 @@ git add .
 git commit -q -m "Initial commit"
 cd - > /dev/null
 
-OUTPUT=$($PICARD_PLUGINS --install "$BLACKLISTED_PLUGIN_REPO" --yes 2>&1 || true)
+OUTPUT=$($PICARD_CLI --yes plugins install "$BLACKLISTED_PLUGIN_REPO" 2>&1 || true)
 if echo "$OUTPUT" | grep -qi "blacklisted"; then
     echo "✓ Installing local plugin with blacklisted UUID correctly blocked"
 else
     echo "✗ ERROR: Installing local plugin with blacklisted UUID should have been blocked"
     echo "  Output: $OUTPUT"
-    $PICARD_PLUGINS --remove "$BLACKLISTED_UUID" --purge --yes 2>/dev/null || true
+    $PICARD_CLI --yes plugins remove "$BLACKLISTED_UUID" --purge 2>/dev/null || true
     exit 1
 fi
 echo
 
 # Test 41: Retroactive blacklisting - install then blacklist
 echo "41. Retroactive blacklisting - install plugin, then add to blacklist"
-$PICARD_PLUGINS --remove "$TEST_PLUGIN_UUID" --purge --yes 2>/dev/null || true
+$PICARD_CLI --yes plugins remove "$TEST_PLUGIN_UUID" --purge 2>/dev/null || true
 cd "$PLUGIN_REPO"
 git checkout v1.2.0 -q 2>/dev/null || true
 cd - > /dev/null
-$PICARD_PLUGINS --install test-plugin --yes
+$PICARD_CLI --yes plugins install test-plugin
 echo "✓ Installed test plugin"
 
 # Add the test plugin UUID to the blacklist
@@ -578,10 +579,10 @@ uuid = "$TEST_PLUGIN_UUID"
 reason = "Retroactively blacklisted for testing"
 blacklisted_at = "2025-12-01T10:00:00Z"
 EOF
-$PICARD_PLUGINS --refresh-registry
+$PICARD_PLUGINS refresh-registry
 
 # Verify the plugin is now detected as blacklisted
-if $PICARD_PLUGINS --check-blacklist "$PLUGIN_REPO" --uuid "$TEST_PLUGIN_UUID" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist "$PLUGIN_REPO" --uuid "$TEST_PLUGIN_UUID" 2>/dev/null; then
     echo "✗ ERROR: Retroactively blacklisted plugin should be detected"
     exit 1
 else
@@ -589,7 +590,7 @@ else
 fi
 
 # Clean up: remove the test plugin and restore registry
-$PICARD_PLUGINS --remove "$TEST_PLUGIN_UUID" --purge --yes 2>/dev/null || true
+$PICARD_CLI --yes plugins remove "$TEST_PLUGIN_UUID" --purge 2>/dev/null || true
 
 # Restore registry without the retroactive blacklist entry
 cat > "$REGISTRY_FILE" << EOF
@@ -621,12 +622,12 @@ uuid = "c0mb0bad-c0mb-4bad-c0mb-c0mb0badc0mb"
 reason = "Specific fork blacklisted"
 blacklisted_at = "2025-11-23T10:00:00Z"
 EOF
-$PICARD_PLUGINS --refresh-registry
+$PICARD_PLUGINS refresh-registry
 echo
 
 # Test 42: UUID+URL combo blacklist - both match
 echo "42. UUID+URL combo blacklist - both match (should fail)"
-if $PICARD_PLUGINS --check-blacklist "https://github.com/specific/combo-blocked" --uuid "c0mb0bad-c0mb-4bad-c0mb-c0mb0badc0mb" 2>/dev/null; then
+if $PICARD_PLUGINS check-blacklist "https://github.com/specific/combo-blocked" --uuid "c0mb0bad-c0mb-4bad-c0mb-c0mb0badc0mb" 2>/dev/null; then
     echo "✗ ERROR: UUID+URL combo blacklist should have been detected"
     exit 1
 else
@@ -636,12 +637,12 @@ echo
 
 # Test 43: UUID+URL combo blacklist - only UUID matches (should pass)
 echo "43. UUID+URL combo blacklist - only UUID matches, different URL (should pass)"
-$PICARD_PLUGINS --check-blacklist "https://github.com/other/repo" --uuid "c0mb0bad-c0mb-4bad-c0mb-c0mb0badc0mb"
+$PICARD_PLUGINS check-blacklist "https://github.com/other/repo" --uuid "c0mb0bad-c0mb-4bad-c0mb-c0mb0badc0mb"
 echo
 
 # Test 44: UUID+URL combo blacklist - only URL matches (should pass)
 echo "44. UUID+URL combo blacklist - only URL matches, different UUID (should pass)"
-$PICARD_PLUGINS --check-blacklist "https://github.com/specific/combo-blocked" --uuid "innocent-uuid-1234"
+$PICARD_PLUGINS check-blacklist "https://github.com/specific/combo-blocked" --uuid "innocent-uuid-1234"
 echo
 
 echo "=== All Local Tests Completed Successfully ==="

--- a/scripts/test_plugin_commands_no_registry.sh
+++ b/scripts/test_plugin_commands_no_registry.sh
@@ -11,7 +11,8 @@ TEST_PLUGIN_UUID="87654321-4321-4765-8321-876543218765"
 # Disable registry completely
 unset PICARD_PLUGIN_REGISTRY_URL
 export PICARD_PLUGIN_REGISTRY_URL=""
-PICARD_PLUGINS="picard-cli plugins"
+PICARD_CLI="picard-cli"
+PICARD_PLUGINS="$PICARD_CLI plugins"
 
 echo "=== Testing Plugin Commands (Local Directory WITHOUT Registry) ==="
 echo "Test directory: $TEST_DIR"
@@ -84,12 +85,12 @@ echo
 
 # Test 1: Install plugin from local directory (not registry)
 echo "1. Install plugin from local directory (no registry)"
-$PICARD_PLUGINS --install "$PLUGIN_REPO" --ref v1.0.0 --yes
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO" --ref v1.0.0
 echo
 
 # Test 2: Verify installation
 echo "2. Verify plugin installation"
-$PICARD_PLUGINS --info $TEST_PLUGIN_UUID
+$PICARD_PLUGINS info $TEST_PLUGIN_UUID
 echo
 
 # Test 3: Check if plugin has git remotes (Fix 1 test)
@@ -123,22 +124,22 @@ echo
 echo "5. Check for updates (Fix 2 test - should detect v1.2.0 without versioning_scheme)"
 echo "Before fix: Would skip plugin due to no versioning_scheme"
 echo "After fix: Should detect new tag v1.2.0"
-$PICARD_PLUGINS --check-updates
+$PICARD_PLUGINS check-updates
 echo
 
 # Test 6: List available refs (should show v1.2.0 after fetch)
 echo "6. List available refs (should show v1.2.0 after remote fetch)"
-$PICARD_PLUGINS --list-refs $TEST_PLUGIN_UUID
+$PICARD_PLUGINS refs $TEST_PLUGIN_UUID
 echo
 
 # Test 7: Update to newer tag
 echo "7. Update plugin to newer tag"
-$PICARD_PLUGINS --update $TEST_PLUGIN_UUID --yes
+$PICARD_CLI --yes plugins update $TEST_PLUGIN_UUID
 echo
 
 # Test 8: Verify update worked
 echo "8. Verify plugin was updated"
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}' || echo "unknown")
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}' || echo "unknown")
 echo "Current commit: $STORED_COMMIT"
 echo "Expected v1.2.0 commit: ${COMMIT_V1_2_0:0:7}"
 if [ "$STORED_COMMIT" = "${COMMIT_V1_2_0:0:7}" ]; then
@@ -159,7 +160,7 @@ echo
 
 # Test 10: Clean up
 echo "10. Clean up test plugin"
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge
 echo
 
 echo "Cleanup: Removing test directory"

--- a/scripts/test_plugin_redirects.sh
+++ b/scripts/test_plugin_redirects.sh
@@ -12,12 +12,13 @@ TEST_PLUGIN_UUID="aabbccdd-1234-4678-9234-aabbccddeeff"
 PLUGIN_DIR_NAME="test_redirect_plugin_${TEST_PLUGIN_UUID}"
 
 export PICARD_PLUGIN_REGISTRY_URL="$REGISTRY_FILE"
-PICARD_PLUGINS="picard-cli plugins"
+PICARD_CLI="picard-cli"
+PICARD_PLUGINS="$PICARD_CLI plugins"
 
 cleanup() {
     echo "Cleanup: Removing test directory and plugin"
     rm -rf "$TEST_DIR"
-    $PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>/dev/null || true
+    $PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>/dev/null || true
     echo "✓ Cleanup complete"
 }
 trap cleanup EXIT
@@ -113,14 +114,14 @@ git_url = "$PLUGIN_REPO_OLD"
 uuid = "$TEST_PLUGIN_UUID"
 versioning_scheme = "semver"
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install from old repo at v1.0.0
-$PICARD_PLUGINS --install redirect-test --ref v1.0.0 --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins install redirect-test --ref v1.0.0 2>&1 | tail -1
 echo "✓ Installed v1.0.0 from old repo"
 
 # Verify installed version
-STORED_COMMIT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color | grep -oP 'Version:.*@\K[a-f0-9]{7}')
+STORED_COMMIT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID | grep -oP 'Version:.*@\K[a-f0-9]{7}')
 if [ "$STORED_COMMIT" = "${COMMIT_V1_0_0:0:7}" ]; then
     echo "✓ Verified at v1.0.0 (${COMMIT_V1_0_0:0:7})"
 else
@@ -140,14 +141,14 @@ redirect_from = [
     "$PLUGIN_REPO_OLD",
 ]
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Update should follow redirect to new repo and get v2.1.0
-$PICARD_PLUGINS --update $TEST_PLUGIN_UUID --yes 2>&1 | grep -E "✓|✗|→"
+$PICARD_CLI --yes plugins update $TEST_PLUGIN_UUID 2>&1 | grep -E "✓|✗|→"
 echo "✓ Update completed"
 
 # Verify plugin updated to new repo's latest version
-INFO_OUTPUT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color 2>&1)
+INFO_OUTPUT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID 2>&1)
 if echo "$INFO_OUTPUT" | grep -q "2.1.0"; then
     echo "✓ Plugin updated to v2.1.0 from new repository"
 elif echo "$INFO_OUTPUT" | grep -q "2.0.0"; then
@@ -165,7 +166,7 @@ else
     echo "? Source URL may not be updated in display (metadata was updated)"
 fi
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 # =============================================================================
@@ -181,10 +182,10 @@ name = "Redirect Test Plugin"
 git_url = "$PLUGIN_REPO_OLD"
 uuid = "$TEST_PLUGIN_UUID"
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install from old repo on main branch (no specific tag)
-$PICARD_PLUGINS --install "$PLUGIN_REPO_OLD" --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO_OLD" 2>&1 | tail -1
 echo "✓ Installed from old repo (main branch)"
 
 # Redirect registry to new repo
@@ -198,21 +199,21 @@ redirect_from = [
     "$PLUGIN_REPO_OLD",
 ]
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Update should follow redirect
-$PICARD_PLUGINS --update $TEST_PLUGIN_UUID --yes 2>&1 | grep -E "✓|✗|→"
+$PICARD_CLI --yes plugins update $TEST_PLUGIN_UUID 2>&1 | grep -E "✓|✗|→"
 echo "✓ Branch-based update through redirect completed"
 
 # Verify it got content from new repo
-INFO_OUTPUT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color 2>&1)
+INFO_OUTPUT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID 2>&1)
 if echo "$INFO_OUTPUT" | grep -q "2\.\(0\|1\)\.0"; then
     echo "✓ Plugin updated to new repo content"
 else
     echo "? Plugin version: $(echo "$INFO_OUTPUT" | grep Version)"
 fi
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 # =============================================================================
@@ -232,16 +233,16 @@ redirect_from = [
     "$PLUGIN_REPO_OLD",
 ]
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install using old URL - should be found via redirect_from in registry
-$PICARD_PLUGINS --install "$PLUGIN_REPO_OLD" --yes 2>&1 | tail -2
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO_OLD" 2>&1 | tail -2
 echo "✓ Install via old URL found plugin in registry"
 
-INFO_OUTPUT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color 2>&1)
+INFO_OUTPUT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID 2>&1)
 echo "  $(echo "$INFO_OUTPUT" | grep Version)"
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 # =============================================================================
@@ -285,16 +286,16 @@ redirect_from = [
     "$PLUGIN_REPO_OLD",
 ]
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install using oldest URL - should still find via redirect_from
-$PICARD_PLUGINS --install "$PLUGIN_REPO_OLDEST" --yes 2>&1 | tail -2
+$PICARD_CLI --yes plugins install "$PLUGIN_REPO_OLDEST" 2>&1 | tail -2
 echo "✓ Install via oldest URL found plugin in registry"
 
-INFO_OUTPUT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color 2>&1)
+INFO_OUTPUT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID 2>&1)
 echo "  $(echo "$INFO_OUTPUT" | grep Version)"
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 # =============================================================================
@@ -311,10 +312,10 @@ git_url = "$PLUGIN_REPO_OLD"
 uuid = "$TEST_PLUGIN_UUID"
 versioning_scheme = "semver"
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install from old repo at v1.0.0
-$PICARD_PLUGINS --install redirect-test --ref v1.0.0 --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins install redirect-test --ref v1.0.0 2>&1 | tail -1
 echo "✓ Installed v1.0.0 from old repo"
 
 # Now redirect to new repo AND blacklist the UUID
@@ -333,10 +334,10 @@ redirect_from = [
 uuid = "$TEST_PLUGIN_UUID"
 reason = "Security vulnerability found"
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Update should be blocked by blacklist
-UPDATE_OUTPUT=$($PICARD_PLUGINS --update $TEST_PLUGIN_UUID --yes 2>&1) || true
+UPDATE_OUTPUT=$($PICARD_CLI --yes plugins update $TEST_PLUGIN_UUID 2>&1) || true
 if echo "$UPDATE_OUTPUT" | grep -qi "blacklist"; then
     echo "✓ Update correctly blocked: plugin is blacklisted"
 else
@@ -345,7 +346,7 @@ else
     exit 1
 fi
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 # =============================================================================
@@ -364,14 +365,14 @@ redirect_from = [
     "$PLUGIN_REPO_OLD",
 ]
 EOF
-$PICARD_PLUGINS --refresh-registry 2>&1 | head -1
+$PICARD_PLUGINS refresh-registry 2>&1 | head -1
 
 # Install using old URL directly - should redirect to new repo
-INSTALL_OUTPUT=$($PICARD_PLUGINS --install "$PLUGIN_REPO_OLD" --yes 2>&1)
+INSTALL_OUTPUT=$($PICARD_CLI --yes plugins install "$PLUGIN_REPO_OLD" 2>&1)
 echo "$INSTALL_OUTPUT" | grep -i "redirect" || true
 
 # Verify plugin was installed from new repo (check plugin name contains "Moved")
-INFO_OUTPUT=$($PICARD_PLUGINS --info $TEST_PLUGIN_UUID --no-color 2>&1)
+INFO_OUTPUT=$($PICARD_CLI --no-color plugins info $TEST_PLUGIN_UUID 2>&1)
 if echo "$INFO_OUTPUT" | grep -q "$PLUGIN_REPO_NEW"; then
     echo "✓ Install via old URL was redirected to new repo"
 else
@@ -380,7 +381,7 @@ else
     exit 1
 fi
 
-$PICARD_PLUGINS --remove $TEST_PLUGIN_UUID --purge --yes 2>&1 | tail -1
+$PICARD_CLI --yes plugins remove $TEST_PLUGIN_UUID --purge 2>&1 | tail -1
 echo
 
 echo "=== All Redirect Tests Completed Successfully ==="


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Updates the four shell test scripts in `scripts/` to use the new subcommand-style CLI syntax introduced in #3252.

## Problem

After merging #3252, the plugin CLI uses subcommand-style syntax (`picard-cli plugins list`) instead of flag-style (`picard-cli plugins --list`). The test scripts in `scripts/test_plugin_*.sh` still use the old syntax.

## Solution

Convert all four scripts:
- `--list` → `list`, `--install X` → `install X`, `--list-refs X` → `refs X`, etc.
- `--update-all` → `update --all`
- `--yes` and `--no-color` are now top-level `picard-cli` options, placed before `plugins`

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)