### PR TITLE
Add grouped subcommand help for plugin CLI

### DIFF
--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -170,16 +170,19 @@ plugin commands:
     info            show detailed plugin information
     search          search plugins in registry
     browse          browse all plugins from registry
-    init            create a new plugin project
-    validate        validate a plugin MANIFEST
     refs            list available git refs for a plugin
     switch-ref      switch plugin to a different git ref
-    manifest        show MANIFEST.toml (template if no argument)
     check-blacklist check if URL/UUID is blacklisted
     clean-config    delete saved options for a plugin
     refresh-registry
                     force refresh of plugin registry cache
     check-updates   check for available updates
+
+development commands:
+  <command>
+    init            create a new plugin project
+    validate        validate a plugin MANIFEST
+    manifest        show MANIFEST.toml (template if no argument)
 
 Trust Levels:
   🛡️ official: Reviewed by Picard team (highest trust)
@@ -194,6 +197,8 @@ For more information, visit: https://picard.musicbrainz.org/docs/plugins/
 
 ## Commands Summary
 
+### Plugin Commands
+
 | Command | Description |
 |---------|-------------|
 | `list` | List all installed plugins |
@@ -204,17 +209,22 @@ For more information, visit: https://picard.musicbrainz.org/docs/plugins/
 | `update <plugin>` | Update specific plugin |
 | `update --all` | Update all plugins |
 | `info <plugin>` | Show plugin details and status |
+| `search <term>` | Search official plugins |
+| `browse` | Browse official plugins |
 | `refs <plugin>` | List available git refs for plugin |
 | `switch-ref <plugin> <ref>` | Switch plugin to different ref |
-| `check-updates` | Check for updates within installed ref |
-| `validate <path-or-url>` | Validate plugin MANIFEST |
-| `manifest [target]` | Show MANIFEST.toml (template or from plugin) |
-| `init [name]` | Create a new plugin project |
-| `browse` | Browse official plugins |
-| `search <term>` | Search official plugins |
 | `check-blacklist [url]` | Check if URL and/or UUID is blacklisted |
 | `clean-config [plugin]` | Delete plugin saved options or list orphaned configs |
 | `refresh-registry` | Force refresh plugin registry cache |
+| `check-updates` | Check for updates within installed ref |
+
+### Development Commands
+
+| Command | Description |
+|---------|-------------|
+| `init [name]` | Create a new plugin project |
+| `validate <path-or-url>` | Validate plugin MANIFEST |
+| `manifest [target]` | Show MANIFEST.toml (template or from plugin) |
 
 ---
 

--- a/picard/cli/argparse_grouped.py
+++ b/picard/cli/argparse_grouped.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Argparse extensions for grouped subcommand help output.
+
+Provides a SubParsersAction subclass that supports grouping commands under
+titled sections in help output, and a matching HelpFormatter.
+
+Usage:
+    parser = argparse.ArgumentParser(formatter_class=GroupedHelpFormatter)
+    sp = parser.add_subparsers(action=GroupedSubParsersAction, ...)
+
+    sp.add_parser('list', help='list items')
+    sp.add_parser('install', help='install item')
+
+    sp.start_group('development commands')
+    sp.add_parser('init', help='create a project')
+    sp.add_parser('validate', help='validate a manifest')
+"""
+
+import argparse
+
+
+class GroupedSubParsersAction(argparse._SubParsersAction):
+    """SubParsersAction that groups commands under titled sections in help.
+
+    Commands added before the first start_group() call appear in the
+    default section (whose title is set via add_subparsers(title=...)).
+    Commands added after a start_group() call appear in a separate
+    titled section in help output.
+
+    All commands share the same namespace and dispatch mechanism regardless
+    of their group — grouping is purely visual.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._group_map = {}  # parser_name -> group_title
+        self._groups = {}  # group_title -> [parser_names] (ordered)
+        self._current_group = None
+
+    def start_group(self, title):
+        """Start a new group for subsequent add_parser() calls."""
+        self._current_group = title
+        if title not in self._groups:
+            self._groups[title] = []
+
+    def add_parser(self, name, **kwargs):
+        if self._current_group:
+            self._group_map[name] = self._current_group
+            self._groups[self._current_group].append(name)
+        parser = super().add_parser(name, **kwargs)
+        return parser
+
+    def _get_subactions(self):
+        """Yield only ungrouped actions for the default section."""
+        for choice_action in self._choices_actions:
+            if choice_action.dest not in self._group_map:
+                yield choice_action
+
+
+class GroupedHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """Help formatter that renders grouped subparser sections.
+
+    Works with GroupedSubParsersAction to display commands in
+    multiple titled sections.
+    """
+
+    def _format_action(self, action):
+        if not isinstance(action, GroupedSubParsersAction):
+            return super()._format_action(action)
+
+        # Format the main (ungrouped) subparsers section
+        parts = [super()._format_action(action)]
+
+        # Add additional sections for each group
+        for group_title, names in action._groups.items():
+            parts.append(f'\n{group_title}:\n')
+            parts.append('  <command>\n')
+            for name in names:
+                for choice_action in action._choices_actions:
+                    if choice_action.dest == name:
+                        help_text = choice_action.help or ''
+                        parts.append(f'    {name:<16}{help_text}\n')
+                        break
+
+        return ''.join(parts)

--- a/picard/cli/plugins.py
+++ b/picard/cli/plugins.py
@@ -41,6 +41,10 @@ Usage:
     picard-cli plugins check-updates
 """
 
+from picard.cli.argparse_grouped import (
+    GroupedHelpFormatter,
+    GroupedSubParsersAction,
+)
 from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 
 
@@ -50,7 +54,7 @@ def register_subcommand(subparsers):
         'plugins',
         help='manage Picard plugins',
         description='Install, update, enable, and manage Picard plugins.',
-        formatter_class=_argparse().RawDescriptionHelpFormatter,
+        formatter_class=GroupedHelpFormatter,
         epilog=(
             "Trust Levels:\n"
             "  🛡️ official: Reviewed by Picard team (highest trust)\n"
@@ -74,6 +78,7 @@ def register_subcommand(subparsers):
         dest='verb',
         title='plugin commands',
         metavar='<command>',
+        action=GroupedSubParsersAction,
     )
 
     # --- list ---
@@ -134,6 +139,41 @@ def register_subcommand(subparsers):
     p_browse.add_argument('--trust', metavar='LEVEL', help="filter by trust level")
     p_browse.set_defaults(run_command=_run_plugins)
 
+    # --- refs ---
+    p_refs = verb_parsers.add_parser('refs', help='list available git refs for a plugin')
+    p_refs.add_argument('plugin', metavar='PLUGIN', help="plugin name, ID, URL, or UUID")
+    p_refs.set_defaults(run_command=_run_plugins)
+
+    # --- switch-ref ---
+    p_switch_ref = verb_parsers.add_parser('switch-ref', help='switch plugin to a different git ref')
+    p_switch_ref.add_argument('plugin', metavar='PLUGIN', help="plugin name, ID, or UUID")
+    p_switch_ref.add_argument('ref', metavar='REF', help="target branch, tag, or commit")
+    p_switch_ref.set_defaults(run_command=_run_plugins)
+
+    # --- check-blacklist ---
+    p_blacklist = verb_parsers.add_parser('check-blacklist', help='check if URL/UUID is blacklisted')
+    p_blacklist.add_argument('url', nargs='?', default='', metavar='URL', help="git URL to check")
+    p_blacklist.add_argument('--uuid', metavar='UUID', help="plugin UUID to check")
+    p_blacklist.set_defaults(run_command=_run_plugins)
+
+    # --- clean-config ---
+    p_clean = verb_parsers.add_parser('clean-config', help='delete saved options for a plugin')
+    p_clean.add_argument(
+        'plugin', nargs='?', default='', metavar='PLUGIN', help="plugin to clean (omit to list orphaned configs)"
+    )
+    p_clean.set_defaults(run_command=_run_plugins)
+
+    # --- refresh-registry ---
+    p_refresh = verb_parsers.add_parser('refresh-registry', help='force refresh of plugin registry cache')
+    p_refresh.set_defaults(run_command=_run_plugins)
+
+    # --- check-updates ---
+    p_check = verb_parsers.add_parser('check-updates', help='check for available updates')
+    p_check.set_defaults(run_command=_run_plugins)
+
+    # --- Development commands ---
+    verb_parsers.start_group('development commands')
+
     # --- init ---
     p_init = verb_parsers.add_parser('init', help='create a new plugin project')
     p_init.add_argument('name', nargs='?', default='', metavar='NAME', help="plugin name (interactive if omitted)")
@@ -158,44 +198,12 @@ def register_subcommand(subparsers):
     p_validate.add_argument('--ref', metavar='REF', help="git ref to checkout for validation")
     p_validate.set_defaults(run_command=_run_plugins)
 
-    # --- refs ---
-    p_refs = verb_parsers.add_parser('refs', help='list available git refs for a plugin')
-    p_refs.add_argument('plugin', metavar='PLUGIN', help="plugin name, ID, URL, or UUID")
-    p_refs.set_defaults(run_command=_run_plugins)
-
-    # --- switch-ref ---
-    p_switch_ref = verb_parsers.add_parser('switch-ref', help='switch plugin to a different git ref')
-    p_switch_ref.add_argument('plugin', metavar='PLUGIN', help="plugin name, ID, or UUID")
-    p_switch_ref.add_argument('ref', metavar='REF', help="target branch, tag, or commit")
-    p_switch_ref.set_defaults(run_command=_run_plugins)
-
     # --- manifest ---
     p_manifest = verb_parsers.add_parser('manifest', help='show MANIFEST.toml (template if no argument)')
     p_manifest.add_argument(
         'target', nargs='?', default='', metavar='PLUGIN_OR_PATH', help="plugin, path, or URL (omit for template)"
     )
     p_manifest.set_defaults(run_command=_run_plugins)
-
-    # --- check-blacklist ---
-    p_blacklist = verb_parsers.add_parser('check-blacklist', help='check if URL/UUID is blacklisted')
-    p_blacklist.add_argument('url', nargs='?', default='', metavar='URL', help="git URL to check")
-    p_blacklist.add_argument('--uuid', metavar='UUID', help="plugin UUID to check")
-    p_blacklist.set_defaults(run_command=_run_plugins)
-
-    # --- clean-config ---
-    p_clean = verb_parsers.add_parser('clean-config', help='delete saved options for a plugin')
-    p_clean.add_argument(
-        'plugin', nargs='?', default='', metavar='PLUGIN', help="plugin to clean (omit to list orphaned configs)"
-    )
-    p_clean.set_defaults(run_command=_run_plugins)
-
-    # --- refresh-registry ---
-    p_refresh = verb_parsers.add_parser('refresh-registry', help='force refresh of plugin registry cache')
-    p_refresh.set_defaults(run_command=_run_plugins)
-
-    # --- check-updates ---
-    p_check = verb_parsers.add_parser('check-updates', help='check for available updates')
-    p_check.set_defaults(run_command=_run_plugins)
 
     # Default handler when no verb is given
     plugins_parser.set_defaults(run_command=_run_plugins)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Separates plugin CLI commands into "plugin commands" (user-facing) and "development commands" (init, validate, manifest) in help output.

## Problem

The `picard-cli plugins --help` output lists all commands in a single flat list, mixing user-facing commands (list, install, update...) with plugin developer tools (init, validate, manifest). This makes it harder to scan and discover relevant commands.

Related: #3253 adds `compile-ui` which is also a development command.

## Solution

Add `GroupedSubParsersAction` and `GroupedHelpFormatter` (in a new reusable `picard/cli/argparse_grouped.py` module) that allow visually grouping subcommands under titled sections in help output.

The grouping is purely visual — all commands remain in the same namespace and dispatch identically. Plugin developer commands (`init`, `validate`, `manifest`) are grouped under "development commands", making it easy to add future dev tools like `compile-ui`.

```
plugin commands:
  <command>
    list              list all installed plugins
    install           install plugin(s) from git URL(s) or registry ID
    ...
    check-updates     check for available updates

development commands:
  <command>
    init            create a new plugin project
    validate        validate a plugin MANIFEST
    manifest        show MANIFEST.toml (template if no argument)
```

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)