### PR TITLE
Adjust CLI plugins output to format command groups identical to main group

### DIFF
--- a/picard/cli/argparse_grouped.py
+++ b/picard/cli/argparse_grouped.py
@@ -92,13 +92,18 @@ class GroupedHelpFormatter(argparse.RawDescriptionHelpFormatter):
 
         # Add additional sections for each group
         for group_title, names in action._groups.items():
-            parts.append(f'\n{group_title}:\n')
-            parts.append('  <command>\n')
+            t = self._theme
+            parts.append(f'\n{t.heading}{group_title}:{t.reset}\n')
+            parts.append(self._current_indent * ' ')
+            parts.append(self._format_action_invocation(action))
+            parts.append('\n')
+
+            self._indent()
             for name in names:
                 for choice_action in action._choices_actions:
                     if choice_action.dest == name:
-                        help_text = choice_action.help or ''
-                        parts.append(f'    {name:<16}{help_text}\n')
+                        parts.append(self._format_action(choice_action))
                         break
+            self._dedent()
 
         return ''.join(parts)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The grouped subcommands added in #3256 do not fully follow the formatting of the main group. The "development commands" section does not use colors and has slightly different indendation for the command descriptions.

<img width="1611" height="1516" alt="grafik" src="https://github.com/user-attachments/assets/de26b9eb-bd08-4c3c-a67e-835035f0528a" />



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Refactor the output of `GroupedHelpFormatter._format_action` to use existing helper functions for formatting if possible and honor the color theme.

Result:

<img width="1611" height="1516" alt="grafik" src="https://github.com/user-attachments/assets/3407da7a-95eb-4e4b-b85b-44171bd02f12" />



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
