### PR TITLE
PICARD-3339: Exclude plugin options from quick settings menu

### DIFF
--- a/picard/config.py
+++ b/picard/config.py
@@ -721,6 +721,9 @@ def register_quick_menu_item(
     """
     if option.qtype is not bool:
         return
+    # Plugin options are not supported in the quick settings menu yet
+    if option.section != 'setting':
+        return
     title = option.title
     if not title:
         log.warning("BoolOption '%s/%s' has no title, using option name for quick menu", option.section, option.name)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Exclude plugin BoolOptions from the quick settings menu registration since the menu only supports core (`setting` section) options.

## Problem

* JIRA ticket: [PICARD-3339](https://tickets.metabrainz.org/browse/PICARD-3339)

Plugin boolean options (e.g. from replaygain2 or XQAF) were being shown in the Quick Settings Menu configuration tree, but triggered multiple issues:
1. Plugin options appeared top-level instead of under "Plugins" (parent node not found, warning logged)
2. Even if selected, the options did not show up in the actual quick settings menu (it only checks `Option.exists('setting', name)`)

## Solution

Filter out non-`setting` section options early in `register_quick_menu_item()`. This is a minimal fix — full plugin quick settings support (with section-aware config access) can be added as a separate feature later.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Implementation developed with AI assistance (Kiro CLI). All decisions were reviewed and directed by the developer.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)