### PR TITLE
PICARD-3342: Fix profile option highlights overwriting options in different section

### DIFF
--- a/picard/profile.py
+++ b/picard/profile.py
@@ -108,11 +108,11 @@ def profile_groups_all_settings() -> set[str]:
     return _known_settings
 
 
-def profile_groups_update_highlights(option_name: str, highlights: Iterable[str]) -> None:
+def profile_groups_update_highlights(section: str, option_name: str, highlights: Iterable[str]) -> None:
     """Update highlights for an already-registered setting."""
     for group in _settings_groups.values():
         for i, setting in enumerate(group.get('settings', [])):
-            if setting.name == option_name:
+            if setting.section == section and setting.name == option_name:
                 group['settings'][i] = SettingDesc(setting.name, highlights, setting.section)
                 return
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -179,12 +179,13 @@ class OptionsPage(QtWidgets.QWidget, HasDisplayTitle):
     def register_setting(cls, name, highlights=None):
         """Register a setting edited in the page, used to restore defaults
         and to highlight when profiles are used"""
-        option = Option.get(cls.OPTION_SECTION, name)
+        section = cls.OPTION_SECTION
+        option = Option.get(section, name)
         if option is None:
             raise Exception(f"Cannot register setting for non-existing option {name}")
         OptionsPage._registered_settings[cls.NAME].append(option)
         register_quick_menu_item(cls.SORT_ORDER, cls.NAME, cls.PARENT, cls.display_title(), option)
-        pkey = setting_profile_key(name, cls.OPTION_SECTION)
+        pkey = setting_profile_key(name, section)
         if option.in_profile and pkey not in profile_groups_all_settings():
             profile_groups_add_setting(
                 cls.NAME,
@@ -192,7 +193,7 @@ class OptionsPage(QtWidgets.QWidget, HasDisplayTitle):
                 tuple(highlights) if highlights else (),
                 title=cls.display_title(),
                 parent=cls.PARENT,
-                section=cls.OPTION_SECTION,
+                section=section,
             )
         elif option.in_profile and highlights:
-            profile_groups_update_highlights(name, tuple(highlights))
+            profile_groups_update_highlights(section, name, tuple(highlights))

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -87,7 +87,7 @@ class TestPicardProfilesCommon(PicardTestCase):
             group = 'group%d' % (n % 2)
             title = 'title_' + group
             name = 'opt%d' % n
-            highlights = ('obj%d' % i for i in range(0, n))
+            highlights = tuple('obj%d' % i for i in range(0, n))
             profile_groups_add_setting(group, name, highlights, title=title)
         option_settings = list(profile_groups_all_settings())
         self.test_setting_0 = option_settings[0]
@@ -187,11 +187,14 @@ class TestUserProfileGroups(TestPicardProfilesCommon):
         self.assertIn('opt0', profile_groups_all_settings())
 
     def test_update_highlights(self):
-        # Update highlights for opt1
-        profile_groups_update_highlights('opt1', ('new_widget',))
+        profile_groups_add_setting('group1', 'opt1', ('old_widget',), section='section2')
+        # Update highlights for opt1 in section 'section2'
+        profile_groups_update_highlights('section2', 'opt1', ('new_widget',))
         settings = list(profile_groups_settings('group1'))
-        opt1_updated = next(s for s in settings if s.name == 'opt1')
+        opt1_updated = next(s for s in settings if s.name == 'opt1' and s.section == 'section2')
         self.assertEqual(opt1_updated.highlights, ('new_widget',))
+        opt1_unchanged = next(s for s in settings if s.name == 'opt1' and s.section == 'setting')
+        self.assertEqual(opt1_unchanged.highlights, ('obj0',))
 
 
 class TestUserProfiles(TestPicardProfilesCommon):


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3342
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

If options in different sections (e.g. plugins and settings) use the same name, registering option highlights would overwrite options in wrong section.

Noticed this with my fanarttv and audiodb plugins, which both have a `use_cdart` option.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Consider the section in `profile_groups_update_highlights`


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
