### PR TITLE
Fix picard-cli -V showing "invalid nullptr parameter" error

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1791,7 +1791,6 @@ def main(localedir=None, autoupdate=True):
     cmdline_args = process_cmdline_args()
 
     if cmdline_args.long_version:
-        _ = QtCore.QCoreApplication(sys.argv)
         print_message_and_exit(versions.as_string())
     if cmdline_args.version:
         print_message_and_exit(f"{PICARD_ORG_NAME} {PICARD_APP_NAME} {PICARD_FANCY_VERSION_STR}")

--- a/picard/util/versions.py
+++ b/picard/util/versions.py
@@ -23,12 +23,15 @@
 
 
 from collections import OrderedDict
+from collections.abc import Generator
+from contextlib import contextmanager
 from platform import python_version
 
 from mutagen import version_string as mutagen_version
 
 from PyQt6.QtCore import (
     PYQT_VERSION_STR as pyqt_version,
+    QCoreApplication,
     qVersion,
 )
 from PyQt6.QtNetwork import QSslSocket
@@ -77,10 +80,27 @@ def _load_versions() -> None:
             ('mutagen-version', mutagen_version),
             ('discid-version', discid_version),
             ('astrcmp', astrcmp_implementation),
-            ('ssl-version', QSslSocket.sslLibraryVersionString()),
+            ('ssl-version', _ssl_version()),
             ('pygit2-version', pygit2_version),
         )
     )
+
+
+@contextmanager
+def _ensure_qt_app() -> Generator[None, None, None]:
+    app = QCoreApplication.instance()
+    if not app:
+        # If no app is running, create a temporary new one, but close after use.
+        app = QCoreApplication([])
+        yield
+        app.exit()
+    else:
+        yield
+
+
+def _ssl_version() -> str | None:
+    with _ensure_qt_app():
+        return QSslSocket.sslLibraryVersionString()
 
 
 def _value_as_text(value: str | None, i18n: bool = False) -> str:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The call to `QSslSocket.sslLibraryVersionString()` causes an error "QObject::connect(QObject, Unknown): invalid nullptr parameter" being printed, as there is no existing `QCoreApplication` instance.

```
% uv run picard-cli -V
qt.core.qobject.connect: QObject::connect(QObject, Unknown): invalid nullptr parameter
Picard 3.0.0b7, Python 3.14.2, PyQt 6.11.0, Qt 6.11.1, Mutagen 1.48.1, Discid discid 1.4.1, libdiscid 0.6.4, astrcmp C, SSL OpenSSL 3.0.13 30 Jan 2024, pygit2 1.19.3
```

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Use a context manager that ensures there exists a `QCoreApplication` before calling `sslLibraryVersionString`, if necessary create a temporary instance, but exit it after use. This allows running the command without warning:

```
% uv run picard-cli -V
Picard 3.0.0b7, Python 3.14.2, PyQt 6.11.0, Qt 6.11.1, Mutagen 1.48.1, Discid discid 1.4.1, libdiscid 0.6.4, astrcmp C, SSL OpenSSL 3.0.13 30 Jan 2024, pygit2 1.19.3
```

Also remove a similar workaround that was added to `tagger.py` in a8e9b6000721cb91744dbb89583eaada0b7ecfcb. This is no longer needed, with the changes running `picard -V` directly shows no warning either.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
