### PR TITLE
PICARD-3344: Fix crash when collection menu callback fires after widget deletion

### DIFF
--- a/picard/ui/collectionmenu.py
+++ b/picard/ui/collectionmenu.py
@@ -143,7 +143,12 @@ class CollectionCheckBox(QtWidgets.QCheckBox):
             self.setCheckState(QtCore.Qt.CheckState.Unchecked)
 
     def _update_text(self):
-        self.setText(self._label())
+        try:
+            self.setText(self._label())
+        except RuntimeError:
+            # The underlying C++ widget may have been deleted if the menu
+            # was closed before the async web service response arrived.
+            pass
 
     def _label(self):
         c = self.collection


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix a crash (`RuntimeError: wrapped C/C++ object of type CollectionCheckBox has been deleted`) that occurs when the async web service response arrives after the user has closed the collection menu.

## Problem

* JIRA ticket: PICARD-3344

When a user adds/removes a release from a collection via the context menu and closes the menu before the web service response arrives, the callback `_update_text` tries to call `setText()` on a destroyed Qt widget, causing a crash.

## Solution

Wrap the `setText()` call in `CollectionCheckBox._update_text()` with a `try/except RuntimeError` to gracefully handle the case where the underlying C++ widget has already been deleted. This is the only async entry point to the widget, and `_label()` only accesses Python-side attributes, so the exception is precisely scoped.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
