### PR TITLE
PICARD-3345: Fix errors when parsing SYLT tags

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -678,6 +678,9 @@ class ID3File(File):
         return values
 
     def _parse_sylt_text(self, text, length):
+        if not text:
+            return ''
+
         def milliseconds_to_timestamp(ms):
             minutes = ms // (60 * 1000)
             seconds = (ms % (60 * 1000)) // 1000
@@ -693,7 +696,8 @@ class ID3File(File):
             if '\n' in lyrics:
                 split = lyrics.split('\n')
                 lrc_lyrics.append(f"<{timestamp}>{split[0]}")
-                distribution = (milliseconds[i + 1] - milliseconds[i]) / len(lyrics.replace('\n', ''))
+                length = len(lyrics.replace('\n', '')) or 1
+                distribution = (milliseconds[i + 1] - milliseconds[i]) / length
                 estimation = milliseconds[i] + distribution * len(split[0])
                 for line in split[1:]:
                     timestamp = milliseconds_to_timestamp(int(estimation))

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -825,6 +825,8 @@ class ID3FileTest(PicardTestCase):
             [("Test newline\nin the middle", 0), ("of the text", 1000)],
             [("Test empty lyrics at the end\n", 0), ("", 1000)],
             [("Test timestamp estimation", 0), ("in the\nlast phrase", 1000)],
+            [("start", 54940), ("\n", 60000), ("end", 119680)],
+            [],
         )
         correct_lrcs = (
             "[00:00.000]<00:00.000>Test<00:00.500>normal\n[00:01.000]<00:01.000>behaviour",
@@ -832,6 +834,8 @@ class ID3FileTest(PicardTestCase):
             "[00:00.000]<00:00.000>Test newline\n[00:00.480]in the middle<00:01.000>of the text",
             "[00:00.000]<00:00.000>Test empty lyrics at the end\n[00:01.000]<00:01.000>",
             "[00:00.000]<00:00.000>Test timestamp estimation<00:01.000>in the\n[00:01.352]last phrase",
+            "[00:54.940]<00:54.940>start<01:00.000>\n[01:00.000]<01:59.680>end",
+            "",
         )
         for sylt, correct_lrc in zip(sylts, correct_lrcs, strict=True):
             lrc = self.file._parse_sylt_text(sylt, 2)


### PR DESCRIPTION
- Fix division by zero exception, if the SYLT tag contains a segment consisting only of a newline character
- Handle completely empty segment list

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3345
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Reading a SYLT tag that contained an entry that consist only of a newline character (`"\n"`) would throw a division by zero exception.



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
- Fix division by zero exception, if the SYLT tag contains a segment consisting only of a newline character
- Handle completely empty segment list
- Added tests

The case where this happens is from https://lrclib.net/api/get?track_name=3-5-7&artist_name=All%20Them%20Witches&album_name=Sleeping%20Through%20the%20War . The LRC data contains a line `[01:00.00]`, which when getting stored as `SYLT` got converted to just `"\n"`.

The test case added uses the timings from the real example to verify correct decoding.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
