### PR TITLE
PICARD-30: Add _artistcomment and _albumartistcomment variables

### DIFF
--- a/picard/const/tags.py
+++ b/picard/const/tags.py
@@ -102,6 +102,25 @@ ALL_TAGS = TagVars(
         is_multi_value=True,
     ),
     TagVar(
+        'albumartists_comments',
+        shortdesc=N_('Album Artists Comments'),
+        longdesc=N_(
+            'The disambiguation comments for all of the credited album artists, in the same order as the artists.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+        is_multi_value=True,
+    ),
+    TagVar(
+        'albumartistcomment',
+        shortdesc=N_('Album Artist Comment'),
+        longdesc=N_(
+            'The disambiguation comment for the album artist. This is only set if there is a single album artist.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+    ),
+    TagVar(
         'albumartistsort',
         shortdesc=N_('Album Artist Sort Order'),
         longdesc=N_('The release artists sort names, separated by the specified join phrases. (e.g.: "Beatles, The")'),
@@ -170,6 +189,25 @@ ALL_TAGS = TagVars(
         is_hidden=True,
         is_tag=False,
         is_multi_value=True,
+    ),
+    TagVar(
+        'artists_comments',
+        shortdesc=N_('Artists Comments'),
+        longdesc=N_(
+            'The disambiguation comments for all of the credited track artists, in the same order as the artists.'
+        ),
+        is_hidden=True,
+        is_tag=False,
+        is_multi_value=True,
+    ),
+    TagVar(
+        'artistcomment',
+        shortdesc=N_('Artist Comment'),
+        longdesc=N_(
+            'The disambiguation comment for the track artist. This is only set if there is a single track artist.'
+        ),
+        is_hidden=True,
+        is_tag=False,
     ),
     TagVar(
         'artistsort',

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -159,6 +159,7 @@ class ArtistCreditInfo:
     names: list[str]
     sort_names: list[str]
     countries: list[str]
+    comments: list[str]
 
 
 @dataclass
@@ -640,6 +641,7 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
     artist_names = []
     artist_sort_names = []
     artist_countries = []
+    artist_comments = []
     config = get_config()
     standardize_names_mode = config.setting['standardize_artist_names']
     for artist_info in node:
@@ -650,6 +652,7 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
         if artist and 'id' in artist and artist['id']:
             # Add artist's country code if specified, otherwise 'XX' (Unknown Country)
             artist_countries.append(artist['country'] if 'country' in artist and artist['country'] else 'XX')
+            artist_comments.append(artist.get('disambiguation', ''))
         translated_alias = _translate_artist_node(artist, config=config)
         has_translation = translated_alias.name != artist['name']
         if not has_translation and use_credited_as and 'name' in artist_info:
@@ -665,7 +668,9 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
         if 'joinphrase' in artist_info:
             artist_name += artist_info['joinphrase'] or ''
             artist_sort_name += artist_info['joinphrase'] or ''
-    return ArtistCreditInfo(artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries)
+    return ArtistCreditInfo(
+        artist_name, artist_sort_name, artist_names, artist_sort_names, artist_countries, artist_comments
+    )
 
 
 def should_standardize_artist_name(mode: StandardizeArtistNames, credited_name: str, artist: Node) -> bool:
@@ -698,6 +703,8 @@ def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = F
         m['~albumartists'] = credits.names
         m['~albumartists_sort'] = credits.sort_names
         m['~albumartists_countries'] = credits.countries
+        m['~albumartists_comments'] = credits.comments
+        m['~albumartistcomment'] = credits.comments[0] if len(credits.comments) == 1 else ''
     else:
         m['musicbrainz_artistid'] = ids
         m['artist'] = credits.name
@@ -705,6 +712,8 @@ def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = F
         m['artists'] = credits.names
         m['~artists_sort'] = credits.sort_names
         m['~artists_countries'] = credits.countries
+        m['~artists_comments'] = credits.comments
+        m['~artistcomment'] = credits.comments[0] if len(credits.comments) == 1 else ''
 
 
 def _release_event_iter(node: Node) -> Iterator[Node]:

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -391,6 +391,8 @@ class RecordingTest(MBJSONTest):
         self.assertEqual(m['~recording_firstreleasedate'], '2014-06-20')
         self.assertEqual(m['~video'], '')
         self.assertEqual(m['~artists_countries'], 'GB')
+        self.assertEqual(m['~artistcomment'], 'famous UK singer-songwriter')
+        self.assertEqual(m.getall('~artists_comments'), ['famous UK singer-songwriter'])
         self.assertNotIn('originaldate', m)
         self.assertNotIn('originalyear', m)
         self.assertEqual(t.folksonomy_tags, {'blue-eyed soul': 1, 'pop': 3})
@@ -433,6 +435,7 @@ class RecordingMultiArtistsTest1(MBJSONTest):
             ['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'],
             ['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'],
             ['GB', 'US', 'US'],
+            ['UK singer-songwriter, \u201cShape of You\u201d', '', ''],
         )
         self.assertEqual(expected, credits)
 
@@ -452,6 +455,11 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         self.assertEqual(['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'], m.getall('artists'))
         self.assertEqual(['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'], m.getall('~artists_sort'))
         self.assertEqual(['GB', 'US', 'US'], m.getall('~artists_countries'))
+        self.assertEqual(
+            ['UK singer-songwriter, \u201cShape of You\u201d', '', ''],
+            m.getall('~artists_comments'),
+        )
+        self.assertEqual('', m['~artistcomment'])
 
     def test_artist_credit_to_metadata_release(self):
         m = Metadata()
@@ -469,6 +477,11 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         self.assertEqual(['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'], m.getall('~albumartists'))
         self.assertEqual(['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'], m.getall('~albumartists_sort'))
         self.assertEqual(['GB', 'US', 'US'], m.getall('~albumartists_countries'))
+        self.assertEqual(
+            ['UK singer-songwriter, \u201cShape of You\u201d', '', ''],
+            m.getall('~albumartists_comments'),
+        )
+        self.assertEqual('', m['~albumartistcomment'])
 
 
 class RecordingMultiArtistsTest2(MBJSONTest):


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Expose artist disambiguation comments from MusicBrainz as scripting variables (`%_artistcomment%`, `%_albumartistcomment%`, `%_artists_comments%`, `%_albumartists_comments%`), enabling users to automatically disambiguate artists with identical names in file naming scripts.

## Problem

* JIRA ticket: [PICARD-30](https://tickets.metabrainz.org/browse/PICARD-30)

When two different artists share the same name (e.g., multiple artists called "Nirvana" or "Nelly"), Picard's file naming scripts produce identical folder paths, causing files from different artists to land in the same directory.

Currently, users must either:
- Append the full MBID to folder names (ugly and unreadable)
- Hardcode specific MBIDs in scripts to set custom names (fragile and manual)
- Manually rename folders after tagging (defeats the purpose of automation)

MusicBrainz already provides disambiguation comments for artists (e.g., "American grunge/alternative rock band" vs "60s British psychedelic/progressive rock"), and the data is already returned by the web service API in artist credit nodes. However, Picard did not expose this data in track/album metadata for use in scripting.

This has been requested multiple times over the years:
- [PICARD-30](https://tickets.metabrainz.org/browse/PICARD-30) (filed 2011, 8 votes)
- [Community thread: disambiguation variable for file/folder naming?](https://community.metabrainz.org/t/different-artists-with-the-same-name-disambiguation-variable-for-file-folder-naming/616031) (2022)
- [Community thread: Artist Folder Naming: How Do You Handle Artists With Identical Names?](https://community.metabrainz.org/t/artist-folder-naming-how-do-you-handle-artists-with-identical-names/814857) (2026)

## Solution

Extract the `disambiguation` field from each artist node within artist credits and expose it as metadata variables:

| Variable | Description |
|----------|-------------|
| `%_artistcomment%` | Disambiguation comment for the track artist. Only set for single-artist credits (empty for collaborations, as suggested in PICARD-30). |
| `%_albumartistcomment%` | Same, for the album artist. |
| `%_artists_comments%` | Multi-value list of disambiguation comments for all credited track artists (one per artist, in order). |
| `%_albumartists_comments%` | Same, for album artists. |

The single-value variants are empty for multi-artist credits (collaborations) to avoid ambiguity, following option 2 from the PICARD-30 ticket discussion. Users needing per-artist comments in collaborations can use the multi-value variants with `$get()`.

**Example usage in naming scripts:**
```
$if(%_albumartistcomment%,%albumartist% (%_albumartistcomment%),%albumartist%)
```
Produces: `Nirvana (American grunge/alternative rock band)/` instead of just `Nirvana/`

**Implementation:**
- Added `comments` field to `ArtistCreditInfo` dataclass
- `artist_credit_from_node()` now collects `disambiguation` from each artist node
- `artist_credit_to_metadata()` stores the comments in metadata
- Registered 4 new `TagVar` entries in `const/tags.py`

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed with AI assistance (Kiro CLI) under human direction and review. Design decisions (behavior for multi-artist credits, variable naming) were made by the human developer.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

The new variables should be documented in the scripting variables reference.
