### PR TITLE
PICARD-3346, PICARD-3347: Cyanrip log support + disc_log_readers extension point

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -871,6 +871,62 @@ def enable(api):
 
 ---
 
+### Disc Log Readers
+
+#### `register_disc_log_reader(function)`
+
+Register a custom CD ripping log parser for the *Lookup CD log file* feature.
+
+When a user opens a log file, all registered readers are tried in sequence until
+one succeeds. The function should raise any exception if it cannot parse the file
+(e.g., wrong format); Picard will catch the exception and try the next reader.
+
+**Signature**: `function(path: str) -> TocNumbers`
+
+The returned `TocNumbers` (a `tuple[int, ...]`) must be a MusicBrainz TOC:
+`(first_track, last_track, leadout_offset, offset_1, offset_2, ...)`
+
+```python
+import re
+
+from picard.disc.utils import (
+    TocEntry,
+    calculate_mb_toc_numbers,
+    NotSupportedTOCError,
+)
+
+def my_ripper_toc_from_file(path):
+    """Parse MyRipper log files for disc ID lookup."""
+    entries = []
+    with open(path, encoding='utf-8') as f:
+        first_line = f.readline()
+        if not first_line.startswith('MyRipper'):
+            raise NotSupportedTOCError("Not a MyRipper log")
+        for line in f:
+            m = re.match(r"Track (\d+): (\d+)-(\d+)", line)
+            if m:
+                entries.append(TocEntry(int(m[1]), int(m[2]), int(m[3])))
+    return calculate_mb_toc_numbers(entries)
+
+def enable(api):
+    api.register_disc_log_reader(my_ripper_toc_from_file)
+```
+
+**Parameters**:
+- `function`: A callable taking a file path (`str`) and returning `TocNumbers`
+  (from `picard.disc.utils`). Should raise an exception (e.g.,
+  `NotSupportedTOCError`) if it cannot parse the file.
+
+**Tips**:
+- Validate the file format early (e.g., check a header line) so that
+  unrecognized files fail fast without reading the entire file.
+- Use `picard.disc.utils.TocEntry` and `calculate_mb_toc_numbers()` to build
+  the TOC from track start/end sectors.
+- Built-in readers support EAC, XLD, fre:ac, Whipper, Cyanrip, dBpoweramp,
+  and SCSI TOC formats. Plugin readers are tried after all built-in readers.
+
+---
+
 ## Album Background Task Management
 
 Plugins can track asynchronous operations (like web requests) without blocking album loading.

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -37,6 +37,11 @@ from picard import (
     log,
     tagger_instance,
 )
+from picard.disc.dbpoweramplog import toc_from_file as _dbpoweramp_toc_from_file
+from picard.disc.eaclog import toc_from_file as _eac_toc_from_file
+from picard.disc.scsitoc import toc_from_file as _scsitoc_toc_from_file
+from picard.disc.whipperlog import toc_from_file as _whipper_toc_from_file
+from picard.extension_points.disc_log_readers import register_disc_log_reader
 from picard.util.mbserver import build_submission_url
 
 from picard.ui.cdlookup import CDLookupDialog
@@ -188,3 +193,10 @@ class Disc:
 discid_version: str | None = None
 if discid is not None:
     discid_version = "discid %s, %s" % (discid.__version__, discid.LIBDISCID_VERSION_STRING)
+
+
+# Register built-in disc log readers
+register_disc_log_reader(_eac_toc_from_file)
+register_disc_log_reader(_whipper_toc_from_file)
+register_disc_log_reader(_dbpoweramp_toc_from_file)
+register_disc_log_reader(_scsitoc_toc_from_file)

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -37,6 +37,7 @@ from picard import (
     log,
     tagger_instance,
 )
+from picard.disc.cyanriplog import toc_from_file as _cyanrip_toc_from_file
 from picard.disc.dbpoweramplog import toc_from_file as _dbpoweramp_toc_from_file
 from picard.disc.eaclog import toc_from_file as _eac_toc_from_file
 from picard.disc.scsitoc import toc_from_file as _scsitoc_toc_from_file
@@ -198,5 +199,6 @@ if discid is not None:
 # Register built-in disc log readers
 register_disc_log_reader(_eac_toc_from_file)
 register_disc_log_reader(_whipper_toc_from_file)
+register_disc_log_reader(_cyanrip_toc_from_file)
 register_disc_log_reader(_dbpoweramp_toc_from_file)
 register_disc_log_reader(_scsitoc_toc_from_file)

--- a/picard/disc/cyanriplog.py
+++ b/picard/disc/cyanriplog.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections.abc import (
+    Iterable,
+    Iterator,
+)
+import re
+
+from picard.disc.utils import (
+    NotSupportedTOCError,
+    TocEntry,
+    TocNumbers,
+    calculate_mb_toc_numbers,
+)
+
+
+RE_TRACK_HEADER = re.compile(r"^Track (?P<num>\d+) ripped")
+RE_START_LSN = re.compile(r"^\s+Start LSN:\s+(?P<lsn>\d+)\s*$")
+RE_END_LSN = re.compile(r"^\s+End LSN:\s+(?P<lsn>\d+)\s*$")
+RE_CYANRIP_HEADER = re.compile(r"^cyanrip\s+\d+\.\d+")
+
+
+def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
+    """Parse cyanrip log lines and yield TocEntry for each track."""
+    current_track = None
+    start_lsn = None
+
+    for line in lines:
+        track_match = RE_TRACK_HEADER.match(line)
+        if track_match:
+            current_track = int(track_match['num'])
+            start_lsn = None
+            continue
+
+        if current_track is not None:
+            start_match = RE_START_LSN.match(line)
+            if start_match:
+                start_lsn = int(start_match['lsn'])
+                continue
+
+            end_match = RE_END_LSN.match(line)
+            if end_match and start_lsn is not None:
+                end_lsn = int(end_match['lsn'])
+                yield TocEntry(current_track, start_lsn, end_lsn)
+                current_track = None
+                start_lsn = None
+
+
+def toc_from_file(path: str) -> TocNumbers:
+    """Reads cyanrip log files, generates MusicBrainz disc TOC listing for use as discid."""
+    with open(path, encoding='utf-8') as f:
+        first_line = f.readline()
+        if not RE_CYANRIP_HEADER.match(first_line):
+            raise NotSupportedTOCError("Not a cyanrip log file")
+        f.seek(0)
+        return calculate_mb_toc_numbers(filter_toc_entries(f))

--- a/picard/disc/dbpoweramplog.py
+++ b/picard/disc/dbpoweramplog.py
@@ -30,6 +30,7 @@ import re
 from picard.disc.utils import (
     NotSupportedTOCError,
     TocEntry,
+    TocNumbers,
     calculate_mb_toc_numbers,
 )
 from picard.util import detect_file_encoding
@@ -55,7 +56,7 @@ def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
             yield TocEntry(track_num, int(m['start_sector']), int(m['end_sector']) - 1)
 
 
-def toc_from_file(path: str) -> tuple[int, ...]:
+def toc_from_file(path: str) -> TocNumbers:
     """Reads dBpoweramp log files, generates MusicBrainz disc TOC listing for use as discid."""
     encoding = detect_file_encoding(path)
     with open(path, 'r', encoding=encoding) as f:

--- a/picard/disc/eaclog.py
+++ b/picard/disc/eaclog.py
@@ -30,6 +30,7 @@ import re
 
 from picard.disc.utils import (
     TocEntry,
+    TocNumbers,
     calculate_mb_toc_numbers,
 )
 from picard.util import detect_file_encoding
@@ -84,7 +85,7 @@ def filter_toc_entries(lines: Iterator[str]) -> Iterator[TocEntry]:
         yield TocEntry(int(m['num']), int(m['start_sector']), int(m['end_sector']))
 
 
-def toc_from_file(path: str) -> tuple[int, ...]:
+def toc_from_file(path: str) -> TocNumbers:
     """Reads EAC / XLD / fre:ac log files, generates MusicBrainz disc TOC listing for use as discid.
 
     Warning: may work wrong for discs having data tracks. May generate wrong

--- a/picard/disc/scsitoc.py
+++ b/picard/disc/scsitoc.py
@@ -26,13 +26,14 @@ from picard.disc.utils import (
     DATA_TRACK_GAP,
     PREGAP_LENGTH,
     NotSupportedTOCError,
+    TocNumbers,
 )
 
 
 ScsiTocEntry = namedtuple('ScsiTocEntry', 'number start_sector is_data')
 
 
-def parse_toc_entries(f: BinaryIO) -> tuple[int, ...]:
+def parse_toc_entries(f: BinaryIO) -> TocNumbers:
     """Parse a TOC in the format used by SCSI's READ TOC command."""
 
     data = f.read()
@@ -73,7 +74,7 @@ def parse_toc_entries(f: BinaryIO) -> tuple[int, ...]:
     return (first_track, last_track, leadout_offset + PREGAP_LENGTH) + offsets
 
 
-def toc_from_file(path: str) -> tuple[int, ...]:
+def toc_from_file(path: str) -> TocNumbers:
     """Reads a TOC in the SCSI format, generates MusicBrainz disc TOC listing for use as discid."""
 
     with open(path, 'rb') as f:

--- a/picard/disc/utils.py
+++ b/picard/disc/utils.py
@@ -34,12 +34,16 @@ DATA_TRACK_GAP: int = 11400
 
 TocEntry = namedtuple('TocEntry', 'number start_sector end_sector')
 
+# Type alias for MusicBrainz TOC numbers tuple:
+# (first_track, last_track, leadout_offset, offset_1, offset_2, ...)
+TocNumbers = tuple[int, ...]
+
 
 class NotSupportedTOCError(Exception):
     pass
 
 
-def calculate_mb_toc_numbers(toc: Iterable[TocEntry]) -> tuple[int, ...]:
+def calculate_mb_toc_numbers(toc: Iterable[TocEntry]) -> TocNumbers:
     """
     Take iterator of TOC entries, return a tuple of numbers for MusicBrainz disc id
 

--- a/picard/disc/whipperlog.py
+++ b/picard/disc/whipperlog.py
@@ -24,11 +24,12 @@ import yaml
 
 from picard.disc.utils import (
     TocEntry,
+    TocNumbers,
     calculate_mb_toc_numbers,
 )
 
 
-def toc_from_file(path: str) -> tuple[int, ...]:
+def toc_from_file(path: str) -> TocNumbers:
     """Reads whipper log files, generates musicbrainz disc TOC listing for use as discid.
 
     Warning: may work wrong for discs having data tracks. May generate wrong

--- a/picard/extension_points/disc_log_readers.py
+++ b/picard/extension_points/disc_log_readers.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections.abc import Callable
+
+from picard.disc.utils import TocNumbers
+from picard.extension_points import ExtensionPoint
+
+
+ext_point_disc_log_readers = ExtensionPoint(label='disc_log_readers')
+
+
+def register_disc_log_reader(function: Callable[[str], TocNumbers]) -> None:
+    """Registers a disc log reader function.
+
+    A disc log reader is a function that takes a file path and returns
+    a MusicBrainz TOC tuple (first_track, last_track, leadout_offset,
+    offset_1, offset_2, ...) or raises an exception if the file cannot
+    be parsed by this reader.
+
+    Args:
+        function: A callable taking a file path (str) and returning
+            TocNumbers representing the MusicBrainz disc TOC.
+            Should raise an exception if the file format is not supported.
+    """
+    ext_point_disc_log_readers.register(function.__module__, function)

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -64,6 +64,9 @@ from picard.extension_points.cover_art_processors import (
 from picard.extension_points.cover_art_providers import (
     register_cover_art_provider,
 )
+from picard.extension_points.disc_log_readers import (
+    register_disc_log_reader,
+)
 from picard.extension_points.event_hooks import (
     register_album_post_removal_processor,
     register_file_post_addition_to_track_processor,
@@ -114,6 +117,7 @@ except (ImportError, ModuleNotFoundError):
 
 
 if TYPE_CHECKING:
+    from picard.disc.utils import TocNumbers
     from picard.tagger import Tagger
 
 
@@ -1150,6 +1154,43 @@ class PluginApi:
                 api.register_format(MyFormat)
         """
         return self._tagger.format_registry.register(format)
+
+    # Disc log readers
+    def register_disc_log_reader(self, function: Callable[[str], 'TocNumbers']) -> None:
+        """Register a custom disc log reader.
+
+        A disc log reader parses CD ripping log files and extracts table of
+        contents (TOC) data for disc ID calculation. When a user opens a log
+        file via *Lookup CD log file*, all registered readers are tried in
+        sequence until one succeeds.
+
+        The function should raise any exception if it cannot parse the file
+        (e.g., wrong format). Picard will catch the exception and try the
+        next reader.
+
+        Args:
+            function: A callable that takes a file path (``str``) and returns
+                ``TocNumbers`` — a tuple of ints representing the MusicBrainz
+                disc TOC:
+                ``(first_track, last_track, leadout_offset, offset_1, offset_2, ...)``.
+
+        Example:
+            import re
+            from picard.disc.utils import TocEntry, calculate_mb_toc_numbers
+
+            def my_ripper_toc_from_file(path):
+                entries = []
+                with open(path) as f:
+                    for line in f:
+                        m = re.match(r"Track (\\d+): (\\d+)-(\\d+)", line)
+                        if m:
+                            entries.append(TocEntry(int(m[1]), int(m[2]), int(m[3])))
+                return calculate_mb_toc_numbers(entries)
+
+            def enable(api):
+                api.register_disc_log_reader(my_ripper_toc_from_file)
+        """
+        return register_disc_log_reader(function)
 
     # Scripting
     def register_script_function(

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -120,11 +120,8 @@ from picard.coverart.image import DataHash
 from picard.debug_opts import DebugOpt
 from picard.disc import (
     Disc,
-    dbpoweramplog,
-    eaclog,
-    scsitoc,
-    whipperlog,
 )
+from picard.extension_points.disc_log_readers import ext_point_disc_log_readers
 from picard.file import File
 from picard.formats import DEFAULT_FORMATS
 from picard.formats.registry import FormatRegistry
@@ -1334,13 +1331,7 @@ class Tagger(QtWidgets.QApplication):
         )
 
     def _parse_disc_ripping_log(self, disc, path):
-        log_readers = (
-            eaclog.toc_from_file,
-            whipperlog.toc_from_file,
-            dbpoweramplog.toc_from_file,
-            scsitoc.toc_from_file,
-        )
-        for reader in log_readers:
+        for reader in ext_point_disc_log_readers:
             module_name = reader.__module__
             try:
                 log.debug('Trying to parse "%s" with %s…', path, module_name)

--- a/test/data/cyanrip.log
+++ b/test/data/cyanrip.log
@@ -1,0 +1,139 @@
+cyanrip 0.9.3 (c23f1c4)
+System device: /dev/cdrom
+Device model: Dell DVD+/-RW DW316 A1C3 SCSI CD-ROM
+Offset: +0 samples
+Overread: +0 frames
+Overread mode: fill with silence in lead-in/lead-out
+Speed: default (unchangeable)
+C2 errors: supported by drive
+Paranoia level: max
+Frame retries: 10
+HDCD decoding: disabled
+Album Art: none
+Outputs: flac
+Disc tracks: 2
+Tracks to rip: all
+DiscID: 7rGk5fXmuE8VcWYpbwoobOZIcIE-
+CDDB ID: 140C2C02
+Album: Norns
+Album artist: Natural Snow Buildings
+AccurateRip: not found
+Total time: 00:51:56.306
+Gaps: None signalled
+Tracks:
+
+Track 1 ripped and encoded successfully!
+
+  Summary:
+    Integrated loudness:    I:    -8.9 LUFS
+    Threshold:             -18.9 LUFS
+    Loudness range:        LRA:     3.2 LU
+    Threshold:             -28.9 LUFS
+    LRA low:               -10.8 LUFS
+    LRA high:               -7.6 LUFS
+    True peak:             Peak:   -0.7 dBFS
+
+  Preemphasis: none detected
+
+  Properties:
+    Duration: 00:30:25.180
+    Samples: 80508960
+    Frames: 136920
+    Pregap LSN: none
+    Start LSN: 0
+    End LSN: 136919
+
+    EAC CRC32: E84207DD
+    Accurip: not found
+    Accurip v1: 4D32A287
+    Accurip v2: 29FCBEFC
+    Accurip 450: 15DA27EA
+
+  Metadata:
+    track: 1
+    tracktotal: 2
+    discid: 7rGk5fXmuE8VcWYpbwoobOZIcIE-
+    cddb: 140C2C02
+    media_type: CD
+    comment: cyanrip 0.9.3
+    title: Norns
+    album: Norns
+    album_artist: Natural Snow Buildings
+    artist: Natural Snow Buildings
+    creation_time: 2026-07-12T13:49:04
+    REPLAYGAIN_TRACK_GAIN: -9.09 dB
+    R128_TRACK_GAIN: -1046
+    REPLAYGAIN_TRACK_RANGE: 3.19 dB
+    REPLAYGAIN_TRACK_PEAK: 0.919832
+    REPLAYGAIN_REFERENCE_LOUDNESS: -18.00 LUFS
+
+  File(s):
+    Norns [FLAC]/1 - Norns.flac
+
+
+Track 2 ripped and encoded successfully!
+
+  Summary:
+    Integrated loudness:    I:    -9.9 LUFS
+    Threshold:             -19.9 LUFS
+    Loudness range:        LRA:     0.9 LU
+    Threshold:             -29.9 LUFS
+    LRA low:               -10.4 LUFS
+    LRA high:               -9.4 LUFS
+    True peak:             Peak:   -1.3 dBFS
+
+  Preemphasis: none detected
+
+  Properties:
+    Duration: 00:21:31.126
+    Samples: 56938980
+    Frames: 96835
+    Pregap LSN: none
+    Start LSN: 136920
+    End LSN: 233754
+
+    EAC CRC32: 023E6E8C
+    Accurip: not found
+    Accurip v1: 09BAC5C2
+    Accurip v2: EFCDD99F
+    Accurip 450: 0BE9A70E
+
+  Metadata:
+    track: 2
+    tracktotal: 2
+    discid: 7rGk5fXmuE8VcWYpbwoobOZIcIE-
+    cddb: 140C2C02
+    media_type: CD
+    comment: cyanrip 0.9.3
+    title: Radiant Maid of the Underworld
+    album: Norns
+    album_artist: Natural Snow Buildings
+    artist: Natural Snow Buildings
+    creation_time: 2026-07-12T14:01:10
+    REPLAYGAIN_TRACK_GAIN: -8.07 dB
+    R128_TRACK_GAIN: -787
+    REPLAYGAIN_TRACK_RANGE: 0.93 dB
+    REPLAYGAIN_TRACK_PEAK: 0.860882
+    REPLAYGAIN_REFERENCE_LOUDNESS: -18.00 LUFS
+
+  File(s):
+    Norns [FLAC]/2 - Radiant Maid of the Underworld.flac
+
+
+Album Loudness Summary:
+  Integrated loudness:    I:    -9.3 LUFS
+  Threshold:             -19.3 LUFS
+  Loudness range:        LRA:     2.9 LU
+  Threshold:             -29.3 LUFS
+  LRA low:               -10.5 LUFS
+  LRA high:               -7.7 LUFS
+  True peak:             Peak:   -0.7 dBFS
+
+Paranoia status counts:
+  READ: 18773
+  VERIFY: 1287
+  OVERLAP: 382
+
+Ripping errors: 0
+Ripping finished at 2026-07-12T14:08:47
+Log FUN512: 6o0EbHpOpwkSSakBU7as7Xkj78qhx4Dis_tHVhU5GLDp.x3LkQvfVmkcE5s01iP1UCc5LjhQ.Wpcr4CdJlhNMg

--- a/test/test_disc_cyanriplog.py
+++ b/test/test_disc_cyanriplog.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from collections.abc import Iterator
+
+from test.picardtestcase import (
+    PicardTestCase,
+    get_test_data_path,
+)
+
+from picard.disc.cyanriplog import (
+    filter_toc_entries,
+    toc_from_file,
+)
+from picard.disc.utils import (
+    NotSupportedTOCError,
+    TocEntry,
+)
+
+
+test_log = [
+    "cyanrip 0.9.3 (c23f1c4)",
+    "System device: /dev/cdrom",
+    "Disc tracks: 3",
+    "DiscID: testid123",
+    "Tracks:",
+    "",
+    "Track 1 ripped and encoded successfully!",
+    "",
+    "  Properties:",
+    "    Duration: 00:05:32.000",
+    "    Start LSN: 0",
+    "    End LSN: 24913",
+    "",
+    "Track 2 ripped and encoded successfully!",
+    "",
+    "  Properties:",
+    "    Duration: 00:04:07.000",
+    "    Start LSN: 24914",
+    "    End LSN: 43460",
+    "",
+    "Track 3 ripped and encoded successfully!",
+    "",
+    "  Properties:",
+    "    Duration: 00:03:50.000",
+    "    Start LSN: 43461",
+    "    End LSN: 60739",
+    "",
+    "Ripping errors: 0",
+]
+
+test_entries = [
+    TocEntry(1, 0, 24913),
+    TocEntry(2, 24914, 43460),
+    TocEntry(3, 43461, 60739),
+]
+
+
+class TestFilterTocEntries(PicardTestCase):
+    def test_filter_toc_entries(self):
+        result = filter_toc_entries(test_log)
+        self.assertIsInstance(result, Iterator)
+        entries = list(result)
+        self.assertEqual(test_entries, entries)
+
+    def test_empty_log(self):
+        result = list(filter_toc_entries([]))
+        self.assertEqual([], result)
+
+    def test_no_tracks(self):
+        log = [
+            "cyanrip 0.9.3 (c23f1c4)",
+            "System device: /dev/cdrom",
+            "Ripping errors: 0",
+        ]
+        result = list(filter_toc_entries(log))
+        self.assertEqual([], result)
+
+
+class TestTocFromFile(PicardTestCase):
+    def test_toc_from_file(self):
+        test_log = get_test_data_path('cyanrip.log')
+        toc = toc_from_file(test_log)
+        # Track 1: Start LSN 0, End LSN 136919
+        # Track 2: Start LSN 136920, End LSN 233754
+        # Expected: (first_track, last_track, leadout_offset, offset_1, offset_2)
+        # leadout = 233754 + 150 + 1 = 233905
+        # offset_1 = 0 + 150 = 150
+        # offset_2 = 136920 + 150 = 137070
+        self.assertEqual((1, 2, 233905, 150, 137070), toc)
+
+    def test_toc_from_empty_file(self):
+        test_log = get_test_data_path('eac-empty.log')
+        with self.assertRaises(NotSupportedTOCError):
+            toc_from_file(test_log)
+
+    def test_not_a_cyanrip_log(self):
+        # An EAC log should be rejected by the cyanrip header check
+        test_log = get_test_data_path('eac-utf8.log')
+        with self.assertRaises(NotSupportedTOCError):
+            toc_from_file(test_log)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add a `disc_log_readers` extension point to the plugin v3 API, refactor existing disc log parsers to use it, and implement a new cyanrip log parser.

## Problem

* JIRA tickets: PICARD-3347, PICARD-3346

The list of supported CD ripping log formats is hardcoded in `_parse_disc_ripping_log()`. Adding support for new formats requires modifying Picard core. Additionally, cyanrip — an open-source CD ripper — produces log files that Picard cannot currently parse for disc ID lookup.

## Solution

1. **`TocNumbers` type alias** — Introduces a semantic type alias for the MusicBrainz TOC tuple in `picard/disc/utils.py`, replacing opaque `tuple[int, ...]` annotations across all disc log parsers.

2. **`disc_log_readers` extension point** — New extension point (`picard/extension_points/disc_log_readers.py`) with `api.register_disc_log_reader(function)` in the plugin v3 API. Documented in `docs/PLUGINSV3/API.md`.

3. **Refactor existing readers** — Built-in log readers (EAC, Whipper, dBpoweramp, SCSI TOC) now register through `register_disc_log_reader()` in `picard/disc/__init__.py`. `_parse_disc_ripping_log()` simply iterates the extension point.

4. **Cyanrip log parser** — New `picard/disc/cyanriplog.py` that extracts Start/End LSN per track from cyanrip logs. Test data is the real log from the PICARD-3346 ticket.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed through iterative discussion with an AI assistant (Kiro/Claude), with human review and direction at each step.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
