### PR TITLE
Fix crash in profile options when copying without selection

### DIFF
--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -396,10 +396,7 @@ class ProfilesOptionsPage(OptionsPage):
         Returns:
             ProfileListWidgetItem: Currently selected item
         """
-        items = self.ui.profile_list.selectedItems()
-        if items:
-            return items[0]
-        return None
+        return self.ui.profile_list.currentItem()
 
     def profile_selected(self, update_settings=True):
         """Update working profile information for the selected item in the profiles list.
@@ -472,12 +469,6 @@ class ProfilesOptionsPage(OptionsPage):
             new_item (ProfileListWidgetItem): Newly selected item
             old_item (ProfileListWidgetItem): Previously selected item
         """
-        if self.loading:
-            return
-        # Set self.loading to avoid looping through the `.currentItemChanged` event.
-        self.loading = True
-        self.ui.profile_list.setCurrentItem(new_item)
-        self.loading = False
         self.profile_selected()
 
     def _get_settings_from_children(self, parent_item, settings=None):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The profile view would update on the list's current item changing, but act on the list's selected item. Those are distinct in Qt. If the user cleared the selection, this would cause there being a current but no selected item.

This would cause the actions to misbehave. Specifically the "Copy" button would crash.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Change the logic to always act on the current item, not the selection. If there is no current item, the buttons are disabled.

Also change the `currentItemChanged` handler not to again call `setCurrentItem`. The signal indicates that the item changed, and the handler gets the new value. It does not need to call `setCurrentItem` again. This just triggered a callback loop, which the handler then tried to workaround by setting the loading flag.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
