### PR TITLE
Dark/light theme detection refactoring

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -298,10 +298,6 @@ class BaseTheme:
 class WindowsTheme(BaseTheme):
     """Windows dark mode theme."""
 
-    def setup(self, app):
-        app.setStyle('Fusion')
-        super().setup(app)
-
     @property
     def is_dark_theme(self):
         if self._loaded_config_theme != UiTheme.DEFAULT:

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -133,7 +133,7 @@ class MacOverrideStyle(QtWidgets.QProxyStyle):
         return super().styleHint(hint, option, widget, returnData)
 
 
-def apply_dark_palette_colors(palette):
+def apply_dark_palette_colors(palette: QtGui.QPalette) -> None:
     """Apply dark palette colors to the given palette."""
     for key, value in DARK_PALETTE_COLORS.items():
         if isinstance(key, tuple):
@@ -143,7 +143,7 @@ def apply_dark_palette_colors(palette):
             palette.setColor(key, value)
 
 
-def set_color_scheme(color_scheme):
+def set_color_scheme(color_scheme: QtCore.Qt.ColorScheme) -> None:
     """Set the color scheme using style hints if available.
 
     Args:
@@ -158,7 +158,7 @@ def set_color_scheme(color_scheme):
         style_hints.setColorScheme(color_scheme)
 
 
-def apply_dark_theme_to_palette(palette: QtGui.QPalette):
+def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
     """Apply dark theme colors to the given palette using Qt's color scheme or manual fallback.
 
     This method tries to use Qt's built-in color scheme first, and falls back to
@@ -179,9 +179,9 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette):
 
 class BaseTheme:
     def __init__(self):
-        self._loaded_config_theme = UiTheme.DEFAULT
-        self._dark_theme = False
-        self._accent_color = None
+        self._loaded_config_theme: UiTheme = UiTheme.DEFAULT
+        self._dark_theme: bool = False
+        self._accent_color: QtGui.QColor | None = None
         # Registry of dark mode detection strategies for Linux DEs
         self._dark_mode_strategies = get_linux_dark_mode_strategies()
 
@@ -193,7 +193,7 @@ class BaseTheme:
         log.debug("No Linux system dark mode detected, defaulting to light mode.")
         return False
 
-    def setup(self, app):
+    def setup(self, app: QtWidgets.QApplication) -> None:
         config = get_config()
         ui_theme = config.setting['ui_theme']
         self._loaded_config_theme = UiTheme(config.setting['ui_theme'])
@@ -266,7 +266,7 @@ class BaseTheme:
         app.setPalette(palette)
 
     @property
-    def is_dark_theme(self):
+    def is_dark_theme(self) -> bool:
         if self._loaded_config_theme == UiTheme.DARK:
             return True
         elif self._loaded_config_theme == UiTheme.LIGHT:
@@ -275,11 +275,11 @@ class BaseTheme:
             return self._dark_theme
 
     @property
-    def accent_color(self):  # pylint: disable=no-self-use
+    def accent_color(self) -> QtGui.QColor | None:  # pylint: disable=no-self-use
         return self._accent_color
 
     # pylint: disable=no-self-use
-    def update_palette(self, palette, dark_theme, accent_color):
+    def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
         if accent_color:
             accent_text_color = (
                 QtCore.Qt.GlobalColor.white if accent_color.lightness() < 160 else QtCore.Qt.GlobalColor.black
@@ -299,7 +299,7 @@ class WindowsTheme(BaseTheme):
     """Windows dark mode theme."""
 
     @property
-    def is_dark_theme(self):
+    def is_dark_theme(self) -> bool:
         if self._loaded_config_theme != UiTheme.DEFAULT:
             return self._loaded_config_theme == UiTheme.DARK
         dark_theme = False
@@ -314,7 +314,7 @@ class WindowsTheme(BaseTheme):
         return dark_theme
 
     @property
-    def accent_color(self):
+    def accent_color(self) -> QtGui.QColor | None:
         accent_color = None
         try:
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\DWM") as key:
@@ -325,7 +325,7 @@ class WindowsTheme(BaseTheme):
             log.warning("Failed reading ColorizationColor from registry")
         return accent_color
 
-    def update_palette(self, palette, dark_theme, accent_color):
+    def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
         # Adapt to Windows 10 color scheme (dark / light theme and accent color)
         super().update_palette(palette, dark_theme, accent_color)
         if dark_theme:
@@ -353,7 +353,7 @@ elif IS_MACOS:
             pass
 
     class MacTheme(BaseTheme):
-        def setup(self, app):
+        def setup(self, app: QtWidgets.QApplication) -> None:
             super().setup(app)
 
             if self._loaded_config_theme != UiTheme.DEFAULT:
@@ -374,7 +374,7 @@ elif IS_MACOS:
                     pass
 
         @property
-        def is_dark_theme(self):
+        def is_dark_theme(self) -> bool:
             if not OS_SUPPORTS_THEMES:
                 # Fall back to generic dark color palette detection
                 return super().is_dark_theme
@@ -384,7 +384,7 @@ elif IS_MACOS:
                 return self._loaded_config_theme == UiTheme.DARK
 
         # pylint: disable=no-self-use
-        def update_palette(self, palette, dark_theme, accent_color):
+        def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
             pass  # No palette changes, theme is fully handled by Qt
 
     theme = MacTheme()
@@ -393,5 +393,5 @@ else:
     theme = BaseTheme()
 
 
-def setup(app):
+def setup(app: QtWidgets.QApplication) -> None:
     theme.setup(app)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
+# Copyright (C) 2019-2022, 2024-2026 Philipp Wolfer
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021-2024 Laurent Monin
 #
@@ -21,7 +21,9 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import Callable
 from enum import Enum
+from typing import Literal
 
 from PyQt6 import (
     QtCore,
@@ -158,46 +160,62 @@ def set_color_scheme(color_scheme: QtCore.Qt.ColorScheme) -> None:
         style_hints.setColorScheme(color_scheme)
 
 
-def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
-    """Apply dark theme colors to the given palette using Qt's color scheme or manual fallback.
+def palette_is_dark(palette: QtGui.QPalette) -> bool:
+    """Determine if the given palette is dark based on its base color."""
+    base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+    return base_color.lightness() < 128
 
-    This method tries to use Qt's built-in color scheme first, and falls back to
-    manually applying dark colors if style hints are unavailable.
+
+def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
+    """Apply dark theme colors to the given palette.
+
+    The function applies a lightness check on the existing palette's base color. Only
+    if the base color appears to be light, dark colors are applied to the palette.
 
     Args:
         palette: The palette to apply dark colors to
     """
-    style_hints = get_style_hints()
-    if style_hints is not None and hasattr(QtCore.Qt, 'ColorScheme'):
-        style_hints.setColorScheme(QtCore.Qt.ColorScheme.Dark)
-        # Test whether the change was successful
-        if style_hints.colorScheme() == QtCore.Qt.ColorScheme.Dark:
-            return
-    # Fall back to manually applying dark colors
-    apply_dark_palette_colors(palette)
+    # Modern Qt should already set dark colors based on the color scheme.
+    # But if the current palette color appear to be light, explicitly apply dark
+    # colors to the palette.
+    if not palette_is_dark(palette):
+        apply_dark_palette_colors(palette)
+
+
+def get_accent_color_from_palette(palette: QtGui.QPalette) -> QtGui.QColor:
+    """Returns the accent color from the palette."""
+    if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
+        accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Accent)
+    else:
+        accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+    return accent_color
+
+
+def apply_accent_color_to_palette(palette: QtGui.QPalette, accent_color: QtGui.QColor) -> None:
+    """Updates the palette to use the accent color."""
+    palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight, accent_color)
+    accent_text_color = QtCore.Qt.GlobalColor.white if accent_color.lightness() < 160 else QtCore.Qt.GlobalColor.black
+    palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.HighlightedText, accent_text_color)
+    # Accent is available since Qt 6.6
+    if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
+        palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Accent, accent_color)
+
+    link_color = QtGui.QColor()
+    link_color.setHsl(accent_color.hue(), accent_color.saturation(), 160, accent_color.alpha())
+    palette.setColor(QtGui.QPalette.ColorRole.Link, link_color)
 
 
 class BaseTheme:
     def __init__(self):
         self._loaded_config_theme: UiTheme = UiTheme.DEFAULT
-        self._dark_theme: bool = False
+        self._applied_theme: UiTheme = UiTheme.DEFAULT
         self._accent_color: QtGui.QColor | None = None
-        # Registry of dark mode detection strategies for Linux DEs
-        self._dark_mode_strategies = get_linux_dark_mode_strategies()
-
-    def _detect_linux_dark_mode(self) -> bool:
-        # Iterate through all registered strategies
-        for strategy in self._dark_mode_strategies:
-            if strategy():
-                return True
-        log.debug("No Linux system dark mode detected, defaulting to light mode.")
-        return False
+        self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
         config = get_config()
-        ui_theme = config.setting['ui_theme']
-        self._loaded_config_theme = UiTheme(config.setting['ui_theme'])
-
+        wanted_theme = UiTheme(config.setting['ui_theme'])
+        self._loaded_config_theme = wanted_theme
         # Use the new fusion style from PyQt6 for a modern and consistent look
         # across all OSes, except for macOS and Haiku.
         if not IS_MACOS and not IS_HAIKU:
@@ -209,188 +227,149 @@ class BaseTheme:
             'QGroupBox::title { /* PICARD-1206, Qt bug workaround */ }',
         )
 
-        # Set color scheme based on theme configuration (Qt 6.5+)
-        if hasattr(QtCore.Qt, 'ColorScheme'):
-            if self._loaded_config_theme == UiTheme.DARK:
-                set_color_scheme(QtCore.Qt.ColorScheme.Dark)
-            elif self._loaded_config_theme == UiTheme.LIGHT:
-                set_color_scheme(QtCore.Qt.ColorScheme.Light)
-            else:
-                # For DEFAULT theme, let Qt follow system settings
-                set_color_scheme(QtCore.Qt.ColorScheme.Unknown)
+        # Apply dark/light theme based on configuration or system settings
+        if wanted_theme == UiTheme.DEFAULT:
+            wanted_theme = self.get_system_theme(app)
+        self.apply_theme(app, wanted_theme)
 
-        palette = QtGui.QPalette(app.palette())
-        base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
-        self._dark_theme = base_color.lightness() < 128
-        self._accent_color = None
-        if self._dark_theme:
-            self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+        # Get the system accent color, if available, and apply if to the palette
+        system_accent_color = self.get_system_accent_color()
+        if system_accent_color:
+            self._accent_color = system_accent_color
+            palette = app.palette()
+            apply_accent_color_to_palette(palette, self._accent_color)
+            app.setPalette(palette)
+        else:
+            self._accent_color = get_accent_color_from_palette(app.palette())
 
-        # Linux-specific: If DEFAULT theme, try to detect system dark mode
-        # Do not apply override if already dark theme, or if a subclass already
-        # determined a dark theme state (e.g., WindowsTheme via registry on tests).
-        is_dark_theme = self.is_dark_theme
-        if (
-            not self._dark_theme
-            and not is_dark_theme
-            and not IS_WIN
-            and not IS_MACOS
-            and not IS_HAIKU
-            and self._loaded_config_theme == UiTheme.DEFAULT
-        ):
-            is_dark_theme = self._detect_linux_dark_mode()
-            if is_dark_theme:
-                # Apply dark theme to palette using Qt's color scheme or manual fallback
-                apply_dark_theme_to_palette(palette)
-                self._dark_theme = True
-                self._accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
-            else:
-                self._dark_theme = False
-                self._accent_color = None
-
-        accent_color = self.accent_color
-        if accent_color:
-            accent_color_str = accent_color.name(QtGui.QColor.NameFormat.HexArgb)
+        if self._accent_color:
+            accent_color_str = self._accent_color.name(QtGui.QColor.NameFormat.HexArgb)
         else:
             accent_color_str = "None"
 
         log.debug(
-            "Theme: %s (%s) dark=%s accent_color=%s",
-            ui_theme,
+            "Theme (%s): config=%s applied=%s accent_color=%s",
             self.__class__.__name__,
-            is_dark_theme,
+            self._loaded_config_theme.value,
+            self._applied_theme.value,
             accent_color_str,
         )
 
-        self.update_palette(palette, is_dark_theme, accent_color)
-        app.setPalette(palette)
+    def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
+        # Iterate through all registered strategies
+        for strategy in self._dark_mode_strategies:
+            if strategy():
+                return UiTheme.DARK
+
+        if palette_is_dark(app.palette()):
+            log.debug("No system dark mode detected, but palette is already dark.")
+            return UiTheme.DARK
+
+        log.debug("No system dark mode detected, defaulting to light mode.")
+        return UiTheme.LIGHT
+
+    def get_system_accent_color(self) -> QtGui.QColor | None:
+        return None
+
+    def apply_theme(self, app: QtWidgets.QApplication, theme: UiTheme) -> None:
+        qt_color_theme = QtCore.Qt.ColorScheme.Dark if theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
+        set_color_scheme(qt_color_theme)
+        if theme == UiTheme.DARK:
+            palette = app.palette()
+            apply_dark_theme_to_palette(palette)
+            app.setPalette(palette)
+        self._applied_theme = theme
 
     @property
     def is_dark_theme(self) -> bool:
-        if self._loaded_config_theme == UiTheme.DARK:
+        if self._applied_theme == UiTheme.DARK:
             return True
-        elif self._loaded_config_theme == UiTheme.LIGHT:
-            return False
         else:
-            return self._dark_theme
+            return False
 
     @property
     def accent_color(self) -> QtGui.QColor | None:  # pylint: disable=no-self-use
         return self._accent_color
 
-    # pylint: disable=no-self-use
-    def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
-        if accent_color:
-            accent_text_color = (
-                QtCore.Qt.GlobalColor.white if accent_color.lightness() < 160 else QtCore.Qt.GlobalColor.black
-            )
-            palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight, accent_color)
-            palette.setColor(
-                QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.HighlightedText, accent_text_color
-            )
 
-            link_color = QtGui.QColor()
-            link_color.setHsl(accent_color.hue(), accent_color.saturation(), 160, accent_color.alpha())
-            palette.setColor(QtGui.QPalette.ColorRole.Link, link_color)
+class GenericTheme(BaseTheme):
+    """Generic theme detection."""
+
+    def __init__(self):
+        super().__init__()
+        # Registry of dark mode detection strategies for Linux DEs
+        self._dark_mode_strategies = get_linux_dark_mode_strategies()
 
 
-# Move `WindowsTheme` to outside of IS_WIN to enable testing.
 class WindowsTheme(BaseTheme):
-    """Windows dark mode theme."""
+    """Windows dark mode theme detection."""
 
-    @property
-    def is_dark_theme(self) -> bool:
-        if self._loaded_config_theme != UiTheme.DEFAULT:
-            return self._loaded_config_theme == UiTheme.DARK
-        dark_theme = False
+    def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
         try:
             with winreg.OpenKey(
                 winreg.HKEY_CURRENT_USER,
                 r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
             ) as key:
                 dark_theme = winreg.QueryValueEx(key, "AppsUseLightTheme")[0] == 0
+                return UiTheme.DARK if dark_theme else UiTheme.LIGHT
         except OSError:
             log.warning("Failed reading AppsUseLightTheme from registry")
-        return dark_theme
+            return UiTheme.LIGHT
 
-    @property
-    def accent_color(self) -> QtGui.QColor | None:
-        accent_color = None
+    def get_system_accent_color(self) -> QtGui.QColor | None:
         try:
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\DWM") as key:
                 accent_color_dword = winreg.QueryValueEx(key, "ColorizationColor")[0]
                 accent_color_hex = '#{:06x}'.format(accent_color_dword & 0xFFFFFF)
-                accent_color = QtGui.QColor(accent_color_hex)
+                return QtGui.QColor(accent_color_hex)
         except OSError:
             log.warning("Failed reading ColorizationColor from registry")
-        return accent_color
+            return None
 
-    def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
-        # Adapt to Windows 10 color scheme (dark / light theme and accent color)
-        super().update_palette(palette, dark_theme, accent_color)
-        if dark_theme:
-            # Apply dark theme to palette using Qt's color scheme or manual fallback
-            apply_dark_theme_to_palette(palette)
+
+class MacTheme(BaseTheme):
+    """macOS dark mode theme detection."""
+
+    def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
+        if OS_SUPPORTS_THEMES and AppKit:
+            # Default procedure to identify the current appearance (theme)
+            appearance = AppKit.NSAppearance.currentAppearance()
+            try:
+                basic_appearance = appearance.bestMatchFromAppearancesWithNames_(
+                    [
+                        AppKit.NSAppearanceNameAqua,
+                        AppKit.NSAppearanceNameDarkAqua,
+                    ]
+                )
+                dark_appearance = basic_appearance == AppKit.NSAppearanceNameDarkAqua
+                return UiTheme.DARK if dark_appearance else UiTheme.LIGHT
+            except AttributeError:
+                return UiTheme.LIGHT
+        else:
+            return UiTheme.LIGHT
+
+    def apply_theme(self, app: QtWidgets.QApplication, theme: UiTheme) -> None:
+        super().apply_theme(app, theme)
+
+        # MacOS uses a NSAppearance object to change the current application appearance
+        # We call this even if UiTheme is the default, preventing MacOS from switching on-the-fly
+        if OS_SUPPORTS_THEMES and AppKit:
+            try:
+                if theme == UiTheme.DARK:
+                    appearance = AppKit.NSAppearance._darkAquaAppearance()
+                else:
+                    appearance = AppKit.NSAppearance._aquaAppearance()
+                AppKit.NSApplication.sharedApplication().setAppearance_(appearance)
+            except AttributeError:
+                pass
 
 
 if IS_WIN:
     theme = WindowsTheme()
-
 elif IS_MACOS:
-    dark_appearance = False
-    if OS_SUPPORTS_THEMES and AppKit:
-        # Default procedure to identify the current appearance (theme)
-        appearance = AppKit.NSAppearance.currentAppearance()
-        try:
-            basic_appearance = appearance.bestMatchFromAppearancesWithNames_(
-                [
-                    AppKit.NSAppearanceNameAqua,
-                    AppKit.NSAppearanceNameDarkAqua,
-                ]
-            )
-            dark_appearance = basic_appearance == AppKit.NSAppearanceNameDarkAqua
-        except AttributeError:
-            pass
-
-    class MacTheme(BaseTheme):
-        def setup(self, app: QtWidgets.QApplication) -> None:
-            super().setup(app)
-
-            if self._loaded_config_theme != UiTheme.DEFAULT:
-                dark_theme = self._loaded_config_theme == UiTheme.DARK
-            else:
-                dark_theme = dark_appearance
-
-            # MacOS uses a NSAppearance object to change the current application appearance
-            # We call this even if UiTheme is the default, preventing MacOS from switching on-the-fly
-            if OS_SUPPORTS_THEMES and AppKit:
-                try:
-                    if dark_theme:
-                        appearance = AppKit.NSAppearance._darkAquaAppearance()
-                    else:
-                        appearance = AppKit.NSAppearance._aquaAppearance()
-                    AppKit.NSApplication.sharedApplication().setAppearance_(appearance)
-                except AttributeError:
-                    pass
-
-        @property
-        def is_dark_theme(self) -> bool:
-            if not OS_SUPPORTS_THEMES:
-                # Fall back to generic dark color palette detection
-                return super().is_dark_theme
-            elif self._loaded_config_theme == UiTheme.DEFAULT:
-                return dark_appearance
-            else:
-                return self._loaded_config_theme == UiTheme.DARK
-
-        # pylint: disable=no-self-use
-        def update_palette(self, palette: QtGui.QPalette, dark_theme: bool, accent_color: QtGui.QColor | None) -> None:
-            pass  # No palette changes, theme is fully handled by Qt
-
     theme = MacTheme()
-
 else:
-    theme = BaseTheme()
+    theme = GenericTheme()
 
 
 def setup(app: QtWidgets.QApplication) -> None:

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -243,7 +243,7 @@ def detect_lxqt_dark_wrapper() -> bool:
     return False
 
 
-def get_linux_dark_mode_strategies() -> list:
+def get_linux_dark_mode_strategies() -> list[Callable[[], bool]]:
     """Return the list of dark mode detection strategies in order of priority."""
     return [
         # Pure D-Bus methods (will gracefully fail if D-Bus unavailable)

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -2,7 +2,7 @@
 #
 # Picard, the next-generation MusicBrainz tagger
 #
-# Copyright (C) 2019-2022, 2024-2025 Philipp Wolfer
+# Copyright (C) 2019-2022, 2024-2026 Philipp Wolfer
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021-2024 Laurent Monin
 #
@@ -29,11 +29,7 @@ import subprocess  # noqa: S404
 
 from picard import log
 
-from picard.ui.theme_detect_qtdbus import (
-    DBusThemeDetector,
-    detect_freedesktop_color_scheme_dbus,
-    get_dbus_detector,
-)
+from picard.ui.theme_detect_qtdbus import detect_freedesktop_color_scheme_dbus
 
 
 def gsettings_get(key: str) -> str | None:
@@ -54,27 +50,6 @@ def gsettings_get(key: str) -> str | None:
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.debug(f"gsettings get {key} failed.")
         return None
-
-
-def _try_dbus_detection(detection_method: Callable[[DBusThemeDetector], bool | None], method_name: str) -> bool | None:
-    """
-    Helper function to safely attempt D-Bus theme detection.
-
-    Args:
-        detection_method: The detection method to call on the detector
-        method_name: Name of the method for logging purposes
-
-    Returns:
-        The result of the detection method, or None if detection fails
-    """
-    try:
-        detector = get_dbus_detector()
-        result = detection_method(detector)
-        if result is not None:
-            return result
-    except (RuntimeError, AttributeError, TypeError):
-        log.debug(f"Unable to detect {method_name} with dbus.")
-    return None
 
 
 def detect_gnome_color_scheme_dark() -> bool:

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -32,7 +32,6 @@ from picard import log
 from picard.ui.theme_detect_qtdbus import (
     DBusThemeDetector,
     detect_freedesktop_color_scheme_dbus,
-    detect_gnome_color_scheme_dbus,
     get_dbus_detector,
 )
 
@@ -206,10 +205,9 @@ def detect_lxqt_dark_wrapper() -> bool:
 def get_linux_dark_mode_strategies() -> list[Callable[[], bool]]:
     """Return the list of dark mode detection strategies in order of priority."""
     return [
-        # Pure D-Bus methods (will gracefully fail if D-Bus unavailable)
+        # D-Bus based detection using the using org.freedesktop.portal.Settings interface
         detect_freedesktop_color_scheme_dbus,
-        detect_gnome_color_scheme_dbus,
-        # Hybrid methods (D-Bus with subprocess fallback)
+        # Legacy methods (settings based on desktop environment)
         detect_gnome_dark_wrapper,
         detect_kde_dark_wrapper,
         detect_xfce_dark_wrapper,

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -80,12 +80,6 @@ def _try_dbus_detection(detection_method: Callable[[DBusThemeDetector], bool | N
 
 def detect_gnome_color_scheme_dark() -> bool:
     """Detect if GNOME color-scheme is set to dark."""
-    # Try D-Bus first (secure method)
-    result = _try_dbus_detection(lambda detector: detector.gnome_color_scheme_is_dark(), "gnome color scheme")
-    if result is not None:
-        return result
-
-    # Fallback to subprocess method (legacy support)
     value = gsettings_get("color-scheme")
     if value and "dark" in value.lower():
         log.debug("Detected GNOME color-scheme: dark")

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -154,40 +154,6 @@ def detect_lxqt_dark_theme() -> bool:
     return False
 
 
-def detect_freedesktop_color_scheme_dark() -> bool:
-    """Detect dark mode using org.freedesktop.appearance.color-scheme (XDG portal, cross-desktop)."""
-    # Try D-Bus first (secure method)
-    result = _try_dbus_detection(
-        lambda detector: detector.freedesktop_portal_color_scheme_is_dark(), "freedesktop color scheme"
-    )
-    if result is not None:
-        return result
-
-    # Fallback to subprocess method (legacy support)
-    try:
-        proc_result = subprocess.run(  # nosec B603 B607
-            [
-                "gsettings",
-                "get",
-                "org.freedesktop.appearance",
-                "color-scheme",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        value = proc_result.stdout.strip().strip("'\"")
-        if value == "1":
-            log.debug("Detected org.freedesktop.appearance.color-scheme: dark (1)")
-            return True
-        if value == "0":
-            log.debug("Detected org.freedesktop.appearance.color-scheme: light (0)")
-            return False
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        log.debug("gsettings get org.freedesktop.appearance.color-scheme failed.")
-    return False
-
-
 def get_current_desktop_environment() -> str:
     """Detect the current desktop environment (DE) as a lowercase string."""
     de = os.environ.get("XDG_CURRENT_DESKTOP")
@@ -244,7 +210,6 @@ def get_linux_dark_mode_strategies() -> list[Callable[[], bool]]:
         detect_freedesktop_color_scheme_dbus,
         detect_gnome_color_scheme_dbus,
         # Hybrid methods (D-Bus with subprocess fallback)
-        detect_freedesktop_color_scheme_dark,
         detect_gnome_dark_wrapper,
         detect_kde_dark_wrapper,
         detect_xfce_dark_wrapper,

--- a/picard/ui/theme_detect_qtdbus.py
+++ b/picard/ui/theme_detect_qtdbus.py
@@ -36,7 +36,6 @@ class DBusThemeDetector:
     def __init__(self):
         self.session_bus = None
         self.portal_interface = None
-        self.gnome_interface = None
         self._initialize_dbus()
 
     def _initialize_dbus(self) -> None:
@@ -55,18 +54,9 @@ class DBusThemeDetector:
                     self.session_bus,
                 )
 
-            if self._is_service_available("ca.desrt.dconf"):
-                self.gnome_interface = QDBusInterface(
-                    "ca.desrt.dconf",
-                    "/ca/desrt/dconf/Writer/user",
-                    "ca.desrt.dconf.Writer",
-                    self.session_bus,
-                )
-
         except Exception:  # noqa: BLE001
             self.session_bus = None
             self.portal_interface = None
-            self.gnome_interface = None
 
     def _is_service_available(self, service_name: str) -> bool:
         """Check if a D-Bus service is available."""
@@ -119,40 +109,6 @@ class DBusThemeDetector:
         else:
             return None
 
-    def gnome_color_scheme_is_dark(self) -> bool | None:
-        """
-        Detect GNOME color scheme using D-Bus dconf interface.
-        Returns
-        -------
-            True for dark theme, False for light theme, None if unavailable
-        """
-        try:
-            if not self.gnome_interface or not self.gnome_interface.isValid():
-                return None
-            # Get the color-scheme property from org.gnome.desktop.interface using dconf
-            reply = self.gnome_interface.call("Read", "/org/gnome/desktop/interface/color-scheme")
-
-            if reply.type() != QDBusMessage.MessageType.ErrorMessage:
-                value = reply.arguments()[0] if reply.arguments() else None
-                if value:
-                    return isinstance(value, str) and "dark" in value.lower()
-        except (RuntimeError, AttributeError, TypeError):
-            pass
-
-        # Try gtk-theme as fallback
-        try:
-            reply = self.gnome_interface.call("Read", "/org/gnome/desktop/interface/gtk-theme")
-
-            if reply.type() != QDBusMessage.MessageType.ErrorMessage:
-                value = reply.arguments()[0] if reply.arguments() else None
-                if value and isinstance(value, str) and "dark" in value.lower():
-                    return True
-
-        except (RuntimeError, AttributeError, TypeError):
-            pass
-
-        return None
-
 
 # Global D-Bus detector instance
 _dbus_detector = None
@@ -171,17 +127,6 @@ def detect_freedesktop_color_scheme_dbus() -> bool:
     try:
         detector = get_dbus_detector()
         result = detector.freedesktop_portal_color_scheme_is_dark()
-    except (RuntimeError, AttributeError, TypeError):
-        return False
-    else:
-        return result is True
-
-
-def detect_gnome_color_scheme_dbus() -> bool:
-    """Detect GNOME color scheme using D-Bus interface."""
-    try:
-        detector = get_dbus_detector()
-        result = detector.gnome_color_scheme_is_dark()
     except (RuntimeError, AttributeError, TypeError):
         return False
     else:

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -431,15 +431,15 @@ def assert_palette_not_dark(palette, expected_colors):
 
 
 @pytest.mark.parametrize(
-    ("already_dark_theme", "dark_mode", "expect_dark_palette"),
+    ("already_dark_theme", "system_theme", "expect_dark_palette"),
     [
-        (True, True, False),  # Already dark, detection True: do NOT override
-        (True, False, False),  # Already dark, detection False: do NOT override
-        (False, True, True),  # Not dark, detection True: override
-        (False, False, False),  # Not dark, detection False: do NOT override
+        (True, theme_mod.UiTheme.DARK, False),  # Already dark, detection dark: do NOT override
+        (True, theme_mod.UiTheme.LIGHT, False),  # Already dark, detection light: do NOT override
+        (False, theme_mod.UiTheme.DARK, True),  # Not dark, detection dark: override
+        (False, theme_mod.UiTheme.LIGHT, False),  # Not dark, detection light: do NOT override
     ],
 )
-def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, expect_dark_palette):
+def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, system_theme, expect_dark_palette):
     # Simulate Linux (not Windows, not macOS, not Haiku)
     monkeypatch.setattr(theme_mod, "IS_WIN", False)
     monkeypatch.setattr(theme_mod, "IS_MACOS", False)
@@ -448,9 +448,9 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, dark_mode, ex
     config_mock = MagicMock()
     config_mock.setting = {"ui_theme": "default"}
     monkeypatch.setattr(theme_mod, "get_config", lambda: config_mock)
-    # Patch _detect_linux_dark_mode to return dark_mode
+    # Patch get_system_theme to return dark_mode
     theme = theme_mod.BaseTheme()
-    theme._detect_linux_dark_mode = lambda: dark_mode
+    theme.get_system_theme = lambda app: system_theme
 
     # Mock QGuiApplication.styleHints() to return None to force manual fallback
     monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: None)
@@ -613,38 +613,3 @@ def test_de_specific_wrappers_only_run_for_matching_de_param(args):
         else:
             mock_detect.assert_not_called()
             assert result is False
-
-
-@pytest.mark.parametrize(
-    ("already_dark_theme", "linux_dark_mode_detected", "expect_dark_palette"),
-    [
-        (True, True, False),  # Already dark, detection True: do NOT override
-        (True, False, False),  # Already dark, detection False: do NOT override
-        (False, True, True),  # Not dark, detection True: override
-        (False, False, False),  # Not dark, detection False: do NOT override
-    ],
-)
-def test_linux_dark_palette_override_only_if_not_already_dark(
-    monkeypatch, already_dark_theme, linux_dark_mode_detected, expect_dark_palette
-):
-    monkeypatch.setattr(theme_mod, "IS_WIN", False)
-    monkeypatch.setattr(theme_mod, "IS_MACOS", False)
-    monkeypatch.setattr(theme_mod, "IS_HAIKU", False)
-    config_mock = MagicMock()
-    config_mock.setting = {"ui_theme": "default"}
-    monkeypatch.setattr(theme_mod, "get_config", lambda: config_mock)
-    # Force manual fallback for palette changes
-    monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: None)
-    app = DummyApp(already_dark_theme)
-    theme = theme_mod.BaseTheme()
-    theme._detect_linux_dark_mode = lambda: linux_dark_mode_detected
-    theme.setup(app)
-    palette = app._palette
-    if expect_dark_palette:
-        assert_palette_matches_expected(palette, EXPECTED_DARK_PALETTE_COLORS)
-    else:
-        # The Window color should remain the unique color if not overridden
-        window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
-        assert window_color == QtGui.QColor(123, 123, 123), (
-            f"Palette should not be overridden, got {window_color.getRgb()}"
-        )

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -205,13 +205,13 @@ def test_detect_linux_dark_mode_priority(tmp_path: Path) -> None:
             mock_get_detector.side_effect = RuntimeError("D-Bus unavailable")
 
             with patch("subprocess.run") as mock_run:
-                # First call: freedesktop (returns '1' for dark)
+                # First call: gnome gsettings
                 # Other calls: return '' (should not be called, but if so, not dark)
-                mock_run.return_value.stdout = "1"
+                mock_run.return_value.stdout = "dark"
                 mock_run.return_value.returncode = 0
 
                 # Test the specific function that should work with subprocess fallback
-                result = theme_detect.detect_freedesktop_color_scheme_dark()
+                result = theme_detect.detect_gnome_color_scheme_dark()
                 assert result is True
 
 
@@ -305,49 +305,6 @@ def test_lxqt_dark_theme_detection_failure(file_exists: bool, raises, tmp_path: 
                 assert theme_detect.detect_lxqt_dark_theme() is False
         elif not file_exists:
             assert theme_detect.detect_lxqt_dark_theme() is False
-
-
-@pytest.mark.parametrize(
-    ("gsettings_value", "expected"),
-    [
-        ("1", True),
-        ("0", False),
-        ("", False),
-    ],
-)
-def test_freedesktop_color_scheme_detection(gsettings_value: str, expected: bool) -> None:
-    with (
-        patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector,
-        patch("subprocess.run") as mock_run,
-    ):
-        # Mock D-Bus detector to return None (force fallback to subprocess)
-        mock_detector = Mock()
-        mock_detector.freedesktop_portal_color_scheme_is_dark.return_value = None
-        mock_get_detector.return_value = mock_detector
-
-        mock_run.return_value.stdout = gsettings_value
-        mock_run.return_value.returncode = 0
-        assert theme_detect.detect_freedesktop_color_scheme_dark() is expected
-
-
-@pytest.mark.parametrize(
-    "side_effect",
-    [
-        FileNotFoundError(),
-        subprocess.CalledProcessError(1, "gsettings"),
-    ],
-)
-def test_freedesktop_color_scheme_detection_failure(side_effect) -> None:
-    with (
-        patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector,
-        patch("subprocess.run", side_effect=side_effect),
-    ):
-        # Mock D-Bus detector to return None (force fallback to subprocess)
-        mock_detector = Mock()
-        mock_detector.freedesktop_portal_color_scheme_is_dark.return_value = None
-        mock_get_detector.return_value = mock_detector
-
-        assert theme_detect.detect_freedesktop_color_scheme_dark() is False
 
 
 # Shared expected dark palette colors (should match DARK_PALETTE_COLORS in theme.py)

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -165,8 +165,8 @@ def test_detect_linux_dark_mode_integration(
         patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": de}, clear=True),
         patch("pathlib.Path.home", return_value=kde_config_dir.parent),
         patch("picard.ui.theme_detect.gsettings_get") as mock_gsettings,
-        patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector,
-        patch("picard.ui.theme_detect.detect_freedesktop_color_scheme_dbus", return_value=False),
+        patch("picard.ui.theme_detect_qtdbus.get_dbus_detector") as mock_get_detector,
+        patch("picard.ui.theme_detect_qtdbus.detect_freedesktop_color_scheme_dbus", return_value=False),
     ):
         # Mock D-Bus detector to return None (force fallback to subprocess)
         mock_detector = Mock()
@@ -194,11 +194,11 @@ def test_detect_linux_dark_mode_integration(
 def test_detect_linux_dark_mode_priority(tmp_path: Path) -> None:
     # If freedesktop returns dark, it should take priority over others
     with (
-        patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector,
+        patch("picard.ui.theme_detect_qtdbus.get_dbus_detector") as mock_get_detector,
         patch("subprocess.run") as mock_run,
     ):
         # Mock D-Bus to fail so we test subprocess fallback
-        with patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector:
+        with patch("picard.ui.theme_detect_qtdbus.get_dbus_detector") as mock_get_detector:
             # Mock D-Bus detector to raise exception (simulating D-Bus unavailable)
             mock_get_detector.side_effect = RuntimeError("D-Bus unavailable")
 

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -167,12 +167,10 @@ def test_detect_linux_dark_mode_integration(
         patch("picard.ui.theme_detect.gsettings_get") as mock_gsettings,
         patch("picard.ui.theme_detect.get_dbus_detector") as mock_get_detector,
         patch("picard.ui.theme_detect.detect_freedesktop_color_scheme_dbus", return_value=False),
-        patch("picard.ui.theme_detect.detect_gnome_color_scheme_dbus", return_value=False),
     ):
         # Mock D-Bus detector to return None (force fallback to subprocess)
         mock_detector = Mock()
         mock_detector.freedesktop_portal_color_scheme_is_dark.return_value = None
-        mock_detector.gnome_color_scheme_is_dark.return_value = None
         mock_get_detector.return_value = mock_detector
 
         def gsettings_get_side_effect(key):

--- a/test/test_theme_detect_qtdbus.py
+++ b/test/test_theme_detect_qtdbus.py
@@ -32,7 +32,6 @@ import pytest
 from picard.ui.theme_detect_qtdbus import (
     DBusThemeDetector,
     detect_freedesktop_color_scheme_dbus,
-    detect_gnome_color_scheme_dbus,
     get_dbus_detector,
 )
 
@@ -109,16 +108,12 @@ class TestDBusThemeDetector:
     """Test the DBusThemeDetector class."""
 
     @pytest.mark.parametrize(
-        ("connection_connected", "expected_session_bus"),
-        [
-            (True, Mock()),
-            (False, None),
-        ],
+        ("connection_connected"),
+        [True, False],
     )
     def test_initialize_dbus_success(
         self,
         connection_connected: bool,
-        expected_session_bus: Mock | None,
     ) -> None:
         """Test successful D-Bus initialization."""
         with (
@@ -133,7 +128,7 @@ class TestDBusThemeDetector:
             mock_db_interface = Mock()
             mock_db_message = Mock()
             mock_db_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop", "ca.desrt.dconf"]]
+            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop"]]
             mock_db_interface.call.return_value = mock_db_message
 
             # Configure QDBusInterface to return different mocks for different calls
@@ -149,12 +144,10 @@ class TestDBusThemeDetector:
             if connection_connected:
                 assert detector.session_bus is not None
                 assert detector.portal_interface is not None
-                assert detector.gnome_interface is not None
             else:
                 # When connection is not connected, the session_bus is still set but interfaces are None
                 assert detector.session_bus is not None
                 assert detector.portal_interface is None
-                assert detector.gnome_interface is None
 
     def test_initialize_dbus_exception(self) -> None:
         """Test D-Bus initialization with exception."""
@@ -167,7 +160,6 @@ class TestDBusThemeDetector:
             # When an exception occurs during initialization, all interfaces should be None
             assert detector.session_bus is None
             assert detector.portal_interface is None
-            assert detector.gnome_interface is None
 
     @pytest.mark.parametrize(
         ("portal_valid", "message_type", "arguments", "expected"),
@@ -219,99 +211,6 @@ class TestDBusThemeDetector:
         mock_portal_interface.call.side_effect = exception_type("Test exception")
 
         result = mock_dbus_detector.freedesktop_portal_color_scheme_is_dark()
-        assert result is None
-
-    @pytest.mark.parametrize(
-        (
-            "gnome_valid",
-            "color_scheme_message_type",
-            "color_scheme_args",
-            "gtk_theme_message_type",
-            "gtk_theme_args",
-            "expected",
-        ),
-        [
-            # Color scheme tests - when color scheme returns a valid response
-            (True, QDBusMessage.MessageType.ReplyMessage, ["dark"], QDBusMessage.MessageType.ErrorMessage, [], True),
-            (True, QDBusMessage.MessageType.ReplyMessage, ["light"], QDBusMessage.MessageType.ErrorMessage, [], False),
-            (
-                True,
-                QDBusMessage.MessageType.ReplyMessage,
-                ["default"],
-                QDBusMessage.MessageType.ErrorMessage,
-                [],
-                False,
-            ),
-            # Color scheme fails, fallback to gtk theme
-            (
-                True,
-                QDBusMessage.MessageType.ErrorMessage,
-                [],
-                QDBusMessage.MessageType.ReplyMessage,
-                ["Adwaita-dark"],
-                True,
-            ),
-            (True, QDBusMessage.MessageType.ErrorMessage, [], QDBusMessage.MessageType.ReplyMessage, ["Adwaita"], None),
-            (True, QDBusMessage.MessageType.ErrorMessage, [], QDBusMessage.MessageType.ReplyMessage, ["default"], None),
-            # Invalid interface
-            (False, QDBusMessage.MessageType.ReplyMessage, ["dark"], QDBusMessage.MessageType.ErrorMessage, [], None),
-        ],
-    )
-    def test_detect_gnome_color_scheme_dbus(
-        self,
-        gnome_valid: bool,
-        color_scheme_message_type: QDBusMessage.MessageType,
-        color_scheme_args: list[str],
-        gtk_theme_message_type: QDBusMessage.MessageType,
-        gtk_theme_args: list[str],
-        expected: bool | None,
-        mock_dbus_detector: DBusThemeDetector,
-        mock_gnome_interface: Mock,
-    ) -> None:
-        """Test GNOME color scheme detection via D-Bus."""
-        # Mock service availability to return True for GNOME service
-        with patch.object(mock_dbus_detector, '_is_service_available', return_value=True):
-            mock_gnome_interface.isValid.return_value = gnome_valid
-
-            # Create mock messages for color scheme and gtk theme calls
-            color_scheme_message = Mock()
-            color_scheme_message.type.return_value = color_scheme_message_type
-            color_scheme_message.arguments.return_value = color_scheme_args
-
-            gtk_theme_message = Mock()
-            gtk_theme_message.type.return_value = gtk_theme_message_type
-            gtk_theme_message.arguments.return_value = gtk_theme_args
-
-            # Configure the call method to return different messages based on the argument
-            def call_side_effect(method: str, *args: str) -> Mock:
-                if "color-scheme" in args[0]:
-                    return color_scheme_message
-                else:
-                    return gtk_theme_message
-
-            mock_gnome_interface.call.side_effect = call_side_effect
-
-            result = mock_dbus_detector.gnome_color_scheme_is_dark()
-            assert result == expected
-
-    @pytest.mark.parametrize(
-        ("exception_type",),
-        [
-            (RuntimeError,),
-            (AttributeError,),
-            (TypeError,),
-        ],
-    )
-    def test_detect_gnome_color_scheme_dbus_exception(
-        self,
-        exception_type: type[Exception],
-        mock_dbus_detector: DBusThemeDetector,
-        mock_gnome_interface: Mock,
-    ) -> None:
-        """Test GNOME color scheme detection with exceptions."""
-        mock_gnome_interface.call.side_effect = exception_type("Test exception")
-
-        result = mock_dbus_detector.gnome_color_scheme_is_dark()
         assert result is None
 
     @pytest.mark.parametrize(
@@ -385,10 +284,6 @@ class TestDBusThemeDetector:
                 # Test portal detection
                 portal_result = detector.freedesktop_portal_color_scheme_is_dark()
                 assert portal_result == (True if expected_portal else None)
-
-                # Test GNOME detection
-                gnome_result = detector.gnome_color_scheme_is_dark()
-                assert gnome_result == (True if expected_gnome else None)
 
 
 class TestServiceAvailability:
@@ -598,88 +493,9 @@ class TestGlobalFunctions:
             result = detect_freedesktop_color_scheme_dbus()
             assert result is False
 
-    @pytest.mark.parametrize(
-        ("detector_result", "expected"),
-        [
-            (True, True),
-            (False, False),
-            (None, False),
-        ],
-    )
-    def test_detect_gnome_color_scheme_dbus(
-        self,
-        detector_result: bool | None,
-        expected: bool,
-    ) -> None:
-        """Test the global detect_gnome_color_scheme_dbus function."""
-        with patch("picard.ui.theme_detect_qtdbus.get_dbus_detector") as mock_get_detector:
-            mock_detector = Mock()
-            mock_detector.gnome_color_scheme_is_dark.return_value = detector_result
-            mock_get_detector.return_value = mock_detector
-
-            result = detect_gnome_color_scheme_dbus()
-            assert result == expected
-
-    @pytest.mark.parametrize(
-        ("exception_type",),
-        [
-            (RuntimeError,),
-            (AttributeError,),
-            (TypeError,),
-        ],
-    )
-    def test_detect_gnome_color_scheme_dbus_exception(
-        self,
-        exception_type: type[Exception],
-    ) -> None:
-        """Test detect_gnome_color_scheme_dbus with exceptions."""
-        with patch("picard.ui.theme_detect_qtdbus.get_dbus_detector", side_effect=exception_type("Test exception")):
-            result = detect_gnome_color_scheme_dbus()
-            assert result is False
-
 
 class TestIntegration:
     """Integration tests for the D-Bus theme detection."""
-
-    @pytest.mark.parametrize(
-        ("portal_dark", "gnome_dark", "expected_dark"),
-        [
-            (True, False, True),  # Portal takes precedence
-            (False, True, False),  # Portal takes precedence
-            (None, True, True),  # Fallback to GNOME
-            (None, False, False),  # Fallback to GNOME
-            (None, None, False),  # No detection
-        ],
-    )
-    def test_detection_priority(
-        self,
-        portal_dark: bool | None,
-        gnome_dark: bool | None,
-        expected_dark: bool,
-    ) -> None:
-        """Test that freedesktop portal detection takes priority over GNOME detection."""
-        # Mock the detector methods to return the expected values
-        with patch("picard.ui.theme_detect_qtdbus.get_dbus_detector") as mock_get_detector:
-            mock_detector = Mock()
-
-            # Configure the detector methods to return the test values
-            def freedesktop_side_effect():
-                return portal_dark
-
-            def gnome_side_effect():
-                return gnome_dark
-
-            mock_detector.freedesktop_portal_color_scheme_is_dark.side_effect = freedesktop_side_effect
-            mock_detector.gnome_color_scheme_is_dark.side_effect = gnome_side_effect
-            mock_get_detector.return_value = mock_detector
-
-            # Test portal detection
-            portal_result = detect_freedesktop_color_scheme_dbus()
-            assert portal_result == (portal_dark is True)
-
-            # Test GNOME detection
-            gnome_result = detect_gnome_color_scheme_dbus()
-            assert gnome_result == (gnome_dark is True)
 
     def test_dbus_message_types(self) -> None:
         """Test handling of different D-Bus message types."""

--- a/test/test_theme_detect_qtdbus.py
+++ b/test/test_theme_detect_qtdbus.py
@@ -53,18 +53,9 @@ def mock_portal_interface() -> Mock:
 
 
 @pytest.fixture
-def mock_gnome_interface() -> Mock:
-    """Create a mock GNOME dconf interface."""
-    mock_interface = Mock()
-    mock_interface.isValid.return_value = True
-    return mock_interface
-
-
-@pytest.fixture
 def mock_dbus_detector(
     mock_dbus_connection: Mock,
     mock_portal_interface: Mock,
-    mock_gnome_interface: Mock,
 ) -> DBusThemeDetector:
     """Create a DBusThemeDetector with mocked D-Bus components."""
     with (
@@ -77,14 +68,12 @@ def mock_dbus_detector(
         def qdbus_interface_side_effect(*args, **kwargs):
             if "org.freedesktop.portal.Settings" in args:
                 return mock_portal_interface
-            elif "ca.desrt.dconf.Writer" in args:
-                return mock_gnome_interface
             elif "org.freedesktop.DBus" in args:
                 # Mock for service availability checking
                 mock_db_interface = Mock()
                 mock_db_message = Mock()
                 mock_db_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-                mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop", "ca.desrt.dconf"]]
+                mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop"]]
                 mock_db_interface.call.return_value = mock_db_message
                 return mock_db_interface
             return Mock()
@@ -214,20 +203,16 @@ class TestDBusThemeDetector:
         assert result is None
 
     @pytest.mark.parametrize(
-        ("portal_service_available", "gnome_service_available", "expected_portal", "expected_gnome"),
+        ("portal_service_available", "expected_portal"),
         [
-            (True, True, True, True),  # Both services available
-            (True, False, True, False),  # Only portal available
-            (False, True, False, True),  # Only GNOME available
-            (False, False, False, False),  # Neither service available
+            (True, True),  # Portal service available
+            (False, False),  # Portal service not available
         ],
     )
     def test_detection_with_service_availability(
         self,
         portal_service_available: bool,
-        gnome_service_available: bool,
         expected_portal: bool,
-        expected_gnome: bool,
     ) -> None:
         """Test detection methods when services are not available."""
         with (
@@ -242,15 +227,13 @@ class TestDBusThemeDetector:
             def service_availability_side_effect(service_name: str) -> bool:
                 if "portal" in service_name:
                     return portal_service_available
-                elif "dconf" in service_name:
-                    return gnome_service_available
                 return False
 
             # Mock the D-Bus interface for service listing
             mock_db_interface = Mock()
             mock_db_message = Mock()
             mock_db_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop", "ca.desrt.dconf"]]
+            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop"]]
             mock_db_interface.call.return_value = mock_db_message
 
             # Configure QDBusInterface to return different mocks for different calls
@@ -265,14 +248,6 @@ class TestDBusThemeDetector:
                     mock_portal_message.arguments.return_value = [1]  # Dark theme
                     mock_portal.call.return_value = mock_portal_message
                     return mock_portal
-                elif "ca.desrt.dconf.Writer" in args:
-                    mock_gnome = Mock()
-                    mock_gnome.isValid.return_value = True
-                    mock_gnome_message = Mock()
-                    mock_gnome_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-                    mock_gnome_message.arguments.return_value = ["dark"]
-                    mock_gnome.call.return_value = mock_gnome_message
-                    return mock_gnome
                 return Mock()
 
             mock_qdbus_interface.side_effect = qdbus_interface_side_effect
@@ -292,10 +267,10 @@ class TestServiceAvailability:
     @pytest.mark.parametrize(
         ("service_name", "available_services", "expected"),
         [
-            ("org.freedesktop.portal.Desktop", ["org.freedesktop.portal.Desktop", "ca.desrt.dconf"], True),
-            ("ca.desrt.dconf", ["org.freedesktop.portal.Desktop", "ca.desrt.dconf"], True),
-            ("org.freedesktop.portal.Desktop", ["ca.desrt.dconf"], False),
-            ("ca.desrt.dconf", ["org.freedesktop.portal.Desktop"], False),
+            ("org.freedesktop.portal.Desktop", ["org.freedesktop.portal.Desktop", "org.example.Service"], True),
+            ("org.example.Service", ["org.freedesktop.portal.Desktop", "org.example.Service"], True),
+            ("org.freedesktop.portal.Desktop", ["org.example.Service"], False),
+            ("org.example.Service", ["org.freedesktop.portal.Desktop"], False),
             ("org.freedesktop.portal.Desktop", [], False),
         ],
     )

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -394,7 +394,8 @@ class TestWindowsTheme:
             mock_winreg.QueryValueEx.assert_called_once_with(
                 mock_winreg.OpenKey.return_value.__enter__.return_value, 'ColorizationColor'
             )
-            assert result == QtGui.QColor(0xAABBCC11)
+            # The code masks out the alpha byte (& 0xFFFFFF), so only RGB is used
+            assert result == QtGui.QColor('#bbcc11')
 
     def test_get_system_accent_color_error_fallback(self):
         theme = theme_mod.WindowsTheme()

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -138,28 +138,76 @@ class TestApplyDarkPaletteColors:
         assert new_disabled_text == QtCore.Qt.GlobalColor.darkGray
 
 
+class TestPaletteIsDark:
+    """Test the is_dark method."""
+
+    @pytest.mark.parametrize(
+        ("base_color", "is_dark"),
+        [
+            (QtGui.QColor(QtCore.Qt.GlobalColor.black), True),
+            (QtGui.QColor(QtCore.Qt.GlobalColor.black), True),
+            (QtGui.QColor(128, 128, 128), False),
+            (QtGui.QColor(127, 127, 127), True),
+        ],
+    )
+    def test_is_dark(self, base_color, is_dark):
+        palette = QtGui.QPalette()
+        palette.setColor(QtGui.QPalette.ColorRole.Base, base_color)
+        assert theme_mod.palette_is_dark(palette) == is_dark
+
+
 class TestApplyDarkThemeToPalette:
     """Test the apply_dark_theme_to_palette method."""
 
-    def test_apply_dark_theme_to_palette_with_style_hints(self, mock_palette, mock_style_hints):
-        """Test apply_dark_theme_to_palette uses style hints when available."""
-        with patch("picard.ui.theme.get_style_hints", return_value=mock_style_hints):
-            theme_mod.apply_dark_theme_to_palette(mock_palette)
-            mock_style_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
+    def test_apply_dark_theme_to_palette(self):
+        """Test integration of manual fallback with real palette objects."""
+        palette = QtGui.QPalette()
+        original_base_color = QtGui.QColor(QtCore.Qt.GlobalColor.white)
+        palette.setColor(QtGui.QPalette.ColorRole.Base, original_base_color)
 
-    def test_apply_dark_theme_to_palette_without_style_hints(self, mock_palette):
-        """Test apply_dark_theme_to_palette falls back to manual colors when no style hints."""
+        # Test without style hints (manual fallback)
         with patch("picard.ui.theme.get_style_hints", return_value=None):
-            with patch("picard.ui.theme.apply_dark_palette_colors") as mock_apply_colors:
-                theme_mod.apply_dark_theme_to_palette(mock_palette)
-                mock_apply_colors.assert_called_once_with(mock_palette)
+            theme_mod.apply_dark_theme_to_palette(palette)
+            # Verify that manual colors were applied
+            new_base_color = palette.color(QtGui.QPalette.ColorRole.Base)
+            assert new_base_color != original_base_color
 
-    def test_apply_dark_theme_to_palette_calls_manual_fallback(self, mock_palette):
-        """Test apply_dark_theme_to_palette calls manual fallback when style hints unavailable."""
+    def test_apply_dark_theme_to_palette_skipped_if_dark(self):
+        """Test integration of manual fallback with real palette objects."""
+        palette = QtGui.QPalette()
+        original_base_color = QtGui.QColor(QtCore.Qt.GlobalColor.black)
+        palette.setColor(QtGui.QPalette.ColorRole.Base, original_base_color)
+
+        # Test without style hints (manual fallback)
         with patch("picard.ui.theme.get_style_hints", return_value=None):
-            with patch("picard.ui.theme.apply_dark_palette_colors") as mock_apply_colors:
-                theme_mod.apply_dark_theme_to_palette(mock_palette)
-                mock_apply_colors.assert_called_once_with(mock_palette)
+            theme_mod.apply_dark_theme_to_palette(palette)
+            # Verify that manual colors were applied
+            new_base_color = palette.color(QtGui.QPalette.ColorRole.Base)
+            assert new_base_color == original_base_color
+
+
+class TestGetAccentColorFromPalette:
+    def test_get_accent_color_from_palette(self):
+        palette = QtGui.QPalette()
+        accent_color = QtGui.QColor(40, 10, 40)
+        if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
+            palette.setColor(QtGui.QPalette.ColorRole.Accent, accent_color)
+        else:
+            palette.setColor(QtGui.QPalette.ColorRole.Highlight, accent_color)
+
+        new_accent_color = theme_mod.get_accent_color_from_palette(palette)
+        assert new_accent_color == accent_color
+
+
+class TestApplyAccentColorToPalette:
+    def test_apply_accent_color_to_palette(self):
+        palette = QtGui.QPalette()
+        accent_color = QtGui.QColor(220, 220, 120)
+        theme_mod.apply_accent_color_to_palette(palette, accent_color)
+        assert palette.color(QtGui.QPalette.ColorRole.Highlight) == accent_color
+        if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
+            assert palette.color(QtGui.QPalette.ColorRole.Accent) == accent_color
+        assert palette.color(QtGui.QPalette.ColorRole.HighlightedText) == QtGui.QColor(QtCore.Qt.GlobalColor.black)
 
 
 class TestThemeAvailability:
@@ -238,8 +286,8 @@ class TestSetupColorScheme:
         [
             ("dark", QtCore.Qt.ColorScheme.Dark),
             ("light", QtCore.Qt.ColorScheme.Light),
-            ("default", QtCore.Qt.ColorScheme.Unknown),
-            ("system", QtCore.Qt.ColorScheme.Unknown),
+            ("default", QtCore.Qt.ColorScheme.Light),
+            ("system", QtCore.Qt.ColorScheme.Light),
         ],
     )
     def test_setup_sets_color_scheme_based_on_theme(
@@ -253,7 +301,7 @@ class TestSetupColorScheme:
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
             patch("picard.ui.theme.get_style_hints", return_value=mock_style_hints),
-            patch.object(theme_mod.BaseTheme, "_detect_linux_dark_mode", return_value=False),
+            patch.object(theme_mod.BaseTheme, "get_system_theme", return_value=theme_mod.UiTheme.LIGHT),
             patch.object(theme_mod, "MacOverrideStyle") as _,
         ):
             mock_style_hints.setColorScheme.reset_mock()
@@ -275,24 +323,154 @@ class TestSetupColorScheme:
             base_theme.setup(mock_app)
 
 
-class TestWindowsTheme:
-    """Test Windows-specific theme behavior."""
+class TestGenericTheme:
+    """Generic theme behavior."""
 
-    def test_windows_theme_apply_dark_theme_to_palette(self, mock_palette):
+    def test_apply_theme_light(self, mock_palette):
         """Test WindowsTheme uses apply_dark_theme_to_palette in update_palette."""
+        app = MagicMock()
+        app.palette.return_value = mock_palette
+        theme = theme_mod.GenericTheme()
+
+        with (
+            patch("picard.ui.theme.set_color_scheme") as mock_set_color_scheme,
+            patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply,
+        ):
+            theme.apply_theme(app, theme_mod.UiTheme.LIGHT)
+            mock_set_color_scheme.assert_called_once()
+            mock_apply.assert_not_called()
+
+    def test_apply_theme_dark(self, mock_palette):
+        """Test WindowsTheme uses apply_dark_theme_to_palette in update_palette."""
+        app = MagicMock()
+        app.palette.return_value = mock_palette
         theme = theme_mod.WindowsTheme()
 
-        with patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply:
-            theme.update_palette(mock_palette, True, None)
+        with (
+            patch("picard.ui.theme.set_color_scheme") as mock_set_color_scheme,
+            patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply,
+        ):
+            theme.apply_theme(app, theme_mod.UiTheme.DARK)
+            mock_set_color_scheme.assert_called_once()
             mock_apply.assert_called_once_with(mock_palette)
 
-    def test_windows_theme_does_not_apply_dark_theme_when_not_dark(self, mock_palette):
-        """Test WindowsTheme does not apply dark theme when dark_theme is False."""
-        theme = theme_mod.WindowsTheme()
 
-        with patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply:
-            theme.update_palette(mock_palette, False, None)
-            mock_apply.assert_not_called()
+class TestWindowsTheme:
+    """Test Windows specific theme behavior."""
+
+    def test_get_system_theme_calls_registry(self):
+        theme = theme_mod.WindowsTheme()
+        app = MagicMock()
+
+        with patch("picard.ui.theme.winreg") as mock_winreg:
+            mock_winreg.QueryValueEx.return_value = (0, None)
+            result = theme.get_system_theme(app)
+            mock_winreg.OpenKey.assert_called_once_with(
+                mock_winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+            )
+            mock_winreg.QueryValueEx.assert_called_once_with(
+                mock_winreg.OpenKey.return_value.__enter__.return_value, 'AppsUseLightTheme'
+            )
+            assert result == theme_mod.UiTheme.DARK
+
+    def test_get_system_theme_error_fallback(self):
+        theme = theme_mod.WindowsTheme()
+        app = MagicMock()
+        with patch("picard.ui.theme.winreg") as mock_winreg:
+            mock_winreg.OpenKey.side_effect = OSError
+            result = theme.get_system_theme(app)
+            assert result == theme_mod.UiTheme.LIGHT
+
+    def test_get_system_accent_color(self):
+        theme = theme_mod.WindowsTheme()
+        with patch("picard.ui.theme.winreg") as mock_winreg:
+            mock_winreg.QueryValueEx.return_value = (0xAABBCC11, None)
+            result = theme.get_system_accent_color()
+            mock_winreg.OpenKey.assert_called_once_with(
+                mock_winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\DWM",
+            )
+            mock_winreg.QueryValueEx.assert_called_once_with(
+                mock_winreg.OpenKey.return_value.__enter__.return_value, 'ColorizationColor'
+            )
+            assert result == QtGui.QColor(0xAABBCC11)
+
+    def test_get_system_accent_color_error_fallback(self):
+        theme = theme_mod.WindowsTheme()
+        with patch("picard.ui.theme.winreg") as mock_winreg:
+            mock_winreg.OpenKey.side_effect = OSError
+            result = theme.get_system_accent_color()
+            assert result is None
+
+
+class TestMacTheme:
+    """Test macOS specific theme behavior."""
+
+    def test_get_system_theme(self):
+        theme = theme_mod.MacTheme()
+        app = MagicMock()
+        with (
+            patch("picard.ui.theme.OS_SUPPORTS_THEMES", True),
+            patch("picard.ui.theme.AppKit") as mock_appkit,
+        ):
+            mock_appearance = MagicMock()
+            mock_appearance.bestMatchFromAppearancesWithNames_.return_value = mock_appkit.NSAppearanceNameDarkAqua
+            mock_appkit.NSAppearance.currentAppearance.return_value = mock_appearance
+            result = theme.get_system_theme(app)
+            mock_appearance.bestMatchFromAppearancesWithNames_.assert_called_once_with(
+                [mock_appkit.NSAppearanceNameAqua, mock_appkit.NSAppearanceNameDarkAqua]
+            )
+            assert result == theme_mod.UiTheme.DARK
+
+    def test_get_system_theme_error_fallback(self):
+        theme = theme_mod.MacTheme()
+        app = MagicMock()
+        with (
+            patch("picard.ui.theme.OS_SUPPORTS_THEMES", True),
+            patch("picard.ui.theme.AppKit") as mock_appkit,
+        ):
+            mock_appearance = MagicMock()
+            mock_appkit.NSAppearance.currentAppearance.return_value = mock_appearance
+            mock_appearance.side_effect = OSError
+            result = theme.get_system_theme(app)
+            assert result == theme_mod.UiTheme.LIGHT
+
+    def test_get_system_theme_no_appkit_fallback(self):
+        theme = theme_mod.MacTheme()
+        app = MagicMock()
+        with (
+            patch("picard.ui.theme.OS_SUPPORTS_THEMES", True),
+            patch("picard.ui.theme.AppKit", None),
+        ):
+            result = theme.get_system_theme(app)
+            assert result == theme_mod.UiTheme.LIGHT
+
+    def test_apply_theme(self):
+        theme = theme_mod.MacTheme()
+        app = MagicMock()
+        with (
+            patch("picard.ui.theme.OS_SUPPORTS_THEMES", True),
+            patch("picard.ui.theme.AppKit") as mock_appkit,
+            patch("picard.ui.theme.BaseTheme.apply_theme") as mock_base_apply,
+        ):
+            theme.apply_theme(app, theme_mod.UiTheme.DARK)
+            mock_base_apply.assert_called_once()
+            mock_appkit.NSApplication.sharedApplication().setAppearance_.assert_called_once_with(
+                mock_appkit.NSAppearance._darkAquaAppearance()
+            )
+
+    def test_get_system_theme_no_theme_support(self):
+        theme = theme_mod.MacTheme()
+        app = MagicMock()
+        with (
+            patch("picard.ui.theme.OS_SUPPORTS_THEMES", False),
+            patch("picard.ui.theme.AppKit") as mock_appkit,
+            patch("picard.ui.theme.BaseTheme.apply_theme") as mock_base_apply,
+        ):
+            theme.apply_theme(app, theme_mod.UiTheme.DARK)
+            mock_base_apply.assert_called_once()
+            mock_appkit.NSApplication.sharedApplication().setAppearance_.assert_not_called()
 
 
 class TestLinuxDarkModeDetection:
@@ -310,10 +488,10 @@ class TestLinuxDarkModeDetection:
     @pytest.mark.parametrize(
         ("config_theme", "detect_result", "expected_apply_called"),
         [
-            ("default", True, True),  # Should apply dark theme
-            ("default", False, False),  # Should not apply dark theme
-            ("dark", True, False),  # Should not apply (already dark)
-            ("light", True, False),  # Should not apply (explicit light)
+            ("default", theme_mod.UiTheme.DARK, True),  # Should apply dark theme
+            ("default", theme_mod.UiTheme.LIGHT, False),  # Should not apply dark theme
+            ("dark", theme_mod.UiTheme.DARK, True),  # Should apply dark theme
+            ("light", theme_mod.UiTheme.DARK, False),  # Should not apply (light configured)
         ],
     )
     def test_linux_dark_mode_detection_logic(
@@ -331,7 +509,7 @@ class TestLinuxDarkModeDetection:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(linux_theme, "_detect_linux_dark_mode", return_value=detect_result),
+            patch.object(linux_theme, "get_system_theme", return_value=detect_result),
             patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply,
             patch("picard.ui.theme.get_style_hints", return_value=None),
         ):
@@ -341,7 +519,7 @@ class TestLinuxDarkModeDetection:
             else:
                 mock_apply.assert_not_called()
 
-    def test_linux_dark_mode_not_applied_when_already_dark(self, linux_theme, mock_app):
+    def test_linux_dark_mode_palette_not_applied_when_already_dark(self, linux_theme, mock_app):
         """Test Linux dark mode is not applied when palette is already dark."""
         # Mock config
         config_mock = MagicMock()
@@ -354,8 +532,8 @@ class TestLinuxDarkModeDetection:
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),
-            patch.object(linux_theme, "_detect_linux_dark_mode", return_value=True),
-            patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply,
+            patch.object(linux_theme, "get_system_theme", return_value=theme_mod.UiTheme.DARK),
+            patch("picard.ui.theme.apply_dark_palette_colors") as mock_apply,
             patch("picard.ui.theme.get_style_hints", return_value=None),
         ):
             linux_theme.setup(mock_app)
@@ -365,28 +543,6 @@ class TestLinuxDarkModeDetection:
 
 class TestIntegration:
     """Test integration scenarios."""
-
-    def test_style_hints_integration_with_real_palette(self):
-        """Test integration of style hints with real palette objects."""
-        palette = QtGui.QPalette()
-
-        # Test with style hints available
-        mock_hints = MagicMock()
-        with patch("picard.ui.theme.get_style_hints", return_value=mock_hints):
-            theme_mod.apply_dark_theme_to_palette(palette)
-            mock_hints.setColorScheme.assert_called_once_with(QtCore.Qt.ColorScheme.Dark)
-
-    def test_manual_fallback_integration(self):
-        """Test integration of manual fallback with real palette objects."""
-        palette = QtGui.QPalette()
-        original_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
-
-        # Test without style hints (manual fallback)
-        with patch("picard.ui.theme.get_style_hints", return_value=None):
-            theme_mod.apply_dark_theme_to_palette(palette)
-            # Verify that manual colors were applied
-            new_window_color = palette.color(QtGui.QPalette.ColorRole.Window)
-            assert new_window_color != original_window_color
 
     def test_theme_setup_integration(self, mock_app):
         """Test complete theme setup integration."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
This PR refactors the theme detection code. The previous code was rather convoluted, with widely different code paths based on system.

Also the various detection strategies applied for Linux were partially redundant or even implemented approaches not available at all.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

1. The core change is unifying the initial theme detection across platforms. On all platforms this will now:
    1. If the configured theme is "default", try to detect the system field
    2. Always apply the theme (either as configured light / dark, or if "default" the system theme). Applying the theme will always:
        - Update `QStyle.colorScheme`
        - If the wanted theme is dark, and the palette is not already dark, update with a dark palette.
    3. Get the system accent color
        - If there is a system accent color, apply it to the palette
        - If not, use the palette to determine the accent color (for use at other places in the UI)

2. Additionally this PR clean ups the theme detection strategies (applied on Linux)
    - Remove `detect_freedesktop_color_scheme_dark`: this used a D-Bus call already implemented in `detect_freedesktop_color_scheme_dbus`, and an invalid gsettings call which never could have worked
    - Remove `detect_gnome_color_scheme_dbus`: This used a D-Bus approach that is not available and again never could have worked. This change includes removing also the redundant D-Bus call from `detect_gnome_color_scheme_dark`.

3. Update tests
    - Adjust tests for changes
    - Removed some redundant tests
    - Added tests for new functions
    - Run the tests for `MacTheme` and `WindowsTheme` on all platforms by mocking the underlying calls

Tested on GNOME, macOS and Windows.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
