### PR TITLE
PICARD-163, PICARD-2961: Add Lookup by ISRC in a 'Lookup by...' submenu

### DIFF
--- a/picard/ui/enums.py
+++ b/picard/ui/enums.py
@@ -114,5 +114,6 @@ class MainAction(str, Enum):
     SAVE_SESSION_AS = 'save_session_action'
     SAVE_SESSION = 'quick_save_session_action'
     LOAD_SESSION = 'load_session_action'
+    LOOKUP_ISRC = 'lookup_isrc_action'
     NEW_SESSION = 'close_session_action'
     CLEAR_RECENT_SESSIONS = 'clear_recent_sessions_action'

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -270,6 +270,9 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             )
             plugin_actions = list(ext_point_clusterlist_actions)
         elif isinstance(obj, File):
+            lookup_by_menu = QtWidgets.QMenu(_("Lookup by…"), menu)
+            lookup_by_menu.setIcon(icontheme.lookup('system-search'))
+            lookup_by_menu.addAction(self.window.action_map[MainAction.LOOKUP_ISRC])
             add_actions(
                 MainAction.VIEW_INFO if can_view_info else None,
                 MainAction.PLAY if can_play else None,
@@ -282,6 +285,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                 MainAction.AUTOTAG,
                 MainAction.ANALYZE,
                 MainAction.TRACK_SEARCH,
+                lookup_by_menu,
                 MainAction.GENERATE_FINGERPRINTS,
             )
             plugin_actions = list(ext_point_file_actions)

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -237,6 +237,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                     MainAction.PLAY_FILE_EXTERNAL,
                     MainAction.OPEN_FOLDER,
                     MainAction.TRACK_SEARCH,
+                    self.window.create_lookup_by_menu(menu),
                 )
                 # Extend with file actions, avoiding duplicates
                 file_actions = list(ext_point_file_actions)
@@ -270,9 +271,6 @@ class BaseTreeView(QtWidgets.QTreeWidget):
             )
             plugin_actions = list(ext_point_clusterlist_actions)
         elif isinstance(obj, File):
-            lookup_by_menu = QtWidgets.QMenu(_("Lookup by…"), menu)
-            lookup_by_menu.setIcon(icontheme.lookup('system-search'))
-            lookup_by_menu.addAction(self.window.action_map[MainAction.LOOKUP_ISRC])
             add_actions(
                 MainAction.VIEW_INFO if can_view_info else None,
                 MainAction.PLAY if can_play else None,
@@ -285,7 +283,7 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                 MainAction.AUTOTAG,
                 MainAction.ANALYZE,
                 MainAction.TRACK_SEARCH,
-                lookup_by_menu,
+                self.window.create_lookup_by_menu(menu),
                 MainAction.GENERATE_FINGERPRINTS,
             )
             plugin_actions = list(ext_point_file_actions)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -757,6 +757,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         dialog.search(f'isrc:{escape_lucene_query(isrc)}')
         dialog.exec()
 
+    def create_lookup_by_menu(self, parent):
+        """Create a 'Lookup by…' submenu for use in context menus."""
+        lookup_menu = QtWidgets.QMenu(_("Lookup by…"), parent)
+        lookup_menu.setIcon(icontheme.lookup('system-search'))
+        lookup_menu.addAction(self.action_map[MainAction.LOOKUP_ISRC])
+        return lookup_menu
+
     def _create_actions(self):
         self.action_map = dict(create_actions(self))
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -86,6 +86,7 @@ from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
+from picard.debug_opts import DebugOpt
 from picard.extension_points.plugin_tools_menu import (
     ext_point_plugin_tools_items,
     signaler,
@@ -127,7 +128,9 @@ from picard.util.cdrom import (
     discid,
     get_cdrom_drives,
 )
+from picard.util.isrc import valid_isrc
 from picard.util.readthedocs import ReadTheDocs
+from picard.webservice.api_helpers import escape_lucene_query
 
 from picard.ui import (
     PicardDialog,
@@ -724,6 +727,35 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         dialog = ISRCSubmitDialog(details, parent=self)
         if dialog.exec():
             manager.submit(isrcs_to_submit=dialog.get_submitted_isrcs())
+
+    def _on_lookup_isrc(self):
+        objects = self.selected_objects
+        if not objects:
+            return
+        # Find the first valid ISRC from selected files
+        source_file = None
+        isrc = None
+        for obj in objects:
+            if hasattr(obj, 'metadata'):
+                for value in obj.metadata.getall('isrc'):
+                    isrc = valid_isrc(value)
+                    if isrc:
+                        source_file = obj
+                        break
+            if isrc:
+                break
+        else:
+            log.debug_if(DebugOpt.ISRC, "ISRC lookup: no ISRC found in selected files")
+            return
+
+        log.debug_if(
+            DebugOpt.ISRC,
+            "ISRC lookup: searching for ISRC %s",
+            isrc,
+        )
+        dialog = TrackSearchDialog(self, force_advanced_search=True, matched_file=source_file)
+        dialog.search(f'isrc:{escape_lucene_query(isrc)}')
+        dialog.exec()
 
     def _create_actions(self):
         self.action_map = dict(create_actions(self))
@@ -1846,6 +1878,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.enable_action(MainAction.SIMILAR_ITEMS_SEARCH, is_file or is_cluster)
         self.enable_action(MainAction.TRACK_SEARCH, is_file)
         self.enable_action(MainAction.ALBUM_SEARCH, is_cluster)
+        self.enable_action(MainAction.LOOKUP_ISRC, have_files)
         self.enable_action(MainAction.ALBUM_OTHER_VERSIONS, is_album)
 
     def enable_action(self, action_id, enabled):

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -250,6 +250,15 @@ def _create_browser_lookup_action(parent):
     return action
 
 
+@add_action(MainAction.LOOKUP_ISRC)
+def _create_lookup_isrc_action(parent):
+    action = QtGui.QAction(_("Lookup by &ISRC"), parent)
+    action.setStatusTip(_("Lookup selected item by ISRC"))
+    action.setEnabled(False)
+    action.triggered.connect(parent._on_lookup_isrc)
+    return action
+
+
 @add_action(MainAction.SUBMIT_CLUSTER)
 def _create_submit_cluster_action(parent):
     if addrelease.is_available():

--- a/picard/ui/searchdialog/track.py
+++ b/picard/ui/searchdialog/track.py
@@ -24,7 +24,7 @@
 from operator import attrgetter
 
 from picard.config import get_config
-from picard.file import FILE_COMPARISON_WEIGHTS
+from picard.file import FILE_COMPARISON_WEIGHTS, File
 from picard.i18n import (
     N_,
     gettext as _,
@@ -59,7 +59,7 @@ from picard.ui.searchdialog import (
 class TrackSearchDialog(SearchDialog):
     dialog_header_state = 'tracksearchdialog_header_state'
 
-    def __init__(self, parent, force_advanced_search=None):
+    def __init__(self, parent, force_advanced_search: bool | None = None, matched_file: File | None = None):
         self.columns = Columns(
             (
                 Column(N_("Name"), 'title', width=150),
@@ -88,27 +88,27 @@ class TrackSearchDialog(SearchDialog):
             search_type='track',
             force_advanced_search=force_advanced_search,
         )
-        self.file_ = None
+        self._file = matched_file
 
-    def search(self, text):
+    def search(self, query: str):
         """Perform search using query provided by the user."""
-        self.retry_params = Retry(self.search, text)
-        self.search_box_text(text)
+        self.retry_params = Retry(self.search, query)
+        self.search_box_text(query)
         self.show_progress()
         config = get_config()
         self.tagger.mb_api.find_tracks(
             self.handle_reply,
-            query=text,
+            query=query,
             search=True,
             advanced_search=self.use_advanced_search,
             limit=config.setting['query_limit'],
         )
 
-    def show_similar_tracks(self, file_):
+    def show_similar_tracks(self, matched_file: File):
         """Perform search using existing metadata information
         from the file as query."""
-        self.file_ = file_
-        metadata = file_.orig_metadata
+        self._file = matched_file
+        metadata = matched_file.orig_metadata
         query = {
             'track': metadata['title'],
             'artist': metadata['artist'],
@@ -141,8 +141,8 @@ class TrackSearchDialog(SearchDialog):
             self.no_results_found()
             return
 
-        if self.file_:
-            metadata = self.file_.orig_metadata
+        if self._file:
+            metadata = self._file.orig_metadata
             candidates = (compare_to_track(metadata, track, FILE_COMPARISON_WEIGHTS) for track in tracks)
             tracks = (result.track for result in sort_by_similarity(candidates))
 
@@ -192,7 +192,7 @@ class TrackSearchDialog(SearchDialog):
         recording_id = track['musicbrainz_recordingid']
         album_id = track['musicbrainz_albumid']
         releasegroup_id = track['musicbrainz_releasegroupid']
-        file = self.file_
+        file = self._file
 
         self.tagger.get_release_group_by_id(releasegroup_id).loaded_albums.add(album_id)
         if file:
@@ -213,7 +213,7 @@ class TrackSearchDialog(SearchDialog):
 
     def _load_selection_nat(self, track, node):
         recording_id = track['musicbrainz_recordingid']
-        file = self.file_
+        file = self._file
 
         if file:
             # Search is performed for a file.


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add a "Lookup by…" submenu to the file context menu with "ISRC" as the first entry. Right-click a file and look up its recording via the track search dialog using a MusicBrainz ISRC query.

## Problem

* JIRA tickets: PICARD-163, PICARD-2961

Users with files that have ISRCs but no other MusicBrainz identifiers have no way to use the ISRC for lookup within Picard. They must manually search on the website. PICARD-2961 describes the broader need for a "Lookup by..." submenu with various identifier-based lookups.

## Solution

Depends on #3280 (ISRC submission from files, for the `picard/util/isrc` module).

### Commit 1: Refactor TrackSearchDialog to accept a file in constructor

- Add `matched_file` parameter to `TrackSearchDialog.__init__()` so a file can be passed directly at construction time (instead of only via `show_similar_tracks()`)
- Rename `file_` to `_file` (private attribute), add type hints, rename `search()` parameter to `query`

### Commit 2: Add 'Lookup by ISRC' context menu action for files

- Add a "Lookup by…" submenu to the file context menu (PICARD-2961), with "ISRC" as the first entry
- Use the search API (`isrc:<value>` query in the track search dialog) as a workaround for MBS-10185 (the `/isrc/` endpoint ignores `inc=releases` in JSON mode)
- Action enabled when any files are selected; uses the first valid ISRC found
- Debug logging (via `--debug-opts=isrc`) for the ISRC being searched
- The submenu structure prepares for future additions (barcode, catalogue number, disc ID)

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed collaboratively with an AI assistant (Kiro CLI), with human review, design decisions, and manual testing by the author.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

