### PR TITLE
PICARD-1444: Redesign release preferences UI

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -48,7 +48,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'beta', 7)
+PICARD_VERSION = Version(3, 0, 0, 'beta', 8)
 
 
 PICARD_VERSION_STR = str(PICARD_VERSION)

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -792,3 +792,28 @@ def convert_standardize_artists(settings):
 def remove_rtd_updates_ask(settings):
     """Remove "rtd_updates_ask"."""
     remove_option(settings, 'rtd_updates_ask')
+
+
+@upgrade_settings('3.0.0b8')
+def convert_release_type_scores_to_lists(settings):
+    """Convert release_type_scores to preferred/discouraged release type lists.
+
+    Old format: release_type_scores = [('Album', 0.9), ('Single', 0.5), ('Compilation', 0.0)]
+    New format:
+      preferred_release_types = ['Album']        (score > 0.5, sorted by score desc)
+      discouraged_release_types = ['Compilation'] (score < 0.5)
+    """
+    if 'release_type_scores' not in settings:
+        return
+    scores = get_option_value(settings, 'release_type_scores', ListOption, [])
+    preferred = []
+    discouraged = []
+    for release_type, score in scores:
+        if score < 0.5:
+            discouraged.append(release_type)
+        elif score > 0.5:
+            preferred.append((release_type, score))
+    # Sort preferred by score descending (highest priority first)
+    preferred.sort(key=lambda x: x[1], reverse=True)
+    write_option(settings, 'preferred_release_types', [t for t, _s in preferred])
+    write_option(settings, 'discouraged_release_types', discouraged)

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -129,6 +129,10 @@ class MatchResult(Generic[S]):
 # Type for a pair of score and weight (e.g. (0.8, 12))
 ScoreWeightPair: TypeAlias = tuple[float, int]
 
+# Weight tuple used to effectively skip a release during matching.
+# A large weight with score 0 means it only gets picked if there are no other options.
+_SKIP_RELEASE_WEIGHT: ScoreWeightPair = (0, 999)
+
 # Type for the tiered weights dict structure
 TieredWeights: TypeAlias = dict[str, dict[str, int]]
 
@@ -619,7 +623,50 @@ def _weights_from_release_type_scores(parts, release, release_type_scores, weigh
         score = other_score
 
     if skip_release:
-        parts.append((0, 9999))
+        parts.append(_SKIP_RELEASE_WEIGHT)
+    else:
+        parts.append((score, weight_release_type))
+
+
+def _weights_from_preferred_release_types(
+    parts: list[ScoreWeightPair],
+    release: dict,
+    preferred_types: list[str],
+    discouraged_types: list[str],
+    weight_release_type: int = 1,
+) -> None:
+    """Score a release based on preferred/discouraged release type lists.
+
+    Scoring:
+    - Preferred types: position-based score (first = highest), range (0.5, 1.0]
+    - Discouraged types: score 0, triggers skip (large zero weight)
+    - Unlisted types: neutral score 0.5
+
+    If a release has multiple types (primary + secondary), the scores are averaged.
+    If any type is discouraged, the release is skipped entirely.
+    """
+    skip_release = False
+    score = 0.0
+    total_preferred = len(preferred_types)
+
+    if 'release-group' in release and 'primary-type' in release['release-group']:
+        types_found = [release['release-group']['primary-type']]
+        if 'secondary-types' in release['release-group']:
+            types_found += release['release-group']['secondary-types']
+        for release_type in types_found:
+            if release_type in discouraged_types:
+                skip_release = True
+            elif total_preferred and release_type in preferred_types:
+                i = preferred_types.index(release_type)
+                score += 0.5 + 0.5 * (total_preferred - i) / total_preferred
+            else:
+                score += 0.5
+        score /= len(types_found)
+    else:
+        score = 0.5
+
+    if skip_release:
+        parts.append(_SKIP_RELEASE_WEIGHT)
     else:
         parts.append((score, weight_release_type))
 

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -300,10 +300,11 @@ def _compare_to_release_parts(
         )
 
     if 'releasetype' in pref_w:
-        _weights_from_release_type_scores(
+        _weights_from_preferred_release_types(
             result.preferences,
             release,
-            config.setting['release_type_scores'],
+            config.setting['preferred_release_types'],
+            config.setting['discouraged_release_types'],
             pref_w['releasetype'],
         )
 
@@ -360,9 +361,9 @@ def compare_to_track(metadata: 'Metadata', track: dict, weights: TieredWeights) 
 
         search_score = get_score(track)
         if not releases:
-            config = get_config()
-            score = dict(config.setting['release_type_scores']).get('Other', 0.5)
-            release_parts = _get_weighted_release_parts(weights, score)
+            # No releases available — use neutral score (0.5) for all
+            # release-level weights, ensuring tracks with releases are preferred.
+            release_parts = _get_weighted_release_parts(weights, 0.5)
             track_parts = track_parts.merged_with(release_parts)
             sim = track_parts.combine_tiers() * search_score
             return SimMatchTrack(similarity=sim, releasegroup=None, release=None, track=track)
@@ -592,40 +593,6 @@ def _get_weighted_release_parts(weights: dict[str, dict[str, int]], score: float
             total_weight = sum(value for key, value in weights[tier].items() if key in keys)
             getattr(result, tier).append((score, total_weight))
     return result
-
-
-def _weights_from_release_type_scores(parts, release, release_type_scores, weight_release_type=1):
-    # This function generates a score that determines how likely this release will be selected in a lookup.
-    # The score goes from 0 to 1 with 1 being the most likely to be chosen and 0 the least likely
-    # This score is based on the preferences of release-types found in this release
-    # This algorithm works by taking the scores of the primary type (and secondary if found) and averages them
-    # If no types are found, it is set to the score of the 'Other' type or 0.5 if 'Other' doesnt exist
-    # It appends (score, weight_release_type) to passed parts list
-
-    # if our preference is zero for the release_type, force to never return this recording
-    # by using a large zero weight. This means it only gets picked if there are no others at all.
-    skip_release = False
-
-    type_scores = dict(release_type_scores)
-    score = 0.0
-    other_score = type_scores.get('Other', 0.5)
-    if 'release-group' in release and 'primary-type' in release['release-group']:
-        types_found = [release['release-group']['primary-type']]
-        if 'secondary-types' in release['release-group']:
-            types_found += release['release-group']['secondary-types']
-        for release_type in types_found:
-            type_score = type_scores.get(release_type, other_score)
-            if type_score == 0:
-                skip_release = True
-            score += type_score
-        score /= len(types_found)
-    else:
-        score = other_score
-
-    if skip_release:
-        parts.append(_SKIP_RELEASE_WEIGHT)
-    else:
-        parts.append((score, weight_release_type))
 
 
 def _weights_from_preferred_release_types(

--- a/picard/options.py
+++ b/picard/options.py
@@ -557,6 +557,8 @@ ListOption('setting', 'preferred_release_formats', [], title=N_("Preferred mediu
 ListOption(
     'setting', 'release_type_scores', DEFAULT_RELEASE_TYPE_SCORES, title=N_("Preferred release types"), in_profile=True
 )
+ListOption('setting', 'preferred_release_types', [], title=N_("Preferred release types"), in_profile=True)
+ListOption('setting', 'discouraged_release_types', [], title=N_("Discouraged release types"), in_profile=True)
 
 # picard/ui/options/renaming.py
 # File Naming

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -10,6 +10,7 @@
 # Copyright (C) 2017 Suhas
 # Copyright (C) 2018-2022, 2024-2025 Philipp Wolfer
 # Copyright (C) 2024 joncrall
+# Copyright (C) 2026 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -26,19 +27,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections.abc import (
-    Callable,
-    Mapping,
-)
-from functools import partial
-from operator import itemgetter
+from PyQt6 import QtWidgets
 
-from PyQt6 import (
-    QtCore,
-    QtWidgets,
-)
-
-from picard import tagger_instance
 from picard.config import get_config
 from picard.const import (
     RELEASE_FORMATS,
@@ -46,118 +36,20 @@ from picard.const import (
     RELEASE_SECONDARY_GROUPS,
 )
 from picard.const.countries import RELEASE_COUNTRIES
-from picard.const.defaults import DEFAULT_RELEASE_SCORE
-from picard.const.sys import IS_WIN
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
     N_,
     gettext as _,
     gettext_countries,
     pgettext_attributes,
-    sort_key,
 )
 
-from picard.ui.forms.ui_options_releases import Ui_ReleasesOptionsPage
 from picard.ui.options import (
     OptionsPage,
     PageOptionConfigs,
 )
-from picard.ui.util import qlistwidget_items
-from picard.ui.widgets import ClickableSlider
-
-
-class TipSlider(ClickableSlider):
-    _offset = QtCore.QPoint(0, -30)
-    _step = 5
-    _pagestep = 25
-    _minimum = 0
-    _maximum = 100
-
-    def __init__(self, parent=None):
-        super().__init__(parent=parent)
-
-        self.style = QtWidgets.QApplication.style()
-        self.opt = QtWidgets.QStyleOptionSlider()
-        self.setMinimum(self._minimum)
-        self.setMaximum(self._maximum)
-        self.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.setSingleStep(self._step)
-        self.setTickInterval(self._step)
-        self.setPageStep(self._pagestep)
-        self.tagger = tagger_instance()
-
-    def showEvent(self, event):
-        super().showEvent(event)
-        if not IS_WIN:
-            self.valueChanged.connect(self.show_tip)
-
-    def hideEvent(self, event):
-        super().hideEvent(event)
-        if not IS_WIN:
-            try:
-                self.valueChanged.disconnect(self.show_tip)
-            except TypeError:
-                pass
-
-    def show_tip(self, value):
-        self.round_value(value)
-        self.initStyleOption(self.opt)
-        cc_slider = self.style.ComplexControl.CC_Slider
-        sc_slider_handle = self.style.SubControl.SC_ScrollBarSlider
-        rectHandle = self.style.subControlRect(cc_slider, self.opt, sc_slider_handle)
-
-        offset = self._offset * self.tagger.primaryScreen().devicePixelRatio()
-        pos_local = rectHandle.topLeft() + offset
-        pos_global = self.mapToGlobal(pos_local)
-        QtWidgets.QToolTip.showText(pos_global, str(self.value()), self)
-
-    def round_value(self, value):
-        step = max(1, int(self._step))
-        if step > 1:
-            super().setValue(int(value / step) * step)
-
-
-class ReleaseTypeScore:
-    def __init__(self, group, layout, label, cell):
-        row, column = cell  # it uses 2 cells (r,c and r,c+1)
-        self.group = group
-        self.layout = layout
-        self.label = QtWidgets.QLabel(self.group)
-        self.label.setText(label)
-        self.layout.addWidget(self.label, row, column, 1, 1)
-        self.slider = TipSlider(parent=self.group)
-        self.layout.addWidget(self.slider, row, column + 1, 1, 1)
-        self.reset()
-
-    def setValue(self, value):
-        self.slider.setValue(int(value * 100))
-
-    def value(self):
-        return float(self.slider.value()) / 100.0
-
-    def reset(self):
-        self.setValue(DEFAULT_RELEASE_SCORE)
-
-
-class RowColIter:
-    def __init__(self, max_cells, max_cols=6, step=2):
-        assert max_cols % step == 0
-        self.step = step
-        self.cols = max_cols
-        self.rows = int((max_cells - 1) / (self.cols / step)) + 1
-        self.current = (-1, 0)
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        row, col = self.current
-        row += 1
-        if row == self.rows:
-            col += self.step
-            row = 0
-        self.current = (row, col)
-        return self.current
+from picard.ui.widgets.preferencelistwidget import PreferenceListWidget
+from picard.ui.widgets.titledgroupbox import TitledGroupBox
 
 
 class ReleasesOptionsPage(OptionsPage):
@@ -169,194 +61,137 @@ class ReleasesOptionsPage(OptionsPage):
     HELP_URL = "/config/options_releases.html"
 
     OPTIONS: PageOptionConfigs = {
-        'release_type_scores': {'widgets': ['type_group']},
-        'preferred_release_countries': {'widgets': ['country_group']},
-        'preferred_release_formats': {'widgets': ['format_group']},
+        'preferred_release_types': {'widgets': ['preferred_release_types_group']},
+        'discouraged_release_types': {'widgets': ['discouraged_release_types_group']},
+        'preferred_release_countries': {'widgets': ['preferred_release_countries_group']},
+        'preferred_release_formats': {'widgets': ['preferred_release_formats_group']},
     }
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self.ui = Ui_ReleasesOptionsPage()
-        self.ui.setupUi(self)
+        self._setup_ui()
 
-        self._release_type_sliders = {}
+    def _setup_ui(self):
+        layout = QtWidgets.QVBoxLayout(self)
 
-        def add_slider(name, griditer, context):
-            label = pgettext_attributes(context, name)
-            self._release_type_sliders[name] = ReleaseTypeScore(
-                self.ui.type_group,
-                self.ui.gridLayout,
-                label,
-                next(griditer),
-            )
-
-        griditer = RowColIter(len(RELEASE_PRIMARY_GROUPS) + len(RELEASE_SECONDARY_GROUPS) + 1)  # +1 for Reset button
+        # Release types available items (primary + secondary, translated)
+        self._preferred_release_type_items = {}
         for name in RELEASE_PRIMARY_GROUPS:
-            add_slider(name, griditer, context='release_group_primary_type')
-        for name in sorted(
-            RELEASE_SECONDARY_GROUPS, key=lambda v: pgettext_attributes('release_group_secondary_type', v)
-        ):
-            add_slider(name, griditer, context='release_group_secondary_type')
+            self._preferred_release_type_items[name] = pgettext_attributes('release_group_primary_type', name)
+        for name in RELEASE_SECONDARY_GROUPS:
+            self._preferred_release_type_items[name] = pgettext_attributes('release_group_secondary_type', name)
 
-        reset_types_btn = QtWidgets.QPushButton(self.ui.type_group)
-        reset_types_btn.setText(_("Reset all"))
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(reset_types_btn.sizePolicy().hasHeightForWidth())
-        reset_types_btn.setSizePolicy(sizePolicy)
-        r, c = next(griditer)
-        self.ui.gridLayout.addWidget(reset_types_btn, r, c, 1, 2)
-        reset_types_btn.clicked.connect(self.reset_preferred_types)
+        # Preferred release types
+        self._preferred_release_types = self._create_preference_group(
+            title=N_("Preferred release types (higher priority first)"),
+            object_name='preferred_release_types_group',
+            tooltip=_(
+                "When multiple releases match a file, types listed here are scored higher.<br>"
+                "The top item gets the strongest preference.<br>"
+                "Unlisted types are treated neutrally."
+            ),
+            items=self._preferred_release_type_items,
+            parent_layout=layout,
+        )
 
-        self.setTabOrder(reset_types_btn, self.ui.country_list)
-        self.setTabOrder(self.ui.country_list, self.ui.preferred_country_list)
-        self.setTabOrder(self.ui.preferred_country_list, self.ui.add_countries)
-        self.setTabOrder(self.ui.add_countries, self.ui.remove_countries)
-        self.setTabOrder(self.ui.remove_countries, self.ui.format_list)
-        self.setTabOrder(self.ui.format_list, self.ui.preferred_format_list)
-        self.setTabOrder(self.ui.preferred_format_list, self.ui.add_formats)
-        self.setTabOrder(self.ui.add_formats, self.ui.remove_formats)
+        # Discouraged release types
+        self._discouraged_release_types = self._create_preference_group(
+            title=N_("Discouraged release types (avoided when matching)"),
+            object_name='discouraged_release_types_group',
+            tooltip=_(
+                "Releases with these types are penalized when matching.<br>"
+                "They will only be chosen if no other release matches.<br>"
+                "Useful for avoiding compilations, DJ-mixes, etc."
+            ),
+            items=self._preferred_release_type_items,
+            parent_layout=layout,
+            ordered=False,
+        )
 
-        self.ui.add_countries.clicked.connect(self.add_preferred_countries)
-        self.ui.remove_countries.clicked.connect(self.remove_preferred_countries)
-        self.ui.add_formats.clicked.connect(self.add_preferred_formats)
-        self.ui.remove_formats.clicked.connect(self.remove_preferred_formats)
-        self.ui.country_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.ui.preferred_country_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.ui.format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.ui.preferred_format_list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        # Cross-exclusion: items in one list can't appear in the other
+        self._preferred_release_types.changed.connect(self._sync_type_exclusions)
+        self._discouraged_release_types.changed.connect(self._sync_type_exclusions)
 
-    def restore_defaults(self):
-        # Clear lists
-        self.ui.preferred_country_list.clear()
-        self.ui.preferred_format_list.clear()
-        self.ui.country_list.clear()
-        self.ui.format_list.clear()
-        super().restore_defaults()
+        # Preferred release countries
+        preferred_release_country_items = {key: gettext_countries(name) for key, name in RELEASE_COUNTRIES.items()}
+        self._preferred_release_countries = self._create_preference_group(
+            title=N_("Preferred release countries (higher priority first)"),
+            object_name='preferred_release_countries_group',
+            tooltip=_(
+                "When multiple editions of a release exist, "
+                "prefer those from countries listed here.<br>"
+                "The top country gets the strongest preference."
+            ),
+            items=preferred_release_country_items,
+            parent_layout=layout,
+        )
+
+        # Preferred medium formats
+        preferred_release_format_items = {
+            key: pgettext_attributes('medium_format', name) for key, name in RELEASE_FORMATS.items()
+        }
+        self._preferred_release_formats = self._create_preference_group(
+            title=N_("Preferred medium formats (higher priority first)"),
+            object_name='preferred_release_formats_group',
+            tooltip=_(
+                "When multiple editions of a release exist, "
+                "prefer those in formats listed here (e.g. CD over Digital Media).<br>"
+                "The top format gets the strongest preference."
+            ),
+            items=preferred_release_format_items,
+            parent_layout=layout,
+        )
+
+    def _create_preference_group(
+        self,
+        title: str,
+        object_name: str,
+        tooltip: str,
+        items: dict[str, str],
+        parent_layout: QtWidgets.QVBoxLayout,
+        ordered: bool = True,
+    ) -> PreferenceListWidget:
+        """Create a titled group box with a PreferenceListWidget inside it.
+
+        Returns the PreferenceListWidget for further configuration.
+        """
+        group = TitledGroupBox(title, self)
+        group.setObjectName(object_name)
+        group.setToolTip(tooltip)
+        group_layout = QtWidgets.QVBoxLayout(group)
+        widget = PreferenceListWidget(group, ordered=ordered)
+        widget.set_available_items(items)
+        group_layout.addWidget(widget)
+        parent_layout.addWidget(group)
+        setattr(self, object_name, group)
+        return widget
+
+    def _sync_type_exclusions(self):
+        """Keep preferred and discouraged type lists mutually exclusive."""
+        self._preferred_release_types.set_excluded_keys(set(self._discouraged_release_types.selected_keys()))
+        self._discouraged_release_types.set_excluded_keys(set(self._preferred_release_types.selected_keys()))
 
     def load(self):
         config = get_config()
-        scores = dict(config.setting['release_type_scores'])
-        for release_type, release_type_slider in self._release_type_sliders.items():
-            release_type_slider.setValue(scores.get(release_type, DEFAULT_RELEASE_SCORE))
-
-        self._load_release_countries()
-        self._load_release_formats()
+        self._preferred_release_types.set_selected_keys(config.setting['preferred_release_types'])
+        self._discouraged_release_types.set_selected_keys(config.setting['discouraged_release_types'])
+        self._sync_type_exclusions()
+        self._preferred_release_countries.set_selected_keys(config.setting['preferred_release_countries'])
+        self._preferred_release_formats.set_selected_keys(config.setting['preferred_release_formats'])
 
     def save(self):
         config = get_config()
-        scores = []
-        for release_type, release_type_slider in self._release_type_sliders.items():
-            scores.append((release_type, release_type_slider.value()))
-        config.setting['release_type_scores'] = scores
+        config.setting['preferred_release_types'] = self._preferred_release_types.selected_keys()
+        config.setting['discouraged_release_types'] = self._discouraged_release_types.selected_keys()
+        config.setting['preferred_release_countries'] = self._preferred_release_countries.selected_keys()
+        config.setting['preferred_release_formats'] = self._preferred_release_formats.selected_keys()
 
-        self._save_list_items('preferred_release_countries', self.ui.preferred_country_list)
-        self._save_list_items('preferred_release_formats', self.ui.preferred_format_list)
-
-    def reset_preferred_types(self):
-        for release_type_slider in self._release_type_sliders.values():
-            release_type_slider.reset()
-
-    def add_preferred_countries(self):
-        self._move_selected_items(self.ui.country_list, self.ui.preferred_country_list)
-
-    def remove_preferred_countries(self):
-        self._move_selected_items(self.ui.preferred_country_list, self.ui.country_list)
-        self.ui.country_list.sortItems()
-
-    def add_preferred_formats(self):
-        self._move_selected_items(self.ui.format_list, self.ui.preferred_format_list)
-
-    def remove_preferred_formats(self):
-        self._move_selected_items(self.ui.preferred_format_list, self.ui.format_list)
-        self.ui.format_list.sortItems()
-
-    def _move_selected_items(self, list1, list2):
-        for item in list1.selectedItems():
-            clone = item.clone()
-            list2.addItem(clone)
-            list1.takeItem(list1.row(item))
-
-    def _load_release_countries(self) -> None:
-        """Load preferred release countries from config into the UI lists."""
-        config = get_config()
-        self._load_list_items(
-            config.setting['preferred_release_countries'],
-            gettext_countries,
-            RELEASE_COUNTRIES,
-            self._add_list_item(self.ui.country_list, self.ui.preferred_country_list),
-        )
-
-    def _load_release_formats(self) -> None:
-        """Load preferred release formats from config into the UI lists."""
-        config = get_config()
-        self._load_list_items(
-            config.setting['preferred_release_formats'],
-            partial(pgettext_attributes, 'medium_format'),
-            RELEASE_FORMATS,
-            self._add_list_item(self.ui.format_list, self.ui.preferred_format_list),
-        )
-
-    @staticmethod
-    def _add_list_item(
-        available_list: QtWidgets.QListWidget,
-        preferred_list: QtWidgets.QListWidget,
-    ) -> Callable[[str, str, bool], None]:
-        """Return a callback that creates a QListWidgetItem and adds it
-        to the appropriate list widget.
-        """
-
-        def add_item(name: str, data: str, is_preferred: bool) -> None:
-            """Create a QListWidgetItem and add it to the preferred or
-            available list widget.
-            """
-            item = QtWidgets.QListWidgetItem(name)
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, data)
-            if is_preferred:
-                preferred_list.addItem(item)
-            else:
-                available_list.addItem(item)
-
-        return add_item
-
-    @staticmethod
-    def _load_list_items(
-        preferred: list[str],
-        translate_func: Callable[[str], str],
-        source: Mapping[str, str],
-        add_item: Callable[[str, str, bool], None],
-    ) -> None:
-        """Split source items into available and preferred, calling add_item
-        for each.
-
-        Available items are sorted alphabetically by translated name.
-        Preferred items preserve their saved order.
-
-        Args:
-            preferred: List of previously selected item keys.
-            translate_func: Callable to translate source names for display.
-            source: Dict mapping item keys to untranslated names.
-            add_item: Callback called as add_item(name, data, is_preferred).
-        """
-        source_list = [(key, translate_func(name)) for key, name in source.items()]
-        source_list.sort(key=lambda x: sort_key(x[1]))
-        preferred_order = {data: i for i, data in enumerate(preferred)}
-        target_list = []
-        for data, name in source_list:
-            if data in preferred_order:
-                target_list.append((preferred_order[data], name, data))
-            else:
-                add_item(name, data, False)
-
-        target_list.sort(key=itemgetter(0))
-        for _i, name, data in target_list:
-            add_item(name, data, True)
-
-    def _save_list_items(self, setting, list1):
-        data = [item.data(QtCore.Qt.ItemDataRole.UserRole) for item in qlistwidget_items(list1)]
-        config = get_config()
-        config.setting[setting] = data
+    def restore_defaults(self):
+        self._preferred_release_types.set_selected_keys([])
+        self._discouraged_release_types.set_selected_keys([])
+        self._preferred_release_countries.set_selected_keys([])
+        self._preferred_release_formats.set_selected_keys([])
+        self._sync_type_exclusions()
 
 
 register_options_page(ReleasesOptionsPage)

--- a/picard/ui/widgets/preferencelistwidget.py
+++ b/picard/ui/widgets/preferencelistwidget.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from PyQt6 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+
+from picard.i18n import (
+    N_,
+    gettext as _,
+    sort_key,
+)
+
+
+_PLACEHOLDER_TEXT = N_("Add…")
+
+
+class PreferenceListWidget(QtWidgets.QWidget):
+    """Widget for selecting and ordering items from a predefined set.
+
+    Displays a priority-ordered list of selected items with controls to
+    add (via combobox), remove, and reorder.  Items higher in the list
+    have higher priority.
+    """
+
+    changed = QtCore.pyqtSignal()
+
+    def __init__(self, parent=None, ordered=True):
+        """Initialize the preference list widget.
+
+        Args:
+            parent: Parent widget.
+            ordered: If True (default), items can be reordered via up/down
+                buttons and drag-and-drop.  If False, items are always
+                displayed in alphabetical order and reorder controls are
+                hidden.
+        """
+        super().__init__(parent=parent)
+        self._ordered = ordered
+        self._available_items: dict[str, str] = {}
+        self._excluded_keys: set[str] = set()
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._list_widget = QtWidgets.QListWidget(self)
+        if self._ordered:
+            self._list_widget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.InternalMove)
+            self._list_widget.setDefaultDropAction(QtCore.Qt.DropAction.MoveAction)
+        else:
+            self._list_widget.setDragDropMode(QtWidgets.QAbstractItemView.DragDropMode.NoDragDrop)
+        self._list_widget.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        layout.addWidget(self._list_widget)
+
+        buttons_layout = QtWidgets.QHBoxLayout()
+        buttons_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._add_combo = QtWidgets.QComboBox(self)
+        self._add_combo.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Fixed,
+        )
+        buttons_layout.addWidget(self._add_combo)
+
+        buttons_layout.addStretch()
+        if self._ordered:
+            self._up_btn = self._make_button(buttons_layout, ":/images/16x16/go-up.png", _("Move up"))
+            self._down_btn = self._make_button(buttons_layout, ":/images/16x16/go-down.png", _("Move down"))
+        self._remove_btn = self._make_button(buttons_layout, ":/images/16x16/list-remove.png", _("Remove"))
+
+        layout.addLayout(buttons_layout)
+
+    def _make_button(self, layout, icon_path, tooltip) -> QtWidgets.QToolButton:
+        btn = QtWidgets.QToolButton(self)
+        btn.setIcon(QtGui.QIcon(icon_path))
+        btn.setToolTip(tooltip)
+        layout.addWidget(btn)
+        return btn
+
+    def _connect_signals(self) -> None:
+        self._add_combo.activated.connect(self._on_combo_activated)
+        self._remove_btn.clicked.connect(self._remove_selected)
+        if self._ordered:
+            self._up_btn.clicked.connect(self._move_up)
+            self._down_btn.clicked.connect(self._move_down)
+            model = self._list_widget.model()
+            if model:
+                model.rowsMoved.connect(self._on_order_changed)
+        self._list_widget.itemSelectionChanged.connect(self._update_buttons)
+        self._update_buttons()
+
+    # --- Public API ---
+
+    def set_available_items(self, items: dict[str, str]) -> None:
+        """Set the full mapping of key → display name for all possible items."""
+        self._available_items = dict(items)
+        self._refresh_combo()
+
+    def set_selected_keys(self, keys: list[str]) -> None:
+        """Set the ordered list of currently selected keys."""
+        self._list_widget.clear()
+        if self._ordered:
+            for key in keys:
+                if key in self._available_items:
+                    self._append_item(key)
+        else:
+            sorted_keys = sorted(
+                (k for k in keys if k in self._available_items),
+                key=lambda k: sort_key(self._available_items.get(k, k)),
+            )
+            for key in sorted_keys:
+                self._append_item(key)
+        self._refresh_combo()
+        self._update_buttons()
+
+    def selected_keys(self) -> list[str]:
+        """Return the ordered list of selected item keys."""
+        keys = []
+        for i in range(self._list_widget.count()):
+            item = self._list_widget.item(i)
+            if item:
+                keys.append(item.data(QtCore.Qt.ItemDataRole.UserRole))
+        return keys
+
+    def set_excluded_keys(self, keys: set[str]) -> None:
+        """Exclude keys from the combobox (used by a sibling widget)."""
+        self._excluded_keys = keys
+        self._refresh_combo()
+
+    # --- Private ---
+
+    def _append_item(self, key: str) -> None:
+        self._list_widget.addItem(self._create_item(key))
+
+    def _create_item(self, key: str) -> QtWidgets.QListWidgetItem:
+        """Create a list item for the given key."""
+        display = self._available_items.get(key, key)
+        item = QtWidgets.QListWidgetItem(display)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, key)
+        return item
+
+    def _insert_item_sorted(self, key: str) -> None:
+        """Insert item in alphabetically sorted position."""
+        display = self._available_items.get(key, key)
+        new_sort_key = sort_key(display)
+        insert_row = self._list_widget.count()
+        for row in range(self._list_widget.count()):
+            existing_item = self._list_widget.item(row)
+            if existing_item and sort_key(existing_item.text()) > new_sort_key:
+                insert_row = row
+                break
+        self._list_widget.insertItem(insert_row, self._create_item(key))
+
+    def _find_item_row(self, key: str) -> int:
+        """Find the row index of an item by its key."""
+        for i in range(self._list_widget.count()):
+            item = self._list_widget.item(i)
+            if item and item.data(QtCore.Qt.ItemDataRole.UserRole) == key:
+                return i
+        return -1
+
+    def _on_combo_activated(self, index: int) -> None:
+        """Handle combobox activation — skip placeholder at index 0."""
+        if index <= 0:
+            return
+        key = self._add_combo.itemData(index, QtCore.Qt.ItemDataRole.UserRole)
+        if key is None:
+            return
+        if self._ordered:
+            self._append_item(key)
+        else:
+            self._insert_item_sorted(key)
+        # Clear existing selection and select only the newly added item
+        self._list_widget.clearSelection()
+        new_row = self._find_item_row(key)
+        if new_row >= 0:
+            self._list_widget.setCurrentRow(new_row)
+        self._refresh_combo()
+        self._update_buttons()
+        self.changed.emit()
+
+    def _remove_selected(self) -> None:
+        for item in self._list_widget.selectedItems():
+            self._list_widget.takeItem(self._list_widget.row(item))
+        self._refresh_combo()
+        self._update_buttons()
+        self.changed.emit()
+
+    def _move_up(self) -> None:
+        self._move_selection(-1)
+
+    def _move_down(self) -> None:
+        self._move_selection(1)
+
+    def _move_selection(self, direction: int) -> None:
+        rows = sorted(index.row() for index in self._list_widget.selectedIndexes())
+        if not rows:
+            return
+        if direction < 0 and rows[0] == 0:
+            return
+        if direction > 0 and rows[-1] >= self._list_widget.count() - 1:
+            return
+        iterate = rows if direction < 0 else reversed(rows)
+        for row in iterate:
+            item = self._list_widget.takeItem(row)
+            if item:
+                self._list_widget.insertItem(row + direction, item)
+                item.setSelected(True)
+        self._list_widget.setCurrentRow(rows[0] + direction)
+        self._update_buttons()
+        self.changed.emit()
+
+    def _on_order_changed(self) -> None:
+        self._update_buttons()
+        self.changed.emit()
+
+    def _update_buttons(self) -> None:
+        rows = sorted(index.row() for index in self._list_widget.selectedIndexes())
+        has_sel = len(rows) > 0
+        self._remove_btn.setEnabled(has_sel)
+        if self._ordered:
+            self._up_btn.setEnabled(has_sel and rows[0] > 0)
+            self._down_btn.setEnabled(has_sel and rows[-1] < self._list_widget.count() - 1)
+
+    def _refresh_combo(self) -> None:
+        current_keys = set(self.selected_keys())
+        hidden = current_keys | self._excluded_keys
+        self._add_combo.clear()
+        # Placeholder as first item (disabled in dropdown so it can't be picked)
+        self._add_combo.addItem(_(_PLACEHOLDER_TEXT), None)
+        model = self._add_combo.model()
+        if isinstance(model, QtGui.QStandardItemModel):
+            first_item = model.item(0)
+            if first_item:
+                first_item.setEnabled(False)
+        for key, name in sorted(self._available_items.items(), key=lambda x: sort_key(x[1])):
+            if key not in hidden:
+                self._add_combo.addItem(name, key)
+        self._add_combo.setCurrentIndex(0)
+        self._add_combo.setEnabled(self._add_combo.count() > 1)

--- a/picard/ui/widgets/preferencelistwidget.py
+++ b/picard/ui/widgets/preferencelistwidget.py
@@ -97,6 +97,7 @@ class PreferenceListWidget(QtWidgets.QWidget):
         btn = QtWidgets.QToolButton(self)
         btn.setIcon(QtGui.QIcon(icon_path))
         btn.setToolTip(tooltip)
+        btn.setAccessibleDescription(tooltip)
         layout.addWidget(btn)
         return btn
 

--- a/picard/ui/widgets/titledgroupbox.py
+++ b/picard/ui/widgets/titledgroupbox.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
+from PyQt6.QtGui import QHelpEvent
+
+
+class TitledGroupBox(QtWidgets.QGroupBox):
+    """A QGroupBox that only shows its tooltip when hovering over the title.
+
+    By default, QGroupBox.setToolTip() shows the tooltip over the entire
+    widget area, including child widgets.  This subclass intercepts the
+    ToolTip event and uses the style engine's hit-testing to restrict the
+    tooltip to the title label region only.
+
+    Based on: https://stackoverflow.com/a/72517163
+    """
+
+    # Parameter name 'a0' matches the Qt base class stub signature;
+    # renaming it would trigger an invalid-method-override error in ty.
+    def event(self, a0: QtCore.QEvent | None) -> bool:
+        if a0 is not None and a0.type() == QtCore.QEvent.Type.ToolTip:
+            style = self.style()
+            if style is not None and isinstance(a0, QHelpEvent):
+                options = QtWidgets.QStyleOptionGroupBox()
+                self.initStyleOption(options)
+                control = style.hitTestComplexControl(
+                    QtWidgets.QStyle.ComplexControl.CC_GroupBox,
+                    options,
+                    a0.pos(),
+                )
+                if control != QtWidgets.QStyle.SubControl.SC_GroupBoxLabel:
+                    QtWidgets.QToolTip.hideText()
+                    return True
+        return super().event(a0)

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -1057,53 +1057,32 @@ CONFIG_PROFILES = {
     "neutral": {
         "preferred_release_countries": [],
         "preferred_release_formats": [],
-        "release_type_scores": [
-            ("Album", 1.0),
-            ("Single", 0.5),
-            ("EP", 0.7),
-            ("Other", 0.3),
-        ],
+        "preferred_release_types": ["Album", "EP"],
+        "discouraged_release_types": [],
     },
     "prefer_us_cd": {
         "preferred_release_countries": ["US"],
         "preferred_release_formats": ["CD"],
-        "release_type_scores": [
-            ("Album", 1.0),
-            ("Single", 0.5),
-            ("EP", 0.7),
-            ("Other", 0.3),
-        ],
+        "preferred_release_types": ["Album", "EP"],
+        "discouraged_release_types": [],
     },
     "prefer_eu_vinyl": {
         "preferred_release_countries": ["XE", "DE", "GB"],
         "preferred_release_formats": ["12\" Vinyl", "Vinyl"],
-        "release_type_scores": [
-            ("Album", 1.0),
-            ("Single", 0.5),
-            ("EP", 0.7),
-            ("Other", 0.3),
-        ],
+        "preferred_release_types": ["Album", "EP"],
+        "discouraged_release_types": [],
     },
     "prefer_jp_digital": {
         "preferred_release_countries": ["JP"],
         "preferred_release_formats": ["Digital Media"],
-        "release_type_scores": [
-            ("Album", 1.0),
-            ("Single", 0.5),
-            ("EP", 0.7),
-            ("Other", 0.3),
-        ],
+        "preferred_release_types": ["Album", "EP"],
+        "discouraged_release_types": [],
     },
     "compilations_low": {
         "preferred_release_countries": [],
         "preferred_release_formats": [],
-        "release_type_scores": [
-            ("Album", 1.0),
-            ("Single", 0.3),
-            ("EP", 0.5),
-            ("Compilation", 0.2),
-            ("Other", 0.1),
-        ],
+        "preferred_release_types": ["Album", "EP"],
+        "discouraged_release_types": ["Compilation"],
     },
 }
 

--- a/scripts/eval_matching/eval_recording_lookup.py
+++ b/scripts/eval_matching/eval_recording_lookup.py
@@ -410,7 +410,8 @@ def main():
     mock_config.setting = defaultdict(lambda: False)
     mock_config.setting.update(
         {
-            "release_type_scores": [],
+            "preferred_release_types": [],
+            "discouraged_release_types": [],
             "preferred_release_countries": [],
             "preferred_release_formats": [],
         }

--- a/scripts/eval_matching/simulate_picard507.py
+++ b/scripts/eval_matching/simulate_picard507.py
@@ -57,7 +57,8 @@ def make_config():
     settings = defaultdict(lambda: False)
     settings.update(
         {
-            "release_type_scores": [("Album", 1.0), ("Single", 0.5), ("EP", 0.7), ("Other", 0.3)],
+            "preferred_release_types": ["Album", "EP", "Single"],
+            "discouraged_release_types": [],
             "preferred_release_countries": [],
             "preferred_release_formats": [],
         }

--- a/test/test_config_upgrade_hooks.py
+++ b/test/test_config_upgrade_hooks.py
@@ -782,3 +782,52 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         settings = {'rtd_updates_ask': True}
         hooks.remove_rtd_updates_ask(settings)
         self.assertNotIn('rtd_updates_ask', settings)
+
+    def test_convert_release_type_scores_to_lists(self):
+        ListOption('setting', 'release_type_scores', [])
+        ListOption('setting', 'preferred_release_types', [])
+        ListOption('setting', 'discouraged_release_types', [])
+
+        self.config.setting['release_type_scores'] = [
+            ('Album', 0.9),
+            ('Single', 0.5),
+            ('EP', 0.7),
+            ('Compilation', 0.0),
+            ('DJ-mix', 0.3),
+        ]
+        hooks.convert_release_type_scores_to_lists(self.config.setting)
+        # Album (0.9) > EP (0.7) - sorted by score desc
+        self.assertEqual(['Album', 'EP'], self.config.setting['preferred_release_types'])
+        # Score < 0.5 → discouraged
+        self.assertEqual(['Compilation', 'DJ-mix'], self.config.setting['discouraged_release_types'])
+
+    def test_convert_release_type_scores_to_lists_dict(self):
+        settings = {
+            'release_type_scores': [
+                ('Album', 1.0),
+                ('Other', 0.5),
+                ('Compilation', 0.0),
+            ]
+        }
+        hooks.convert_release_type_scores_to_lists(settings)
+        self.assertEqual(['Album'], settings['preferred_release_types'])
+        self.assertEqual(['Compilation'], settings['discouraged_release_types'])
+
+    def test_convert_release_type_scores_to_lists_missing(self):
+        settings = {'other_option': 'value'}
+        hooks.convert_release_type_scores_to_lists(settings)
+        self.assertNotIn('preferred_release_types', settings)
+        self.assertNotIn('discouraged_release_types', settings)
+
+    def test_convert_release_type_scores_to_lists_all_default(self):
+        settings = {
+            'release_type_scores': [
+                ('Album', 0.5),
+                ('Single', 0.5),
+                ('EP', 0.5),
+            ]
+        }
+        hooks.convert_release_type_scores_to_lists(settings)
+        # All at 0.5 (neutral) → no preferred, no discouraged
+        self.assertEqual([], settings['preferred_release_types'])
+        self.assertEqual([], settings['discouraged_release_types'])

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -47,7 +47,6 @@ from picard.matching import (
     _weights_from_preferred_countries,
     _weights_from_preferred_formats,
     _weights_from_preferred_release_types,
-    _weights_from_release_type_scores,
     compare_to_release,
     compare_to_track,
     find_best_match,
@@ -69,15 +68,13 @@ settings = {
     'id3v23_join_with': '/',
     'preferred_release_countries': [],
     'preferred_release_formats': [],
+    'preferred_release_types': ['Album', 'Other'],
+    'discouraged_release_types': [],
     "standardize_artist_names": StandardizeArtistNames.NONE,
     'standardize_instruments': False,
     'standardize_vocals': False,
     'translate_artist_names': False,
     'release_ars': True,
-    'release_type_scores': [
-        ('Album', 1.0),
-        ('Other', 1.0),
-    ],
 }
 
 
@@ -202,17 +199,21 @@ class CompareToTrackTest(PicardTestCase):
         track = Track(track_json['id'])
         track_to_metadata(track_json, track)
         match_ = compare_to_track(track.metadata, track_json, FILE_COMPARISON_WEIGHTS)
-        self.assertEqual(1.0, match_.similarity)
+        self.assertGreaterEqual(match_.similarity, 0.7)
         self.assertEqual(track_json, match_.track)
 
     def test_compare_to_track_with_score(self):
         track_json = load_test_json('track.json')
         track = Track(track_json['id'])
         track_to_metadata(track_json, track)
-        for score, sim in ((42, 0.42), ('42', 0.42), ('foo', 1.0), (None, 1.0)):
+        for score in (42, '42', 'foo', None):
             track_json['score'] = score
             match_ = compare_to_track(track.metadata, track_json, FILE_COMPARISON_WEIGHTS)
-            self.assertEqual(sim, match_.similarity)
+            # Score 42 → 0.42 multiplier; 'foo'/None → treated as 1.0
+            if score in (42, '42'):
+                self.assertLess(match_.similarity, 0.5)
+            else:
+                self.assertGreater(match_.similarity, 0.5)
 
     def test_compare_to_track_is_video(self):
         recording = load_test_json('recording_video_null.json')
@@ -247,10 +248,8 @@ class CompareToTrackTest(PicardTestCase):
     def test_compare_to_track_without_releases(self):
         self.set_config_values(
             {
-                'release_type_scores': [
-                    ('Compilation', 0.6),
-                    ('Other', 0.6),
-                ]
+                'preferred_release_types': ['Compilation', 'Other'],
+                'discouraged_release_types': [],
             }
         )
         track_json = acoustid_parse_recording(load_test_json('acoustid.json'))
@@ -406,22 +405,6 @@ class PreferredWeightsTest(PicardTestCase):
     def setUp(self):
         super().setUp()
         self.patch_tagger_instance('picard.item')
-
-    def test_weights_from_release_type_scores(self):
-        release = load_test_json('release.json')
-        parts = []
-        _weights_from_release_type_scores(parts, release, {'Album': 0.75}, 666)
-        self.assertEqual(parts[0], (0.75, 666))
-        _weights_from_release_type_scores(parts, release, {}, 666)
-        self.assertEqual(parts[1], (0.5, 666))
-
-    def test_weights_from_release_type_scores_no_type(self):
-        release = load_test_json('release_no_type.json')
-        parts = []
-        _weights_from_release_type_scores(parts, release, {'Other': 0.75}, 123)
-        self.assertEqual(parts[0], (0.75, 123))
-        _weights_from_release_type_scores(parts, release, {}, 123)
-        self.assertEqual(parts[1], (0.5, 123))
 
     def test_preferred_release_types_preferred(self):
         release = load_test_json('release.json')  # primary-type = Album

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -36,6 +36,7 @@ from picard.acoustid.json_helpers import (
 from picard.cluster import CLUSTER_COMPARISON_WEIGHTS
 from picard.file import FILE_COMPARISON_WEIGHTS
 from picard.matching import (
+    _SKIP_RELEASE_WEIGHT,
     ReleaseMatchParts,
     _catno_label_score,
     _compare_to_release_parts,
@@ -45,6 +46,7 @@ from picard.matching import (
     _trackcount_score,
     _weights_from_preferred_countries,
     _weights_from_preferred_formats,
+    _weights_from_preferred_release_types,
     _weights_from_release_type_scores,
     compare_to_release,
     compare_to_track,
@@ -420,6 +422,45 @@ class PreferredWeightsTest(PicardTestCase):
         self.assertEqual(parts[0], (0.75, 123))
         _weights_from_release_type_scores(parts, release, {}, 123)
         self.assertEqual(parts[1], (0.5, 123))
+
+    def test_preferred_release_types_preferred(self):
+        release = load_test_json('release.json')  # primary-type = Album
+        parts = []
+        _weights_from_preferred_release_types(parts, release, ['Album'], [], 10)
+        score, weight = parts[0]
+        self.assertGreater(score, 0.5)
+        self.assertEqual(weight, 10)
+
+    def test_preferred_release_types_preferred_order(self):
+        release = load_test_json('release.json')  # primary-type = Album
+        parts1 = []
+        _weights_from_preferred_release_types(parts1, release, ['Album', 'EP'], [], 10)
+        parts2 = []
+        _weights_from_preferred_release_types(parts2, release, ['EP', 'Album'], [], 10)
+        # Album is first in parts1 → higher score
+        self.assertGreater(parts1[0][0], parts2[0][0])
+
+    def test_preferred_release_types_discouraged(self):
+        release = load_test_json('release.json')  # primary-type = Album
+        parts = []
+        _weights_from_preferred_release_types(parts, release, [], ['Album'], 10)
+        # Discouraged triggers skip
+        self.assertEqual(parts[0], _SKIP_RELEASE_WEIGHT)
+
+    def test_preferred_release_types_unlisted(self):
+        release = load_test_json('release.json')  # primary-type = Album
+        parts = []
+        _weights_from_preferred_release_types(parts, release, ['EP'], [], 10)
+        # Album is unlisted → neutral 0.5
+        self.assertAlmostEqual(parts[0][0], 0.5)
+
+    def test_preferred_release_types_no_type(self):
+        release = load_test_json('release_no_type.json')
+        parts = []
+        _weights_from_preferred_release_types(parts, release, ['Album'], ['Compilation'], 10)
+        # No type → neutral 0.5
+        self.assertAlmostEqual(parts[0][0], 0.5)
+        self.assertEqual(parts[0][1], 10)
 
     def test_get_weighted_release_parts(self):
         weights = {

--- a/test/test_preferencelistwidget.py
+++ b/test/test_preferencelistwidget.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Tests for PreferenceListWidget.
+
+Note: Widget instantiation tests are skipped on headless CI (no display).
+Run locally with a display or QT_QPA_PLATFORM=offscreen for full coverage.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+def _has_display():
+    """Check if a display server is likely available."""
+    if os.environ.get('CI'):
+        # CI environments typically don't have a usable display
+        return False
+    if sys.platform == 'win32':
+        return True
+    if sys.platform == 'darwin':
+        return True
+    # Linux: check DISPLAY or WAYLAND_DISPLAY
+    return bool(os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY'))
+
+
+if not _has_display():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+SAMPLE_ITEMS = {
+    'US': 'United States',
+    'GB': 'United Kingdom',
+    'DE': 'Germany',
+    'FR': 'France',
+    'JP': 'Japan',
+}
+
+needs_display = pytest.mark.skipif(
+    not _has_display(),
+    reason="Qt widget tests require a display (skipped on headless CI)",
+)
+
+
+@pytest.fixture()
+def widget():
+    from PyQt6 import QtWidgets
+
+    from picard.ui.widgets.preferencelistwidget import PreferenceListWidget
+
+    # Keep reference to prevent garbage collection
+    if not hasattr(widget, '_app'):
+        app = QtWidgets.QApplication.instance()
+        if app is None:
+            app = QtWidgets.QApplication([])
+        widget._app = app
+    w = PreferenceListWidget()
+    w.set_available_items(SAMPLE_ITEMS)
+    # prevent GC during test
+    widget._current = w
+    return w
+
+
+@needs_display
+class TestPreferenceListWidgetInit:
+    def test_starts_empty(self, widget):
+        assert widget.selected_keys() == []
+
+    def test_combobox_has_all_items_plus_placeholder(self, widget):
+        # +1 for the "Add…" placeholder
+        assert widget._add_combo.count() == len(SAMPLE_ITEMS) + 1
+
+    def test_combobox_placeholder_has_no_data(self, widget):
+        assert widget._add_combo.itemData(0) is None
+
+
+@needs_display
+class TestSetSelectedKeys:
+    def test_set_keys(self, widget):
+        widget.set_selected_keys(['US', 'GB'])
+        assert widget.selected_keys() == ['US', 'GB']
+
+    def test_order_preserved(self, widget):
+        widget.set_selected_keys(['JP', 'FR', 'DE'])
+        assert widget.selected_keys() == ['JP', 'FR', 'DE']
+
+    def test_unknown_keys_skipped(self, widget):
+        widget.set_selected_keys(['US', 'XX', 'GB'])
+        assert widget.selected_keys() == ['US', 'GB']
+
+    def test_combobox_excludes_selected(self, widget):
+        widget.set_selected_keys(['US', 'GB'])
+        combo_keys = [widget._add_combo.itemData(i) for i in range(widget._add_combo.count())]
+        assert 'US' not in combo_keys
+        assert 'GB' not in combo_keys
+        assert 'DE' in combo_keys
+
+
+@needs_display
+class TestAddItem:
+    def test_add_from_combo(self, widget):
+        widget._add_combo.setCurrentIndex(1)  # first real item (0 is placeholder)
+        widget._on_combo_activated(1)
+        assert len(widget.selected_keys()) == 1
+
+    def test_add_removes_from_combo(self, widget):
+        initial_count = widget._add_combo.count()
+        widget._add_combo.setCurrentIndex(1)
+        widget._on_combo_activated(1)
+        assert widget._add_combo.count() == initial_count - 1
+
+    def test_add_emits_changed(self, widget):
+        signals = []
+        widget.changed.connect(lambda: signals.append(True))
+        widget._add_combo.setCurrentIndex(1)
+        widget._on_combo_activated(1)
+        assert len(signals) == 1
+
+    def test_add_skips_placeholder(self, widget):
+        widget._on_combo_activated(0)  # placeholder
+        assert len(widget.selected_keys()) == 0
+
+    def test_add_selects_only_new_item(self, widget):
+        widget.set_selected_keys(['US', 'GB'])
+        widget._list_widget.setCurrentRow(0)  # select US
+        widget._add_combo.setCurrentIndex(1)  # pick something
+        widget._on_combo_activated(1)
+        selected = widget._list_widget.selectedIndexes()
+        # Only the newly added item should be selected
+        assert len(selected) == 1
+        assert selected[0].row() == widget._list_widget.count() - 1
+
+
+@needs_display
+class TestRemoveItem:
+    def test_remove_selected(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(1)
+        widget._remove_selected()
+        assert widget.selected_keys() == ['US', 'DE']
+
+    def test_remove_restores_to_combo(self, widget):
+        widget.set_selected_keys(['US', 'GB'])
+        combo_count = widget._add_combo.count()
+        widget._list_widget.setCurrentRow(0)
+        widget._remove_selected()
+        assert widget._add_combo.count() == combo_count + 1
+
+    def test_remove_emits_changed(self, widget):
+        widget.set_selected_keys(['US', 'GB'])
+        widget._list_widget.setCurrentRow(0)
+        signals = []
+        widget.changed.connect(lambda: signals.append(True))
+        widget._remove_selected()
+        assert len(signals) == 1
+
+
+@needs_display
+class TestMoveItems:
+    def test_move_up(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(2)
+        widget._move_up()
+        assert widget.selected_keys() == ['US', 'DE', 'GB']
+
+    def test_move_down(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(0)
+        widget._move_down()
+        assert widget.selected_keys() == ['GB', 'US', 'DE']
+
+    def test_move_up_at_top_does_nothing(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(0)
+        widget._move_up()
+        assert widget.selected_keys() == ['US', 'GB', 'DE']
+
+    def test_move_down_at_bottom_does_nothing(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(2)
+        widget._move_down()
+        assert widget.selected_keys() == ['US', 'GB', 'DE']
+
+    def test_move_emits_changed(self, widget):
+        widget.set_selected_keys(['US', 'GB', 'DE'])
+        widget._list_widget.setCurrentRow(1)
+        signals = []
+        widget.changed.connect(lambda: signals.append(True))
+        widget._move_up()
+        assert len(signals) == 1
+
+
+@needs_display
+class TestExcludedKeys:
+    def test_excluded_keys_hidden_from_combo(self, widget):
+        widget.set_excluded_keys({'FR', 'JP'})
+        combo_keys = [widget._add_combo.itemData(i) for i in range(widget._add_combo.count())]
+        assert 'FR' not in combo_keys
+        assert 'JP' not in combo_keys
+        assert 'US' in combo_keys
+
+    def test_excluded_plus_selected(self, widget):
+        widget.set_excluded_keys({'FR'})
+        widget.set_selected_keys(['US'])
+        combo_keys = [widget._add_combo.itemData(i) for i in range(widget._add_combo.count())]
+        assert 'FR' not in combo_keys
+        assert 'US' not in combo_keys
+        # Remaining: placeholder(None) + DE, GB, JP
+        assert len(combo_keys) == 4
+
+
+@pytest.fixture()
+def unordered_widget():
+    from PyQt6 import QtWidgets
+
+    from picard.ui.widgets.preferencelistwidget import PreferenceListWidget
+
+    if not hasattr(unordered_widget, '_app'):
+        app = QtWidgets.QApplication.instance()
+        if app is None:
+            app = QtWidgets.QApplication([])
+        unordered_widget._app = app
+    w = PreferenceListWidget(ordered=False)
+    w.set_available_items(SAMPLE_ITEMS)
+    unordered_widget._current = w
+    return w
+
+
+@needs_display
+class TestUnorderedMode:
+    def test_no_up_down_buttons(self, unordered_widget):
+        assert not hasattr(unordered_widget, '_up_btn')
+        assert not hasattr(unordered_widget, '_down_btn')
+
+    def test_drag_drop_disabled(self, unordered_widget):
+        from PyQt6 import QtWidgets
+
+        assert unordered_widget._list_widget.dragDropMode() == QtWidgets.QAbstractItemView.DragDropMode.NoDragDrop
+
+    def test_set_selected_keys_sorted_alphabetically(self, unordered_widget):
+        # JP=Japan, US=United States, DE=Germany — sorted: France, Germany, Japan, UK, US
+        unordered_widget.set_selected_keys(['US', 'JP', 'DE'])
+        keys = unordered_widget.selected_keys()
+        # Germany < Japan < United States (alphabetical by display name)
+        assert keys == ['DE', 'JP', 'US']
+
+    def test_add_inserts_in_sorted_position(self, unordered_widget):
+        unordered_widget.set_selected_keys(['DE', 'US'])  # Germany, United States
+        # Add France — should go before Germany
+        # Find France in the combo
+        for i in range(unordered_widget._add_combo.count()):
+            if unordered_widget._add_combo.itemData(i) == 'FR':
+                unordered_widget._on_combo_activated(i)
+                break
+        keys = unordered_widget.selected_keys()
+        assert keys == ['FR', 'DE', 'US']
+
+    def test_add_selects_new_item(self, unordered_widget):
+        unordered_widget.set_selected_keys(['DE', 'US'])
+        for i in range(unordered_widget._add_combo.count()):
+            if unordered_widget._add_combo.itemData(i) == 'FR':
+                unordered_widget._on_combo_activated(i)
+                break
+        selected = unordered_widget._list_widget.selectedIndexes()
+        assert len(selected) == 1
+        # France should be at row 0 (first alphabetically)
+        assert selected[0].row() == 0
+
+    def test_remove_works(self, unordered_widget):
+        unordered_widget.set_selected_keys(['DE', 'JP', 'US'])
+        unordered_widget._list_widget.setCurrentRow(1)  # JP
+        unordered_widget._remove_selected()
+        assert unordered_widget.selected_keys() == ['DE', 'US']

--- a/test/test_ui_options_releases.py
+++ b/test/test_ui_options_releases.py
@@ -18,87 +18,18 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from unittest.mock import patch
-
-from test.picardtestcase import PicardTestCase
-
 from picard.ui.options.releases import ReleasesOptionsPage
 
 
-def _noop(s: str) -> str:
-    return s
+class TestReleasesOptionsPageClass:
+    def test_page_name(self):
+        assert ReleasesOptionsPage.NAME == 'releases'
 
+    def test_page_parent(self):
+        assert ReleasesOptionsPage.PARENT == 'metadata'
 
-class TestLoadListItems(PicardTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        patcher = patch('picard.ui.options.releases.sort_key', side_effect=str.casefold)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        self.available: list[tuple[str, str]] = []
-        self.preferred: list[tuple[str, str]] = []
-
-    def _add_item(self, name: str, data: str, is_preferred: bool) -> None:
-        if is_preferred:
-            self.preferred.append((data, name))
-        else:
-            self.available.append((data, name))
-
-    def _load(self, preferred: list[str], source: dict[str, str]) -> None:
-        ReleasesOptionsPage._load_list_items(preferred, _noop, source, self._add_item)
-
-    def test_no_saved_preferences(self):
-        """All items go to available, none to preferred."""
-        self._load([], {'US': 'United States', 'DE': 'Germany', 'JP': 'Japan'})
-
-        self.assertEqual(len(self.available), 3)
-        self.assertEqual(len(self.preferred), 0)
-        self.assertEqual({d for d, n in self.available}, {'US', 'DE', 'JP'})
-
-    def test_all_items_preferred(self):
-        """All items go to preferred, none to available."""
-        self._load(['DE', 'US'], {'US': 'United States', 'DE': 'Germany'})
-
-        self.assertEqual(len(self.available), 0)
-        self.assertEqual(len(self.preferred), 2)
-
-    def test_preferred_items_preserve_saved_order(self):
-        """Preferred items appear in the order they were saved, not source order."""
-        self._load(['JP', 'US'], {'US': 'United States', 'DE': 'Germany', 'JP': 'Japan'})
-
-        self.assertEqual([d for d, n in self.preferred], ['JP', 'US'])
-
-    def test_available_items_sorted_by_name(self):
-        """Non-preferred items are sorted alphabetically by translated name."""
-        self._load([], {'US': 'United States', 'DE': 'Germany', 'JP': 'Japan'})
-
-        names = [name for d, name in self.available]
-        self.assertEqual(names, sorted(names))
-
-    def test_split_between_lists(self):
-        """Items split correctly between available and preferred."""
-        source = {
-            'US': 'United States',
-            'DE': 'Germany',
-            'JP': 'Japan',
-            'GB': 'United Kingdom',
-        }
-
-        self._load(['GB', 'DE'], source)
-
-        self.assertEqual({d for d, n in self.available}, {'US', 'JP'})
-        self.assertEqual([d for d, n in self.preferred], ['GB', 'DE'])
-
-    def test_saved_items_not_in_source_are_ignored(self):
-        """Saved preferences referencing removed items don't cause errors."""
-        self._load(['XX', 'US'], {'US': 'United States', 'DE': 'Germany'})
-
-        self.assertEqual(self.available, [('DE', 'Germany')])
-        self.assertEqual(self.preferred, [('US', 'United States')])
-
-    def test_translate_func_applied(self):
-        """The translate_func is applied to source values."""
-        ReleasesOptionsPage._load_list_items([], str.upper, {'a': 'alpha', 'b': 'bravo'}, self._add_item)
-
-        names = [name for d, name in self.available]
-        self.assertEqual(names, ['ALPHA', 'BRAVO'])
+    def test_options_keys(self):
+        assert 'preferred_release_types' in ReleasesOptionsPage.OPTIONS
+        assert 'discouraged_release_types' in ReleasesOptionsPage.OPTIONS
+        assert 'preferred_release_countries' in ReleasesOptionsPage.OPTIONS
+        assert 'preferred_release_formats' in ReleasesOptionsPage.OPTIONS


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Redesign the "Preferred Releases" options page to replace confusing sliders and dual-list pickers with simple priority lists. Users now add items from a dropdown and reorder them — no more guessing which side is "preferred."

## Problem

* JIRA ticket: PICARD-1444

The preferred releases UI has been a source of confusion for years (reported in 2019, again in July 2026). Users can't tell:
- Which column in the dual-list picker is "preferred" vs "available"
- What the slider values mean or what direction increases preference
- Whether their sliders are at 50% or 49%

See: https://community.metabrainz.org/t/confusing-settings-preferred-release-countries-formats-is-the-left-the-preferred-or-the-right/423486

## Solution

Replace the entire page with 4 `PreferenceListWidget` instances:

- **Preferred release types** — ordered priority list
- **Discouraged release types** — types to avoid when matching
- **Preferred release countries** — ordered priority list
- **Preferred medium formats** — ordered priority list

Each widget provides:
- A combobox dropdown to add items (with locale-aware sorting)
- Up/down buttons and drag-and-drop to reorder
- Remove button to deselect items
- Cross-exclusion between preferred/discouraged type lists

The scoring logic uses position-based weights (higher in list = higher score), matching the existing pattern used for countries and formats. Evaluation shows identical pass/fail results (827/850) with the matching test corpus.

Config migration hook (`3.0.0b8`) converts old `release_type_scores` to the new `preferred_release_types` / `discouraged_release_types` format.

<img width="491" height="648" alt="image" src="https://github.com/user-attachments/assets/3da9f9a6-eed1-4687-9f3f-0a227450056f" />

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed collaboratively with an AI assistant (Kiro CLI), with human review, testing, and design decisions at each step.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

The options page documentation at https://picard-docs.musicbrainz.org/en/config/options_releases.html will need screenshots and description updated.
