### PR TITLE
PICARD-1164: Tag diff highlighting in metadata box

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -911,32 +911,60 @@ class MetadataBox(QtWidgets.QTableWidget):
             tag_status = self.tag_diff.tag_status(tag)
             color = colors.get(tag_status, colors[TagStatus.UNCHANGED])
 
+            # Tag name column gets the status color
+            tag_item.setForeground(color)
+
             orig_item = get_table_item(row, self.COLUMN_ORIG)
             self._set_item_value(orig_item, self.tag_diff.old, tag, color)
 
             new_item = get_table_item(row, self.COLUMN_NEW)
             if not self.tag_diff.is_readonly(tag):
                 new_item.setFlags(editable_item_flags)
-            strikeout = tag_status == TagStatus.REMOVED
             new_color = placeholder_color if tag_status == TagStatus.UNCHANGED else color
-            self._set_item_value(new_item, self.tag_diff.new, tag, new_color, strikeout=strikeout)
+            if tag_status == TagStatus.REMOVED:
+                # For removed tags, leave the new value column empty
+                new_item.setText("")
+                new_item.setData(QtCore.Qt.ItemDataRole.UserRole, tag)
+                font = new_item.font()
+                font.setItalic(False)
+                font.setStrikeOut(False)
+                new_item.setFont(font)
+            else:
+                self._set_item_value(new_item, self.tag_diff.new, tag, new_color)
 
             # Compute diff highlights for changed tags with concrete values.
             # For opaque identifiers (MBIDs), use full-string highlight.
             # For other tags, use hybrid word/character-level diff.
+            # For removed tags, highlight the entire old value.
+            # When diff HTML is active, use normal text color since the
+            # background highlights carry the change information.
             old_diff_html = None
             new_diff_html = None
-            if tag_status == TagStatus.CHANGED:
+            if tag_status == TagStatus.REMOVED:
+                old_status = self.tag_diff.old.status(tag)
+                if not old_status.is_grouped:
+                    old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
+                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
+                    old_diff_html, new_diff_html = compute_full_diff_html(old_text, "", normal_text_color)
+                    new_diff_html = None
+            elif tag_status == TagStatus.ADDED:
+                new_status = self.tag_diff.new.status(tag)
+                if not new_status.is_grouped:
+                    new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
+                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
+                    old_diff_html, new_diff_html = compute_full_diff_html("", new_text, normal_text_color)
+                    old_diff_html = None
+            elif tag_status == TagStatus.CHANGED:
                 old_status = self.tag_diff.old.status(tag)
                 new_status = self.tag_diff.new.status(tag)
                 if not old_status.is_grouped and not new_status.is_grouped:
                     old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
                     new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
-                    text_color = interface_colors.get_qcolor('tagstatus_changed')
+                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
                     if tag in self.LOOKUP_TAGS:
-                        old_diff_html, new_diff_html = compute_full_diff_html(old_text, new_text, text_color)
+                        old_diff_html, new_diff_html = compute_full_diff_html(old_text, new_text, normal_text_color)
                     else:
-                        old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, text_color)
+                        old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, normal_text_color)
             orig_item.setData(DIFF_HTML_ROLE, old_diff_html)
             new_item.setData(DIFF_HTML_ROLE, new_diff_html)
 

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -856,6 +856,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             TagStatus.ADDED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_added')),
             TagStatus.CHANGED: QtGui.QBrush(interface_colors.get_qcolor('tagstatus_changed')),
         }
+        placeholder_color = self.palette().color(QtGui.QPalette.ColorRole.PlaceholderText)
 
         def get_table_item(row, column):
             """
@@ -874,7 +875,8 @@ class MetadataBox(QtWidgets.QTableWidget):
             tag_item = get_table_item(row, self.COLUMN_TAG)
             self._set_item_tag(tag_item, tag)
 
-            color = colors.get(self.tag_diff.tag_status(tag), colors[TagStatus.UNCHANGED])
+            tag_status = self.tag_diff.tag_status(tag)
+            color = colors.get(tag_status, colors[TagStatus.UNCHANGED])
 
             orig_item = get_table_item(row, self.COLUMN_ORIG)
             self._set_item_value(orig_item, self.tag_diff.old, tag, color)
@@ -882,8 +884,9 @@ class MetadataBox(QtWidgets.QTableWidget):
             new_item = get_table_item(row, self.COLUMN_NEW)
             if not self.tag_diff.is_readonly(tag):
                 new_item.setFlags(editable_item_flags)
-            strikeout = self.tag_diff.tag_status(tag) == TagStatus.REMOVED
-            self._set_item_value(new_item, self.tag_diff.new, tag, color, strikeout=strikeout)
+            strikeout = tag_status == TagStatus.REMOVED
+            new_color = placeholder_color if tag_status == TagStatus.UNCHANGED else color
+            self._set_item_value(new_item, self.tag_diff.new, tag, new_color, strikeout=strikeout)
 
             # Adjust row height to content size
             self.setRowHeight(row, self.sizeHintForRow(row))

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -78,16 +78,20 @@ from .tagdiff import (
 )
 
 from picard.ui.colors import interface_colors
-from picard.ui.metadatabox.difftextdocument import (
-    compute_diff_html,
-    compute_full_diff_html,
-    create_diff_document,
-)
+from picard.ui.metadatabox.difftextdocument import create_diff_document
 from picard.ui.metadatabox.mimedatahelper import MimeDataHelper
+from picard.ui.metadatabox.tagdiffhtml import (
+    compute_diff,
+    highlight_full,
+)
 
 
 # Custom data role for storing diff HTML on table items
 DIFF_HTML_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
+
+# Alpha values for diff highlight backgrounds (0-255)
+DIFF_HIGHLIGHT_ALPHA_LIGHT = 60
+DIFF_HIGHLIGHT_ALPHA_DARK = 90
 
 
 class TableTagEditorDelegate(TagEditorDelegate):
@@ -775,12 +779,17 @@ class MetadataBox(QtWidgets.QTableWidget):
         if new_selection:
             self._update_selection()
         thread.run_task(
-            partial(self._update_tags, new_selection, drop_album_caches),
+            partial(
+                self._update_tags,
+                new_selection,
+                drop_album_caches,
+                self.palette().color(QtGui.QPalette.ColorRole.Text).name(),
+            ),
             self._update_items,
             thread_pool=self.tagger.priority_thread_pool,
         )
 
-    def _update_tags(self, new_selection=True, drop_album_caches=False):
+    def _update_tags(self, new_selection=True, drop_album_caches=False, text_color_css=None):
         """
         Build a TagDiff object representing the differences between original and new metadata
         for the current selection of files and tracks.
@@ -813,6 +822,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         self._add_tracks_to_tag_diff(tracks, tag_diff, config)
 
         tag_diff.update_tag_names(config.persist['show_changes_first'], top_tags)
+        self._compute_diff_html(tag_diff, text_color_css)
         return tag_diff
 
     def _add_files_to_tag_diff(self, files, tag_diff, config, top_tags):
@@ -864,6 +874,55 @@ class MetadataBox(QtWidgets.QTableWidget):
             length = str(track.metadata.length)
             tag_diff.add('~length', old=length, new=length, removable=False, readonly=True)
             tag_diff.objects += 1
+
+    def _compute_diff_html(self, tag_diff, text_color_css):
+        """Compute diff HTML for all tags in the background thread.
+
+        Stores results in tag_diff.diff_html as a dict mapping tag names
+        to (old_html, new_html) tuples.
+
+        Args:
+            tag_diff: The TagDiff object with tag data.
+            text_color_css: CSS color string for normal text.
+        """
+        diff_alpha = DIFF_HIGHLIGHT_ALPHA_DARK if interface_colors.dark_theme else DIFF_HIGHLIGHT_ALPHA_LIGHT
+        removed_bg = interface_colors.get_color_css_rgba('tagstatus_removed', alpha=diff_alpha)
+        added_bg = interface_colors.get_color_css_rgba('tagstatus_added', alpha=diff_alpha)
+
+        for tag in tag_diff.tag_names:
+            tag_status = tag_diff.tag_status(tag)
+            old_diff_html = None
+            new_diff_html = None
+
+            if tag_status == TagStatus.REMOVED:
+                old_status = tag_diff.old.status(tag)
+                if not old_status.is_grouped:
+                    old_text = MULTI_VALUED_JOINER.join(tag_diff.old[tag])
+                    old_diff_html, new_diff_html = highlight_full(old_text, "", removed_bg, added_bg, text_color_css)
+                    new_diff_html = None
+            elif tag_status == TagStatus.ADDED:
+                new_status = tag_diff.new.status(tag)
+                if not new_status.is_grouped:
+                    new_text = MULTI_VALUED_JOINER.join(tag_diff.new[tag])
+                    old_diff_html, new_diff_html = highlight_full("", new_text, removed_bg, added_bg, text_color_css)
+                    old_diff_html = None
+            elif tag_status == TagStatus.CHANGED:
+                old_status = tag_diff.old.status(tag)
+                new_status = tag_diff.new.status(tag)
+                if not old_status.is_grouped and not new_status.is_grouped:
+                    old_text = MULTI_VALUED_JOINER.join(tag_diff.old[tag])
+                    new_text = MULTI_VALUED_JOINER.join(tag_diff.new[tag])
+                    if tag in self.LOOKUP_TAGS:
+                        old_diff_html, new_diff_html = highlight_full(
+                            old_text, new_text, removed_bg, added_bg, text_color_css
+                        )
+                    else:
+                        old_diff_html, new_diff_html = compute_diff(
+                            old_text, new_text, removed_bg, added_bg, text_color_css
+                        )
+
+            if old_diff_html or new_diff_html:
+                tag_diff.diff_html[tag] = (old_diff_html, new_diff_html)
 
     def _update_items(self, result=None, error=None):
         if self.editing:
@@ -932,39 +991,8 @@ class MetadataBox(QtWidgets.QTableWidget):
             else:
                 self._set_item_value(new_item, self.tag_diff.new, tag, new_color)
 
-            # Compute diff highlights for changed tags with concrete values.
-            # For opaque identifiers (MBIDs), use full-string highlight.
-            # For other tags, use hybrid word/character-level diff.
-            # For removed tags, highlight the entire old value.
-            # When diff HTML is active, use normal text color since the
-            # background highlights carry the change information.
-            old_diff_html = None
-            new_diff_html = None
-            if tag_status == TagStatus.REMOVED:
-                old_status = self.tag_diff.old.status(tag)
-                if not old_status.is_grouped:
-                    old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
-                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
-                    old_diff_html, new_diff_html = compute_full_diff_html(old_text, "", normal_text_color)
-                    new_diff_html = None
-            elif tag_status == TagStatus.ADDED:
-                new_status = self.tag_diff.new.status(tag)
-                if not new_status.is_grouped:
-                    new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
-                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
-                    old_diff_html, new_diff_html = compute_full_diff_html("", new_text, normal_text_color)
-                    old_diff_html = None
-            elif tag_status == TagStatus.CHANGED:
-                old_status = self.tag_diff.old.status(tag)
-                new_status = self.tag_diff.new.status(tag)
-                if not old_status.is_grouped and not new_status.is_grouped:
-                    old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
-                    new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
-                    normal_text_color = self.palette().color(QtGui.QPalette.ColorRole.Text)
-                    if tag in self.LOOKUP_TAGS:
-                        old_diff_html, new_diff_html = compute_full_diff_html(old_text, new_text, normal_text_color)
-                    else:
-                        old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, normal_text_color)
+            # Apply precomputed diff HTML (computed in background thread)
+            old_diff_html, new_diff_html = self.tag_diff.diff_html.get(tag, (None, None))
             orig_item.setData(DIFF_HTML_ROLE, old_diff_html)
             new_item.setData(DIFF_HTML_ROLE, new_diff_html)
 

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -80,6 +80,7 @@ from .tagdiff import (
 from picard.ui.colors import interface_colors
 from picard.ui.metadatabox.difftextdocument import (
     compute_diff_html,
+    compute_full_diff_html,
     create_diff_document,
 )
 from picard.ui.metadatabox.mimedatahelper import MimeDataHelper
@@ -920,7 +921,9 @@ class MetadataBox(QtWidgets.QTableWidget):
             new_color = placeholder_color if tag_status == TagStatus.UNCHANGED else color
             self._set_item_value(new_item, self.tag_diff.new, tag, new_color, strikeout=strikeout)
 
-            # Compute character-level diff for changed tags with concrete values
+            # Compute diff highlights for changed tags with concrete values.
+            # For opaque identifiers (MBIDs), use full-string highlight.
+            # For other tags, use hybrid word/character-level diff.
             old_diff_html = None
             new_diff_html = None
             if tag_status == TagStatus.CHANGED:
@@ -930,7 +933,10 @@ class MetadataBox(QtWidgets.QTableWidget):
                     old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
                     new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
                     text_color = interface_colors.get_qcolor('tagstatus_changed')
-                    old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, text_color)
+                    if tag in self.LOOKUP_TAGS:
+                        old_diff_html, new_diff_html = compute_full_diff_html(old_text, new_text, text_color)
+                    else:
+                        old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, text_color)
             orig_item.setData(DIFF_HTML_ROLE, old_diff_html)
             new_item.setData(DIFF_HTML_ROLE, new_diff_html)
 

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -78,7 +78,15 @@ from .tagdiff import (
 )
 
 from picard.ui.colors import interface_colors
+from picard.ui.metadatabox.difftextdocument import (
+    compute_diff_html,
+    create_diff_document,
+)
 from picard.ui.metadatabox.mimedatahelper import MimeDataHelper
+
+
+# Custom data role for storing diff HTML on table items
+DIFF_HTML_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
 
 
 class TableTagEditorDelegate(TagEditorDelegate):
@@ -89,10 +97,34 @@ class TableTagEditorDelegate(TagEditorDelegate):
     editing of tag values within metadata box QTableWidget.
     It ensures that the editor is sized appropriately for multiline content
     and that the row height is adjusted to fit the editor.
+
+    When diff HTML is stored on an item (via DIFF_HTML_ROLE), the delegate
+    renders the HTML with highlighted character differences instead of
+    plain text.
     """
 
     MIN_EDITOR_HEIGHT = 80  # The minimum height for the editor widget
     MAX_ROW_HEIGHT = 160  # The maximum height for a row
+
+    def paint(self, painter, option, index):
+        """Render HTML diff highlighting if available, otherwise use default painting."""
+        diff_html = index.data(DIFF_HTML_ROLE)
+        if diff_html:
+            painter.save()
+            # Draw background/selection using the base delegate
+            self.drawBackground(painter, option, index)
+            # Render the diff HTML document within the cell rect
+            doc = create_diff_document(diff_html, option.font)
+            doc.setTextWidth(option.rect.width())
+            painter.translate(option.rect.topLeft())
+            painter.setClipRect(option.rect.translated(-option.rect.topLeft()))
+            doc.drawContents(painter)
+            painter.restore()
+            # Draw focus rect if needed
+            if option.state & QtWidgets.QStyle.StateFlag.State_HasFocus:
+                self.drawFocus(painter, option, option.rect)
+        else:
+            super().paint(painter, option, index)
 
     def createEditor(self, parent, option, index):
         """
@@ -887,6 +919,20 @@ class MetadataBox(QtWidgets.QTableWidget):
             strikeout = tag_status == TagStatus.REMOVED
             new_color = placeholder_color if tag_status == TagStatus.UNCHANGED else color
             self._set_item_value(new_item, self.tag_diff.new, tag, new_color, strikeout=strikeout)
+
+            # Compute character-level diff for changed tags with concrete values
+            old_diff_html = None
+            new_diff_html = None
+            if tag_status == TagStatus.CHANGED:
+                old_status = self.tag_diff.old.status(tag)
+                new_status = self.tag_diff.new.status(tag)
+                if not old_status.is_grouped and not new_status.is_grouped:
+                    old_text = MULTI_VALUED_JOINER.join(self.tag_diff.old[tag])
+                    new_text = MULTI_VALUED_JOINER.join(self.tag_diff.new[tag])
+                    text_color = interface_colors.get_qcolor('tagstatus_changed')
+                    old_diff_html, new_diff_html = compute_diff_html(old_text, new_text, text_color)
+            orig_item.setData(DIFF_HTML_ROLE, old_diff_html)
+            new_item.setData(DIFF_HTML_ROLE, new_diff_html)
 
             # Adjust row height to content size
             self.setRowHeight(row, self.sizeHintForRow(row))

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -32,6 +32,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections import namedtuple
 from functools import partial
 import json
 
@@ -62,6 +63,7 @@ from picard.tags.preserved import UserPreservedTags
 from picard.track import Track
 from picard.util import (
     IgnoreUpdatesContext,
+    format_time,
     icontheme,
     restore_method,
     thread,
@@ -92,6 +94,12 @@ DIFF_HTML_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
 # Alpha values for diff highlight backgrounds (0-255)
 DIFF_HIGHLIGHT_ALPHA_LIGHT = 60
 DIFF_HIGHLIGHT_ALPHA_DARK = 90
+
+
+# Colors resolved from the main thread for use in background diff computation.
+# Qt widget palette can only be accessed from the main thread. These colors are
+# resolved before dispatching to the background thread and passed as CSS strings.
+DiffColors = namedtuple('DiffColors', ('text', 'placeholder', 'removed_bg', 'added_bg'))
 
 
 class TableTagEditorDelegate(TagEditorDelegate):
@@ -778,18 +786,23 @@ class MetadataBox(QtWidgets.QTableWidget):
             return
         if new_selection:
             self._update_selection()
+        # Resolve palette colors in the main thread (Qt widgets are not thread-safe).
+        diff_alpha = DIFF_HIGHLIGHT_ALPHA_DARK if interface_colors.dark_theme else DIFF_HIGHLIGHT_ALPHA_LIGHT
+        diff_colors = DiffColors(
+            text=self.palette().color(QtGui.QPalette.ColorRole.Text).name(QtGui.QColor.NameFormat.HexArgb),
+            placeholder=self.palette()
+            .color(QtGui.QPalette.ColorRole.PlaceholderText)
+            .name(QtGui.QColor.NameFormat.HexArgb),
+            removed_bg=interface_colors.get_color_css_rgba('tagstatus_removed', alpha=diff_alpha),
+            added_bg=interface_colors.get_color_css_rgba('tagstatus_added', alpha=diff_alpha),
+        )
         thread.run_task(
-            partial(
-                self._update_tags,
-                new_selection,
-                drop_album_caches,
-                self.palette().color(QtGui.QPalette.ColorRole.Text).name(),
-            ),
+            partial(self._update_tags, new_selection, drop_album_caches, diff_colors),
             self._update_items,
             thread_pool=self.tagger.priority_thread_pool,
         )
 
-    def _update_tags(self, new_selection=True, drop_album_caches=False, text_color_css=None):
+    def _update_tags(self, new_selection=True, drop_album_caches=False, diff_colors=None):
         """
         Build a TagDiff object representing the differences between original and new metadata
         for the current selection of files and tracks.
@@ -822,7 +835,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         self._add_tracks_to_tag_diff(tracks, tag_diff, config)
 
         tag_diff.update_tag_names(config.persist['show_changes_first'], top_tags)
-        self._compute_diff_html(tag_diff, text_color_css)
+        self._compute_diff_html(tag_diff, diff_colors)
         return tag_diff
 
     def _add_files_to_tag_diff(self, files, tag_diff, config, top_tags):
@@ -875,7 +888,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             tag_diff.add('~length', old=length, new=length, removable=False, readonly=True)
             tag_diff.objects += 1
 
-    def _compute_diff_html(self, tag_diff, text_color_css):
+    def _compute_diff_html(self, tag_diff, diff_colors):
         """Compute diff HTML for all tags in the background thread.
 
         Stores results in tag_diff.diff_html as a dict mapping tag names
@@ -883,42 +896,47 @@ class MetadataBox(QtWidgets.QTableWidget):
 
         Args:
             tag_diff: The TagDiff object with tag data.
-            text_color_css: CSS color string for normal text.
+            diff_colors: DiffColors instance with resolved CSS color strings.
         """
-        diff_alpha = DIFF_HIGHLIGHT_ALPHA_DARK if interface_colors.dark_theme else DIFF_HIGHLIGHT_ALPHA_LIGHT
-        removed_bg = interface_colors.get_color_css_rgba('tagstatus_removed', alpha=diff_alpha)
-        added_bg = interface_colors.get_color_css_rgba('tagstatus_added', alpha=diff_alpha)
+        removed_bg = diff_colors.removed_bg
+        added_bg = diff_colors.added_bg
 
         for tag in tag_diff.tag_names:
             tag_status = tag_diff.tag_status(tag)
             old_diff_html = None
             new_diff_html = None
 
-            if tag_status == TagStatus.REMOVED:
-                old_status = tag_diff.old.status(tag)
-                if not old_status.is_grouped:
+            if tag == '~length':
+                # Always show diff for length when display values differ,
+                # regardless of tolerance-based status (it's read-only/informational).
+                # Skip when values are grouped (multiple files with different lengths).
+                # Use placeholder color for new value since this tag is never written.
+                if not tag_diff.old.status(tag).is_grouped and not tag_diff.new.status(tag).is_grouped:
+                    old_text = format_time(tag_diff.old.get(tag, 0))
+                    new_text = format_time(tag_diff.new.get(tag, 0))
+                    old_diff_html, _unused = compute_diff(old_text, new_text, removed_bg, added_bg, diff_colors.text)
+                    _unused, new_diff_html = compute_diff(
+                        old_text, new_text, removed_bg, added_bg, diff_colors.placeholder
+                    )
+            elif tag_status == TagStatus.REMOVED:
+                if not tag_diff.old.status(tag).is_grouped:
                     old_text = MULTI_VALUED_JOINER.join(tag_diff.old[tag])
-                    old_diff_html, new_diff_html = highlight_full(old_text, "", removed_bg, added_bg, text_color_css)
-                    new_diff_html = None
+                    old_diff_html, _unused = highlight_full(old_text, "", removed_bg, added_bg, diff_colors.text)
             elif tag_status == TagStatus.ADDED:
-                new_status = tag_diff.new.status(tag)
-                if not new_status.is_grouped:
+                if not tag_diff.new.status(tag).is_grouped:
                     new_text = MULTI_VALUED_JOINER.join(tag_diff.new[tag])
-                    old_diff_html, new_diff_html = highlight_full("", new_text, removed_bg, added_bg, text_color_css)
-                    old_diff_html = None
+                    _unused, new_diff_html = highlight_full("", new_text, removed_bg, added_bg, diff_colors.text)
             elif tag_status == TagStatus.CHANGED:
-                old_status = tag_diff.old.status(tag)
-                new_status = tag_diff.new.status(tag)
-                if not old_status.is_grouped and not new_status.is_grouped:
+                if not tag_diff.old.status(tag).is_grouped and not tag_diff.new.status(tag).is_grouped:
                     old_text = MULTI_VALUED_JOINER.join(tag_diff.old[tag])
                     new_text = MULTI_VALUED_JOINER.join(tag_diff.new[tag])
                     if tag in self.LOOKUP_TAGS:
                         old_diff_html, new_diff_html = highlight_full(
-                            old_text, new_text, removed_bg, added_bg, text_color_css
+                            old_text, new_text, removed_bg, added_bg, diff_colors.text
                         )
                     else:
                         old_diff_html, new_diff_html = compute_diff(
-                            old_text, new_text, removed_bg, added_bg, text_color_css
+                            old_text, new_text, removed_bg, added_bg, diff_colors.text
                         )
 
             if old_diff_html or new_diff_html:
@@ -979,7 +997,9 @@ class MetadataBox(QtWidgets.QTableWidget):
             new_item = get_table_item(row, self.COLUMN_NEW)
             if not self.tag_diff.is_readonly(tag):
                 new_item.setFlags(editable_item_flags)
-            new_color = placeholder_color if tag_status == TagStatus.UNCHANGED else color
+            new_color = (
+                placeholder_color if tag_status == TagStatus.UNCHANGED or self.tag_diff.is_readonly(tag) else color
+            )
             if tag_status == TagStatus.REMOVED:
                 # For removed tags, leave the new value column empty
                 new_item.setText("")

--- a/picard/ui/metadatabox/difftextdocument.py
+++ b/picard/ui/metadatabox/difftextdocument.py
@@ -28,7 +28,10 @@ for rendering.
 from PyQt6 import QtGui
 
 from picard.ui.colors import interface_colors
-from picard.ui.metadatabox.tagdiffhtml import compute_diff
+from picard.ui.metadatabox.tagdiffhtml import (
+    compute_diff,
+    highlight_full,
+)
 
 
 def _get_diff_colors() -> tuple[str, str]:
@@ -62,6 +65,31 @@ def compute_diff_html(
         return None, None
     removed_bg, added_bg = _get_diff_colors()
     return compute_diff(old_text, new_text, removed_bg, added_bg, text_color.name())
+
+
+def compute_full_diff_html(
+    old_text: str,
+    new_text: str,
+    text_color: QtGui.QColor,
+) -> tuple[str | None, str | None]:
+    """Highlight entire old/new strings as fully replaced.
+
+    Used for opaque values (MBIDs, etc.) where character-level diff
+    is meaningless.
+
+    Args:
+        old_text: The original text string.
+        new_text: The new text string.
+        text_color: QColor for the base text.
+
+    Returns:
+        A tuple (old_html, new_html) with full-string highlights.
+        Returns (None, None) if inputs are identical.
+    """
+    if old_text == new_text:
+        return None, None
+    removed_bg, added_bg = _get_diff_colors()
+    return highlight_full(old_text, new_text, removed_bg, added_bg, text_color.name())
 
 
 def create_diff_document(html: str, font: QtGui.QFont) -> QtGui.QTextDocument:

--- a/picard/ui/metadatabox/difftextdocument.py
+++ b/picard/ui/metadatabox/difftextdocument.py
@@ -18,34 +18,20 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-"""Character/word-level diff highlighting for the metadata box.
+"""Qt display layer for diff highlighting in the metadata box.
 
-Provides hybrid diff computation: first diffs at the word/token level,
-then refines with character-level diffs within similar replaced tokens.
+This module bridges the pure diff logic (tagdiffhtml) with Qt,
+providing color resolution from the theme and QTextDocument creation
+for rendering.
 """
-
-from difflib import SequenceMatcher
-from html import escape
-import re
 
 from PyQt6 import QtGui
 
 from picard.ui.colors import interface_colors
+from picard.ui.metadatabox.tagdiffhtml import compute_diff
 
 
-# If two replaced tokens have a similarity ratio at or above this threshold,
-# show character-level diff within the token. Below this, highlight the
-# entire token as changed.
-_CHAR_DIFF_RATIO_THRESHOLD = 0.5
-
-# Split text into tokens: runs of word characters, or individual non-word
-# characters (punctuation, symbols), or whitespace runs.
-# This ensures punctuation is a separate token from the word it's attached to,
-# e.g. "Rock'n'Roll!" -> ["Rock", "'", "n", "'", "Roll", "!"]
-_TOKEN_RE = re.compile(r"(\w+|[^\w\s]|\s+)")
-
-
-def _get_diff_colors():
+def _get_diff_colors() -> tuple[str, str]:
     """Return (removed_bg, added_bg) as CSS rgba strings with transparency."""
     removed = interface_colors.get_qcolor('tagstatus_removed')
     added = interface_colors.get_qcolor('tagstatus_added')
@@ -54,88 +40,19 @@ def _get_diff_colors():
     return removed_bg, added_bg
 
 
-def _tokenize(text):
-    """Split text into tokens: words, punctuation, and whitespace separately."""
-    return _TOKEN_RE.findall(text)
+def compute_diff_html(
+    old_text: str,
+    new_text: str,
+    text_color: QtGui.QColor,
+) -> tuple[str | None, str | None]:
+    """Compute diff HTML using the current theme colors.
 
-
-def _highlight(text, bg_color):
-    """Wrap escaped text in a colored background span."""
-    return f'<span style="background-color: {bg_color};">{escape(text)}</span>'
-
-
-def _char_diff_within_token(old_token, new_token, removed_bg, added_bg):
-    """Compute character-level diff within a pair of similar tokens.
-
-    Args:
-        old_token: The original token string.
-        new_token: The new token string.
-        removed_bg: CSS color for removed character background.
-        added_bg: CSS color for added character background.
-
-    Returns:
-        Tuple (old_html, new_html) with per-character highlights.
-    """
-    matcher = SequenceMatcher(None, old_token, new_token)
-    old_parts = []
-    new_parts = []
-
-    for op, i1, i2, j1, j2 in matcher.get_opcodes():
-        if op == 'equal':
-            chunk = escape(old_token[i1:i2])
-            old_parts.append(chunk)
-            new_parts.append(chunk)
-        elif op == 'replace':
-            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
-            new_parts.append(_highlight(new_token[j1:j2], added_bg))
-        elif op == 'delete':
-            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
-        elif op == 'insert':
-            new_parts.append(_highlight(new_token[j1:j2], added_bg))
-
-    return ''.join(old_parts), ''.join(new_parts)
-
-
-def _process_replace(old_tokens, new_tokens, removed_bg, added_bg, old_parts, new_parts):
-    """Process a 'replace' opcode from the token-level diff.
-
-    Pairs up tokens positionally. For each pair, if the tokens are similar
-    enough, applies character-level diff; otherwise highlights the whole token.
-    Leftover unpaired tokens are fully highlighted.
-    """
-    pairs = min(len(old_tokens), len(new_tokens))
-    for k in range(pairs):
-        old_tok = old_tokens[k]
-        new_tok = new_tokens[k]
-        ratio = SequenceMatcher(None, old_tok, new_tok).ratio()
-        if ratio >= _CHAR_DIFF_RATIO_THRESHOLD:
-            old_html, new_html = _char_diff_within_token(old_tok, new_tok, removed_bg, added_bg)
-            old_parts.append(old_html)
-            new_parts.append(new_html)
-        else:
-            old_parts.append(_highlight(old_tok, removed_bg))
-            new_parts.append(_highlight(new_tok, added_bg))
-    # Leftover tokens on either side
-    for k in range(pairs, len(old_tokens)):
-        old_parts.append(_highlight(old_tokens[k], removed_bg))
-    for k in range(pairs, len(new_tokens)):
-        new_parts.append(_highlight(new_tokens[k], added_bg))
-
-
-def compute_diff_html(old_text, new_text, text_color):
-    """Compute a hybrid word/character-level diff and return (old_html, new_html).
-
-    Strategy:
-    1. Tokenize both texts into words, punctuation, and whitespace.
-    2. Diff at the token level.
-    3. For replaced token pairs that are similar enough (ratio >= threshold),
-       do a character-level diff within the token.
-    4. For replaced tokens that are too different, highlight the whole token.
+    Resolves Qt theme colors and delegates to the pure diff logic.
 
     Args:
         old_text: The original text string.
         new_text: The new text string.
-        text_color: QColor for the base text color.
+        text_color: QColor for the base text.
 
     Returns:
         A tuple (old_html, new_html) with highlighted differences.
@@ -143,44 +60,11 @@ def compute_diff_html(old_text, new_text, text_color):
     """
     if old_text == new_text:
         return None, None
-
     removed_bg, added_bg = _get_diff_colors()
-    text_css = text_color.name()
-
-    old_tokens = _tokenize(old_text)
-    new_tokens = _tokenize(new_text)
-
-    matcher = SequenceMatcher(None, old_tokens, new_tokens)
-    old_parts = []
-    new_parts = []
-
-    for op, i1, i2, j1, j2 in matcher.get_opcodes():
-        if op == 'equal':
-            chunk = escape(''.join(old_tokens[i1:i2]))
-            old_parts.append(chunk)
-            new_parts.append(chunk)
-        elif op == 'replace':
-            _process_replace(
-                old_tokens[i1:i2],
-                new_tokens[j1:j2],
-                removed_bg,
-                added_bg,
-                old_parts,
-                new_parts,
-            )
-        elif op == 'delete':
-            for tok in old_tokens[i1:i2]:
-                old_parts.append(_highlight(tok, removed_bg))
-        elif op == 'insert':
-            for tok in new_tokens[j1:j2]:
-                new_parts.append(_highlight(tok, added_bg))
-
-    old_html = f'<span style="color: {text_css};">{"".join(old_parts)}</span>'
-    new_html = f'<span style="color: {text_css};">{"".join(new_parts)}</span>'
-    return old_html, new_html
+    return compute_diff(old_text, new_text, removed_bg, added_bg, text_color.name())
 
 
-def create_diff_document(html, font):
+def create_diff_document(html: str, font: QtGui.QFont) -> QtGui.QTextDocument:
     """Create a QTextDocument configured for rendering diff HTML.
 
     Args:

--- a/picard/ui/metadatabox/difftextdocument.py
+++ b/picard/ui/metadatabox/difftextdocument.py
@@ -20,76 +20,11 @@
 
 """Qt display layer for diff highlighting in the metadata box.
 
-This module bridges the pure diff logic (tagdiffhtml) with Qt,
-providing color resolution from the theme and QTextDocument creation
-for rendering.
+This module provides QTextDocument creation for rendering diff HTML
+produced by the tagdiffhtml module.
 """
 
 from PyQt6 import QtGui
-
-from picard.ui.colors import interface_colors
-from picard.ui.metadatabox.tagdiffhtml import (
-    compute_diff,
-    highlight_full,
-)
-
-
-def _get_diff_colors() -> tuple[str, str]:
-    """Return (removed_bg, added_bg) as CSS rgba strings with transparency."""
-    removed = interface_colors.get_qcolor('tagstatus_removed')
-    added = interface_colors.get_qcolor('tagstatus_added')
-    removed_bg = f'rgba({removed.red()}, {removed.green()}, {removed.blue()}, 60)'
-    added_bg = f'rgba({added.red()}, {added.green()}, {added.blue()}, 60)'
-    return removed_bg, added_bg
-
-
-def compute_diff_html(
-    old_text: str,
-    new_text: str,
-    text_color: QtGui.QColor,
-) -> tuple[str | None, str | None]:
-    """Compute diff HTML using the current theme colors.
-
-    Resolves Qt theme colors and delegates to the pure diff logic.
-
-    Args:
-        old_text: The original text string.
-        new_text: The new text string.
-        text_color: QColor for the base text.
-
-    Returns:
-        A tuple (old_html, new_html) with highlighted differences.
-        Returns (None, None) if inputs are identical.
-    """
-    if old_text == new_text:
-        return None, None
-    removed_bg, added_bg = _get_diff_colors()
-    return compute_diff(old_text, new_text, removed_bg, added_bg, text_color.name())
-
-
-def compute_full_diff_html(
-    old_text: str,
-    new_text: str,
-    text_color: QtGui.QColor,
-) -> tuple[str | None, str | None]:
-    """Highlight entire old/new strings as fully replaced.
-
-    Used for opaque values (MBIDs, etc.) where character-level diff
-    is meaningless.
-
-    Args:
-        old_text: The original text string.
-        new_text: The new text string.
-        text_color: QColor for the base text.
-
-    Returns:
-        A tuple (old_html, new_html) with full-string highlights.
-        Returns (None, None) if inputs are identical.
-    """
-    if old_text == new_text:
-        return None, None
-    removed_bg, added_bg = _get_diff_colors()
-    return highlight_full(old_text, new_text, removed_bg, added_bg, text_color.name())
 
 
 def create_diff_document(html: str, font: QtGui.QFont) -> QtGui.QTextDocument:

--- a/picard/ui/metadatabox/difftextdocument.py
+++ b/picard/ui/metadatabox/difftextdocument.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Character/word-level diff highlighting for the metadata box.
+
+Provides hybrid diff computation: first diffs at the word/token level,
+then refines with character-level diffs within similar replaced tokens.
+"""
+
+from difflib import SequenceMatcher
+from html import escape
+import re
+
+from PyQt6 import QtGui
+
+from picard.ui.colors import interface_colors
+
+
+# If two replaced tokens have a similarity ratio at or above this threshold,
+# show character-level diff within the token. Below this, highlight the
+# entire token as changed.
+_CHAR_DIFF_RATIO_THRESHOLD = 0.5
+
+# Split text into tokens: runs of word characters, or individual non-word
+# characters (punctuation, symbols), or whitespace runs.
+# This ensures punctuation is a separate token from the word it's attached to,
+# e.g. "Rock'n'Roll!" -> ["Rock", "'", "n", "'", "Roll", "!"]
+_TOKEN_RE = re.compile(r"(\w+|[^\w\s]|\s+)")
+
+
+def _get_diff_colors():
+    """Return (removed_bg, added_bg) as CSS rgba strings with transparency."""
+    removed = interface_colors.get_qcolor('tagstatus_removed')
+    added = interface_colors.get_qcolor('tagstatus_added')
+    removed_bg = f'rgba({removed.red()}, {removed.green()}, {removed.blue()}, 60)'
+    added_bg = f'rgba({added.red()}, {added.green()}, {added.blue()}, 60)'
+    return removed_bg, added_bg
+
+
+def _tokenize(text):
+    """Split text into tokens: words, punctuation, and whitespace separately."""
+    return _TOKEN_RE.findall(text)
+
+
+def _highlight(text, bg_color):
+    """Wrap escaped text in a colored background span."""
+    return f'<span style="background-color: {bg_color};">{escape(text)}</span>'
+
+
+def _char_diff_within_token(old_token, new_token, removed_bg, added_bg):
+    """Compute character-level diff within a pair of similar tokens.
+
+    Args:
+        old_token: The original token string.
+        new_token: The new token string.
+        removed_bg: CSS color for removed character background.
+        added_bg: CSS color for added character background.
+
+    Returns:
+        Tuple (old_html, new_html) with per-character highlights.
+    """
+    matcher = SequenceMatcher(None, old_token, new_token)
+    old_parts = []
+    new_parts = []
+
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == 'equal':
+            chunk = escape(old_token[i1:i2])
+            old_parts.append(chunk)
+            new_parts.append(chunk)
+        elif op == 'replace':
+            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
+            new_parts.append(_highlight(new_token[j1:j2], added_bg))
+        elif op == 'delete':
+            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
+        elif op == 'insert':
+            new_parts.append(_highlight(new_token[j1:j2], added_bg))
+
+    return ''.join(old_parts), ''.join(new_parts)
+
+
+def _process_replace(old_tokens, new_tokens, removed_bg, added_bg, old_parts, new_parts):
+    """Process a 'replace' opcode from the token-level diff.
+
+    Pairs up tokens positionally. For each pair, if the tokens are similar
+    enough, applies character-level diff; otherwise highlights the whole token.
+    Leftover unpaired tokens are fully highlighted.
+    """
+    pairs = min(len(old_tokens), len(new_tokens))
+    for k in range(pairs):
+        old_tok = old_tokens[k]
+        new_tok = new_tokens[k]
+        ratio = SequenceMatcher(None, old_tok, new_tok).ratio()
+        if ratio >= _CHAR_DIFF_RATIO_THRESHOLD:
+            old_html, new_html = _char_diff_within_token(old_tok, new_tok, removed_bg, added_bg)
+            old_parts.append(old_html)
+            new_parts.append(new_html)
+        else:
+            old_parts.append(_highlight(old_tok, removed_bg))
+            new_parts.append(_highlight(new_tok, added_bg))
+    # Leftover tokens on either side
+    for k in range(pairs, len(old_tokens)):
+        old_parts.append(_highlight(old_tokens[k], removed_bg))
+    for k in range(pairs, len(new_tokens)):
+        new_parts.append(_highlight(new_tokens[k], added_bg))
+
+
+def compute_diff_html(old_text, new_text, text_color):
+    """Compute a hybrid word/character-level diff and return (old_html, new_html).
+
+    Strategy:
+    1. Tokenize both texts into words, punctuation, and whitespace.
+    2. Diff at the token level.
+    3. For replaced token pairs that are similar enough (ratio >= threshold),
+       do a character-level diff within the token.
+    4. For replaced tokens that are too different, highlight the whole token.
+
+    Args:
+        old_text: The original text string.
+        new_text: The new text string.
+        text_color: QColor for the base text color.
+
+    Returns:
+        A tuple (old_html, new_html) with highlighted differences.
+        Returns (None, None) if inputs are identical.
+    """
+    if old_text == new_text:
+        return None, None
+
+    removed_bg, added_bg = _get_diff_colors()
+    text_css = text_color.name()
+
+    old_tokens = _tokenize(old_text)
+    new_tokens = _tokenize(new_text)
+
+    matcher = SequenceMatcher(None, old_tokens, new_tokens)
+    old_parts = []
+    new_parts = []
+
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == 'equal':
+            chunk = escape(''.join(old_tokens[i1:i2]))
+            old_parts.append(chunk)
+            new_parts.append(chunk)
+        elif op == 'replace':
+            _process_replace(
+                old_tokens[i1:i2],
+                new_tokens[j1:j2],
+                removed_bg,
+                added_bg,
+                old_parts,
+                new_parts,
+            )
+        elif op == 'delete':
+            for tok in old_tokens[i1:i2]:
+                old_parts.append(_highlight(tok, removed_bg))
+        elif op == 'insert':
+            for tok in new_tokens[j1:j2]:
+                new_parts.append(_highlight(tok, added_bg))
+
+    old_html = f'<span style="color: {text_css};">{"".join(old_parts)}</span>'
+    new_html = f'<span style="color: {text_css};">{"".join(new_parts)}</span>'
+    return old_html, new_html
+
+
+def create_diff_document(html, font):
+    """Create a QTextDocument configured for rendering diff HTML.
+
+    Args:
+        html: HTML string with diff markup.
+        font: QFont to use for the document.
+
+    Returns:
+        A QTextDocument ready for painting.
+    """
+    doc = QtGui.QTextDocument()
+    doc.setDefaultFont(font)
+    doc.setDocumentMargin(2)
+    doc.setHtml(html)
+    return doc

--- a/picard/ui/metadatabox/tagdiff.py
+++ b/picard/ui/metadatabox/tagdiff.py
@@ -217,7 +217,7 @@ class TagDiff:
     OLD_VALUE = 'old'
     REMOVED_VALUE = 'removed'
 
-    __slots__ = ('tag_names', 'new', 'old', 'status', 'objects', 'tag_ne_handlers', 'removed_tags')
+    __slots__ = ('tag_names', 'new', 'old', 'status', 'objects', 'tag_ne_handlers', 'removed_tags', 'diff_html')
 
     def __init__(self, max_length_diff=2):
         """
@@ -233,6 +233,7 @@ class TagDiff:
         self.status = defaultdict(lambda: TagStatus.NONE)
         self.objects = 0
         self.removed_tags = set()
+        self.diff_html = {}
         self.tag_ne_handlers = defaultdict(lambda: lambda old, new: old != new)
         # handling the special case of '~length'
         max_length_delta_ms = max_length_diff * 1000

--- a/picard/ui/metadatabox/tagdiffhtml.py
+++ b/picard/ui/metadatabox/tagdiffhtml.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Hybrid word/character-level diff computation for tag values.
+
+This module contains the pure diff logic without any Qt dependency.
+It tokenizes text, computes diffs, and produces HTML markup strings
+that can be rendered by the UI layer.
+
+Strategy:
+1. Tokenize both texts into words, punctuation, and whitespace.
+2. Diff at the token level using SequenceMatcher.
+3. For replaced token pairs that are similar enough (ratio >= threshold),
+   refine with character-level diff within the token.
+4. For dissimilar replaced tokens, highlight the entire token.
+"""
+
+from difflib import SequenceMatcher
+from html import escape
+import re
+
+
+# If two replaced tokens have a similarity ratio at or above this threshold,
+# show character-level diff within the token. Below this, highlight the
+# entire token as changed.
+CHAR_DIFF_RATIO_THRESHOLD = 0.5
+
+# Split text into tokens: runs of word characters, or individual non-word
+# characters (punctuation, symbols), or whitespace runs.
+# This ensures punctuation is a separate token from the word it's attached to,
+# e.g. "Rock'n'Roll!" -> ["Rock", "'", "n", "'", "Roll", "!"]
+_TOKEN_RE = re.compile(r"(\w+|[^\w\s]|\s+)")
+
+
+def tokenize(text: str) -> list[str]:
+    """Split text into tokens: words, punctuation, and whitespace separately.
+
+    Args:
+        text: The input string to tokenize.
+
+    Returns:
+        A list of token strings.
+    """
+    return _TOKEN_RE.findall(text)
+
+
+def _highlight(text: str, bg_color: str) -> str:
+    """Wrap escaped text in a colored background span.
+
+    Args:
+        text: The raw text to highlight.
+        bg_color: CSS color value for the background.
+
+    Returns:
+        An HTML span string with the text escaped and highlighted.
+    """
+    return f'<span style="background-color: {bg_color};">{escape(text)}</span>'
+
+
+def _char_diff_within_token(
+    old_token: str,
+    new_token: str,
+    removed_bg: str,
+    added_bg: str,
+) -> tuple[str, str]:
+    """Compute character-level diff within a pair of similar tokens.
+
+    Args:
+        old_token: The original token string.
+        new_token: The new token string.
+        removed_bg: CSS color for removed character background.
+        added_bg: CSS color for added character background.
+
+    Returns:
+        Tuple (old_html, new_html) with per-character highlights.
+    """
+    matcher = SequenceMatcher(None, old_token, new_token)
+    old_parts: list[str] = []
+    new_parts: list[str] = []
+
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == 'equal':
+            chunk = escape(old_token[i1:i2])
+            old_parts.append(chunk)
+            new_parts.append(chunk)
+        elif op == 'replace':
+            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
+            new_parts.append(_highlight(new_token[j1:j2], added_bg))
+        elif op == 'delete':
+            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
+        elif op == 'insert':
+            new_parts.append(_highlight(new_token[j1:j2], added_bg))
+
+    return ''.join(old_parts), ''.join(new_parts)
+
+
+def _process_replace(
+    old_tokens: list[str],
+    new_tokens: list[str],
+    removed_bg: str,
+    added_bg: str,
+    old_parts: list[str],
+    new_parts: list[str],
+    threshold: float = CHAR_DIFF_RATIO_THRESHOLD,
+) -> None:
+    """Process a 'replace' opcode from the token-level diff.
+
+    Pairs up tokens positionally. For each pair, if the tokens are similar
+    enough (ratio >= threshold), applies character-level diff; otherwise
+    highlights the whole token.
+    Leftover unpaired tokens are fully highlighted.
+
+    Args:
+        old_tokens: List of old tokens in the replaced range.
+        new_tokens: List of new tokens in the replaced range.
+        removed_bg: CSS color for removed token background.
+        added_bg: CSS color for added token background.
+        old_parts: Accumulator list for old HTML parts (mutated in place).
+        new_parts: Accumulator list for new HTML parts (mutated in place).
+        threshold: Similarity ratio threshold for character-level refinement.
+    """
+    pairs = min(len(old_tokens), len(new_tokens))
+    for old_tok, new_tok in zip(old_tokens[:pairs], new_tokens[:pairs], strict=True):
+        sm = SequenceMatcher(None, old_tok, new_tok)
+        # quick_ratio() is an upper bound; if even that is below threshold,
+        # skip the expensive full ratio() computation.
+        if sm.quick_ratio() >= threshold and sm.ratio() >= threshold:
+            old_html, new_html = _char_diff_within_token(old_tok, new_tok, removed_bg, added_bg)
+            old_parts.append(old_html)
+            new_parts.append(new_html)
+        else:
+            old_parts.append(_highlight(old_tok, removed_bg))
+            new_parts.append(_highlight(new_tok, added_bg))
+    # Leftover unpaired tokens on either side
+    old_parts.extend(_highlight(tok, removed_bg) for tok in old_tokens[pairs:])
+    new_parts.extend(_highlight(tok, added_bg) for tok in new_tokens[pairs:])
+
+
+def compute_diff(
+    old_text: str,
+    new_text: str,
+    removed_bg: str,
+    added_bg: str,
+    text_color: str,
+    threshold: float = CHAR_DIFF_RATIO_THRESHOLD,
+) -> tuple[str | None, str | None]:
+    """Compute a hybrid word/character-level diff and return (old_html, new_html).
+
+    This is the main entry point for diff computation. It takes raw CSS color
+    strings so it has no dependency on Qt or the color configuration system.
+
+    Args:
+        old_text: The original text string.
+        new_text: The new text string.
+        removed_bg: CSS color for removed/deleted highlights.
+        added_bg: CSS color for added/inserted highlights.
+        text_color: CSS color for the base text.
+        threshold: Similarity ratio threshold for character-level refinement
+                   within replaced tokens.
+
+    Returns:
+        A tuple (old_html, new_html) with highlighted differences.
+        Returns (None, None) if inputs are identical.
+    """
+    if old_text == new_text:
+        return None, None
+
+    old_tokens = tokenize(old_text)
+    new_tokens = tokenize(new_text)
+
+    matcher = SequenceMatcher(None, old_tokens, new_tokens)
+    old_parts: list[str] = []
+    new_parts: list[str] = []
+
+    for op, i1, i2, j1, j2 in matcher.get_opcodes():
+        if op == 'equal':
+            chunk = escape(''.join(old_tokens[i1:i2]))
+            old_parts.append(chunk)
+            new_parts.append(chunk)
+        elif op == 'replace':
+            _process_replace(
+                old_tokens[i1:i2],
+                new_tokens[j1:j2],
+                removed_bg,
+                added_bg,
+                old_parts,
+                new_parts,
+                threshold,
+            )
+        elif op == 'delete':
+            old_parts.extend(_highlight(tok, removed_bg) for tok in old_tokens[i1:i2])
+        elif op == 'insert':
+            new_parts.extend(_highlight(tok, added_bg) for tok in new_tokens[j1:j2])
+
+    old_html = f'<span style="color: {text_color};">{"".join(old_parts)}</span>'
+    new_html = f'<span style="color: {text_color};">{"".join(new_parts)}</span>'
+    return old_html, new_html

--- a/picard/ui/metadatabox/tagdiffhtml.py
+++ b/picard/ui/metadatabox/tagdiffhtml.py
@@ -44,9 +44,13 @@ CHAR_DIFF_RATIO_THRESHOLD = 0.5
 
 # Split text into tokens: runs of word characters, or individual non-word
 # characters (punctuation, symbols), or whitespace runs.
+# CJK ideographs are split as individual characters since each character
+# is semantically a word in Chinese/Japanese kanji.
 # This ensures punctuation is a separate token from the word it's attached to,
 # e.g. "Rock'n'Roll!" -> ["Rock", "'", "n", "'", "Roll", "!"]
-_TOKEN_RE = re.compile(r"(\w+|[^\w\s]|\s+)")
+# e.g. "周杰倫" -> ["周", "杰", "倫"]
+_CJK_IDEOGRAPH = r'[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\U00020000-\U0002a6df]'
+_TOKEN_RE = re.compile(rf"({_CJK_IDEOGRAPH}|\w+|[^\w\s]|\s+)")
 
 
 def tokenize(text: str) -> list[str]:

--- a/picard/ui/metadatabox/tagdiffhtml.py
+++ b/picard/ui/metadatabox/tagdiffhtml.py
@@ -87,6 +87,31 @@ def _wrap_diff(content: str, text_color: str) -> str:
     return f'<span style="color: {text_color}; white-space: pre;">{content}</span>'
 
 
+def _common_prefix_len(a: str, b: str) -> int:
+    """Return the length of the common prefix of two strings."""
+    max_len = min(len(a), len(b))
+    for i in range(max_len):
+        if a[i] != b[i]:
+            return i
+    return max_len
+
+
+def _common_suffix_len(a: str, b: str, prefix_len: int) -> int:
+    """Return the length of the common suffix of two strings.
+
+    Args:
+        a: First string.
+        b: Second string.
+        prefix_len: Length of the already-matched common prefix,
+                    to avoid overlapping.
+    """
+    max_len = min(len(a), len(b)) - prefix_len
+    for i in range(1, max_len + 1):
+        if a[-i] != b[-i]:
+            return i - 1
+    return max_len
+
+
 def _char_diff_within_token(
     old_token: str,
     new_token: str,
@@ -95,6 +120,11 @@ def _char_diff_within_token(
 ) -> tuple[str, str]:
     """Compute character-level diff within a pair of similar tokens.
 
+    Uses the common prefix/suffix approach (like git's diff-highlight):
+    find the common prefix and suffix, and highlight everything in the
+    middle as changed. This avoids confusing results from SequenceMatcher
+    on short strings with transpositions (e.g. "10" vs "09").
+
     Args:
         old_token: The original token string.
         new_token: The new token string.
@@ -102,26 +132,31 @@ def _char_diff_within_token(
         added_bg: CSS color for added character background.
 
     Returns:
-        Tuple (old_html, new_html) with per-character highlights.
+        Tuple (old_html, new_html) with highlighted differences.
     """
-    matcher = SequenceMatcher(None, old_token, new_token)
-    old_parts: list[str] = []
-    new_parts: list[str] = []
+    prefix_len = _common_prefix_len(old_token, new_token)
+    suffix_len = _common_suffix_len(old_token, new_token, prefix_len)
 
-    for op, i1, i2, j1, j2 in matcher.get_opcodes():
-        if op == 'equal':
-            chunk = escape(old_token[i1:i2])
-            old_parts.append(chunk)
-            new_parts.append(chunk)
-        elif op == 'replace':
-            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
-            new_parts.append(_highlight(new_token[j1:j2], added_bg))
-        elif op == 'delete':
-            old_parts.append(_highlight(old_token[i1:i2], removed_bg))
-        elif op == 'insert':
-            new_parts.append(_highlight(new_token[j1:j2], added_bg))
+    # -suffix_len works as a slice end when suffix_len > 0;
+    # when suffix_len == 0, -0 == 0 (falsy), so `or None` means "to end".
+    end = -suffix_len or None
+    prefix = escape(old_token[:prefix_len])
+    suffix = escape(old_token[end:]) if suffix_len else ""
 
-    return ''.join(old_parts), ''.join(new_parts)
+    old_middle = old_token[prefix_len:end]
+    new_middle = new_token[prefix_len:end]
+
+    old_html = prefix
+    if old_middle:
+        old_html += _highlight(old_middle, removed_bg)
+    old_html += suffix
+
+    new_html = prefix
+    if new_middle:
+        new_html += _highlight(new_middle, added_bg)
+    new_html += suffix
+
+    return old_html, new_html
 
 
 def _process_replace(

--- a/picard/ui/metadatabox/tagdiffhtml.py
+++ b/picard/ui/metadatabox/tagdiffhtml.py
@@ -74,6 +74,19 @@ def _highlight(text: str, bg_color: str) -> str:
     return f'<span style="background-color: {bg_color};">{escape(text)}</span>'
 
 
+def _wrap_diff(content: str, text_color: str) -> str:
+    """Wrap diff content in an outer span with text color and preserved whitespace.
+
+    Args:
+        content: The inner HTML content (already escaped/highlighted).
+        text_color: CSS color for the text.
+
+    Returns:
+        An HTML span string with color and white-space: pre.
+    """
+    return f'<span style="color: {text_color}; white-space: pre;">{content}</span>'
+
+
 def _char_diff_within_token(
     old_token: str,
     new_token: str,
@@ -209,8 +222,8 @@ def compute_diff(
         elif op == 'insert':
             new_parts.extend(_highlight(tok, added_bg) for tok in new_tokens[j1:j2])
 
-    old_html = f'<span style="color: {text_color};">{"".join(old_parts)}</span>'
-    new_html = f'<span style="color: {text_color};">{"".join(new_parts)}</span>'
+    old_html = _wrap_diff("".join(old_parts), text_color)
+    new_html = _wrap_diff("".join(new_parts), text_color)
     return old_html, new_html
 
 
@@ -239,6 +252,6 @@ def highlight_full(
     """
     if old_text == new_text:
         return None, None
-    old_html = f'<span style="color: {text_color};">{_highlight(old_text, removed_bg)}</span>'
-    new_html = f'<span style="color: {text_color};">{_highlight(new_text, added_bg)}</span>'
+    old_html = _wrap_diff(_highlight(old_text, removed_bg), text_color)
+    new_html = _wrap_diff(_highlight(new_text, added_bg), text_color)
     return old_html, new_html

--- a/picard/ui/metadatabox/tagdiffhtml.py
+++ b/picard/ui/metadatabox/tagdiffhtml.py
@@ -212,3 +212,33 @@ def compute_diff(
     old_html = f'<span style="color: {text_color};">{"".join(old_parts)}</span>'
     new_html = f'<span style="color: {text_color};">{"".join(new_parts)}</span>'
     return old_html, new_html
+
+
+def highlight_full(
+    old_text: str,
+    new_text: str,
+    removed_bg: str,
+    added_bg: str,
+    text_color: str,
+) -> tuple[str | None, str | None]:
+    """Highlight the entire old and new strings as fully replaced.
+
+    Used for opaque values (MBIDs, etc.) or completely different strings
+    where character-level diff is meaningless.
+
+    Args:
+        old_text: The original text string.
+        new_text: The new text string.
+        removed_bg: CSS color for the removed highlight background.
+        added_bg: CSS color for the added highlight background.
+        text_color: CSS color for the base text.
+
+    Returns:
+        A tuple (old_html, new_html) with full-string highlights.
+        Returns (None, None) if inputs are identical.
+    """
+    if old_text == new_text:
+        return None, None
+    old_html = f'<span style="color: {text_color};">{_highlight(old_text, removed_bg)}</span>'
+    new_html = f'<span style="color: {text_color};">{_highlight(new_text, added_bg)}</span>'
+    return old_html, new_html

--- a/test/test_tagdiffhtml.py
+++ b/test/test_tagdiffhtml.py
@@ -22,6 +22,7 @@ from test.picardtestcase import PicardTestCase
 
 from picard.ui.metadatabox.tagdiffhtml import (
     compute_diff,
+    highlight_full,
     tokenize,
 )
 
@@ -154,3 +155,70 @@ class TestComputeDiff(PicardTestCase):
         self.assertNotIn("<style>", new_html)
         self.assertIn("&lt;", old_html)
         self.assertIn("&gt;", old_html)
+
+
+class TestHighlightFull(PicardTestCase):
+    def test_identical_strings_returns_none(self):
+        result = highlight_full("same", "same", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(result, (None, None))
+
+    def test_empty_strings_returns_none(self):
+        result = highlight_full("", "", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(result, (None, None))
+
+    def test_full_highlight_both(self):
+        old_html, new_html = highlight_full("abc-123-def", "xyz-789-ghi", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Old value entirely highlighted with removed color
+        self.assertEqual(old_html, _wrap(_hl_removed("abc-123-def")))
+        # New value entirely highlighted with added color
+        self.assertEqual(new_html, _wrap(_hl_added("xyz-789-ghi")))
+
+    def test_old_empty_new_highlighted(self):
+        # Simulates an added tag (no old value)
+        old_html, new_html = highlight_full("", "new value", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Old is an empty highlight span
+        self.assertEqual(old_html, _wrap(_hl_removed("")))
+        # New value fully highlighted
+        self.assertEqual(new_html, _wrap(_hl_added("new value")))
+
+    def test_new_empty_old_highlighted(self):
+        # Simulates a removed tag (no new value)
+        old_html, new_html = highlight_full("old value", "", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Old value fully highlighted
+        self.assertEqual(old_html, _wrap(_hl_removed("old value")))
+        # New is an empty highlight span
+        self.assertEqual(new_html, _wrap(_hl_added("")))
+
+    def test_html_escaping(self):
+        old_html, new_html = highlight_full("<b>old</b>", "<i>new</i>", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertNotIn("<b>", old_html)
+        self.assertNotIn("<i>", new_html)
+        self.assertIn("&lt;b&gt;", old_html)
+        self.assertIn("&lt;i&gt;", new_html)
+
+
+class TestComputeDiffEdgeCases(PicardTestCase):
+    def test_old_empty_new_has_value(self):
+        old_html, new_html = compute_diff("", "added text", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Everything in new should be highlighted as added
+        self.assertIn(_hl_added("added"), new_html)
+        self.assertIn(_hl_added("text"), new_html)
+
+    def test_old_has_value_new_empty(self):
+        old_html, new_html = compute_diff("removed text", "", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Everything in old should be highlighted as removed
+        self.assertIn(_hl_removed("removed"), old_html)
+        self.assertIn(_hl_removed("text"), old_html)
+
+    def test_whitespace_only_change(self):
+        old_html, new_html = compute_diff("a  b", "a b", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # The extra space in old should be highlighted as removed
+        self.assertIn(REMOVED_BG, old_html)
+        # The words should not be highlighted
+        self.assertNotIn(_hl_removed("a"), old_html)
+        self.assertNotIn(_hl_removed("b"), old_html)
+
+    def test_single_char_change(self):
+        old_html, new_html = compute_diff("a", "b", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(old_html, _wrap(_hl_removed("a")))
+        self.assertEqual(new_html, _wrap(_hl_added("b")))

--- a/test/test_tagdiffhtml.py
+++ b/test/test_tagdiffhtml.py
@@ -66,6 +66,21 @@ class TestTokenize(PicardTestCase):
             ["Hello", ",", " ", "world", "!", " ", "(", "test", ")"],
         )
 
+    def test_cjk_characters_split_individually(self):
+        self.assertEqual(tokenize("周杰倫"), ["周", "杰", "倫"])
+
+    def test_cjk_mixed_with_latin(self):
+        self.assertEqual(
+            tokenize("周杰倫 Jay Chou"),
+            ["周", "杰", "倫", " ", "Jay", " ", "Chou"],
+        )
+
+    def test_cjk_with_punctuation(self):
+        self.assertEqual(
+            tokenize("周杰倫feat.蔡依林"),
+            ["周", "杰", "倫", "feat", ".", "蔡", "依", "林"],
+        )
+
 
 class TestComputeDiff(PicardTestCase):
     def test_identical_strings_returns_none(self):
@@ -237,3 +252,13 @@ class TestComputeDiffEdgeCases(PicardTestCase):
         old_html, new_html = highlight_full("3:30", "4:06", REMOVED_BG, ADDED_BG, TEXT_COLOR)
         self.assertEqual(old_html, _wrap(_hl_removed("3:30")))
         self.assertEqual(new_html, _wrap(_hl_added("4:06")))
+
+    def test_cjk_single_character_change(self):
+        # "周杰倫" vs "周杰伦" - last character differs (traditional vs simplified)
+        old_html, new_html = compute_diff("周杰倫", "周杰伦", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # "周" and "杰" should be common (not highlighted)
+        self.assertIn("周", old_html)
+        self.assertIn("杰", old_html)
+        # "倫" vs "伦" should be highlighted
+        self.assertIn(_hl_removed("倫"), old_html)
+        self.assertIn(_hl_added("伦"), new_html)

--- a/test/test_tagdiffhtml.py
+++ b/test/test_tagdiffhtml.py
@@ -41,7 +41,7 @@ def _hl_added(text: str) -> str:
 
 
 def _wrap(inner: str) -> str:
-    return f'<span style="color: {TEXT_COLOR};">{inner}</span>'
+    return f'<span style="color: {TEXT_COLOR}; white-space: pre;">{inner}</span>'
 
 
 class TestTokenize(PicardTestCase):

--- a/test/test_tagdiffhtml.py
+++ b/test/test_tagdiffhtml.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.metadatabox.tagdiffhtml import (
+    compute_diff,
+    tokenize,
+)
+
+
+REMOVED_BG = 'rgba(255, 0, 0, 60)'
+ADDED_BG = 'rgba(0, 255, 0, 60)'
+TEXT_COLOR = '#b8860b'
+
+
+def _hl_removed(text: str) -> str:
+    return f'<span style="background-color: {REMOVED_BG};">{text}</span>'
+
+
+def _hl_added(text: str) -> str:
+    return f'<span style="background-color: {ADDED_BG};">{text}</span>'
+
+
+def _wrap(inner: str) -> str:
+    return f'<span style="color: {TEXT_COLOR};">{inner}</span>'
+
+
+class TestTokenize(PicardTestCase):
+    def test_simple_words(self):
+        self.assertEqual(tokenize("hello world"), ["hello", " ", "world"])
+
+    def test_punctuation_separated(self):
+        self.assertEqual(tokenize("Rock'n'Roll!"), ["Rock", "'", "n", "'", "Roll", "!"])
+
+    def test_whitespace_preserved(self):
+        self.assertEqual(tokenize("a  b"), ["a", "  ", "b"])
+
+    def test_empty_string(self):
+        self.assertEqual(tokenize(""), [])
+
+    def test_unicode(self):
+        self.assertEqual(tokenize("Björk"), ["Björk"])
+
+    def test_mixed_punctuation_and_words(self):
+        self.assertEqual(
+            tokenize("Hello, world! (test)"),
+            ["Hello", ",", " ", "world", "!", " ", "(", "test", ")"],
+        )
+
+
+class TestComputeDiff(PicardTestCase):
+    def test_identical_strings_returns_none(self):
+        result = compute_diff("same", "same", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(result, (None, None))
+
+    def test_empty_strings_returns_none(self):
+        result = compute_diff("", "", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(result, (None, None))
+
+    def test_completely_different_words(self):
+        old_html, new_html = compute_diff("Mitchell", "Johnson", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Words are too dissimilar (ratio < 0.5), entire tokens highlighted
+        self.assertEqual(old_html, _wrap(_hl_removed("Mitchell")))
+        self.assertEqual(new_html, _wrap(_hl_added("Johnson")))
+
+    def test_similar_word_char_diff(self):
+        # "Mitchell" vs "Mitchel" - similar enough for char-level diff
+        old_html, new_html = compute_diff("Mitchell", "Mitchel", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # Should show char-level diff: the extra 'l' at the end is removed
+        self.assertIn("Mitche", old_html)
+        self.assertIn("Mitche", new_html)
+        # The removed 'll' vs 'l' should be highlighted
+        self.assertIn(REMOVED_BG, old_html)
+
+    def test_apostrophe_change(self):
+        # Typographic apostrophe replacement: only the quote chars differ
+        old_html, new_html = compute_diff("Rock'n'Roll", "Rock\u2019n\u2019Roll", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # "Rock" and "Roll" and "n" should not be highlighted
+        self.assertIn("Rock", old_html)
+        self.assertIn("Roll", old_html)
+        # The apostrophes should be highlighted (escape() converts ' to &#x27;)
+        self.assertIn(_hl_removed("&#x27;"), old_html)
+        self.assertIn(_hl_added("\u2019"), new_html)
+
+    def test_word_added(self):
+        old_html, new_html = compute_diff("The Beatles", "The Fab Beatles", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # "Fab " is added in new
+        self.assertIn(_hl_added("Fab"), new_html)
+        # "The" and "Beatles" should appear unchanged in both
+        self.assertIn("The", old_html)
+        self.assertIn("Beatles", old_html)
+        self.assertIn("The", new_html)
+        self.assertIn("Beatles", new_html)
+
+    def test_word_removed(self):
+        old_html, new_html = compute_diff("The Fab Beatles", "The Beatles", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # "Fab " is removed from old
+        self.assertIn(_hl_removed("Fab"), old_html)
+        self.assertIn("The", new_html)
+        self.assertIn("Beatles", new_html)
+
+    def test_multi_value_joiner(self):
+        # Simulating multi-valued tag joined with "; "
+        old_html, new_html = compute_diff(
+            "Artist A; Artist B",
+            "Artist A; Artist C",
+            REMOVED_BG,
+            ADDED_BG,
+            TEXT_COLOR,
+        )
+        # "Artist A; Artist " should be common
+        self.assertIn("Artist", old_html)
+        # "B" vs "C" should be highlighted
+        self.assertIn(REMOVED_BG, old_html)
+        self.assertIn(ADDED_BG, new_html)
+
+    def test_custom_threshold(self):
+        # With threshold=1.0, even similar words get full highlight
+        old_html, new_html = compute_diff(
+            "Mitchell",
+            "Mitchel",
+            REMOVED_BG,
+            ADDED_BG,
+            TEXT_COLOR,
+            threshold=1.0,
+        )
+        # Entire word should be highlighted since ratio < 1.0
+        self.assertEqual(old_html, _wrap(_hl_removed("Mitchell")))
+        self.assertEqual(new_html, _wrap(_hl_added("Mitchel")))
+
+    def test_html_escaping(self):
+        # Ensure special characters are escaped
+        old_html, new_html = compute_diff("<script>", "<style>", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # No raw < or > in output (they should be escaped)
+        self.assertNotIn("<script>", old_html)
+        self.assertNotIn("<style>", new_html)
+        self.assertIn("&lt;", old_html)
+        self.assertIn("&gt;", old_html)

--- a/test/test_tagdiffhtml.py
+++ b/test/test_tagdiffhtml.py
@@ -222,3 +222,18 @@ class TestComputeDiffEdgeCases(PicardTestCase):
         old_html, new_html = compute_diff("a", "b", REMOVED_BG, ADDED_BG, TEXT_COLOR)
         self.assertEqual(old_html, _wrap(_hl_removed("a")))
         self.assertEqual(new_html, _wrap(_hl_added("b")))
+
+    def test_formatted_time_diff(self):
+        # Simulates ~length handling: formatted time strings like "4:05" vs "4:06"
+        old_html, new_html = compute_diff("4:05", "4:06", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        # The "4:" prefix is common, only "05" vs "06" differs
+        self.assertIn("4", old_html)
+        self.assertIn("4", new_html)
+        self.assertIn(REMOVED_BG, old_html)
+        self.assertIn(ADDED_BG, new_html)
+
+    def test_formatted_time_full_diff(self):
+        # Very different times get full highlight
+        old_html, new_html = highlight_full("3:30", "4:06", REMOVED_BG, ADDED_BG, TEXT_COLOR)
+        self.assertEqual(old_html, _wrap(_hl_removed("3:30")))
+        self.assertEqual(new_html, _wrap(_hl_added("4:06")))


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add word/character-level diff highlighting to the metadata box. Changed tag values now show exactly which parts differ using colored background highlights, making it much easier to spot changes in long tag values.

## Problem

* JIRA ticket: PICARD-1164
* Related: PICARD-1163 (partially addressed)

When tag values change, the metadata box shows the old and new values side by side, but for long values (e.g. artist names, titles) it's hard to see exactly what part changed. The entire row was colored in a status color (golden for changed, red for removed, green for added) without indicating which specific characters or words differ.

## Solution

A hybrid word/character-level diff highlighting system:

1. **Placeholder color for unchanged values** — New Value column uses muted/placeholder text when unchanged, reducing visual noise.
2. **Hybrid diff algorithm** — Tokenizes into words, punctuation, and whitespace. Diffs at token level first, then refines with character-level diff within similar tokens (ratio >= 0.5). This handles both word-level changes (artist reordering) and subtle character changes (typographic apostrophes).
3. **Full-string highlight for opaque identifiers** — MBIDs/AcoustIDs get full red/green background since char-level diff is meaningless for UUIDs.
4. **Status color on tag name only** — The tag name column carries the status color (golden/red/green) for quick scanning; value columns use normal text with background highlights.
5. **Removed tags** — Old value with red background, new column empty (no more strikethrough).
6. **Added tags** — New value with green background.
7. **Whitespace preservation** — Uses `white-space: pre` in HTML so extra spaces are visible.
8. **Dark theme support** — Higher highlight alpha (90) for dark theme, lower (60) for light.
9. **Background thread** — Diff computation runs in the background thread pool, keeping the UI responsive.

Architecture:
- `tagdiffhtml.py` — Pure diff logic, no Qt dependency, fully testable (26 tests)
- `difftextdocument.py` — Thin Qt display layer (color resolution, QTextDocument creation)
- `__init__.py` — Delegate paint override + integration in `_update_items`

Dark theme:
<img width="739" height="272" alt="image" src="https://github.com/user-attachments/assets/6a8d1cae-ec4f-4f9d-bf93-a689d03ea38a" />

Light theme:
<img width="792" height="274" alt="image" src="https://github.com/user-attachments/assets/e5713304-a2ff-4c84-8103-cfbfbf5b7def" />

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed iteratively using Kiro CLI (Claude) with continuous human review and testing at each step. All design decisions (hybrid diff approach, color strategy, MBID handling, dark theme, whitespace preservation) were driven by human feedback on visual results.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
