### PR TITLE
PICARD-3349: Fix copy of deleted tags in metadata box

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -310,10 +310,18 @@ class MetadataBox(QtWidgets.QTableWidget):
         for item in items:
             tag, value = self._get_row_info(item.row())
             col = item.column()
+            removed = self.tag_diff.tag_status(tag) == TagStatus.REMOVED
+            # Don't copy the displayed value for removed tags in the new column,
+            # as it does not represent the actual new state.
+            if col == self.COLUMN_NEW and removed:
+                new = None
+            else:
+                new = value[self.COLUMN_NEW] if col == self.COLUMN_NEW else None
             result.add(
                 tag=tag,
                 old=value[self.COLUMN_ORIG] if col == self.COLUMN_ORIG else None,
-                new=value[self.COLUMN_NEW] if col == self.COLUMN_NEW else None,
+                new=new,
+                removed=removed if col == self.COLUMN_NEW else False,
                 removable=self.tag_diff.status[tag] != TagStatus.NOTREMOVABLE,
                 readonly=self.tag_diff.status[tag] == TagStatus.READONLY,
             )
@@ -373,7 +381,9 @@ class MetadataBox(QtWidgets.QTableWidget):
                 else:
                     tag, value = self._get_row_info(item.row())
                     value = value[column]
-                    if tag == '~length':
+                    if column == self.COLUMN_NEW and self.tag_diff.tag_status(tag) == TagStatus.REMOVED:
+                        value = []
+                    elif tag == '~length':
                         value = self.tag_diff.handle_length(value, prettify_times=True)
                     if value is not None:
                         log.debug("Copying '%s' to clipboard (from tag '%s')", value, tag)
@@ -390,6 +400,10 @@ class MetadataBox(QtWidgets.QTableWidget):
         def _apply_tag_dict(data):
             for tag in data:
                 if self._tag_is_editable(tag):
+                    if data[tag].get(TagDiff.REMOVED_VALUE) is True:
+                        log.info("Removing tag '%s' from JSON clipboard paste", tag)
+                        yield from self._set_tag_values_delayed_updates(tag, [])
+                        continue
                     # Prefer 'new' values, but fall back to 'old' if not available
                     value = data[tag].get(TagDiff.NEW_VALUE) or data[tag].get(TagDiff.OLD_VALUE)
                     if value:

--- a/picard/ui/metadatabox/tagdiff.py
+++ b/picard/ui/metadatabox/tagdiff.py
@@ -215,8 +215,9 @@ class TagDiff:
 
     NEW_VALUE = 'new'
     OLD_VALUE = 'old'
+    REMOVED_VALUE = 'removed'
 
-    __slots__ = ('tag_names', 'new', 'old', 'status', 'objects', 'tag_ne_handlers')
+    __slots__ = ('tag_names', 'new', 'old', 'status', 'objects', 'tag_ne_handlers', 'removed_tags')
 
     def __init__(self, max_length_diff=2):
         """
@@ -231,6 +232,7 @@ class TagDiff:
         self.old = TagCounter(self)
         self.status = defaultdict(lambda: TagStatus.NONE)
         self.objects = 0
+        self.removed_tags = set()
         self.tag_ne_handlers = defaultdict(lambda: lambda old, new: old != new)
         # handling the special case of '~length'
         max_length_delta_ms = max_length_diff * 1000
@@ -286,15 +288,19 @@ class TagDiff:
 
         if (old and not new) or removed:
             self.status[tag] |= TagStatus.REMOVED
-        elif new and not old:
-            self.status[tag] |= TagStatus.ADDED
-            removable = True
-        elif old and new and self.__tag_ne(tag, old, new):
-            self.status[tag] |= TagStatus.CHANGED
-        elif not (old or new or tag in top_tags):
-            self.status[tag] |= TagStatus.EMPTY
+            if removed:
+                self.removed_tags.add(tag)
         else:
-            self.status[tag] |= TagStatus.UNCHANGED
+            self.removed_tags.discard(tag)
+            if new and not old:
+                self.status[tag] |= TagStatus.ADDED
+                removable = True
+            elif old and new and self.__tag_ne(tag, old, new):
+                self.status[tag] |= TagStatus.CHANGED
+            elif not (old or new or tag in top_tags):
+                self.status[tag] |= TagStatus.EMPTY
+            else:
+                self.status[tag] |= TagStatus.UNCHANGED
 
         if not removable:
             self.status[tag] |= TagStatus.NOTREMOVABLE
@@ -332,7 +338,7 @@ class TagDiff:
             changes_first (bool): Whether to display changed tags first.
             top_tags (set): Set of tags to always be displayed at the top.
         """
-        all_tags = set(list(self.old) + list(self.new))
+        all_tags = set(list(self.old) + list(self.new) + list(self.removed_tags))
         common_tags = [tag for tag in top_tags if tag in all_tags] if top_tags else []
         tag_names = common_tags + sorted(all_tags.difference(common_tags), key=lambda x: display_tag_name(x).lower())
 
@@ -355,6 +361,8 @@ class TagDiff:
                 result[tag][self.OLD_VALUE] = self.old[tag]
             if tag in self.new:
                 result[tag][self.NEW_VALUE] = self.new[tag]
+            if tag in self.removed_tags:
+                result[tag][self.REMOVED_VALUE] = True
 
         return json.dumps(result)
 

--- a/test/test_metadatabox_copypaste.py
+++ b/test/test_metadatabox_copypaste.py
@@ -352,3 +352,78 @@ class MetadataBoxCopyPasteTest(PicardTestCase):
         data = json.loads(md.data(MetadataBox.MIMETYPE_PICARD_TAGS).data())
         self.assertEqual(data['artist']['new'], ['NA'])
         self.assertEqual(data['title']['new'], ['NT'])
+
+    def _add_tags_extended(self, *tags):
+        """Set up tag_diff with full control. tags: dict with keys: name, old, new, readonly, removed."""
+        td = TagDiff()
+        for entry in tags:
+            td.add(
+                entry['name'],
+                old=entry.get('old'),
+                new=entry.get('new'),
+                readonly=entry.get('readonly', False),
+                removed=entry.get('removed', False),
+            )
+        td.objects += 1
+        td.update_tag_names()
+        self.box.tag_diff = td
+
+    # ── copy removed tags ──
+
+    def test_copy_single_removed_tag_new_column(self):
+        """Copying the new column of a removed tag should copy empty string."""
+        self._add_tags_extended(
+            {'name': 'artist', 'old': ['Old Artist'], 'new': ['Old Artist'], 'removed': True},
+        )
+        self._select_tag('artist', MetadataBox.COLUMN_NEW)
+        self.box._copy_value()
+        self.tagger.clipboard().setText.assert_called_with('')
+
+    def test_copy_single_removed_tag_old_column(self):
+        """Copying the old column of a removed tag should copy the old value."""
+        self._add_tags_extended(
+            {'name': 'artist', 'old': ['Old Artist'], 'new': ['Old Artist'], 'removed': True},
+        )
+        self._select_tag('artist', MetadataBox.COLUMN_ORIG)
+        self.box._copy_value()
+        self.tagger.clipboard().setText.assert_called_with('Old Artist')
+
+    def test_copy_multiple_tags_with_removed(self):
+        """Multi-tag copy should include removed flag in JSON and exclude new value."""
+        self._add_tags_extended(
+            {'name': 'artist', 'old': ['OA'], 'new': ['OA'], 'removed': True},
+            {'name': 'title', 'old': ['OT'], 'new': ['NT']},
+        )
+        self.box.set_selected(
+            [
+                (self._row('artist'), MetadataBox.COLUMN_NEW),
+                (self._row('title'), MetadataBox.COLUMN_NEW),
+            ]
+        )
+        self.box._copy_value()
+        self.tagger.clipboard().setMimeData.assert_called_once()
+        md = self.tagger.clipboard().setMimeData.call_args[0][0]
+        data = json.loads(md.data(MetadataBox.MIMETYPE_PICARD_TAGS).data())
+        # Removed tag should have the removed flag and no new value
+        self.assertTrue(data['artist']['removed'])
+        self.assertNotIn('new', data['artist'])
+        # Normal tag should have its new value
+        self.assertEqual(data['title']['new'], ['NT'])
+
+    # ── paste removed tags ──
+
+    def test_paste_json_removed_tag(self):
+        """Pasting a tag marked as removed should delete it from metadata."""
+        self._add_tags(('artist', ['Old'], ['Cur']))
+        obj = self._make_obj()
+        obj.metadata['artist'] = ['Existing']
+        list(self.box._paste_from_json(self._json_mimedata({'artist': {'removed': True}})))
+        self.assertNotIn('artist', obj.metadata)
+
+    def test_paste_json_removed_with_old_value(self):
+        """Pasting a removed tag with old value should still delete it."""
+        self._add_tags(('artist', ['Old'], ['Cur']))
+        obj = self._make_obj()
+        obj.metadata['artist'] = ['Existing']
+        list(self.box._paste_from_json(self._json_mimedata({'artist': {'old': ['Old'], 'removed': True}})))
+        self.assertNotIn('artist', obj.metadata)

--- a/test/test_tagdiff.py
+++ b/test/test_tagdiff.py
@@ -362,3 +362,46 @@ class TestTagDiff(PicardTestCase):
         self.tag_diff.update_tag_names()
         tags = self.tag_diff.to_tsv(prettify_times=False)
         self.assertEqual(tags, '~length\t10000\t20000\r\n')
+
+    def test_removed_tag_to_json(self):
+        self.tag_diff.add("artist", old=["Artist 1"], removed=True)
+        self.tag_diff.update_tag_names()
+        tags = self.tag_diff.to_json()
+        self.assertEqual(tags, '{"artist": {"old": ["Artist 1"], "removed": true}}')
+
+    def test_removed_tag_no_values_to_json(self):
+        self.tag_diff.add("artist", removed=True)
+        self.tag_diff.update_tag_names()
+        tags = self.tag_diff.to_json()
+        self.assertEqual(tags, '{"artist": {"removed": true}}')
+
+    def test_removed_tag_to_tsv(self):
+        self.tag_diff.add("artist", old=["Artist 1"], removed=True)
+        self.tag_diff.update_tag_names()
+        tags = self.tag_diff.to_tsv()
+        self.assertEqual(tags, 'artist\tArtist 1\t\r\n')
+
+    def test_removed_tag_no_values_to_tsv(self):
+        self.tag_diff.add("artist", removed=True)
+        self.tag_diff.update_tag_names()
+        tags = self.tag_diff.to_tsv()
+        self.assertEqual(tags, 'artist\t\t\r\n')
+
+    def test_removed_tag_included_in_tag_names(self):
+        self.tag_diff.add("artist", removed=True)
+        self.tag_diff.update_tag_names()
+        self.assertIn("artist", self.tag_diff.tag_names)
+
+    def test_removed_tags_tracked(self):
+        self.tag_diff.add("artist", old=["Artist 1"], removed=True)
+        self.assertIn("artist", self.tag_diff.removed_tags)
+
+    def test_non_removed_tag_not_in_removed_tags(self):
+        self.tag_diff.add("artist", old=["Artist 1"])
+        self.assertNotIn("artist", self.tag_diff.removed_tags)
+
+    def test_removed_tag_discarded_on_subsequent_non_removed_add(self):
+        self.tag_diff.add("artist", old=["Artist 1"], removed=True)
+        self.assertIn("artist", self.tag_diff.removed_tags)
+        self.tag_diff.add("artist", old=["Artist 1"], new=["Artist 1"])
+        self.assertNotIn("artist", self.tag_diff.removed_tags)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix metadata box copy outputting old values for deleted tags instead of reflecting the actual removed state.

## Problem

* JIRA ticket: [PICARD-3349](https://tickets.metabrainz.org/browse/PICARD-3349)

When a tag is marked as deleted in the metadata box, the "new" column displays the old value with strikethrough to visually indicate the tag will be removed on save. However, when copying that cell (Ctrl+C), the clipboard receives the old value as if it were the actual new value. This also means pasting (within Picard via the internal JSON format) would set the tag to the old value rather than deleting it.

## Solution

- Add a `removed_tags` set to `TagDiff` to explicitly track tags marked for removal via the `removed=True` parameter (distinguishing from tags that merely have `old` without `new`).
- In `get_selected_tags()` and the single-item copy path: when copying the "new" column of a REMOVED tag, output empty instead of the displayed old value.
- Include a `"removed": true` flag in the JSON clipboard format so that paste can correctly delete the tag on the target.
- Handle the `removed` flag in `_paste_from_json()` to delete the tag rather than ignoring it.
- Discard tag from `removed_tags` if subsequently added without `removed=True` (multi-object consistency).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code and tests were developed with AI assistance (Kiro CLI), with human review and direction throughout.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
