### PR TITLE
Format markdown code blocks for ruff 0.16.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,14 @@
 def background_task():
     self.label.setText("Done")  # CRASH!
 
+
 # ✅ Use signals or run_task callback
 from picard.util.thread import run_task
 
+
 def callback(result):
     self.label.setText(result)  # Safe - runs in main thread
+
 
 run_task(heavy_operation, callback=callback)
 ```
@@ -68,6 +71,7 @@ metadata['artist'] = ['Artist 1', 'Artist 2']
 ```python
 # ✅ Always use config.setting
 from picard import config
+
 value = config.setting['option_name']
 
 # ❌ Don't access internal structures directly
@@ -89,7 +93,9 @@ result = slow_network_call()  # UI freezes!
 # ❌ Don't use inline imports (unless breaking circular dependencies)
 def my_function():
     from picard.some_module import something
+
     return something()
+
 
 # ❌ Don't put multiple imports on one line
 from picard.plugin3.validator import generate_uuid, validate_manifest_dict
@@ -131,10 +137,12 @@ license_url = "https://www.gnu.org/licenses/gpl-2.0.html"
 ```python
 from picard.plugin3.api import PluginApi
 
+
 def enable(api: PluginApi):
     """Called when plugin is enabled."""
     api.plugin_config.register_option("my_option", "default")
     api.register_track_metadata_processor(process_metadata)
+
 
 def process_metadata(api, album, metadata, track, release):
     metadata['custom'] = api.plugin_config['my_option']
@@ -257,6 +265,7 @@ TITLE = N_("Options")  # Translated at usage: _(TITLE)
 # Plugin translations (Plugin v3)
 from picard.plugin3.api import t_
 
+
 class ManifestTranslations:
     NAME = t_("manifest.name", "My Plugin")
     DESC = t_("manifest.description", "Plugin description")
@@ -282,6 +291,7 @@ python setup.py build_ui
 ### Qt Signals
 ```python
 from PyQt6.QtCore import pyqtSignal
+
 
 class MyWidget(QWidget):
     # Define signals
@@ -349,6 +359,7 @@ class MyWidget(QWidget):
 ```python
 from picard.script import script_function
 
+
 @script_function
 def func_myfunction(parser, arg1, arg2='default'):
     """$myfunction(arg1,arg2) - Description"""
@@ -365,8 +376,10 @@ def func_myfunction(parser, arg1, arg2='default'):
 ```python
 from picard.extension_points.metadata import register_track_metadata_processor
 
+
 def my_processor(album, metadata, track, release):
     metadata['custom'] = 'value'
+
 
 register_track_metadata_processor(my_processor)
 ```
@@ -392,6 +405,7 @@ pytest --cov=picard test/
 ```python
 from test.picardtestcase import PicardTestCase
 
+
 class TestMyFeature(PicardTestCase):
     def setUp(self):
         super().setUp()
@@ -415,6 +429,7 @@ picard --debug-opts=option1,option2
 ```python
 # In code
 from picard import log
+
 log.debug('Debug: %s', value)
 log.error('Error', exc_info=True)
 ```

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -14,6 +14,7 @@ def enable(api):
     api.logger.info("Plugin loaded")
     api.register_track_metadata_processor(my_processor)
 
+
 def disable():
     """Optional cleanup when plugin is disabled."""
     # Custom cleanup code here
@@ -35,6 +36,7 @@ Get the `PluginApi` instance from anywhere in your plugin code without explicitl
 
 ```python
 from picard.plugin3.api import PluginApi
+
 
 class MyWidget(QWidget):
     def __init__(self):
@@ -87,8 +89,10 @@ The following classes are available through the `api` module:
 ```python
 from picard.plugin3.api import BaseAction, OptionsPage, File, CoverArtProvider, Metadata
 
+
 class MyProvider(CoverArtProvider):
     NAME = "My Provider"
+
 
 class MyFormat(File):
     NAME = "Custom Format"
@@ -224,6 +228,7 @@ def enable(api):
 ```python
 from picard.plugin3.api import PluginApi, OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     def __init__(self):
         super().__init__()
@@ -256,7 +261,8 @@ To make an option profile-eligible, pass `title` and `in_profile=True` to `regis
 ```python
 def enable(api):
     api.plugin_config.register_option(
-        'greeting', 'Hello World',
+        'greeting',
+        'Hello World',
         title='Greeting message',
         in_profile=True,
     )
@@ -273,6 +279,7 @@ Declare widgets in the page's `OPTIONS` dict to enable visual highlighting when 
 
 ```python
 from picard.plugin3.api import OptionsPage, PageOptionConfigs
+
 
 class MyOptionsPage(OptionsPage):
     OPTIONS: PageOptionConfigs = {
@@ -303,6 +310,7 @@ Path to the plugin directory (read-only).
 ```python
 from pathlib import Path
 import json
+
 
 def enable(api):
     # Access plugin directory
@@ -356,7 +364,7 @@ def my_processor(api, album, metadata, release):
         '/api/endpoint',
         response_handler,
         priority=True,
-        important=False
+        important=False,
     )
 ```
 
@@ -372,7 +380,7 @@ def my_processor(api, album, metadata, release):
     api.mb_api.get_release_by_id(
         release_id,
         handler,
-        inc=['artists', 'recordings']
+        inc=['artists', 'recordings'],
     )
 ```
 
@@ -474,6 +482,7 @@ ERROR_MESSAGES = {
 # Define plural forms
 FILE_COUNT = t_('files.count', '{n} file', '{n} files')
 
+
 # Use in class definitions
 class MyAction(BaseAction):
     TITLE = "My Custom Action"
@@ -481,6 +490,7 @@ class MyAction(BaseAction):
     def __init__(self):
         super().__init__()
         self.setText(self.api.tr("action.name", "My Custom Action"))
+
 
 def enable(api):
     # Translate at runtime
@@ -526,6 +536,7 @@ def process_track(api, track, metadata, track_node, release_node=None):
     api.logger.info(f"Processing: {metadata['title']}")
     metadata['custom_tag'] = 'value'
 
+
 def enable(api):
     api.register_track_metadata_processor(process_track)
     # With priority
@@ -549,6 +560,7 @@ def process_album(api, album, metadata, release_node):
     """Process album metadata."""
     metadata['custom_album_tag'] = 'value'
 
+
 def enable(api):
     api.register_album_metadata_processor(process_album)
 ```
@@ -567,6 +579,7 @@ Called after a file is loaded.
 def on_file_loaded(api, file):
     api.logger.info(f"File loaded: {file.filename}")
 
+
 def enable(api):
     api.register_file_post_load_processor(on_file_loaded)
 ```
@@ -583,6 +596,7 @@ Called just before a file is saved.
 def on_file_saved(api, file):
     api.logger.info(f"File saved: {file.filename}")
 
+
 def enable(api):
     api.register_file_pre_save_processor(on_file_saved)
 ```
@@ -598,6 +612,7 @@ Called after a file is saved.
 ```python
 def on_file_saved(api, file):
     api.logger.info(f"File saved: {file.filename}")
+
 
 def enable(api):
     api.register_file_post_save_processor(on_file_saved)
@@ -640,12 +655,13 @@ def my_script_func(parser, arg1, arg2):
     """Custom script function."""
     return f"{arg1}-{arg2}"
 
+
 def enable(api):
     api.register_script_function(
         my_script_func,
         name="my_func",  # Optional: defaults to function name
         documentation="Combines two arguments with a dash",
-        signature="$my_func(arg1,arg2)"
+        signature="$my_func(arg1,arg2)",
     )
 ```
 
@@ -668,7 +684,7 @@ Register a variable name for script autocomplete.
 def enable(api):
     api.register_script_variable(
         "my_plugin_var",
-        documentation="A custom variable from my plugin"
+        documentation="A custom variable from my plugin",
     )
 ```
 
@@ -697,12 +713,14 @@ Register menu actions for different object types.
 ```python
 from picard.plugin3.api import BaseAction
 
+
 class MyAction(BaseAction):
     TITLE = "My Custom Action"
 
     def callback(self, objs):
         for obj in objs:
             self.api.logger.info(f"Action on: {obj}")
+
 
 def enable(api):
     # Context menus
@@ -730,6 +748,7 @@ Register a settings page in Picard's options dialog.
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     NAME = "my_plugin"
     TITLE = "My Plugin"
@@ -746,6 +765,7 @@ class MyOptionsPage(OptionsPage):
     def save(self):
         # Save settings to self.api.plugin_config or self.api.global_config
         pass
+
 
 def enable(api):
     api.register_options_page(MyOptionsPage)
@@ -771,12 +791,14 @@ Register a custom cover art provider.
 ```python
 from picard.plugin3.api import CoverArtProvider
 
+
 class MyProvider(CoverArtProvider):
     NAME = "My Provider"
 
     def queue_images(self):
         # Queue cover art images
         pass
+
 
 def enable(api):
     api.register_cover_art_provider(MyProvider)
@@ -794,6 +816,7 @@ def my_cover_filter(api, metadata, image):
     # Return True to keep, False to discard
     return image.width >= 500
 
+
 def enable(api):
     api.register_cover_art_filter(my_cover_filter)
 ```
@@ -810,6 +833,7 @@ Register a filter to process cover art metadata.
 def my_metadata_filter(api, metadata, image_metadata):
     """Filter cover art by metadata."""
     return image_metadata.get('type') == 'front'
+
 
 def enable(api):
     api.register_cover_art_metadata_filter(my_metadata_filter)
@@ -838,6 +862,7 @@ class MyProcessor:
         # Modify image
         return image
 
+
 def enable(api):
     api.register_cover_art_processor(MyProcessor)
 ```
@@ -853,6 +878,7 @@ Register support for a custom file format.
 ```python
 from picard.plugin3.api import File
 
+
 class MyFormat(File):
     EXTENSIONS = [".myformat"]
     NAME = "My Format"
@@ -864,6 +890,7 @@ class MyFormat(File):
     def _save(self, filename):
         # Save file
         pass
+
 
 def enable(api):
     api.register_format(MyFormat)
@@ -895,6 +922,7 @@ from picard.disc.utils import (
     NotSupportedTOCError,
 )
 
+
 def my_ripper_toc_from_file(path):
     """Parse MyRipper log files for disc ID lookup."""
     entries = []
@@ -907,6 +935,7 @@ def my_ripper_toc_from_file(path):
             if m:
                 entries.append(TocEntry(int(m[1]), int(m[2]), int(m[3])))
     return calculate_mb_toc_numbers(entries)
+
 
 def enable(api):
     api.register_disc_log_reader(my_ripper_toc_from_file)
@@ -947,6 +976,7 @@ Add a plugin task to an album. Plugin tasks default to non-blocking and won't pr
 ```python
 from functools import partial
 
+
 def fetch_album_data(api, album, metadata, release):
     artist_id = metadata.get('musicbrainz_artistid')
     if not artist_id:
@@ -957,14 +987,16 @@ def fetch_album_data(api, album, metadata, release):
     def create_request():
         return api.web_service.get_url(
             url=f'https://api.example.com/artist/{artist_id}',
-            handler=partial(handle_response, api, album, metadata, task_id)
+            handler=partial(handle_response, api, album, metadata, task_id),
         )
 
     api.add_album_task(
-        album, task_id,
+        album,
+        task_id,
         f'Fetching artist bio for {artist_id}',
-        request_factory=create_request
+        request_factory=create_request,
     )
+
 
 def handle_response(api, album, metadata, task_id, data, error):
     try:
@@ -972,6 +1004,7 @@ def handle_response(api, album, metadata, task_id, data, error):
             metadata['~artist_bio'] = data.get('biography', '')
     finally:
         api.complete_album_task(album, task_id)
+
 
 def enable(api):
     api.register_album_metadata_processor(fetch_album_data)
@@ -1001,9 +1034,10 @@ def fetch_custom_cover(api, album, metadata, release):
 
     request = api.web_service.download_url(
         url=f'https://covers.example.com/{album_id}.jpg',
-        handler=lambda data, http, error: handle_cover(api, album, task_id, data, error)
+        handler=lambda data, http, error: handle_cover(api, album, task_id, data, error),
     )
     api.set_album_task_request(album, task_id, request)
+
 
 def handle_cover(api, album, task_id, data, error):
     try:
@@ -1012,6 +1046,7 @@ def handle_cover(api, album, task_id, data, error):
             api.logger.info(f"Downloaded cover art: {len(data)} bytes")
     finally:
         api.complete_album_task(album, task_id)
+
 
 def enable(api):
     api.register_album_metadata_processor(fetch_custom_cover)
@@ -1033,6 +1068,7 @@ def my_processor(api, track, metadata, track_node, release=None):
     # api is automatically injected as first parameter
     api.logger.info("Processing")
 
+
 def enable(api):
     # Picard wraps this as: partial(my_processor, api)
     api.register_track_metadata_processor(my_processor)
@@ -1042,9 +1078,11 @@ def enable(api):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class MyPage(OptionsPage):
     def load(self):
         self.api.logger.info("Loading")
+
 
 def enable(api):
     api.register_options_page(MyPage)

--- a/docs/PLUGINSV3/GUI.md
+++ b/docs/PLUGINSV3/GUI.md
@@ -321,27 +321,27 @@ async_manager.install_plugin(
     url='https://github.com/user/plugin',
     ref='main',
     progress_callback=lambda update: print(f"{update.percent}%: {update.message}"),
-    callback=lambda result: print(f"Installed: {result.value}")
+    callback=lambda result: print(f"Installed: {result.value}"),
 )
 
 # Update plugin
 async_manager.update_plugin(
     plugin=plugin,
     progress_callback=progress_handler,
-    callback=completion_handler
+    callback=completion_handler,
 )
 
 # Update all plugins
 async_manager.update_all_plugins(
     progress_callback=progress_handler,
-    callback=completion_handler
+    callback=completion_handler,
 )
 
 # Uninstall plugin
 async_manager.uninstall_plugin(
     plugin=plugin,
     purge=True,
-    callback=completion_handler
+    callback=completion_handler,
 )
 
 # Fast synchronous operations (no async needed)
@@ -354,12 +354,12 @@ async_manager.find_plugin(identifier)
 ```python
 @dataclass
 class ProgressUpdate:
-    operation: str          # 'install', 'update', 'update_all', 'uninstall'
-    message: str           # Human-readable status message
-    percent: int = 0       # Progress percentage (0-100)
+    operation: str  # 'install', 'update', 'update_all', 'uninstall'
+    message: str  # Human-readable status message
+    percent: int = 0  # Progress percentage (0-100)
     plugin_id: str = None  # Plugin being operated on
-    current: int = None    # Current item (for batch operations)
-    total: int = None      # Total items (for batch operations)
+    current: int = None  # Current item (for batch operations)
+    total: int = None  # Total items (for batch operations)
 ```
 
 **OperationResult** (`picard/plugin3/asyncops/callbacks.py`):
@@ -367,7 +367,7 @@ class ProgressUpdate:
 @dataclass
 class OperationResult:
     success: bool
-    value: Any = None      # Return value on success
+    value: Any = None  # Return value on success
     error: Exception = None  # Exception on failure
 ```
 
@@ -392,27 +392,32 @@ from picard.plugin3.asyncops.manager import AsyncPluginManager
 
 async_manager = AsyncPluginManager(manager)
 
+
 def on_progress(update):
     # Update progress bar
     progress_bar.setValue(update.percent)
     status_label.setText(update.message)
 
+
 def on_complete(result):
     if result.success:
-        QMessageBox.information(parent, "Success",
-                               f"Plugin {result.value} installed successfully")
+        QMessageBox.information(parent, "Success", f"Plugin {result.value} installed successfully")
     else:
         if isinstance(result.error, PluginBlacklistedError):
-            QMessageBox.critical(parent, "Blocked",
-                                f"Plugin is blacklisted: {result.error.reason}")
+            QMessageBox.critical(parent, "Blocked", f"Plugin is blacklisted: {result.error.reason}")
         elif isinstance(result.error, PluginAlreadyInstalledError):
-            QMessageBox.information(parent, "Already Installed",
-                                   f"Plugin {result.error.plugin_name} is already installed")
+            QMessageBox.information(
+                parent, "Already Installed", f"Plugin {result.error.plugin_name} is already installed"
+            )
         elif isinstance(result.error, PluginManifestInvalidError):
-            QMessageBox.critical(parent, "Invalid Plugin",
-                                f"Invalid MANIFEST.toml:\n" + "\n".join(result.error.errors))
+            QMessageBox.critical(
+                parent,
+                "Invalid Plugin",
+                f"Invalid MANIFEST.toml:\n" + "\n".join(result.error.errors),
+            )
         else:
             QMessageBox.critical(parent, "Error", str(result.error))
+
 
 # Start async installation
 async_manager.install_plugin(url, ref=ref, progress_callback=on_progress, callback=on_complete)
@@ -424,8 +429,7 @@ async_manager.install_plugin(url, ref=ref, progress_callback=on_progress, callba
 is_blacklisted, reason = registry.is_blacklisted(url, uuid)
 if is_blacklisted:
     # GUI shows error dialog with reason
-    QMessageBox.critical(parent, "Plugin Blocked",
-                        f"This plugin is blacklisted:\n{reason}")
+    QMessageBox.critical(parent, "Plugin Blocked", f"This plugin is blacklisted:\n{reason}")
 ```
 
 **Trust Level Checks:**
@@ -435,21 +439,27 @@ trust_level = registry.get_trust_level(url)
 
 if trust_level == 'community':
     # GUI shows warning dialog
-    result = QMessageBox.warning(parent, "Community Plugin",
+    result = QMessageBox.warning(
+        parent,
+        "Community Plugin",
         "This is a community plugin.\n"
         "Community plugins are not reviewed by the Picard team.\n"
         "Only install plugins from sources you trust.",
-        QMessageBox.Ok | QMessageBox.Cancel)
+        QMessageBox.Ok | QMessageBox.Cancel,
+    )
     if result == QMessageBox.Cancel:
         return
 
 elif trust_level == 'unregistered':
     # GUI shows stronger warning
-    result = QMessageBox.warning(parent, "Unregistered Plugin",
+    result = QMessageBox.warning(
+        parent,
+        "Unregistered Plugin",
         "This plugin is not in the official registry.\n"
         "Installing unregistered plugins may pose security risks.\n"
         "Only install plugins from sources you trust.",
-        QMessageBox.Ok | QMessageBox.Cancel)
+        QMessageBox.Ok | QMessageBox.Cancel,
+    )
     if result == QMessageBox.Cancel:
         return
 ```

--- a/docs/PLUGINSV3/LOCAL_NON_GIT.md
+++ b/docs/PLUGINSV3/LOCAL_NON_GIT.md
@@ -145,7 +145,7 @@ Local non-git plugins use the same `plugins3_metadata` config dict as git-manage
     "url": "/absolute/path/to/plugin",
     "ref": "local",
     "commit": "",
-    "ref_type": "local"
+    "ref_type": "local",
 }
 ```
 

--- a/docs/PLUGINSV3/MANIFEST.md
+++ b/docs/PLUGINSV3/MANIFEST.md
@@ -31,6 +31,7 @@ api = ["3.0"]
 # __init__.py
 from picard.plugin3.api import PluginApi
 
+
 def enable(api: PluginApi):
     """Called when plugin is enabled"""
 
@@ -45,6 +46,7 @@ def enable(api: PluginApi):
     def my_action(album):
         # Do something when user clicks action
         pass
+
 
 def disable():
     """Called when plugin is disabled (optional)"""
@@ -426,6 +428,7 @@ Every plugin must have an `__init__.py` file with an `enable()` function:
 ```python
 from picard.plugin3.api import PluginApi
 
+
 def enable(api: PluginApi):
     """
     Called when plugin is enabled.
@@ -436,6 +439,7 @@ def enable(api: PluginApi):
     """
     # Your plugin initialization code here
     pass
+
 
 def disable():
     """
@@ -581,6 +585,7 @@ def enable(api: PluginApi):
 # __init__.py
 from picard.plugin3.api import PluginApi
 
+
 def enable(api: PluginApi):
     @api.on_album_metadata_loaded
     def add_custom_tag(album, metadata):
@@ -593,6 +598,7 @@ def enable(api: PluginApi):
 ```python
 # __init__.py
 from picard.plugin3.api import PluginApi
+
 
 def enable(api: PluginApi):
     @api.register_cover_art_provider
@@ -609,11 +615,13 @@ def enable(api: PluginApi):
 # __init__.py
 from picard.plugin3.api import PluginApi
 
+
 def enable(api: PluginApi):
     @api.register_album_action("Export to CSV")
     def export_to_csv(album):
         # Export album data to CSV
         import csv
+
         with open('export.csv', 'w') as f:
             writer = csv.writer(f)
             for track in album.tracks:

--- a/docs/PLUGINSV3/MIGRATION.md
+++ b/docs/PLUGINSV3/MIGRATION.md
@@ -229,6 +229,7 @@ def enable(api):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class ExampleOptionsPage(OptionsPage):
     NAME = "example"
     TITLE = "Example"
@@ -267,13 +268,15 @@ If your v2 plugin used `album._requests` to track web requests, you need to migr
 ```python
 from picard.metadata import register_album_metadata_processor
 
+
 def fetch_data(album, metadata, release):
     album._requests += 1
     album.tagger.webservice.get(
         'example.com',
         '/api/data',
-        handler=lambda response, reply, error: handle_response(album, response, error)
+        handler=lambda response, reply, error: handle_response(album, response, error),
     )
+
 
 def handle_response(album, response, error):
     try:
@@ -284,6 +287,7 @@ def handle_response(album, response, error):
         album._requests -= 1
         album._finalize_loading(None)
 
+
 register_album_metadata_processor(fetch_data)
 ```
 
@@ -291,20 +295,23 @@ register_album_metadata_processor(fetch_data)
 ```python
 from functools import partial
 
+
 def fetch_data(api, album, metadata, release):
     task_id = f'data_{album.id}'
 
     def create_request():
         return api.web_service.get_url(
             url='https://example.com/api/data',
-            handler=partial(handle_response, api, album, task_id)
+            handler=partial(handle_response, api, album, task_id),
         )
 
     api.add_album_task(
-        album, task_id,
+        album,
+        task_id,
         'Fetching data',
-        request_factory=create_request
+        request_factory=create_request,
     )
+
 
 def handle_response(api, album, task_id, data, error):
     try:
@@ -313,6 +320,7 @@ def handle_response(api, album, task_id, data, error):
             pass
     finally:
         api.complete_album_task(album, task_id)
+
 
 def enable(api):
     api.register_album_metadata_processor(fetch_data)
@@ -422,6 +430,7 @@ from picard.metadata import register_track_metadata_processor
 from picard.ui.options import register_options_page, OptionsPage
 from PyQt5.QtWidgets import QCheckBox
 
+
 class ExampleOptionsPage(OptionsPage):
     NAME = "example"
     TITLE = "Example Plugin"
@@ -438,10 +447,12 @@ class ExampleOptionsPage(OptionsPage):
     def save(self):
         config.setting['example_enabled'] = self.checkbox.isChecked()
 
+
 def process_track(api, album, metadata, track, release):
     log.info("Processing track: %s", track)
     if config.setting['example_enabled']:
         metadata['example'] = 'processed'
+
 
 def register():
     log.info("Registering Example Plugin")
@@ -541,8 +552,10 @@ def process(api, track, metadata):
     if api.plugin_config.get('my_enabled', True):
         text = api.plugin_config.get('my_key', 'default')
 
+
 # In OptionsPage
 from picard.plugin3.api import OptionsPage
+
 
 class MyPage(OptionsPage):
     def load(self):
@@ -556,11 +569,13 @@ class MyPage(OptionsPage):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 # V2 - options attribute for metadata
 class MyPage(OptionsPage):
     options = [
         config.BoolOption("setting", "my_option", True),
     ]
+
 
 # V3 - no options attribute needed
 class MyPage(OptionsPage):

--- a/docs/PLUGINSV3/REGISTRY.md
+++ b/docs/PLUGINSV3/REGISTRY.md
@@ -1088,7 +1088,7 @@ def check_for_updates(self, plugin):
             'available': True,
             'local': local_commit[:7],
             'remote': remote_commit[:7],
-            'ref': local_ref
+            'ref': local_ref,
         }
     return {'available': False}
 ```

--- a/docs/PLUGINSV3/TRANSLATIONS.md
+++ b/docs/PLUGINSV3/TRANSLATIONS.md
@@ -83,6 +83,7 @@ A nested structure with tables is only used for plural forms to notate the diffe
 from picard.plugin3.api import PluginApi
 from picard.i18n import gettext as _  # Picard's translations
 
+
 def enable(api: PluginApi):
     # Use Picard's translations for standard UI
     menu_text = _("Plugins")  # Picard translates this
@@ -124,9 +125,11 @@ ERROR_MESSAGES = {
 # Define plural forms
 FILE_COUNT = t_('files.count', '{n} file', '{n} files')
 
+
 # Use in class definitions
 class MyAction(BaseAction):
     TITLE = t_("My Custom Action")
+
 
 def enable(api):
     # Translate at runtime
@@ -156,6 +159,7 @@ from picard.plugin3.api import t_
 
 # Define once
 PLURALS = t_('items.count', 'There is {n} item.', 'There are {n} items.')
+
 
 # Use multiple times without repetition
 def callback(self, objs):
@@ -418,6 +422,7 @@ Plugin translations work alongside Qt's translation system:
 ```python
 from PyQt6.QtWidgets import QDialog, QPushButton, QLabel
 
+
 class MyPluginDialog(QDialog):
     def __init__(self, api):
         super().__init__()
@@ -469,6 +474,7 @@ def retranslateUi(self, VariablesDialog):
 **Your plugin code:**
 ```python
 from .ui_variables_dialog import Ui_VariablesDialog
+
 
 class VariablesDialog(QDialog, Ui_VariablesDialog):
     def __init__(self, api, parent=None):
@@ -582,6 +588,7 @@ fr = "Soumettez votre musique sur ListenBrainz"
 ```python
 from picard.plugin3.api import PluginApi
 from picard.i18n import gettext as _
+
 
 def enable(api: PluginApi):
     # Use Picard's translations for standard UI

--- a/docs/PLUGINSV3/WEBSITE.md
+++ b/docs/PLUGINSV3/WEBSITE.md
@@ -371,6 +371,7 @@ REGISTRY_URL = "https://raw.githubusercontent.com/metabrainz/picard-plugins-regi
 CACHE_FILE = "/tmp/plugins_registry.json"
 CACHE_TTL = 3600  # 1 hour
 
+
 def get_registry():
     """Get registry JSON with caching"""
     cache_path = Path(CACHE_FILE)
@@ -391,6 +392,7 @@ def get_registry():
         f.write(response.text)
 
     return response.text
+
 
 @app.route('/api/v3/plugins.toml')
 def plugins_json():

--- a/docs/Plugin2to3MigrationGuide.md
+++ b/docs/Plugin2to3MigrationGuide.md
@@ -102,8 +102,10 @@ license = "GPL-2.0-or-later"
 ```python
 from picard.metadata import register_track_metadata_processor
 
+
 def process_track(album, metadata, track, release):
     metadata['custom'] = 'value'
+
 
 register_track_metadata_processor(process_track)
 ```
@@ -112,6 +114,7 @@ register_track_metadata_processor(process_track)
 ```python
 def process_track(track, metadata):
     metadata['custom'] = 'value'
+
 
 def enable(api):
     """Called when plugin is enabled."""
@@ -123,6 +126,7 @@ def enable(api):
 ```python
 from picard.script import register_script_function
 
+
 @register_script_function
 def my_function(parser, arg):
     return result
@@ -132,6 +136,7 @@ def my_function(parser, arg):
 ```python
 def my_function(parser, arg):
     return result
+
 
 def enable(api):
     api.register_script_function(my_function)
@@ -154,6 +159,7 @@ def my_processor(api, track, metadata):
     if api.global_config.setting['enabled']:
         metadata['custom'] = 'value'
 
+
 def enable(api):
     api.register_track_metadata_processor(my_processor)
 ```
@@ -161,6 +167,7 @@ def enable(api):
 **After - In Classes**:
 ```python
 from picard.plugin3.api import OptionsPage
+
 
 class MyOptionsPage(OptionsPage):
     def __init__(self, api=None, parent=None):
@@ -184,6 +191,7 @@ my_text = TextOption("setting", "my_plugin_text", "default")
 my_bool = BoolOption("setting", "my_plugin_enabled", True)
 my_int = IntOption("setting", "my_plugin_count", 10)
 
+
 def process(album, metadata, track, release):
     if my_bool.value:
         text = my_text.value
@@ -203,6 +211,7 @@ def process(api, track, metadata):
 from picard import config
 from picard.ui.options import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     options = [
         config.BoolOption("setting", "my_option", True),
@@ -217,6 +226,7 @@ class MyOptionsPage(OptionsPage):
 **V3 - No options attribute needed**:
 ```python
 from picard.plugin3.api import OptionsPage
+
 
 class MyOptionsPage(OptionsPage):
     # No 'options' attribute needed in V3
@@ -311,6 +321,7 @@ class MyOptionsPage(OptionsPage):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     def __init__(self, api, parent=None):
         self.api = api
@@ -323,12 +334,14 @@ class MyOptionsPage(OptionsPage):
 ```python
 from picard.ui.itemviews import BaseAction, register_file_action
 
+
 class MyAction(BaseAction):
     NAME = 'My Action'
 
     def callback(self, objs):
         # Do something
         pass
+
 
 # Instantiate and register
 action = MyAction()
@@ -338,6 +351,7 @@ register_file_action(action)
 **After** - V3 registers the class, not instance:
 ```python
 from picard.plugin3.api import BaseAction
+
 
 class MyAction(BaseAction):
     TITLE = 'My Action'
@@ -349,6 +363,7 @@ class MyAction(BaseAction):
     def callback(self, objs):
         # Use self.api to access Picard
         files = self.api.tagger.get_files_from_objects(objs)
+
 
 def enable(api):
     api.register_file_action(MyAction)  # Register class, not instance
@@ -406,9 +421,11 @@ from picard.tagger import tagger
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 # Processors get api as first parameter
 def my_processor(api, track, metadata):
     api.logger.info("Processing")
+
 
 # Classes get api in __init__
 class MyPage(OptionsPage):
@@ -506,6 +523,7 @@ def enable(api):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     """OptionsPage receives api in __init__."""
 
@@ -532,10 +550,12 @@ def enable(api):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 # In processors - use api parameter
 def my_processor(api, track, metadata):
     api.logger.info("Processing")
     api.global_config.setting['option']
+
 
 # In classes - use self.api
 class MyPage(OptionsPage):
@@ -554,13 +574,15 @@ class MyPage(OptionsPage):
 ```python
 from picard.metadata import register_album_metadata_processor
 
+
 def fetch_data(album, metadata, release):
     album._requests += 1
     album.tagger.webservice.get(
         'example.com',
         '/api/data',
-        handler=lambda response, reply, error: handle_response(album, response, error)
+        handler=lambda response, reply, error: handle_response(album, response, error),
     )
+
 
 def handle_response(album, response, error):
     try:
@@ -571,6 +593,7 @@ def handle_response(album, response, error):
         album._requests -= 1
         album._finalize_loading(None)
 
+
 register_album_metadata_processor(fetch_data)
 ```
 
@@ -578,20 +601,23 @@ register_album_metadata_processor(fetch_data)
 ```python
 from functools import partial
 
+
 def fetch_data(api, album, metadata, release):
     task_id = f'data_{album.id}'
 
     def create_request():
         return api.web_service.get_url(
             url='https://example.com/api/data',
-            handler=partial(handle_response, api, album, task_id)
+            handler=partial(handle_response, api, album, task_id),
         )
 
     api.add_album_task(
-        album, task_id,
+        album,
+        task_id,
         'Fetching data',
-        request_factory=create_request
+        request_factory=create_request,
     )
+
 
 def handle_response(api, album, task_id, data, error):
     try:
@@ -600,6 +626,7 @@ def handle_response(api, album, task_id, data, error):
             pass
     finally:
         api.complete_album_task(album, task_id)
+
 
 def enable(api):
     api.register_album_metadata_processor(fetch_data)
@@ -624,8 +651,10 @@ PLUGIN_NAME = "Title Cleaner"
 
 from picard.metadata import register_track_metadata_processor
 
+
 def clean_title(album, metadata, track, release):
     metadata['title'] = metadata['title'].strip()
+
 
 register_track_metadata_processor(clean_title)
 ```
@@ -634,6 +663,7 @@ register_track_metadata_processor(clean_title)
 ```python
 def clean_title(api, track, metadata):
     metadata['title'] = metadata['title'].strip()
+
 
 def enable(api):
     api.register_track_metadata_processor(clean_title)
@@ -646,6 +676,7 @@ def enable(api):
 from picard import config
 from picard.ui.options import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     def load(self):
         self.checkbox.setChecked(config.setting['my_option'])
@@ -655,6 +686,7 @@ class MyOptionsPage(OptionsPage):
 ```python
 from picard.plugin3.api import OptionsPage
 
+
 class MyOptionsPage(OptionsPage):
     def __init__(self, api=None, parent=None):
         super().__init__(parent)
@@ -662,6 +694,7 @@ class MyOptionsPage(OptionsPage):
 
     def load(self):
         self.checkbox.setChecked(self.api.global_config.setting['my_option'])
+
 
 def enable(api):
     api.register_options_page(MyOptionsPage)
@@ -673,6 +706,7 @@ def enable(api):
 ```python
 from picard.script import register_script_function
 
+
 @register_script_function
 def my_func(parser, arg):
     return result
@@ -682,6 +716,7 @@ def my_func(parser, arg):
 ```python
 def my_func(parser, arg):
     return result
+
 
 def enable(api):
     api.register_script_function(my_func)

--- a/scripts/eval_matching/README.md
+++ b/scripts/eval_matching/README.md
@@ -231,7 +231,7 @@ define the expected outcome per config profile:
     ],
     "scenario": "non_latin_editions",
     "expectations": {
-        "*": "ambiguous",              # wildcard default
+        "*": "ambiguous",  # wildcard default
         "prefer_jp_digital": "correct",
         "prefer_us_cd": "wrong",
     },


### PR DESCRIPTION
## Summary

Ruff 0.16.0 now formats Python code blocks inside markdown files. This PR applies the new formatting and adds trailing commas to multi-line function calls to preserve readability (without them, ruff collapses arguments onto one line).

## Changes

- Add blank lines between top-level definitions in code blocks (ruff requirement)
- Add trailing commas to multi-line function call arguments
- Minor whitespace adjustments in code blocks

## Files affected

Only markdown documentation files — no Python source changes.

## AI Usage

Moderate use (identifying collapsed calls, applying trailing commas).