### PR TITLE
PICARD-3351: Make Options dialog scrollable and constrain to screen

### DIFF
--- a/picard/ui/forms/ui_options.py
+++ b/picard/ui/forms/ui_options.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -42,7 +42,7 @@ class Ui_OptionsDialog(object):
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.frame)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.pages_stack = QtWidgets.QStackedWidget(parent=self.frame)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Ignored, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Ignored, QtWidgets.QSizePolicy.Policy.Ignored)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.pages_stack.sizePolicy().hasHeightForWidth())

--- a/picard/ui/forms/ui_options_interface_colors.py
+++ b/picard/ui/forms/ui_options_interface_colors.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options_interface_colors.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -18,35 +18,11 @@ class Ui_InterfaceColorsOptionsPage(object):
     def setupUi(self, InterfaceColorsOptionsPage):
         InterfaceColorsOptionsPage.setObjectName("InterfaceColorsOptionsPage")
         InterfaceColorsOptionsPage.resize(171, 137)
-        self.vboxlayout = QtWidgets.QVBoxLayout(InterfaceColorsOptionsPage)
-        self.vboxlayout.setContentsMargins(0, 0, 0, 0)
-        self.vboxlayout.setSpacing(6)
-        self.vboxlayout.setObjectName("vboxlayout")
-        self.scrollArea = QtWidgets.QScrollArea(parent=InterfaceColorsOptionsPage)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
-        sizePolicy.setHorizontalStretch(0)
-        sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.scrollArea.sizePolicy().hasHeightForWidth())
-        self.scrollArea.setSizePolicy(sizePolicy)
-        self.scrollArea.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        self.scrollArea.setFrameShadow(QtWidgets.QFrame.Shadow.Plain)
-        self.scrollArea.setLineWidth(0)
-        self.scrollArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.scrollArea.setWidgetResizable(True)
-        self.scrollArea.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeading|QtCore.Qt.AlignmentFlag.AlignLeft|QtCore.Qt.AlignmentFlag.AlignTop)
-        self.scrollArea.setObjectName("scrollArea")
-        self.scrollAreaWidgetContents = QtWidgets.QWidget()
-        self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 199, 137))
-        self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
-        self.verticalLayout = QtWidgets.QVBoxLayout(self.scrollAreaWidgetContents)
-        self.verticalLayout.setContentsMargins(9, 9, 9, 9)
-        self.verticalLayout.setSpacing(6)
+        self.verticalLayout = QtWidgets.QVBoxLayout(InterfaceColorsOptionsPage)
         self.verticalLayout.setObjectName("verticalLayout")
-        self.colors = QtWidgets.QGroupBox(parent=self.scrollAreaWidgetContents)
+        self.colors = QtWidgets.QGroupBox(parent=InterfaceColorsOptionsPage)
         self.colors.setObjectName("colors")
         self.verticalLayout.addWidget(self.colors)
-        self.scrollArea.setWidget(self.scrollAreaWidgetContents)
-        self.vboxlayout.addWidget(self.scrollArea)
 
         self.retranslateUi(InterfaceColorsOptionsPage)
         QtCore.QMetaObject.connectSlotsByName(InterfaceColorsOptionsPage)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -167,6 +167,37 @@ def _is_simple_value(value) -> bool:
     return isinstance(value, (str, int, float, bool))
 
 
+class _PageScrollArea(QtWidgets.QScrollArea):
+    """A scroll area for options pages that only scrolls when content truly
+    cannot fit in the available viewport.
+
+    Unlike QScrollArea with widgetResizable=True (which scrolls whenever the
+    widget's sizeHint exceeds the viewport), this uses the widget's
+    minimumSizeHint as the threshold.  The widget is resized to fill the
+    viewport when it fits, and keeps its minimum size when it doesn't,
+    allowing scrolling only when genuinely needed.
+    """
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._relayout_widget()
+
+    def _relayout_widget(self):
+        widget = self.widget()
+        if widget is None:
+            return
+        viewport_size = self.viewport().size()
+        min_hint = widget.minimumSizeHint()
+        # Width: always fill the viewport horizontally
+        w = viewport_size.width()
+        # Height: use viewport height unless the minimum required exceeds it
+        if min_hint.height() > viewport_size.height():
+            h = min_hint.height()
+        else:
+            h = viewport_size.height()
+        widget.resize(w, h)
+
+
 class OptionsDialog(PicardDialog, SingletonDialog):
     defaultsize = QtCore.QSize(860, 720)
     suspend_signals = False
@@ -407,13 +438,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         """Switch the stacked widget to show the given page.
 
         On first show, the page is wrapped in a QScrollArea so that content
-        taller than the viewport can be scrolled.
+        taller than the viewport can be scrolled.  The scrollbar only appears
+        when the page's minimum size hint exceeds the available viewport,
+        avoiding premature scrollbars when the content still fits.
         """
         scroll_area = self._page_scroll_areas.get(page)
         if scroll_area is None:
-            scroll_area = QtWidgets.QScrollArea()
+            scroll_area = _PageScrollArea()
             scroll_area.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-            scroll_area.setWidgetResizable(True)
             scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
             self.ui.pages_stack.removeWidget(page)
             scroll_area.setWidget(page)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -168,6 +168,7 @@ def _is_simple_value(value) -> bool:
 
 
 class OptionsDialog(PicardDialog, SingletonDialog):
+    defaultsize = QtCore.QSize(860, 720)
     suspend_signals = False
 
     def add_pages(self, parent_pagename, default_pagename, parent_item):
@@ -377,24 +378,17 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         if screen is None:
             return
         available = screen.availableGeometry()
-        frame = self.frameGeometry()
-        if available.contains(frame):
-            return
-        # Clamp size to available area
-        size = frame.size().boundedTo(available.size())
-        self.resize(size)
-        # Move into bounds
-        frame = self.frameGeometry()
-        frame.moveCenter(frame.center())
-        if frame.left() < available.left():
-            frame.moveLeft(available.left())
-        if frame.top() < available.top():
-            frame.moveTop(available.top())
-        if frame.right() > available.right():
-            frame.moveRight(available.right())
-        if frame.bottom() > available.bottom():
-            frame.moveBottom(available.bottom())
-        self.move(frame.topLeft())
+        geom = self.geometry()
+        # Cap size to available screen area
+        new_size = geom.size().boundedTo(available.size())
+        if new_size != geom.size():
+            self.resize(new_size)
+        # Reposition if needed to keep within screen bounds
+        pos = self.pos()
+        x = max(available.left(), min(pos.x(), available.right() - self.width()))
+        y = max(available.top(), min(pos.y(), available.bottom() - self.height()))
+        if x != pos.x() or y != pos.y():
+            self.move(x, y)
 
     def _add_page_to_stack(self, page):
         """Add a page to the stacked widget."""

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -247,6 +247,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.ui = Ui_OptionsDialog()
         self.ui.setupUi(self)
 
+        # Each page is wrapped in a QScrollArea inside the stacked widget.
+        # This ensures pages that exceed available height are scrollable,
+        # while keeping the dialog resizable and buttons always accessible.
+        self._page_scroll_areas: dict[QtWidgets.QWidget, QtWidgets.QScrollArea] = {}
+
         # Profile warning
         profile_layout = self.ui.profile_warning.layout()
         profile_warning_icon = QtWidgets.QLabel()
@@ -305,7 +310,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 # create an empty page with the error message in place of the failing page
                 # this approach still allows subpages of the failing page to load
                 page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
-            self.ui.pages_stack.addWidget(page)
+            self._add_page_to_stack(page)
             self.pages.append(page)
 
         self.item_to_page = {}
@@ -361,6 +366,74 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Set initial selection after plugin refresh
         if self.default_item:
             self.ui.pages_tree.setCurrentItem(self.default_item)  # this will call switch_page
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._constrain_to_screen()
+
+    def _constrain_to_screen(self):
+        """Ensure the dialog fits within the available screen geometry."""
+        screen = self.screen()
+        if screen is None:
+            return
+        available = screen.availableGeometry()
+        frame = self.frameGeometry()
+        if available.contains(frame):
+            return
+        # Clamp size to available area
+        size = frame.size().boundedTo(available.size())
+        self.resize(size)
+        # Move into bounds
+        frame = self.frameGeometry()
+        frame.moveCenter(frame.center())
+        if frame.left() < available.left():
+            frame.moveLeft(available.left())
+        if frame.top() < available.top():
+            frame.moveTop(available.top())
+        if frame.right() > available.right():
+            frame.moveRight(available.right())
+        if frame.bottom() > available.bottom():
+            frame.moveBottom(available.bottom())
+        self.move(frame.topLeft())
+
+    def _add_page_to_stack(self, page):
+        """Add a page to the stacked widget."""
+        self.ui.pages_stack.addWidget(page)
+
+    def _remove_page_from_stack(self, page):
+        """Remove a page (and its scroll area wrapper if any) from the stacked widget."""
+        scroll_area = self._page_scroll_areas.pop(page, None)
+        if scroll_area is not None:
+            self.ui.pages_stack.removeWidget(scroll_area)
+            scroll_area.deleteLater()
+        else:
+            self.ui.pages_stack.removeWidget(page)
+
+    def _show_page(self, page):
+        """Switch the stacked widget to show the given page.
+
+        On first show, the page is wrapped in a QScrollArea so that content
+        taller than the viewport can be scrolled.
+        """
+        scroll_area = self._page_scroll_areas.get(page)
+        if scroll_area is None:
+            scroll_area = QtWidgets.QScrollArea()
+            scroll_area.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+            scroll_area.setWidgetResizable(True)
+            scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            self.ui.pages_stack.removeWidget(page)
+            scroll_area.setWidget(page)
+            self.ui.pages_stack.addWidget(scroll_area)
+            self._page_scroll_areas[page] = scroll_area
+        self.ui.pages_stack.setCurrentWidget(scroll_area)
+        scroll_area.verticalScrollBar().setValue(0)
+
+    def _current_page(self):
+        """Return the currently visible page widget."""
+        scroll_area = self.ui.pages_stack.currentWidget()
+        if isinstance(scroll_area, QtWidgets.QScrollArea):
+            return scroll_area.widget()
+        return scroll_area
 
     @property
     def initialized_pages(self):
@@ -607,7 +680,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             page = self.item_to_page[items[0]]
             self.set_profiles_button_and_highlight(page)
             self.ui.reset_button.setDisabled(not page.loaded)
-            self.ui.pages_stack.setCurrentWidget(page)
+            self._show_page(page)
             config = get_config()
             log.debug("switch_page: Saving page '%s' to options_last_active_page", page.NAME)
             config.persist['options_last_active_page'] = page.NAME
@@ -665,7 +738,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Remove disabled plugin pages from UI stack and pages list
         for page in pages_to_remove:
             log.debug("refresh_plugin_pages: Removing page: %s", type(page).__name__)
-            self.ui.pages_stack.removeWidget(page)
+            self._remove_page_from_stack(page)
             self.pages.remove(page)
             page.deleteLater()  # Clean up the widget
 
@@ -681,7 +754,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                     page = Page()
                     page.set_dialog(self)
                     page.initialized = True
-                    self.ui.pages_stack.addWidget(page)
+                    self._add_page_to_stack(page)
                     self.pages.append(page)
                     # Load the page if needed
                     try:
@@ -694,7 +767,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                     log.exception("Failed creating options page %r", Page)
                     # Create an error page in place of the failing page
                     page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
-                    self.ui.pages_stack.addWidget(page)
+                    self._add_page_to_stack(page)
                     self.pages.append(page)
 
         # Clear and rebuild the pages tree
@@ -737,7 +810,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     @property
     def help_url(self):
-        current_page = self.ui.pages_stack.currentWidget()
+        current_page = self._current_page()
         url = current_page.HELP_URL
         # If URL is empty, use the first non empty parent help URL.
         while current_page.PARENT and not url:
@@ -828,7 +901,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.suspend_signals = False
 
     def restore_page_defaults(self):
-        current_page = self.ui.pages_stack.currentWidget()
+        current_page = self._current_page()
         if current_page.loaded:
             current_page.restore_defaults()
             self.highlight_enabled_profile_options(load_settings=False)

--- a/ui/options.ui
+++ b/ui/options.ui
@@ -70,7 +70,7 @@
        <item>
         <widget class="QStackedWidget" name="pages_stack">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+          <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/ui/options_interface_colors.ui
+++ b/ui/options_interface_colors.ui
@@ -10,82 +10,12 @@
     <height>137</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QGroupBox" name="colors">
+     <property name="title">
+      <string>Colors</string>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>0</number>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>199</width>
-        <height>137</height>
-       </rect>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="leftMargin">
-        <number>9</number>
-       </property>
-       <property name="topMargin">
-        <number>9</number>
-       </property>
-       <property name="rightMargin">
-        <number>9</number>
-       </property>
-       <property name="bottomMargin">
-        <number>9</number>
-       </property>
-       <item>
-        <widget class="QGroupBox" name="colors">
-         <property name="title">
-          <string>Colors</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Make the Options dialog always fit on screen by wrapping each page in a scroll area and constraining the dialog to available screen geometry.

## Problem

* JIRA ticket: PICARD-3351

On systems where the Options dialog is taller than the screen (e.g. small screens, HiDPI, certain window managers), the "Make It So!" button becomes inaccessible, and the dialog cannot be resized down or moved up.

## Solution

- Each options page is lazily wrapped in a `QScrollArea` when first navigated to, so pages taller than the viewport become scrollable.
- Added `_constrain_to_screen()` in `showEvent` to cap dialog size to available screen geometry and reposition if off-screen (handles restored geometry from a previously larger monitor).
- Changed stacked widget vertical size policy from `Preferred` to `Ignored` so it no longer forces the dialog to grow to the tallest page.
- Removed the internal `QScrollArea` from the colors options page to avoid double scrollbars (the per-page wrapper handles scrolling generically for all pages, including plugin pages).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed using Kiro CLI with Claude, with direction and review from the developer.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
