### PR TITLE
Show picard-cli subcommands in picard --help and refactor registration

### DIFF
--- a/picard/cli/__init__.py
+++ b/picard/cli/__init__.py
@@ -30,6 +30,8 @@ Commands:
 """
 
 import argparse
+from collections import namedtuple
+from importlib import import_module
 import sys
 
 from picard import (
@@ -43,22 +45,50 @@ from picard.util import (
 )
 
 
-# Subcommand metadata: (name, help_text)
+# Subcommand registry.
 # Adding an entry here automatically updates both picard-cli and picard --help.
+# Each module_path must contain a register_subcommand(subparsers) function.
+Subcommand = namedtuple('Subcommand', ('name', 'help', 'module_path', 'examples'))
+
 SUBCOMMANDS = (
-    ('plugins', 'manage Picard plugins'),
-    ('profiles', 'manage Picard profiles'),
+    Subcommand(
+        name='plugins',
+        help='manage Picard plugins',
+        module_path='picard.cli.plugins',
+        examples=(
+            'plugins list',
+            'plugins --help',
+        ),
+    ),
+    Subcommand(
+        name='profiles',
+        help='manage Picard profiles',
+        module_path='picard.profiles.cli',
+        examples=(
+            'profiles list',
+            'profiles export "My Profile" -o profile.toml',
+        ),
+    ),
 )
 
 
 def get_subcommands_help():
     """Return a formatted string listing picard-cli subcommands for use in epilogs."""
     lines = ["Additional commands available via picard-cli:"]
-    max_name_len = max(len(name) for name, _ in SUBCOMMANDS)
-    for name, help_text in SUBCOMMANDS:
-        lines.append(f"  {name:<{max_name_len}}  {help_text}")
+    max_name_len = max(len(cmd.name) for cmd in SUBCOMMANDS)
+    for cmd in SUBCOMMANDS:
+        lines.append(f"  {cmd.name:<{max_name_len}}  {cmd.help}")
     lines.append("")
     lines.append("Use 'picard-cli <command> --help' for more information.")
+    return "\n".join(lines)
+
+
+def _build_examples_epilog():
+    """Build the examples epilog from SUBCOMMANDS entries."""
+    lines = ["examples:"]
+    for cmd in SUBCOMMANDS:
+        for example in cmd.examples:
+            lines.append(f"  picard-cli {example}")
     return "\n".join(lines)
 
 
@@ -68,6 +98,7 @@ def build_root_parser():
         prog='picard-cli',
         description='MusicBrainz Picard command-line interface',
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_build_examples_epilog(),
     )
 
     # Global options (shared by all subcommands)
@@ -123,26 +154,12 @@ def build_root_parser():
         metavar='<command>',
     )
 
-    # Register available subcommands
-    _register_plugins_subcommand(subparsers)
-    _register_profiles_subcommand(subparsers)
+    # Register available subcommands (lazy import to avoid heavy deps at parse time)
+    for cmd in SUBCOMMANDS:
+        module = import_module(cmd.module_path)
+        module.register_subcommand(subparsers)
 
     return parser
-
-
-def _register_plugins_subcommand(subparsers):
-    """Register the 'plugins' subcommand group."""
-    # Lazy import to avoid loading heavy dependencies at parse time
-    from picard.cli.plugins import register_subcommand
-
-    register_subcommand(subparsers)
-
-
-def _register_profiles_subcommand(subparsers):
-    """Register the 'profiles' subcommand group."""
-    from picard.profiles.cli import register_subcommand
-
-    register_subcommand(subparsers)
 
 
 def main():

--- a/picard/cli/__init__.py
+++ b/picard/cli/__init__.py
@@ -39,6 +39,25 @@ from picard.util import (
 )
 
 
+# Subcommand metadata: (name, help_text)
+# Adding an entry here automatically updates both picard-cli and picard --help.
+SUBCOMMANDS = (
+    ('plugins', 'manage Picard plugins'),
+    ('profiles', 'manage Picard profiles'),
+)
+
+
+def get_subcommands_help():
+    """Return a formatted string listing picard-cli subcommands for use in epilogs."""
+    lines = ["Additional commands available via picard-cli:"]
+    max_name_len = max(len(name) for name, _ in SUBCOMMANDS)
+    for name, help_text in SUBCOMMANDS:
+        lines.append(f"  {name:<{max_name_len}}  {help_text}")
+    lines.append("")
+    lines.append("Use 'picard-cli <command> --help' for more information.")
+    return "\n".join(lines)
+
+
 def build_root_parser():
     """Build the root argument parser with global options and subcommands."""
     parser = argparse.ArgumentParser(

--- a/picard/cli/__init__.py
+++ b/picard/cli/__init__.py
@@ -156,10 +156,20 @@ def build_root_parser():
 
     # Register available subcommands (lazy import to avoid heavy deps at parse time)
     for cmd in SUBCOMMANDS:
-        module = import_module(cmd.module_path)
-        module.register_subcommand(subparsers)
+        _register_subcommand(subparsers, cmd)
 
     return parser
+
+
+def _register_subcommand(subparsers, cmd):
+    """Register a single subcommand from its metadata.
+
+    Creates the subparser with name/help from SUBCOMMANDS, then delegates
+    to the module's setup_parser() to populate arguments and verbs.
+    """
+    module = import_module(cmd.module_path)
+    parser = subparsers.add_parser(cmd.name, help=cmd.help)
+    module.setup_parser(parser)
 
 
 def main():

--- a/picard/cli/__init__.py
+++ b/picard/cli/__init__.py
@@ -21,8 +21,12 @@
 """picard-cli: Modern subcommand-based CLI for MusicBrainz Picard.
 
 Usage:
-    picard-cli plugins <command> [options]
+    picard-cli <command> [options]
     picard-cli --version
+
+Commands:
+    plugins     Manage Picard plugins
+    profiles    Manage Picard profiles
 """
 
 import argparse

--- a/picard/cli/plugins.py
+++ b/picard/cli/plugins.py
@@ -48,21 +48,17 @@ from picard.cli.argparse_grouped import (
 from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 
 
-def register_subcommand(subparsers):
-    """Register the 'plugins' subcommand with all its verbs."""
-    plugins_parser = subparsers.add_parser(
-        'plugins',
-        help='manage Picard plugins',
-        description='Install, update, enable, and manage Picard plugins.',
-        formatter_class=GroupedHelpFormatter,
-        epilog=(
-            "Trust Levels:\n"
-            "  🛡️ official: Reviewed by Picard team (highest trust)\n"
-            "  ✓ trusted: Known authors, not reviewed (high trust)\n"
-            "  ⚠️ community: Other authors, not reviewed (use caution)\n"
-            "  🔓 unregistered: Not in registry (local/unknown source - lowest trust)\n"
-            "\nFor more information, visit: https://picard.musicbrainz.org/docs/plugins/"
-        ),
+def setup_parser(plugins_parser):
+    """Configure the 'plugins' subcommand parser with all its verbs."""
+    plugins_parser.description = 'Install, update, enable, and manage Picard plugins.'
+    plugins_parser.formatter_class = GroupedHelpFormatter
+    plugins_parser.epilog = (
+        "Trust Levels:\n"
+        "  🛡️ official: Reviewed by Picard team (highest trust)\n"
+        "  ✓ trusted: Known authors, not reviewed (high trust)\n"
+        "  ⚠️ community: Other authors, not reviewed (use caution)\n"
+        "  🔓 unregistered: Not in registry (local/unknown source - lowest trust)\n"
+        "\nFor more information, visit: https://picard.musicbrainz.org/docs/plugins/"
     )
 
     # Common options for the plugins group

--- a/picard/profiles/cli.py
+++ b/picard/profiles/cli.py
@@ -83,13 +83,9 @@ def _print_resolve_error(query: str, result: ResolveResult, output):
             output.info(f"{p['title']} (id: {p['id']})")
 
 
-def register_subcommand(subparsers):
-    """Register the 'profiles' subcommand with all its verbs."""
-    profiles_parser = subparsers.add_parser(
-        'profiles',
-        help='manage Picard profiles',
-        description='Export, import, and list Picard profiles.',
-    )
+def setup_parser(profiles_parser):
+    """Configure the 'profiles' subcommand parser with all its verbs."""
+    profiles_parser.description = 'Export, import, and list Picard profiles.'
 
     # Profile sub-subcommands (verbs)
     verb_parsers = profiles_parser.add_subparsers(

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -90,6 +90,7 @@ from picard.album import (
 from picard.audit import setup_audit
 from picard.browser.filelookup import FileLookup
 from picard.browser.server import BrowserIntegration
+from picard.cli import get_subcommands_help
 from picard.cluster import (
     Cluster,
     ClusterList,
@@ -1612,10 +1613,17 @@ def print_help_for_commands():
 
 
 def process_cmdline_args():
+    epilog = (
+        "If one of the filenames begins with a hyphen, use -- to separate the\n"
+        "options from the filenames.\n"
+        "If a new instance will not be spawned files/directories will be passed\n"
+        "to the existing instance\n"
+        "\n" + get_subcommands_help()
+    )
+
     parser = CmdlineArgsParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""If one of the filenames begins with a hyphen, use -- to separate the options from the filenames.
-If a new instance will not be spawned files/directories will be passed to the existing instance""",
+        epilog=epilog,
     )
     # Qt default arguments. Parse them so Picard does not interpret the
     # arguments as file names to load.


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

The `picard --help` output now mentions `picard-cli` subcommands (plugins, profiles) in its epilog, and the subcommand registry is refactored to use a single `SUBCOMMANDS` namedtuple that drives both registration and help generation.

## Problem

Running `picard --help` gave no indication that `picard-cli plugins` and `picard-cli profiles` commands exist. Users had no way to discover them from the GUI command's help.

## Solution

- Added a `SUBCOMMANDS` namedtuple registry in `picard/cli/__init__.py` with `name`, `help`, `module_path`, and `examples` fields.
- `get_subcommands_help()` generates the epilog text for `picard --help` from this registry.
- `build_root_parser()` loops over `SUBCOMMANDS` for registration (removing individual `_register_*` functions).
- The `picard-cli --help` epilog with usage examples is also auto-generated from the same registry.
- Adding a new subcommand now requires only a single tuple entry.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed interactively with AI (Kiro CLI), with human review and direction at each step.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
