### PR TITLE
Thread typehints

### DIFF
--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -196,7 +196,7 @@ class CoverArtImageProcessing:
         if coverartimage.can_be_processed:
             run_processors = partial(self._run_image_processors, coverartimage, initial_data, image_info)
 
-            def next_func(result, error=None):
+            def next_func(result=None, error=None):
                 callback(coverartimage, error)
 
             thread.run_task(run_processors, next_func=next_func, task_counter=self.task_counter)

--- a/picard/plugin3/manager/update_checker.py
+++ b/picard/plugin3/manager/update_checker.py
@@ -54,7 +54,7 @@ class PluginUpdateChecker:
         except Exception as e:
             log.error("Failed to refresh all plugins: %s", e, exc_info=True)
 
-    def _on_plugin_update_checks_finished(self, *args, **kwargs):
+    def _on_plugin_update_checks_finished(self, result=None, error=None):
         log.debug("Finished checking for plugin updates.")
         self.plugin_manager.refresh_updates_available.emit()
         self.plugin_manager.plugin_update_checks_complete.emit(self.updates)

--- a/picard/util/thread.py
+++ b/picard/util/thread.py
@@ -34,7 +34,12 @@ import sys
 import threading
 import time
 import traceback
-from typing import Any
+from typing import (
+    Any,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+)
 
 from PyQt6.QtCore import (
     QCoreApplication,
@@ -49,8 +54,16 @@ from picard import (
 )
 
 
+P = ParamSpec('P')
+R = TypeVar('R')
+
+
+class Callback(Protocol[R]):
+    def __call__(self, result: R | None = None, error: BaseException | None = None) -> None: ...
+
+
 class ProxyToMainEvent(QEvent):
-    def __init__(self, func: Callable, *args: Any, **kwargs: Any):
+    def __init__(self, func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs):
         super().__init__(QEvent.Type.User)
         self.func = func
         self.args = args
@@ -84,7 +97,11 @@ class TaskCounter:
 
 class Runnable(QRunnable):
     def __init__(
-        self, func: Callable, next_func: Callable, task_counter: TaskCounter | None = None, traceback: bool = True
+        self,
+        func: Callable[[], R],
+        next_func: Callback[R],
+        task_counter: TaskCounter | None = None,
+        traceback: bool = True,
     ):
         super().__init__()
         self.func = func
@@ -107,8 +124,8 @@ class Runnable(QRunnable):
 
 
 def run_task(
-    func: Callable,
-    next_func: Callable | None = None,
+    func: Callable[[], R],
+    next_func: Callback[R] | None = None,
     priority: int = 0,
     thread_pool: QThreadPool | None = None,
     task_counter: TaskCounter | None = None,
@@ -141,11 +158,11 @@ def run_task(
     thread_pool.start(Runnable(func, next_func, task_counter, traceback), priority)
 
 
-def to_main(func: Callable, *args: Any, **kwargs: Any) -> None:
+def to_main(func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> None:
     QCoreApplication.postEvent(QCoreApplication.instance(), ProxyToMainEvent(func, *args, **kwargs))
 
 
-def to_main_with_blocking(func: Callable, *args: Any, **kwargs: Any) -> None:
+def to_main_with_blocking(func: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> None:
     """Executes a command as a user-defined event, and waits until the event has
     closed before returning.  Note that any new threads started while processing
     the event will not be considered when releasing the blocking of the function.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

The functions in `picard.util.thread` usually expect callables as argument, but the exact form of those callables is not simple to see. You usually have to look up other uses to figure it out. Also type checkers can not easily find mistakes.

This PR improves the type hints for callable arguments to make the expected structure clear and allow type checkers to validate.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Define a protocol for Callback arguments, with a generic result type. Using a protocol allows type checking that the callback provides both the "result" and "error" keyword arguments, and both are optional.

Make use of ParamSpec and TypeVar to type check the return values and arguments of callables passed as argument to threading functions. This allows type checkers:

- To verify that the return type of the function to run in `run_task` matches the result type in the `next_func`
- The args and kwargs passed to `to_main` and `to_main_with_blocking` match the args and kwargs of the passed callable

Also fixed a case of a `thread.run_task` call with invalid next_func (the result was not optional, leading to a potential crash on exceptions during image processing).

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
