### PR TITLE
Simplify cover art image selection flow

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -133,15 +133,26 @@ class CoverArt:
             self._queue_generator = None
             self.image_processing.wait_for_processing()
 
+    def _all_images_satisfied(self, config=None) -> bool:
+        """Check if all configured image needs have been met.
+
+        Returns True if no more images need to be downloaded, considering
+        both embedding and external file settings symmetrically.
+        """
+        if not self.front_image_found:
+            return False
+        if config is None:
+            config = get_config()
+        need_more_for_tags = config.setting['save_images_to_tags'] and not config.setting['embed_only_one_front_image']
+        need_more_for_files = config.setting['save_images_to_files'] and not config.setting['save_only_one_front_image']
+        return not need_more_for_tags and not need_more_for_files
+
     def _start_queue(self) -> Generator[None, None, None]:
         """Creates a generator that processes all cover art providers.
         The generator will yield if async providers are loading data, otherwise
         it iterates over queued images and processes them.
         """
         config = get_config()
-        save_images_to_tags = config.setting['save_images_to_tags']
-        save_images_to_files = config.setting['save_images_to_files']
-        embed_only_one_front_image = config.setting['embed_only_one_front_image']
 
         while True:
             if self.album.id not in self.album.tagger.albums:
@@ -149,13 +160,7 @@ class CoverArt:
                 log.debug(f'Cover art processing aborted, {self.album} got removed')
                 return
 
-            if (
-                self.front_image_found
-                and save_images_to_tags
-                and not save_images_to_files
-                and embed_only_one_front_image
-            ):
-                # no need to continue
+            if self._all_images_satisfied(config):
                 return
 
             while self._queue_empty():

--- a/picard/file.py
+++ b/picard/file.py
@@ -770,15 +770,7 @@ class File(MetadataItem):
         if not metadata.images:
             return
         counters = Counter()
-        images = []
-        config = get_config()
-        if config.setting['save_only_one_front_image']:
-            front = metadata.images.get_front_image()
-            if front:
-                images.append(front)
-        if not images:
-            images = metadata.images
-        for image in images:
+        for image in metadata.images.to_be_saved_to_files():
             image.save(dirname, metadata, counters)
 
     def _move_additional_files(self, old_filename, new_filename, config):

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -105,6 +105,24 @@ class ImageList(MutableSequence['CoverArtImage']):
                 else:
                     yield image
 
+    def to_be_saved_to_files(self, settings: SettingConfigSection | None = None) -> Iterator['CoverArtImage']:
+        """Generator returning images to be saved as external files according to
+        passed settings or config.setting.
+
+        When save_only_one_front_image is enabled, yields only the first front
+        image. Falls back to yielding all images if no front image is found.
+        """
+        if settings is None:
+            config = get_config()
+            settings = config.setting
+        if settings['save_images_to_files']:
+            if settings['save_only_one_front_image']:
+                front = self.get_front_image()
+                if front:
+                    yield front
+                    return
+            yield from self
+
     def strip_front_images(self) -> None:
         self._images = [image for image in self._images if not image.is_front_image()]
         self._dirty = True

--- a/test/test_coverart_queue.py
+++ b/test/test_coverart_queue.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from unittest.mock import Mock
+
+from test.picardtestcase import PicardTestCase
+
+from picard.coverart import CoverArt
+
+
+class CoverArtAllImagesSatisfiedTest(PicardTestCase):
+    """Tests for CoverArt._all_images_satisfied optimization."""
+
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.coverart')
+        album = Mock()
+        album.tagger = Mock()
+        metadata = Mock()
+        release = {}
+        self.coverart = CoverArt(album, metadata, release)
+
+    def _make_config(self, save_to_tags=True, embed_only_front=True, save_to_files=True, save_only_front_file=False):
+        config = Mock()
+        config.setting = {
+            'save_images_to_tags': save_to_tags,
+            'embed_only_one_front_image': embed_only_front,
+            'save_images_to_files': save_to_files,
+            'save_only_one_front_image': save_only_front_file,
+        }
+        return config
+
+    def test_not_satisfied_when_no_front_found(self):
+        """Never satisfied if no front image has been found yet."""
+        self.coverart.front_image_found = False
+        config = self._make_config()
+        self.assertFalse(self.coverart._all_images_satisfied(config))
+
+    def test_satisfied_tags_only_front_no_files(self):
+        """Original case: only embedding one front, no external files."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=True,
+            embed_only_front=True,
+            save_to_files=False,
+            save_only_front_file=False,
+        )
+        self.assertTrue(self.coverart._all_images_satisfied(config))
+
+    def test_not_satisfied_tags_wants_all(self):
+        """Tags wants all images (embed_only_one_front_image=False)."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=True,
+            embed_only_front=False,
+            save_to_files=False,
+            save_only_front_file=False,
+        )
+        self.assertFalse(self.coverart._all_images_satisfied(config))
+
+    def test_not_satisfied_files_wants_all(self):
+        """Files wants all images (save_only_one_front_image=False)."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=True,
+            embed_only_front=True,
+            save_to_files=True,
+            save_only_front_file=False,
+        )
+        self.assertFalse(self.coverart._all_images_satisfied(config))
+
+    def test_satisfied_both_want_only_front(self):
+        """Both tags and files want only the front image."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=True,
+            embed_only_front=True,
+            save_to_files=True,
+            save_only_front_file=True,
+        )
+        self.assertTrue(self.coverart._all_images_satisfied(config))
+
+    def test_satisfied_files_only_front_no_tags(self):
+        """Only saving files with only front, tags disabled."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=False,
+            embed_only_front=False,
+            save_to_files=True,
+            save_only_front_file=True,
+        )
+        self.assertTrue(self.coverart._all_images_satisfied(config))
+
+    def test_not_satisfied_both_disabled(self):
+        """Both disabled — technically satisfied (nothing needed)."""
+        self.coverart.front_image_found = True
+        config = self._make_config(
+            save_to_tags=False,
+            embed_only_front=False,
+            save_to_files=False,
+            save_only_front_file=False,
+        )
+        self.assertTrue(self.coverart._all_images_satisfied(config))

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -334,6 +334,49 @@ class ImageListTest(PicardTestCase):
         with self.assertRaises(KeyError):
             next(to_be_saved(settings))
 
+    def test_to_be_saved_to_files(self):
+        def to_be_saved(settings):
+            return self.imagelist.to_be_saved_to_files(settings=settings)
+
+        settings = {
+            "save_images_to_files": True,
+            "save_only_one_front_image": False,
+        }
+        # save all but no images in list
+        self.assertEqual(list(to_be_saved(settings)), [])
+
+        # save all, only one non-front image in the list
+        self.imagelist.append(self.images['a'])
+        self.assertEqual(list(to_be_saved(settings)), [self.images['a']])
+
+        # save all, 2 images, one of them is a front image (b)
+        self.imagelist.append(self.images['b'])
+        self.assertEqual(list(to_be_saved(settings)), [self.images['a'], self.images['b']])
+
+        # save only one front, 2 images, one of them is a front image (b)
+        settings["save_only_one_front_image"] = True
+        self.assertEqual(list(to_be_saved(settings)), [self.images['b']])
+
+        # save only one front, 3 images, two of them have front type (b & c)
+        self.imagelist.append(self.images['c'])
+        self.assertEqual(list(to_be_saved(settings)), [self.images['b']])
+
+        # save only one front, but no front image exists — falls back to all
+        self.imagelist = ImageList()
+        self.imagelist.append(self.images['a'])
+        self.assertEqual(list(to_be_saved(settings)), [self.images['a']])
+
+        # 3 images, but save disabled
+        self.imagelist.append(self.images['b'])
+        self.imagelist.append(self.images['c'])
+        settings["save_images_to_files"] = False
+        self.assertEqual(list(to_be_saved(settings)), [])
+
+        # settings is missing a setting
+        del settings["save_images_to_files"]
+        with self.assertRaises(KeyError):
+            next(to_be_saved(settings))
+
     def test_strip_front_images(self):
         self.imagelist.append(self.images['a'])
         self.imagelist.append(self.images['b'])


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Simplify the cover art image selection logic by extracting a clear early-termination method and adding a symmetric `to_be_saved_to_files()` method on `ImageList`.

## Problem

The cover art download early-termination logic in `_start_queue` was an inline condition that only handled the "tags only, one front" case. The external file saving logic in `File._save_images` used ad-hoc inline filtering rather than the same pattern as `to_be_saved_to_tags()`.

## Solution

**Commit 1: Refactor early termination into `_all_images_satisfied`**

Extract the inline condition into a dedicated method that considers both embedding and external file settings symmetrically. This also extends the optimization to cover cases not previously handled (e.g., both tags and files configured to save only the front image, or only files enabled with `save_only_one_front_image`).

**Commit 2: Add `ImageList.to_be_saved_to_files()`**

Add `to_be_saved_to_files()` as the symmetric counterpart to `to_be_saved_to_tags()`. Both methods follow the same pattern: check if saving is enabled, apply the "only one front" filter if configured, and yield matching images. Refactors `File._save_images` to use it, removing inline filtering logic.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed collaboratively with an AI assistant (Kiro CLI), with human review and design decisions by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

No documentation update needed — internal refactoring only.