### PR TITLE
Make tomlkit optional, disable profile export if tomlkit is not available

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,6 @@ For development or building from source, follow the instructions below.
 * [Mutagen 1.45 or newer](https://mutagen.readthedocs.io/)
 * [PyYAML 5.1 or newer](https://pyyaml.org/)
 * [pygit2 1.18.2 or newer](https://www.pygit2.org/) - For plugin system
-* [tomlkit 0.12.4 or newer](https://github.com/python-poetry/tomlkit) - For profile exports
 * gettext (`msgfmt`):
   * **Windows:** Download from [gettext-iconv-windows](https://github.com/mlocati/gettext-iconv-windows/releases) and add to PATH
   * **Linux:** `sudo apt install gettext` (Ubuntu/Debian) or equivalent
@@ -40,6 +39,7 @@ For development or building from source, follow the instructions below.
 * [Markdown 3.2 or newer](https://python-markdown.github.io/install/) - For enhanced internal documentation (scripting, plugins, etc.)
 * [PyJWT 2.0 or newer](https://pyjwt.readthedocs.io/) - For "add cluster as release" functionality
 * [charset-normalizer 3.3 or newer](https://pypi.org/project/charset-normalizer/) - For character encoding detection in CD ripping log files
+* [tomlkit 0.12.4 or newer](https://github.com/python-poetry/tomlkit) - For profile exports
 * [chromaprint](https://acoustid.org/chromaprint) - For audio fingerprinting (AcoustID), allows identifying files by their actual audio content
 * PyQt6 multimedia support - For embedded audio player (Linux: `python3-pyqt6.qtmultimedia libqt6multimedia6`)
 

--- a/picard/cli/profiles.py
+++ b/picard/cli/profiles.py
@@ -34,7 +34,10 @@ import os
 
 from picard.cli.base import ExitCode
 from picard.config import get_config
-from picard.profiles.exporter import export_profile
+from picard.profiles.exporter import (
+    export_available,
+    export_profile,
+)
 from picard.profiles.importer import (
     ProfileImportError,
     import_profile,
@@ -153,6 +156,10 @@ def cmd_list(output):
 
 def cmd_export(args, output):
     """Export a profile to a TOML file."""
+    if not export_available:
+        output.error("Export unavailable, tomlkit is not installed")
+        return ExitCode.ERROR
+
     config = get_config()
 
     resolve = _resolve_profile_query(config, args.profile)

--- a/picard/profiles/exporter.py
+++ b/picard/profiles/exporter.py
@@ -36,7 +36,14 @@ from picard.profile import is_plugin_profile_key
 from picard.profiles import PROFILE_FORMAT_VERSION
 from picard.script import get_file_naming_script_presets
 
-import tomlkit
+
+tomlkit = None
+try:
+    import tomlkit
+
+    export_available = True
+except ImportError:
+    export_available = False
 
 
 # Options that are represented as scripts in the TOML format
@@ -71,6 +78,7 @@ def export_profile(
     Returns:
         A TOML-formatted string representing the exported profile.
     """
+    assert tomlkit, "tomlkit unavailable"
     all_settings = config.profiles['user_profile_settings']
     profile_settings = all_settings.get(profile_id, {})
 
@@ -137,6 +145,7 @@ def export_profile(
 
 def _export_value(value):
     """Convert an option value to a TOML-compatible type."""
+    assert tomlkit, "tomlkit unavailable"
     if isinstance(value, Enum):
         return value.value
     if isinstance(value, dict):
@@ -150,6 +159,7 @@ def _export_value(value):
 
 def _export_scripts(doc, config, profile_settings, mode):
     """Export naming and tagger scripts into the TOML document."""
+    assert tomlkit, "tomlkit unavailable"
     scripts_added = False
 
     # File naming script
@@ -222,6 +232,7 @@ def _resolve_naming_script(config, script_id: str) -> tuple[dict | None, bool]:
     return False
 
 
-def _multiline_string(text: str) -> tomlkit.items.String:
+def _multiline_string(text: str) -> 'tomlkit.items.String':
     """Create a TOML multiline literal string for script content."""
+    assert tomlkit, "tomlkit unavailable"
     return tomlkit.string(text, multiline=True, literal=True)

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -59,7 +59,10 @@ from picard.profile import (
     profile_groups_values,
     setting_profile_key,
 )
-from picard.profiles.exporter import export_profile
+from picard.profiles.exporter import (
+    export_available,
+    export_profile,
+)
 from picard.profiles.importer import (
     ProfileImportError,
     import_profile,
@@ -162,6 +165,9 @@ class ProfilesOptionsPage(OptionsPage):
         self.export_profile_button = QtWidgets.QPushButton(_("Export"))
         self.export_profile_button.setToolTip(_("Export the profile to a file"))
         self.export_profile_button.clicked.connect(self.export_profile)
+        if not export_available:
+            self.export_profile_button.setEnabled(False)
+            self.export_profile_button.setToolTip(_("Export unavailable, tomlkit is not installed"))
         self.ui.profile_list_buttonbox.addButton(
             self.export_profile_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole
         )
@@ -875,7 +881,7 @@ class ProfilesOptionsPage(OptionsPage):
         state = self.current_profile_id is not None
         self.copy_profile_button.setEnabled(state)
         self.delete_profile_button.setEnabled(state)
-        self.export_profile_button.setEnabled(state)
+        self.export_profile_button.setEnabled(state and export_available)
 
 
 register_options_page(ProfilesOptionsPage)

--- a/picard/ui/widgets/profilelistwidget.py
+++ b/picard/ui/widgets/profilelistwidget.py
@@ -35,6 +35,7 @@ from picard.i18n import (
     gettext as _,
     gettext_constants,
 )
+from picard.profiles.exporter import export_available
 from picard.util import unique_numbered_title
 
 from picard.ui import HashableListWidgetItem
@@ -59,6 +60,7 @@ class ProfileListWidget(QtWidgets.QListWidget):
             menu.addSeparator()
             export_action = QtGui.QAction(_("Export profile…"), self)
             export_action.triggered.connect(partial(self.export_requested.emit, item))
+            export_action.setEnabled(export_available)
             menu.addAction(export_action)
             copy_action = QtGui.QAction(_("Copy to clipboard"), self)
             copy_action.triggered.connect(partial(self.copy_to_clipboard_requested.emit, item))

--- a/test/test_profile_export.py
+++ b/test/test_profile_export.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import sys
+import unittest
 
 
 if sys.version_info < (3, 11):
@@ -37,9 +38,13 @@ from picard.config import (
     TextOption,
 )
 from picard.const.cover_processing import ImageFormat
-from picard.profiles.exporter import export_profile
+from picard.profiles.exporter import (
+    export_available,
+    export_profile,
+)
 
 
+@unittest.skipUnless(export_available, "profile export requires tomlkit")
 class TestProfileExport(TestPicardConfigCommon):
     def setUp(self):
         super().setUp()

--- a/test/test_profiles_cli.py
+++ b/test/test_profiles_cli.py
@@ -21,6 +21,7 @@
 from io import StringIO
 import os
 from types import SimpleNamespace
+import unittest
 from unittest.mock import patch
 
 from test.test_config import TestPicardConfigCommon
@@ -38,6 +39,7 @@ from picard.config import (
     Option,
     TextOption,
 )
+from picard.profiles.exporter import export_available
 
 
 def _make_output():
@@ -92,6 +94,7 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertIn('Classical', out)
         self.assertIn('disabled', out)
 
+    @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_export_to_stdout(self, mock_get_config):
         mock_get_config.return_value = self.config
@@ -109,6 +112,7 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertIn('My Rock Profile', out)
         self.assertIn('rename_files', out)
 
+    @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_export_to_file(self, mock_get_config):
         mock_get_config.return_value = self.config
@@ -126,6 +130,7 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertIn('[profile]', content)
         self.assertIn('My Rock Profile', content)
 
+    @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_export_profile_not_found(self, mock_get_config):
         mock_get_config.return_value = self.config
@@ -203,6 +208,7 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Invalid TOML', stderr.getvalue())
 
+    @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_export_backup_mode(self, mock_get_config):
         mock_get_config.return_value = self.config
@@ -222,6 +228,7 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertEqual(exit_code, ExitCode.SUCCESS)
         self.assertIn('secret', mock_out.getvalue())
 
+    @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_import_round_trip(self, mock_get_config):
         """Test that export → import produces a valid profile."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Since tomlkit is only strictly needed for profile export, and both profiles and more so their export is non-essential functionality, we can keep this as an optional, but highly recommended, dependency.

We do the same with e.g. PyJWT or charset-normalizer, which we really recommend being installed, but Picard will run when missing (and disable the corresponding functionality).

We still have it as a normal dependency in `pyrpoject.toml`. When installing via pypi this dependency is easily resolved, but it might be missing elsewhere.



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Conditionally import tomlkit. If not available, disable the export button (but show a explaining tooltip) and in picard-cli show a proper error message.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
