### PR TITLE
PICARD-3355: Allow plugins to unregister script variables

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -680,6 +680,10 @@ def enable(api):
 
 Register a variable name for script autocomplete.
 
+If the same variable name has already been registered by this plugin, the
+existing entry is replaced (no duplicate is created). This allows plugins to
+safely re-register variables without needing to unregister first.
+
 ```python
 def enable(api):
     api.register_script_variable(
@@ -691,6 +695,47 @@ def enable(api):
 **Parameters**:
 - `name`: Variable name (without % symbols)
 - `documentation`: Optional help text for the variable
+
+---
+
+#### `unregister_script_variable(name)`
+
+Unregister a single script variable previously registered by this plugin.
+
+```python
+def enable(api):
+    api.register_script_variable("my_var", "My variable")
+    # Later, when the variable is no longer needed:
+    api.unregister_script_variable("my_var")
+```
+
+**Parameters**:
+- `name`: The variable name to unregister
+
+**Note**: Only removes the variable registered by this plugin. If another plugin
+has registered the same variable name, that registration is unaffected.
+
+---
+
+#### `unregister_all_script_variables()`
+
+Unregister all script variables registered by this plugin.
+
+This is useful when a plugin needs to re-register variables that depend on
+configuration. Call this before re-registering to avoid stale entries from a
+previous configuration.
+
+```python
+def on_config_changed(api):
+    # Remove all previously registered variables
+    api.unregister_all_script_variables()
+    # Re-register based on current config
+    for var_name, description in get_configured_variables():
+        api.register_script_variable(var_name, description)
+```
+
+**Note**: Only removes variables registered by this plugin. Other plugins'
+registrations are unaffected.
 
 ---
 

--- a/picard/extension_points/__init__.py
+++ b/picard/extension_points/__init__.py
@@ -34,7 +34,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import (
+    Callable,
+    Iterator,
+)
 from typing import Any
 import uuid
 
@@ -67,6 +70,20 @@ class ExtensionPoint:
             # uncomment to debug internal extensions loaded at startup
             # print("ExtensionPoint: %s register <- item=%r" % (self.label, item))
         self.__dict[name].append(item)
+
+    def unregister(self, module: str, match: Callable[[Any], bool]) -> None:
+        """Remove items registered by *module* for which *match* returns True.
+
+        Args:
+            module: Full module path (same value passed to :meth:`register`).
+            match: A callable receiving an item; return True to remove it.
+        """
+        if module.startswith(PLUGIN_MODULE_PREFIX):
+            name = module[PLUGIN_MODULE_PREFIX_LEN:].split('.')[0]
+        else:
+            name = None
+        if name in self.__dict:
+            self.__dict[name] = [item for item in self.__dict[name] if not match(item)]
 
     def unregister_module(self, name: str | None) -> None:
         try:

--- a/picard/extension_points/__init__.py
+++ b/picard/extension_points/__init__.py
@@ -61,14 +61,17 @@ class ExtensionPoint:
         self.__dict = defaultdict(list)
         _extension_points.append(self)
 
-    def register(self, module: str, item: Any) -> None:
+    @staticmethod
+    def _derive_key(module: str) -> str | None:
+        """Derive the internal storage key from a full module path."""
         if module.startswith(PLUGIN_MODULE_PREFIX):
-            name = module[PLUGIN_MODULE_PREFIX_LEN:].split('.')[0]
+            return module[PLUGIN_MODULE_PREFIX_LEN:].split('.')[0]
+        return None
+
+    def register(self, module: str, item: Any) -> None:
+        name = self._derive_key(module)
+        if name is not None:
             log.debug("ExtensionPoint: %s register <- plugin=%r item=%r", self.label, name, item)
-        else:
-            name = None
-            # uncomment to debug internal extensions loaded at startup
-            # print("ExtensionPoint: %s register <- item=%r" % (self.label, item))
         self.__dict[name].append(item)
 
     def unregister(self, module: str, match: Callable[[Any], bool]) -> None:
@@ -78,10 +81,7 @@ class ExtensionPoint:
             module: Full module path (same value passed to :meth:`register`).
             match: A callable receiving an item; return True to remove it.
         """
-        if module.startswith(PLUGIN_MODULE_PREFIX):
-            name = module[PLUGIN_MODULE_PREFIX_LEN:].split('.')[0]
-        else:
-            name = None
+        name = self._derive_key(module)
         if name in self.__dict:
             self.__dict[name] = [item for item in self.__dict[name] if not match(item)]
 

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -19,10 +19,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import TYPE_CHECKING
+
 from picard.i18n import _
 from picard.plugin import ExtensionPoint
 from picard.script.variable_pattern import VARIABLE_NAME_FULLMATCH_RE
 from picard.tags import script_variable_tag_names
+
+
+if TYPE_CHECKING:
+    from picard.plugin3.api_impl import PluginApi
 
 
 ext_point_script_variables = ExtensionPoint(label='script_variables')
@@ -49,8 +55,11 @@ def _is_valid_plugin_variable_name(name: str | None) -> bool:
     return bool(VARIABLE_NAME_FULLMATCH_RE.match(name))
 
 
-def register_script_variable(name: str, documentation: str | None = None, api=None) -> None:
+def register_script_variable(name: str, documentation: str | None = None, api: 'PluginApi | None' = None) -> None:
     """Register a variable that plugins can provide for script completion.
+
+    If the same variable name has already been registered by the same plugin,
+    the existing entry is replaced (no duplicate is created).
 
     Parameters
     ----------
@@ -58,6 +67,8 @@ def register_script_variable(name: str, documentation: str | None = None, api=No
         The variable name (without % symbols)
     documentation : str, optional
         Optional documentation for the variable
+    api : PluginApi, optional
+        The plugin API instance
 
     Examples
     --------
@@ -71,8 +82,8 @@ def register_script_variable(name: str, documentation: str | None = None, api=No
     if api and duplicate:
         api.logger.warning("Tag '%s' also found in %s.", name, duplicate)
 
-    if api and api._plugin_module:
-        module_name = api._plugin_module.__name__
+    if api:
+        module_name = api.module_path
     else:
         module_name = 'unknown'
 
@@ -83,7 +94,33 @@ def register_script_variable(name: str, documentation: str | None = None, api=No
     if plugin_name:
         plugin_documentation += _("Plugin: %s") % plugin_name
 
+    # Remove any existing entry with the same name from this plugin to avoid duplicates
+    ext_point_script_variables.unregister(module_name, lambda item: item[0] == name)
     ext_point_script_variables.register(module_name, (name, plugin_documentation, plugin_name))
+
+
+def unregister_script_variable(name: str, api: 'PluginApi') -> None:
+    """Unregister a single script variable previously registered by this plugin.
+
+    Parameters
+    ----------
+    name : str
+        The variable name to unregister
+    api : PluginApi
+        The plugin API instance (identifies which plugin's registration to remove)
+    """
+    ext_point_script_variables.unregister(api.module_path, lambda item: item[0] == name)
+
+
+def unregister_all_script_variables(api: 'PluginApi') -> None:
+    """Unregister all script variables registered by this plugin.
+
+    Parameters
+    ----------
+    api : PluginApi
+        The plugin API instance (identifies which plugin's registrations to remove)
+    """
+    ext_point_script_variables.unregister(api.module_path, lambda item: True)
 
 
 def get_plugin_variable_names() -> set[str]:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -90,7 +90,11 @@ from picard.extension_points.metadata import (
 from picard.extension_points.options_pages import register_options_page
 from picard.extension_points.plugin_tools_menu import register_tools_menu_action
 from picard.extension_points.script_functions import register_script_function
-from picard.extension_points.script_variables import register_script_variable
+from picard.extension_points.script_variables import (
+    register_script_variable,
+    unregister_all_script_variables,
+    unregister_script_variable,
+)
 from picard.file import File
 from picard.metadata import Metadata
 from picard.plugin3.i18n import (
@@ -501,6 +505,16 @@ class PluginApi:
     def plugin_id(self) -> str:
         """Plugin identifier (module name)."""
         return self._manifest.module_name
+
+    @property
+    def module_path(self) -> str:
+        """Full module path used for extension point registration.
+
+        This is the value that :class:`ExtensionPoint` uses internally to
+        group items by plugin (e.g. ``picard.plugins.myplugin``).
+        """
+        assert self._plugin_module is not None
+        return self._plugin_module.__name__
 
     @property
     def global_config(self) -> Config:
@@ -1257,6 +1271,35 @@ class PluginApi:
                 )
         """
         return register_script_variable(name, documentation, self)
+
+    def unregister_script_variable(self, name: str) -> None:
+        """Unregister a single script variable previously registered by this plugin.
+
+        Args:
+            name: The variable name to unregister.
+
+        Example:
+            def enable(api):
+                api.register_script_variable("my_var", "My variable")
+                # Later, when the variable is no longer needed:
+                api.unregister_script_variable("my_var")
+        """
+        return unregister_script_variable(name, self)
+
+    def unregister_all_script_variables(self) -> None:
+        """Unregister all script variables registered by this plugin.
+
+        This is useful when a plugin needs to re-register variables that
+        depend on configuration. Call this before re-registering to avoid
+        stale entries.
+
+        Example:
+            def on_config_changed(api):
+                api.unregister_all_script_variables()
+                for var in get_current_variables():
+                    api.register_script_variable(var.name, var.docs)
+        """
+        return unregister_all_script_variables(self)
 
     # Menu actions
     def register_album_action(self, action: type[BaseAction]) -> None:

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -36,6 +36,8 @@ from picard.extension_points.script_variables import (
     get_plugin_variable_documentation,
     get_plugin_variable_names,
     register_script_variable,
+    unregister_all_script_variables,
+    unregister_script_variable,
 )
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.plugin import Plugin
@@ -215,39 +217,119 @@ class TestExtensionPoints(PicardTestCase):
 
 
 class TestExtensionPointsScriptVariable(PicardTestCase):
-    @patch(
-        'picard.extension_points.script_variables.ext_point_script_variables', ExtensionPoint(label='test_variables')
-    )
+    def setUp(self):
+        super().setUp()
+        patcher_ep = patch(
+            'picard.extension_points.script_variables.ext_point_script_variables',
+            ExtensionPoint(label='test_variables'),
+        )
+        patcher_config = patch('picard.extension_points.get_config', return_value=None)
+        self.ext_point = patcher_ep.start()
+        patcher_config.start()
+        self.addCleanup(patcher_ep.stop)
+        self.addCleanup(patcher_config.stop)
+
+    def _make_api(self, module='picard.plugins.testplugin', name='Test Plugin'):
+        api = MagicMock()
+        api._plugin_module.__name__ = module
+        api.module_path = module
+        api.manifest.name_i18n.return_value = name
+        return api
+
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
         self.assertEqual('some docs\n\nPlugin: Unknown Plugin', get_plugin_variable_documentation('my_var1'))
 
-    @patch(
-        'picard.extension_points.script_variables.ext_point_script_variables', ExtensionPoint(label='test_variables')
-    )
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
         self.assertEqual({'my_var1'}, get_plugin_variable_names())
         self.assertEqual('Plugin: Unknown Plugin', get_plugin_variable_documentation('my_var1'))
 
-    @patch(
-        'picard.extension_points.script_variables.ext_point_script_variables', ExtensionPoint(label='test_variables')
-    )
     def test_register_script_variable_with_api(self):
-        api = MagicMock()
-        api._plugin_module.__name__ = 'test_plugin'
-        api.manifest.name_i18n.return_value = 'Test Plugin'
+        api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
         self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
         self.assertEqual('Some docs\n\nPlugin: Test Plugin', get_plugin_variable_documentation('my_var1'))
         self.assertEqual('Plugin: Test Plugin', get_plugin_variable_documentation('my_var2'))
 
-    @patch(
-        'picard.extension_points.script_variables.ext_point_script_variables', ExtensionPoint(label='test_variables')
-    )
     def test_register_script_variable_invalid_name(self):
         with self.assertRaises(ValueError):
             register_script_variable('my-var1')
+
+    def test_register_script_variable_deduplication(self):
+        """Registering the same variable twice from the same plugin should update, not duplicate."""
+        api = self._make_api()
+        register_script_variable('my_var', 'First docs', api)
+        register_script_variable('my_var', 'Updated docs', api)
+        self.assertEqual({'my_var'}, get_plugin_variable_names())
+        self.assertEqual('Updated docs\n\nPlugin: Test Plugin', get_plugin_variable_documentation('my_var'))
+
+    def test_register_same_variable_different_plugins(self):
+        """Same variable name from different plugins should both be kept."""
+        api1 = self._make_api('picard.plugins.plugin1', 'Plugin One')
+        api2 = self._make_api('picard.plugins.plugin2', 'Plugin Two')
+        register_script_variable('shared_var', 'Docs from plugin1', api1)
+        register_script_variable('shared_var', 'Docs from plugin2', api2)
+        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual('Docs from plugin1\n\nPlugin: Plugin One', get_plugin_variable_documentation('shared_var'))
+
+    def test_unregister_script_variable(self):
+        """Unregistering a single variable should remove only that variable."""
+        api = self._make_api()
+        register_script_variable('var1', 'Docs 1', api)
+        register_script_variable('var2', 'Docs 2', api)
+        self.assertEqual({'var1', 'var2'}, get_plugin_variable_names())
+        unregister_script_variable('var1', api)
+        self.assertEqual({'var2'}, get_plugin_variable_names())
+
+    def test_unregister_script_variable_nonexistent(self):
+        """Unregistering a variable that doesn't exist should not raise."""
+        api = self._make_api()
+        unregister_script_variable('nonexistent', api)
+
+    def test_unregister_all_script_variables(self):
+        """Unregistering all variables should remove all variables from a plugin."""
+        api = self._make_api()
+        register_script_variable('var1', 'Docs 1', api)
+        register_script_variable('var2', 'Docs 2', api)
+        register_script_variable('var3', 'Docs 3', api)
+        self.assertEqual({'var1', 'var2', 'var3'}, get_plugin_variable_names())
+        unregister_all_script_variables(api)
+        self.assertEqual(set(), get_plugin_variable_names())
+
+    def test_unregister_all_does_not_affect_other_plugins(self):
+        """Unregistering all variables from one plugin should not affect another."""
+        api1 = self._make_api('picard.plugins.plugin1', 'Plugin One')
+        api2 = self._make_api('picard.plugins.plugin2', 'Plugin Two')
+        register_script_variable('var_from_p1', 'Docs', api1)
+        register_script_variable('var_from_p2', 'Docs', api2)
+        unregister_all_script_variables(api1)
+        self.assertEqual({'var_from_p2'}, get_plugin_variable_names())
+
+    def test_unregister_does_not_affect_other_plugins(self):
+        """Unregistering a variable name should only remove it from the calling plugin."""
+        api1 = self._make_api('picard.plugins.plugin1', 'Plugin One')
+        api2 = self._make_api('picard.plugins.plugin2', 'Plugin Two')
+        register_script_variable('shared_var', 'Docs from p1', api1)
+        register_script_variable('shared_var', 'Docs from p2', api2)
+        unregister_script_variable('shared_var', api1)
+        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual('Docs from p2\n\nPlugin: Plugin Two', get_plugin_variable_documentation('shared_var'))
+
+    def test_extension_point_unregister_with_match(self):
+        """ExtensionPoint.unregister should remove only items matching the callable."""
+        ep = ExtensionPoint(label='test_unregister')
+        ep.register('picard.plugins.testplugin', ('a', 'data_a'))
+        ep.register('picard.plugins.testplugin', ('b', 'data_b'))
+        ep.register('picard.plugins.testplugin', ('c', 'data_c'))
+
+        uuid = 'a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d'
+        set_plugin_uuid(uuid, 'testplugin')
+        mock_plugin = create_mock_plugin(uuid)
+        PluginManager(Mock()).enable_plugin(mock_plugin)
+
+        ep.unregister('picard.plugins.testplugin', lambda item: item[0] == 'b')
+        self.assertEqual([('a', 'data_a'), ('c', 'data_c')], list(ep))


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add `unregister_script_variable()` and `unregister_all_script_variables()` to the Plugin API, and prevent duplicate documentation entries when a plugin re-registers the same variable name.

## Problem

* JIRA ticket: PICARD-3355

The plugin API assumes variables are registered once in `enable()` and never change. But plugins with dynamic, config-dependent variable names (e.g. Simple Classical) need to re-register variables at runtime. Currently there is no clean way to unregister variables, and calling `register_script_variable` twice for the same name creates duplicate entries in documentation.

See https://community.metabrainz.org/t/simple-classical-picard-3-plugin-for-tagging-classical-music/815330/8

## Solution

- Add `ExtensionPoint.unregister(module, match)` — a generic method for selective item removal using a callable predicate.
- Add `unregister_script_variable(name, api)` — removes a single variable registered by the calling plugin.
- Add `unregister_all_script_variables(api)` — removes all variables registered by the calling plugin.
- `register_script_variable()` now automatically replaces an existing entry with the same name from the same plugin (deduplication), so plugins can safely call it multiple times without needing to unregister first.
- Expose both unregister functions as `PluginApi` methods.
- Cross-plugin isolation: unregistering only affects the calling plugin's own registrations.

### Plugin usage example

A plugin whose variable names depend on user configuration can now cleanly
re-register them whenever settings change:

```python
def register_variables(api):
    # Clear all previously registered variables for this plugin.
    # This removes stale entries from a previous configuration.
    api.unregister_all_script_variables()

    # Re-register based on current config.
    # Each variable will appear in script/tag editor autocomplete.
    for name in api.plugin_config['tag_names']:
        api.register_script_variable(name, "Custom tag from My Plugin")


def enable(api):
    # Set up a default list of tag names the plugin writes to
    api.plugin_config.register_option('tag_names', ['composer', 'conductor'])

    # Register variables on startup
    register_variables(api)
    api.register_options_page(MyOptionsPage)


class MyOptionsPage(OptionsPage):
    def save(self):
        # User changed tag names in settings — persist them
        self.api.plugin_config['tag_names'] = self.tag_names_input.text().split(', ')

        # Update registered variables so autocomplete reflects
        # the new names immediately, without restarting Picard.
        register_variables(self.api)
```

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Implementation, tests, and documentation were developed with AI assistance under human review and direction.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
