### PR TITLE
config: Separate volatile UI state from valuable application state

### DIFF
--- a/picard/collection.py
+++ b/picard/collection.py
@@ -203,7 +203,7 @@ def add_release_to_user_collections(release_node: dict[str, Any]) -> None:
     if 'collections' in release_node:
         release_id = release_node['id']
         config = get_config()
-        username = config.persist['oauth_username'].lower()
+        username = config.state['oauth_username'].lower()
         for node in release_node['collections']:
             if node['editor'].lower() == username:
                 collection = get_user_collection(node['id'])

--- a/picard/config.py
+++ b/picard/config.py
@@ -677,6 +677,14 @@ class Config(QtCore.QSettings):
             return False
         return self._save_backup(backup_path)
 
+    def sync(self):
+        """Write all pending configuration changes to disk.
+
+        Override of QSettings.sync() to provide a single extension point
+        for syncing additional backing stores in the future.
+        """
+        super().sync()
+
 
 class OptionError(Exception):
     def __init__(self, message, section, name):

--- a/picard/config.py
+++ b/picard/config.py
@@ -214,9 +214,9 @@ class ConfigSection(QtCore.QObject):
     # Signal emitted when the value of a setting has changed.
     setting_changed = QtCore.pyqtSignal(str, object, object)
 
-    def __init__(self, config: 'Config', name: str):
+    def __init__(self, config: QtCore.QSettings, name: str):
         super().__init__()
-        self.__qt_config = config
+        self._config_store = config
         self.__name = name
         self.__prefix = self.__name + '/'
         self._memoization: dict[str, Memovar] = defaultdict(Memovar)
@@ -241,13 +241,13 @@ class ConfigSection(QtCore.QObject):
         key = self.key(name)
         if isinstance(value, Enum):
             value = value.value
-        self.__qt_config.setValue(key, value)
+        self._config_store.setValue(key, value)
         self._memoization[key].dirty = True
         if value != old_value:
             self.setting_changed.emit(name, old_value, value)
 
     def __contains__(self, name):
-        return self.__qt_config.contains(self.key(name))
+        return self._config_store.contains(self.key(name))
 
     def as_dict(self):
         return {key: self[key] for section, key in list(Option.registry) if section == self.__name}
@@ -259,15 +259,15 @@ class ConfigSection(QtCore.QObject):
         Option), this returns every key present in the underlying storage,
         including keys that have no corresponding Option registration.
         """
-        self.__qt_config.beginGroup(self.__name)
+        self._config_store.beginGroup(self.__name)
         try:
-            return list(self.__qt_config.childKeys())
+            return list(self._config_store.childKeys())
         finally:
-            self.__qt_config.endGroup()
+            self._config_store.endGroup()
 
     def remove(self, name: str):
         key = self.key(name)
-        config = self.__qt_config
+        config = self._config_store
         if config.contains(key):
             config.remove(key)
         try:
@@ -279,9 +279,9 @@ class ConfigSection(QtCore.QObject):
         """Return an option value without any type conversion."""
         key = self.key(name)
         if qtype is not None:
-            value = self.__qt_config.value(key, type=qtype)
+            value = self._config_store.value(key, type=qtype)
         else:
-            value = self.__qt_config.value(key)
+            value = self._config_store.value(key)
         return value
 
     def value(self, option: Option, default: ConfigValueType | None = None) -> Any:

--- a/picard/config.py
+++ b/picard/config.py
@@ -252,6 +252,19 @@ class ConfigSection(QtCore.QObject):
     def as_dict(self):
         return {key: self[key] for section, key in list(Option.registry) if section == self.__name}
 
+    def keys(self) -> list[str]:
+        """Return all key names stored in this section's backing store.
+
+        Unlike :meth:`as_dict` (which only returns keys with a registered
+        Option), this returns every key present in the underlying storage,
+        including keys that have no corresponding Option registration.
+        """
+        self.__qt_config.beginGroup(self.__name)
+        try:
+            return list(self.__qt_config.childKeys())
+        finally:
+            self.__qt_config.endGroup()
+
     def remove(self, name: str):
         key = self.key(name)
         config = self.__qt_config

--- a/picard/config.py
+++ b/picard/config.py
@@ -550,6 +550,7 @@ class Config(QtCore.QSettings):
         self.profiles: ConfigSection = ConfigSection(self, 'profiles')
         self.setting: SettingConfigSection = SettingConfigSection(self, 'setting')
         self.persist: ConfigSection = ConfigSection(self, 'persist')
+        self.state: ConfigSection = ConfigSection(self, 'state')
 
         if 'version' not in self.application or not self.application['version']:
             TextOption('application', 'version', '0.0.0dev0')
@@ -694,19 +695,21 @@ class OptionError(Exception):
 config = None
 setting = None
 persist = None
+state = None
 profiles = None
 
 
 def setup_config(app=None, filename=None):
     if app is None:
         app = tagger_instance()
-    global config, setting, persist, profiles
+    global config, setting, persist, state, profiles
     if filename is None:
         config = Config.from_app(app)
     else:
         config = Config.from_file(app, filename)
     setting = config.setting
     persist = config.persist
+    state = config.state
     profiles = config.profiles
 
 

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -624,9 +624,9 @@ def clear_qt5_state(config):
 
     # We need to make sure to load all keys in the config file, not just
     # those for which an initialized Option exists.
-    for key in config.allKeys():
-        if key.startswith('persist/') and key[8:] not in keep_persist:
-            config.remove(key)
+    for key in config.persist.keys():
+        if key not in keep_persist:
+            config.persist.remove(key)
 
 
 @upgrade_config('3.0.0dev2')

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -829,3 +829,27 @@ def clamp_browser_integration_port(settings):
         return max(BROWSER_INTEGRATION_MIN_PORT, min(BROWSER_INTEGRATION_MAX_PORT, int(value)))
 
     upgrade_option_value(settings, 'browser_integration_port', _clamp_port)
+
+
+@upgrade_config('3.0.0b10')
+def move_state_keys_from_persist(config):
+    """Move valuable non-volatile keys from persist to the new state section."""
+    keys_to_move = (
+        'oauth_access_token',
+        'oauth_access_token_expires',
+        'oauth_refresh_token',
+        'oauth_refresh_token_scopes',
+        'oauth_username',
+        'tutorial_steps_shown',
+        'tutorial_disabled',
+        'setup_wizard_completed',
+        'show_plugin_install_warning',
+        'last_session_path',
+        'recent_sessions',
+        'session_autosave_path',
+        'cli_plugins_init',
+    )
+    for key in keys_to_move:
+        if key in config.persist:
+            config.state[key] = config.persist.raw_value(key)
+            config.persist.remove(key)

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -85,65 +85,65 @@ class OAuthManager:
         return config.setting
 
     @property
-    def persist(self):
+    def state(self):
         config = get_config()
-        return config.persist
+        return config.state
 
     @property
     def refresh_token(self):
-        return self.persist['oauth_refresh_token']
+        return self.state['oauth_refresh_token']
 
     @refresh_token.setter
     def refresh_token(self, value):
-        self.persist['oauth_refresh_token'] = value
+        self.state['oauth_refresh_token'] = value
 
     @refresh_token.deleter
     def refresh_token(self):
-        self.persist.remove('oauth_refresh_token')
+        self.state.remove('oauth_refresh_token')
 
     @property
     def refresh_token_scopes(self):
-        return self.persist['oauth_refresh_token_scopes']
+        return self.state['oauth_refresh_token_scopes']
 
     @refresh_token_scopes.setter
     def refresh_token_scopes(self, value):
-        self.persist['oauth_refresh_token_scopes'] = value
+        self.state['oauth_refresh_token_scopes'] = value
 
     @refresh_token_scopes.deleter
     def refresh_token_scopes(self):
-        self.persist.remove('oauth_refresh_token_scopes')
+        self.state.remove('oauth_refresh_token_scopes')
 
     @property
     def access_token(self):
-        return self.persist['oauth_access_token']
+        return self.state['oauth_access_token']
 
     @access_token.setter
     def access_token(self, value):
-        self.persist['oauth_access_token'] = value
+        self.state['oauth_access_token'] = value
 
     @access_token.deleter
     def access_token(self):
-        self.persist.remove('oauth_access_token')
+        self.state.remove('oauth_access_token')
 
     @property
     def access_token_expires(self):
-        return self.persist['oauth_access_token_expires']
+        return self.state['oauth_access_token_expires']
 
     @access_token_expires.setter
     def access_token_expires(self, value):
-        self.persist['oauth_access_token_expires'] = value
+        self.state['oauth_access_token_expires'] = value
 
     @access_token_expires.deleter
     def access_token_expires(self):
-        self.persist.remove('oauth_access_token_expires')
+        self.state.remove('oauth_access_token_expires')
 
     @property
     def username(self):
-        return self.persist['oauth_username']
+        return self.state['oauth_username']
 
     @username.setter
     def username(self, value):
-        self.persist['oauth_username'] = value
+        self.state['oauth_username'] = value
 
     def is_authorized(self):
         return bool(self.refresh_token and self.refresh_token_scopes)

--- a/picard/options.py
+++ b/picard/options.py
@@ -156,13 +156,13 @@ BoolOption('persist', 'window_maximized', False)
 Option('persist', 'window_state', QtCore.QByteArray())
 ListOption('persist', 'filters_FileTreeView', DEFAULT_FILTER_COLUMNS)
 ListOption('persist', 'filters_AlbumTreeView', DEFAULT_FILTER_COLUMNS)
-TextOption('persist', 'last_session_path', '')
-ListOption('persist', 'recent_sessions', [])
-TextOption('persist', 'session_autosave_path', '')
-ListOption('persist', 'tutorial_steps_shown', [])
-BoolOption('persist', 'tutorial_disabled', False)
-BoolOption('persist', 'setup_wizard_completed', False)
-BoolOption('persist', 'show_plugin_install_warning', True)
+TextOption('state', 'last_session_path', '')
+ListOption('state', 'recent_sessions', [])
+TextOption('state', 'session_autosave_path', '')
+ListOption('state', 'tutorial_steps_shown', [])
+BoolOption('state', 'tutorial_disabled', False)
+BoolOption('state', 'setup_wizard_completed', False)
+BoolOption('state', 'show_plugin_install_warning', True)
 
 # picard/ui/metadatabox.py
 #
@@ -334,11 +334,11 @@ BoolOption('setting', 'save_acoustid_fingerprints', False, title=N_('Save Acoust
 
 # picard/ui/options/general.py
 # General
-TextOption('persist', 'oauth_access_token', '')
-IntOption('persist', 'oauth_access_token_expires', 0)
-TextOption('persist', 'oauth_refresh_token', '')
-TextOption('persist', 'oauth_refresh_token_scopes', '')
-TextOption('persist', 'oauth_username', '')
+TextOption('state', 'oauth_access_token', '')
+IntOption('state', 'oauth_access_token_expires', 0)
+TextOption('state', 'oauth_refresh_token', '')
+TextOption('state', 'oauth_refresh_token_scopes', '')
+TextOption('state', 'oauth_username', '')
 BoolOption('setting', 'analyze_new_files', False, title=N_("Automatically scan all new files"), in_profile=True)
 BoolOption('setting', 'cluster_new_files', False, title=N_("Automatically cluster all new files"), in_profile=True)
 BoolOption('setting', 'ignore_file_mbids', False, title=N_("Ignore MBIDs when loading new files"), in_profile=True)

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -44,6 +44,7 @@ from picard.album import Album
 from picard.album_requests import TaskType
 from picard.config import (
     Config,
+    ConfigSection,
     ProfileConfigSection,
     get_config,
 )
@@ -198,6 +199,8 @@ class PluginApi:
         self._logger = getLogger(f'main.plugin.{self._manifest.module_name}')
         self._api_config = ProfileConfigSection(get_config(), full_name)
         self._api_config.display_name = manifest.name()
+        self._api_state = ConfigSection(get_config(), f'plugin_state.{self._manifest.uuid}')
+        self._api_persist = ConfigSection(get_config(), f'plugin_persist.{self._manifest.uuid}')
         self._translations: dict[str, dict] = {}
         self._source_locale = manifest.source_locale
         self._plugin_dir: Path | None = None
@@ -526,6 +529,31 @@ class PluginApi:
     def plugin_config(self) -> ProfileConfigSection:
         """Configuration private to the plugin"""
         return self._api_config
+
+    @property
+    def plugin_state(self) -> ConfigSection:
+        """Non-volatile state storage private to the plugin.
+
+        Use this for data that is valuable and should be preserved across
+        config resets or synced between machines, but is not user-configurable.
+        Examples: cached tokens, completion flags, last-used paths.
+
+        Data stored here does not participate in user profiles.
+        """
+        return self._api_state
+
+    @property
+    def plugin_persist(self) -> ConfigSection:
+        """Volatile per-machine storage private to the plugin.
+
+        Use this for data that is specific to the current machine and can
+        be safely discarded without data loss. Examples: window positions,
+        dialog geometry, UI state.
+
+        Data stored here does not participate in user profiles and may be
+        cleared during major version upgrades.
+        """
+        return self._api_persist
 
     @property
     def plugin_dir(self) -> Path | None:

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -147,7 +147,7 @@ def compile_ui(ui_file: Path, py_file: Path) -> None:
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 MAX_VERSIONS = 20
 
-Option('persist', 'cli_plugins_init', {})
+Option('state', 'cli_plugins_init', {})
 
 
 class PluginCLI(BaseCLI):
@@ -1871,7 +1871,7 @@ class PluginCLI(BaseCLI):
 
         # Author (optional) - prefer persisted value, then git config
         config = get_config()
-        saved = config.persist['cli_plugins_init']
+        saved = config.state['cli_plugins_init']
         git_name, git_email = get_git_config_author()
         default_name = saved.get('author_name', '') or git_name
         default_email_val = saved.get('author_email', '') or git_email
@@ -1928,7 +1928,7 @@ class PluginCLI(BaseCLI):
         self._out.nl()
 
         # Save defaults for next run
-        config.persist['cli_plugins_init'] = {
+        config.state['cli_plugins_init'] = {
             'author_name': author,
             'author_email': author_email,
             'license': license_id,

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -749,7 +749,7 @@ class Tagger(QtWidgets.QApplication):
         config = get_config()
         # Load last session if configured
         if config.setting['session_load_last_on_startup']:
-            last_path = config.persist['last_session_path']
+            last_path = config.state['last_session_path']
             if last_path:
                 try:
                     load_session_from_path(self, last_path)
@@ -778,12 +778,12 @@ class Tagger(QtWidgets.QApplication):
             self._session_autosave_timer.setInterval(max(1, interval_min) * 60 * 1000)
 
             def _autosave():
-                path = config.persist['session_autosave_path'] or None
+                path = config.state['session_autosave_path'] or None
                 if not path:
-                    path = config.persist['last_session_path'] or None
+                    path = config.state['last_session_path'] or None
                 if not path:
                     path = str(Path(sessions_folder()) / ("autosave" + SessionConstants.SESSION_FILE_EXTENSION))
-                    config.persist['session_autosave_path'] = path
+                    config.state['session_autosave_path'] = path
 
                 with contextlib.suppress(OSError, PermissionError, FileNotFoundError, ValueError, OverflowError):
                     # Best effort autosave; do not crash programme
@@ -1103,7 +1103,7 @@ class Tagger(QtWidgets.QApplication):
         """Lookup the users collections on the MusicBrainz website."""
         lookup = self.get_file_lookup()
         config = get_config()
-        lookup.collection_lookup(config.persist['oauth_username'])
+        lookup.collection_lookup(config.state['oauth_username'])
 
     def browser_lookup(self, item):
         """Lookup the object's metadata on the MusicBrainz website."""

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -60,7 +60,7 @@ class InstallConfirmDialog(PicardDialog):
 
         # General security warning (with "don't show again")
         config = get_config()
-        if config.persist['show_plugin_install_warning']:
+        if config.state['show_plugin_install_warning']:
             warning_content = QtWidgets.QHBoxLayout()
 
             icon_label = QtWidgets.QLabel()
@@ -196,6 +196,6 @@ class InstallConfirmDialog(PicardDialog):
         """Handle install button click."""
         if self._dont_show_checkbox and self._dont_show_checkbox.isChecked():
             config = get_config()
-            config.persist['show_plugin_install_warning'] = False
+            config.state['show_plugin_install_warning'] = False
         self.selected_ref = self.ref_selector.get_selected_ref()
         self.accept()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -528,13 +528,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             True if saved successfully, False otherwise.
         """
         config = get_config()
-        path = config.persist['last_session_path'] or ''
+        path = config.state['last_session_path'] or ''
         if path:
             try:
                 save_session_to_path(self.tagger, path)
 
                 # Ensure the known path remains persisted explicitly
-                config.persist['last_session_path'] = path
+                config.state['last_session_path'] = path
                 self.set_statusbar_message(N_('Session saved to "%(path)s"'), {'path': path})
                 self._add_to_recent_sessions(path)
             except (OSError, PermissionError, FileNotFoundError, ValueError, OverflowError) as e:
@@ -786,7 +786,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _get_recent_sessions(self):
         """Return the list of recent session paths from persistent config."""
         config = get_config()
-        value = config.persist['recent_sessions']
+        value = config.state['recent_sessions']
         if isinstance(value, list):
             return [str(p) for p in value]
         return []
@@ -794,7 +794,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _set_recent_sessions(self, paths):
         """Persist the given list of recent session paths and refresh the menu."""
         config = get_config()
-        config.persist['recent_sessions'] = list(paths)
+        config.state['recent_sessions'] = list(paths)
         if hasattr(self, 'recent_sessions_menu') and isinstance(self.recent_sessions_menu, QtWidgets.QMenu):
             self._populate_recent_sessions_menu()
 
@@ -1489,7 +1489,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         config = get_config()
 
         # Use known path's parent directory if available, otherwise fall back to sessions folder
-        known_path = config.persist['last_session_path'] or ''
+        known_path = config.state['last_session_path'] or ''
         if known_path:
             start_dir = Path(known_path).parent
         else:
@@ -1510,7 +1510,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         if path:
             try:
                 save_session_to_path(self.tagger, path)
-                config.persist['last_session_path'] = path
+                config.state['last_session_path'] = path
             except (OSError, PermissionError, FileNotFoundError, ValueError, OverflowError) as e:
                 QtWidgets.QMessageBox.critical(self, _("Failed to save session"), str(e))
                 return False
@@ -1527,7 +1527,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         config = get_config()
 
-        last_session_path = config.persist['last_session_path'] or ''
+        last_session_path = config.state['last_session_path'] or ''
         if last_session_path:
             start_dir = Path(str(last_session_path)).parent
         else:
@@ -1557,7 +1557,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 )
                 return
             else:
-                config.persist['last_session_path'] = path
+                config.state['last_session_path'] = path
                 self.set_statusbar_message(N_('Session loaded from "%(path)s"'), {'path': path})
                 # Track in recent sessions
                 self._add_to_recent_sessions(path)
@@ -1584,7 +1584,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             return
         else:
             config = get_config()
-            config.persist['last_session_path'] = path
+            config.state['last_session_path'] = path
             self.set_statusbar_message(N_('Session loaded from "%(path)s"'), {'path': path})
             self._add_to_recent_sessions(path)
 
@@ -1596,7 +1596,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.tagger.clear_session()
         # Reset last_session_path so subsequent saves prompt for a new path
         config = get_config()
-        config.persist['last_session_path'] = ''
+        config.state['last_session_path'] = ''
 
     def remove_selected_objects(self):
         """Tell the tagger to remove the selected objects."""

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -118,7 +118,7 @@ class GeneralOptionsPage(OptionsPage):
             return
         if self.tagger.webservice.oauth_manager.is_logged_in():
             config = get_config()
-            self.ui.logged_in.setText(_("Logged in as <b>%s</b>.") % config.persist['oauth_username'])
+            self.ui.logged_in.setText(_("Logged in as <b>%s</b>.") % config.state['oauth_username'])
             self.ui.logged_in.show()
             self.ui.login_error.hide()
             self.ui.login.hide()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -241,9 +241,9 @@ class InterfaceOptionsPage(OptionsPage):
         )
         if dialog.exec() == QtWidgets.QMessageBox.StandardButton.Yes:
             config = get_config()
-            config.persist['tutorial_steps_shown'] = []
-            config.persist['tutorial_disabled'] = False
-            config.persist['setup_wizard_completed'] = False
+            config.state['tutorial_steps_shown'] = []
+            config.state['tutorial_disabled'] = False
+            config.state['setup_wizard_completed'] = False
 
 
 register_options_page(InterfaceOptionsPage)

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -390,15 +390,15 @@ class SetupWizard(QtWidgets.QWizard):
         config = get_config()
         for page in self._pages:
             page.save_settings(config)
-        config.persist['setup_wizard_completed'] = True
+        config.state['setup_wizard_completed'] = True
         super().accept()
 
     def reject(self) -> None:
         config = get_config()
-        config.persist['setup_wizard_completed'] = True
+        config.state['setup_wizard_completed'] = True
         super().reject()
 
     @staticmethod
     def should_show() -> bool:
         config = get_config()
-        return not config.persist['setup_wizard_completed']
+        return not config.state['setup_wizard_completed']

--- a/picard/ui/tutorial.py
+++ b/picard/ui/tutorial.py
@@ -221,20 +221,20 @@ class TutorialManager:
 
     def should_show(self, step_id: str) -> bool:
         config = get_config()
-        if config.persist['tutorial_disabled']:
+        if config.state['tutorial_disabled']:
             return False
-        return step_id not in config.persist['tutorial_steps_shown']
+        return step_id not in config.state['tutorial_steps_shown']
 
     def mark_shown(self, step_id: str) -> None:
         config = get_config()
-        shown = config.persist['tutorial_steps_shown']
+        shown = config.state['tutorial_steps_shown']
         if step_id not in shown:
             shown.append(step_id)
-            config.persist['tutorial_steps_shown'] = shown
+            config.state['tutorial_steps_shown'] = shown
 
     def disable(self) -> None:
         config = get_config()
-        config.persist['tutorial_disabled'] = True
+        config.state['tutorial_disabled'] = True
 
     def show(self, step_id: str) -> bool:
         """Show a tutorial tip by step ID. Returns True if shown."""

--- a/scripts/tools/check_settings.py
+++ b/scripts/tools/check_settings.py
@@ -27,7 +27,7 @@ import sys
 ROOT_DIR = 'picard'
 IGNORE_DIR = '__pycache__'
 
-OPTION_TYPES_TO_CHECK = {'setting', 'persist'}
+OPTION_TYPES_TO_CHECK = {'setting', 'persist', 'state'}
 
 # Identify options created
 RE_CREATE_OPTION = re.compile(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -92,14 +92,16 @@ def _install_defaulting_config(monkeypatch):
 
     setting = _make_defaulting_section("setting")
     persist = _make_defaulting_section("persist")
+    state = _make_defaulting_section("state")
     profiles = _make_defaulting_section("profiles")
 
-    fake_config = SimpleNamespace(setting=setting, persist=persist, profiles=profiles)
+    fake_config = SimpleNamespace(setting=setting, persist=persist, state=state, profiles=profiles)
 
     # Expose module-level aliases commonly used in code/tests
     monkeypatch.setattr(cfg_mod, "config", fake_config, raising=False)
     monkeypatch.setattr(cfg_mod, "setting", setting, raising=False)
     monkeypatch.setattr(cfg_mod, "persist", persist, raising=False)
+    monkeypatch.setattr(cfg_mod, "state", state, raising=False)
     monkeypatch.setattr(cfg_mod, "profiles", profiles, raising=False)
 
     # Provide get_config() that returns our fake config unless overridden by other fixtures
@@ -113,6 +115,7 @@ def _install_defaulting_config(monkeypatch):
             cfg_mod.config = fake_config
             cfg_mod.setting = setting
             cfg_mod.persist = persist
+            cfg_mod.state = state
             cfg_mod.profiles = profiles
 
         monkeypatch.setattr(ptc.PicardTestCase, "init_config", staticmethod(_init_config_override), raising=False)

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -83,21 +83,26 @@ class PicardTestCase(unittest.TestCase):
         fake_config = Mock()
         fake_config.setting = {}
         fake_config.persist = {}
+        fake_config.state = {}
         fake_config.profiles = {}
         # Make config object available for legacy use
         config.config = fake_config
         config.setting = fake_config.setting
         config.persist = fake_config.persist
+        config.state = fake_config.state
         config.profiles = fake_config.profiles
 
     @staticmethod
-    def set_config_values(setting=None, persist=None, profiles=None):
+    def set_config_values(setting=None, persist=None, state=None, profiles=None):
         if setting:
             for key, value in setting.items():
                 config.config.setting[key] = value
         if persist:
             for key, value in persist.items():
                 config.config.persist[key] = value
+        if state:
+            for key, value in state.items():
+                config.config.state[key] = value
         if profiles:
             for key, value in profiles.items():
                 config.config.profiles[key] = value

--- a/test/plugins3/test_api.py
+++ b/test/plugins3/test_api.py
@@ -323,6 +323,41 @@ class TestPluginApi(PicardTestCase):
         finally:
             config_file.unlink(missing_ok=True)
 
+    def test_plugin_state_and_persist(self):
+        """Test that plugin_state and plugin_persist are namespaced ConfigSections."""
+        manifest = load_plugin_manifest('example')
+        test_uuid = manifest.uuid
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            config_file = Path(f.name)
+
+        try:
+            settings = QSettings(str(config_file), QSettings.Format.IniFormat)
+            api = PluginApi(manifest, self.tagger)
+            api._api_state._config_store = settings
+            api._api_persist._config_store = settings
+
+            # Verify section names are correctly namespaced
+            self.assertEqual(api.plugin_state.section_name, f'plugin_state.{test_uuid}')
+            self.assertEqual(api.plugin_persist.section_name, f'plugin_persist.{test_uuid}')
+
+            # Write to plugin_state
+            from picard.config import TextOption
+
+            TextOption(f'plugin_state.{test_uuid}', 'last_dir', '')
+            api.plugin_state['last_dir'] = '/home/user'
+            settings.sync()
+            self.assertEqual(settings.value(f'plugin_state.{test_uuid}/last_dir'), '/home/user')
+
+            # Write to plugin_persist
+            TextOption(f'plugin_persist.{test_uuid}', 'window_geom', '')
+            api.plugin_persist['window_geom'] = 'some_bytes'
+            settings.sync()
+            self.assertEqual(settings.value(f'plugin_persist.{test_uuid}/window_geom'), 'some_bytes')
+
+        finally:
+            config_file.unlink(missing_ok=True)
+
     def test_plugin_config_operations(self):
         """Test all plugin_config operations."""
         manifest = load_plugin_manifest('example')

--- a/test/plugins3/test_api.py
+++ b/test/plugins3/test_api.py
@@ -290,7 +290,7 @@ class TestPluginApi(PicardTestCase):
 
             # Create API with the test config
             api = PluginApi(manifest, self.tagger)
-            api._api_config._ConfigSection__qt_config = settings
+            api._api_config._config_store = settings
 
             # Set some config values
             api.plugin_config['test_string'] = 'hello'
@@ -315,7 +315,7 @@ class TestPluginApi(PicardTestCase):
 
             # Verify raw_value can read them back
             api2 = PluginApi(manifest, self.tagger)
-            api2._api_config._ConfigSection__qt_config = settings2
+            api2._api_config._config_store = settings2
             self.assertEqual(api2.plugin_config.raw_value('test_string'), 'hello')
             self.assertEqual(api2.plugin_config.raw_value('test_int'), 42)
             self.assertEqual(api2.plugin_config.raw_value('test_bool'), True)
@@ -333,7 +333,7 @@ class TestPluginApi(PicardTestCase):
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
             api = PluginApi(manifest, self.tagger)
-            api._api_config._ConfigSection__qt_config = settings
+            api._api_config._config_store = settings
 
             # Test registering options
             api.plugin_config.register_option('string', 'default')
@@ -381,7 +381,7 @@ class TestPluginApi(PicardTestCase):
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
             api2 = PluginApi(manifest, self.tagger)
-            api2._api_config._ConfigSection__qt_config = settings2
+            api2._api_config._config_store = settings2
 
             self.assertEqual(api2.plugin_config['list'], [1, 2, 3])
             self.assertEqual(api2.plugin_config['dict'], {'key': 'value'})
@@ -399,7 +399,7 @@ class TestPluginApi(PicardTestCase):
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
             api = PluginApi(manifest, self.tagger)
-            api._api_config._ConfigSection__qt_config = settings
+            api._api_config._config_store = settings
 
             # Register options
             api.plugin_config.register_option('bool_true', False)
@@ -423,7 +423,7 @@ class TestPluginApi(PicardTestCase):
             # Load in new QSettings instance (same process)
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
             api2 = PluginApi(manifest, self.tagger)
-            api2._api_config._ConfigSection__qt_config = settings2
+            api2._api_config._config_store = settings2
 
             # Types are preserved due to QSettings in-memory cache
             self.assertIs(api2.plugin_config['bool_true'], True)
@@ -457,7 +457,7 @@ class TestPluginApi(PicardTestCase):
 
             # Create API
             api = PluginApi(manifest, self.tagger)
-            api._api_config._ConfigSection__qt_config = settings
+            api._api_config._config_store = settings
 
             # Register options for the plugin
             TextOption(f'plugin.{test_uuid}', 'text_setting', 'default_text')
@@ -478,7 +478,7 @@ class TestPluginApi(PicardTestCase):
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
             api2 = PluginApi(manifest, self.tagger)
-            api2._api_config._ConfigSection__qt_config = settings2
+            api2._api_config._config_store = settings2
 
             # Values should persist and be properly typed
             self.assertEqual(api2.plugin_config['text_setting'], 'hello')

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -122,7 +122,7 @@ class CollectionTest(PicardTestCase):
         )
 
     def test_add_release_to_user_collections(self):
-        self.set_config_values(persist={'oauth_username': 'theuser'})
+        self.set_config_values(state={'oauth_username': 'theuser'})
         release_node = {
             'id': '54292079-790c-4e99-bf8d-12efa29fa3e9',
             'collections': [

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -86,6 +86,17 @@ class TestPicardConfig(TestPicardConfigCommon):
         self.config.setting.remove("text_option")
         self.assertEqual(self.config.setting["text_option"], "abc")
 
+    def test_sync_persists_to_disk(self):
+        from PyQt6.QtCore import QSettings
+
+        TextOption("setting", "sync_test", "default")
+        self.config.setting["sync_test"] = "written"
+        self.config.sync()
+
+        # Re-read the file from disk with raw QSettings to confirm persistence
+        raw = QSettings(self.configpath, QSettings.Format.IniFormat)
+        self.assertEqual(raw.value("setting/sync_test"), "written")
+
 
 class TestPicardConfigOption(TestPicardConfigCommon):
     def test_basic_option(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -97,6 +97,16 @@ class TestPicardConfig(TestPicardConfigCommon):
         raw = QSettings(self.configpath, QSettings.Format.IniFormat)
         self.assertEqual(raw.value("setting/sync_test"), "written")
 
+    def test_state_section_exists(self):
+        self.assertIsNotNone(self.config.state)
+        self.assertEqual(self.config.state.section_name, 'state')
+
+    def test_state_section_read_write(self):
+        TextOption("state", "test_key", "default")
+        self.assertEqual(self.config.state["test_key"], "default")
+        self.config.state["test_key"] = "new_value"
+        self.assertEqual(self.config.state["test_key"], "new_value")
+
 
 class TestPicardConfigOption(TestPicardConfigCommon):
     def test_basic_option(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -176,6 +176,30 @@ class TestPicardConfigSection(TestPicardConfigCommon):
 
         self.assertEqual(expected, self.config.setting.as_dict())
 
+    def test_keys_returns_all_stored_keys(self):
+        TextOption("setting", "text_option", "abc")
+        IntOption("setting", "int_option", 42)
+
+        # Write values so they exist in the backing store
+        self.config.setting["text_option"] = "hello"
+        self.config.setting["int_option"] = 7
+
+        keys = self.config.setting.keys()
+        self.assertIn("text_option", keys)
+        self.assertIn("int_option", keys)
+
+    def test_keys_includes_unregistered_keys(self):
+        # Write a raw key with no Option registration
+        self.config.setValue("setting/orphan_key", "value")
+
+        keys = self.config.setting.keys()
+        self.assertIn("orphan_key", keys)
+
+    def test_keys_empty_section(self):
+        # A section with no stored keys should return empty list
+        keys = self.config.persist.keys()
+        self.assertEqual(keys, [])
+
     def test_register_option(self):
         class TestEnum(Enum):
             A = "a"

--- a/test/test_config_upgrade_hooks.py
+++ b/test/test_config_upgrade_hooks.py
@@ -846,3 +846,48 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         settings = {'browser_integration_port': 8021}
         hooks.clamp_browser_integration_port(settings)
         self.assertEqual(8020, settings['browser_integration_port'])
+
+    def test_move_state_keys_from_persist(self):
+        from picard.config import (
+            IntOption,
+            TextOption,
+        )
+
+        # Register options in their old location (persist) so raw_value works
+        TextOption('persist', 'oauth_username', '')
+        IntOption('persist', 'oauth_access_token_expires', 0)
+        TextOption('persist', 'last_session_path', '')
+
+        # Also register in new location (state) for __setitem__ to work
+        TextOption('state', 'oauth_username', '')
+        IntOption('state', 'oauth_access_token_expires', 0)
+        TextOption('state', 'last_session_path', '')
+
+        # Populate persist with values
+        self.config.persist['oauth_username'] = 'testuser'
+        self.config.persist['oauth_access_token_expires'] = 12345
+        self.config.persist['last_session_path'] = '/tmp/session.picard'
+
+        hooks.move_state_keys_from_persist(self.config)
+
+        # Keys should now be in state
+        self.assertEqual('testuser', self.config.state['oauth_username'])
+        self.assertEqual(12345, self.config.state['oauth_access_token_expires'])
+        self.assertEqual('/tmp/session.picard', self.config.state['last_session_path'])
+
+        # Keys should be removed from persist
+        self.assertNotIn('oauth_username', self.config.persist)
+        self.assertNotIn('oauth_access_token_expires', self.config.persist)
+        self.assertNotIn('last_session_path', self.config.persist)
+
+    def test_move_state_keys_from_persist_missing_keys(self):
+        """Hook should be a no-op for keys that don't exist in persist."""
+        from picard.config import TextOption
+
+        TextOption('state', 'oauth_username', '')
+
+        # Don't set any persist keys
+        hooks.move_state_keys_from_persist(self.config)
+
+        # State should have the default (nothing was migrated)
+        self.assertEqual('', self.config.state['oauth_username'])


### PR DESCRIPTION
## Summary

Preparatory work toward separating volatile UI state (`persist`) from valuable application state, motivated by [PICARD-3354](https://tickets.metabrainz.org/browse/PICARD-3354).

Introduces a new `state` config section for data that is valuable (should survive config resets and be syncable across machines) but is not user-configurable settings. Migrates 13 keys from `persist` to `state` and exposes `plugin_state`/`plugin_persist` in the plugin v3 API.

## Changes

### Mechanical prep (commits 1-4, no behavior change)
- Add `ConfigSection.keys()` method for section key enumeration
- Add `Config.sync()` override as extension point for future multi-store sync
- Refactor `clear_qt5_state` upgrade hook to use section API instead of raw `allKeys()`
- Decouple `ConfigSection` from `Config` type (accept `QSettings`, rename internal attribute)

### Feature work (commits 5-7)
- Add `state` ConfigSection to `Config` for valuable non-volatile data
- Add `plugin_state` and `plugin_persist` properties to `PluginApi`
- Migrate 13 keys from `persist` → `state` with upgrade hook at 3.0.0b10

### Keys migrated to `state`
- OAuth credentials: `oauth_access_token`, `oauth_access_token_expires`, `oauth_refresh_token`, `oauth_refresh_token_scopes`, `oauth_username`
- Progress flags: `tutorial_steps_shown`, `tutorial_disabled`, `setup_wizard_completed`, `show_plugin_install_warning`
- Session management: `last_session_path`, `recent_sessions`, `session_autosave_path`
- CLI state: `cli_plugins_init`

### What remains in `persist` (volatile, per-machine)
Window geometry, splitter positions, column widths/lock state, panel visibility toggles, media player volume/rate, file browser path, filter columns, metadata box state.

## Problem

Picard writes user configuration and volatile UI state into a single INI file. The `[persist]` section holds window geometry, splitter positions, etc. (rewritten on nearly every quit) alongside OAuth tokens, tutorial flags, and session paths that have real value to the user. This makes the config file impossible to share across machines and noisy to back up or version-control.

## Solution

Introduce semantic separation now (while in beta) so the sections have clean, well-defined purposes:
- `setting`: user preferences, profile-aware
- `state`: valuable application state, non-profile, syncable  
- `persist`: volatile per-machine UI state, disposable

This also prepares for a future file split (PICARD-3354) where `persist` would live in its own file.

## AI Usage

This PR was developed with AI assistance (Kiro CLI) for code audit, implementation, and test writing. All changes were verified by the existing test suite (5633 tests passing).

## Tickets to create

The following follow-up tickets should be created on [tickets.metabrainz.org](https://tickets.metabrainz.org/projects/PICARD):

- **Separate persist section into its own file** — The actual file split proposed in PICARD-3354. With the semantic separation done, this becomes: construct a second `QSettings` for persist, extend `Config.sync()`, update backup/restore to handle two files, add `PICARD_PERSIST_FILE` env var / `--persist-file` CLI option.
- **Document plugin_state and plugin_persist in plugin v3 docs** — Update `docs/PLUGINSV3/API.md` with usage examples and guidelines for when to use each storage type.
- **Consider OS keychain for OAuth tokens** — The tokens are now in `state` (syncable), but ideally credentials would use the OS keychain (libsecret/Keychain/Credential Manager). This would be a further improvement on top of the current separation.
- **Add PICARD_VERSION bump to 3.0.0b10** — The upgrade hook is registered at `3.0.0b10` but `PICARD_VERSION` is still at `3.0.0b9`. Version bump needed before release.
