### PR TITLE
PICARD-3356: Add plugin_persist to PluginApi

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -303,6 +303,44 @@ The widget will be highlighted in the options dialog when the option is tracked 
 
 ---
 
+### `plugin_persist: ConfigSection`
+
+Volatile per-machine storage private to the plugin.
+
+Use this for data that is specific to the current machine and can be safely
+discarded without data loss. Unlike `plugin_config` (which stores user settings
+and participates in profiles), `plugin_persist` is for transient state that
+should not be synced between machines.
+
+**Examples:** window positions, dialog geometry, last-used directory paths,
+dismissed warnings, UI state.
+
+```python
+def enable(api):
+    # Register options with defaults
+    api.plugin_persist.register_option('last_directory', '')
+    api.plugin_persist.register_option('dialog_dismissed', False)
+
+    # Write values
+    api.plugin_persist['last_directory'] = '/home/user/music'
+    api.plugin_persist['dialog_dismissed'] = True
+
+    # Read values
+    last_dir = api.plugin_persist['last_directory']
+    dismissed = api.plugin_persist['dialog_dismissed']
+
+    # Check and remove
+    if 'last_directory' in api.plugin_persist:
+        api.plugin_persist.remove('last_directory')
+```
+
+**Key differences from `plugin_config`:**
+- No profile support — values are never overridden by user profiles
+- Data may be cleared during major version upgrades
+- Stored under `plugin_persist.{uuid}` (separate from plugin settings)
+
+---
+
 ### `plugin_dir: Path`
 
 Path to the plugin directory (read-only).

--- a/picard/config.py
+++ b/picard/config.py
@@ -294,6 +294,48 @@ class ConfigSection(QtCore.QObject):
                 return memovar.value
         return default
 
+    def register_option(
+        self,
+        name: str,
+        default: ConfigValueType,
+        title: str | None = None,
+        in_profile: bool = False,
+    ) -> 'Option':
+        """Register an option in this config section.
+
+        The option type is determined by the type of the default value.
+
+        Args:
+            name: Option name.
+            default: Default value. Must not be None. Type determines the Option subclass.
+            title: Human-readable title (used by ProfileConfigSection for profiles UI).
+            in_profile: If True, the option can be overridden by user profiles
+                (only effective in ProfileConfigSection).
+
+        Returns:
+            The registered Option instance.
+
+        Raises:
+            TypeError: If default is None.
+        """
+        if default is None:
+            raise TypeError('Option default value must not be None')
+
+        if isinstance(default, str):
+            option_type = TextOption
+        elif isinstance(default, bool):
+            option_type = BoolOption  # type: ignore[assignment]
+        elif isinstance(default, int):
+            option_type = IntOption  # type: ignore[assignment]
+        elif isinstance(default, float):
+            option_type = FloatOption  # type: ignore[assignment]
+        elif isinstance(default, (list, tuple)):
+            option_type = ListOption  # type: ignore[assignment]
+        else:
+            option_type = Option  # type: ignore[assignment]
+
+        return option_type(self.section_name, name, default, title=title, in_profile=in_profile)
+
 
 class ProfileConfigSection(ConfigSection):
     """Configuration section with profile override support.
@@ -413,7 +455,7 @@ class ProfileConfigSection(ConfigSection):
     ) -> Option:
         """Register an option in this config section.
 
-        The option type is determined by the type of the default value.
+        Extends the base class method with profile support.
 
         Args:
             name: Option name.
@@ -428,25 +470,7 @@ class ProfileConfigSection(ConfigSection):
         Raises:
             TypeError: If default is None.
         """
-        if default is None:
-            raise TypeError('Option default value must not be None')
-
-        if isinstance(default, str):
-            option_type = TextOption
-        elif isinstance(default, bool):
-            option_type = BoolOption  # type: ignore[assignment]
-        elif isinstance(default, int):
-            option_type = IntOption  # type: ignore[assignment]
-        elif isinstance(default, float):
-            option_type = FloatOption  # type: ignore[assignment]
-        elif isinstance(default, list) or isinstance(default, tuple):
-            option_type = ListOption  # type: ignore[assignment]
-        elif isinstance(default, Enum):
-            option_type = Option  # type: ignore[assignment]
-        else:
-            option_type = Option  # type: ignore[assignment]
-
-        opt = option_type(self.section_name, name, default, title=title, in_profile=in_profile)
+        opt = super().register_option(name, default, title=title, in_profile=in_profile)
         if in_profile:
             group_name = self.section_name
             group_title = self.display_name or self.section_name

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -44,6 +44,7 @@ from picard.album import Album
 from picard.album_requests import TaskType
 from picard.config import (
     Config,
+    ConfigSection,
     ProfileConfigSection,
     get_config,
 )
@@ -202,6 +203,7 @@ class PluginApi:
         self._logger = getLogger(f'main.plugin.{self._manifest.module_name}')
         self._api_config = ProfileConfigSection(get_config(), full_name)
         self._api_config.display_name = manifest.name()
+        self._api_persist = ConfigSection(get_config(), f'plugin_persist.{self._manifest.uuid}')
         self._translations: dict[str, dict] = {}
         self._source_locale = manifest.source_locale
         self._plugin_dir: Path | None = None
@@ -540,6 +542,19 @@ class PluginApi:
     def plugin_config(self) -> ProfileConfigSection:
         """Configuration private to the plugin"""
         return self._api_config
+
+    @property
+    def plugin_persist(self) -> ConfigSection:
+        """Volatile per-machine storage private to the plugin.
+
+        Use this for data that is specific to the current machine and can
+        be safely discarded without data loss. Examples: window positions,
+        dialog geometry, last-used directory paths, UI state.
+
+        Data stored here does not participate in user profiles and may be
+        cleared during major version upgrades.
+        """
+        return self._api_persist
 
     @property
     def plugin_dir(self) -> Path | None:

--- a/test/plugins3/test_api.py
+++ b/test/plugins3/test_api.py
@@ -323,6 +323,33 @@ class TestPluginApi(PicardTestCase):
         finally:
             config_file.unlink(missing_ok=True)
 
+    def test_plugin_persist(self):
+        """Test that plugin_persist provides namespaced volatile storage."""
+        manifest = load_plugin_manifest('example')
+        test_uuid = manifest.uuid
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            config_file = Path(f.name)
+
+        try:
+            settings = QSettings(str(config_file), QSettings.Format.IniFormat)
+            api = PluginApi(manifest, self.tagger)
+            api._api_persist._ConfigSection__qt_config = settings
+
+            # Verify section name is correctly namespaced
+            self.assertEqual(api.plugin_persist.section_name, f'plugin_persist.{test_uuid}')
+
+            # Register and write
+            api.plugin_persist.register_option('window_geom', '')
+            api.plugin_persist['window_geom'] = 'geom_data'
+            settings.sync()
+
+            # Verify stored under correct key in QSettings
+            self.assertEqual(settings.value(f'plugin_persist.{test_uuid}/window_geom'), 'geom_data')
+
+        finally:
+            config_file.unlink(missing_ok=True)
+
     def test_plugin_config_operations(self):
         """Test all plugin_config operations."""
         manifest = load_plugin_manifest('example')


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add `api.plugin_persist` to the plugin v3 API, giving plugins dedicated volatile per-machine storage namespaced under `[plugin_persist.<uuid>]`. Also adds `register_option()` to `ConfigSection` base class.

## Problem

* JIRA ticket: [PICARD-3356](https://tickets.metabrainz.org/browse/PICARD-3356)

Plugins currently have no official way to store volatile per-machine data (window positions, dialog geometry, last-used paths, UI state). They either use `plugin_config` (which participates in profiles — overkill for transient state) or reach into `global_config.persist` (undocumented, pollutes the global namespace, no isolation between plugins).

## Solution

Add `api.plugin_persist` — a plain `ConfigSection` (no profile participation) with the same `register_option()` / `[]` access pattern as `plugin_config`:

```python
def enable(api):
    api.plugin_persist.register_option("last_directory", "")
    api.plugin_persist["last_directory"] = "/home/user/music"
    last_dir = api.plugin_persist["last_directory"]
```

Changes:
- `picard/config.py`: Add `ConfigSection.register_option()` method
- `picard/plugin3/api_impl.py`: Add `_api_persist` + `plugin_persist` property
- `test/plugins3/test_api.py`: Test for namespaced storage
- `docs/PLUGINSV3/API.md`: Document `plugin_persist` with usage examples

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code and tests developed with Kiro CLI. Design decisions and review by human maintainer.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other
