### PR TITLE
PICARD-3357: Fix parsing some cyanrip log files

### DIFF
--- a/picard/disc/cyanriplog.py
+++ b/picard/disc/cyanriplog.py
@@ -34,8 +34,8 @@ from picard.disc.utils import (
 
 
 RE_TRACK_HEADER = re.compile(r"^Track (?P<num>\d+) ripped")
-RE_START_LSN = re.compile(r"^\s+Start LSN:\s+(?P<lsn>\d+)\s*$")
-RE_END_LSN = re.compile(r"^\s+End LSN:\s+(?P<lsn>\d+)\s*$")
+RE_START_LSN = re.compile(r"^\s*Start LSN:\s+(?P<lsn>\d+)\s*$")
+RE_END_LSN = re.compile(r"^\s*End LSN:\s+(?P<lsn>\d+)\s*")
 RE_CYANRIP_HEADER = re.compile(r"^cyanrip\s+\d+\.\d+")
 
 

--- a/test/data/cyanrip.log
+++ b/test/data/cyanrip.log
@@ -90,7 +90,7 @@ Track 2 ripped and encoded successfully!
     Frames: 96835
     Pregap LSN: none
     Start LSN: 136920
-    End LSN: 233754
+    End LSN: 233754 (with offset: 233755)
 
     EAC CRC32: 023E6E8C
     Accurip: not found


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3357
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Some log files have an additional offset for the "End LSN" line, such as

        End LSN:     19841 (with offset: 19842)

Instead of just:

        End LSN:     19841

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Be more tolerant when parsing files, also with leading whitespace.



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
