### PR TITLE
Add workflow_dispatch trigger to CI workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,7 @@ on:
     paths: *path-list
   schedule:
     - cron: '0 14 * * 6'
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ on:
     - 'po/appstream/*.po'
   pull_request:
     paths: *path-list
+  workflow_dispatch:
 
 jobs:
   ruff:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,6 +22,7 @@ on:
     - 'win.version-info.txt.in'
   pull_request:
     paths: *path-list
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,7 @@ on:
     - 'win.version-info.txt.in'
   pull_request:
     paths: *path-list
+  workflow_dispatch:
 permissions: {}
 
 concurrency:


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add `workflow_dispatch` trigger to all main CI workflows, allowing manual re-runs from the Actions UI or via `gh workflow run`.

## Problem

When CI workflows fail with `startup_failure` (e.g. after first-time contributor approval), they cannot be re-triggered via the API or CLI. The only workarounds are empty commits or close/reopen the PR.

## Solution

Add `workflow_dispatch:` to the `on:` section of:
- `run-tests.yml`
- `package.yml`
- `lint.yml`
- `codeql-analysis.yml`

This is a no-op for normal operation — workflows still trigger on push/PR as before. It just enables the "Run workflow" button in the Actions UI and `gh workflow run` from the CLI.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)