### PR TITLE
Fix test crash caused by QApplication lifecycle with random test ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,22 @@ class TestMyFeature(PicardTestCase):
         self.assertEqual(expected, actual)
 ```
 
+### Qt Widget Tests
+A session-scoped `qapp` fixture in `test/conftest.py` provides a shared
+`QApplication` for the entire test run. Always use it for widget tests:
+
+```python
+@pytest.fixture()
+def my_widget(qapp):
+    from picard.ui.widgets.mywidget import MyWidget
+
+    return MyWidget()
+```
+
+**Never** create a local `QApplication` or `QCoreApplication` in tests — it causes
+crashes with random test ordering. For unittest-based tests that need an event loop,
+use `QCoreApplication.instance()` and only create one if it returns `None`.
+
 ---
 
 ## Debugging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,28 @@ pytest -n auto
 uv run pytest -n auto
 ```
 
+### Writing Tests
+
+Tests live in the `test/` directory and use pytest. A shared `test/conftest.py`
+provides session-wide fixtures and config defaults.
+
+**Qt widget tests:** A session-scoped `qapp` fixture in `conftest.py` provides a
+`QApplication` instance that lives for the entire test run. Tests that create Qt
+widgets must request it as a dependency:
+
+```python
+@pytest.fixture()
+def my_widget(qapp):
+    from picard.ui.widgets.mywidget import MyWidget
+
+    return MyWidget()
+```
+
+Do **not** create your own `QApplication` or `QCoreApplication` in tests — doing so
+causes crashes when `pytest-randomly` reorders tests. Always reuse the shared `qapp`
+fixture. If a unittest-based test needs a Qt event loop, call
+`QCoreApplication.instance()` and only create a new one if it returns `None`.
+
 ## Development Workflow
 
 ### Dependency Management

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,9 +37,29 @@ What this conftest currently does:
 """
 
 from contextlib import suppress
+import os
 from types import SimpleNamespace
 
 import pytest
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qapp():
+    """Session-scoped QApplication instance shared by all tests that need Qt.
+
+    This ensures a single QApplication lives for the entire test session,
+    preventing crashes when test ordering (pytest-randomly) places tests
+    that create a QCoreApplication before tests that create widgets.
+    """
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
 
 
 def _make_defaulting_section(section_name, initial=None):

--- a/test/test_custom_columns_manager_dialog.py
+++ b/test/test_custom_columns_manager_dialog.py
@@ -34,7 +34,6 @@ and parametrize to reduce code duplication while ensuring comprehensive coverage
 """
 
 from dataclasses import asdict
-import os
 from unittest.mock import (
     Mock,
     call,
@@ -159,26 +158,8 @@ def mock_spec_service() -> Mock:
     return Mock(spec=ColumnSpecService)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def qtapp():
-    """QApplication instance for widget tests."""
-    # Set Qt platform to offscreen for headless testing
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-    # Ensure we have a clean Qt application instance
-    app = QtWidgets.QApplication.instance()
-    if app is None:
-        app = QtWidgets.QApplication([])
-
-    # Ensure the application is properly initialized
-    if hasattr(app, 'processEvents'):
-        app.processEvents()
-
-    return app
-
-
 @pytest.fixture
-def mock_form_widgets(qtapp) -> dict[str, QtWidgets.QWidget]:
+def mock_form_widgets(qapp) -> dict[str, QtWidgets.QWidget]:
     """Mock form input widgets for ColumnFormHandler testing."""
     view_selector = Mock(spec=QtWidgets.QWidget)
     view_selector.get_selected = Mock(return_value=["file", "album"])

--- a/test/test_custom_columns_manager_dialog_decoupling.py
+++ b/test/test_custom_columns_manager_dialog_decoupling.py
@@ -33,7 +33,6 @@ Classes Under Test:
 
 from collections.abc import Iterable
 from dataclasses import replace
-import os
 from unittest.mock import (
     Mock,
     call,
@@ -62,37 +61,6 @@ from picard.ui.itemviews.custom_columns.validation import (
     ValidationContext,
     ValidationReport,
 )
-
-
-@pytest.fixture(autouse=True)
-def qt_app():
-    """QApplication instance for widget tests - safe for parallel execution."""
-    import sys
-
-    # Set platform to offscreen for headless testing
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-    try:
-        # For parallel execution, handle QApplication carefully
-        app = QtWidgets.QApplication.instance()
-        if app is None:
-            # Create new application with minimal arguments
-            app = QtWidgets.QApplication(sys.argv[:1])  # Only pass program name
-            app.setQuitOnLastWindowClosed(False)
-
-        # Process any pending events to ensure clean state
-        if hasattr(app, 'processEvents'):
-            app.processEvents()
-
-        yield app
-
-        # Minimal cleanup - don't quit app as it might be shared
-        if hasattr(app, 'processEvents'):
-            app.processEvents()
-
-    except Exception as e:
-        # If Qt setup fails, yield None and tests should handle gracefully
-        pytest.skip(f"Qt application setup failed: {e}")
 
 
 @pytest.fixture
@@ -334,7 +302,7 @@ class TestColumnSpecService:
         base_spec: CustomColumnSpec,
         initial_specs: list[tuple[str, str]],
         expected_final_count: int,
-        qt_app: QtWidgets.QApplication,
+        qapp: QtWidgets.QApplication,
     ) -> None:
         """Test deduplication preserves order and removes duplicates."""
         specs = [replace(base_spec, key=key, title=title) for key, title in initial_specs]
@@ -429,12 +397,12 @@ class TestSpecListModel:
     """Test SpecListModel Qt model - ensures proper Qt model interface implementation."""
 
     @pytest.fixture
-    def model(self, spec_collection: list[CustomColumnSpec], qt_app: QtWidgets.QApplication) -> SpecListModel:
+    def model(self, spec_collection: list[CustomColumnSpec], qapp: QtWidgets.QApplication) -> SpecListModel:
         """Model instance with test data."""
         return SpecListModel(spec_collection)
 
     def test_initialization_stores_specs(
-        self, spec_collection: list[CustomColumnSpec], qt_app: QtWidgets.QApplication
+        self, spec_collection: list[CustomColumnSpec], qapp: QtWidgets.QApplication
     ) -> None:
         """Test model initialization properly stores specs."""
         model = SpecListModel(spec_collection)
@@ -454,7 +422,7 @@ class TestSpecListModel:
         spec_collection: list[CustomColumnSpec],
         spec_count: int,
         expected_row_count: int,
-        qt_app: QtWidgets.QApplication,
+        qapp: QtWidgets.QApplication,
     ) -> None:
         """Test rowCount returns correct spec count."""
         specs = spec_collection[:spec_count] if spec_count <= len(spec_collection) else spec_collection
@@ -511,7 +479,7 @@ class TestSpecListModel:
             assert result == spec_collection[row]
 
     def test_set_specs_resets_model(
-        self, model: SpecListModel, base_spec: CustomColumnSpec, qt_app: QtWidgets.QApplication
+        self, model: SpecListModel, base_spec: CustomColumnSpec, qapp: QtWidgets.QApplication
     ) -> None:
         """Test set_specs triggers model reset."""
         new_specs = [base_spec]
@@ -701,7 +669,7 @@ class TestComponentIntegration:
     """Test integration between components - ensures proper collaboration."""
 
     def test_controller_service_integration(
-        self, spec_collection: list[CustomColumnSpec], qt_app: QtWidgets.QApplication
+        self, spec_collection: list[CustomColumnSpec], qapp: QtWidgets.QApplication
     ) -> None:
         """Test controller integrates properly with real services."""
         service = ColumnSpecService()
@@ -744,7 +712,7 @@ class TestComponentIntegration:
         controller.first_invalid_spec = original_method
 
     def test_model_service_integration(
-        self, spec_collection: list[CustomColumnSpec], qt_app: QtWidgets.QApplication
+        self, spec_collection: list[CustomColumnSpec], qapp: QtWidgets.QApplication
     ) -> None:
         """Test model integrates properly with service operations."""
         model = SpecListModel(spec_collection)
@@ -762,7 +730,7 @@ class TestComponentIntegration:
         assert final_count == initial_count - 1
 
     @patch('picard.ui.itemviews.custom_columns.user_dialog_service.QtWidgets.QMessageBox.question')
-    def test_dialog_service_integration(self, mock_question: Mock, qt_app: QtWidgets.QApplication) -> None:
+    def test_dialog_service_integration(self, mock_question: Mock, qapp: QtWidgets.QApplication) -> None:
         """Test dialog service integration patterns."""
         parent = Mock(spec=QtWidgets.QWidget)
         service = UserDialogService(parent)
@@ -795,7 +763,7 @@ class TestEdgeCasesAndErrorHandling:
             controller = ColumnController(None, None)  # type: ignore[arg-type]
             controller.validate_specs([])
 
-    def test_model_with_empty_specs(self, qt_app: QtWidgets.QApplication) -> None:
+    def test_model_with_empty_specs(self, qapp: QtWidgets.QApplication) -> None:
         """Test model handles empty specification list."""
         model = SpecListModel([])
 
@@ -828,7 +796,7 @@ class TestEdgeCasesAndErrorHandling:
         ],
     )
     def test_model_invalid_row_operations(
-        self, spec_collection: list[CustomColumnSpec], qt_app: QtWidgets.QApplication, invalid_row: int, operation: str
+        self, spec_collection: list[CustomColumnSpec], qapp: QtWidgets.QApplication, invalid_row: int, operation: str
     ) -> None:
         """Test model handles invalid row operations appropriately."""
         model = SpecListModel(spec_collection)
@@ -886,7 +854,7 @@ class TestPerformanceAndMemory:
 
     @pytest.mark.parametrize("spec_count", [10, 100, 500])
     def test_model_performance_with_large_datasets(
-        self, base_spec: CustomColumnSpec, spec_count: int, qt_app: QtWidgets.QApplication
+        self, base_spec: CustomColumnSpec, spec_count: int, qapp: QtWidgets.QApplication
     ) -> None:
         """Test model performance with large numbers of specifications."""
         # Generate large spec collection
@@ -904,9 +872,7 @@ class TestPerformanceAndMemory:
         row = model.find_row_by_key(middle_key)
         assert row == spec_count // 2
 
-    def test_service_deduplication_efficiency(
-        self, base_spec: CustomColumnSpec, qt_app: QtWidgets.QApplication
-    ) -> None:
+    def test_service_deduplication_efficiency(self, base_spec: CustomColumnSpec, qapp: QtWidgets.QApplication) -> None:
         """Test service deduplication is efficient with many duplicates."""
         # Create specs with many duplicates
         specs_with_duplicates = []

--- a/test/test_preferencelistwidget.py
+++ b/test/test_preferencelistwidget.py
@@ -18,11 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-"""Tests for PreferenceListWidget.
-
-Note: Widget instantiation tests are skipped on headless CI (no display).
-Run locally with a display or QT_QPA_PLATFORM=offscreen for full coverage.
-"""
+"""Tests for PreferenceListWidget."""
 
 import os
 import sys
@@ -43,10 +39,6 @@ def _has_display():
     return bool(os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY'))
 
 
-if not _has_display():
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-
-
 SAMPLE_ITEMS = {
     'US': 'United States',
     'GB': 'United Kingdom',
@@ -62,21 +54,11 @@ needs_display = pytest.mark.skipif(
 
 
 @pytest.fixture()
-def widget():
-    from PyQt6 import QtWidgets
-
+def widget(qapp):
     from picard.ui.widgets.preferencelistwidget import PreferenceListWidget
 
-    # Keep reference to prevent garbage collection
-    if not hasattr(widget, '_app'):
-        app = QtWidgets.QApplication.instance()
-        if app is None:
-            app = QtWidgets.QApplication([])
-        widget._app = app
     w = PreferenceListWidget()
     w.set_available_items(SAMPLE_ITEMS)
-    # prevent GC during test
-    widget._current = w
     return w
 
 
@@ -229,19 +211,11 @@ class TestExcludedKeys:
 
 
 @pytest.fixture()
-def unordered_widget():
-    from PyQt6 import QtWidgets
-
+def unordered_widget(qapp):
     from picard.ui.widgets.preferencelistwidget import PreferenceListWidget
 
-    if not hasattr(unordered_widget, '_app'):
-        app = QtWidgets.QApplication.instance()
-        if app is None:
-            app = QtWidgets.QApplication([])
-        unordered_widget._app = app
     w = PreferenceListWidget(ordered=False)
     w.set_available_items(SAMPLE_ITEMS)
-    unordered_widget._current = w
     return w
 
 

--- a/test/test_util_thread.py
+++ b/test/test_util_thread.py
@@ -58,7 +58,9 @@ class ThreadTest(PicardTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.app = QCoreApplication([])
+        cls.app = QCoreApplication.instance()
+        if cls.app is None:
+            cls.app = QCoreApplication([])
         cls.threadpool = QThreadPool()
         cls.event_interceptor = MainEventInterceptor()
 


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix a test crash caused by Qt application lifecycle issues when `pytest-randomly` reorders tests. Add a shared session-scoped `qapp` fixture and document the pattern.

## Problem

When `pytest-randomly` places `test_util_thread.py` (which creates a `QCoreApplication`) before `test_preferencelistwidget.py` (which needs a `QApplication` to create widgets), the test suite aborts with a fatal Python error. This happens because Qt only allows one application instance per process — once the `QCoreApplication` from `test_util_thread.py` is garbage-collected, Qt's internal state is corrupted and no new application can be created.

## Solution

- Add a session-scoped `autouse=True` `qapp` fixture in `test/conftest.py` that creates a single `QApplication` (with `QT_QPA_PLATFORM=offscreen`) before any test runs. This instance lives for the entire test session.
- Modify `test_util_thread.py` to reuse the existing `QCoreApplication.instance()` instead of unconditionally creating a new one.
- Simplify `test_preferencelistwidget.py` to depend on the shared `qapp` fixture.
- Remove redundant local Qt app fixtures from `test_custom_columns_manager_dialog.py` and `test_custom_columns_manager_dialog_decoupling.py`.
- Document the pattern in `CONTRIBUTING.md` and `AGENTS.md`.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Root cause analysis, fix implementation, and documentation written by AI assistant (Kiro), directed and reviewed by human.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
