### PR TITLE
Disable ISRC extraction if not supported by libdiscid on the platform

### DIFF
--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -31,7 +31,6 @@
 
 from functools import partial
 import traceback
-from types import ModuleType
 
 from picard import (
     log,
@@ -45,7 +44,10 @@ from picard.disc.eaclog import toc_from_file as _eac_toc_from_file
 from picard.disc.scsitoc import toc_from_file as _scsitoc_toc_from_file
 from picard.disc.whipperlog import toc_from_file as _whipper_toc_from_file
 from picard.extension_points.disc_log_readers import register_disc_log_reader
-from picard.util.cdrom import has_isrc_support
+from picard.util.cdrom import (
+    discid,
+    has_isrc_support,
+)
 from picard.util.isrc import (
     format_isrc,
     valid_isrc,
@@ -53,18 +55,6 @@ from picard.util.isrc import (
 from picard.util.mbserver import build_submission_url
 
 from picard.ui.cdlookup import CDLookupDialog
-
-
-discid: ModuleType | None = None
-try:
-    # use python-libdiscid (http://pythonhosted.org/python-libdiscid/)
-    from libdiscid.compat import discid  # type: ignore[unresolved-import,no-redef]
-except ImportError:
-    try:
-        # use python-discid (http://python-discid.readthedocs.org/en/latest/)
-        import discid  # type: ignore[unresolved-import,no-redef]
-    except (ImportError, OSError):
-        pass
 
 
 class Disc:

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -45,6 +45,7 @@ from picard.disc.eaclog import toc_from_file as _eac_toc_from_file
 from picard.disc.scsitoc import toc_from_file as _scsitoc_toc_from_file
 from picard.disc.whipperlog import toc_from_file as _whipper_toc_from_file
 from picard.extension_points.disc_log_readers import register_disc_log_reader
+from picard.util.cdrom import has_isrc_support
 from picard.util.isrc import (
     format_isrc,
     valid_isrc,
@@ -83,7 +84,7 @@ class Disc:
             device = discid.get_default_device()
         log.debug("Reading CD using device: %r", device)
         features = ['mcn']
-        if 'isrc' in discid.FEATURES:
+        if has_isrc_support():
             config = get_config()
             if config.setting['read_isrcs_from_disc']:
                 features.append('isrc')

--- a/picard/options.py
+++ b/picard/options.py
@@ -74,6 +74,7 @@ from picard.const.defaults import (
     DEFAULT_WIN_COMPAT_REPLACEMENTS,
 )
 from picard.i18n import N_
+from picard.util.cdrom import has_isrc_support
 
 from picard.ui.colors import InterfaceColors
 
@@ -345,7 +346,7 @@ BoolOption('setting', 'ignore_file_mbids', False, title=N_("Ignore MBIDs when lo
 TextOption('setting', 'server_host', MUSICBRAINZ_SERVERS[0], title=N_("Server address"), in_profile=True)
 IntOption('setting', 'server_port', 443, title=N_("Port"), in_profile=True)
 BoolOption('setting', 'use_server_for_submission', False, title=N_("Submit to configured server"), in_profile=True)
-BoolOption('setting', 'read_isrcs_from_disc', True, title=N_("Read ISRCs from CD"), in_profile=True)
+BoolOption('setting', 'read_isrcs_from_disc', has_isrc_support(), title=N_("Read ISRCs from CD"), in_profile=True)
 BoolOption('setting', 'enable_user_collections', True, title=N_("Enable managing user collections"), in_profile=True)
 BoolOption(
     'setting',

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -125,8 +125,11 @@ from picard.util import (
     webbrowser2,
 )
 from picard.util.cdrom import (
+    DISCID_NO_ISRC_MESSAGE,
+    DISCID_NOT_LOADED_MESSAGE,
     discid,
     get_cdrom_drives,
+    has_isrc_support,
 )
 from picard.util.isrc import valid_isrc
 from picard.util.readthedocs import ReadTheDocs
@@ -856,11 +859,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _init_cd_lookup_menu(self):
         if discid is None:
-            log.warning("CDROM: discid library not found - Lookup CD functionality disabled")
+            log.warning(DISCID_NOT_LOADED_MESSAGE)
             self.enable_action(MainAction.CD_LOOKUP, False)
             self.enable_action(MainAction.DISCID_FROM_LOGFILE, False)
             self.update_cd_lookup_menu(None)
         else:
+            if not has_isrc_support():
+                log.warning(DISCID_NO_ISRC_MESSAGE)
             thread.run_task(get_cdrom_drives, self._update_cd_lookup_actions)
 
     def _update_cd_lookup_actions(self, result=None, error=None):

--- a/picard/ui/options/cdlookup.py
+++ b/picard/ui/options/cdlookup.py
@@ -26,10 +26,14 @@
 
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
-from picard.i18n import N_
+from picard.i18n import (
+    N_,
+    _,
+)
 from picard.util.cdrom import (
     AUTO_DETECT_DRIVES,
     get_cdrom_drives,
+    has_isrc_support,
 )
 
 from picard.ui.options import (
@@ -64,6 +68,9 @@ class CDLookupOptionsPage(OptionsPage):
         if AUTO_DETECT_DRIVES:
             self._device_list = get_cdrom_drives()
             self.ui.cd_lookup_device.addItems(self._device_list)
+        if not has_isrc_support():
+            self.ui.read_isrcs_from_disc.setDisabled(True)
+            self.ui.read_isrcs_from_disc.setToolTip(_('ISRC extraction is not supported on this platform.'))
 
     def load(self):
         config = get_config()

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -43,9 +43,11 @@ from picard.const.sys import (
 
 discid: ModuleType | None = None
 try:
+    # use python-libdiscid (https://python-libdiscid.readthedocs.io/)
     from libdiscid.compat import discid  # type: ignore[unresolved-import,no-redef,import-not-found]
 except ImportError:
     try:
+        # use python-discid (httpds://python-discid.readthedocs.org/)
         import discid  # type: ignore[unresolved-import,no-redef,import-not-found]
     except (ImportError, OSError):
         pass

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -52,7 +52,12 @@ except ImportError:
 
 
 DISCID_NOT_LOADED_MESSAGE = "CDROM: discid library not found - Lookup CD functionality disabled"
+DISCID_NO_ISRC_MESSAGE = "CDROM: discid library has no ISRC support - ISRC extraction from CD disabled"
 LINUX_CDROM_INFO = '/proc/sys/dev/cdrom/info'
+
+
+def has_isrc_support():
+    return discid is not None and 'isrc' in discid.FEATURES
 
 
 def get_default_cdrom_drives() -> list[str]:

--- a/test/test_disc.py
+++ b/test/test_disc.py
@@ -94,6 +94,7 @@ class DiscTest(PicardTestCase):
                 'server_host': 'musicbrainz.org',
                 'server_port': 443,
                 'use_server_for_submission': False,
+                'read_isrcs_from_disc': False,
             }
         )
         mock_discid.read = Mock(return_value=MockDisc())
@@ -200,13 +201,15 @@ class DiscIsrcTest(PicardTestCase):
                 'server_host': 'musicbrainz.org',
                 'server_port': 443,
                 'use_server_for_submission': False,
+                'read_isrcs_from_disc': True,
             }
         )
         mock_discid.FEATURES = ['mcn', 'isrc']
         mock_discid.read = Mock(return_value=MockDiscWithIsrcs())
         device = '/dev/cdrom1'
         disc = picard.disc.Disc()
-        disc.read(device)
+        with patch.object(picard.disc, 'has_isrc_support', return_value=True):
+            disc.read(device)
         mock_discid.read.assert_called_with(device, features=['mcn', 'isrc'])
         self.assertEqual({1: 'USRC17607839', 2: 'GBAYE0000351', 4: 'FRZ039100014'}, disc.isrcs)
 
@@ -217,13 +220,15 @@ class DiscIsrcTest(PicardTestCase):
                 'server_host': 'musicbrainz.org',
                 'server_port': 443,
                 'use_server_for_submission': False,
+                'read_isrcs_from_disc': True,
             }
         )
         mock_discid.FEATURES = ['mcn']
         mock_discid.read = Mock(return_value=MockDiscNoIsrcAttr())
         device = '/dev/cdrom1'
         disc = picard.disc.Disc()
-        disc.read(device)
+        with patch.object(picard.disc, 'has_isrc_support', return_value=False):
+            disc.read(device)
         mock_discid.read.assert_called_with(device, features=['mcn'])
         self.assertEqual({}, disc.isrcs)
 
@@ -234,13 +239,15 @@ class DiscIsrcTest(PicardTestCase):
                 'server_host': 'musicbrainz.org',
                 'server_port': 443,
                 'use_server_for_submission': False,
+                'read_isrcs_from_disc': True,
             }
         )
         mock_discid.FEATURES = ['mcn', 'isrc']
         mock_discid.read = Mock(return_value=MockDiscWithInvalidIsrcs())
         device = '/dev/cdrom1'
         disc = picard.disc.Disc()
-        disc.read(device)
+        with patch.object(picard.disc, 'has_isrc_support', return_value=True):
+            disc.read(device)
         # Only valid ISRCs should be stored
         self.assertEqual({1: 'USRC17607839', 4: 'GBAYE0000351'}, disc.isrcs)
 

--- a/test/test_util_cdrom.py
+++ b/test/test_util_cdrom.py
@@ -23,6 +23,7 @@
 from collections.abc import Iterable
 import io
 import unittest
+from unittest.mock import patch
 
 from test.picardtestcase import PicardTestCase
 
@@ -78,6 +79,19 @@ Can read MRW:
 Can write MRW:
 Can write RAM:
 """
+
+
+class HasIrscSupportTest(PicardTestCase):
+    @patch.object(cdrom, 'discid')
+    def test_has_isrc_support(self, mock_discid):
+        mock_discid.FEATURES = ['isrc']
+        self.assertTrue(cdrom.has_isrc_support())
+        mock_discid.FEATURES = []
+        self.assertFalse(cdrom.has_isrc_support())
+
+    @patch.object(cdrom, 'discid', None)
+    def test_has_isrc_support_no_discid(self):
+        self.assertFalse(cdrom.has_isrc_support())
 
 
 class LinuxParseCdromInfoTest(PicardTestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

libdiscid does not support ISRC extraction on all platforms. If the ISRC feature is unavailable, it does not make sense to allow the user to enable the feature.

Note: From currently realistically used platforms this affects only Haiku. 

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
If ISRC is not supported by libdiscid, disable the checkbox in options and show a tooltip explaining it. Also set the default value of the "read_isrcs_from_disc" option to `False`.

Add a new `cdrom.has_isrc_support` helper with tests.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
