### PR TITLE
PICARD-3368: Batch object updates when removing multiple tags

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -623,7 +623,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         Adds actions for removing, restoring, and merging tags to the context menu.
         """
         remove_tag_action = QtGui.QAction(_("Remove"), self)
-        remove_tag_action.triggered.connect(partial(self._apply_update_funcs, removals))
+        remove_tag_action.triggered.connect(partial(self._remove_tags, removals))
         remove_tag_action.setShortcut(self.remove_tag_shortcut.key())
         remove_tag_action.setEnabled(bool(removals))
         menu.addAction(remove_tag_action)
@@ -686,7 +686,7 @@ class MetadataBox(QtWidgets.QTableWidget):
                             menu.addAction(lookup_action)
                     # Collect removable tags
                     if self._tag_is_removable(tag):
-                        removals.append(partial(self._remove_tag, tag))
+                        removals.append(tag)
                     # Collect actions for restoring/merging original tag values
                     self._collect_orig_tag_actions(tag, useorigs, mergeorigs)
                 # Add actions for removing, restoring, merging tags
@@ -764,13 +764,16 @@ class MetadataBox(QtWidgets.QTableWidget):
     def _set_tag_values(self, tag, values, objects=None):
         self._update_objects(self._set_tag_values_delayed_updates(tag, values, objects=objects))
 
-    def _remove_tag(self, tag):
-        self._set_tag_values(tag, [])
+    def _remove_tags(self, tags):
+        objects_to_update = set()
+        with self.tagger.window.ignore_selection_changes:
+            for tag in tags:
+                objects_to_update.update(self._set_tag_values_delayed_updates(tag, []))
+        self._update_objects(objects_to_update)
+        self.tagger.window.update_selection(new_selection=False, drop_album_caches=True)
 
     def remove_selected_tags(self):
-        for tag in self._selected_tags(filter_func=self._tag_is_removable):
-            self._remove_tag(tag)
-        self.tagger.window.update_selection(new_selection=False, drop_album_caches=True)
+        self._remove_tags(self._selected_tags(filter_func=self._tag_is_removable))
 
     def _tag_is_removable(self, tag):
         return self.tag_diff.status[tag] & TagStatus.NOTREMOVABLE == 0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Removing multiple tags from multiple tracks is slow and freezes the UI for an unnecessarily long time.

Previously, removing N tags from M selected objects called obj.update() NxM times. Each call performs a full metadata comparison and UI refresh, making bulk tag removal noticeably slow with large selections.

* JIRA ticket (_optional_): PICARD-3368
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Introduce `_remove_tags()` which applies all metadata deletions first using the existing `_set_tag_values_delayed_updates()` generator, accumulates the affected objects, then calls obj.update() exactly once per object.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->

Used to determine if there were existing batching methods and to implement objects_to_update.update() batching.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
