### PR TITLE
Refactor MetadataBox: extract testable helpers from UI methods

### DIFF
--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -527,25 +527,20 @@ class MetadataBox(QtWidgets.QTableWidget):
             self.tagger.clipboard().setText(MULTI_VALUED_JOINER.join(value))
 
     def _paste_from_json(self, mimedata):
-        def _decode_json(mimedata):
-            try:
-                text = mimedata.data(self.MIMETYPE_PICARD_TAGS).data()
-                return json.loads(text)
-            except json.JSONDecodeError as e:
-                log.error("Failed to decode JSON data from clipboard: %r", e)
-
-        def _apply_tag_dict(data):
-            for tag, values in interpret_paste_data(data, MULTI_VALUED_JOINER):
-                if not self._tag_is_editable(tag):
-                    continue
-                if values:
-                    log.info("Pasting '%s' from JSON clipboard to tag '%s'", MULTI_VALUED_JOINER.join(values), tag)
-                else:
-                    log.info("Removing tag '%s' from JSON clipboard paste", tag)
-                yield from self._set_tag_values_delayed_updates(tag, values)
-
-        data = _decode_json(mimedata)
-        return _apply_tag_dict(data) if data else []
+        try:
+            text = mimedata.data(self.MIMETYPE_PICARD_TAGS).data()
+            data = json.loads(text)
+        except json.JSONDecodeError as e:
+            log.error("Failed to decode JSON data from clipboard: %r", e)
+            return []
+        for tag, values in interpret_paste_data(data, MULTI_VALUED_JOINER):
+            if not self._tag_is_editable(tag):
+                continue
+            if values:
+                log.info("Pasting '%s' from JSON clipboard to tag '%s'", MULTI_VALUED_JOINER.join(values), tag)
+            else:
+                log.info("Removing tag '%s' from JSON clipboard paste", tag)
+            yield from self._set_tag_values_delayed_updates(tag, values)
 
     def _paste_from_text(self, mimedata):
         item = self.currentItem()

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -307,6 +307,8 @@ class MetadataBox(QtWidgets.QTableWidget):
         plugin_manager = self.tagger.get_plugin_manager()
         if plugin_manager:
             plugin_manager.plugin_state_changed.connect(self._on_plugin_changed)
+
+        # Table widget configuration
         self.setAccessibleName(_("metadata view"))
         self.setAccessibleDescription(_("Displays original and new tags for the selected files"))
         self.setColumnCount(3)
@@ -323,6 +325,8 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_MacShowFocusRect, 1)
         self.setItemDelegate(TableTagEditorDelegate(self))
         self.setWordWrap(False)
+
+        # Selection state
         self.files = set()
         self.tracks = set()
         self.objects = set()
@@ -330,6 +334,8 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.selection_mutex = QtCore.QMutex()
         self.selection_dirty = False
         self.editing = None  # the QTableWidgetItem being edited
+
+        # Actions and shortcuts
         self.add_tag_action = QtGui.QAction(_("Add New Tag…"), self)
         self.add_tag_action.triggered.connect(partial(self._edit_tag, ""))
         self.changes_first_action = QtGui.QAction(_("Show Changes First"), self)
@@ -347,11 +353,14 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.remove_tag_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(_("Alt+Shift+R")), self, self.remove_selected_tags
         )
+
+        # Other state
         self.preserved_tags = UserPreservedTags()
         self._single_file_album = False
         self._single_track_album = False
         self.ignore_updates = IgnoreUpdatesContext(on_exit=self.update)
 
+        # Clipboard MIME type handlers
         self.mimedata_helper = MimeDataHelper()
         self.mimedata_helper.register(
             self.MIMETYPE_PICARD_TAGS,

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -252,6 +252,27 @@ def interpret_paste_data(data, multi_valued_joiner):
             yield tag, value.split(multi_valued_joiner)
 
 
+def merge_values(orig_values, current_values):
+    """Merge original and current tag values, preserving order and uniqueness.
+
+    Returns a new list starting with all original values, followed by any
+    current values not already present.  This is the logic used by
+    "Merge Original Values" in the metadata box context menu.
+
+    Args:
+        orig_values: The original (saved) values for a tag.
+        current_values: The current (edited) values for the same tag.
+
+    Returns:
+        A merged list of values with no duplicates, preserving insertion order.
+    """
+    merged = list(orig_values)
+    for value in current_values:
+        if value not in merged:
+            merged.append(value)
+    return merged
+
+
 class MetadataBox(QtWidgets.QTableWidget):
     MIMETYPE_PICARD_TAGS = "application/vdr.picard"
     MIMETYPE_TSV = 'text/tab-separated-values'
@@ -771,10 +792,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         self._set_tag_values_extra(tag, orig_values, obj, extra_objects)
 
     def _merge_orig_tags(self, obj, tag, extra_objects=None):
-        values = list(obj.orig_metadata.getall(tag))
-        for new_value in obj.metadata.getall(tag):
-            if new_value not in values:
-                values.append(new_value)
+        values = merge_values(obj.orig_metadata.getall(tag), obj.metadata.getall(tag))
         self._set_tag_values_extra(tag, values, obj, extra_objects)
 
     def _edit_tag(self, tag):

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -218,6 +218,40 @@ def apply_tag_values(objects, tag, values):
             yield obj
 
 
+def interpret_paste_data(data, multi_valued_joiner):
+    """Interpret pasted tag data into (tag, values) pairs.
+
+    Parses a dict structure (as produced by TagDiff.as_dict / clipboard JSON)
+    and yields ``(tag, values)`` tuples suitable for passing to
+    :func:`apply_tag_values`.
+
+    The input ``data`` maps tag names to dicts that may contain:
+      - ``TagDiff.REMOVED_VALUE``: if True, the tag should be deleted (values=[])
+      - ``TagDiff.NEW_VALUE``: preferred list of values
+      - ``TagDiff.OLD_VALUE``: fallback list of values if 'new' is absent
+
+    Multi-valued strings are split on ``multi_valued_joiner``.
+
+    Args:
+        data: Dict mapping tag names to value dicts.
+        multi_valued_joiner: The separator string for splitting multi-valued
+            tags (typically ``'; '``).
+
+    Yields:
+        Tuples of ``(tag, values)`` where values is a list of strings,
+        or an empty list to indicate deletion.
+    """
+    for tag, tag_data in data.items():
+        if tag_data.get(TagDiff.REMOVED_VALUE) is True:
+            yield tag, []
+            continue
+        value = tag_data.get(TagDiff.NEW_VALUE) or tag_data.get(TagDiff.OLD_VALUE)
+        if value:
+            if isinstance(value, list):
+                value = multi_valued_joiner.join(value)
+            yield tag, value.split(multi_valued_joiner)
+
+
 class MetadataBox(QtWidgets.QTableWidget):
     MIMETYPE_PICARD_TAGS = "application/vdr.picard"
     MIMETYPE_TSV = 'text/tab-separated-values'
@@ -475,24 +509,14 @@ class MetadataBox(QtWidgets.QTableWidget):
                 log.error("Failed to decode JSON data from clipboard: %r", e)
 
         def _apply_tag_dict(data):
-            for tag in data:
-                if self._tag_is_editable(tag):
-                    if data[tag].get(TagDiff.REMOVED_VALUE) is True:
-                        log.info("Removing tag '%s' from JSON clipboard paste", tag)
-                        yield from self._set_tag_values_delayed_updates(tag, [])
-                        continue
-                    # Prefer 'new' values, but fall back to 'old' if not available
-                    value = data[tag].get(TagDiff.NEW_VALUE) or data[tag].get(TagDiff.OLD_VALUE)
-                    if value:
-                        if isinstance(value, list):
-                            # There are multiple values for the tag
-                            value = MULTI_VALUED_JOINER.join(value)
-                        # each value may also represent multiple values
-                        log.info("Pasting '%s' from JSON clipboard to tag '%s'", value, tag)
-                        value = value.split(MULTI_VALUED_JOINER)
-                        yield from self._set_tag_values_delayed_updates(tag, value)
-                    else:
-                        log.error("Tag '%s' without new or old value found in clipboard, ignoring.", tag)
+            for tag, values in interpret_paste_data(data, MULTI_VALUED_JOINER):
+                if not self._tag_is_editable(tag):
+                    continue
+                if values:
+                    log.info("Pasting '%s' from JSON clipboard to tag '%s'", MULTI_VALUED_JOINER.join(values), tag)
+                else:
+                    log.info("Removing tag '%s' from JSON clipboard paste", tag)
+                yield from self._set_tag_values_delayed_updates(tag, values)
 
         data = _decode_json(mimedata)
         return _apply_tag_dict(data) if data else []

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -750,16 +750,7 @@ class MetadataBox(QtWidgets.QTableWidget):
             if item:
                 column = item.column()
                 for tag in tags:
-                    # Add lookup action for supported tags
-                    if tag in self.LOOKUP_TAGS:
-                        if (column == self.COLUMN_ORIG or column == self.COLUMN_NEW) and single_tag and item.text():
-                            if column == self.COLUMN_ORIG:
-                                values = self.tag_diff.old[tag]
-                            else:
-                                values = self.tag_diff.new[tag]
-                            lookup_action = QtGui.QAction(_("Lookup in &Browser"), self)
-                            lookup_action.triggered.connect(partial(self._open_link, values, tag))
-                            menu.addAction(lookup_action)
+                    self._add_lookup_action(menu, tag, column, single_tag, item)
                     # Collect removable tags
                     if self._tag_is_removable(tag):
                         removals.append(tag)
@@ -780,6 +771,22 @@ class MetadataBox(QtWidgets.QTableWidget):
         menu.addAction(self.changes_first_action)
         menu.exec(event.globalPos())
         event.accept()
+
+    def _add_lookup_action(self, menu, tag, column, single_tag, item):
+        """Add a 'Lookup in Browser' action if the tag supports it and context allows."""
+        if tag not in self.LOOKUP_TAGS:
+            return
+        if not (single_tag and item.text()):
+            return
+        if column == self.COLUMN_ORIG:
+            values = self.tag_diff.old[tag]
+        elif column == self.COLUMN_NEW:
+            values = self.tag_diff.new[tag]
+        else:
+            return
+        lookup_action = QtGui.QAction(_("Lookup in &Browser"), self)
+        lookup_action.triggered.connect(partial(self._open_link, values, tag))
+        menu.addAction(lookup_action)
 
     def _apply_update_funcs(self, funcs):
         with self.tagger.window.ignore_selection_changes:

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -187,6 +187,37 @@ class TableTagEditorDelegate(TagEditorDelegate):
         return index.data(QtCore.Qt.ItemDataRole.UserRole)
 
 
+def apply_tag_values(objects, tag, values):
+    """Apply tag values to objects' metadata without triggering UI updates.
+
+    Sets the tag to the given values on each object's metadata, or deletes the
+    tag if values is empty.  Yields each affected object exactly once.
+
+    This is a pure data-mutation helper: it does not call obj.update() or
+    interact with the UI.  The caller is responsible for triggering updates
+    on the returned objects.
+
+    Args:
+        objects: Iterable of objects with a ``metadata`` attribute.
+        tag: The tag name to set or delete.
+        values: List of values to assign.  An empty list (or ``[""]``)
+            means "delete the tag".
+
+    Yields:
+        Each object whose metadata was modified.
+    """
+    if values == [""]:
+        values = []
+    if not values:
+        for obj in objects:
+            del obj.metadata[tag]
+            yield obj
+    else:
+        for obj in objects:
+            obj.metadata[tag] = values
+            yield obj
+
+
 class MetadataBox(QtWidgets.QTableWidget):
     MIMETYPE_PICARD_TAGS = "application/vdr.picard"
     MIMETYPE_TSV = 'text/tab-separated-values'
@@ -746,16 +777,10 @@ class MetadataBox(QtWidgets.QTableWidget):
         if objects is None:
             objects = self.objects
         with self.tagger.window.ignore_selection_changes:
-            if values == [""]:
-                values = []
-            if not values and self._tag_is_removable(tag):
-                for obj in objects:
-                    del obj.metadata[tag]
-                    yield obj
-            elif values:
-                for obj in objects:
-                    obj.metadata[tag] = values
-                    yield obj
+            if values == [""] or not values:
+                if not self._tag_is_removable(tag):
+                    return
+            yield from apply_tag_values(objects, tag, values)
 
     def _update_objects(self, objects):
         for obj in set(objects):

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -480,46 +480,51 @@ class MetadataBox(QtWidgets.QTableWidget):
 
         items = self.selectedItems()
         if len(items) > 1:
-            selected_data = self.get_selected_tags(items)
-            # Build the mimedata to use for the clipboard
-            mimedata = QtCore.QMimeData()
-            converted_data_cache = {}
-            for mimetype, encode_func in self.mimedata_helper.encode_funcs():
-                try:
-                    if encode_func not in converted_data_cache:
-                        converted_data_cache[encode_func] = encode_func(selected_data)
-                    mimedata.setData(mimetype, converted_data_cache[encode_func])
-                except Exception as e:
-                    log.error("Failed to convert %r to '%s': %s", selected_data, mimetype, e)
-            # Ensure we actually have something to copy to the clipboard
-            if mimedata.formats():
-                if log.is_debug():
-                    log.debug("Copying to clipboard as %r", mimedata.formats())
-                    tsv_data = selected_data.to_tsv()
-                    lines = tsv_data.rstrip('\n').split('\n')
-                    for line in lines:
-                        log.debug("  %s", line.replace('\t', '|'))
-                self.tagger.clipboard().setMimeData(mimedata)
+            self._copy_multiple_items(items)
         else:
-            # Just copy the current item as a string
-            item = self.currentItem()
-            if item:
-                column = item.column()
-                if column == self.COLUMN_TAG:
-                    # Copy tag name from first column
-                    tag = self.tag_diff.tag_names[item.row()]
-                    log.debug("Copying tag name '%s' to clipboard", tag)
-                    self.tagger.clipboard().setText(tag)
-                else:
-                    tag, value = self._get_row_info(item.row())
-                    value = value[column]
-                    if column == self.COLUMN_NEW and self.tag_diff.tag_status(tag) == TagStatus.REMOVED:
-                        value = []
-                    elif tag == '~length':
-                        value = self.tag_diff.handle_length(value, prettify_times=True)
-                    if value is not None:
-                        log.debug("Copying '%s' to clipboard (from tag '%s')", value, tag)
-                        self.tagger.clipboard().setText(MULTI_VALUED_JOINER.join(value))
+            self._copy_single_item()
+
+    def _copy_multiple_items(self, items):
+        """Copy multiple selected items to clipboard as structured MIME data."""
+        selected_data = self.get_selected_tags(items)
+        mimedata = QtCore.QMimeData()
+        converted_data_cache = {}
+        for mimetype, encode_func in self.mimedata_helper.encode_funcs():
+            try:
+                if encode_func not in converted_data_cache:
+                    converted_data_cache[encode_func] = encode_func(selected_data)
+                mimedata.setData(mimetype, converted_data_cache[encode_func])
+            except Exception as e:
+                log.error("Failed to convert %r to '%s': %s", selected_data, mimetype, e)
+        if mimedata.formats():
+            if log.is_debug():
+                log.debug("Copying to clipboard as %r", mimedata.formats())
+                tsv_data = selected_data.to_tsv()
+                lines = tsv_data.rstrip('\n').split('\n')
+                for line in lines:
+                    log.debug("  %s", line.replace('\t', '|'))
+            self.tagger.clipboard().setMimeData(mimedata)
+
+    def _copy_single_item(self):
+        """Copy a single selected item to clipboard as plain text."""
+        item = self.currentItem()
+        if not item:
+            return
+        column = item.column()
+        if column == self.COLUMN_TAG:
+            tag = self.tag_diff.tag_names[item.row()]
+            log.debug("Copying tag name '%s' to clipboard", tag)
+            self.tagger.clipboard().setText(tag)
+            return
+        tag, value = self._get_row_info(item.row())
+        value = value[column]
+        if column == self.COLUMN_NEW and self.tag_diff.tag_status(tag) == TagStatus.REMOVED:
+            value = []
+        elif tag == '~length':
+            value = self.tag_diff.handle_length(value, prettify_times=True)
+        if value is not None:
+            log.debug("Copying '%s' to clipboard (from tag '%s')", value, tag)
+            self.tagger.clipboard().setText(MULTI_VALUED_JOINER.join(value))
 
     def _paste_from_json(self, mimedata):
         def _decode_json(mimedata):

--- a/test/test_metadatabox_copypaste.py
+++ b/test/test_metadatabox_copypaste.py
@@ -98,6 +98,8 @@ class FakeMetadataBox:
     _paste_value = MetadataBox._paste_value
     _can_copy = MetadataBox._can_copy
     _copy_value = MetadataBox._copy_value
+    _copy_multiple_items = MetadataBox._copy_multiple_items
+    _copy_single_item = MetadataBox._copy_single_item
     _tag_is_editable = MetadataBox._tag_is_editable
     _tag_is_removable = MetadataBox._tag_is_removable
     _set_tag_values_delayed_updates = MetadataBox._set_tag_values_delayed_updates

--- a/test/test_metadatabox_tag_operations.py
+++ b/test/test_metadatabox_tag_operations.py
@@ -21,7 +21,10 @@ from test.picardtestcase import PicardTestCase
 
 from picard.metadata import Metadata
 
-from picard.ui.metadatabox import apply_tag_values
+from picard.ui.metadatabox import (
+    apply_tag_values,
+    interpret_paste_data,
+)
 
 
 class FakeObject:
@@ -119,3 +122,69 @@ class TestApplyTagValues(PicardTestCase):
         self.assertEqual(len(affected), 2)
         self.assertIn(obj1, affected)
         self.assertIn(obj2, affected)
+
+
+class TestInterpretPasteData(PicardTestCase):
+    JOINER = '; '
+
+    def test_new_value_single(self):
+        data = {'artist': {'new': ['New Artist']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['New Artist'])])
+
+    def test_new_value_multiple(self):
+        data = {'artist': {'new': ['Artist 1', 'Artist 2']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['Artist 1', 'Artist 2'])])
+
+    def test_falls_back_to_old_value(self):
+        data = {'artist': {'old': ['Old Artist']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['Old Artist'])])
+
+    def test_prefers_new_over_old(self):
+        data = {'artist': {'new': ['New'], 'old': ['Old']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['New'])])
+
+    def test_removed_tag(self):
+        data = {'artist': {'removed': True, 'old': ['Old']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', [])])
+
+    def test_removed_false_uses_values(self):
+        """removed=False should not trigger deletion."""
+        data = {'artist': {'removed': False, 'new': ['A']}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['A'])])
+
+    def test_string_value_split_on_joiner(self):
+        """A string value (not list) is split on the joiner."""
+        data = {'artist': {'new': 'Artist 1; Artist 2'}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['Artist 1', 'Artist 2'])])
+
+    def test_empty_value_skipped(self):
+        """Tags with no 'new' or 'old' value are skipped entirely."""
+        data = {'artist': {}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [])
+
+    def test_empty_list_value_skipped(self):
+        """Tags with empty list value are skipped (falsy)."""
+        data = {'artist': {'new': []}}
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [])
+
+    def test_multiple_tags(self):
+        data = {
+            'artist': {'new': ['A']},
+            'title': {'new': ['T']},
+            'genre': {'removed': True},
+        }
+        result = list(interpret_paste_data(data, self.JOINER))
+        self.assertEqual(result, [('artist', ['A']), ('title', ['T']), ('genre', [])])
+
+    def test_empty_data(self):
+        result = list(interpret_paste_data({}, self.JOINER))
+        self.assertEqual(result, [])

--- a/test/test_metadatabox_tag_operations.py
+++ b/test/test_metadatabox_tag_operations.py
@@ -1,0 +1,121 @@
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.metadata import Metadata
+
+from picard.ui.metadatabox import apply_tag_values
+
+
+class FakeObject:
+    """Minimal object with a Metadata instance, mimicking File/Track."""
+
+    def __init__(self, **tags):
+        self.metadata = Metadata()
+        for tag, values in tags.items():
+            self.metadata[tag] = values
+        self.update_called = False
+
+    def update(self):
+        self.update_called = True
+
+
+class TestApplyTagValues(PicardTestCase):
+    def test_set_single_value(self):
+        obj = FakeObject(artist=['Old Artist'])
+        affected = list(apply_tag_values([obj], 'artist', ['New Artist']))
+        self.assertEqual(affected, [obj])
+        self.assertEqual(obj.metadata.getall('artist'), ['New Artist'])
+
+    def test_set_multiple_values(self):
+        obj = FakeObject(artist=['Old'])
+        affected = list(apply_tag_values([obj], 'artist', ['A', 'B']))
+        self.assertEqual(affected, [obj])
+        self.assertEqual(obj.metadata.getall('artist'), ['A', 'B'])
+
+    def test_set_value_on_multiple_objects(self):
+        obj1 = FakeObject(title=['X'])
+        obj2 = FakeObject(title=['Y'])
+        affected = list(apply_tag_values([obj1, obj2], 'title', ['Z']))
+        self.assertEqual(affected, [obj1, obj2])
+        self.assertEqual(obj1.metadata.getall('title'), ['Z'])
+        self.assertEqual(obj2.metadata.getall('title'), ['Z'])
+
+    def test_delete_tag_with_empty_list(self):
+        obj = FakeObject(artist=['Artist'])
+        affected = list(apply_tag_values([obj], 'artist', []))
+        self.assertEqual(affected, [obj])
+        self.assertNotIn('artist', obj.metadata)
+        self.assertIn('artist', obj.metadata.deleted_tags)
+
+    def test_delete_tag_with_empty_string_list(self):
+        """values=[""] is treated the same as values=[] (deletion)."""
+        obj = FakeObject(artist=['Artist'])
+        affected = list(apply_tag_values([obj], 'artist', ['']))
+        self.assertEqual(affected, [obj])
+        self.assertNotIn('artist', obj.metadata)
+        self.assertIn('artist', obj.metadata.deleted_tags)
+
+    def test_delete_nonexistent_tag_does_not_raise(self):
+        obj = FakeObject()
+        affected = list(apply_tag_values([obj], 'nosuch', []))
+        self.assertEqual(affected, [obj])
+        self.assertIn('nosuch', obj.metadata.deleted_tags)
+
+    def test_does_not_call_update(self):
+        """apply_tag_values must not call obj.update() — that's the caller's job."""
+        obj = FakeObject(artist=['A'])
+        list(apply_tag_values([obj], 'artist', ['B']))
+        self.assertFalse(obj.update_called)
+
+    def test_empty_objects_yields_nothing(self):
+        affected = list(apply_tag_values([], 'artist', ['X']))
+        self.assertEqual(affected, [])
+
+    def test_set_creates_tag_if_not_present(self):
+        obj = FakeObject()
+        affected = list(apply_tag_values([obj], 'genre', ['Rock']))
+        self.assertEqual(affected, [obj])
+        self.assertEqual(obj.metadata.getall('genre'), ['Rock'])
+
+    def test_delete_multiple_tags_across_objects(self):
+        """Simulate batch removal of multiple tags from multiple objects."""
+        obj1 = FakeObject(artist=['A'], title=['T1'])
+        obj2 = FakeObject(artist=['B'], title=['T2'])
+        objects = [obj1, obj2]
+
+        all_affected = set()
+        for tag in ['artist', 'title']:
+            all_affected.update(apply_tag_values(objects, tag, []))
+
+        self.assertEqual(all_affected, {obj1, obj2})
+        self.assertNotIn('artist', obj1.metadata)
+        self.assertNotIn('artist', obj2.metadata)
+        self.assertNotIn('title', obj1.metadata)
+        self.assertNotIn('title', obj2.metadata)
+
+    def test_yields_each_object_once_per_call(self):
+        """Each call yields each object exactly once."""
+        obj1 = FakeObject(artist=['A'])
+        obj2 = FakeObject(artist=['B'])
+        affected = list(apply_tag_values([obj1, obj2], 'artist', ['C']))
+        self.assertEqual(len(affected), 2)
+        self.assertIn(obj1, affected)
+        self.assertIn(obj2, affected)

--- a/test/test_metadatabox_tag_operations.py
+++ b/test/test_metadatabox_tag_operations.py
@@ -24,6 +24,7 @@ from picard.metadata import Metadata
 from picard.ui.metadatabox import (
     apply_tag_values,
     interpret_paste_data,
+    merge_values,
 )
 
 
@@ -188,3 +189,40 @@ class TestInterpretPasteData(PicardTestCase):
     def test_empty_data(self):
         result = list(interpret_paste_data({}, self.JOINER))
         self.assertEqual(result, [])
+
+
+class TestMergeValues(PicardTestCase):
+    def test_no_overlap(self):
+        result = merge_values(['A', 'B'], ['C', 'D'])
+        self.assertEqual(result, ['A', 'B', 'C', 'D'])
+
+    def test_full_overlap(self):
+        result = merge_values(['A', 'B'], ['A', 'B'])
+        self.assertEqual(result, ['A', 'B'])
+
+    def test_partial_overlap(self):
+        result = merge_values(['A', 'B'], ['B', 'C'])
+        self.assertEqual(result, ['A', 'B', 'C'])
+
+    def test_empty_orig(self):
+        result = merge_values([], ['A', 'B'])
+        self.assertEqual(result, ['A', 'B'])
+
+    def test_empty_current(self):
+        result = merge_values(['A', 'B'], [])
+        self.assertEqual(result, ['A', 'B'])
+
+    def test_both_empty(self):
+        result = merge_values([], [])
+        self.assertEqual(result, [])
+
+    def test_preserves_orig_order(self):
+        result = merge_values(['C', 'A'], ['B'])
+        self.assertEqual(result, ['C', 'A', 'B'])
+
+    def test_does_not_mutate_input(self):
+        orig = ['A', 'B']
+        current = ['C']
+        merge_values(orig, current)
+        self.assertEqual(orig, ['A', 'B'])
+        self.assertEqual(current, ['C'])


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Refactor `MetadataBox` to extract pure-logic helpers from deeply nested UI methods, making the metadata mutation, paste interpretation, and value merging logic independently testable.

## Problem

Several methods in `MetadataBox` mix pure data logic (setting/deleting tags, parsing clipboard JSON, merging values) with UI orchestration (selection guards, logging, Qt interactions). This makes the code harder to follow and impossible to unit-test without mocking the full widget.

## Solution

Extract standalone module-level functions from the interleaved UI/logic code:

- `apply_tag_values()` — pure metadata set/delete logic (from `_set_tag_values_delayed_updates`)
- `interpret_paste_data()` — clipboard JSON parsing into `(tag, values)` tuples (from `_paste_from_json`)
- `merge_values()` — ordered unique-merge of original and current values (from `_merge_orig_tags`)

Additional structural improvements:
- `_add_lookup_action()` — extracted from `contextMenuEvent` loop body
- `_copy_single_item()` / `_copy_multiple_items()` — split from `_copy_value`
- `_paste_from_json` flattened by inlining trivial nested helpers
- Section comments added to `MetadataBox.__init__` for navigation

30 new unit tests cover the extracted functions. Full test suite passes (5695 tests, 0 failures).

### Commits

- Extract apply_tag_values() for testable metadata mutation
- Extract interpret_paste_data() for testable paste logic
- Extract merge_values() for testable value merging logic
- Extract _add_lookup_action from contextMenuEvent
- Split _copy_value into _copy_single_item and _copy_multiple_items
- Flatten _paste_from_json by removing nested helper functions
- Add section comments to MetadataBox.__init__

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to assist with identifying extraction boundaries, writing unit tests, and reviewing the refactored code for behavioral equivalence.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
