### PR TITLE
PICARD-3369: Add file matching test playground for local coverart option

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -111,7 +111,7 @@ class ProviderOptionsLocal(ProviderOptions):
             line = line.strip()
             fmt = self.fmt_clear
             if line:
-                if coverart_filter.match(line):
+                if coverart_filter.search(line):
                     fmt = self.fmt_match
                 else:
                     fmt = self.fmt_skip

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -25,6 +25,12 @@
 import os
 import re
 
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import (
+    QTextBlockFormat,
+    QTextCursor,
+)
+
 from picard.config import get_config
 from picard.coverart.image import LocalFileCoverArtImage
 from picard.coverart.providers.provider import (
@@ -56,6 +62,19 @@ class ProviderOptionsLocal(ProviderOptions):
         super().__init__(parent)
         self.init_regex_checker(self.ui.local_cover_regex_edit, self.ui.local_cover_regex_error)
 
+        self.ui.local_cover_regex_edit.textChanged.connect(self.update_test_coverart_filter)
+        self.ui.test_coverart_filter.textChanged.connect(self.update_test_coverart_filter)
+
+        # FIXME: colors aren't great from accessibility POV
+        self.fmt_match = QTextBlockFormat()
+        self.fmt_match.setBackground(Qt.GlobalColor.green)
+
+        self.fmt_skip = QTextBlockFormat()
+        self.fmt_skip.setBackground(Qt.GlobalColor.red)
+
+        self.fmt_clear = QTextBlockFormat()
+        self.fmt_clear.clearBackground()
+
     def load(self):
         config = get_config()
         self.ui.local_cover_regex_edit.setText(config.setting['local_cover_regex'])
@@ -63,6 +82,40 @@ class ProviderOptionsLocal(ProviderOptions):
     def save(self):
         config = get_config()
         config.setting['local_cover_regex'] = self.ui.local_cover_regex_edit.text()
+
+    def update_test_coverart_filter(self):
+        test_text = self.ui.test_coverart_filter.toPlainText()
+
+        try:
+            coverart_filter = re.compile(self.ui.local_cover_regex_edit.text(), re.IGNORECASE)
+        except re.error:
+            coverart_filter = None
+
+        def set_line_fmt(lineno, textformat):
+            obj = self.ui.test_coverart_filter
+            if lineno < 0:
+                # use current cursor position
+                cursor = obj.textCursor()
+            else:
+                cursor = QTextCursor(obj.document().findBlockByNumber(lineno))
+            obj.blockSignals(True)
+            cursor.setBlockFormat(textformat)
+            obj.blockSignals(False)
+
+        set_line_fmt(-1, self.fmt_clear)
+
+        if not coverart_filter:
+            return
+
+        for lineno, line in enumerate(test_text.splitlines()):
+            line = line.strip()
+            fmt = self.fmt_clear
+            if line:
+                if coverart_filter.match(line):
+                    fmt = self.fmt_match
+                else:
+                    fmt = self.fmt_skip
+            set_line_fmt(lineno, fmt)
 
 
 class CoverArtProviderLocal(CoverArtProvider):

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -38,10 +38,24 @@ from picard.coverart.providers.provider import (
     ProviderOptions,
 )
 from picard.coverart.utils import CAA_TYPES
-from picard.i18n import N_
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 
 from picard.ui.forms.ui_provider_options_local import Ui_LocalOptions
 from picard.ui.options import PageOptionConfigs
+
+
+TOOLTIP_TEST_COVERART_FILTER = N_("""<html><head/><body>
+<p>Enter file names to test the regex against, one per line.<br/>
+This playground will not be preserved on exit.
+</p>
+<p>
+Red background means the file name does not match.<br/>
+Green background means the file name matches.
+</p>
+</body></html>""")
 
 
 class ProviderOptionsLocal(ProviderOptions):
@@ -63,6 +77,7 @@ class ProviderOptionsLocal(ProviderOptions):
         self.init_regex_checker(self.ui.local_cover_regex_edit, self.ui.local_cover_regex_error)
 
         self.ui.local_cover_regex_edit.textChanged.connect(self.update_test_coverart_filter)
+        self.ui.test_coverart_filter.setToolTip(_(TOOLTIP_TEST_COVERART_FILTER))
         self.ui.test_coverart_filter.textChanged.connect(self.update_test_coverart_filter)
 
         # FIXME: colors aren't great from accessibility POV

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -101,8 +101,9 @@ class ProviderOptionsLocal(ProviderOptions):
     def update_test_coverart_filter(self):
         test_text = self.ui.test_coverart_filter.toPlainText()
 
+        regex_text = self.ui.local_cover_regex_edit.text()
         try:
-            coverart_filter = re.compile(self.ui.local_cover_regex_edit.text(), re.IGNORECASE)
+            coverart_filter = re.compile(regex_text, re.IGNORECASE) if regex_text else None
         except re.error:
             coverart_filter = None
 

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -25,7 +25,6 @@
 import os
 import re
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtGui import (
     QTextBlockFormat,
     QTextCursor,
@@ -43,6 +42,7 @@ from picard.i18n import (
     gettext as _,
 )
 
+from picard.ui.colors import interface_colors
 from picard.ui.forms.ui_provider_options_local import Ui_LocalOptions
 from picard.ui.options import PageOptionConfigs
 
@@ -83,13 +83,20 @@ class ProviderOptionsLocal(ProviderOptions):
 
         # FIXME: colors aren't great from accessibility POV
         self.fmt_match = QTextBlockFormat()
-        self.fmt_match.setBackground(Qt.GlobalColor.green)
+        self.fmt_match.setBackground(self._highlight_color('tagstatus_added'))
 
         self.fmt_skip = QTextBlockFormat()
-        self.fmt_skip.setBackground(Qt.GlobalColor.red)
+        self.fmt_skip.setBackground(self._highlight_color('tagstatus_removed'))
 
         self.fmt_clear = QTextBlockFormat()
         self.fmt_clear.clearBackground()
+
+    @staticmethod
+    def _highlight_color(color_key):
+        alpha = 90 if interface_colors.dark_theme else 60
+        color = interface_colors.get_qcolor(color_key)
+        color.setAlpha(alpha)
+        return color
 
     def load(self):
         config = get_config()

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -78,6 +78,7 @@ class ProviderOptionsLocal(ProviderOptions):
 
         self.ui.local_cover_regex_edit.textChanged.connect(self.update_test_coverart_filter)
         self.ui.test_coverart_filter.setToolTip(_(TOOLTIP_TEST_COVERART_FILTER))
+        self.ui.test_coverart_filter.setPlaceholderText(_("Enter file names to test, one per line"))
         self.ui.test_coverart_filter.textChanged.connect(self.update_test_coverart_filter)
 
         # FIXME: colors aren't great from accessibility POV

--- a/picard/ui/forms/ui_provider_options_local.py
+++ b/picard/ui/forms/ui_provider_options_local.py
@@ -40,7 +40,9 @@ class Ui_LocalOptions(object):
         self.note.setWordWrap(True)
         self.note.setObjectName("note")
         self.verticalLayout.addWidget(self.note)
-        spacerItem = QtWidgets.QSpacerItem(20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed)
+        spacerItem = QtWidgets.QSpacerItem(
+            20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed
+        )
         self.verticalLayout.addItem(spacerItem)
         self.label_test_coverart_filter = QtWidgets.QLabel(parent=LocalOptions)
         self.label_test_coverart_filter.setObjectName("label_test_coverart_filter")
@@ -48,7 +50,9 @@ class Ui_LocalOptions(object):
         self.test_coverart_filter = QtWidgets.QPlainTextEdit(parent=LocalOptions)
         self.test_coverart_filter.setObjectName("test_coverart_filter")
         self.verticalLayout.addWidget(self.test_coverart_filter)
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem1)
 
         self.retranslateUi(LocalOptions)
@@ -57,5 +61,9 @@ class Ui_LocalOptions(object):
     def retranslateUi(self, LocalOptions):
         LocalOptions.setWindowTitle(_("Form"))
         self.local_cover_regex_label.setText(_("Local cover art files match the following regular expression:"))
-        self.note.setText(_("First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."))
-        self.label_test_coverart_filter.setText(_("Playground for cover art file matching (cleared on exit):"))
+        self.note.setText(
+            _(
+                "First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."
+            )
+        )
+        self.label_test_coverart_filter.setText(_("Test file name matching:"))

--- a/picard/ui/forms/ui_provider_options_local.py
+++ b/picard/ui/forms/ui_provider_options_local.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/provider_options_local.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -17,7 +17,7 @@ from picard.i18n import gettext as _
 class Ui_LocalOptions(object):
     def setupUi(self, LocalOptions):
         LocalOptions.setObjectName("LocalOptions")
-        LocalOptions.resize(472, 215)
+        LocalOptions.resize(472, 277)
         self.verticalLayout = QtWidgets.QVBoxLayout(LocalOptions)
         self.verticalLayout.setObjectName("verticalLayout")
         self.local_cover_regex_label = QtWidgets.QLabel(parent=LocalOptions)
@@ -40,8 +40,16 @@ class Ui_LocalOptions(object):
         self.note.setWordWrap(True)
         self.note.setObjectName("note")
         self.verticalLayout.addWidget(self.note)
-        spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem = QtWidgets.QSpacerItem(20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed)
         self.verticalLayout.addItem(spacerItem)
+        self.label_test_coverart_filter = QtWidgets.QLabel(parent=LocalOptions)
+        self.label_test_coverart_filter.setObjectName("label_test_coverart_filter")
+        self.verticalLayout.addWidget(self.label_test_coverart_filter)
+        self.test_coverart_filter = QtWidgets.QPlainTextEdit(parent=LocalOptions)
+        self.test_coverart_filter.setObjectName("test_coverart_filter")
+        self.verticalLayout.addWidget(self.test_coverart_filter)
+        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        self.verticalLayout.addItem(spacerItem1)
 
         self.retranslateUi(LocalOptions)
         QtCore.QMetaObject.connectSlotsByName(LocalOptions)
@@ -50,3 +58,4 @@ class Ui_LocalOptions(object):
         LocalOptions.setWindowTitle(_("Form"))
         self.local_cover_regex_label.setText(_("Local cover art files match the following regular expression:"))
         self.note.setText(_("First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."))
+        self.label_test_coverart_filter.setText(_("Playground for cover art file matching (cleared on exit):"))

--- a/ui/provider_options_local.ui
+++ b/ui/provider_options_local.ui
@@ -69,7 +69,7 @@
    <item>
     <widget class="QLabel" name="label_test_coverart_filter">
      <property name="text">
-      <string>Playground for cover art file matching (cleared on exit):</string>
+      <string>Test file name matching:</string>
      </property>
     </widget>
    </item>

--- a/ui/provider_options_local.ui
+++ b/ui/provider_options_local.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>472</width>
-    <height>215</height>
+    <height>277</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -51,9 +51,35 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_test_coverart_filter">
+     <property name="text">
+      <string>Playground for cover art file matching (cleared on exit):</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="test_coverart_filter"/>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds a file matching test playground for local coverart option

## Problem

The local coverart option page accepted a regex for file matching, but no way to evaluate the regex.

* JIRA ticket (_optional_): PICARD-3369

## Solution

Add a playground for file name test matching, similar to the playground used for the Genres options page.

<img width="475" height="454" alt="image" src="https://github.com/user-attachments/assets/a9b63536-aa2d-4017-b213-c2307b1cc43a" />


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
