### PR TITLE
PICARD-3371: Optimize Options dialog open time (lazy page instantiation)

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -205,12 +205,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
     suspend_signals = False
 
     def add_pages(self, parent_pagename, default_pagename, parent_item):
-        pages = (p for p in self.pages if p.PARENT == parent_pagename)
+        page_classes = (cls for cls in self._page_classes if cls.PARENT == parent_pagename)
         items = []
-        for page in sorted(pages, key=lambda p: (p.SORT_ORDER, p.NAME)):
+        for PageCls in sorted(page_classes, key=lambda p: (p.SORT_ORDER, p.NAME)):
             # Check if this is a plugin option page and if the plugin is enabled
-            page_active = page.ACTIVE
-            api = getattr(type(page), 'api', None)
+            page_active = PageCls.ACTIVE
+            api = getattr(PageCls, 'api', None)
             if api is not None:  # This is a plugin option page
                 try:
                     plugin_uuid = api._manifest.uuid if hasattr(api, '_manifest') and api._manifest else None
@@ -230,29 +230,26 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                 continue
 
             item = HashableTreeWidgetItem(parent_item)
-            if not page.initialized:
-                title = _("%s (error)") % page.display_title()
-            else:
-                title = page.display_title()
+            title = PageCls.display_title()
             item.setText(0, title)
             if page_active:
-                self.item_to_page[item] = page
-                self.pagename_to_item[page.NAME] = item
-                profile_groups_order(page.NAME)
+                self.item_to_page[item] = PageCls
+                self.pagename_to_item[PageCls.NAME] = item
+                profile_groups_order(PageCls.NAME)
 
                 # If this is a plugin page and it matches the saved page, select it
                 if (
                     api is not None
                     and not self.default_item
-                    and page.NAME == get_config().persist['options_last_active_page']
+                    and PageCls.NAME == get_config().persist['options_last_active_page']
                 ):
-                    log.debug("add_pages: Found saved plugin page '%s', setting as default_item", page.NAME)
+                    log.debug("add_pages: Found saved plugin page '%s', setting as default_item", PageCls.NAME)
                     self.default_item = item
             else:
                 item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.add_pages(page.NAME, default_pagename, item)
-            if page.NAME == default_pagename:
-                log.debug("add_pages: Found matching page '%s', setting as default_item", page.NAME)
+            self.add_pages(PageCls.NAME, default_pagename, item)
+            if PageCls.NAME == default_pagename:
+                log.debug("add_pages: Found matching page '%s', setting as default_item", PageCls.NAME)
                 self.default_item = item
             items.append(item)
         if not self.default_item and not parent_pagename:
@@ -335,20 +332,10 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
         config = get_config()
 
-        self.pages = []
-        with DebugOpt.TIMINGS.timing("OptionsDialog: page instantiation"):
-            for Page in ext_point_options_pages:
-                try:
-                    page = Page()
-                    page.set_dialog(self)
-                    page.initialized = True
-                except Exception as e:
-                    log.exception("Failed initializing options page %r", Page)
-                    # create an empty page with the error message in place of the failing page
-                    # this approach still allows subpages of the failing page to load
-                    page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
-                self._add_page_to_stack(page)
-                self.pages.append(page)
+        # Store page classes for tree building; instances are created lazily.
+        with DebugOpt.TIMINGS.timing("OptionsDialog: page registration"):
+            self._page_classes = list(ext_point_options_pages)
+        self._page_instances: dict[str, OptionsPage] = {}
 
         self.item_to_page = {}
         self.pagename_to_item = {}
@@ -479,14 +466,19 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     @property
     def initialized_pages(self):
-        yield from (page for page in self.pages if page.initialized)
+        yield from (page for page in self._page_instances.values() if page.initialized)
 
     @property
     def loaded_pages(self):
-        yield from (page for page in self.pages if page.loaded)
+        yield from (page for page in self._page_instances.values() if page.loaded)
 
     def load_all_pages(self):
-        for page in self.initialized_pages:
+        for PageCls in self._page_classes:
+            if PageCls.NAME not in self.pagename_to_item:
+                continue  # Skip inactive/disabled pages
+            page = self._instantiate_page(PageCls)
+            if not page.initialized:
+                continue
             try:
                 page.load()
                 page.loaded = True
@@ -513,7 +505,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         items = self.ui.pages_tree.selectedItems()
         if not items:
             return
-        page = self.item_to_page[items[0]]
+        PageCls = self.item_to_page[items[0]]
+        page = self._instantiate_page(PageCls)
         option_group = profile_groups_group_from_page(page)
         if option_group:
             self.display_attached_profiles(option_group)
@@ -685,7 +678,29 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             break
 
     def get_page(self, pagename):
-        return self.item_to_page[self.pagename_to_item[pagename]]
+        """Get a page instance by name, instantiating lazily if needed."""
+        page = self._page_instances.get(pagename)
+        if page is not None:
+            return page
+        # Instantiate the page on first access
+        PageCls = self.item_to_page[self.pagename_to_item[pagename]]
+        return self._instantiate_page(PageCls)
+
+    def _instantiate_page(self, PageCls):
+        """Create a page instance from its class and register it."""
+        name = PageCls.NAME
+        if name in self._page_instances:
+            return self._page_instances[name]
+        try:
+            page = PageCls()
+            page.set_dialog(self)
+            page.initialized = True
+        except Exception as e:
+            log.exception("Failed initializing options page %r", PageCls)
+            page = ErrorOptionsPage(from_cls=PageCls, errmsg=str(e), dialog=self)
+        self._page_instances[name] = page
+        self._add_page_to_stack(page)
+        return page
 
     def set_profiles_button_and_highlight(self, page):
         option_group = profile_groups_group_from_page(page)
@@ -734,7 +749,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
     def switch_page(self):
         items = self.ui.pages_tree.selectedItems()
         if items:
-            page = self.item_to_page[items[0]]
+            PageCls = self.item_to_page[items[0]]
+            page = self._instantiate_page(PageCls)
             # Lazy-load page on first visit
             if not page.loaded and page.initialized:
                 try:
@@ -790,50 +806,28 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             log.debug("refresh_plugin_pages: UUID to module mapping: %s", _plugin_uuid_to_module)
 
         # Remove pages from disabled plugins
-        pages_to_remove = []
-        for page in self.pages:
-            page_class = type(page)
-            # Check if this is a plugin page that's no longer active
-            # For error pages, check the original class
-            original_class = getattr(page, '_original_class', page_class)
+        classes_to_remove = []
+        for PageCls in self._page_classes:
+            original_class = PageCls
             if hasattr(original_class, 'api') and original_class not in active_page_classes:
-                pages_to_remove.append(page)
-                log.debug("refresh_plugin_pages: Marking page for removal: %s", page_class.__name__)
+                classes_to_remove.append(PageCls)
+                log.debug("refresh_plugin_pages: Marking page for removal: %s", PageCls.__name__)
 
-        # Remove disabled plugin pages from UI stack and pages list
-        for page in pages_to_remove:
-            log.debug("refresh_plugin_pages: Removing page: %s", type(page).__name__)
-            self._remove_page_from_stack(page)
-            self.pages.remove(page)
-            page.deleteLater()  # Clean up the widget
+        # Remove disabled plugin pages from class list and destroy instances
+        for PageCls in classes_to_remove:
+            self._page_classes.remove(PageCls)
+            page = self._page_instances.pop(PageCls.NAME, None)
+            if page is not None:
+                log.debug("refresh_plugin_pages: Removing page instance: %s", type(page).__name__)
+                self._remove_page_from_stack(page)
+                page.deleteLater()
 
-        # Add new plugin pages
-        existing_page_classes = {type(page) for page in self.pages}
-        # Also track original classes for error pages to prevent duplicates
-        existing_original_classes = {getattr(page, '_original_class', type(page)) for page in self.pages}
-
+        # Add new plugin pages (just register the class; instantiation is lazy)
+        existing_classes = set(self._page_classes)
         for Page in active_page_classes:
-            if Page not in existing_page_classes and Page not in existing_original_classes:
-                log.debug("refresh_plugin_pages: Adding new page: %s", Page.__name__)
-                try:
-                    page = Page()
-                    page.set_dialog(self)
-                    page.initialized = True
-                    self._add_page_to_stack(page)
-                    self.pages.append(page)
-                    # Load the page if needed
-                    try:
-                        page.load()
-                        page.loaded = True
-                        log.debug("refresh_plugin_pages: Successfully loaded page: %s", Page.__name__)
-                    except Exception:
-                        log.exception("Failed loading options page %r", page)
-                except Exception as e:
-                    log.exception("Failed creating options page %r", Page)
-                    # Create an error page in place of the failing page
-                    page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
-                    self._add_page_to_stack(page)
-                    self.pages.append(page)
+            if Page not in existing_classes:
+                log.debug("refresh_plugin_pages: Adding new page class: %s", Page.__name__)
+                self._page_classes.append(Page)
 
         # Clear and rebuild the pages tree
         self.ui.pages_tree.clear()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -333,8 +333,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         config = get_config()
 
         # Store page classes for tree building; instances are created lazily.
-        with DebugOpt.TIMINGS.timing("OptionsDialog: page registration"):
-            self._page_classes = list(ext_point_options_pages)
+        self._page_classes = list(ext_point_options_pages)
         self._page_instances: dict[str, OptionsPage] = {}
 
         self.item_to_page = {}
@@ -361,15 +360,13 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Load only pages needed for init signals and the visible page.
         # Other pages are loaded lazily on first visit in switch_page().
         with DebugOpt.TIMINGS.timing("OptionsDialog: load initial pages"):
-            self._load_page('maintenance')
-            self._load_page('profiles')
+            maintenance_page = self._load_page('maintenance')
+            profile_page = self._load_page('profiles')
 
-        maintenance_page = self.get_page('maintenance')
-        if maintenance_page.loaded:
+        if maintenance_page and maintenance_page.loaded:
             maintenance_page.signal_reload.connect(self.load_all_pages)
 
-        profile_page = self.get_page('profiles')
-        if profile_page.loaded:
+        if profile_page and profile_page.loaded:
             profile_page.signal_refresh.connect(self.update_from_profile_changes)
 
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -395,11 +395,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             self.plugin_manager.plugin_installed.connect(self.refresh_plugin_pages)
             self.plugin_manager.plugin_state_changed.connect(self.refresh_plugin_pages)
             self.plugin_manager.plugin_uninstalled.connect(self.refresh_plugin_pages)
-
-            # Initial refresh to pick up any plugin option pages that were registered
-            # since the last time the options dialog was opened
-            with DebugOpt.TIMINGS.timing("OptionsDialog: refresh_plugin_pages"):
-                self.refresh_plugin_pages()
         except AttributeError:
             # Plugin manager not available - this should not happen in normal operation
             pass

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -381,8 +381,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         profile_page = self.get_page('profiles')
         if profile_page.loaded:
             profile_page.signal_refresh.connect(self.update_from_profile_changes)
-            with DebugOpt.TIMINGS.timing("OptionsDialog: highlight_enabled_profile_options"):
-                self.highlight_enabled_profile_options()
 
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)
 
@@ -409,6 +407,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
     def showEvent(self, event):
         super().showEvent(event)
         self._constrain_to_screen()
+        # Defer profile highlighting so the dialog paints first.
+        # Highlights are cosmetic (background colors on widgets) and
+        # applying them after the first paint avoids blocking display.
+        QtCore.QTimer.singleShot(0, self._deferred_highlight_profile_options)
+
+    def _deferred_highlight_profile_options(self):
+        with DebugOpt.TIMINGS.timing("OptionsDialog: highlight_enabled_profile_options"):
+            self.highlight_enabled_profile_options()
 
     def _constrain_to_screen(self):
         """Ensure the dialog fits within the available screen geometry."""

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -931,6 +931,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def restore_all_defaults(self):
         self.suspend_signals = True
+        self.load_all_pages()
         for page in self.loaded_pages:
             try:
                 page.restore_defaults()

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -852,9 +852,13 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         current_page = self._current_page()
         url = current_page.HELP_URL
         # If URL is empty, use the first non empty parent help URL.
-        while current_page.PARENT and not url:
-            current_page = self.get_page(current_page.PARENT)
-            url = current_page.HELP_URL
+        parent = current_page.PARENT
+        while parent and not url:
+            parent_cls = self.item_to_page.get(self.pagename_to_item.get(parent))
+            if parent_cls is None:
+                break
+            url = parent_cls.HELP_URL
+            parent = parent_cls.PARENT
         if not url:
             url = 'doc_options'  # key in PICARD_DOCS_URLS
         return url

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -32,6 +32,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+import time
 from typing import TYPE_CHECKING
 
 from PyQt6 import (
@@ -49,6 +50,7 @@ from picard.config import (
     OptionError,
     get_config,
 )
+from picard.debug_opts import DebugOpt
 from picard.extension_points.options_pages import ext_point_options_pages
 from picard.i18n import (
     N_,
@@ -258,6 +260,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def __init__(self, default_page=None, parent=None):
         super().__init__(parent=parent)
+        if DebugOpt.TIMINGS.enabled:
+            _init_t0 = time.perf_counter_ns()
         if modal_options():
             # On macOS: use WindowModal (blocks MainWindow, allows child windows
             # like Script Editor to be shown above). Add Window flag to prevent
@@ -332,18 +336,19 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         config = get_config()
 
         self.pages = []
-        for Page in ext_point_options_pages:
-            try:
-                page = Page()
-                page.set_dialog(self)
-                page.initialized = True
-            except Exception as e:
-                log.exception("Failed initializing options page %r", Page)
-                # create an empty page with the error message in place of the failing page
-                # this approach still allows subpages of the failing page to load
-                page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
-            self._add_page_to_stack(page)
-            self.pages.append(page)
+        with DebugOpt.TIMINGS.timing("OptionsDialog: page instantiation"):
+            for Page in ext_point_options_pages:
+                try:
+                    page = Page()
+                    page.set_dialog(self)
+                    page.initialized = True
+                except Exception as e:
+                    log.exception("Failed initializing options page %r", Page)
+                    # create an empty page with the error message in place of the failing page
+                    # this approach still allows subpages of the failing page to load
+                    page = ErrorOptionsPage(from_cls=Page, errmsg=str(e), dialog=self)
+                self._add_page_to_stack(page)
+                self.pages.append(page)
 
         self.item_to_page = {}
         self.pagename_to_item = {}
@@ -352,7 +357,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             default_page = config.persist['options_last_active_page']
         self._default_page = default_page
         log.debug("OptionsDialog init: Trying to restore page '%s'", default_page)
-        self.add_pages(None, default_page, self.ui.pages_tree)
+        with DebugOpt.TIMINGS.timing("OptionsDialog: add_pages"):
+            self.add_pages(None, default_page, self.ui.pages_tree)
 
         # work-around to set optimal option pane width
         self.ui.pages_tree.expandAll()
@@ -365,7 +371,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.restoreWindowState()
         self.finished.connect(self.saveWindowState)
 
-        self.load_all_pages()
+        with DebugOpt.TIMINGS.timing("OptionsDialog: load_all_pages"):
+            self.load_all_pages()
 
         maintenance_page = self.get_page('maintenance')
         if maintenance_page.loaded:
@@ -374,7 +381,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         profile_page = self.get_page('profiles')
         if profile_page.loaded:
             profile_page.signal_refresh.connect(self.update_from_profile_changes)
-            self.highlight_enabled_profile_options()
+            with DebugOpt.TIMINGS.timing("OptionsDialog: highlight_enabled_profile_options"):
+                self.highlight_enabled_profile_options()
 
         self.ui.pages_tree.itemSelectionChanged.connect(self.switch_page)
 
@@ -390,7 +398,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
             # Initial refresh to pick up any plugin option pages that were registered
             # since the last time the options dialog was opened
-            self.refresh_plugin_pages()
+            with DebugOpt.TIMINGS.timing("OptionsDialog: refresh_plugin_pages"):
+                self.refresh_plugin_pages()
         except AttributeError:
             # Plugin manager not available - this should not happen in normal operation
             pass
@@ -398,6 +407,9 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Set initial selection after plugin refresh
         if self.default_item:
             self.ui.pages_tree.setCurrentItem(self.default_item)  # this will call switch_page
+
+        if DebugOpt.TIMINGS.enabled:
+            log.debug("OptionsDialog: total __init__ in %.1f ms", (time.perf_counter_ns() - _init_t0) / 1_000_000)
 
     def showEvent(self, event):
         super().showEvent(event)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -474,39 +474,29 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def load_all_pages(self):
         for PageCls in self._page_classes:
-            if PageCls.NAME not in self.pagename_to_item:
-                continue  # Skip inactive/disabled pages
-            page = self._instantiate_page(PageCls)
-            if not page.initialized:
-                continue
+            if PageCls.NAME in self.pagename_to_item:
+                self._load_page(PageCls.NAME)
+
+    def _load_page(self, pagename):
+        """Ensure a page is instantiated and loaded. Returns the page or None."""
+        try:
+            page = self.get_page(pagename)
+        except KeyError:
+            return None
+        if not page.loaded and page.initialized:
             try:
                 page.load()
                 page.loaded = True
             except Exception:
                 log.exception("Failed loading options page %r", page)
                 self.disable_page(page.NAME)
-
-    def _load_page(self, pagename):
-        """Load a single page by name if not already loaded."""
-        try:
-            page = self.get_page(pagename)
-        except KeyError:
-            return
-        if page.loaded or not page.initialized:
-            return
-        try:
-            page.load()
-            page.loaded = True
-        except Exception:
-            log.exception("Failed loading options page %r", page)
-            self.disable_page(page.NAME)
+        return page
 
     def show_attached_profiles_dialog(self):
         items = self.ui.pages_tree.selectedItems()
         if not items:
             return
-        PageCls = self.item_to_page[items[0]]
-        page = self._instantiate_page(PageCls)
+        page = self.get_page(self.item_to_page[items[0]].NAME)
         option_group = profile_groups_group_from_page(page)
         if option_group:
             self.display_attached_profiles(option_group)
@@ -679,10 +669,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def get_page(self, pagename):
         """Get a page instance by name, instantiating lazily if needed."""
-        page = self._page_instances.get(pagename)
-        if page is not None:
-            return page
-        # Instantiate the page on first access
+        if pagename in self._page_instances:
+            return self._page_instances[pagename]
         PageCls = self.item_to_page[self.pagename_to_item[pagename]]
         return self._instantiate_page(PageCls)
 
@@ -750,15 +738,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         items = self.ui.pages_tree.selectedItems()
         if items:
             PageCls = self.item_to_page[items[0]]
-            page = self._instantiate_page(PageCls)
-            # Lazy-load page on first visit
-            if not page.loaded and page.initialized:
-                try:
-                    page.load()
-                    page.loaded = True
-                except Exception:
-                    log.exception("Failed loading options page %r", page)
-                    self.disable_page(page.NAME)
+            page = self._load_page(PageCls.NAME)
             self.set_profiles_button_and_highlight(page)
             self.ui.reset_button.setDisabled(not page.loaded)
             self._show_page(page)

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -371,8 +371,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.restoreWindowState()
         self.finished.connect(self.saveWindowState)
 
-        with DebugOpt.TIMINGS.timing("OptionsDialog: load_all_pages"):
-            self.load_all_pages()
+        # Load only pages needed for init signals and the visible page.
+        # Other pages are loaded lazily on first visit in switch_page().
+        with DebugOpt.TIMINGS.timing("OptionsDialog: load initial pages"):
+            self._load_page('maintenance')
+            self._load_page('profiles')
 
         maintenance_page = self.get_page('maintenance')
         if maintenance_page.loaded:
@@ -490,6 +493,21 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             except Exception:
                 log.exception("Failed loading options page %r", page)
                 self.disable_page(page.NAME)
+
+    def _load_page(self, pagename):
+        """Load a single page by name if not already loaded."""
+        try:
+            page = self.get_page(pagename)
+        except KeyError:
+            return
+        if page.loaded or not page.initialized:
+            return
+        try:
+            page.load()
+            page.loaded = True
+        except Exception:
+            log.exception("Failed loading options page %r", page)
+            self.disable_page(page.NAME)
 
     def show_attached_profiles_dialog(self):
         items = self.ui.pages_tree.selectedItems()
@@ -717,6 +735,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         items = self.ui.pages_tree.selectedItems()
         if items:
             page = self.item_to_page[items[0]]
+            # Lazy-load page on first visit
+            if not page.loaded and page.initialized:
+                try:
+                    page.load()
+                    page.loaded = True
+                except Exception:
+                    log.exception("Failed loading options page %r", page)
+                    self.disable_page(page.NAME)
             self.set_profiles_button_and_highlight(page)
             self.ui.reset_button.setDisabled(not page.loaded)
             self._show_page(page)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Optimize the Options dialog open time from ~1600ms down to ~170ms by lazily instantiating and loading pages only when first navigated to, and adding DebugOpt.TIMINGS instrumentation for ongoing performance monitoring.

## Problem

* JIRA ticket: PICARD-3371

Opening the Options dialog has a noticeable delay (~1.6 seconds) caused by eagerly constructing all 34+ page widgets, loading all their settings, running profile highlighting, and redundantly rebuilding the pages tree.

## Solution

A series of incremental, independently-verifiable optimizations:

1. **Add DebugOpt.TIMINGS instrumentation** — measure each phase of `__init__` with `--debug-opts=timings`
2. **Skip redundant `refresh_plugin_pages()`** — the tree is already built by `add_pages()` moments before
3. **Defer `highlight_enabled_profile_options()`** — cosmetic highlighting runs after the dialog is painted via `QTimer.singleShot(0, ...)`
4. **Lazy-load pages** — only call `page.load()` when a page is first shown, not all upfront
5. **Lazy page instantiation** — store page classes, build the tree from class attributes, only call `Page()` when the user navigates to that page
6. **Code cleanup** — deduplicate patterns, fix `help_url` to avoid unnecessary instantiation, ensure `restore_all_defaults` loads all pages first

Measured results (Linux, Python 3.12, PyQt 6.11):
```
Original:                           1608 ms
+ Skip redundant refresh:           1521 ms
+ Defer profile highlights:         1453 ms
+ Lazy-load pages:                  1073 ms
+ Lazy page instantiation:           558 ms
+ Final (with general as start):     168 ms  (-90%)
```

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed interactively with AI assistance (Kiro CLI), with each step manually tested and verified by the developer before committing.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
