### PR TITLE
PICARD-3372: Fix infinite retry loop when OAuth refresh token is revoked

### DIFF
--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -315,9 +315,13 @@ class OAuthManager(QObject):
             if error:
                 log.error("OAuth: access_token refresh failed: %s", data)
                 if self._http_code(http) == 400:
-                    response = load_json(data)
-                    if response['error'] == 'invalid_grant':
-                        self.forget_refresh_token()
+                    # Per RFC 6749 Section 5.2, the token endpoint returns
+                    # HTTP 400 for all grant error conditions (invalid_grant,
+                    # invalid_request, etc.). None of these are retryable
+                    # with the same refresh token, so forget it to stop the
+                    # retry loop and let the user re-authenticate.
+                    log.warning("OAuth: refresh token is no longer valid, logging out")
+                    self.forget_refresh_token()
             else:
                 access_token = data['access_token']
                 self.set_access_token(access_token, data['expires_in'])


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fix an infinite retry loop that occurs when the OAuth refresh token has been revoked server-side but Picard never forgets it, causing endless failed refresh attempts and preventing releases from loading.

## Problem

* JIRA ticket (_optional_): PICARD-3372

When a refresh token is revoked (e.g. by the user revoking access, another session, or server-side expiration), the MusicBrainz OAuth server returns:

```
HTTP 400
{"error": "invalid_request", "error_description": "'refresh_token' in request was already revoked."}
```

The existing code only forgot the refresh token on `invalid_grant` errors:

```python
if response['error'] == 'invalid_grant':
    self.forget_refresh_token()
```

Since the server returns `invalid_request` instead, the token was **never forgotten**. This caused an infinite loop:

1. Authenticated API request (e.g. fetch release with `user-collections`) → server returns 401
2. Webservice checks `is_authorized()` → True (refresh token still stored)
3. Triggers `refresh_access_token()` → POST to `/oauth2/token`
4. Token endpoint returns HTTP 400 with `invalid_request`
5. Code doesn't match `invalid_grant` → token NOT forgotten
6. Callback called with `access_token=None`
7. Original request retried → 401 again → back to step 2

This loop repeats every ~2 seconds indefinitely, consuming rate limit budget and preventing any authenticated request (including release lookups with user data) from ever completing.

## Solution

Per [RFC 6749 Section 5.2](https://www.rfc-editor.org/info/rfc6749/), the token endpoint returns HTTP 400 for **all** grant error conditions (`invalid_grant`, `invalid_request`, `invalid_client`, `unauthorized_client`, `unsupported_grant_type`, `invalid_scope`). None of these are retryable with the same refresh token.

The fix: forget the refresh token on **any** HTTP 400 response from the token endpoint, regardless of the specific error code. This:

- Breaks the infinite loop immediately after the first failed refresh
- Sets `is_authorized()` to False, which triggers the "Authorization Required" dialog
- Allows GET requests to be retried without user-specific params (so releases load with public data)
- Handles any future error code the server might return

Transient errors (5xx, network timeouts) are unaffected — the token is preserved and retries can succeed once the server recovers.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI assisted with root cause analysis (tracing the retry loop through webservice and OAuth code), RFC research, and drafting the fix. The developer identified the symptom, verified the fix manually, and confirmed correct behavior.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
