### PR TITLE
Fix blank line at the end of a playground inheriting color from the previous line

### DIFF
--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -83,8 +83,14 @@ class Playground:
         fmt_skip = self._get_fmt_skip()
         fmt_clear = self._get_fmt_clear()
 
+        text = self.playground_widget.toPlainText()
+        lines = text.splitlines()
+        # Add an empty string to the list of lines to process if the playground text ends with a new line. This is to
+        # ensure that the blank line at the end of the playground widget doesn't inherit the color from the previous line.
+        if text and text[-1] in "\n\r":
+            lines.append('')
         with QSignalBlocker(self.playground_widget):
-            for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
+            for lineno, line in enumerate(lines):
                 line = line.strip()
                 if not line or match_function is None:
                     fmt = fmt_clear


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

When a new line is entered at the end of the playground, it immediately inherits the color of the previous line.

Steps to reproduce:

1. Open the "Cover Art" > "Local Files" page under Options.
2. In the "Test file name matching:" section (QPlainTextEdit) enter "test" and press Enter to move to a new line.
3. Note that the new (blank) line inherits the color from the previous line.

<img width="478" height="243" alt="image" src="https://github.com/user-attachments/assets/f798f76b-9d61-496f-bb88-cf28aaba7e5b" />


* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



## Solution

Check if the string ends with a `\n` or `\r` character, and if so append an empty string to the list of lines for processing.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
