### PR TITLE
Fix bugs and improvements in authors-between-releases script

### DIFF
--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -31,6 +31,7 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.error
 from urllib.parse import (
     quote,
     urlencode,
@@ -284,9 +285,12 @@ def get_github_display_names(github_users):
                 name = data.get('name')
                 if name:
                     display_names[git_name] = name
+        except urllib.error.HTTPError as e:
+            debug(f"GitHub API error for {gh_user}: {e}")
+            if e.code in (403, 429):
+                break  # rate limited, skip remaining
         except Exception as e:
             debug(f"GitHub API error for {gh_user}: {e}")
-            break  # likely rate limited, skip remaining
     if display_names:
         debug(f"Resolved {len(display_names)} display names from GitHub")
     return display_names

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -98,7 +98,7 @@ def get_github_users_from_merges(rev_range):
     """Map author names to GitHub usernames from PR merge commits."""
     pr_parents = {}
     for line in git('log', '--merges', '--format=%P %s', rev_range).splitlines():
-        match = re.match(r'\w+ (\w+) Merge pull request #\d+ from ([^/]+)/', line)
+        match = re.match(r'[0-9a-f]+ ([0-9a-f]+) Merge pull request #\d+ from ([^/]+)/', line)
         if match:
             pr_parents[match.group(1)] = match.group(2)
 

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -222,7 +222,7 @@ def get_weblate_users_from_api(api_key, rev_range):
                             credits.setdefault(full_name, username)
         debug(f"Found {len(credits)} translators from Weblate API")
     except Exception as e:
-        debug(f"Weblate API error: {e}")
+        debug(f"Weblate API error for {url}: {e}")
     return credits
 
 

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -59,9 +59,13 @@ WEBLATE_URL = 'https://translations.metabrainz.org/user'
 GITHUB_URL = 'https://github.com'
 
 
+QUIET = False
+
+
 def debug(msg):
-    """Print a debug message to stderr."""
-    print(f"  {msg}", file=sys.stderr)
+    """Print a debug message to stderr unless quiet mode is enabled."""
+    if not QUIET:
+        print(f"  {msg}", file=sys.stderr)
 
 
 def _find_git():
@@ -350,7 +354,16 @@ def main():
         default=None,
         help="ending release tag (default: most recent release)",
     )
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help="suppress progress messages on stderr",
+    )
     args = parser.parse_args()
+
+    global QUIET
+    QUIET = args.quiet
 
     if not args.from_tag or not args.to_tag:
         tags = get_release_tags()
@@ -362,7 +375,7 @@ def main():
             args.from_tag = tags[1]
 
     rev_range = f'{args.from_tag}..{args.to_tag}'
-    print(f"{rev_range}:", file=sys.stderr)
+    debug(f"{rev_range}:")
 
     github_users = get_github_users(rev_range)
     weblate_users = get_weblate_users(rev_range)

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -250,17 +250,10 @@ def html_link(url, text):
 
 
 def quote_name(name):
-    """Enclose name in quotes if it contains a comma.
-
-    Handles both plain text and HTML link formatted names.
-    """
-    if ',' not in name:
-        return name
-    # If name is an HTML link, quote the link text inside the tag
-    match = re.match(r'^(<a\b[^>]*>)(.*)(</a>)$', name)
-    if match:
-        return f'{match.group(1)}"{match.group(2)}"{match.group(3)}'
-    return f'"{name}"'
+    """Enclose name in quotes if it contains a comma."""
+    if ',' in name:
+        return f'"{name}"'
+    return name
 
 
 def join_names(names):
@@ -306,7 +299,7 @@ def format_code_authors(code_authors, github_users, display_names):
         gh_user = github_users.get(name)
         display = display_names.get(name, name)
         if gh_user:
-            names.append(html_link(f'{GITHUB_URL}/{quote(gh_user)}', display))
+            names.append(html_link(f'{GITHUB_URL}/{quote(gh_user)}', quote_name(display)))
         else:
             names.append(quote_name(display))
     return f"Code contributions by {join_names(names)}."
@@ -318,7 +311,7 @@ def format_translators(translators, translator_langs, weblate_users):
     for name in sorted(translators, key=str.casefold):
         wb_user = weblate_users.get(name)
         if wb_user:
-            linked_name = html_link(f'{WEBLATE_URL}/{quote(wb_user)}/', name)
+            linked_name = html_link(f'{WEBLATE_URL}/{quote(wb_user)}/', quote_name(name))
         else:
             linked_name = quote_name(name)
         langs = ', '.join(sorted(translator_langs[name]))

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -25,6 +25,10 @@ Examples:
 """
 
 import argparse
+from datetime import (
+    date,
+    timedelta,
+)
 import json
 import os
 import re
@@ -177,11 +181,14 @@ def get_weblate_users_from_api(api_key, rev_range):
     """Fetch translator usernames from the Weblate project credits API.
 
     Uses the date range of the two release tags to query credits.
+    The end date is set to the day after the target tag to ensure
+    translations made on the tag date are included.
     Returns a dict mapping full_name to Weblate username.
     """
     from_tag, to_tag = rev_range.split('..', 1)
     start = get_tag_date(from_tag)
-    end = get_tag_date(to_tag)
+    end_date = date.fromisoformat(get_tag_date(to_tag)) + timedelta(days=1)
+    end = end_date.isoformat()
 
     debug(f"Fetching Weblate credits for {start}..{end}")
     credits = {}

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -118,13 +118,29 @@ def get_github_users_from_merges(rev_range):
     return github_users
 
 
+def iter_git_log(rev_range, format_fields, *pathspecs):
+    """Yield tuples from git log with tab-separated format fields.
+
+    Args:
+        rev_range: Git revision range (e.g. 'tag1..tag2')
+        format_fields: Git format placeholders (e.g. '%aN', '%aE', '%s')
+        *pathspecs: Optional pathspec arguments for git log
+    """
+    fmt = '\t'.join(format_fields)
+    args = ['log', f'--format={fmt}', rev_range]
+    if pathspecs:
+        args.extend(('--', *pathspecs))
+    num_fields = len(format_fields)
+    for line in git(*args).splitlines():
+        if '\t' not in line:
+            continue
+        yield line.split('\t', num_fields - 1)
+
+
 def get_github_users_from_emails(rev_range):
     """Map author names to GitHub usernames from noreply emails."""
     github_users = {}
-    for line in git('log', '--format=%aN\t%aE', rev_range).splitlines():
-        if '\t' not in line:
-            continue
-        name, email = line.split('\t', 1)
+    for name, email in iter_git_log(rev_range, ('%aN', '%aE')):
         match = re.match(r'(?:\d+\+)?(.+)@users\.noreply\.github\.com$', email)
         if match and name not in EXCLUDE:
             github_users.setdefault(name, match.group(1))
@@ -144,10 +160,7 @@ def get_github_users(rev_range):
 def get_weblate_users_from_emails(rev_range):
     """Map author names to Weblate usernames from noreply emails in git log."""
     weblate_users = {}
-    for line in git('log', '--format=%aN\t%aE', rev_range, '--', *TRANSLATION_PATHS).splitlines():
-        if '\t' not in line:
-            continue
-        name, email = line.split('\t', 1)
+    for name, email in iter_git_log(rev_range, ('%aN', '%aE'), *TRANSLATION_PATHS):
         match = re.match(r'(.+)@users\.noreply\.translations\.metabrainz\.org$', email)
         if match and name not in EXCLUDE:
             weblate_users.setdefault(name, match.group(1))
@@ -232,10 +245,7 @@ def get_translator_langs(rev_range):
     Parses "Translated using Weblate (Language)" commit messages.
     """
     translator_langs = {}
-    for line in git('log', '--format=%aN\t%s', rev_range, '--', *TRANSLATION_PATHS).splitlines():
-        if '\t' not in line:
-            continue
-        author, subject = line.split('\t', 1)
+    for author, subject in iter_git_log(rev_range, ('%aN', '%s'), *TRANSLATION_PATHS):
         if author in EXCLUDE:
             continue
         match = re.search(r'Translated using Weblate \((.+)\)', subject)

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -195,7 +195,7 @@ def get_weblate_api_key() -> str | None:
     api_key = os.environ.get('WEBLATE_API_KEY')
     if not api_key and WeblateConfig:
         config_path = os.path.join(os.path.dirname(__file__), '..', '..', '.weblate.ini')
-        if os.path.exists:
+        if os.path.exists(config_path):
             config = WeblateConfig()
             config.load(config_path)
             url, key = config.get_url_key()

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -329,16 +329,26 @@ def get_github_display_names(github_users):
     return display_names
 
 
-def format_code_authors(code_authors, github_users, display_names):
-    """Format code contributors with optional GitHub links."""
+def format_code_authors(code_authors, github_users, display_names, translator_langs, weblate_users):
+    """Format code contributors with optional GitHub links.
+
+    For authors who also contributed translations (confirmed via Weblate
+    user identification), their translated languages are shown.
+    """
     names = []
     for name in sorted(code_authors, key=str.casefold):
         gh_user = github_users.get(name)
         display = display_names.get(name, name)
         if gh_user:
-            names.append(html_link(f'{GITHUB_URL}/{quote(gh_user)}', quote_name(display)))
+            entry = html_link(f'{GITHUB_URL}/{quote(gh_user)}', quote_name(display))
         else:
-            names.append(quote_name(display))
+            entry = quote_name(display)
+        # Only show translation languages if the person is a confirmed
+        # Weblate translator (not just the merge author of squashed commits)
+        if name in weblate_users and name in translator_langs:
+            langs = ', '.join(sorted(translator_langs[name]))
+            entry += f" ({langs}+)"
+        names.append(entry)
     return f"Code contributions by {join_names(names)}."
 
 
@@ -407,7 +417,7 @@ def main():
     )
 
     if code_authors:
-        print(format_code_authors(code_authors, github_users, display_names))
+        print(format_code_authors(code_authors, github_users, display_names, translator_langs, weblate_users))
     if translators:
         print(format_translators(translators, translator_langs, weblate_users))
 

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -66,6 +66,13 @@ GITHUB_URL = 'https://github.com'
 QUIET = False
 
 
+# Pre-compiled regex patterns used in loops
+RE_MERGE_PR = re.compile(r'^[0-9a-f]+ ([0-9a-f]+) Merge pull request #\d+ from ([^/]+)/')
+RE_GITHUB_NOREPLY = re.compile(r'^(?:\d+\+)?(.+)@users\.noreply\.github\.com$')
+RE_WEBLATE_NOREPLY = re.compile(r'^(.+)@users\.noreply\.translations\.metabrainz\.org$')
+RE_WEBLATE_LANG = re.compile(r'Translated using Weblate \((.+)\)')
+
+
 def debug(msg):
     """Print a debug message to stderr unless quiet mode is enabled."""
     if not QUIET:
@@ -102,7 +109,7 @@ def get_github_users_from_merges(rev_range):
     """Map author names to GitHub usernames from PR merge commits."""
     pr_parents = {}
     for line in git('log', '--merges', '--format=%P %s', rev_range).splitlines():
-        match = re.match(r'[0-9a-f]+ ([0-9a-f]+) Merge pull request #\d+ from ([^/]+)/', line)
+        match = RE_MERGE_PR.search(line)
         if match:
             pr_parents[match.group(1)] = match.group(2)
 
@@ -151,7 +158,7 @@ def get_github_users_from_emails(rev_range):
     """Map author names to GitHub usernames from noreply emails."""
     github_users = {}
     for name, email in iter_git_log(rev_range, ('%aN', '%aE')):
-        match = re.match(r'(?:\d+\+)?(.+)@users\.noreply\.github\.com$', email)
+        match = RE_GITHUB_NOREPLY.search(email)
         if match and name not in EXCLUDE:
             github_users.setdefault(name, match.group(1))
     if github_users:
@@ -171,7 +178,7 @@ def get_weblate_users_from_emails(rev_range):
     """Map author names to Weblate usernames from noreply emails in git log."""
     weblate_users = {}
     for name, email in iter_git_log(rev_range, ('%aN', '%aE'), *TRANSLATION_PATHS):
-        match = re.match(r'(.+)@users\.noreply\.translations\.metabrainz\.org$', email)
+        match = RE_WEBLATE_NOREPLY.search(email)
         if match and name not in EXCLUDE:
             weblate_users.setdefault(name, match.group(1))
     if weblate_users:
@@ -261,7 +268,7 @@ def get_translator_langs(rev_range):
     for author, subject in iter_git_log(rev_range, ('%aN', '%s'), *TRANSLATION_PATHS):
         if author in EXCLUDE:
             continue
-        match = re.search(r'Translated using Weblate \((.+)\)', subject)
+        match = RE_WEBLATE_LANG.search(subject)
         if match:
             translator_langs.setdefault(author, set()).add(match.group(1))
     debug(f"Found {len(translator_langs)} translators from commit messages")

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -119,6 +119,8 @@ def get_github_users_from_merges(rev_range):
         input='\n'.join(pr_parents),
     )
     for line in result.splitlines():
+        if ' ' not in line:
+            continue
         sha, author = line.split(' ', 1)
         if author and author not in EXCLUDE:
             github_users.setdefault(author, pr_parents[sha])

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -230,11 +230,14 @@ def get_weblate_api_key() -> str | None:
     if not api_key and WeblateConfig:
         config_path = os.path.join(os.path.dirname(__file__), '..', '..', '.weblate.ini')
         if os.path.exists(config_path):
-            config = WeblateConfig()
-            config.load(config_path)
-            url, key = config.get_url_key()
-            if url.rstrip('/') == WEBLATE_API_URL:
-                api_key = key
+            try:
+                config = WeblateConfig()
+                config.load(config_path)
+                url, key = config.get_url_key()
+                if url.rstrip('/') == WEBLATE_API_URL:
+                    api_key = key
+            except Exception as e:
+                debug(f"Warning: Failed to read Weblate config: {e}")
     return api_key
 
 

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -330,6 +330,22 @@ def _get_rate_limit_wait(headers):
 MAX_RATE_LIMIT_RETRIES = 2
 
 
+def _get_github_token():
+    """Get GitHub token from environment or gh CLI."""
+    token = os.environ.get('GITHUB_TOKEN')
+    if token:
+        return token
+    gh = shutil.which('gh')
+    if gh:
+        try:
+            token = subprocess.check_output([gh, 'auth', 'token'], text=True, stderr=subprocess.DEVNULL).strip()
+            if token:
+                return token
+        except (subprocess.CalledProcessError, OSError):
+            pass
+    return None
+
+
 def get_github_display_names(github_users):
     """Fetch real names from GitHub API for all known GitHub users."""
     if not github_users:
@@ -337,11 +353,11 @@ def get_github_display_names(github_users):
     debug(f"Fetching display names for {len(github_users)} GitHub users")
     display_names = {}
     headers = {'Accept': 'application/json'}
-    token = os.environ.get('GITHUB_TOKEN')
+    token = _get_github_token()
     if token:
         headers['Authorization'] = f'token {token}'
     else:
-        debug("Warning: GITHUB_TOKEN not set, GitHub API rate limits may apply")
+        debug("Warning: No GitHub token found, API rate limits may apply")
     retries_left = MAX_RATE_LIMIT_RETRIES
     users_iter = iter(github_users.items())
     git_name, gh_user = None, None

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -37,7 +37,7 @@ import subprocess
 import sys
 import urllib.error
 from urllib.parse import (
-    quote,
+    quote as url_quote,
     urlencode,
 )
 from urllib.request import (
@@ -311,7 +311,7 @@ def get_github_display_names(github_users):
         debug("Warning: GITHUB_TOKEN not set, GitHub API rate limits may apply")
     for git_name, gh_user in github_users.items():
         try:
-            url = f'https://api.github.com/users/{quote(gh_user)}'
+            url = f'https://api.github.com/users/{url_quote(gh_user)}'
             req = Request(url, headers=headers)
             with urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read())
@@ -340,7 +340,7 @@ def format_code_authors(code_authors, github_users, display_names, translator_la
         gh_user = github_users.get(name)
         display = display_names.get(name, name)
         if gh_user:
-            entry = html_link(f'{GITHUB_URL}/{quote(gh_user)}', quote_name(display))
+            entry = html_link(f'{GITHUB_URL}/{url_quote(gh_user)}', quote_name(display))
         else:
             entry = quote_name(display)
         # Only show translation languages if the person is a confirmed
@@ -358,7 +358,7 @@ def format_translators(translators, translator_langs, weblate_users):
     for name in sorted(translators, key=str.casefold):
         wb_user = weblate_users.get(name)
         if wb_user:
-            linked_name = html_link(f'{WEBLATE_URL}/{quote(wb_user)}/', quote_name(name))
+            linked_name = html_link(f'{WEBLATE_URL}/{url_quote(wb_user)}/', quote_name(name))
         else:
             linked_name = quote_name(name)
         langs = ', '.join(sorted(translator_langs[name]))

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -37,10 +37,7 @@ import subprocess
 import sys
 import time
 import urllib.error
-from urllib.parse import (
-    quote as url_quote,
-    urlencode,
-)
+from urllib.parse import quote as url_quote
 from urllib.request import (
     Request,
     urlopen,
@@ -187,10 +184,30 @@ def get_weblate_users_from_emails(rev_range):
     return weblate_users
 
 
-def get_weblate_users_from_api(api_key, rev_range):
-    """Fetch translator usernames from the Weblate project credits API.
+WEBLATE_REPORT_POLL_INTERVAL = 2  # seconds between task polls
+WEBLATE_REPORT_TIMEOUT = 30  # max seconds to wait for report generation
 
-    Uses the date range of the two release tags to query credits.
+
+def _weblate_api_request(api_key, url, method='GET', data=None):
+    """Make an authenticated request to the Weblate API."""
+    headers = {
+        'Authorization': f'Token {api_key}',
+        'Accept': 'application/json',
+    }
+    if data is not None:
+        body = json.dumps(data).encode()
+        headers['Content-Type'] = 'application/json'
+    else:
+        body = None
+    req = Request(url, data=body, headers=headers, method=method)
+    with urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def get_weblate_users_from_api(api_key, rev_range):
+    """Fetch translator usernames from the Weblate Reports API.
+
+    Schedules a credits report, polls for completion, and parses the result.
     The end date is set to the day after the target tag to ensure
     translations made on the tag date are included.
     Returns a dict mapping full_name to Weblate username.
@@ -203,26 +220,49 @@ def get_weblate_users_from_api(api_key, rev_range):
     debug(f"Fetching Weblate credits for {start}..{end}")
     credits = {}
     try:
-        url = f'{WEBLATE_API_URL}/projects/picard/credits/?{urlencode({"start": start, "end": end})}'
-        req = Request(
-            url,
-            headers={
-                'Authorization': f'Token {api_key}',
-                'Accept': 'application/json',
-            },
+        # Schedule the credits report
+        report = _weblate_api_request(
+            api_key,
+            f'{WEBLATE_API_URL}/reports/',
+            method='POST',
+            data={'kind': 'credits', 'start': start, 'end': end, 'project': 'picard'},
         )
-        with urlopen(req, timeout=10) as resp:
-            data = json.loads(resp.read())
-            for lang_entry in data:
-                for users in lang_entry.values():
-                    for user in users:
-                        full_name = user.get('full_name', '')
-                        username = user.get('username', '')
-                        if full_name and username:
-                            credits.setdefault(full_name, username)
+        task_path = report.get('task_url', '')
+        if not task_path:
+            debug("Weblate API: no task_url in response")
+            return credits
+
+        # Poll until the task completes
+        task_url = WEBLATE_API_URL.rsplit('/api', 1)[0] + task_path
+        elapsed = 0
+        while elapsed < WEBLATE_REPORT_TIMEOUT:
+            time.sleep(WEBLATE_REPORT_POLL_INTERVAL)
+            elapsed += WEBLATE_REPORT_POLL_INTERVAL
+            task = _weblate_api_request(api_key, task_url)
+            if task.get('completed'):
+                break
+        else:
+            debug("Weblate API: report generation timed out")
+            return credits
+
+        # Fetch the report JSON data
+        report_path = task.get('result', {}).get('url', '')
+        if not report_path:
+            debug("Weblate API: no report URL in task result")
+            return credits
+        report_url = WEBLATE_API_URL.rsplit('/api', 1)[0] + report_path + 'json/'
+        data = _weblate_api_request(api_key, report_url)
+
+        for lang_entry in data:
+            for users in lang_entry.values():
+                for user in users:
+                    full_name = user.get('full_name', '')
+                    username = user.get('username', '')
+                    if full_name and username:
+                        credits.setdefault(full_name, username)
         debug(f"Found {len(credits)} translators from Weblate API")
     except Exception as e:
-        debug(f"Weblate API error for {url}: {e}")
+        debug(f"Weblate API error: {e}")
     return credits
 
 
@@ -477,6 +517,7 @@ def main():
 
     github_users = get_github_users(rev_range)
     weblate_users = get_weblate_users(rev_range)
+    weblate_email_users = get_weblate_users_from_emails(rev_range)
     code_authors = get_code_authors(rev_range)
     translator_langs = get_translator_langs(rev_range)
     translators = set(translator_langs.keys()) - code_authors
@@ -486,7 +527,9 @@ def main():
     )
 
     if code_authors:
-        print(format_code_authors(code_authors, github_users, display_names, translator_langs, weblate_users))
+        # Use email-confirmed users only for dual-contributor check to avoid
+        # crediting admins who appear in API credits from merge operations
+        print(format_code_authors(code_authors, github_users, display_names, translator_langs, weblate_email_users))
     if translators:
         print(format_translators(translators, translator_langs, weblate_users))
 

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -244,8 +244,23 @@ def html_link(url, text):
     return f'<a href="{url}">{text}</a>'
 
 
+def quote_name(name):
+    """Enclose name in quotes if it contains a comma.
+
+    Handles both plain text and HTML link formatted names.
+    """
+    if ',' not in name:
+        return name
+    # If name is an HTML link, quote the link text inside the tag
+    match = re.match(r'^(<a\b[^>]*>)(.*)(</a>)$', name)
+    if match:
+        return f'{match.group(1)}"{match.group(2)}"{match.group(3)}'
+    return f'"{name}"'
+
+
 def join_names(names):
     """Join names with commas and 'and' before the last one."""
+    names = [quote_name(n) for n in names]
     if len(names) <= 1:
         return ''.join(names)
     return ', '.join(names[:-1]) + ' and ' + names[-1]

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -35,6 +35,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import urllib.error
 from urllib.parse import (
     quote as url_quote,
@@ -297,6 +298,38 @@ def join_names(names):
     return ', '.join(names[:-1]) + ' and ' + names[-1]
 
 
+MAX_RATE_LIMIT_WAIT = 10  # seconds; give up if wait is longer
+
+
+def _get_rate_limit_wait(headers):
+    """Extract wait time in seconds from rate-limit response headers.
+
+    Returns None if the wait would exceed MAX_RATE_LIMIT_WAIT.
+    """
+    wait = None
+    retry_after = headers.get('Retry-After')
+    if retry_after:
+        try:
+            wait = int(retry_after)
+        except ValueError:
+            pass
+    if wait is None:
+        reset = headers.get('X-RateLimit-Reset')
+        if reset:
+            try:
+                wait = max(0, int(reset) - int(time.time())) + 1
+            except ValueError:
+                pass
+    if wait is None:
+        wait = MAX_RATE_LIMIT_WAIT
+    if wait > MAX_RATE_LIMIT_WAIT:
+        return None
+    return wait
+
+
+MAX_RATE_LIMIT_RETRIES = 2
+
+
 def get_github_display_names(github_users):
     """Fetch real names from GitHub API for all known GitHub users."""
     if not github_users:
@@ -309,7 +342,15 @@ def get_github_display_names(github_users):
         headers['Authorization'] = f'token {token}'
     else:
         debug("Warning: GITHUB_TOKEN not set, GitHub API rate limits may apply")
-    for git_name, gh_user in github_users.items():
+    retries_left = MAX_RATE_LIMIT_RETRIES
+    users_iter = iter(github_users.items())
+    git_name, gh_user = None, None
+    while True:
+        if git_name is None:
+            item = next(users_iter, None)
+            if item is None:
+                break
+            git_name, gh_user = item
         try:
             url = f'https://api.github.com/users/{url_quote(gh_user)}'
             req = Request(url, headers=headers)
@@ -318,12 +359,24 @@ def get_github_display_names(github_users):
                 name = data.get('name')
                 if name:
                     display_names[git_name] = name
+            git_name, gh_user = None, None  # advance to next user
         except urllib.error.HTTPError as e:
+            is_rate_limit = e.code == 429 or (e.code == 403 and e.headers.get('X-RateLimit-Remaining') == '0')
+            if is_rate_limit and retries_left > 0:
+                wait = _get_rate_limit_wait(e.headers)
+                if wait is not None:
+                    debug(f"Rate limited, waiting {wait}s ({retries_left} retries left)")
+                    time.sleep(wait)
+                    retries_left -= 1
+                    continue
+            if is_rate_limit:
+                debug(f"Rate limited on {gh_user}, skipping remaining")
+                break
             debug(f"GitHub API error for {gh_user}: {e}")
-            if e.code in (403, 429):
-                break  # rate limited, skip remaining
+            git_name, gh_user = None, None  # skip this user, continue
         except Exception as e:
             debug(f"GitHub API error for {gh_user}: {e}")
+            git_name, gh_user = None, None  # skip this user, continue
     if display_names:
         debug(f"Resolved {len(display_names)} display names from GitHub")
     return display_names

--- a/scripts/tools/authors-between-releases.py
+++ b/scripts/tools/authors-between-releases.py
@@ -49,6 +49,10 @@ except ImportError:
 
 EXCLUDE = {'Weblate', 'dependabot[bot]'}
 
+# Paths containing translation files managed via Weblate.
+# Used to separate translators from code contributors.
+TRANSLATION_PATHS = ('po/', 'installer/i18n/sources/')
+
 WEBLATE_API_URL = 'https://translations.metabrainz.org/api'
 WEBLATE_URL = 'https://translations.metabrainz.org/user'
 GITHUB_URL = 'https://github.com'
@@ -139,7 +143,7 @@ def get_github_users(rev_range):
 def get_weblate_users_from_emails(rev_range):
     """Map author names to Weblate usernames from noreply emails in git log."""
     weblate_users = {}
-    for line in git('log', '--format=%aN\t%aE', rev_range, '--', 'po/').splitlines():
+    for line in git('log', '--format=%aN\t%aE', rev_range, '--', *TRANSLATION_PATHS).splitlines():
         if '\t' not in line:
             continue
         name, email = line.split('\t', 1)
@@ -213,8 +217,9 @@ def get_weblate_users(rev_range):
 
 
 def get_code_authors(rev_range):
-    """Return set of author names who committed changes outside po/."""
-    lines = git('log', '--format=%aN', rev_range, '--', ':!po/').splitlines()
+    """Return set of author names who committed changes outside translation paths."""
+    excludes = [f':!{path}' for path in TRANSLATION_PATHS]
+    lines = git('log', '--format=%aN', rev_range, '--', *excludes).splitlines()
     authors = set(a for a in lines if a and a not in EXCLUDE)
     debug(f"Found {len(authors)} code authors")
     return authors
@@ -226,7 +231,7 @@ def get_translator_langs(rev_range):
     Parses "Translated using Weblate (Language)" commit messages.
     """
     translator_langs = {}
-    for line in git('log', '--format=%aN\t%s', rev_range, '--', 'po/').splitlines():
+    for line in git('log', '--format=%aN\t%s', rev_range, '--', *TRANSLATION_PATHS).splitlines():
         if '\t' not in line:
             continue
         author, subject = line.split('\t', 1)
@@ -260,7 +265,6 @@ def quote_name(name):
 
 def join_names(names):
     """Join names with commas and 'and' before the last one."""
-    names = [quote_name(n) for n in names]
     if len(names) <= 1:
         return ''.join(names)
     return ', '.join(names[:-1]) + ' and ' + names[-1]
@@ -304,7 +308,7 @@ def format_code_authors(code_authors, github_users, display_names):
         if gh_user:
             names.append(html_link(f'{GITHUB_URL}/{quote(gh_user)}', display))
         else:
-            names.append(display)
+            names.append(quote_name(display))
     return f"Code contributions by {join_names(names)}."
 
 
@@ -316,7 +320,7 @@ def format_translators(translators, translator_langs, weblate_users):
         if wb_user:
             linked_name = html_link(f'{WEBLATE_URL}/{quote(wb_user)}/', name)
         else:
-            linked_name = name
+            linked_name = quote_name(name)
         langs = ', '.join(sorted(translator_langs[name]))
         parts.append(f"{linked_name} ({langs})")
     return f"Translations were updated by {join_names(parts)}."


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix several bugs and improve the `scripts/tools/authors-between-releases.py` script: correct author categorization (code vs. translators), handle names with commas, fix Weblate API integration, add rate-limit retry with `gh` CLI fallback, and reduce code redundancy.

## Problem

The script had several issues:
- Author names containing commas (e.g. "ApeKattQuest, MonkeyPython") were visually ambiguous in the comma-separated output
- Commits touching `installer/i18n/sources/` (Weblate translations) were incorrectly counted as code contributions
- `os.path.exists` was referenced but not called, making a condition always truthy
- Names with commas inside HTML links were not quoted
- Any GitHub API error aborted the entire display name resolution loop
- A malformed `.weblate.ini` config file could crash the script
- Regex patterns recompiled on every iteration in loops
- Dual contributors (code + translations) had no acknowledgment of their translation work
- No way to suppress progress messages for pipeline use
- Required manual `GITHUB_TOKEN` export even when `gh` CLI was authenticated
- The Weblate `/projects/picard/credits/` endpoint no longer exists (404), breaking translator profile link resolution

## Solution

18 commits addressing each issue individually:

**Bug fixes:**
- Quote author names containing commas in output
- Exclude `installer/i18n/sources/` from code authors (added `TRANSLATION_PATHS` constant)
- Fix `os.path.exists` not called as a function
- Apply `quote_name` to linked names with commas
- Fix Weblate credits API end date off-by-one
- Guard against empty author in merge commit parsing
- Handle errors when loading Weblate config file
- Update Weblate API to use the new Reports endpoint (`POST /api/reports/` with `kind=credits`)

**Improvements:**
- Add rate-limit retry with short wait cap (10s max) for GitHub API
- Only retry on actual rate limits (429, or 403 with `X-RateLimit-Remaining: 0`)
- Fall back to `gh auth token` when `GITHUB_TOKEN` is not set
- Pre-compile regex patterns, use `.search()` uniformly with `^` anchors
- Extract `iter_git_log` helper to reduce redundancy
- Show translation languages for confirmed dual contributors (email-verified only, to avoid false positives from admin merge operations)
- Add `-q`/`--quiet` flag for pipeline use
- Rename `urllib.parse.quote` import to `url_quote` for clarity
- Use precise `[0-9a-f]+` pattern for SHA matching
- Include URL in Weblate API error messages

**Known limitation:** Contributors whose PRs were squash-merged (no merge commit) and who don't use a GitHub noreply email cannot have their GitHub profile linked automatically.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

All changes were developed interactively with an AI assistant (Kiro CLI), with human review and direction at each step.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
