### PR TITLE
Define OptionsPage.OPTIONS as ClassVar

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -286,11 +286,12 @@ When a profile is active and overrides the option, reads from `api.plugin_config
 Declare widgets in the page's `OPTIONS` dict to enable visual highlighting when a profile overrides the option:
 
 ```python
+from typing import ClassVar
 from picard.plugin3.api import OptionsPage, PageOptionConfigs
 
 
 class MyOptionsPage(OptionsPage):
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'greeting': {'widgets': ['greeting_input']},
     }
 ```

--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -34,6 +34,7 @@ from collections import (
     OrderedDict,
     namedtuple,
 )
+from typing import ClassVar
 
 from PyQt6.QtNetwork import (
     QNetworkReply,
@@ -125,7 +126,7 @@ class ProviderOptionsCaa(ProviderOptions):
     TITLE = N_("Cover Art Archive")
     HELP_URL = "/config/options_cover_art_archive.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'caa_image_size': {'widgets': ['cb_image_size']},
         'caa_approved_only': {'widgets': ['cb_approved_only']},
         'caa_restrict_image_types': {'widgets': ['restrict_images_types']},

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -24,6 +24,7 @@
 
 import os
 import re
+from typing import ClassVar
 
 from picard.config import get_config
 from picard.coverart.image import LocalFileCoverArtImage
@@ -61,7 +62,7 @@ class ProviderOptionsLocal(ProviderOptions):
     NAME = "provider_local"
     HELP_URL = '/config/options_local_files.html'
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'local_cover_regex': {'widgets': ['local_cover_regex_edit']},
     }
 

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -27,6 +27,7 @@
 from collections import defaultdict
 import re
 from typing import (
+    ClassVar,
     TypeAlias,
     TypedDict,
 )
@@ -75,14 +76,14 @@ class OptionsPage(QtWidgets.QWidget, HasDisplayTitle):
     STYLESHEET_SUCCESS = "QWidget { background-color: #292; color: white; padding: 2px; }"
     STYLESHEET_ERROR = "QWidget { background-color: #f55; color: white; font-weight:bold; padding: 2px; }"
     STYLESHEET = "QLabel { qproperty-wordWrap: true; }"
-    OPTIONS: PageOptionConfigs = {}
+    OPTIONS: ClassVar[PageOptionConfigs] = {}
 
     # Config section where this page's options are stored.
     # Core pages use 'setting'. Plugin pages are set to 'plugin.<uuid>'
     # automatically by register_options_page().
     OPTION_SECTION = 'setting'
 
-    _registered_settings: dict[str, list] = defaultdict(list)
+    _registered_settings: ClassVar[dict[str, list]] = defaultdict(list)
     initialized = False
     loaded = False
 

--- a/picard/ui/options/advanced.py
+++ b/picard/ui/options/advanced.py
@@ -22,6 +22,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -41,7 +43,7 @@ class AdvancedOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_advanced.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'ignore_regex': {'widgets': ['ignore_regex']},
         'ignore_hidden_files': {'widgets': ['ignore_hidden_files']},
         'recursively_add_files': {'widgets': ['recursively_add_files']},

--- a/picard/ui/options/cdlookup.py
+++ b/picard/ui/options/cdlookup.py
@@ -24,6 +24,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
@@ -56,7 +58,7 @@ class CDLookupOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_cdlookup.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'cd_lookup_device': {'widgets': ['cd_lookup_device']},
         'read_isrcs_from_disc': {'widgets': ['read_isrcs_from_disc']},
     }

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -27,6 +27,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from PyQt6.QtCore import Qt
 
 from picard.config import (
@@ -60,7 +62,7 @@ class CoverOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_cover.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'save_images_to_tags': {'widgets': ['save_images_to_tags']},
         'embed_only_one_front_image': {'widgets': ['cb_embed_front_only']},
         'dont_replace_with_smaller_cover': {'widgets': ['cb_dont_replace_with_smaller']},

--- a/picard/ui/options/cover_processing.py
+++ b/picard/ui/options/cover_processing.py
@@ -22,6 +22,7 @@
 
 
 from functools import partial
+from typing import ClassVar
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QSpinBox
@@ -55,7 +56,7 @@ class CoverProcessingOptionsPage(OptionsPage):
     SORT_ORDER = 0
     HELP_URL = "/config/options_cover_art_processing.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'filter_cover_by_size': {'widgets': ['filtering']},
         'cover_minimum_width': {'widgets': ['filtering_width_value']},
         'cover_minimum_height': {'widgets': ['filtering_height_value']},

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -24,6 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import os
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -69,7 +70,7 @@ class FingerprintingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_fingerprinting.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'fingerprinting_system': {'widgets': ['disable_fingerprinting', 'use_acoustid']},
         'acoustid_fpcalc': {},
         'acoustid_apikey': {},

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -28,6 +28,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from PyQt6 import QtWidgets
 
 from picard import log
@@ -56,7 +58,7 @@ class GeneralOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_general.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'server_host': {'widgets': ['server_host']},
         'server_port': {'widgets': ['server_port']},
         'use_server_for_submission': {'widgets': ['use_server_for_submission']},

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -22,6 +22,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
@@ -84,7 +86,7 @@ class GenresOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_genres.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'use_genres': {'widgets': ['use_genres']},
         'only_my_genres': {'widgets': ['only_my_genres']},
         'artists_genres': {'widgets': ['artists_genres']},

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -29,6 +29,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import os.path
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -70,7 +71,7 @@ class InterfaceOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'toolbar_show_labels': {'widgets': ['toolbar_show_labels']},
         'show_menu_icons': {'widgets': ['show_menu_icons']},
         'ui_language': {},

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -21,6 +21,7 @@
 
 
 from functools import partial
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -104,7 +105,7 @@ class InterfaceColorsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_colors.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'interface_colors': {},
         'interface_colors_dark': {},
     }

--- a/picard/ui/options/interface_cover_art_box.py
+++ b/picard/ui/options/interface_cover_art_box.py
@@ -19,6 +19,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -40,7 +42,7 @@ class InterfaceCoverArtBoxOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_cover_art_box.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'show_cover_art_details': {'widgets': ['cb_show_cover_art_details']},
         'show_cover_art_details_type': {'widgets': ['cb_show_cover_art_details_type']},
         'show_cover_art_details_filesize': {'widgets': ['cb_show_cover_art_details_filesize']},

--- a/picard/ui/options/interface_quick_menu.py
+++ b/picard/ui/options/interface_quick_menu.py
@@ -19,6 +19,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from PyQt6 import (
     QtCore,
     QtWidgets,
@@ -51,7 +53,7 @@ class InterfaceQuickMenuOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_quick_menu.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'quick_menu_items': {'widgets': ['quick_menu_groupBox']},
     }
 

--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -32,6 +32,7 @@
 
 from collections import namedtuple
 import os.path
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -74,7 +75,7 @@ class InterfaceToolbarOptionsPage(OptionsPage):
     HELP_URL = "/config/options_interface_toolbar.html"
     SEPARATOR = '—' * 5
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'toolbar_layout': {'widgets': ['customize_toolbar_box']},
     }
     TOOLBAR_BUTTONS = {

--- a/picard/ui/options/interface_top_tags.py
+++ b/picard/ui/options/interface_top_tags.py
@@ -20,6 +20,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -39,7 +41,7 @@ class InterfaceTopTagsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_interface_top_tags.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'metadatabox_top_tags': {'widgets': ['top_tags_groupBox']},
     }
 

--- a/picard/ui/options/lookup.py
+++ b/picard/ui/options/lookup.py
@@ -19,6 +19,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -38,7 +40,7 @@ class LookupOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_lookup.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'analyze_new_files': {'widgets': ['analyze_new_files']},
         'cluster_new_files': {'widgets': ['cluster_new_files']},
         'ignore_file_mbids': {'widgets': ['ignore_file_mbids']},

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -23,6 +23,7 @@
 
 import datetime
 import os
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -70,7 +71,7 @@ class MaintenanceOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_maintenance.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'autobackup_directory': {'widgets': ['autobackup_dir']},
     }
     signal_reload = QtCore.pyqtSignal()

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -22,6 +22,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -41,7 +43,7 @@ class MatchingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_matching.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'match_min_similarity': {'widgets': ['match_min_similarity']},
         'match_min_margin': {'widgets': ['match_min_margin']},
         'track_matching_threshold': {'widgets': ['track_matching_threshold']},

--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -27,6 +27,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from PyQt6 import (
     QtCore,
     QtWidgets,
@@ -89,7 +91,7 @@ class MetadataOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_metadata.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'translate_artist_names': {'widgets': ['translate_artist_names']},
         'translate_album_titles': {'widgets': ['translate_album_titles']},
         'translate_track_titles': {'widgets': ['translate_track_titles']},

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -22,6 +22,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.const import (
     BROWSER_INTEGRATION_MAX_PORT,
@@ -52,7 +54,7 @@ class NetworkOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_network.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'use_proxy': {'widgets': ['web_proxy']},
         'proxy_type': {'widgets': ['proxy_type_socks', 'proxy_type_http']},
         'proxy_server_host': {'widgets': ['server_host']},

--- a/picard/ui/options/player.py
+++ b/picard/ui/options/player.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -37,7 +39,7 @@ class PlayerOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_player.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'player_now_playing': {'widgets': ['player_now_playing']},
         'listenbrainz_enabled': {'widgets': ['listenbrainz_enabled']},
         'listenbrainz_submit_only_tagged': {'widgets': ['listenbrainz_submit_only_tagged']},

--- a/picard/ui/options/ratings.py
+++ b/picard/ui/options/ratings.py
@@ -21,6 +21,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -40,7 +42,7 @@ class RatingsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_ratings.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'enable_ratings': {'widgets': ['enable_ratings']},
         'rating_user_email': {'widgets': ['rating_user_email']},
         'submit_ratings': {'widgets': ['submit_ratings']},

--- a/picard/ui/options/releases.py
+++ b/picard/ui/options/releases.py
@@ -27,6 +27,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from PyQt6 import QtWidgets
 
 from picard.config import get_config
@@ -60,7 +62,7 @@ class ReleasesOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_releases.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'preferred_release_types': {'widgets': ['preferred_release_types_group']},
         'discouraged_release_types': {'widgets': ['discouraged_release_types_group']},
         'preferred_release_countries': {'widgets': ['preferred_release_countries_group']},

--- a/picard/ui/options/renaming.py
+++ b/picard/ui/options/renaming.py
@@ -34,6 +34,7 @@
 
 
 import os.path
+from typing import ClassVar
 
 from PyQt6 import QtWidgets
 
@@ -66,7 +67,7 @@ class RenamingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_filerenaming.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'move_files': {'widgets': ['move_files']},
         'move_files_to': {'widgets': ['move_files_to']},
         'move_overwrite_existing_files': {'widgets': ['move_overwrite_existing_files']},

--- a/picard/ui/options/renaming_compat.py
+++ b/picard/ui/options/renaming_compat.py
@@ -35,6 +35,7 @@
 
 import os
 import re
+from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
@@ -70,7 +71,7 @@ class RenamingCompatOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_filerenaming_compat.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'ascii_filenames': {'widgets': ['ascii_filenames']},
         'windows_compatibility': {'widgets': ['windows_compatibility']},
         'win_compat_replacements': {'widgets': ['btn_windows_compatibility_change']},

--- a/picard/ui/options/scripting.py
+++ b/picard/ui/options/scripting.py
@@ -29,6 +29,7 @@
 
 
 import os
+from typing import ClassVar
 
 from PyQt6 import QtCore
 
@@ -107,7 +108,7 @@ class ScriptingOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_scripting.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'enable_tagger_scripts': {'widgets': ['enable_tagger_scripts']},
         'list_of_scripts': {'widgets': ['script_list']},
     }

--- a/picard/ui/options/sessions.py
+++ b/picard/ui/options/sessions.py
@@ -18,6 +18,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from typing import ClassVar
+
 from PyQt6 import QtWidgets
 
 from picard.config import get_config
@@ -44,7 +46,7 @@ class SessionsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_sessions.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'session_safe_restore': {'widgets': ['safe_restore_checkbox']},
         'session_load_last_on_startup': {'widgets': ['load_last_checkbox']},
         'session_autosave_interval_min': {'widgets': ['autosave_spin']},

--- a/picard/ui/options/startup.py
+++ b/picard/ui/options/startup.py
@@ -27,6 +27,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from typing import ClassVar
+
 from PyQt6 import QtCore
 
 from picard import log
@@ -58,7 +60,7 @@ class StartupOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_startup.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'check_rtd_updates': {'widgets': ['check_rtd_updates']},
         'check_for_plugin_updates': {'widgets': ['check_plugin_updates']},
         'check_for_updates': {'widgets': ['check_for_updates']},

--- a/picard/ui/options/tags.py
+++ b/picard/ui/options/tags.py
@@ -27,6 +27,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from typing import ClassVar
+
 from PyQt6 import QtWidgets
 
 from picard.config import get_config
@@ -52,7 +54,7 @@ class TagsOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'enable_tag_saving': {'widgets': ['write_tags']},
         'preserve_timestamps': {'widgets': ['preserve_timestamps']},
         'clear_existing_tags': {'widgets': ['clear_existing_tags']},

--- a/picard/ui/options/tags_compatibility_aac.py
+++ b/picard/ui/options/tags_compatibility_aac.py
@@ -21,6 +21,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -42,7 +44,7 @@ class TagsCompatibilityAACOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_aac.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'aac_save_ape': {'widgets': ['aac_save_ape', 'aac_no_tags']},
         'remove_ape_from_aac': {'widgets': ['remove_ape_from_aac']},
     }

--- a/picard/ui/options/tags_compatibility_ac3.py
+++ b/picard/ui/options/tags_compatibility_ac3.py
@@ -21,6 +21,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import N_
@@ -40,7 +42,7 @@ class TagsCompatibilityAC3OptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_ac3.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'ac3_save_ape': {'widgets': ['ac3_save_ape', 'ac3_no_tags']},
         'remove_ape_from_ac3': {'widgets': ['remove_ape_from_ac3']},
     }

--- a/picard/ui/options/tags_compatibility_id3.py
+++ b/picard/ui/options/tags_compatibility_id3.py
@@ -22,6 +22,7 @@
 
 
 from functools import partial
+from typing import ClassVar
 
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
@@ -42,7 +43,7 @@ class TagsCompatibilityID3OptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_id3.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'write_id3v23': {'widgets': ['write_id3v23', 'write_id3v24']},
         'id3v2_encoding': {'widgets': ['enc_utf8', 'enc_utf16', 'enc_iso88591']},
         'id3v23_join_with': {'widgets': ['id3v23_join_with']},

--- a/picard/ui/options/tags_compatibility_wave.py
+++ b/picard/ui/options/tags_compatibility_wave.py
@@ -21,6 +21,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from picard.config import get_config
 from picard.extension_points.options_pages import register_options_page
 from picard.formats.wav import WAVFile
@@ -41,7 +43,7 @@ class TagsCompatibilityWaveOptionsPage(OptionsPage):
     ACTIVE = True
     HELP_URL = "/config/options_tags_compatibility_wave.html"
 
-    OPTIONS: PageOptionConfigs = {
+    OPTIONS: ClassVar[PageOptionConfigs] = {
         'write_wave_riff_info': {'widgets': ['write_wave_riff_info']},
         'remove_wave_riff_info': {'widgets': ['remove_wave_riff_info']},
         'wave_riff_info_encoding': {'widgets': ['wave_riff_info_enc_cp1252', 'wave_riff_info_enc_utf8']},

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -28,6 +28,7 @@ from enum import (
 import logging
 import os
 import shutil
+from typing import ClassVar
 
 from test.picardtestcase import PicardTestCase
 
@@ -896,7 +897,7 @@ class TestRestoreDefaults(TestPicardConfigCommon):
             PARENT = None
             SORT_ORDER = 9999
             OPTION_SECTION = 'setting'
-            OPTIONS: PageOptionConfigs = {'test_rd_prof': {}}
+            OPTIONS: ClassVar[PageOptionConfigs] = {'test_rd_prof': {}}
 
         from picard.extension_points.options_pages import register_options_page
 
@@ -935,7 +936,7 @@ class TestRestoreDefaults(TestPicardConfigCommon):
             PARENT = None
             SORT_ORDER = 9999
             OPTION_SECTION = 'plugin.test-rd'
-            OPTIONS: PageOptionConfigs = {'opt': {}}
+            OPTIONS: ClassVar[PageOptionConfigs] = {'opt': {}}
 
         from picard.extension_points.options_pages import register_options_page
 
@@ -984,7 +985,7 @@ class TestRestoreDefaults(TestPicardConfigCommon):
             PARENT = None
             SORT_ORDER = 9999
             OPTION_SECTION = 'plugin.test-rd2'
-            OPTIONS: PageOptionConfigs = {'opt': {}}
+            OPTIONS: ClassVar[PageOptionConfigs] = {'opt': {}}
 
         from picard.extension_points.options_pages import register_options_page
 

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -19,6 +19,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from typing import ClassVar
+
 from test.picardtestcase import PicardTestCase
 
 from picard.config import Option
@@ -58,7 +60,7 @@ class OptionsUtilitiesTest(PicardTestCase):
             TITLE = 'Test'
             PARENT = None
             SORT_ORDER = 9999
-            OPTIONS: PageOptionConfigs = {
+            OPTIONS: ClassVar[PageOptionConfigs] = {
                 'test_no_profile_opt': {'widgets': ['some_widget']},
             }
 
@@ -86,7 +88,7 @@ class OptionsUtilitiesTest(PicardTestCase):
             PARENT = None
             SORT_ORDER = 9999
             OPTION_SECTION = 'setting'
-            OPTIONS: PageOptionConfigs = {'test_rd_core': {}}
+            OPTIONS: ClassVar[PageOptionConfigs] = {'test_rd_core': {}}
 
         from picard.extension_points.options_pages import register_options_page
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Define OptionsPage.OPTIONS as ClassVar. Otherwise static type checkers might complain about a mutable class variable, see e.g. https://docs.astral.sh/ruff/rules/mutable-class-default/

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

As this variable is part of the plugin API, define it in a way that allows plugins to implement the OPTIONS without type errors, example:

```python
class ReplayGain2OptionsPage(OptionsPage):
    OPTIONS: ClassVar[PageOptionConfigs] = {
        "album_tags": {"widgets": ["album_tags"]},
    }
```

Note: I considered enabling [RUF012)](https://docs.astral.sh/ruff/rules/mutable-class-default/#mutable-class-default-ruf012) as a rule to check (we have only specific tests enabled in pyproject.toml, not including the RUF* rules). But Picard uses mutable class variables quite a lot, not sure we want to enforce this check and force use of ClassVar everywhere. But if that is preferred I'm not against enabling the rule and updating all places in code.

Just this specific use is special, as it impacts plugins and the ability to define plugins without type warnings. 




## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
