### PR TITLE
Change help link to match file name on ReadTheDocs

### DIFF
--- a/picard/ui/options/interface_cover_art_box.py
+++ b/picard/ui/options/interface_cover_art_box.py
@@ -40,7 +40,7 @@ class InterfaceCoverArtBoxOptionsPage(OptionsPage):
     PARENT = 'interface'
     SORT_ORDER = 50
     ACTIVE = True
-    HELP_URL = "/config/options_interface_cover_art_box.html"
+    HELP_URL = "/config/options_interface_coverart_box.html"
 
     OPTIONS: ClassVar[PageOptionConfigs] = {
         'show_cover_art_details': {'widgets': ['cb_show_cover_art_details']},


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

The help link for the user interface cover art box did not match the url on ReadTheDocs.

* JIRA ticket (_optional_): PICARD-XXX

## Solution

Update the help link.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
