### PR TITLE
Allow local cover art provider to match full path

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2015, 2018-2021, 2023-2024 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Ville Skyttä
-# Copyright (C) 2019-2021 Philipp Wolfer
+# Copyright (C) 2019-2021, 2026 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -22,6 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import Iterator
 import os
 import re
 from typing import ClassVar
@@ -115,6 +116,8 @@ class CoverArtProviderLocal(CoverArtProvider):
         config = get_config()
         regex = config.setting['local_cover_regex']
         if regex:
+            # Normalize backslashes to forward slashes as path separator
+            regex = regex.replace('\\\\', '/')
             _match_re = re.compile(regex, re.IGNORECASE)
             dirs_done = set()
 
@@ -127,16 +130,20 @@ class CoverArtProviderLocal(CoverArtProvider):
                     self.queue_put(image)
         return CoverArtProvider.QueueState.FINISHED
 
-    def get_types(self, string):
+    def get_types(self, string: str) -> list[str]:
         found = {x.lower() for x in self._types_split_re.split(string) if x}
         return list(found.intersection(self._known_types))
 
-    def find_local_images(self, current_dir, match_re):
+    def find_local_images(self, current_dir: str, match_re: re.Pattern) -> Iterator[LocalFileCoverArtImage]:
         for root, _dirs, files in os.walk(current_dir):
             for filename in files:
                 m = match_re.search(filename)
                 if not m:
-                    continue
+                    subpath = os.path.relpath(os.path.join(root, filename), current_dir)
+                    subpath = subpath.replace('\\', '/')
+                    m = match_re.search(subpath)
+                    if not m:
+                        continue
                 filepath = os.path.join(current_dir, root, filename)
                 if not os.path.exists(filepath):
                     continue

--- a/test/test_coverartprovider_local.py
+++ b/test/test_coverartprovider_local.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2020-2021 Philipp Wolfer
+# Copyright (C) 2020-2022 Laurent Monin
+# Copyright (C) 2024 Giorgio Fontanive
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from unittest.mock import Mock
+
+from picard.coverart.image import LocalFileCoverArtImage
+from picard.coverart.providers.local import CoverArtProviderLocal
+
+import pytest
+
+
+@pytest.fixture
+def testdir():
+    tmpdir = Path(tempfile.mkdtemp())
+    Path(tmpdir / 'cover.jpg').touch()
+    Path(tmpdir / 'artwork').mkdir()
+    Path(tmpdir / 'artwork/cover.jpg').touch()
+    Path(tmpdir / 'artwork/cover.png').touch()
+    Path(tmpdir / 'artwork/back.png').touch()
+    yield str(tmpdir)
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected_paths"),
+    [
+        (r"nomatch", []),
+        (r"cover\.jpg", ['cover.jpg', 'artwork/cover.jpg']),
+        (r"cover\.png", ['artwork/cover.png']),
+        (r"cover\.(jpg|png)", ['cover.jpg', 'artwork/cover.png', 'artwork/cover.jpg']),
+        (r"^artwork/.*\.png$", ['artwork/cover.png', 'artwork/back.png']),
+        (r"^artwork/.*\.gif$", []),
+        (r"^artwork/back\.png$", ['artwork/back.png']),
+    ],
+)
+def test_find_local_images(testdir, pattern, expected_paths):
+    provider = CoverArtProviderLocal(Mock())
+    images = list(provider.find_local_images(testdir, re.compile(pattern)))
+    assert all(isinstance(image, LocalFileCoverArtImage) for image in images)
+    found_paths = set(os.path.normpath(image.url.toLocalFile()) for image in images if image.url)
+    expected_paths = set(os.path.normpath(os.path.join(testdir, path)) for path in expected_paths)
+    assert found_paths == expected_paths


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The local cover art provider currently matches a pattern against a file name. The provider walks through the full directory structure in the current directory and applies the pattern against each filename. This allows matching any file in the current directory or any subdirectory.

However, it does not allow to match the pattern against both a specific subdirectory + filename. E.g. if you have placed cover art in a subdirectory `Cover` and want to load all files `^Cover/.*\.jpg$` this is not possible. You can only load `.*\.jpg$`, but this will load any .jpg file in the current directory tree.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Match the pattern against the filename first. If it does not match, also match against the full path relative to the current directory. This way a petter like `^cover\.jpg$` will still, as before, match "cover.jpg" anywhere in the tree, but `^Artwork/cover\.jpg$` will specifically match the file "cover.jpg" in the subdirectory "Artwork".


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
