### PR TITLE
Use generic typing for ExtensionPoint and PluginFunctions

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -1215,8 +1215,8 @@ class NatAlbum(Album):
         return False
 
 
-album_post_removal_processors = PluginFunctions(label='album_post_removal_processors')
+album_post_removal_processors = PluginFunctions[[Album], None](label='album_post_removal_processors')
 
 
-def run_album_post_removal_processors(album_object):
+def run_album_post_removal_processors(album_object: Album):
     album_post_removal_processors.run(album_object)

--- a/picard/extension_points/__init__.py
+++ b/picard/extension_points/__init__.py
@@ -38,7 +38,10 @@ from collections.abc import (
     Callable,
     Iterator,
 )
-from typing import Any
+from typing import (
+    Generic,
+    TypeVar,
+)
 import uuid
 
 from picard import log
@@ -51,8 +54,10 @@ PLUGIN_MODULE_PREFIX_LEN = len(PLUGIN_MODULE_PREFIX)
 _extension_points: list['ExtensionPoint'] = []
 _plugin_uuid_to_module: dict[str, str] = {}  # Maps UUID -> module name for v3 plugins
 
+T = TypeVar('T')
 
-class ExtensionPoint:
+
+class ExtensionPoint(Generic[T]):
     def __init__(self, label: str | None = None) -> None:
         if label is None:
             self.label = uuid.uuid4()
@@ -68,13 +73,13 @@ class ExtensionPoint:
             return module[PLUGIN_MODULE_PREFIX_LEN:].split('.')[0]
         return None
 
-    def register(self, module: str, item: Any) -> None:
+    def register(self, module: str, item: T) -> None:
         name = self._derive_key(module)
         if name is not None:
             log.debug("ExtensionPoint: %s register <- plugin=%r item=%r", self.label, name, item)
         self.__dict[name].append(item)
 
-    def unregister(self, module: str, match: Callable[[Any], bool]) -> None:
+    def unregister(self, module: str, match: Callable[[T], bool]) -> None:
         """Remove items registered by *module* for which *match* returns True.
 
         Args:
@@ -99,7 +104,7 @@ class ExtensionPoint:
             # >>> #^^ no exception, after first read
             pass
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[T]:
         config = get_config()
         if not config:
             # No config available, yield all

--- a/picard/extension_points/cover_art_filters.py
+++ b/picard/extension_points/cover_art_filters.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
+    TypeAlias,
 )
 
 from picard.album import Album
@@ -34,17 +35,16 @@ if TYPE_CHECKING:
     from picard.plugin3.api import ImageInfo
 
 
-ext_point_cover_art_filters = ExtensionPoint(label='cover_art_filters')
-ext_point_cover_art_metadata_filters = ExtensionPoint(label='cover_art_metadata_filters')
+CoverArtFilter: TypeAlias = Callable[[bytes, 'ImageInfo', Album | None, CoverArtImage], bool]
+CoverArtMetadataFilter: TypeAlias = Callable[[dict[str, Any]], bool]
+
+ext_point_cover_art_filters = ExtensionPoint[CoverArtFilter](label='cover_art_filters')
+ext_point_cover_art_metadata_filters = ExtensionPoint[CoverArtMetadataFilter](label='cover_art_metadata_filters')
 
 
-def register_cover_art_filter(
-    cover_art_filter: Callable[[bytes, 'ImageInfo', Album | None, CoverArtImage], bool],
-) -> None:
+def register_cover_art_filter(cover_art_filter: CoverArtFilter) -> None:
     ext_point_cover_art_filters.register(cover_art_filter.__module__, cover_art_filter)
 
 
-def register_cover_art_metadata_filter(
-    cover_art_metadata_filter: Callable[[dict[str, Any]], bool],
-) -> None:
+def register_cover_art_metadata_filter(cover_art_metadata_filter: CoverArtMetadataFilter) -> None:
     ext_point_cover_art_metadata_filters.register(cover_art_metadata_filter.__module__, cover_art_metadata_filter)

--- a/picard/extension_points/cover_art_processors.py
+++ b/picard/extension_points/cover_art_processors.py
@@ -43,9 +43,6 @@ from picard.util.imageinfo import (
 )
 
 
-ext_point_cover_art_processors = ExtensionPoint(label='cover_art_processors')
-
-
 class CoverArtProcessingError(Exception):
     pass
 
@@ -178,6 +175,9 @@ class ImageProcessor:
         pass
 
 
+ext_point_cover_art_processors = ExtensionPoint[ImageProcessor](label='cover_art_processors')
+
+
 def get_cover_art_processors() -> dict[ImageProcessor.Target, list[ImageProcessor]]:
     queues = defaultdict(list)
     for processor in ext_point_cover_art_processors:
@@ -192,6 +192,6 @@ def get_cover_art_processors() -> dict[ImageProcessor.Target, list[ImageProcesso
     return queues
 
 
-def register_cover_art_processor(cover_art_processor):
+def register_cover_art_processor(cover_art_processor: type[ImageProcessor]) -> None:
     instance = cover_art_processor()
     ext_point_cover_art_processors.register(cover_art_processor.__module__, instance)

--- a/picard/extension_points/cover_art_providers.py
+++ b/picard/extension_points/cover_art_providers.py
@@ -29,7 +29,7 @@ from picard.extension_points.options_pages import register_options_page
 from picard.plugin import ExtensionPoint
 
 
-ext_point_cover_art_providers = ExtensionPoint(label='cover_art_providers')
+ext_point_cover_art_providers = ExtensionPoint[type[CoverArtProvider]](label='cover_art_providers')
 
 
 def register_cover_art_provider(provider: type[CoverArtProvider]) -> None:

--- a/picard/extension_points/disc_log_readers.py
+++ b/picard/extension_points/disc_log_readers.py
@@ -20,15 +20,19 @@
 
 
 from collections.abc import Callable
+from typing import TypeAlias
 
 from picard.disc.utils import TocNumbers
 from picard.extension_points import ExtensionPoint
 
 
-ext_point_disc_log_readers = ExtensionPoint(label='disc_log_readers')
+LogReader: TypeAlias = Callable[[str], TocNumbers]
 
 
-def register_disc_log_reader(function: Callable[[str], TocNumbers]) -> None:
+ext_point_disc_log_readers = ExtensionPoint[LogReader](label='disc_log_readers')
+
+
+def register_disc_log_reader(function: LogReader) -> None:
     """Registers a disc log reader function.
 
     A disc log reader is a function that takes a file path and returns

--- a/picard/extension_points/item_actions.py
+++ b/picard/extension_points/item_actions.py
@@ -88,11 +88,11 @@ class BaseAction(QtGui.QAction, HasDisplayTitle):
         raise NotImplementedError
 
 
-ext_point_album_actions = ExtensionPoint(label='album_actions')
-ext_point_cluster_actions = ExtensionPoint(label='cluster_actions')
-ext_point_clusterlist_actions = ExtensionPoint(label='clusterlist_actions')
-ext_point_file_actions = ExtensionPoint(label='file_actions')
-ext_point_track_actions = ExtensionPoint(label='track_actions')
+ext_point_album_actions = ExtensionPoint[type[BaseAction]](label='album_actions')
+ext_point_cluster_actions = ExtensionPoint[type[BaseAction]](label='cluster_actions')
+ext_point_clusterlist_actions = ExtensionPoint[type[BaseAction]](label='clusterlist_actions')
+ext_point_file_actions = ExtensionPoint[type[BaseAction]](label='file_actions')
+ext_point_track_actions = ExtensionPoint[type[BaseAction]](label='track_actions')
 
 
 def register_album_action(action: type[BaseAction]) -> None:

--- a/picard/extension_points/metadata_tag_actions.py
+++ b/picard/extension_points/metadata_tag_actions.py
@@ -18,13 +18,27 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from picard.item import MetadataItem
 from picard.plugin import ExtensionPoint
+from picard.util.display_title_base import HasDisplayTitle
 
 
-ext_point_metadata_tag_actions = ExtensionPoint(label='metadata_tag_actions')
+class MetadataTagAction(HasDisplayTitle):
+    """Base class for metadata tag context menu actions."""
+
+    TITLE: str = ""
+
+    def callback(self, tags: list[str], objects: set[MetadataItem]) -> None:
+        raise NotImplementedError
+
+    def is_visible(self, tags: list[str], objects: set[MetadataItem]) -> bool:
+        return True
 
 
-def register_metadata_tag_action(action: type) -> None:
+ext_point_metadata_tag_actions = ExtensionPoint[type[MetadataTagAction]](label='metadata_tag_actions')
+
+
+def register_metadata_tag_action(action: type[MetadataTagAction]) -> None:
     """Register a context menu action for metadata tags.
 
     The action class must define:

--- a/picard/extension_points/options_pages.py
+++ b/picard/extension_points/options_pages.py
@@ -30,7 +30,7 @@ from picard.plugin import ExtensionPoint
 from picard.ui.options import OptionsPage
 
 
-ext_point_options_pages = ExtensionPoint(label='options_pages')
+ext_point_options_pages = ExtensionPoint[type[OptionsPage]](label='options_pages')
 
 
 def register_options_page(page_class: type[OptionsPage]) -> None:

--- a/picard/extension_points/plugin_tools_menu.py
+++ b/picard/extension_points/plugin_tools_menu.py
@@ -32,7 +32,7 @@ class Signaler(QObject):
 
 
 signaler = Signaler()
-ext_point_plugin_tools_items = ExtensionPoint(label='plugin_tools_items')
+ext_point_plugin_tools_items = ExtensionPoint[type[BaseAction]](label='plugin_tools_items')
 
 
 def register_tools_menu_action(action: type[BaseAction]) -> None:

--- a/picard/extension_points/script_functions.py
+++ b/picard/extension_points/script_functions.py
@@ -59,9 +59,6 @@ except ImportError:
     pass
 
 
-ext_point_script_functions = ExtensionPoint(label='script_functions')
-
-
 Bound = namedtuple('Bound', ['lower', 'upper'])
 
 
@@ -113,6 +110,9 @@ class FunctionRegistryItem:
         else:
             ret = ''
         return self._postprocess(ret, postprocessor)
+
+
+ext_point_script_functions = ExtensionPoint[tuple[str, FunctionRegistryItem]](label='script_functions')
 
 
 def register_script_function(

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -31,15 +31,15 @@ if TYPE_CHECKING:
     from picard.plugin3.api_impl import PluginApi
 
 
-ext_point_script_variables = ExtensionPoint(label='script_variables')
-
-
 @dataclass(frozen=True)
 class PluginVariable:
     name: str
     documentation: str
     plugin_name: str
     title: str | None = None
+
+
+ext_point_script_variables = ExtensionPoint[PluginVariable](label='script_variables')
 
 
 def _check_if_duplicate_variable_name(name: str) -> str | None:

--- a/picard/file.py
+++ b/picard/file.py
@@ -1298,28 +1298,32 @@ class File(MetadataItem):
         return format_key not in disabled
 
 
-file_post_load_processors = PluginFunctions(label='file_post_load_processors')
-file_post_addition_to_track_processors = PluginFunctions(label='file_post_addition_to_track_processors')
-file_post_removal_to_track_processors = PluginFunctions(label='file_post_removal_from_track_processors')
-file_pre_save_processors = PluginFunctions(label='file_pre_save_processors')
-file_post_save_processors = PluginFunctions(label='file_post_save_processors')
+file_post_load_processors = PluginFunctions[[File], None](label='file_post_load_processors')
+file_post_addition_to_track_processors = PluginFunctions[['Track', File], None](
+    label='file_post_addition_to_track_processors'
+)
+file_post_removal_to_track_processors = PluginFunctions[['Track', File], None](
+    label='file_post_removal_from_track_processors'
+)
+file_pre_save_processors = PluginFunctions[[File], None](label='file_pre_save_processors')
+file_post_save_processors = PluginFunctions[[File], None](label='file_post_save_processors')
 
 
-def run_file_post_load_processors(file_object):
+def run_file_post_load_processors(file_object: File):
     file_post_load_processors.run(file_object)
 
 
-def run_file_post_addition_to_track_processors(track_object, file_object):
+def run_file_post_addition_to_track_processors(track_object: 'Track', file_object: File):
     file_post_addition_to_track_processors.run(track_object, file_object)
 
 
-def run_file_post_removal_from_track_processors(track_object, file_object):
+def run_file_post_removal_from_track_processors(track_object: 'Track', file_object: File):
     file_post_removal_to_track_processors.run(track_object, file_object)
 
 
-def run_file_pre_save_processors(file_object):
+def run_file_pre_save_processors(file_object: File):
     file_pre_save_processors.run(file_object)
 
 
-def run_file_post_save_processors(file_object):
+def run_file_post_save_processors(file_object: File):
     file_post_save_processors.run(file_object)

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -57,7 +57,9 @@ from picard.util.imagelist import ImageList
 
 
 if TYPE_CHECKING:
+    from picard.album import Album
     from picard.coverart.image import CoverArtImage
+    from picard.track import Track
 
 MULTI_VALUED_JOINER = '; '
 
@@ -514,13 +516,17 @@ class MultiMetadataProxy:
         return self.__read('__repr__')
 
 
-album_metadata_processors = PluginFunctions(label='album_metadata_processors')
-track_metadata_processors = PluginFunctions(label='track_metadata_processors')
+album_metadata_processors = PluginFunctions[['Album', Metadata, dict], None](label='album_metadata_processors')
+track_metadata_processors = PluginFunctions[['Track', Metadata, dict, dict | None], None](
+    label='track_metadata_processors'
+)
 
 
-def run_album_metadata_processors(album_object, metadata, release_node):
+def run_album_metadata_processors(album_object: 'Album', metadata: Metadata, release_node: dict):
     album_metadata_processors.run(album_object, metadata, release_node)
 
 
-def run_track_metadata_processors(track_object, metadata, track_node, release_node=None):
+def run_track_metadata_processors(
+    track_object: 'Track', metadata: Metadata, track_node: dict, release_node: dict | None = None
+):
     track_metadata_processors.run(track_object, metadata, track_node, release_node)

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -39,6 +39,11 @@ from collections.abc import (
     Iterator,
 )
 from functools import partial
+from typing import (
+    Generic,
+    ParamSpec,
+    TypeVar,
+)
 
 from picard.config import (
     Option,
@@ -65,25 +70,29 @@ PluginInformation = namedtuple(
 )
 
 
-class PluginFunctions:
+P = ParamSpec('P')
+R = TypeVar('R')
+
+
+class PluginFunctions(Generic[P, R]):
     """
     Store ExtensionPoint in a defaultdict with priority as key
     run() method will execute entries with higher priority value first
     """
 
     def __init__(self, label: str | None = None):
-        self.functions = ExtensionPoint(label=label)
+        self.functions = ExtensionPoint[Callable[P, R]](label=label)
         self.priorities: dict = {}
         self.config_priorities: dict = {}
         self.processor_type = label.split('_')[0] if label else ''
         Option.add_if_missing('setting', 'plugins3_exec_order', dict())
 
-    def make_exec_order_key(self, function: Callable) -> str:
+    def make_exec_order_key(self, function: Callable[P, R]) -> str:
         """Make the plugin key based on the module name"""
         key = f"{function.__module__}:{self.processor_type}:{getattr(function, '__name__', str(function))}"
         return key
 
-    def get_priority(self, function: Callable) -> int:
+    def get_priority(self, function: Callable[P, R]) -> int:
         key = self.make_exec_order_key(function)
         if key in self.config_priorities:
             return self.config_priorities[key]
@@ -91,7 +100,7 @@ class PluginFunctions:
             return self.priorities[key]
         return 0  # Default priority
 
-    def register(self, module: str, item: Callable, priority: int = 0) -> None:
+    def register(self, module: str, item: Callable[P, R], priority: int = 0) -> None:
         key = self.make_exec_order_key(item)
         self.priorities[key] = priority
         self.functions.register(module, item)
@@ -130,18 +139,18 @@ class PluginFunctions:
                 plugin_name=plugin_name,
                 plugin_description=plugin_description,
                 processor=processor,
-                function_name=function.__name__,
+                function_name=function.__name__ if hasattr(function, '__name__') else str(function),
                 function_description=getattr(function, '__doc__', None) or _("No function description available."),
                 priority=self.get_priority(function),
             )
 
-    def _get_functions(self) -> Iterator[Callable]:
+    def _get_functions(self) -> Iterator[Callable[P, R]]:
         """Returns registered functions by order of priority (highest first) and registration"""
         config = get_config()
         self.config_priorities = dict(config.setting['plugins3_exec_order'])
         yield from sorted(self.functions, key=lambda i: self.get_priority(i), reverse=True)
 
-    def run(self, *args, **kwargs) -> None:
+    def run(self, *args: P.args, **kwargs: P.kwargs) -> None:
         """Execute registered functions with passed parameters honouring priority"""
         for function in self._get_functions():
             function(*args, **kwargs)

--- a/picard/plugin3/api.py
+++ b/picard/plugin3/api.py
@@ -19,6 +19,7 @@
 
 from picard.cluster import Cluster
 from picard.extension_points.cover_art_processors import ProcessingImage
+from picard.item import MetadataItem
 from picard.plugin3.api_impl import (
     Album,
     BaseAction,
@@ -28,7 +29,6 @@ from picard.plugin3.api_impl import (
     ImageInfo,
     ImageProcessor,
     Metadata,
-    MetadataItem,
     MetadataTagAction,
     OptionsPage,
     PluginApi,

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -88,7 +88,10 @@ from picard.extension_points.metadata import (
     register_album_metadata_processor,
     register_track_metadata_processor,
 )
-from picard.extension_points.metadata_tag_actions import register_metadata_tag_action
+from picard.extension_points.metadata_tag_actions import (
+    MetadataTagAction as _MetadataTagAction,
+    register_metadata_tag_action,
+)
 from picard.extension_points.options_pages import register_options_page
 from picard.extension_points.plugin_tools_menu import register_tools_menu_action
 from picard.extension_points.script_functions import register_script_function
@@ -98,7 +101,6 @@ from picard.extension_points.script_variables import (
     unregister_script_variable,
 )
 from picard.file import File
-from picard.item import MetadataItem
 from picard.metadata import Metadata
 from picard.plugin3.i18n import (
     PluginTranslator,
@@ -190,17 +192,10 @@ class ProviderOptions(_ProviderOptions):
     api: 'PluginApi'
 
 
-class MetadataTagAction(HasDisplayTitle):
+class MetadataTagAction(_MetadataTagAction):
     """Base class for metadata tag context menu actions."""
 
-    TITLE: str = ""
     api: 'PluginApi'
-
-    def callback(self, tags: list[str], objects: set[MetadataItem]) -> None:
-        raise NotImplementedError
-
-    def is_visible(self, tags: list[str], objects: set[MetadataItem]) -> bool:
-        return True
 
 
 class PluginApi:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The `ExtensionPoint` class, while flexible to use, can store arbitrary objects. Code consuming the values from the ExtensionPoint does currently not now about the type and can not benefit from type hint.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Make the extension point mechanism fully type aware using Generic with TypeVar and ParamSpec. That allows consumer of extension points to fully understand the stored types.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
