### PR TITLE
PICARD-3377: Fix running CLI plugins compile-ui command with relative path

### DIFF
--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -92,6 +92,7 @@ from picard.plugin3.registry import (
     RegistryParseError,
 )
 from picard.plugin3.validator import MAX_NAME_LENGTH
+from picard.util.filenaming import replace_extension
 
 
 def get_display_locale(args):
@@ -1818,7 +1819,7 @@ class PluginCLI(BaseCLI):
         """Compile the UI for a plugin."""
 
         ui_file = Path(ui_file)
-        py_file = ui_file.parent.joinpath(os.path.splitext(ui_file)[0] + '.py')
+        py_file = Path(replace_extension(ui_file, '.py'))
 
         if not ui_file.exists():
             self._out.error(f"File {self._out.bold(ui_file.name)} does not exist.")

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -618,7 +618,7 @@ def get_available_filename(new_path: str, old_path: str | None = None) -> str:
     return new_path
 
 
-def replace_extension(filename: str, new_ext: str) -> str:
+def replace_extension(filename: Path | str, new_ext: str) -> str:
     """Replaces the extension in filename with new_ext.
 
     If the file has no extension the extension is added.

--- a/test/test_util_filenaming.py
+++ b/test/test_util_filenaming.py
@@ -26,6 +26,7 @@
 
 import os
 import os.path
+from pathlib import Path
 import sys
 from tempfile import (
     NamedTemporaryFile,
@@ -343,6 +344,7 @@ class ReplaceExtensionTest(PicardTestCase):
         self.assertEqual('foo/bar.wvc', replace_extension('foo/bar.wv', '.wvc'))
         self.assertEqual('foo/bar.wvc', replace_extension('foo/bar.wv', 'wvc'))
         self.assertEqual('foo/bar.wvc', replace_extension('foo/bar', 'wvc'))
+        self.assertEqual(os.path.normpath('foo/bar.wvc'), replace_extension(Path('foo/bar.wv'), '.wvc'))
 
 
 class ShortenFilenameTest(PicardTestCase):


### PR DESCRIPTION

<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3377
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Calling compile-ui with a path including a directory would add the parent directory name twice to the resulting path.

E.g. try running:

```
picard-cli plugins compile-ui ui/aboutdialog.ui
```

It will fail with:

```
Compiling aboutdialog.ui -> aboutdialog.py...
✗ Failed to compile aboutdialog.ui: [Errno 2] Datei oder Verzeichnis nicht gefunden: 'ui/ui/aboutdialog.py'
```

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Don't append the parent dir to the existing path.

Also use existing `replace_extension` function.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
