### PR TITLE
PICARD-3374: Pass PluginApi instance to ripper log callback

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1122,7 +1122,7 @@ from picard.disc.utils import (
 )
 
 
-def my_ripper_toc_from_file(path):
+def my_ripper_toc_from_file(api, path):
     """Parse MyRipper log files for disc ID lookup."""
     entries = []
     with open(path, encoding='utf-8') as f:

--- a/picard/disc/cyanriplog.py
+++ b/picard/disc/cyanriplog.py
@@ -23,6 +23,7 @@ from collections.abc import (
     Iterable,
     Iterator,
 )
+from pathlib import Path
 import re
 
 from picard.disc.utils import (
@@ -65,7 +66,7 @@ def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
                 start_lsn = None
 
 
-def toc_from_file(path: str) -> TocNumbers:
+def toc_from_file(path: Path) -> TocNumbers:
     """Reads cyanrip log files, generates MusicBrainz disc TOC listing for use as discid."""
     with open(path, encoding='utf-8') as f:
         first_line = f.readline()

--- a/picard/disc/dbpoweramplog.py
+++ b/picard/disc/dbpoweramplog.py
@@ -25,6 +25,7 @@ from collections.abc import (
     Iterable,
     Iterator,
 )
+from pathlib import Path
 import re
 
 from picard.disc.utils import (
@@ -56,7 +57,7 @@ def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
             yield TocEntry(track_num, int(m['start_sector']), int(m['end_sector']) - 1)
 
 
-def toc_from_file(path: str) -> TocNumbers:
+def toc_from_file(path: Path) -> TocNumbers:
     """Reads dBpoweramp log files, generates MusicBrainz disc TOC listing for use as discid."""
     encoding = detect_file_encoding(path)
     with open(path, 'r', encoding=encoding) as f:

--- a/picard/disc/eaclog.py
+++ b/picard/disc/eaclog.py
@@ -26,6 +26,7 @@
 # SOFTWARE.
 
 from collections.abc import Iterator
+from pathlib import Path
 import re
 
 from picard.disc.utils import (
@@ -85,7 +86,7 @@ def filter_toc_entries(lines: Iterator[str]) -> Iterator[TocEntry]:
         yield TocEntry(int(m['num']), int(m['start_sector']), int(m['end_sector']))
 
 
-def toc_from_file(path: str) -> TocNumbers:
+def toc_from_file(path: Path) -> TocNumbers:
     """Reads EAC / XLD / fre:ac log files, generates MusicBrainz disc TOC listing for use as discid.
 
     Warning: may work wrong for discs having data tracks. May generate wrong

--- a/picard/disc/scsitoc.py
+++ b/picard/disc/scsitoc.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import namedtuple
+from pathlib import Path
 from typing import BinaryIO
 
 from picard.disc.utils import (
@@ -74,7 +75,7 @@ def parse_toc_entries(f: BinaryIO) -> TocNumbers:
     return (first_track, last_track, leadout_offset + PREGAP_LENGTH) + offsets
 
 
-def toc_from_file(path: str) -> TocNumbers:
+def toc_from_file(path: Path) -> TocNumbers:
     """Reads a TOC in the SCSI format, generates MusicBrainz disc TOC listing for use as discid."""
 
     with open(path, 'rb') as f:

--- a/picard/disc/whipperlog.py
+++ b/picard/disc/whipperlog.py
@@ -20,6 +20,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from pathlib import Path
+
 import yaml
 
 from picard.disc.utils import (
@@ -29,7 +31,7 @@ from picard.disc.utils import (
 )
 
 
-def toc_from_file(path: str) -> TocNumbers:
+def toc_from_file(path: Path) -> TocNumbers:
     """Reads whipper log files, generates musicbrainz disc TOC listing for use as discid.
 
     Warning: may work wrong for discs having data tracks. May generate wrong

--- a/picard/extension_points/disc_log_readers.py
+++ b/picard/extension_points/disc_log_readers.py
@@ -20,13 +20,14 @@
 
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import TypeAlias
 
 from picard.disc.utils import TocNumbers
 from picard.extension_points import ExtensionPoint
 
 
-LogReader: TypeAlias = Callable[[str], TocNumbers]
+LogReader: TypeAlias = Callable[[Path], TocNumbers]
 
 
 ext_point_disc_log_readers = ExtensionPoint[LogReader](label='disc_log_readers')

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -289,7 +289,7 @@ class ID3File(File):
     __lrc_syllable_re_parse = re.compile(r'(<' + __lrc_time_format_re + r'>)')
     __lrc_both_re_parse = re.compile(r'(\[' + __lrc_time_format_re + r'\]|<' + __lrc_time_format_re + r'>)')
 
-    def __init__(self, filename):
+    def __init__(self, filename: str):
         super().__init__(filename)
         self.__casemap = {}
 

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1203,7 +1203,7 @@ class PluginApi:
         return self._tagger.format_registry.register(format)
 
     # Disc log readers
-    def register_disc_log_reader(self, function: Callable[[str], 'TocNumbers']) -> None:
+    def register_disc_log_reader(self, function: Callable[['PluginApi', str], 'TocNumbers']) -> None:
         """Register a custom disc log reader.
 
         A disc log reader parses CD ripping log files and extracts table of
@@ -1237,7 +1237,9 @@ class PluginApi:
             def enable(api):
                 api.register_disc_log_reader(my_ripper_toc_from_file)
         """
-        return register_disc_log_reader(function)
+        wrapped = partial(function, self)
+        update_wrapper(wrapped, function)
+        return register_disc_log_reader(wrapped)
 
     # Scripting
     def register_script_function(

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1203,7 +1203,7 @@ class PluginApi:
         return self._tagger.format_registry.register(format)
 
     # Disc log readers
-    def register_disc_log_reader(self, function: Callable[['PluginApi', str], 'TocNumbers']) -> None:
+    def register_disc_log_reader(self, function: Callable[['PluginApi', Path], 'TocNumbers']) -> None:
         """Register a custom disc log reader.
 
         A disc log reader parses CD ripping log files and extracts table of

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1348,7 +1348,7 @@ class Tagger(QtWidgets.QApplication):
             ]
         )
         if file_chooser.exec():
-            filepath = file_chooser.selectedFiles()[0]
+            filepath = Path(file_chooser.selectedFiles()[0])
             self.run_lookup_discid_from_logfile(filepath)
 
     def run_lookup_discid_from_logfile(self, filepath):

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1303,7 +1303,7 @@ ENCODING_BOMS = {
 }
 
 
-def detect_file_encoding(path: str, max_bytes_to_read: int = 1024 * 256) -> str:
+def detect_file_encoding(path: Path | str, max_bytes_to_read: int = 1024 * 256) -> str:
     """Attempts to guess the unicode encoding of a file based on the BOM, and
     depending on avalibility, using a charset detection method.
 

--- a/test/formats/test_id3_load.py
+++ b/test/formats/test_id3_load.py
@@ -50,7 +50,7 @@ class TestID3Load(PicardTestCase):
     def setUp(self):
         super().setUp()
         self.patch_tagger_instance('picard.item')
-        self.id3_file = ID3File(get_test_data_path("test.mp3"))
+        self.id3_file = ID3File(str(get_test_data_path("test.mp3")))
 
     def test_load_tit1_frame(self):
         frame = MagicMock(spec=TIT1)

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -25,6 +25,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 import shutil
 import stat
 import struct
@@ -159,8 +160,8 @@ class PicardTestCase(unittest.TestCase):
         self.tagger.format_registry = self.format_registry
 
 
-def get_test_data_path(*paths):
-    return os.path.join('test', 'data', *paths)
+def get_test_data_path(*paths) -> Path:
+    return Path('test', 'data', *paths)
 
 
 def create_fake_png(extra: bytes = b''):

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -131,14 +131,9 @@ def load_test_registry():
     except ModuleNotFoundError:
         import tomli as tomllib
 
-    registry_path = Path(get_test_data_path('testplugins3', 'registry.toml'))
+    registry_path = get_test_data_path('testplugins3', 'registry.toml')
     with open(registry_path, 'rb') as f:
         return tomllib.load(f)
-
-
-def get_test_registry_path():
-    """Get path to test registry file."""
-    return Path(get_test_data_path('testplugins3', 'registry.toml'))
 
 
 def create_test_registry():

--- a/test/plugins3/test_manager.py
+++ b/test/plugins3/test_manager.py
@@ -931,7 +931,7 @@ class TestPluginManager(PicardTestCase):
         manager = _create_manager()
 
         # Load compatible plugin (API 3.0, 3.1)
-        plugin = manager._load_plugin(Path(get_test_data_path('testplugins3')), 'example')
+        plugin = manager._load_plugin(get_test_data_path('testplugins3'), 'example')
 
         self.assertIsNotNone(plugin)
         self.assertEqual(plugin.plugin_id, 'example')
@@ -942,7 +942,7 @@ class TestPluginManager(PicardTestCase):
         manager = _create_manager()
 
         # Load incompatible plugin (API 2.0, 2.1)
-        plugin = manager._load_plugin(Path(get_test_data_path('testplugins3')), 'incompatible')
+        plugin = manager._load_plugin(get_test_data_path('testplugins3'), 'incompatible')
 
         self.assertIsNone(plugin)
 
@@ -951,7 +951,7 @@ class TestPluginManager(PicardTestCase):
         manager = _create_manager()
 
         # Load plugin requiring future API (3.5, 3.6)
-        plugin = manager._load_plugin(Path(get_test_data_path('testplugins3')), 'newer-api')
+        plugin = manager._load_plugin(get_test_data_path('testplugins3'), 'newer-api')
 
         self.assertIsNone(plugin)
 

--- a/test/plugins3/test_state.py
+++ b/test/plugins3/test_state.py
@@ -102,7 +102,7 @@ class TestPluginState(PicardTestCase):
 
     def test_plugin_load_manifest(self):
         """Test Plugin.read_manifest() method."""
-        plugins_dir = Path(get_test_data_path('testplugins3'))
+        plugins_dir = get_test_data_path('testplugins3')
         plugin = Plugin(plugins_dir, 'example')
 
         plugin.read_manifest()

--- a/test/test_ui_filter.py
+++ b/test/test_ui_filter.py
@@ -139,7 +139,7 @@ class FilterTestFiltering(PicardTestCase):
         """Test with file-related filters"""
 
         test_file = get_test_data_path('test.flac')
-        test_object = File(test_file)
+        test_object = File(str(test_file))
 
         tests = [
             self.TestConditions(
@@ -226,7 +226,7 @@ class FilterTestFiltering(PicardTestCase):
         """Test with no filter provided"""
 
         test_file = get_test_data_path('test.flac')
-        test_object = File(test_file)
+        test_object = File(str(test_file))
 
         tests = [
             self.TestConditions(
@@ -259,7 +259,7 @@ class FilterTestFiltering(PicardTestCase):
         """Test with non-file-related filter provided"""
 
         test_file = get_test_data_path('test.flac')
-        test_object = File(test_file)
+        test_object = File(str(test_file))
 
         tests = [
             self.TestConditions(


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3374
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

`PluginApi.register_disc_log_reader` was defined as:

```python
def register_disc_log_reader(self, function: Callable[[str], 'TocNumbers']) -> None:
    ...
```

Unlike other PluginApi registration functions that take a callback, the callback here does not receive the PluginApi instance. This is inconsistent, compare e.g.:

```python
def register_file_post_load_processor(
        self, function: Callable[['PluginApi', File], None], priority: int = 0
    ) -> None:
```

Also `register_disc_log_reader` being a new API we can use the chance and pass a `pathlib.Path`.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Change `register_disc_log_reader` to accept a `PluginApi` instance as first parameter and update the code to pass a `pathlib.Path` as second parameter:

```python
def register_disc_log_reader(self, function: Callable[['PluginApi', Path], 'TocNumbers']) -> None:
    ...
```

Update all internal implementations accordingly. Also relax the type hints on the `detect_file_encoding` util function to also accept `Path` (no functional change needed).

Note: This is a breaking change compared to beta 7, but I think we need to get this right before Picard 3 final release.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
