### PR TITLE
PluginApi: _plugin_dir and _plugin_module must not be optional

### DIFF
--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -205,10 +205,10 @@ class PluginApi:
     _module_cache: ClassVar[dict[str, 'PluginApi']] = {}  # Maps module name -> PluginApi instance (for faster lookup)
     _deprecation_warnings_emitted: ClassVar[set[tuple[str, str, int]]] = set()  # Track emitted deprecation warnings
 
-    def __init__(self, manifest: PluginManifest, tagger: 'Tagger') -> None:
+    def __init__(self, manifest: PluginManifest, tagger: 'Tagger', module: types.ModuleType, plugin_dir: Path) -> None:
         self._tagger: Tagger = tagger
         self._manifest = manifest
-        self._plugin_module: types.ModuleType | None = None  # Will be set when plugin is enabled
+        self._plugin_module: types.ModuleType = module
         self._plugin_id = manifest.module_name
         full_name = f'plugin.{self._manifest.uuid}'
         self._logger = getLogger(f'main.plugin.{self._manifest.module_name}')
@@ -217,7 +217,7 @@ class PluginApi:
         self._api_persist = ConfigSection(get_config(), f'plugin_persist.{self._manifest.uuid}')
         self._translations: dict[str, dict] = {}
         self._source_locale = manifest.source_locale
-        self._plugin_dir: Path | None = None
+        self._plugin_dir: Path = plugin_dir
         self._qt_translator: PluginTranslator | None = None
         self._mb_api: MBAPIHelper | None = None
 
@@ -249,7 +249,7 @@ class PluginApi:
         return plugin_name, filename, lineno
 
     @classmethod
-    def deprecation_warning(cls, message, *args, frame_depth=3):
+    def deprecation_warning(cls, message: str, *args: Any, frame_depth: int = 3):
         """Emit a deprecation warning once per unique caller location.
 
         Args:
@@ -331,9 +331,6 @@ class PluginApi:
         Returns:
             (file_path, format) or (None, None) if not found
         """
-        if not self._plugin_dir:
-            return None, None
-
         locale_dir = self._plugin_dir / 'locale'
         if not locale_dir.exists():
             return None, None
@@ -400,9 +397,6 @@ class PluginApi:
 
         Only loads translations for the current locale to avoid unnecessary I/O.
         """
-        if not self._plugin_dir:
-            return
-
         locale_dir = self._plugin_dir / 'locale'
         if not locale_dir.exists():
             return
@@ -526,7 +520,6 @@ class PluginApi:
         This is the value that :class:`ExtensionPoint` uses internally to
         group items by plugin (e.g. ``picard.plugins.myplugin``).
         """
-        assert self._plugin_module is not None
         return self._plugin_module.__name__
 
     @property
@@ -568,11 +561,11 @@ class PluginApi:
         return self._api_persist
 
     @property
-    def plugin_dir(self) -> Path | None:
+    def plugin_dir(self) -> Path:
         """Path to the plugin directory.
 
         Returns:
-            Path: Plugin directory path, or None if not available
+            Path: Plugin directory path
         """
         return self._plugin_dir
 

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -573,12 +573,12 @@ class PluginSourceLocal(PluginSource):
 
 
 class Plugin:
-    local_path: Path | None = None
+    local_path: Path
     remote_url: str | None = None
     ref: str | None = None
-    module_name: str | None = None
+    module_name: str
     manifest: PluginManifest | None = None
-    state: PluginState | None = None
+    state: PluginState
     _module: types.ModuleType | None = None
 
     def __init__(self, plugins_dir: Path, plugin_id: str, uuid: str | None = None):
@@ -709,9 +709,8 @@ class Plugin:
             raise PluginAlreadyEnabledError(self.plugin_id)
 
         assert self.manifest is not None, "Plugin manifest must be loaded before enabling"
-        api = PluginApi(self.manifest, tagger)
-        api._plugin_module = self._module
-        api._plugin_dir = self.local_path
+        assert self._module is not None, "Plugin module must be loaded before enabling"
+        api = PluginApi(self.manifest, tagger, self._module, self.local_path)
         api._load_translations()
         api._install_qt_translator()
 

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -482,8 +482,7 @@ def create_test_plugin_api(plugin_dir, locale='en', module_name='test'):
 
     with open(manifest_path, 'rb') as f:
         manifest = PluginManifest(module_name, f)
-        api = PluginApi(manifest, Mock())
-        api._plugin_dir = plugin_dir
+        api = PluginApi(manifest, Mock(), Mock(), plugin_dir)
         api.get_locale = Mock(return_value=locale)
         api._load_translations()
     return api

--- a/test/plugins3/test_api.py
+++ b/test/plugins3/test_api.py
@@ -46,7 +46,7 @@ from picard.plugin3.api import PluginApi
 
 class TestPluginApiMethods(PicardTestCase):
     def _create_api(self):
-        return PluginApi(load_plugin_manifest('example'), Mock())
+        return PluginApi(load_plugin_manifest('example'), Mock(), Mock(), Path(''))
 
     def test_register_file_processors(self):
         """Test file processor registration methods."""
@@ -87,7 +87,7 @@ class TestPluginApiMethods(PicardTestCase):
     def test_register_format(self):
         """Test file format registration."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
 
         mock_format = Mock()
         self.tagger.format_registry = Mock()
@@ -97,7 +97,7 @@ class TestPluginApiMethods(PicardTestCase):
 
     def test_manifest(self):
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
 
         self.assertEqual(api.manifest, manifest)
         with self.assertRaises(AttributeError):
@@ -174,7 +174,7 @@ class TestPluginApiMethods(PicardTestCase):
         mock_plugin_manager = Mock()
         self.tagger.get_plugin_manager.return_value = mock_plugin_manager
 
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
 
         # Test with git metadata
         mock_metadata = Mock()
@@ -198,7 +198,7 @@ class TestPluginApiMethods(PicardTestCase):
 
 class TestPluginApi(PicardTestCase):
     def _create_api(self):
-        return PluginApi(load_plugin_manifest('example'), Mock())
+        return PluginApi(load_plugin_manifest('example'), Mock(), Mock(), Path(''))
 
     def tearDown(self):
         # Clear plugin options created during tests from registry
@@ -210,7 +210,7 @@ class TestPluginApi(PicardTestCase):
     def test_init(self):
         manifest = load_plugin_manifest('example')
 
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
         self.assertEqual(api.web_service, self.tagger.webservice)
         self.assertEqual(api.logger.name, 'main.plugin.example')
         self.assertEqual(api.global_config, get_config())
@@ -220,7 +220,7 @@ class TestPluginApi(PicardTestCase):
         """Test PluginApi property accessors."""
         manifest = load_plugin_manifest('example')
 
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
 
         # Test property accessors
         self.assertEqual(api.web_service, self.tagger.webservice)
@@ -237,7 +237,7 @@ class TestPluginApi(PicardTestCase):
         logging.disable(logging.NOTSET)
 
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, self.tagger)
+        api = PluginApi(manifest, self.tagger, Mock(), Path(''))
 
         # Verify logger name is correct
         self.assertEqual(api.logger.name, 'main.plugin.example')
@@ -289,7 +289,7 @@ class TestPluginApi(PicardTestCase):
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
 
             # Create API with the test config
-            api = PluginApi(manifest, self.tagger)
+            api = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api._api_config._ConfigSection__qt_config = settings
 
             # Set some config values
@@ -314,7 +314,7 @@ class TestPluginApi(PicardTestCase):
             self.assertEqual(settings2.value(f'plugin.{test_uuid}/test_bool'), True)
 
             # Verify raw_value can read them back
-            api2 = PluginApi(manifest, self.tagger)
+            api2 = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api2._api_config._ConfigSection__qt_config = settings2
             self.assertEqual(api2.plugin_config.raw_value('test_string'), 'hello')
             self.assertEqual(api2.plugin_config.raw_value('test_int'), 42)
@@ -333,7 +333,7 @@ class TestPluginApi(PicardTestCase):
 
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api = PluginApi(manifest, self.tagger)
+            api = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api._api_persist._ConfigSection__qt_config = settings
 
             # Verify section name is correctly namespaced
@@ -359,7 +359,7 @@ class TestPluginApi(PicardTestCase):
 
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api = PluginApi(manifest, self.tagger)
+            api = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api._api_config._ConfigSection__qt_config = settings
 
             # Test registering options
@@ -407,7 +407,7 @@ class TestPluginApi(PicardTestCase):
             # Verify persistence of complex types
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, self.tagger)
+            api2 = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api2._api_config._ConfigSection__qt_config = settings2
 
             self.assertEqual(api2.plugin_config['list'], [1, 2, 3])
@@ -425,7 +425,7 @@ class TestPluginApi(PicardTestCase):
 
         try:
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api = PluginApi(manifest, self.tagger)
+            api = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api._api_config._ConfigSection__qt_config = settings
 
             # Register options
@@ -449,7 +449,7 @@ class TestPluginApi(PicardTestCase):
 
             # Load in new QSettings instance (same process)
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, self.tagger)
+            api2 = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api2._api_config._ConfigSection__qt_config = settings2
 
             # Types are preserved due to QSettings in-memory cache
@@ -483,7 +483,7 @@ class TestPluginApi(PicardTestCase):
             settings = QSettings(str(config_file), QSettings.Format.IniFormat)
 
             # Create API
-            api = PluginApi(manifest, self.tagger)
+            api = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api._api_config._ConfigSection__qt_config = settings
 
             # Register options for the plugin
@@ -504,7 +504,7 @@ class TestPluginApi(PicardTestCase):
             # Verify persistence
             settings.sync()
             settings2 = QSettings(str(config_file), QSettings.Format.IniFormat)
-            api2 = PluginApi(manifest, self.tagger)
+            api2 = PluginApi(manifest, self.tagger, Mock(), Path(''))
             api2._api_config._ConfigSection__qt_config = settings2
 
             # Values should persist and be properly typed

--- a/test/plugins3/test_get_api.py
+++ b/test/plugins3/test_get_api.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
 import sys
 import types
+from unittest.mock import Mock
 
 from test.picardtestcase import PicardTestCase
 
@@ -43,13 +45,12 @@ class TestPluginApiGetApi(PicardTestCase):
 
         manifest = FakeManifest(module_name)
 
-        api = PluginApi(manifest, None)
-
         # Create fake module
         module = types.ModuleType(module_name)
         sys.modules[module_name] = module
 
-        api._plugin_module = module
+        api = PluginApi(manifest, Mock(), module, Path(""))
+
         PluginApi._instances[module_name] = api
 
         return api, module

--- a/test/plugins3/test_install.py
+++ b/test/plugins3/test_install.py
@@ -55,7 +55,7 @@ from picard.plugin3.manager.update import (
     UpdateResult,
 )
 from picard.plugin3.output import PluginOutput
-from picard.plugin3.plugin import Plugin
+from picard.plugin3.plugin import Plugin, PluginState
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.validator import generate_uuid
 
@@ -135,6 +135,7 @@ class TestPluginInstall(PicardTestCase):
 
         # Setup plugin with metadata
         mock_plugin = Mock(spec=Plugin)
+        mock_plugin.state = PluginState.ENABLED
         mock_plugin.plugin_id = 'test-plugin'
         mock_plugin.local_path = Path('/tmp/test-plugin')
         mock_plugin.read_manifest = Mock()

--- a/test/plugins3/test_manager.py
+++ b/test/plugins3/test_manager.py
@@ -261,6 +261,7 @@ uuid = "3fa397ec-0f2a-47dd-9223-e47ce9f2d692"
     def test_update_plugin_dirty_with_discard(self):
         """Test that update_plugin works with discard_changes=True."""
         mock_plugin = Mock(spec=Plugin)
+        mock_plugin.state = PluginState.ENABLED
         mock_plugin.plugin_id = 'test-plugin'
         mock_plugin.local_path = Mock()
         mock_plugin.manifest = Mock()
@@ -974,6 +975,7 @@ class TestPluginErrors(PicardTestCase):
         # Create a plugin that will fail to load
         bad_uuid = 'bad-uuid-1234'
         bad_plugin = Mock(spec=Plugin)
+        bad_plugin.local_path = Path('')
         bad_plugin.plugin_id = 'bad-plugin'
         bad_plugin.manifest = Mock()
         bad_plugin.manifest.uuid = bad_uuid

--- a/test/plugins3/test_qt_translator.py
+++ b/test/plugins3/test_qt_translator.py
@@ -113,9 +113,8 @@ class TestPluginApiQtTranslator(PicardTestCase):
             tagger = self._create_mock_tagger()
             tagger._qt_translators = Translators(tagger)
 
-            api = PluginApi(manifest, tagger)
+            api = PluginApi(manifest, tagger, Mock(), plugin_dir)
             if translations:
-                api._plugin_dir = plugin_dir
                 api.get_locale = Mock(return_value='en')
 
             return api, tagger

--- a/test/plugins3/test_translations.py
+++ b/test/plugins3/test_translations.py
@@ -62,7 +62,7 @@ class TestPluginApiLocale(PicardTestCase):
     def test_get_locale_returns_current_locale(self):
         """Test get_locale() returns current QLocale."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, Mock())
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
 
         locale = api.get_locale()
         # Should return a locale string like 'en_US', 'de_DE', etc.
@@ -74,7 +74,7 @@ class TestPluginTranslations(PicardTestCase):
     def test_tr_with_text(self):
         """Test basic translation with text parameter."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, Mock())
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
 
         result = api.tr('submit_listens', 'Submit listens')
         self.assertEqual(result, 'Submit listens')
@@ -82,7 +82,7 @@ class TestPluginTranslations(PicardTestCase):
     def test_tr_without_text(self):
         """Test translation without text parameter returns key."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, Mock())
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
 
         result = api.tr('submit_listens')
         self.assertEqual(result, 'submit_listens')
@@ -90,7 +90,7 @@ class TestPluginTranslations(PicardTestCase):
     def test_tr_with_placeholders(self):
         """Test translation with placeholder substitution."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, Mock())
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
 
         result = api.tr('greeting', 'Hello {name}', name='World')
         self.assertEqual(result, 'Hello World')
@@ -98,7 +98,7 @@ class TestPluginTranslations(PicardTestCase):
     def test_tr_with_multiple_placeholders(self):
         """Test translation with multiple placeholders."""
         manifest = load_plugin_manifest('example')
-        api = PluginApi(manifest, Mock())
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
 
         result = api.tr('user_info', '{name} has {count} items', name='Alice', count=5)
         self.assertEqual(result, 'Alice has 5 items')
@@ -166,8 +166,7 @@ class TestPluginTranslationLoading(PicardTestCase):
 
             with open(manifest_path, 'rb') as f:
                 manifest = PluginManifest('test', f)
-                api = PluginApi(manifest, Mock())
-                api._plugin_dir = plugin_dir
+                api = PluginApi(manifest, Mock(), Mock(), plugin_dir)
                 api.get_locale = Mock(return_value='en')
 
                 with self.assertLogs(api._logger, level='WARNING') as cm:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The plugin API exposes a `plugin_dir` property, which was defined to return `str | None`, indicating that the plugin_dir is optional and might no exist.

```
@property
    def plugin_dir(self) -> Path | None:
```

This is actually not true. At the point the `PluginApi` is created the plugin must exist and be loaded. `plugin_dir` should never be None. To make this clear to plugins using this property, the type hint needs to be changed.

A similar situation exists for plugin_module.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
When initializing PluginApi both plugin_dir and plugin_module are known and present. Change `PluginApi` to accept both in the constructor as mandatory arguments and adjust the type hints.

Update tests as needed.



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
