### PR TITLE
Reduce debug log noise with DebugOpt gating and StateChangeLogger

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -201,7 +201,7 @@ class CoverArt:
                 log.debug("Trying cover art provider %s …", provider.name)
                 result = instance.queue_images()
             else:
-                log.debug("Skipping cover art provider %s …", provider.name)
+                log.debug_if(DebugOpt.COVERART, "Skipping cover art provider %s …", provider.name)
         except BaseException:
             log.error(traceback.format_exc())
             raise

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -171,3 +171,4 @@ class DebugOpt(DebugOptEnum):
     PLUGIN_DEVELOPMENT = 9, N_('Plugin Development'), N_('Log plugin details typically only used during development')
     TIMINGS = 10, N_('Timings'), N_('Log timing information for operations affecting UI responsiveness')
     ISRC = 11, N_('ISRC'), N_('Log ISRC processing, submission, and lookup details')
+    RATECONTROL = 12, N_('Rate Control'), N_('Log request throttling, congestion window, and backoff details')

--- a/picard/log.py
+++ b/picard/log.py
@@ -351,8 +351,9 @@ class StateChangeLogger:
     Useful for settings or status flags that are checked repeatedly but
     should only produce log output when the value actually transitions.
 
-    Example::
+    Examples::
 
+        # Dict form: value → fixed message
         _update_check_logger = log.StateChangeLogger(
             log.info,
             {
@@ -360,20 +361,25 @@ class StateChangeLogger:
                 False: "Documentation updates disabled in user settings.",
             },
         )
-
-        # Only logs when the value differs from the previous call:
         _update_check_logger.update(config.setting['check_rtd_updates'])
+
+        # Callable form: called with the new value, returns the message
+        _lang_logger = log.StateChangeLogger(
+            log.debug,
+            lambda v: "Matched documentation language set to '%s'" % v,
+        )
+        _lang_logger.update(matched_language)
     """
 
     __slots__ = ('_log_func', '_messages', '_current', '_has_value')
 
-    def __init__(self, log_func, messages: dict):
+    def __init__(self, log_func, messages):
         """
         Args:
             log_func: Logging function to call (e.g. log.info, log.debug).
-            messages: Mapping of value → message string. When the tracked value
-                changes to a key in this dict, the corresponding message is logged.
-                Values not in the dict are tracked silently.
+            messages: Either a dict mapping value → message string, or a
+                callable that receives the new value and returns a message
+                string (or None to suppress logging for that value).
         """
         self._log_func = log_func
         self._messages = messages
@@ -393,7 +399,10 @@ class StateChangeLogger:
             return False
         self._has_value = True
         self._current = value
-        message = self._messages.get(value)
+        if callable(self._messages):
+            message = self._messages(value)
+        else:
+            message = self._messages.get(value)
         if message:
             self._log_func(message)
         return True

--- a/picard/log.py
+++ b/picard/log.py
@@ -343,3 +343,57 @@ def enable_default_handlers() -> None:
     history_handler.setFormatter(history_formatter)
 
     history_logger.addHandler(history_handler)
+
+
+class StateChangeLogger:
+    """Logs a message only when a tracked value changes.
+
+    Useful for settings or status flags that are checked repeatedly but
+    should only produce log output when the value actually transitions.
+
+    Example::
+
+        _update_check_logger = log.StateChangeLogger(
+            log.info,
+            {
+                True: "Documentation updates enabled in user settings.",
+                False: "Documentation updates disabled in user settings.",
+            },
+        )
+
+        # Only logs when the value differs from the previous call:
+        _update_check_logger.update(config.setting['check_rtd_updates'])
+    """
+
+    __slots__ = ('_log_func', '_messages', '_current', '_has_value')
+
+    def __init__(self, log_func, messages: dict):
+        """
+        Args:
+            log_func: Logging function to call (e.g. log.info, log.debug).
+            messages: Mapping of value → message string. When the tracked value
+                changes to a key in this dict, the corresponding message is logged.
+                Values not in the dict are tracked silently.
+        """
+        self._log_func = log_func
+        self._messages = messages
+        self._current = None
+        self._has_value = False
+
+    def update(self, value) -> bool:
+        """Update the tracked value. Logs only if the value changed.
+
+        Args:
+            value: The new value to track.
+
+        Returns:
+            True if the value changed, False otherwise.
+        """
+        if self._has_value and value == self._current:
+            return False
+        self._has_value = True
+        self._current = value
+        message = self._messages.get(value)
+        if message:
+            self._log_func(message)
+        return True

--- a/picard/log.py
+++ b/picard/log.py
@@ -404,5 +404,5 @@ class StateChangeLogger:
         else:
             message = self._messages.get(value)
         if message:
-            self._log_func(message)
+            self._log_func(message, stacklevel=2)
         return True

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -32,6 +32,7 @@ from PyQt6.QtCore import (
 )
 
 from picard import log
+from picard.debug_opts import DebugOpt
 
 
 if TYPE_CHECKING:
@@ -498,7 +499,9 @@ class PluginManager(QObject):
             if entry.is_dir() and not entry.name.startswith('.'):
                 plugin = self._load_plugin(plugin_dir, entry.name)
                 if plugin:
-                    log.debug('Found plugin %s in %s', plugin.plugin_id, plugin.local_path)
+                    log.debug_if(
+                        DebugOpt.PLUGIN_DEVELOPMENT, 'Found plugin %s in %s', plugin.plugin_id, plugin.local_path
+                    )
                     self._plugins.append(plugin)
 
         self._plugin_dirs.append(plugin_dir)

--- a/picard/plugin3/manager/lifecycle.py
+++ b/picard/plugin3/manager/lifecycle.py
@@ -31,6 +31,7 @@ from picard import (
     log,
 )
 from picard.config import get_config
+from picard.debug_opts import DebugOpt
 from picard.extension_points import (
     set_plugin_uuid,
     unset_plugin_uuid,
@@ -202,7 +203,8 @@ class PluginLifecycleManager:
             assert plugin.manifest is not None
             compatible_versions = _compatible_api_versions(plugin.manifest.api_versions)
             if compatible_versions:
-                log.debug(
+                log.debug_if(
+                    DebugOpt.PLUGIN_DEVELOPMENT,
                     'Plugin "%s" is compatible (requires API %s, Picard supports %s)',
                     plugin.plugin_id,
                     plugin.manifest.api_versions,

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1036,7 +1036,7 @@ class Tagger(QtWidgets.QApplication):
                     new_files.append(file)
                 QtCore.QCoreApplication.processEvents()
         if new_files:
-            log.debug("Adding files %r", new_files)
+            log.debug("Adding %d files", len(new_files))
             new_files.sort(key=lambda x: x.filename)
             self.window.suspend_while_loading_enter()
             self._pending_files_count += len(new_files)

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -253,7 +253,6 @@ class MainPanel(QtWidgets.QSplitter):
     def set_sorting(self, sort=True):
         if sort != self._sort_enabled:
             self._sort_enabled = sort
-            log.debug("MainPanel sort=%r", sort)
             for view in self._views:
                 view.setSortingEnabled(sort)
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -261,13 +261,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def suspend_while_loading_enter(self):
         for func in self._suspend_while_loading_funcs:
             if func.on_enter:
-                log.debug("enter, running: %r", func.on_enter)
                 func.on_enter()
 
     def suspend_while_loading_exit(self):
         for func in self._suspend_while_loading_funcs:
             if func.on_exit:
-                log.debug("exit, running: %r", func.on_exit)
                 func.on_exit()
 
     def setupUi(self):

--- a/picard/util/readthedocs.py
+++ b/picard/util/readthedocs.py
@@ -262,6 +262,8 @@ class ReadTheDocs:
         cls._update_languages()
         cls._update_versions()
         cls.matched_language = cls._get_language()
-        cls._matched_language_logger.update(cls.matched_language)
         cls.matched_version = cls._get_version()
-        cls._matched_version_logger.update(cls.matched_version)
+        if cls._languages_api.available_items:
+            cls._matched_language_logger.update(cls.matched_language)
+        if cls._versions_api.available_items:
+            cls._matched_version_logger.update(cls.matched_version)

--- a/picard/util/readthedocs.py
+++ b/picard/util/readthedocs.py
@@ -58,6 +58,13 @@ class ReadTheDocs:
 
     THROTTLED_MESSAGE = "Request was throttled."
     _webservice = None
+    _updates_logger = log.StateChangeLogger(
+        log.info,
+        {
+            True: "Documentation updates enabled in user settings.",
+            False: "Documentation updates disabled in user settings.",
+        },
+    )
 
     _languages_api = RtdApiItem('languages', 'translations')
     _versions_api = RtdApiItem('versions', 'versions')
@@ -106,8 +113,9 @@ class ReadTheDocs:
 
         # User has updating disabled
         config = get_config()
-        if not config.setting['check_rtd_updates']:
-            log.info("Updates disabled in user settings.")
+        updates_enabled = config.setting['check_rtd_updates']
+        cls._updates_logger.update(updates_enabled)
+        if not updates_enabled:
             return
 
         api_item.check_in_progress = True

--- a/picard/util/readthedocs.py
+++ b/picard/util/readthedocs.py
@@ -69,6 +69,15 @@ class ReadTheDocs:
     _languages_api = RtdApiItem('languages', 'translations')
     _versions_api = RtdApiItem('versions', 'versions')
 
+    _matched_language_logger = log.StateChangeLogger(
+        log.debug,
+        lambda v: "Matched documentation language set to '%s'" % v,
+    )
+    _matched_version_logger = log.StateChangeLogger(
+        log.debug,
+        lambda v: "Matched documentation version set to '%s'" % v,
+    )
+
     matched_language = READTHEDOCS_BASE_LANGUAGE
     """Best match to available languages"""
 
@@ -161,6 +170,7 @@ class ReadTheDocs:
 
         if cls._versions_api.available_items:
             cls.matched_version = cls._get_version()
+            cls._matched_version_logger.update(cls.matched_version)
 
         cls._versions_api.check_in_progress = False
 
@@ -195,6 +205,7 @@ class ReadTheDocs:
 
         if cls._languages_api.available_items:
             cls.matched_language = cls._get_language()
+            cls._matched_language_logger.update(cls.matched_language)
 
         cls._languages_api.check_in_progress = False
 
@@ -223,8 +234,6 @@ class ReadTheDocs:
                         matched_language = lang
                         break
 
-            log.debug("Matched documentation language set to '%s'", matched_language)
-
         return matched_language
 
     @classmethod
@@ -244,8 +253,6 @@ class ReadTheDocs:
             if version.identifier == 'final' and rtd_version in cls._versions_api.available_items:
                 matched_version = rtd_version
 
-            log.debug("Matched documentation version set to '%s'", matched_version)
-
         return matched_version
 
     @classmethod
@@ -255,4 +262,6 @@ class ReadTheDocs:
         cls._update_languages()
         cls._update_versions()
         cls.matched_language = cls._get_language()
+        cls._matched_language_logger.update(cls.matched_language)
         cls.matched_version = cls._get_version()
+        cls._matched_version_logger.update(cls.matched_version)

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -675,7 +675,8 @@ class WebService(QtCore.QObject):
             redirect = reply.attribute(QNetworkRequest.Attribute.RedirectionTargetAttribute)
             from_cache = reply.attribute(QNetworkRequest.Attribute.SourceIsFromCacheAttribute)
             cached = ' (CACHED)' if from_cache else ''
-            log.debug(
+            log.debug_if(
+                DebugOpt.WS_REPLIES,
                 "Received reply for %s -> %s %d (%s) %s",
                 display_reply_url,
                 proto,

--- a/picard/webservice/ratecontrol.py
+++ b/picard/webservice/ratecontrol.py
@@ -29,6 +29,7 @@ import time
 from typing import TypeAlias
 
 from picard import log
+from picard.debug_opts import DebugOpt
 from picard.webservice.utils import hostkey_from_url
 
 
@@ -116,19 +117,25 @@ def get_delay_to_next_request(hostkey: HostKey) -> tuple[bool, int]:
 
     interval = REQUEST_DELAY[hostkey]
     if not interval:
-        log.debug("%s: Starting another request without delay", hostkey)
+        log.debug_if(DebugOpt.RATECONTROL, "%s: Starting another request without delay", hostkey)
         return (False, 0)
     last_request = LAST_REQUEST_TIMES[hostkey]
     if not last_request:
-        log.debug("%s: First request", hostkey)
+        log.debug_if(DebugOpt.RATECONTROL, "%s: First request", hostkey)
         _remember_request_time(hostkey)  # set it on first run
         return (False, interval)
     elapsed = (time.time() - last_request) * 1000
     if elapsed >= interval:
-        log.debug("%s: Last request was %d ms ago, starting another one", hostkey, elapsed)
+        log.debug_if(DebugOpt.RATECONTROL, "%s: Last request was %d ms ago, starting another one", hostkey, elapsed)
         return (False, interval)
     delay = int(math.ceil(interval - elapsed))
-    log.debug("%s: Last request was %d ms ago, waiting %d ms before starting another one", hostkey, elapsed, delay)
+    log.debug_if(
+        DebugOpt.RATECONTROL,
+        "%s: Last request was %d ms ago, waiting %d ms before starting another one",
+        hostkey,
+        elapsed,
+        delay,
+    )
     return (True, delay)
 
 
@@ -144,14 +151,14 @@ def increment_requests(hostkey: HostKey):
     _remember_request_time(hostkey)
     # Increment the number of unack'd requests on sending a new one
     CONGESTION_UNACK[hostkey] += 1
-    log.debug("%s: Incrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
+    log.debug_if(DebugOpt.RATECONTROL, "%s: Incrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
 
 
 def decrement_requests(hostkey: HostKey):
     """Decrement counter, it has to be called on each reply"""
     assert CONGESTION_UNACK[hostkey] > 0
     CONGESTION_UNACK[hostkey] -= 1
-    log.debug("%s: Decrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
+    log.debug_if(DebugOpt.RATECONTROL, "%s: Decrementing requests to: %d", hostkey, CONGESTION_UNACK[hostkey])
 
 
 def copy_minimal_delay(from_hostkey: HostKey, to_hostkey: HostKey):
@@ -160,7 +167,8 @@ def copy_minimal_delay(from_hostkey: HostKey, to_hostkey: HostKey):
     """
     if from_hostkey in REQUEST_DELAY_MINIMUM and to_hostkey not in REQUEST_DELAY_MINIMUM:
         REQUEST_DELAY_MINIMUM[to_hostkey] = REQUEST_DELAY_MINIMUM[from_hostkey]
-        log.debug(
+        log.debug_if(
+            DebugOpt.RATECONTROL,
             "%s: Copy minimun delay from %s, setting it to %dms",
             to_hostkey,
             from_hostkey,
@@ -194,7 +202,8 @@ def _slow_down(hostkey: HostKey):
     CONGESTION_SSTHRESH[hostkey] = int(CONGESTION_WINDOW_SIZE[hostkey] / 2.0)
     CONGESTION_WINDOW_SIZE[hostkey] = 1.0
 
-    log.debug(
+    log.debug_if(
+        DebugOpt.RATECONTROL,
         '%s: slowdown; delay: %dms -> %dms; ssthresh: %d; cws: %.3f',
         hostkey,
         REQUEST_DELAY[hostkey],
@@ -226,7 +235,8 @@ def _out_of_backoff(hostkey: HostKey):
         cws += 1
 
     if REQUEST_DELAY[hostkey] != delay or CONGESTION_WINDOW_SIZE[hostkey] != cws:
-        log.debug(
+        log.debug_if(
+            DebugOpt.RATECONTROL,
             '%s: oobackoff; delay: %dms -> %dms; %s; window size %.3f -> %.3f',
             hostkey,
             REQUEST_DELAY[hostkey],

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -421,7 +421,7 @@ class StateChangeLoggerTest(PicardTestCase):
 
         self.logged_messages = []
         self.logger = StateChangeLogger(
-            self.logged_messages.append,
+            lambda msg, **kwargs: self.logged_messages.append(msg),
             {
                 True: "Enabled",
                 False: "Disabled",
@@ -458,7 +458,7 @@ class StateChangeLoggerTest(PicardTestCase):
         from picard.log import StateChangeLogger
 
         logger = StateChangeLogger(
-            self.logged_messages.append,
+            lambda msg, **kwargs: self.logged_messages.append(msg),
             {True: "On"},
         )
         changed = logger.update(False)
@@ -469,7 +469,7 @@ class StateChangeLoggerTest(PicardTestCase):
         from picard.log import StateChangeLogger
 
         logger = StateChangeLogger(
-            self.logged_messages.append,
+            lambda msg, **kwargs: self.logged_messages.append(msg),
             lambda v: "Value is %s" % v,
         )
         logger.update("hello")
@@ -481,7 +481,7 @@ class StateChangeLoggerTest(PicardTestCase):
         from picard.log import StateChangeLogger
 
         logger = StateChangeLogger(
-            self.logged_messages.append,
+            lambda msg, **kwargs: self.logged_messages.append(msg),
             lambda v: "Set to %s" % v if v else None,
         )
         changed = logger.update("")

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -464,3 +464,26 @@ class StateChangeLoggerTest(PicardTestCase):
         changed = logger.update(False)
         self.assertTrue(changed)
         self.assertEqual(self.logged_messages, [])
+
+    def test_callable_messages(self):
+        from picard.log import StateChangeLogger
+
+        logger = StateChangeLogger(
+            self.logged_messages.append,
+            lambda v: "Value is %s" % v,
+        )
+        logger.update("hello")
+        logger.update("hello")
+        logger.update("world")
+        self.assertEqual(self.logged_messages, ["Value is hello", "Value is world"])
+
+    def test_callable_messages_returns_none(self):
+        from picard.log import StateChangeLogger
+
+        logger = StateChangeLogger(
+            self.logged_messages.append,
+            lambda v: "Set to %s" % v if v else None,
+        )
+        changed = logger.update("")
+        self.assertTrue(changed)
+        self.assertEqual(self.logged_messages, [])

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -412,3 +412,55 @@ class NameFilterTestEndingSlashWin(PicardTestCase):
         record = FakeRecord(name=None, pathname='C:/path3/module/file.py')
         self.assertTrue(name_filter(record))
         self.assertEqual(record.name, '\\path3\\module\\file')
+
+
+class StateChangeLoggerTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        from picard.log import StateChangeLogger
+
+        self.logged_messages = []
+        self.logger = StateChangeLogger(
+            self.logged_messages.append,
+            {
+                True: "Enabled",
+                False: "Disabled",
+            },
+        )
+
+    def test_first_update_logs(self):
+        changed = self.logger.update(False)
+        self.assertTrue(changed)
+        self.assertEqual(self.logged_messages, ["Disabled"])
+
+    def test_same_value_does_not_log(self):
+        self.logger.update(False)
+        self.logged_messages.clear()
+        changed = self.logger.update(False)
+        self.assertFalse(changed)
+        self.assertEqual(self.logged_messages, [])
+
+    def test_change_logs_new_message(self):
+        self.logger.update(False)
+        self.logged_messages.clear()
+        changed = self.logger.update(True)
+        self.assertTrue(changed)
+        self.assertEqual(self.logged_messages, ["Enabled"])
+
+    def test_multiple_changes(self):
+        self.logger.update(False)
+        self.logger.update(True)
+        self.logger.update(True)
+        self.logger.update(False)
+        self.assertEqual(self.logged_messages, ["Disabled", "Enabled", "Disabled"])
+
+    def test_value_not_in_messages_is_silent(self):
+        from picard.log import StateChangeLogger
+
+        logger = StateChangeLogger(
+            self.logged_messages.append,
+            {True: "On"},
+        )
+        changed = logger.update(False)
+        self.assertTrue(changed)
+        self.assertEqual(self.logged_messages, [])


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Reduce noise in `--debug` log output by gating repetitive messages behind appropriate `DebugOpt` options, adding a `StateChangeLogger` utility for log-on-change semantics, and removing uninformative UI plumbing messages.

## Problem

The `--debug` log output is overwhelmed by repetitive messages that make it hard to find relevant information when users submit debug logs for troubleshooting. Key offenders:
- Rate control messages (increment/decrement/delay on every HTTP request)
- Per-plugin "is compatible" / "Found plugin" lines on every startup
- HTTP reply status on every response
- Repeated "Updates disabled in user settings" messages
- Duplicate "Matched documentation language/version" messages
- Cover art "Skipping provider" for every disabled provider on every album
- UI plumbing (suspend_while_loading, set_sorting) on every batch operation
- Full file list repr in `add_files`

## Solution

1. **Add `StateChangeLogger` utility** (`picard/log.py`): A reusable class that logs a message only when a tracked value transitions. Accepts either a dict of value→message or a callable for dynamic messages. Uses `stacklevel=2` so log source shows the caller.

2. **Add `DebugOpt.RATECONTROL`**: Gates all `webservice/ratecontrol.py` logging (delay calculations, increment/decrement, backoff, congestion window).

3. **Gate plugin loading behind `DebugOpt.PLUGIN_DEVELOPMENT`**: The per-plugin "is compatible" and "Found plugin" messages.

4. **Gate HTTP reply status behind `DebugOpt.WS_REPLIES`**: The "Received reply for..." line that fires on every response.

5. **Gate "Skipping cover art provider" behind `DebugOpt.COVERART`**.

6. **Fix RTD logging**: Use `StateChangeLogger` for "updates enabled/disabled" (log once per state change) and for matched language/version (log only when resolved from API, not on default fallback).

7. **Remove UI plumbing logs**: `suspend_while_loading_enter/exit` and `set_sorting` debug lines.

8. **Shorten `add_files` log**: Show file count instead of full list repr.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

All code was developed through interactive AI-assisted sessions with human review and testing of each change.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
