### PR TITLE
PICARD-3378: Add $get_new() and $get_original() script functions

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -280,6 +280,25 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         with self._lock.lock_for_read():
             return self._store.__contains__(self.normalize_tag(name))
 
+    def get_new(self, name, default=''):
+        """Get a value only from the new metadata.
+
+        On a plain Metadata object this is the same as get().
+        On a MultiMetadataProxy this ignores the readonly fallback.
+        Provides a consistent interface for script functions.
+        """
+        return self.get(name, default)
+
+    def get_original(self, name, default=''):
+        """Get a value from the original (file) metadata.
+
+        On a plain Metadata object this is the same as get() (there is no
+        separate original source).
+        On a MultiMetadataProxy this reads only from the readonly fallback.
+        Provides a consistent interface for script functions.
+        """
+        return self.get(name, default)
+
     def _del(self, name):
         name = self.normalize_tag(name)
         try:
@@ -462,9 +481,11 @@ class MultiMetadataProxy:
 
     def __init__(self, metadata, *readonly_metadata):
         self.metadata = metadata
-        self.combined_metadata = Metadata()
+        self._original_metadata = Metadata()
         for m in reversed(readonly_metadata):
-            self.combined_metadata.update(m)
+            self._original_metadata.update(m)
+        self.combined_metadata = Metadata()
+        self.combined_metadata.update(self._original_metadata)
         self.combined_metadata.update(metadata)
 
     def __getattr__(self, name):
@@ -478,7 +499,7 @@ class MultiMetadataProxy:
                 return attribute
 
     def __setattr__(self, name, value):
-        if name in {'metadata', 'combined_metadata'}:
+        if name in {'metadata', 'combined_metadata', '_original_metadata'}:
             super().__setattr__(name, value)
         else:
             self.metadata.__setattr__(name, value)
@@ -511,6 +532,28 @@ class MultiMetadataProxy:
 
     def __contains__(self, name):
         return self.__read('__contains__', name)
+
+    def get_new(self, name, default=''):
+        """Get a value only from the new (writable) metadata, ignoring fallback.
+
+        This allows distinguishing values that were set by MusicBrainz/scripts
+        from values that only exist in the readonly fallback (file metadata).
+
+        Returns:
+            The value from the new metadata, or default if not present.
+        """
+        return self.metadata.get(name, default)
+
+    def get_original(self, name, default=''):
+        """Get a value only from the readonly (file) metadata, ignoring new metadata.
+
+        This allows accessing the file's original tag values regardless of
+        what MusicBrainz or scripts have set.
+
+        Returns:
+            The value from the readonly file metadata, or default if not present.
+        """
+        return self._original_metadata.get(name, default)
 
     def __repr__(self):
         return self.__read('__repr__')

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -396,6 +396,54 @@ def func_get(parser, name):
 
 
 @script_function(
+    signature=N_("$get_new(name)"),
+    documentation=N_(
+        """Returns the value of the variable `name` from the new metadata only
+(from MusicBrainz or set by a script), ignoring values that only exist in the
+file's original tags.
+
+This is useful to check whether MusicBrainz actually provided a specific tag.
+When a file is matched to a track, `%name%` may return a value from the file's
+existing tags even if MusicBrainz did not provide one. `$get_new` only returns
+the value if it was set by MusicBrainz or by a script.
+
+Example:
+
+    $if($get_new(composer),,$set(composer,$if2(%lyricist%,%writer%,%arranger%)))
+
+This sets the composer from other fields only if MusicBrainz did not provide one,
+regardless of what composer tag the file originally had.
+
+_Since Picard 3.0_"""
+    ),
+)
+def func_get_new(parser, name):
+    """Returns the variable from new (primary/track) metadata only."""
+    return parser.context.get_new(normalize_tagname(name), "")
+
+
+@script_function(
+    signature=N_("$get_original(name)"),
+    documentation=N_(
+        """Returns the value of the variable `name` from the file's original metadata
+only, ignoring values from MusicBrainz or scripts.
+
+This is useful to access the file's existing tag values regardless of what
+MusicBrainz has provided.
+
+Example:
+
+    $set(comment,Original artist was: $get_original(artist))
+
+_Since Picard 3.0_"""
+    ),
+)
+def func_get_original(parser, name):
+    """Returns the variable from original (file) metadata only."""
+    return parser.context.get_original(normalize_tagname(name), "")
+
+
+@script_function(
     signature=N_("$copy(new,old)"),
     documentation=N_(
         """Copies metadata from variable `old` to `new`.

--- a/test/test_script_is_new.py
+++ b/test/test_script_is_new.py
@@ -1,0 +1,149 @@
+"""Tests for the $get_new and $get_original script functions."""
+
+from test.picardtestcase import PicardTestCase
+
+from picard.metadata import (
+    Metadata,
+    MultiMetadataProxy,
+)
+from picard.script.parser import ScriptParser
+
+
+class TestGetNewFunction(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({'enabled_plugins': ''})
+        self.parser = ScriptParser()
+        ScriptParser._cache = {}
+
+    def test_get_new_with_proxy_tag_in_track_metadata(self):
+        """$get_new returns value when tag exists in track/MB metadata."""
+        track_metadata = Metadata()
+        track_metadata['composer'] = 'MB Composer'
+
+        file_metadata = Metadata()
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_new(composer)", proxy)
+        self.assertEqual(result, "MB Composer")
+
+    def test_get_new_with_proxy_tag_only_in_file(self):
+        """$get_new returns empty when tag only exists in file metadata."""
+        track_metadata = Metadata()
+
+        file_metadata = Metadata()
+        file_metadata['composer'] = 'Old File Composer'
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_new(composer)", proxy)
+        self.assertEqual(result, "")
+
+    def test_get_new_with_proxy_tag_in_both(self):
+        """$get_new returns track value when tag exists in both."""
+        track_metadata = Metadata()
+        track_metadata['composer'] = 'MB Composer'
+
+        file_metadata = Metadata()
+        file_metadata['composer'] = 'Old File Composer'
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_new(composer)", proxy)
+        self.assertEqual(result, "MB Composer")
+
+    def test_get_new_with_proxy_tag_nowhere(self):
+        """$get_new returns empty when tag doesn't exist anywhere."""
+        track_metadata = Metadata()
+        file_metadata = Metadata()
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_new(composer)", proxy)
+        self.assertEqual(result, "")
+
+    def test_get_new_with_plain_metadata(self):
+        """$get_new on plain Metadata returns value (same as %name%)."""
+        metadata = Metadata()
+        metadata['composer'] = 'Some Composer'
+
+        result = self.parser.eval("$get_new(composer)", metadata)
+        self.assertEqual(result, "Some Composer")
+
+    def test_get_new_used_in_if_condition(self):
+        """$get_new works in $if for the user's use case."""
+        track_metadata = Metadata()
+        track_metadata['lyricist'] = 'Some Lyricist'
+
+        file_metadata = Metadata()
+        file_metadata['composer'] = 'Old File Composer'
+
+        metadata = Metadata(track_metadata)
+        proxy = MultiMetadataProxy(metadata, file_metadata)
+
+        script = '$if($get_new(composer),,$set(composer,$if2(%lyricist%,%writer%,%arranger%)))'
+        self.parser.eval(script, proxy)
+
+        # Script fires because $get_new(composer) is empty
+        self.assertEqual(metadata['composer'], 'Some Lyricist')
+
+
+class TestGetOriginalFunction(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({'enabled_plugins': ''})
+        self.parser = ScriptParser()
+        ScriptParser._cache = {}
+
+    def test_get_original_with_proxy_tag_in_file(self):
+        """$get_original returns file's value."""
+        track_metadata = Metadata()
+        track_metadata['composer'] = 'MB Composer'
+
+        file_metadata = Metadata()
+        file_metadata['composer'] = 'Old File Composer'
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_original(composer)", proxy)
+        self.assertEqual(result, "Old File Composer")
+
+    def test_get_original_with_proxy_tag_only_in_track(self):
+        """$get_original returns empty when tag only exists in track metadata."""
+        track_metadata = Metadata()
+        track_metadata['composer'] = 'MB Composer'
+
+        file_metadata = Metadata()
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_original(composer)", proxy)
+        self.assertEqual(result, "")
+
+    def test_get_original_with_proxy_tag_nowhere(self):
+        """$get_original returns empty when tag doesn't exist anywhere."""
+        track_metadata = Metadata()
+        file_metadata = Metadata()
+
+        proxy = MultiMetadataProxy(Metadata(track_metadata), file_metadata)
+        result = self.parser.eval("$get_original(composer)", proxy)
+        self.assertEqual(result, "")
+
+    def test_get_original_with_plain_metadata(self):
+        """$get_original on plain Metadata returns value (same as %name%)."""
+        metadata = Metadata()
+        metadata['composer'] = 'Some Composer'
+
+        result = self.parser.eval("$get_original(composer)", metadata)
+        self.assertEqual(result, "Some Composer")
+
+    def test_get_original_use_in_script(self):
+        """$get_original can be used to reference file's original value."""
+        track_metadata = Metadata()
+        track_metadata['artist'] = 'MB Artist'
+
+        file_metadata = Metadata()
+        file_metadata['artist'] = 'File Artist'
+
+        metadata = Metadata(track_metadata)
+        proxy = MultiMetadataProxy(metadata, file_metadata)
+
+        script = '$set(comment,Original: $get_original(artist))'
+        self.parser.eval(script, proxy)
+
+        self.assertEqual(metadata['comment'], 'Original: File Artist')


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add `$get_new(name)` and `$get_original(name)` script functions to explicitly access new (track/MB) or original (file) metadata values.

## Problem

* JIRA ticket: PICARD-3378

Users writing tagger scripts to fill in missing MusicBrainz data run into a confusing situation: `$if(%composer%,,...)` sees file's existing tags through the `MultiMetadataProxy` fallback, making it impossible to check "did MusicBrainz actually provide this tag?"

For example, this common pattern doesn't work as expected:
```
$if(%composer%,,$set(composer,$if2(%lyricist%,%writer%,%arranger%)))
```

If the file already has a composer tag but MB didn't provide one, `%composer%` is non-empty (from the file fallback), so the `$set` never fires.

Related community post: https://community.metabrainz.org/t/tagger-script-not-executing-automatically/815447

## Solution

Add two getter functions that provide explicit access to each metadata source:

- `$get_new(name)`: returns the value from new metadata only (MusicBrainz or set by a script), ignoring the file's original tags.
- `$get_original(name)`: returns the value from the file's original tags only, ignoring new metadata from MusicBrainz or scripts.

The user's script becomes:
```
$if($get_new(composer),,$set(composer,$if2(%lyricist%,%writer%,%arranger%)))
```

Implementation:
- Add `get_new()` and `get_original()` methods to both `Metadata` (trivial pass-through to `get()`) and `MultiMetadataProxy` (checks only the writable or readonly metadata respectively).
- Store the readonly metadata reference in `MultiMetadataProxy` for `get_original()` access.
- 12 tests covering both functions with proxy and plain metadata contexts.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code developed through interactive AI-assisted session with human design decisions, review, and testing.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
