### PR TITLE
PICARD-3382: Expose debug_if() via plugin API as api.logger.debug_if

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -77,6 +77,7 @@ The following classes are available through the `api` module:
 - `Track` - Track object
 - `File` - File base class (for custom formats)
 - `Cluster` - Cluster object
+- `DebugOpt` - Debug option enum for conditional logging
 - `Metadata` - Metadata container for tags
 - `BaseAction` - Base class for UI actions
 - `MetadataTagAction` - Base class for metadata tag context menu actions
@@ -158,19 +159,66 @@ def enable(api):
 
 ---
 
-### `logger: Logger`
+### `logger: PluginLogger`
 
 Plugin-specific logger instance.
 
+Provides standard logging methods (`debug`, `info`, `warning`, `error`, `exception`)
+plus `debug_if()` for conditional debug logging gated on debug options.
+
 ```python
+from picard.plugin3.api import DebugOpt
+
+
 def enable(api):
+    # Standard logging
     api.logger.debug("Debug message")
     api.logger.info("Info message")
     api.logger.warning("Warning message")
     api.logger.error("Error message")
+
+    # Conditional debug logging (only logs when the option is enabled)
+    api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Processing: %s", item)
+
+    # Lazy formatting (expensive_call() only runs if option is enabled)
+    api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, msg_func=lambda: "State: %s" % expensive_call())
+
+    # Block guard — skip expensive code entirely when disabled
+    if dbg := api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+        for item in items:
+            dbg("item: %r", item)
 ```
 
 **Namespace**: Logs are prefixed with `plugin.{module_name}`
+
+#### `debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs)`
+
+Log a debug message only if the specified debug option is enabled. Users enable
+debug options via `--debug-opts=plugin_development` on the command line.
+
+**Parameters**:
+- `debug_opt`: A `DebugOpt` enum value (e.g., `DebugOpt.PLUGIN_DEVELOPMENT`)
+- `msg`: Format string (optional if using as guard or with `msg_func`)
+- `*args`: Arguments for the format string
+- `msg_func`: Callable returning the message string, only called if the option is
+  enabled. Mutually exclusive with `msg`/`args`.
+
+**Returns**: A truthy callable if enabled (can be used as a logger), a falsy no-op
+if disabled. This enables the walrus-operator guard pattern shown above.
+
+#### Available debug options
+
+| Option | Constant | Description |
+|---|---|---|
+| `plugin_development` | `DebugOpt.PLUGIN_DEVELOPMENT` | General plugin development logging |
+| `coverart` | `DebugOpt.COVERART` | Cover art operations |
+| `matching` | `DebugOpt.MATCHING` | Similarity scores and match decisions |
+
+Use `DebugOpt.PLUGIN_DEVELOPMENT` for general plugin debug output. If your plugin
+is specifically related to a domain (cover art, matching, etc.), use the
+corresponding option for consistency with Picard's own logging.
+
+**Import**: `from picard.plugin3.api import DebugOpt`
 
 ---
 

--- a/picard/log.py
+++ b/picard/log.py
@@ -262,7 +262,7 @@ class _NoOpLogger:
 _NOOP_LOGGER = _NoOpLogger()
 
 
-def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
+def debug_if(debug_opt, msg=None, *args, msg_func=None, stacklevel=3, **kwargs):
     """Log a debug message only if the specified debug option is enabled.
 
     Can also be used as a guard that returns a callable logger for blocks
@@ -274,6 +274,8 @@ def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
         *args: Arguments for the message format string
         msg_func: A callable returning the message string. Called only if the
             debug option is enabled. Mutually exclusive with msg/args.
+        stacklevel: How many frames to skip for source location (default 3).
+            Increase by 1 for each additional wrapper frame.
         **kwargs: Additional keyword arguments passed to logger.debug()
 
     Returns:
@@ -297,7 +299,7 @@ def debug_if(debug_opt, msg=None, *args, msg_func=None, **kwargs):
         if msg is not None or msg_func is not None:
             if msg_func is not None:
                 msg = msg_func()
-            logger(msg, *args, stacklevel=3, **kwargs)
+            logger(msg, *args, stacklevel=stacklevel, **kwargs)
         return logger
     return _NOOP_LOGGER
 

--- a/picard/plugin3/api.py
+++ b/picard/plugin3/api.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from picard.cluster import Cluster
+from picard.debug_opts import DebugOpt
 from picard.extension_points.cover_art_processors import ProcessingImage
 from picard.item import MetadataItem
 from picard.plugin3.api_impl import (
@@ -32,6 +33,7 @@ from picard.plugin3.api_impl import (
     MetadataTagAction,
     OptionsPage,
     PluginApi,
+    PluginLogger,
     ProviderOptions,
     Track,
     t_,
@@ -47,6 +49,7 @@ __all__ = [
     'Cluster',
     'CoverArtImage',
     'CoverArtProvider',
+    'DebugOpt',
     'File',
     'ImageInfo',
     'ImageProcessor',
@@ -56,6 +59,7 @@ __all__ = [
     'OptionsPage',
     'PageOptionConfigs',
     'PluginApi',
+    'PluginLogger',
     'ProcessingImage',
     'ProviderOptions',
     'ScriptParser',

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -202,9 +202,9 @@ class MetadataTagAction(_MetadataTagAction):
 class PluginLogger:
     """Wrapper around :class:`logging.Logger` that adds :meth:`debug_if`.
 
-    Delegates all standard logging methods (debug, info, warning, error, etc.)
-    to the underlying logger via ``__getattr__`` while providing access to
-    Picard's conditional debug logging.
+    Standard logging methods are defined explicitly for editor autocompletion
+    and type checking.  Any other attribute access (e.g. ``name``,
+    ``setLevel``) is forwarded to the underlying :class:`logging.Logger`.
     """
 
     __slots__ = ('_underlying_logger',)
@@ -247,6 +247,26 @@ class PluginLogger:
                     dbg("item: %r", item)
         """
         return log.debug_if(debug_opt, msg, *args, msg_func=msg_func, stacklevel=4, **kwargs)
+
+    def debug(self, msg, *args, **kwargs):
+        """Log a message with level DEBUG."""
+        self._underlying_logger.debug(msg, *args, stacklevel=2, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        """Log a message with level INFO."""
+        self._underlying_logger.info(msg, *args, stacklevel=2, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """Log a message with level WARNING."""
+        self._underlying_logger.warning(msg, *args, stacklevel=2, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        """Log a message with level ERROR."""
+        self._underlying_logger.error(msg, *args, stacklevel=2, **kwargs)
+
+    def exception(self, msg, *args, **kwargs):
+        """Log a message with level ERROR, including exception info."""
+        self._underlying_logger.exception(msg, *args, stacklevel=2, **kwargs)
 
 
 class PluginApi:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -199,6 +199,56 @@ class MetadataTagAction(_MetadataTagAction):
     api: 'PluginApi'
 
 
+class PluginLogger:
+    """Wrapper around :class:`logging.Logger` that adds :meth:`debug_if`.
+
+    Delegates all standard logging methods (debug, info, warning, error, etc.)
+    to the underlying logger via ``__getattr__`` while providing access to
+    Picard's conditional debug logging.
+    """
+
+    __slots__ = ('_underlying_logger',)
+
+    def __init__(self, logger: Logger):
+        self._underlying_logger = logger
+
+    def __getattr__(self, name):
+        return getattr(self._underlying_logger, name)
+
+    def debug_if(self, debug_opt: DebugOpt, msg=None, *args, msg_func=None, **kwargs):
+        """Log a debug message only if the specified debug option is enabled.
+
+        Can also be used as a guard that returns a callable logger for blocks
+        of debug statements.
+
+        Args:
+            debug_opt: A :class:`DebugOpt` enum value to check
+            msg: The message format string
+            *args: Arguments for the message format string
+            msg_func: A callable returning the message string. Called only if
+                the debug option is enabled. Mutually exclusive with msg/args.
+            **kwargs: Additional keyword arguments passed to logger.debug()
+
+        Returns:
+            A truthy callable logger if the debug option is enabled,
+            a falsy no-op otherwise.
+
+        Examples:
+            # Single message
+            api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Processing: %s", item)
+
+            # Lazy formatting with msg_func
+            api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT,
+                                msg_func=lambda: "State: %s" % expensive())
+
+            # Block guard to skip expensive code entirely when disabled
+            if dbg := api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+                for item in items:
+                    dbg("item: %r", item)
+        """
+        return log.debug_if(debug_opt, msg, *args, msg_func=msg_func, stacklevel=4, **kwargs)
+
+
 class PluginApi:
     # Class-level registries for get_api()
     _instances: ClassVar[dict[str, 'PluginApi']] = {}  # Maps module name -> PluginApi instance
@@ -211,7 +261,7 @@ class PluginApi:
         self._plugin_module: types.ModuleType | None = None  # Will be set when plugin is enabled
         self._plugin_id = manifest.module_name
         full_name = f'plugin.{self._manifest.uuid}'
-        self._logger = getLogger(f'main.plugin.{self._manifest.module_name}')
+        self._logger = PluginLogger(getLogger(f'main.plugin.{self._manifest.module_name}'))
         self._api_config = ProfileConfigSection(get_config(), full_name)
         self._api_config.display_name = manifest.name()
         self._api_persist = ConfigSection(get_config(), f'plugin_persist.{self._manifest.uuid}')
@@ -496,14 +546,18 @@ class PluginApi:
         return self._mb_api
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> PluginLogger:
         """Plugin-specific logger instance.
 
         Log messages are namespaced under ``plugin.{module_name}`` so that
         output can be attributed to the originating plugin.
 
+        Provides standard logging methods (debug, info, warning, error) plus
+        :meth:`~PluginLogger.debug_if` for conditional debug logging gated
+        on :class:`~picard.debug_opts.DebugOpt` options.
+
         Returns:
-            Logger: The logger instance for this plugin.
+            PluginLogger: The logger instance for this plugin.
 
         Example:
             def enable(api):
@@ -511,6 +565,9 @@ class PluginApi:
                 api.logger.info("Info message")
                 api.logger.warning("Warning message")
                 api.logger.error("Error message")
+
+                # Conditional debug (only logs if option is enabled)
+                api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Details: %s", data)
         """
         return self._logger
 

--- a/test/plugins3/test_plugin_logger.py
+++ b/test/plugins3/test_plugin_logger.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 The MusicBrainz Picard Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import logging
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+from test.picardtestcase import PicardTestCase
+from test.plugins3.helpers import load_plugin_manifest
+
+from picard.debug_opts import DebugOpt
+from picard.plugin3.api import (
+    DebugOpt as ApiDebugOpt,
+    PluginApi,
+    PluginLogger,
+)
+from picard.plugin3.api_impl import PluginLogger as ImplPluginLogger
+
+
+class TestPluginLoggerExports(PicardTestCase):
+    """Test that DebugOpt and PluginLogger are properly exported from the API."""
+
+    def test_debug_opt_exported(self):
+        """DebugOpt should be importable from picard.plugin3.api."""
+        self.assertIs(ApiDebugOpt, DebugOpt)
+
+    def test_plugin_logger_exported(self):
+        """PluginLogger should be importable from picard.plugin3.api."""
+        self.assertIs(PluginLogger, ImplPluginLogger)
+
+
+class TestPluginLogger(PicardTestCase):
+    """Test PluginLogger wrapper class."""
+
+    def setUp(self):
+        super().setUp()
+        self._underlying = logging.getLogger('test.plugin.myplugin')
+        self._logger = ImplPluginLogger(self._underlying)
+
+    def test_delegates_standard_methods(self):
+        """Standard logging methods should be delegated to the underlying logger."""
+        with patch.object(self._underlying, 'debug') as mock_debug:
+            self._logger.debug("test %s", "msg")
+            mock_debug.assert_called_once_with("test %s", "msg")
+
+        with patch.object(self._underlying, 'info') as mock_info:
+            self._logger.info("info %s", "msg")
+            mock_info.assert_called_once_with("info %s", "msg")
+
+        with patch.object(self._underlying, 'warning') as mock_warning:
+            self._logger.warning("warn %s", "msg")
+            mock_warning.assert_called_once_with("warn %s", "msg")
+
+    def test_delegates_attributes(self):
+        """Attributes like name should be delegated to the underlying logger."""
+        self.assertEqual(self._logger.name, 'test.plugin.myplugin')
+
+    def test_debug_if_enabled(self):
+        """debug_if should log when the debug option is enabled."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = True
+        try:
+            with patch('picard.log.main_logger'):
+                result = self._logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "test %s", "value")
+                self.assertTrue(result)
+        finally:
+            DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+
+    def test_debug_if_disabled(self):
+        """debug_if should not log when the debug option is disabled."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+        with patch('picard.log.main_logger') as mock_main:
+            result = self._logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "test %s", "value")
+            self.assertFalse(result)
+            mock_main.debug.assert_not_called()
+
+    def test_debug_if_guard_pattern(self):
+        """debug_if should work as a block guard (walrus operator pattern)."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = True
+        try:
+            if dbg := self._logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
+                self.assertTrue(dbg)
+                # Should be callable
+                dbg("item: %r", "test")
+        finally:
+            DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+
+    def test_debug_if_guard_disabled(self):
+        """debug_if guard should be falsy when disabled."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+        result = self._logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT)
+        self.assertFalse(result)
+        # No-op logger should still be callable without error
+        result("should not crash: %s", "test")
+
+    def test_debug_if_msg_func(self):
+        """debug_if should support msg_func for lazy formatting."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = True
+        expensive_called = False
+
+        def expensive():
+            nonlocal expensive_called
+            expensive_called = True
+            return "expensive result"
+
+        try:
+            with patch('picard.log.main_logger'):
+                self._logger.debug_if(
+                    DebugOpt.PLUGIN_DEVELOPMENT,
+                    msg_func=lambda: "Result: %s" % expensive(),
+                )
+                self.assertTrue(expensive_called)
+        finally:
+            DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+
+    def test_debug_if_msg_func_not_called_when_disabled(self):
+        """msg_func should not be called when the debug option is disabled."""
+        DebugOpt.PLUGIN_DEVELOPMENT.enabled = False
+        expensive_called = False
+
+        def expensive():
+            nonlocal expensive_called
+            expensive_called = True
+            return "expensive result"
+
+        self._logger.debug_if(
+            DebugOpt.PLUGIN_DEVELOPMENT,
+            msg_func=lambda: "Result: %s" % expensive(),
+        )
+        self.assertFalse(expensive_called)
+
+
+class TestPluginApiLogger(PicardTestCase):
+    """Test that PluginApi.logger returns a PluginLogger."""
+
+    def test_logger_is_plugin_logger(self):
+        """api.logger should return a PluginLogger instance."""
+        api = PluginApi(load_plugin_manifest('example'), Mock())
+        self.assertIsInstance(api.logger, ImplPluginLogger)
+
+    def test_logger_has_debug_if(self):
+        """api.logger should have a debug_if method."""
+        api = PluginApi(load_plugin_manifest('example'), Mock())
+        self.assertTrue(hasattr(api.logger, 'debug_if'))
+        self.assertTrue(callable(api.logger.debug_if))

--- a/test/plugins3/test_plugin_logger.py
+++ b/test/plugins3/test_plugin_logger.py
@@ -57,18 +57,18 @@ class TestPluginLogger(PicardTestCase):
         self._logger = ImplPluginLogger(self._underlying)
 
     def test_delegates_standard_methods(self):
-        """Standard logging methods should be delegated to the underlying logger."""
+        """Standard logging methods should delegate to the underlying logger."""
         with patch.object(self._underlying, 'debug') as mock_debug:
             self._logger.debug("test %s", "msg")
-            mock_debug.assert_called_once_with("test %s", "msg")
+            mock_debug.assert_called_once_with("test %s", "msg", stacklevel=2)
 
         with patch.object(self._underlying, 'info') as mock_info:
             self._logger.info("info %s", "msg")
-            mock_info.assert_called_once_with("info %s", "msg")
+            mock_info.assert_called_once_with("info %s", "msg", stacklevel=2)
 
         with patch.object(self._underlying, 'warning') as mock_warning:
             self._logger.warning("warn %s", "msg")
-            mock_warning.assert_called_once_with("warn %s", "msg")
+            mock_warning.assert_called_once_with("warn %s", "msg", stacklevel=2)
 
     def test_delegates_attributes(self):
         """Attributes like name should be delegated to the underlying logger."""

--- a/test/plugins3/test_translations.py
+++ b/test/plugins3/test_translations.py
@@ -170,7 +170,7 @@ class TestPluginTranslationLoading(PicardTestCase):
                 api._plugin_dir = plugin_dir
                 api.get_locale = Mock(return_value='en')
 
-                with self.assertLogs(api._logger, level='WARNING') as cm:
+                with self.assertLogs('main.plugin.test', level='WARNING') as cm:
                     api._load_translations()
 
                 self.assertTrue(any('nested structure' in msg.lower() for msg in cm.output))


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Expose `debug_if()` to plugin authors via `api.logger.debug_if()`, and export the `DebugOpt` enum from the plugin API so plugins can reduce log noise by gating verbose debug output on debug options.

## Problem

* JIRA ticket: [PICARD-3382](https://tickets.metabrainz.org/browse/PICARD-3382)

Plugin authors have no way to use conditional debug logging (`debug_if`) through the plugin API. The only option is unconditional `api.logger.debug()`, which creates noise in the log output even when the user is not interested in plugin-level debug details.

## Solution

- Add a `PluginLogger` wrapper class in `api_impl.py` that wraps the standard `logging.Logger` and adds a `debug_if()` method delegating to `picard.log.debug_if()`.
- Export `DebugOpt` from `picard.plugin3.api` so plugins can import it directly.
- Add a `stacklevel` parameter to `log.debug_if()` (default unchanged at 3) so wrappers can report correct source locations.
- Update `docs/PLUGINSV3/API.md` with usage documentation.
- Add tests in `test/plugins3/test_plugin_logger.py`.

Usage:
```python
from picard.plugin3.api import DebugOpt, PluginApi

def enable(api: PluginApi):
    api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT, "Details: %s", data)

    if dbg := api.logger.debug_if(DebugOpt.PLUGIN_DEVELOPMENT):
        for item in items:
            dbg("item: %r", item)
```

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code, tests, and documentation were developed with AI assistance (Kiro CLI), with human review and direction throughout.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
