### PR TITLE
PICARD-3381: Add RHEL rcc search path

### DIFF
--- a/resources/compile.py
+++ b/resources/compile.py
@@ -50,7 +50,7 @@ def main():
     qrcfile = os.path.join(topdir, "resources", "picard.qrc")
     if newer(qrcfile, pyfile):
         rcc = 'rcc'
-        rcc_path = which(rcc, path='/usr/lib/qt6/libexec/') or which(rcc)
+        rcc_path = which(rcc, path='/usr/lib64/qt6/libexec/') or which(rcc, path='/usr/lib/qt6/libexec/') or which(rcc)
         if rcc_path is None:
             log.error("%s command not found, cannot build resource file !", rcc)
         else:


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

**Describe this change in 1-2 sentences**:

Adds '/usr/lib64/qt6/libexec/' to the explicit QT6 rcc search path to satisfy RHEL distros.

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Fixes a setup.py issue whereby older (QT4/5) rcc versions cannot parse the '-g' flag and fail.

* JIRA ticket (_optional_): PICARD-3381
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Adds '/usr/lib64/qt6/libexec/' to the explicit QT6 rcc search path to satisfy RHEL distros that also
default to QT4/QT5. This path wasn't being searched and system rcc on Fedora 44 points to QT4.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
