### PR TITLE
PICARD-3380: Add "Remove cover images from tags" option

### DIFF
--- a/picard/coverart/__init__.py
+++ b/picard/coverart/__init__.py
@@ -84,6 +84,7 @@ class CoverArt:
         'save_images_to_tags',
         'save_images_to_files',
         'save_images_overwrite',
+        'remove_images_from_tags',
         'cover_image_filename',
         'image_type_as_filename',
         'filter_cover_by_size',

--- a/picard/coverart/setters/__init__.py
+++ b/picard/coverart/setters/__init__.py
@@ -38,10 +38,7 @@
 from enum import IntEnum
 
 from picard import log
-from picard.config import get_config
 from picard.coverart.image import CoverArtImage
-from picard.coverart.processing.filters import filter_image_for_file
-from picard.debug_opts import DebugOpt
 from picard.file import File
 from picard.item import MetadataItem
 
@@ -97,8 +94,9 @@ class CoverArtSetter:
         """
         Set the cover art image on an object based on the current mode.
 
-        For File objects, applies per-file "never replace" filters when
-        save_images_to_tags is enabled.
+        Per-file "never replace" filters are applied later, when tags are
+        actually saved (see `ImageList.to_be_saved_to_tags`), so the image is
+        always appended here and remains available for external file saving.
 
         Parameters
         ----------
@@ -108,24 +106,8 @@ class CoverArtSetter:
         Returns
         -------
         bool
-            True if the image was set, False if filtered out
+            True if the image was set
         """
-        if isinstance(obj, File) and get_config().setting['save_images_to_tags']:
-            if not filter_image_for_file(self.coverartimage, obj.orig_metadata.images):
-                log.debug_if(
-                    DebugOpt.COVERART,
-                    "Per-file filter rejected %r for %r",
-                    self.coverartimage,
-                    obj,
-                )
-                return False
-            log.debug_if(
-                DebugOpt.COVERART,
-                "Per-file filter accepted %r for %r",
-                self.coverartimage,
-                obj,
-            )
-
         attrs_to_update = ['metadata']
         # Update original metadata, if requested, but not for files unless they
         # are the source object.

--- a/picard/file.py
+++ b/picard/file.py
@@ -767,10 +767,8 @@ class File(MetadataItem):
 
     def _save_images(self, dirname, metadata):
         """Save the cover images to disk."""
-        if not metadata.images:
-            return
         counters = Counter()
-        for image in metadata.images.to_be_saved_to_files():
+        for image in metadata.images.to_be_saved_to_files(previous_images=self.orig_metadata.images):
             image.save(dirname, metadata, counters)
 
     def _move_additional_files(self, old_filename, new_filename, config):

--- a/picard/file.py
+++ b/picard/file.py
@@ -585,6 +585,22 @@ class File(MetadataItem):
             self._save_images(os.path.dirname(new_filename), metadata)
         return new_filename
 
+    def _expected_embedded_images(self) -> 'ImageList':
+        """Images that should end up embedded in tags for the current metadata.
+
+        Mirrors the rules applied when actually saving (see ImageList): per-file
+        "never replace" filters may reject a new image for tags, or
+        remove_images_from_tags may clear tags entirely while the image is kept
+        only as an external file (and, for the CoverArtBox, in self.metadata).
+        """
+        images_to_save = list(self.metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
+        if images_to_save:
+            return ImageList(images_to_save)
+        elif self.metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images):
+            return ImageList()
+        else:
+            return self.orig_metadata.images.copy()
+
     def _saving_finished(self, result=None, error=None):
         # Handle file removed before save
         # Result is None if save was skipped
@@ -599,18 +615,7 @@ class File(MetadataItem):
             length = self.orig_metadata.length
             temp_info = {}
             self._copy_file_info_tags(temp_info, self.orig_metadata)
-            # Determine what images actually ended up embedded in tags, using the
-            # same rules the format save code applies (see ImageList). This can
-            # differ from self.metadata.images alone: per-file "never replace"
-            # filters may reject a new image for tags, or remove_images_from_tags
-            # may have cleared tags while the image was kept as an external file.
-            images_to_save = list(self.metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
-            if images_to_save:
-                embedded_images = ImageList(images_to_save)
-            elif self.metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images):
-                embedded_images = ImageList()
-            else:
-                embedded_images = self.orig_metadata.images.copy()
+            embedded_images = self._expected_embedded_images()
             images_changed = self.orig_metadata.images != embedded_images
             # Copy new metadata to original metadata, applying format specific
             # conversions (e.g. for ID3v2.3)
@@ -962,7 +967,7 @@ class File(MetadataItem):
             else:
                 self.similarity = 1.0
                 if self.state in (File.State.CHANGED, File.State.NORMAL):
-                    if self.metadata.images and self.orig_metadata.images != self.metadata.images:
+                    if self.metadata.images and self.orig_metadata.images != self._expected_embedded_images():
                         self.state = File.State.CHANGED
                     else:
                         self.state = File.State.NORMAL

--- a/picard/file.py
+++ b/picard/file.py
@@ -117,6 +117,7 @@ from picard.util.filenaming import (
     make_short_filename,
     move_ensure_casing,
 )
+from picard.util.imagelist import ImageList
 from picard.util.scripttofilename import script_to_filename_with_metadata
 
 from picard.ui.filter import Filter
@@ -598,7 +599,19 @@ class File(MetadataItem):
             length = self.orig_metadata.length
             temp_info = {}
             self._copy_file_info_tags(temp_info, self.orig_metadata)
-            images_changed = self.orig_metadata.images != self.metadata.images
+            # Determine what images actually ended up embedded in tags, using the
+            # same rules the format save code applies (see ImageList). This can
+            # differ from self.metadata.images alone: per-file "never replace"
+            # filters may reject a new image for tags, or remove_images_from_tags
+            # may have cleared tags while the image was kept as an external file.
+            images_to_save = list(self.metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
+            if images_to_save:
+                embedded_images = ImageList(images_to_save)
+            elif self.metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images):
+                embedded_images = ImageList()
+            else:
+                embedded_images = self.orig_metadata.images.copy()
+            images_changed = self.orig_metadata.images != embedded_images
             # Copy new metadata to original metadata, applying format specific
             # conversions (e.g. for ID3v2.3)
             config = get_config()
@@ -607,6 +620,10 @@ class File(MetadataItem):
                 self.orig_metadata = new_metadata
             else:
                 self.orig_metadata.update(new_metadata)
+            # Metadata.update() (and the plain replace above) leave images
+            # untouched when the new list is empty, but an empty result here is
+            # exactly what "removed from tags" means, so set it explicitly.
+            self.orig_metadata.images = embedded_images
             # After saving deleted tags should no longer be marked deleted
             self.metadata.clear_deleted()
             self.orig_metadata.clear_deleted()

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -203,8 +203,8 @@ class APEv2File(File):
             tags = mutagen.apev2.APEv2(filename)
         except mutagen.apev2.APENoHeaderError:
             tags = mutagen.apev2.APEv2()
-        images_to_save = list(metadata.images.to_be_saved_to_tags())
-        remove_images = metadata.images.should_remove_images_from_tags()
+        images_to_save = list(metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
+        remove_images = metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images)
         if config.setting['clear_existing_tags']:
             preserved = []
             if not remove_images and config.setting['preserve_images']:

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -204,14 +204,15 @@ class APEv2File(File):
         except mutagen.apev2.APENoHeaderError:
             tags = mutagen.apev2.APEv2()
         images_to_save = list(metadata.images.to_be_saved_to_tags())
+        remove_images = metadata.images.should_remove_images_from_tags()
         if config.setting['clear_existing_tags']:
             preserved = []
-            if config.setting['preserve_images']:
+            if not remove_images and config.setting['preserve_images']:
                 preserved = list(self._iter_cover_art_tags(tags))
             tags.clear()
             for name, value in preserved:
                 tags[name] = value
-        elif images_to_save:
+        elif images_to_save or remove_images:
             for name, _value in self._iter_cover_art_tags(tags):
                 del tags[name]
         temp = {}

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -283,6 +283,8 @@ class ASFFile(File):
             cover.append(ASFByteArrayAttribute(tag_data))
         if cover:
             tags['WM/Picture'] = cover
+        elif 'WM/Picture' in tags and metadata.images.should_remove_images_from_tags():
+            del tags['WM/Picture']
         for name, values in metadata.rawitems():
             if name.startswith('lyrics:'):
                 name = 'lyrics'

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -278,12 +278,14 @@ class ASFFile(File):
             if cover:
                 tags['WM/Picture'] = cover
         cover = []
-        for image in metadata.images.to_be_saved_to_tags():
+        for image in metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images):
             tag_data = pack_image(image.mimetype, image.data, image.id3_type, image.comment)
             cover.append(ASFByteArrayAttribute(tag_data))
         if cover:
             tags['WM/Picture'] = cover
-        elif 'WM/Picture' in tags and metadata.images.should_remove_images_from_tags():
+        elif 'WM/Picture' in tags and metadata.images.should_remove_images_from_tags(
+            previous_images=self.orig_metadata.images
+        ):
             del tags['WM/Picture']
         for name, values in metadata.rawitems():
             if name.startswith('lyrics:'):

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -763,9 +763,9 @@ class ID3File(File):
 
     def _save_images_to_tags(self, tags, metadata):
         """Save cover art images to tags."""
-        images_to_save = list(metadata.images.to_be_saved_to_tags())
+        images_to_save = list(metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
         if not images_to_save:
-            if metadata.images.should_remove_images_from_tags():
+            if metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images):
                 tags.delall('APIC')
             return
 

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -765,6 +765,8 @@ class ID3File(File):
         """Save cover art images to tags."""
         images_to_save = list(metadata.images.to_be_saved_to_tags())
         if not images_to_save:
+            if metadata.images.should_remove_images_from_tags():
+                tags.delall('APIC')
             return
 
         tags.delall('APIC')

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -353,6 +353,8 @@ class MP4File(File):
                 covr.append(MP4Cover(image.data, MP4Cover.FORMAT_PNG))
         if covr:
             tags['covr'] = covr
+        elif 'covr' in tags and metadata.images.should_remove_images_from_tags():
+            del tags['covr']
 
         self._remove_deleted_tags(metadata, tags)
 

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -346,14 +346,16 @@ class MP4File(File):
                 tags['disk'] = [(discnumber, totaldiscs)]
 
         covr = []
-        for image in metadata.images.to_be_saved_to_tags():
+        for image in metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images):
             if image.mimetype == 'image/jpeg':
                 covr.append(MP4Cover(image.data, MP4Cover.FORMAT_JPEG))
             elif image.mimetype == 'image/png':
                 covr.append(MP4Cover(image.data, MP4Cover.FORMAT_PNG))
         if covr:
             tags['covr'] = covr
-        elif 'covr' in tags and metadata.images.should_remove_images_from_tags():
+        elif 'covr' in tags and metadata.images.should_remove_images_from_tags(
+            previous_images=self.orig_metadata.images
+        ):
             del tags['covr']
 
         self._remove_deleted_tags(metadata, tags)

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -272,7 +272,7 @@ class VCommentFile(File):
         if file.tags is None:
             file.add_tags()
         assert file.tags is not None
-        remove_images = metadata.images.should_remove_images_from_tags()
+        remove_images = metadata.images.should_remove_images_from_tags(previous_images=self.orig_metadata.images)
         if config.setting['clear_existing_tags']:
             preserve_tags = ['waveformatextensible_channel_mask']
             if not is_flac and not remove_images and config.setting['preserve_images']:
@@ -285,7 +285,7 @@ class VCommentFile(File):
             file.tags.clear()
             for name, value in preserved_values.items():
                 file.tags[name] = value
-        images_to_save = list(metadata.images.to_be_saved_to_tags())
+        images_to_save = list(metadata.images.to_be_saved_to_tags(previous_images=self.orig_metadata.images))
         if is_flac and (
             images_to_save
             or remove_images

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -272,9 +272,10 @@ class VCommentFile(File):
         if file.tags is None:
             file.add_tags()
         assert file.tags is not None
+        remove_images = metadata.images.should_remove_images_from_tags()
         if config.setting['clear_existing_tags']:
             preserve_tags = ['waveformatextensible_channel_mask']
-            if not is_flac and config.setting['preserve_images']:
+            if not is_flac and not remove_images and config.setting['preserve_images']:
                 preserve_tags.append('metadata_block_picture')
                 preserve_tags.append('coverart')
             preserved_values = {}
@@ -286,9 +287,15 @@ class VCommentFile(File):
                 file.tags[name] = value
         images_to_save = list(metadata.images.to_be_saved_to_tags())
         if is_flac and (
-            images_to_save or (config.setting['clear_existing_tags'] and not config.setting['preserve_images'])
+            images_to_save
+            or remove_images
+            or (config.setting['clear_existing_tags'] and not config.setting['preserve_images'])
         ):
             file.clear_pictures()
+        elif not is_flac and not images_to_save and remove_images:
+            for name in ('metadata_block_picture', 'coverart'):
+                if name in file.tags:
+                    del file.tags[name]
         tags = {}
 
         for name, value in metadata.items():

--- a/picard/options.py
+++ b/picard/options.py
@@ -239,6 +239,7 @@ BoolOption(
 BoolOption('setting', 'save_images_overwrite', False, title=N_("Overwrite existing image files"), in_profile=True)
 BoolOption('setting', 'save_images_to_files', False, title=N_("Save images as separate files"), in_profile=True)
 BoolOption('setting', 'save_images_to_tags', True, title=N_("Embed images into tags"), in_profile=True)
+BoolOption('setting', 'remove_images_from_tags', False, title=N_("Remove images from tags"), in_profile=True)
 BoolOption('setting', 'save_only_one_front_image', False, title=N_("Save only one front image"), in_profile=True)
 BoolOption('setting', 'show_cover_art_details', False, title=N_("Show cover art details in view"), in_profile=True)
 BoolOption('setting', 'show_cover_art_details_type', False, title=N_("Show cover art type"), in_profile=True)

--- a/picard/track.py
+++ b/picard/track.py
@@ -63,7 +63,6 @@ from picard.const import (
     SILENCE_TRACK_TITLE,
     VARIOUS_ARTISTS_ID,
 )
-from picard.debug_opts import DebugOpt
 from picard.file import (
     run_file_post_addition_to_track_processors,
     run_file_post_removal_from_track_processors,
@@ -211,24 +210,10 @@ class Track(FileListItem):
         # Apply changes to the track's metadata done manually after the scripts ran
         meta_diff = self.metadata.diff(self.scripted_metadata)
         metadata.update(meta_diff)
-        # Images are not affected by scripting, always use the tracks current images
-        # Apply per-file "never replace" filters against the file's original embedded images
-        if config.setting['save_images_to_tags']:
-            # import here to avoid circular imports
-            from picard.coverart.processing.filters import filter_image_for_file
-
-            metadata.images = self.metadata.images.copy()
-            for image in list(metadata.images):
-                if not filter_image_for_file(image, file.orig_metadata.images):
-                    log.debug_if(
-                        DebugOpt.COVERART,
-                        "update_file_metadata: filtered out %r for %r",
-                        image,
-                        file,
-                    )
-                    metadata.images.remove(image)
-        else:
-            metadata.images = self.metadata.images
+        # Images are not affected by scripting, always use the tracks current images.
+        # Per-file "never replace" filters are applied later, at tag-save time
+        # (see ImageList.to_be_saved_to_tags), so external file saving is unaffected.
+        metadata.images = self.metadata.images
         file.copy_metadata(metadata)
         file.update(signal=False)
         self.update()

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -52,6 +52,7 @@ from picard import (
     log,
     tagger_instance,
 )
+from picard.cluster import Cluster
 from picard.config import get_config
 from picard.coverart.image import (
     CoverArtImage,
@@ -276,8 +277,13 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
         # Predict whether saving will strip cover art already embedded in tags,
         # using the same rules the format save code applies (see ImageList).
+        # Only show the removal indicator for items in the right pane (matched
+        # to an album/track). Files still in a cluster (left pane) haven't been
+        # matched yet, so the warning would be premature.
+        is_unmatched = isinstance(getattr(self.item, 'parent_item', None), Cluster)
         self._removal_predicted = bool(
-            metadata
+            not is_unmatched
+            and metadata
             and orig_metadata
             and orig_metadata.images
             and metadata.images.should_remove_images_from_tags(previous_images=orig_metadata.images)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -69,7 +69,10 @@ from picard.util import (
 )
 from picard.util.lrucache import LRUCache
 
-from .coverartthumbnail import CoverArtThumbnail
+from .coverartthumbnail import (
+    THUMBNAIL_WIDTH,
+    CoverArtThumbnail,
+)
 from .imageurldialog import ImageURLDialog
 
 from picard.ui.util import FileDialog
@@ -109,6 +112,15 @@ class CoverArtBox(QtWidgets.QGroupBox):
             QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
         )
         self.orig_cover_art_info_label.setWordWrap(True)
+        self.cover_removal_warning_label = QtWidgets.QLabel('')
+        self.cover_removal_warning_label.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
+        )
+        self.cover_removal_warning_label.setWordWrap(True)
+        # Keep wrapping within the thumbnail column instead of widening the box
+        self.cover_removal_warning_label.setMaximumWidth(THUMBNAIL_WIDTH)
+        self.cover_removal_warning_label.setStyleSheet('QLabel { color: #a00000; font-weight: bold; }')
+        self.cover_removal_warning_label.setHidden(True)
         self.show_details_button = QtWidgets.QPushButton(_('Show more details'), self)
         self.show_details_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(_("Ctrl+Shift+I")), self, self.show_cover_art_info
@@ -119,6 +131,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.layout.addWidget(self.orig_cover_art_label)
         self.layout.addWidget(self.orig_cover_art)
         self.layout.addWidget(self.orig_cover_art_info_label)
+        self.layout.addWidget(self.cover_removal_warning_label)
         self.layout.addWidget(self.show_details_button)
         self.layout.addSpacerItem(spacerItem)
         self.setLayout(self.layout)
@@ -182,6 +195,12 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.cover_art.setToolTip("<br/>".join(tooltip_cover_lines))
         self.orig_cover_art.setToolTip("<br/>".join(tooltip_orig_lines))
 
+        removal_warning_label = getattr(self, 'cover_removal_warning_label', None)
+        if removal_warning_label is not None:
+            removal_predicted = getattr(self, '_removal_predicted', False)
+            removal_warning_label.setText(_("\u26a0 Cover art will be removed from tags") if removal_predicted else '')
+            removal_warning_label.setVisible(removal_predicted)
+
     def set_item(self, item):
         if not item.can_show_coverart:
             self.cover_art.set_metadata(None)
@@ -209,6 +228,16 @@ class CoverArtBox(QtWidgets.QGroupBox):
         else:
             self.cover_art.set_metadata(metadata)
         self.orig_cover_art.set_metadata(orig_metadata)
+
+        # Predict whether saving will strip cover art already embedded in tags,
+        # using the same rules the format save code applies (see ImageList).
+        self._removal_predicted = bool(
+            metadata
+            and orig_metadata
+            and orig_metadata.images
+            and metadata.images.should_remove_images_from_tags()
+            and not list(metadata.images.to_be_saved_to_tags())
+        )
         self.update_display()
 
     @staticmethod

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -84,6 +84,15 @@ HTML_IMG_SRC_REGEX = re.compile(r'<img .*?src="(.*?)"', re.UNICODE)
 
 
 class CoverArtBox(QtWidgets.QGroupBox):
+    # Settings that affect whether cover art removal is predicted.
+    _REMOVAL_SETTINGS = frozenset(
+        (
+            'remove_images_from_tags',
+            'save_images_to_files',
+            'save_images_to_tags',
+        )
+    )
+
     def __init__(self, parent=None):
         super().__init__("", parent=parent)
         self.layout = QtWidgets.QVBoxLayout()
@@ -135,6 +144,12 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.orig_cover_art.setHidden(True)
         self.show_details_button.setHidden(True)
         self.show_details_button.clicked.connect(self.show_cover_art_info)
+        config = get_config()
+        config.setting.setting_changed.connect(self._on_setting_changed)
+
+    def _on_setting_changed(self, name, old_value, new_value):
+        if name in self._REMOVAL_SETTINGS:
+            self.update_metadata()
 
     def show_cover_art_info(self):
         self.tagger.window.view_info(default_tab=1, item=self.item)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -62,6 +62,7 @@ from picard.coverart.setters import (
     CoverArtSetterMode,
 )
 from picard.i18n import gettext as _
+from picard.metadata import Metadata
 from picard.util import (
     bytes2human,
     imageinfo,
@@ -93,6 +94,10 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.setFlat(True)
         self.item = None
         self._removal_predicted = False
+        # Snapshot of the last image known to be exported to an external file,
+        # kept so the box can still show it once remove_images_from_tags has
+        # cleared it from orig_metadata.images (see update_metadata).
+        self._exported_images = None
         self.pixmap_cache = LRUCache(40)
         self.cover_art_label = QtWidgets.QLabel('')
         self.cover_art_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter)
@@ -155,13 +160,18 @@ class CoverArtBox(QtWidgets.QGroupBox):
         # __eq__ requires both data to be set, so only compare when present
         same_data = not data_missing and self.cover_art == self.orig_cover_art
         removal_predicted = self._removal_predicted
+        # cover_art has no live source of its own anymore (nothing left in
+        # metadata or orig_metadata), it's showing the exported snapshot instead.
+        showing_exported_only = (
+            self.orig_cover_art.data is None and self.cover_art.data is not None and self._exported_images
+        )
         if data_missing or (same_data and not removal_predicted):
             self.show_details_button.setVisible(bool(self.item and self.item.can_view_info))
             self.orig_cover_art.setVisible(False)
             self.orig_cover_art_label.setText('')
             self.orig_cover_art_info_label.setVisible(False)
             # No header above cover art when only one
-            self.cover_art_label.setText('')
+            self.cover_art_label.setText(_('Saved to File') if showing_exported_only else '')
         else:
             self.show_details_button.setVisible(True)
             self.orig_cover_art.setVisible(True)
@@ -212,9 +222,12 @@ class CoverArtBox(QtWidgets.QGroupBox):
             self.cover_art.set_marked_for_removal(False)
             self.orig_cover_art.set_marked_for_removal(False)
             self._removal_predicted = False
+            self._exported_images = None
             self.update_display()
             return
 
+        if self.item is not item:
+            self._exported_images = None
         if self.item and hasattr(self.item, 'metadata_images_changed'):
             self.item.metadata_images_changed.disconnect(self.update_metadata)
         self.item = item
@@ -231,10 +244,19 @@ class CoverArtBox(QtWidgets.QGroupBox):
         if hasattr(self.item, 'orig_metadata'):
             orig_metadata = self.item.orig_metadata
 
-        if not metadata or not metadata.images:
-            self.cover_art.set_metadata(orig_metadata)
-        else:
+        if metadata and metadata.images:
             self.cover_art.set_metadata(metadata)
+            self._exported_images = None
+        elif orig_metadata and orig_metadata.images:
+            self.cover_art.set_metadata(orig_metadata)
+        elif self._exported_images:
+            # remove_images_from_tags already cleared orig_metadata.images, but
+            # the image itself was kept as an external file (see ImageList);
+            # nothing in the current metadata references it anymore, so fall
+            # back to the snapshot taken below before it was cleared.
+            self.cover_art.set_metadata(Metadata(images=self._exported_images))
+        else:
+            self.cover_art.set_metadata(orig_metadata)
         self.orig_cover_art.set_metadata(orig_metadata)
 
         # Predict whether saving will strip cover art already embedded in tags,
@@ -251,6 +273,9 @@ class CoverArtBox(QtWidgets.QGroupBox):
             # The exported copy is shown as its own unmarked panel (see
             # update_display), so only the original needs the overlay.
             self.cover_art.set_marked_for_removal(False)
+            # Snapshot what will be exported before the next save clears
+            # orig_metadata.images, so it stays visible afterwards.
+            self._exported_images = orig_metadata.images.copy()
         else:
             self.cover_art.set_marked_for_removal(False)
             self.orig_cover_art.set_marked_for_removal(False)

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -37,6 +37,7 @@
 
 from collections.abc import Sequence
 from functools import partial
+from html import escape
 import os
 import re
 
@@ -69,13 +70,13 @@ from picard.util import (
 )
 from picard.util.lrucache import LRUCache
 
-from .coverartthumbnail import (
-    THUMBNAIL_WIDTH,
-    CoverArtThumbnail,
-)
+from .coverartthumbnail import CoverArtThumbnail
 from .imageurldialog import ImageURLDialog
 
-from picard.ui.util import FileDialog
+from picard.ui.util import (
+    FileDialog,
+    strikethrough_removal_text,
+)
 
 
 HTML_IMG_SRC_REGEX = re.compile(r'<img .*?src="(.*?)"', re.UNICODE)
@@ -91,6 +92,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.setStyleSheet('''QGroupBox{background-color:none;border:1px;}''')
         self.setFlat(True)
         self.item = None
+        self._removal_predicted = False
         self.pixmap_cache = LRUCache(40)
         self.cover_art_label = QtWidgets.QLabel('')
         self.cover_art_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter)
@@ -112,15 +114,6 @@ class CoverArtBox(QtWidgets.QGroupBox):
             QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
         )
         self.orig_cover_art_info_label.setWordWrap(True)
-        self.cover_removal_warning_label = QtWidgets.QLabel('')
-        self.cover_removal_warning_label.setAlignment(
-            QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
-        )
-        self.cover_removal_warning_label.setWordWrap(True)
-        # Keep wrapping within the thumbnail column instead of widening the box
-        self.cover_removal_warning_label.setMaximumWidth(THUMBNAIL_WIDTH)
-        self.cover_removal_warning_label.setStyleSheet('QLabel { color: #a00000; font-weight: bold; }')
-        self.cover_removal_warning_label.setHidden(True)
         self.show_details_button = QtWidgets.QPushButton(_('Show more details'), self)
         self.show_details_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(_("Ctrl+Shift+I")), self, self.show_cover_art_info
@@ -131,7 +124,6 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.layout.addWidget(self.orig_cover_art_label)
         self.layout.addWidget(self.orig_cover_art)
         self.layout.addWidget(self.orig_cover_art_info_label)
-        self.layout.addWidget(self.cover_removal_warning_label)
         self.layout.addWidget(self.show_details_button)
         self.layout.addSpacerItem(spacerItem)
         self.setLayout(self.layout)
@@ -155,8 +147,15 @@ class CoverArtBox(QtWidgets.QGroupBox):
                 self.orig_cover_art.show()
 
         # We want to show the 2 coverarts only if they are different
-        # and orig_cover_art data is set and not the default cd shadow
-        if self.orig_cover_art.data is None or self.cover_art.data is None or self.cover_art == self.orig_cover_art:
+        # and orig_cover_art data is set and not the default cd shadow.
+        # When removal is predicted, the original tagged image and the
+        # exported copy are shown separately even if they are identical, so
+        # the artwork being kept as a file remains visible and unmarked.
+        data_missing = self.orig_cover_art.data is None or self.cover_art.data is None
+        # __eq__ requires both data to be set, so only compare when present
+        same_data = not data_missing and self.cover_art == self.orig_cover_art
+        removal_predicted = self._removal_predicted
+        if data_missing or (same_data and not removal_predicted):
             self.show_details_button.setVisible(bool(self.item and self.item.can_view_info))
             self.orig_cover_art.setVisible(False)
             self.orig_cover_art_label.setText('')
@@ -167,7 +166,10 @@ class CoverArtBox(QtWidgets.QGroupBox):
             self.show_details_button.setVisible(True)
             self.orig_cover_art.setVisible(True)
             # Show headers above when both are visible
-            self.cover_art_label.setText(_('New Cover Art'))
+            if same_data and removal_predicted:
+                self.cover_art_label.setText(_('Saved to File'))
+            else:
+                self.cover_art_label.setText(_('New Cover Art'))
             self.orig_cover_art_label.setText(_('Original Cover Art'))
             self.orig_cover_art_info_label.setVisible(True)
 
@@ -175,6 +177,14 @@ class CoverArtBox(QtWidgets.QGroupBox):
         # Tooltips must always show details regardless of preference
         tooltip_cover_lines = self._first_image_info_lines(self.cover_art.related_images)
         tooltip_orig_lines = self._first_image_info_lines(self.orig_cover_art.related_images)
+
+        cover_marked = self.cover_art.marked_for_removal
+        orig_marked = self.orig_cover_art.marked_for_removal
+        removal_notice = _("This cover art will be removed from tags when saved")
+        if cover_marked:
+            tooltip_cover_lines = [removal_notice, *tooltip_cover_lines]
+        if orig_marked:
+            tooltip_orig_lines = [removal_notice, *tooltip_orig_lines]
 
         # Labels can be toggled by preference for vertical space
         # Default is False per option definition
@@ -187,24 +197,20 @@ class CoverArtBox(QtWidgets.QGroupBox):
             cover_text_lines = []
             orig_text_lines = []
 
-        self.cover_art_info_label.setText("\n".join(cover_text_lines))
-        self.orig_cover_art_info_label.setText("\n".join(orig_text_lines))
+        self.cover_art_info_label.setText(self._format_info_text(cover_text_lines, marked_for_removal=cover_marked))
+        self.orig_cover_art_info_label.setText(self._format_info_text(orig_text_lines, marked_for_removal=orig_marked))
         self.cover_art_info_label.setVisible(bool(cover_text_lines))
         self.orig_cover_art_info_label.setVisible(bool(orig_text_lines) and self.orig_cover_art.isVisible())
 
         self.cover_art.setToolTip("<br/>".join(tooltip_cover_lines))
         self.orig_cover_art.setToolTip("<br/>".join(tooltip_orig_lines))
 
-        removal_warning_label = getattr(self, 'cover_removal_warning_label', None)
-        if removal_warning_label is not None:
-            removal_predicted = getattr(self, '_removal_predicted', False)
-            removal_warning_label.setText(_("\u26a0 Cover art will be removed from tags") if removal_predicted else '')
-            removal_warning_label.setVisible(removal_predicted)
-
     def set_item(self, item):
         if not item.can_show_coverart:
             self.cover_art.set_metadata(None)
             self.orig_cover_art.set_metadata(None)
+            self.cover_art.set_marked_for_removal(False)
+            self.orig_cover_art.set_marked_for_removal(False)
             self._removal_predicted = False
             self.update_display()
             return
@@ -237,10 +243,27 @@ class CoverArtBox(QtWidgets.QGroupBox):
             metadata
             and orig_metadata
             and orig_metadata.images
-            and metadata.images.should_remove_images_from_tags()
-            and not list(metadata.images.to_be_saved_to_tags())
+            and metadata.images.should_remove_images_from_tags(previous_images=orig_metadata.images)
+            and not list(metadata.images.to_be_saved_to_tags(previous_images=orig_metadata.images))
         )
+        if self._removal_predicted:
+            self.orig_cover_art.set_marked_for_removal(True)
+            # The exported copy is shown as its own unmarked panel (see
+            # update_display), so only the original needs the overlay.
+            self.cover_art.set_marked_for_removal(False)
+        else:
+            self.cover_art.set_marked_for_removal(False)
+            self.orig_cover_art.set_marked_for_removal(False)
         self.update_display()
+
+    @staticmethod
+    def _format_info_text(lines: list[str], *, marked_for_removal: bool = False) -> str:
+        """Join info lines, styled as struck-through red when marked for removal."""
+        if not lines:
+            return ""
+        if marked_for_removal:
+            return strikethrough_removal_text("<br/>".join(escape(line) for line in lines))
+        return "\n".join(lines)
 
     @staticmethod
     def _first_image_info_lines(

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -205,6 +205,8 @@ class CoverArtBox(QtWidgets.QGroupBox):
         if not item.can_show_coverart:
             self.cover_art.set_metadata(None)
             self.orig_cover_art.set_metadata(None)
+            self._removal_predicted = False
+            self.update_display()
             return
 
         if self.item and hasattr(self.item, 'metadata_images_changed'):

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -286,6 +286,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             and metadata
             and orig_metadata
             and orig_metadata.images
+            and not get_config().setting['save_images_to_tags']
             and metadata.images.should_remove_images_from_tags(previous_images=orig_metadata.images)
             and not list(metadata.images.to_be_saved_to_tags(previous_images=orig_metadata.images))
         )

--- a/picard/ui/coverartbox/coverartthumbnail.py
+++ b/picard/ui/coverartbox/coverartthumbnail.py
@@ -49,6 +49,7 @@ from picard.coverart.image import CoverArtImageIOError
 from picard.i18n import gettext as _
 
 from picard.ui.colors import interface_colors
+from picard.ui.util import apply_removal_overlay
 from picard.ui.widgets import ActiveLabel
 
 
@@ -82,6 +83,7 @@ class CoverArtThumbnail(ActiveLabel):
         self.clicked.connect(self.open_release_page)
         self.related_images = []
         self.current_pixmap_key = None
+        self.marked_for_removal = False
 
     def screen_changed(self, screen):
         pixel_ratio = screen.devicePixelRatio()
@@ -169,6 +171,15 @@ class CoverArtThumbnail(ActiveLabel):
     def show(self):
         self.set_data(self.data, True)
 
+    def set_marked_for_removal(self, marked_for_removal):
+        """Toggle the removal overlay and refresh the displayed pixmap."""
+        marked_for_removal = bool(marked_for_removal)
+        if marked_for_removal == self.marked_for_removal:
+            return
+        self.marked_for_removal = marked_for_removal
+        if self.data:
+            self.set_data(self.data, force=True, has_common_images=self.has_common_images)
+
     def set_data(self, data, force=False, has_common_images=True):
         if not force and self.data == data and self.has_common_images == has_common_images:
             return
@@ -188,8 +199,11 @@ class CoverArtThumbnail(ActiveLabel):
             has_common_images = True
 
         key = hash(tuple(sorted(self.data, key=lambda x: x.types_as_string())) + (has_common_images, self.pixel_ratio))
+        # The overlay only affects rendering, not image identity: `key` stays
+        # comparable between thumbnails regardless of removal marking.
+        cache_key = (key, self.marked_for_removal)
         try:
-            pixmap = self._pixmap_cache[key]
+            pixmap = self._pixmap_cache[cache_key]
         except KeyError:
             if len(self.data) == 1:
                 pixmap = QtGui.QPixmap()
@@ -202,7 +216,9 @@ class CoverArtThumbnail(ActiveLabel):
                     pixmap = self.file_missing_pixmap
             else:
                 pixmap = self.render_cover_stack(self.data, has_common_images)
-            self._pixmap_cache[key] = pixmap
+            if self.marked_for_removal:
+                pixmap = apply_removal_overlay(pixmap)
+            self._pixmap_cache[cache_key] = pixmap
 
         self.setPixmap(pixmap)
         self.current_pixmap_key = key

--- a/picard/ui/forms/ui_options_cover.py
+++ b/picard/ui/forms/ui_options_cover.py
@@ -37,9 +37,7 @@ class Ui_CoverOptionsPage(object):
         self.never_replace_types_layout = QtWidgets.QHBoxLayout()
         self.never_replace_types_layout.setObjectName("never_replace_types_layout")
         self.cb_never_replace_types = QtWidgets.QCheckBox(parent=self.save_images_to_tags)
-        sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Fixed
-        )
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.cb_never_replace_types.sizePolicy().hasHeightForWidth())
@@ -82,9 +80,7 @@ class Ui_CoverOptionsPage(object):
         self.verticalLayout_2.addWidget(self.remove_images_from_tags)
         self.verticalLayout.addWidget(self.save_images_to_files)
         self.ca_providers_groupbox = QtWidgets.QGroupBox(parent=CoverOptionsPage)
-        sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
-        )
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.ca_providers_groupbox.sizePolicy().hasHeightForWidth())
@@ -116,15 +112,11 @@ class Ui_CoverOptionsPage(object):
         self.down_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.down_button.setObjectName("down_button")
         self.ca_layout.addWidget(self.down_button)
-        spacerItem = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
-        )
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
         self.ca_layout.addItem(spacerItem)
         self.ca_providers_layout.addLayout(self.ca_layout)
         self.verticalLayout.addWidget(self.ca_providers_groupbox, 0, QtCore.Qt.AlignmentFlag.AlignTop)
-        spacerItem1 = QtWidgets.QSpacerItem(
-            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
-        )
+        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
         self.verticalLayout.addItem(spacerItem1)
         self.label_use_filename.setBuddy(self.cover_image_filename)
 
@@ -141,15 +133,9 @@ class Ui_CoverOptionsPage(object):
         self.label_use_filename.setText(_("Use the following file name for images:"))
         self.save_images_overwrite.setText(_("Overwrite the file if it already exists"))
         self.save_only_one_front_image.setText(_("Save only a single front image as separate file"))
-        self.image_type_as_filename.setToolTip(
-            _("Always use the primary image type as the file name for non-front images")
-        )
+        self.image_type_as_filename.setToolTip(_("Always use the primary image type as the file name for non-front images"))
         self.image_type_as_filename.setText(_("Use the primary image type as the file name"))
-        self.remove_images_from_tags.setToolTip(
-            _(
-                "When saving, remove cover images embedded in tags. Images will only be removed if they are also being saved as separate files."
-            )
-        )
+        self.remove_images_from_tags.setToolTip(_("When saving, remove cover images embedded in tags. Images will only be removed if they are also being saved as separate files."))
         self.remove_images_from_tags.setText(_("Remove cover images from tags"))
         self.ca_providers_groupbox.setTitle(_("Cover Art Providers"))
         self.move_label.setText(_("Reorder Priority:"))

--- a/picard/ui/forms/ui_options_cover.py
+++ b/picard/ui/forms/ui_options_cover.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options_cover.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -75,6 +75,9 @@ class Ui_CoverOptionsPage(object):
         self.image_type_as_filename = QtWidgets.QCheckBox(parent=self.save_images_to_files)
         self.image_type_as_filename.setObjectName("image_type_as_filename")
         self.verticalLayout_2.addWidget(self.image_type_as_filename)
+        self.remove_images_from_tags = QtWidgets.QCheckBox(parent=self.save_images_to_files)
+        self.remove_images_from_tags.setObjectName("remove_images_from_tags")
+        self.verticalLayout_2.addWidget(self.remove_images_from_tags)
         self.verticalLayout.addWidget(self.save_images_to_files)
         self.ca_providers_groupbox = QtWidgets.QGroupBox(parent=CoverOptionsPage)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
@@ -132,6 +135,7 @@ class Ui_CoverOptionsPage(object):
         self.save_only_one_front_image.setText(_("Save only a single front image as separate file"))
         self.image_type_as_filename.setToolTip(_("Always use the primary image type as the file name for non-front images"))
         self.image_type_as_filename.setText(_("Use the primary image type as the file name"))
+        self.remove_images_from_tags.setText(_("Remove cover images from tags"))
         self.ca_providers_groupbox.setTitle(_("Cover Art Providers"))
         self.move_label.setText(_("Reorder Priority:"))
         self.up_button.setToolTip(_("Move selected item up"))

--- a/picard/ui/forms/ui_options_cover.py
+++ b/picard/ui/forms/ui_options_cover.py
@@ -37,7 +37,9 @@ class Ui_CoverOptionsPage(object):
         self.never_replace_types_layout = QtWidgets.QHBoxLayout()
         self.never_replace_types_layout.setObjectName("never_replace_types_layout")
         self.cb_never_replace_types = QtWidgets.QCheckBox(parent=self.save_images_to_tags)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.cb_never_replace_types.sizePolicy().hasHeightForWidth())
@@ -80,7 +82,9 @@ class Ui_CoverOptionsPage(object):
         self.verticalLayout_2.addWidget(self.remove_images_from_tags)
         self.verticalLayout.addWidget(self.save_images_to_files)
         self.ca_providers_groupbox = QtWidgets.QGroupBox(parent=CoverOptionsPage)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.ca_providers_groupbox.sizePolicy().hasHeightForWidth())
@@ -112,11 +116,15 @@ class Ui_CoverOptionsPage(object):
         self.down_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.down_button.setObjectName("down_button")
         self.ca_layout.addWidget(self.down_button)
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
+        spacerItem = QtWidgets.QSpacerItem(
+            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
+        )
         self.ca_layout.addItem(spacerItem)
         self.ca_providers_layout.addLayout(self.ca_layout)
         self.verticalLayout.addWidget(self.ca_providers_groupbox, 0, QtCore.Qt.AlignmentFlag.AlignTop)
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem1)
         self.label_use_filename.setBuddy(self.cover_image_filename)
 
@@ -133,9 +141,15 @@ class Ui_CoverOptionsPage(object):
         self.label_use_filename.setText(_("Use the following file name for images:"))
         self.save_images_overwrite.setText(_("Overwrite the file if it already exists"))
         self.save_only_one_front_image.setText(_("Save only a single front image as separate file"))
-        self.image_type_as_filename.setToolTip(_("Always use the primary image type as the file name for non-front images"))
+        self.image_type_as_filename.setToolTip(
+            _("Always use the primary image type as the file name for non-front images")
+        )
         self.image_type_as_filename.setText(_("Use the primary image type as the file name"))
-        self.remove_images_from_tags.setToolTip(_("Delete cover images embedded in tags when saving"))
+        self.remove_images_from_tags.setToolTip(
+            _(
+                "When saving, remove cover images embedded in tags. Images will only be removed if they are also being saved as separate files."
+            )
+        )
         self.remove_images_from_tags.setText(_("Remove cover images from tags"))
         self.ca_providers_groupbox.setTitle(_("Cover Art Providers"))
         self.move_label.setText(_("Reorder Priority:"))

--- a/picard/ui/forms/ui_options_cover.py
+++ b/picard/ui/forms/ui_options_cover.py
@@ -135,6 +135,7 @@ class Ui_CoverOptionsPage(object):
         self.save_only_one_front_image.setText(_("Save only a single front image as separate file"))
         self.image_type_as_filename.setToolTip(_("Always use the primary image type as the file name for non-front images"))
         self.image_type_as_filename.setText(_("Use the primary image type as the file name"))
+        self.remove_images_from_tags.setToolTip(_("Delete cover images embedded in tags when saving"))
         self.remove_images_from_tags.setText(_("Remove cover images from tags"))
         self.ca_providers_groupbox.setTitle(_("Cover Art Providers"))
         self.move_label.setText(_("Reorder Priority:"))

--- a/picard/ui/infodialog/dialog.py
+++ b/picard/ui/infodialog/dialog.py
@@ -104,6 +104,7 @@ class InfoDialog(PicardDialog):
         # using the same rules the format save code applies (see ImageList).
         self.removal_predicted = bool(
             has_orig_images
+            and not get_config().setting['save_images_to_tags']
             and obj.metadata.images.should_remove_images_from_tags(
                 previous_images=obj.orig_metadata.images if has_orig_images else None
             )

--- a/picard/ui/infodialog/dialog.py
+++ b/picard/ui/infodialog/dialog.py
@@ -92,6 +92,13 @@ class InfoDialog(PicardDialog):
 
         self.has_new_external_images = any(image.external_file_coverart for image in self.new_images)
         has_orig_images = hasattr(obj, 'orig_metadata') and obj.orig_metadata.images
+        # Predict whether saving will strip cover art already embedded in tags,
+        # using the same rules the format save code applies (see ImageList).
+        self.removal_predicted = bool(
+            has_orig_images
+            and obj.metadata.images.should_remove_images_from_tags()
+            and not list(obj.metadata.images.to_be_saved_to_tags())
+        )
         if has_orig_images:
             # Apply per-file "never replace" filters to show what will actually be saved
             if get_config().setting['save_images_to_tags']:
@@ -260,6 +267,14 @@ class InfoDialog(PicardDialog):
             'sourcefile': escape(image.source),
         }
 
+    def _existing_cover_colname(self):
+        """Column showing cover art currently embedded in tags, if any."""
+        if isinstance(self.artwork_table, ArtworkTableExisting):
+            return 'orig'
+        if isinstance(self.artwork_table, ArtworkTableOriginal):
+            return 'new'
+        return None
+
     def _display_artwork_image_cell(self, row_index, colname):
         """Display artwork image, depending on source (new/orig), in the proper column"""
         col_index = self.artwork_table.get_column_index(colname)
@@ -272,6 +287,8 @@ class InfoDialog(PicardDialog):
             source = 'new_external_image'
         image = getattr(self.artwork_rows[row_index], source)
         item = QtWidgets.QTableWidgetItem()
+
+        marked_for_removal = bool(image and self.removal_predicted and colname == self._existing_cover_colname())
 
         if image:
             try:
@@ -286,7 +303,12 @@ class InfoDialog(PicardDialog):
                 if data:
                     pixmap = QtGui.QPixmap()
                     pixmap.loadFromData(data)
-                    item.setToolTip(self._artwork_tooltip(_("Double-click to open in external viewer"), image))
+                    tooltip_message = _("Double-click to open in external viewer")
+                    if marked_for_removal:
+                        tooltip_message = (
+                            _("This cover art will be removed from tags when saved") + "<br />" + tooltip_message
+                        )
+                    item.setToolTip(self._artwork_tooltip(tooltip_message, image))
                     item.setData(QtCore.Qt.ItemDataRole.UserRole, image)
             except CoverArtImageIOError:
                 log.error(traceback.format_exc())
@@ -294,7 +316,7 @@ class InfoDialog(PicardDialog):
                 item.setToolTip(self._artwork_tooltip(_("Missing temporary file"), image))
             infos = "<br />".join(escape(t) for t in self._artwork_infos(image))
 
-        img_wgt = ArtworkCoverWidget(pixmap=pixmap, text=infos)
+        img_wgt = ArtworkCoverWidget(pixmap=pixmap, text=infos, marked_for_removal=marked_for_removal)
         self.artwork_table.setCellWidget(row_index, col_index, img_wgt)
         self.artwork_table.setItem(row_index, col_index, item)
 

--- a/picard/ui/infodialog/dialog.py
+++ b/picard/ui/infodialog/dialog.py
@@ -42,7 +42,6 @@ from picard import log
 from picard.album import Album
 from picard.config import get_config
 from picard.coverart.image import CoverArtImageIOError
-from picard.coverart.processing.filters import filter_image_for_file
 from picard.coverart.utils import translated_types_as_string
 from picard.debug_opts import DebugOpt
 from picard.file import File
@@ -67,13 +66,22 @@ from picard.ui.forms.ui_infodialog import Ui_InfoDialog
 
 
 class ArtworkRow:
-    def __init__(self, orig_image=None, new_image=None, types=None):
+    def __init__(self, orig_image=None, new_image=None, types=None, external_fallback=False):
         self.orig_image = orig_image
         self.new_image = new_image
         self.types = types
         self.new_external_image = None
         if self.new_image:
             self.new_external_image = self.new_image.external_file_coverart
+            if self.new_external_image is None and external_fallback:
+                # Without a separately processed version the image itself
+                # is what gets exported to a file (see CoverArtImage.save)
+                self.new_external_image = self.new_image
+        elif external_fallback and self.orig_image:
+            # No replacement was found for this type: the originally tagged
+            # image itself becomes what gets exported to a file instead of
+            # being lost (see ImageList.to_be_saved_to_files)
+            self.new_external_image = self.orig_image
 
 
 class InfoDialog(PicardDialog):
@@ -96,22 +104,35 @@ class InfoDialog(PicardDialog):
         # using the same rules the format save code applies (see ImageList).
         self.removal_predicted = bool(
             has_orig_images
-            and obj.metadata.images.should_remove_images_from_tags()
-            and not list(obj.metadata.images.to_be_saved_to_tags())
+            and obj.metadata.images.should_remove_images_from_tags(
+                previous_images=obj.orig_metadata.images if has_orig_images else None
+            )
+            and not list(
+                obj.metadata.images.to_be_saved_to_tags(
+                    previous_images=obj.orig_metadata.images if has_orig_images else None
+                )
+            )
         )
+        if self.removal_predicted:
+            # Removal implies save_images_to_files, and higher quality tagged
+            # art is exported instead of being lost, so something always gets
+            # exported even without separately processed versions
+            self.has_new_external_images = True
         if has_orig_images:
-            # Apply per-file "never replace" filters to show what will actually be saved
+            # Show what will actually be embedded in tags, applying the same
+            # per-file "never replace" filters the format save code uses.
+            # Images rejected here may still be saved to an external file.
             if get_config().setting['save_images_to_tags']:
-                self.new_images = [
-                    image for image in self.new_images if filter_image_for_file(image, obj.orig_metadata.images)
-                ]
+                self.new_images = sorted(
+                    obj.metadata.images.to_be_saved_to_tags(previous_images=obj.orig_metadata.images)
+                )
             artworktable_class = ArtworkTableOriginal
             has_new_different_images = sorted(obj.orig_metadata.images) != self.new_images
             if has_new_different_images or self.has_new_external_images:
                 is_track = isinstance(obj, Track)
                 is_linked_file = isinstance(obj, File) and isinstance(obj.parent_item, Track)
                 is_album_with_files = isinstance(obj, Album) and obj.get_num_total_files() > 0
-                if is_track or is_linked_file or is_album_with_files:
+                if is_track or is_linked_file or is_album_with_files or self.removal_predicted:
                     self.orig_images = sorted(obj.orig_metadata.images)
                     artworktable_class = ArtworkTableExisting
 
@@ -344,6 +365,7 @@ class InfoDialog(PicardDialog):
         """Generate artwork rows, trying to match orig/new image types"""
         # we work on a copy, since will pop matched images
         new_images = self.new_images[:]
+        external_fallback = self.removal_predicted
         if self.orig_images:
             for orig_image in self.orig_images:
                 types = orig_image.normalized_types()
@@ -354,10 +376,19 @@ class InfoDialog(PicardDialog):
                         # we found one, pop it from new_images, we don't want to match it again
                         found_new_image = new_images.pop(i)
                         break
-                yield ArtworkRow(orig_image=orig_image, new_image=found_new_image, types=types)
+                yield ArtworkRow(
+                    orig_image=orig_image,
+                    new_image=found_new_image,
+                    types=types,
+                    external_fallback=external_fallback,
+                )
         # now, remaining images that weren't matched to orig images
         for new_image in new_images:
-            yield ArtworkRow(new_image=new_image, types=new_image.normalized_types())
+            yield ArtworkRow(
+                new_image=new_image,
+                types=new_image.normalized_types(),
+                external_fallback=external_fallback,
+            )
 
     def _display_artwork_rows(self):
         """Display rows of images and types in artwork tab"""

--- a/picard/ui/infodialog/widgets.py
+++ b/picard/ui/infodialog/widgets.py
@@ -33,11 +33,15 @@ from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
-    QtGui,
     QtWidgets,
 )
 
 from picard.i18n import gettext as _
+
+from picard.ui.util import (
+    apply_removal_overlay,
+    strikethrough_removal_text,
+)
 
 
 class ArtworkCoverWidget(QtWidgets.QWidget):
@@ -59,7 +63,7 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
                 QtCore.Qt.TransformationMode.SmoothTransformation,
             )
             if marked_for_removal:
-                scaled_pixmap = self._removal_overlay(scaled_pixmap)
+                scaled_pixmap = apply_removal_overlay(scaled_pixmap)
             image_label = QtWidgets.QLabel()
             image_label.setPixmap(scaled_pixmap)
             image_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -67,7 +71,7 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
 
         if text is not None:
             if marked_for_removal:
-                text = self._strikethrough_text(text)
+                text = strikethrough_removal_text(text)
             text_label = QtWidgets.QLabel()
             text_label.setText(text)
             text_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -75,20 +79,6 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
             layout.addWidget(text_label)
 
         self.setLayout(layout)
-
-    @staticmethod
-    def _removal_overlay(pixmap):
-        """Draw a dotted translucent red overlay signaling the image will be removed from tags."""
-        overlaid = QtGui.QPixmap(pixmap)
-        painter = QtGui.QPainter(overlaid)
-        brush = QtGui.QBrush(QtGui.QColor(200, 0, 0, 200), QtCore.Qt.BrushStyle.Dense4Pattern)
-        painter.fillRect(overlaid.rect(), brush)
-        painter.end()
-        return overlaid
-
-    @staticmethod
-    def _strikethrough_text(text):
-        return f'<span style="color:#a00000; text-decoration:line-through;">{text}</span>'
 
 
 class ArtworkTable(QtWidgets.QTableWidget):

--- a/picard/ui/infodialog/widgets.py
+++ b/picard/ui/infodialog/widgets.py
@@ -33,6 +33,7 @@ from typing import ClassVar
 
 from PyQt6 import (
     QtCore,
+    QtGui,
     QtWidgets,
 )
 
@@ -44,26 +45,29 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
 
     SIZE = 170
 
-    def __init__(self, pixmap=None, text=None, size=None, parent=None):
+    def __init__(self, pixmap=None, text=None, size=None, parent=None, marked_for_removal=False):
         super().__init__(parent=parent)
         layout = QtWidgets.QVBoxLayout()
 
         if pixmap is not None:
             if size is None:
                 size = self.SIZE
-            image_label = QtWidgets.QLabel()
-            image_label.setPixmap(
-                pixmap.scaled(
-                    size,
-                    size,
-                    QtCore.Qt.AspectRatioMode.KeepAspectRatio,
-                    QtCore.Qt.TransformationMode.SmoothTransformation,
-                )
+            scaled_pixmap = pixmap.scaled(
+                size,
+                size,
+                QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                QtCore.Qt.TransformationMode.SmoothTransformation,
             )
+            if marked_for_removal:
+                scaled_pixmap = self._removal_overlay(scaled_pixmap)
+            image_label = QtWidgets.QLabel()
+            image_label.setPixmap(scaled_pixmap)
             image_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(image_label)
 
         if text is not None:
+            if marked_for_removal:
+                text = self._strikethrough_text(text)
             text_label = QtWidgets.QLabel()
             text_label.setText(text)
             text_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -71,6 +75,20 @@ class ArtworkCoverWidget(QtWidgets.QWidget):
             layout.addWidget(text_label)
 
         self.setLayout(layout)
+
+    @staticmethod
+    def _removal_overlay(pixmap):
+        """Draw a dotted translucent red overlay signaling the image will be removed from tags."""
+        overlaid = QtGui.QPixmap(pixmap)
+        painter = QtGui.QPainter(overlaid)
+        brush = QtGui.QBrush(QtGui.QColor(200, 0, 0, 200), QtCore.Qt.BrushStyle.Dense4Pattern)
+        painter.fillRect(overlaid.rect(), brush)
+        painter.end()
+        return overlaid
+
+    @staticmethod
+    def _strikethrough_text(text):
+        return f'<span style="color:#a00000; text-decoration:line-through;">{text}</span>'
 
 
 class ArtworkTable(QtWidgets.QTableWidget):

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -139,11 +139,7 @@ class CoverOptionsPage(OptionsPage):
         config.setting['save_images_overwrite'] = self.ui.save_images_overwrite.isChecked()
         config.setting['save_only_one_front_image'] = self.ui.save_only_one_front_image.isChecked()
         config.setting['image_type_as_filename'] = self.ui.image_type_as_filename.isChecked()
-        config.setting['remove_images_from_tags'] = (
-            self.ui.save_images_to_files.isChecked()
-            and self.ui.remove_images_from_tags.isChecked()
-            and not self.ui.save_images_to_tags.isChecked()
-        )
+        config.setting['remove_images_from_tags'] = self.ui.remove_images_from_tags.isChecked()
         config.setting['ca_providers'] = list(self._ca_providers())
 
     def update_ca_providers_groupbox_state(self):
@@ -153,10 +149,10 @@ class CoverOptionsPage(OptionsPage):
 
     def update_remove_images_from_tags_state(self):
         # Embedding into tags and removing from tags are mutually exclusive.
+        # Disable the checkbox when embedding is active, but preserve the
+        # user's checked state so it's restored when embedding is turned off.
         embed_enabled = self.ui.save_images_to_tags.isChecked()
         self.ui.remove_images_from_tags.setDisabled(embed_enabled)
-        if embed_enabled:
-            self.ui.remove_images_from_tags.setChecked(False)
 
     def select_never_replace_image_types(self):
         (included_types, ok) = CoverTypesSelectorDialog.display(

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -84,6 +84,7 @@ class CoverOptionsPage(OptionsPage):
         self.ui.cover_image_filename.setPlaceholderText(Option.get('setting', 'cover_image_filename').default)
         self.ui.save_images_to_files.clicked.connect(self.update_ca_providers_groupbox_state)
         self.ui.save_images_to_tags.clicked.connect(self.update_ca_providers_groupbox_state)
+        self.ui.save_images_to_tags.toggled.connect(self.update_remove_images_from_tags_state)
         self.ui.save_only_one_front_image.toggled.connect(self.ui.image_type_as_filename.setDisabled)
         self.ui.cb_never_replace_types.toggled.connect(self.ui.select_types_button.setEnabled)
         self.ui.select_types_button.clicked.connect(self.select_never_replace_image_types)
@@ -120,6 +121,7 @@ class CoverOptionsPage(OptionsPage):
         self._load_cover_art_providers()
         self.ui.ca_providers_list.setCurrentRow(0)
         self.update_ca_providers_groupbox_state()
+        self.update_remove_images_from_tags_state()
 
     def _ca_providers(self):
         for item in qlistwidget_items(self.ui.ca_providers_list):
@@ -138,7 +140,9 @@ class CoverOptionsPage(OptionsPage):
         config.setting['save_only_one_front_image'] = self.ui.save_only_one_front_image.isChecked()
         config.setting['image_type_as_filename'] = self.ui.image_type_as_filename.isChecked()
         config.setting['remove_images_from_tags'] = (
-            self.ui.save_images_to_files.isChecked() and self.ui.remove_images_from_tags.isChecked()
+            self.ui.save_images_to_files.isChecked()
+            and self.ui.remove_images_from_tags.isChecked()
+            and not self.ui.save_images_to_tags.isChecked()
         )
         config.setting['ca_providers'] = list(self._ca_providers())
 
@@ -146,6 +150,13 @@ class CoverOptionsPage(OptionsPage):
         files_enabled = self.ui.save_images_to_files.isChecked()
         tags_enabled = self.ui.save_images_to_tags.isChecked()
         self.ui.ca_providers_groupbox.setEnabled(files_enabled or tags_enabled)
+
+    def update_remove_images_from_tags_state(self):
+        # Embedding into tags and removing from tags are mutually exclusive.
+        embed_enabled = self.ui.save_images_to_tags.isChecked()
+        self.ui.remove_images_from_tags.setDisabled(embed_enabled)
+        if embed_enabled:
+            self.ui.remove_images_from_tags.setChecked(False)
 
     def select_never_replace_image_types(self):
         (included_types, ok) = CoverTypesSelectorDialog.display(

--- a/picard/ui/options/cover.py
+++ b/picard/ui/options/cover.py
@@ -73,6 +73,7 @@ class CoverOptionsPage(OptionsPage):
         'save_images_overwrite': {'widgets': ['save_images_overwrite']},
         'save_only_one_front_image': {'widgets': ['save_only_one_front_image']},
         'image_type_as_filename': {'widgets': ['image_type_as_filename']},
+        'remove_images_from_tags': {'widgets': ['remove_images_from_tags']},
         'ca_providers': {'widgets': ['ca_providers_groupbox']},
     }
 
@@ -115,6 +116,7 @@ class CoverOptionsPage(OptionsPage):
         self.ui.save_images_overwrite.setChecked(config.setting['save_images_overwrite'])
         self.ui.save_only_one_front_image.setChecked(config.setting['save_only_one_front_image'])
         self.ui.image_type_as_filename.setChecked(config.setting['image_type_as_filename'])
+        self.ui.remove_images_from_tags.setChecked(config.setting['remove_images_from_tags'])
         self._load_cover_art_providers()
         self.ui.ca_providers_list.setCurrentRow(0)
         self.update_ca_providers_groupbox_state()
@@ -135,6 +137,9 @@ class CoverOptionsPage(OptionsPage):
         config.setting['save_images_overwrite'] = self.ui.save_images_overwrite.isChecked()
         config.setting['save_only_one_front_image'] = self.ui.save_only_one_front_image.isChecked()
         config.setting['image_type_as_filename'] = self.ui.image_type_as_filename.isChecked()
+        config.setting['remove_images_from_tags'] = (
+            self.ui.save_images_to_files.isChecked() and self.ui.remove_images_from_tags.isChecked()
+        )
         config.setting['ca_providers'] = list(self._ca_providers())
 
     def update_ca_providers_groupbox_state(self):

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -54,6 +54,21 @@ def find_starting_directory():
     return find_existing_path(path)
 
 
+def apply_removal_overlay(pixmap):
+    """Draw a dotted translucent red overlay signaling the image will be removed from tags."""
+    overlaid = QtGui.QPixmap(pixmap)
+    painter = QtGui.QPainter(overlaid)
+    brush = QtGui.QBrush(QtGui.QColor(200, 0, 0, 200), QtCore.Qt.BrushStyle.Dense4Pattern)
+    painter.fillRect(overlaid.rect(), brush)
+    painter.end()
+    return overlaid
+
+
+def strikethrough_removal_text(text):
+    """Style rich text as struck-through dark red, signaling removal from tags."""
+    return f'<span style="color:#a00000; text-decoration:line-through;">{text}</span>'
+
+
 def _picardize_caption(caption):
     return _("%s - %s") % (caption, PICARD_DISPLAY_NAME)
 

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -42,6 +42,7 @@ from picard.const.sys import IS_LINUX
 from picard.i18n import gettext as _
 from picard.util import find_existing_path
 
+from picard.ui.colors import interface_colors
 from picard.ui.enums import MainAction
 
 
@@ -58,15 +59,18 @@ def apply_removal_overlay(pixmap):
     """Draw a dotted translucent red overlay signaling the image will be removed from tags."""
     overlaid = QtGui.QPixmap(pixmap)
     painter = QtGui.QPainter(overlaid)
-    brush = QtGui.QBrush(QtGui.QColor(200, 0, 0, 200), QtCore.Qt.BrushStyle.Dense4Pattern)
+    color = interface_colors.get_qcolor('tagstatus_removed')
+    color.setAlpha(200)  # Translucent
+    brush = QtGui.QBrush(color, QtCore.Qt.BrushStyle.Dense4Pattern)
     painter.fillRect(overlaid.rect(), brush)
     painter.end()
     return overlaid
 
 
 def strikethrough_removal_text(text):
-    """Style rich text as struck-through dark red, signaling removal from tags."""
-    return f'<span style="color:#a00000; text-decoration:line-through;">{text}</span>'
+    """Style rich text as struck-through red, signaling removal from tags."""
+    color = interface_colors.get_color('tagstatus_removed')
+    return f'<span style="color:{color}; text-decoration:line-through;">{text}</span>'
 
 
 def _picardize_caption(caption):

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -123,6 +123,18 @@ class ImageList(MutableSequence['CoverArtImage']):
                     return
             yield from self
 
+    def should_remove_images_from_tags(self, settings: SettingConfigSection | None = None) -> bool:
+        """Whether images embedded in tags should be removed.
+
+        Only true when explicitly requested and images are also saved to
+        external files, so cover art is never deleted without being kept
+        somewhere else.
+        """
+        if settings is None:
+            config = get_config()
+            settings = config.setting
+        return bool(settings['remove_images_from_tags'] and settings['save_images_to_files'])
+
     def strip_front_images(self) -> None:
         self._images = [image for image in self._images if not image.is_front_image()]
         self._dirty = True

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -86,17 +86,31 @@ class ImageList(MutableSequence['CoverArtImage']):
                 return img
         return None
 
-    def to_be_saved_to_tags(self, settings: SettingConfigSection | None = None) -> Iterator['CoverArtImage']:
+    def to_be_saved_to_tags(
+        self,
+        settings: SettingConfigSection | None = None,
+        previous_images: 'ImageList | None' = None,
+    ) -> Iterator['CoverArtImage']:
         """Generator returning images to be saved to tags according to
-        passed settings or config.setting
+        passed settings or config.setting.
+
+        If `previous_images` (the images currently embedded in a specific file)
+        is given, the per-file "never replace" filters are applied against it,
+        so a new image can still be kept for external file saving even when it
+        is rejected for tags on this particular file.
         """
         if settings is None:
             config = get_config()
             settings = config.setting
         if settings['save_images_to_tags']:
+            # Imported here to avoid a circular import between imagelist and coverart.
+            from picard.coverart.processing.filters import filter_image_for_file
+
             only_one_front = settings['embed_only_one_front_image']
             for image in self:
                 if not image.can_be_saved_to_tags:
+                    continue
+                if previous_images is not None and not filter_image_for_file(image, previous_images):
                     continue
                 if only_one_front:
                     if image.is_front_image():
@@ -105,35 +119,69 @@ class ImageList(MutableSequence['CoverArtImage']):
                 else:
                     yield image
 
-    def to_be_saved_to_files(self, settings: SettingConfigSection | None = None) -> Iterator['CoverArtImage']:
+    def to_be_saved_to_files(
+        self,
+        settings: SettingConfigSection | None = None,
+        previous_images: 'ImageList | None' = None,
+    ) -> Iterator['CoverArtImage']:
         """Generator returning images to be saved as external files according to
         passed settings or config.setting.
 
         When save_only_one_front_image is enabled, yields only the first front
         image. Falls back to yielding all images if no front image is found.
+
+        If `previous_images` (the images currently embedded in tags) is given
+        and tags are about to be cleared (`remove_images_from_tags`), any
+        original image bigger than its replacement here (or with no
+        replacement at all) is used instead, so higher quality tagged art is
+        saved to disk instead of being lost when it is removed from tags.
         """
         if settings is None:
             config = get_config()
             settings = config.setting
-        if settings['save_images_to_files']:
-            if settings['save_only_one_front_image']:
-                front = self.get_front_image()
-                if front:
-                    yield front
-                    return
-            yield from self
+        if not settings['save_images_to_files']:
+            return
 
-    def should_remove_images_from_tags(self, settings: SettingConfigSection | None = None) -> bool:
+        only_one_front = settings['save_only_one_front_image']
+        if only_one_front:
+            front = self.get_front_image()
+            exported = [front] if front else list(self)
+        else:
+            exported = list(self)
+
+        if previous_images and settings['remove_images_from_tags']:
+            index_by_type = {image.normalized_types(): i for i, image in enumerate(exported)}
+            for prev_image in previous_images:
+                if only_one_front and not prev_image.is_front_image():
+                    continue
+                types = prev_image.normalized_types()
+                index = index_by_type.get(types)
+                if index is None:
+                    index_by_type[types] = len(exported)
+                    exported.append(prev_image)
+                elif prev_image.width > exported[index].width or prev_image.height > exported[index].height:
+                    # Keep the higher quality tagged image instead of the smaller replacement.
+                    exported[index] = prev_image
+
+        yield from exported
+
+    def should_remove_images_from_tags(
+        self,
+        settings: SettingConfigSection | None = None,
+        previous_images: 'ImageList | None' = None,
+    ) -> bool:
         """Whether images embedded in tags should be removed.
 
-        Only true when explicitly requested and images are also saved to
-        external files, so cover art is never deleted without being kept
-        somewhere else.
+        Only true when explicitly requested and this list actually has at
+        least one image that will be saved to an external file, so cover art
+        is never deleted without being kept somewhere else.
         """
         if settings is None:
             config = get_config()
             settings = config.setting
-        return bool(settings['remove_images_from_tags'] and settings['save_images_to_files'])
+        if not settings['remove_images_from_tags']:
+            return False
+        return any(self.to_be_saved_to_files(settings, previous_images))
 
     def strip_front_images(self) -> None:
         self._images = [image for image in self._images if not image.is_front_image()]

--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -152,6 +152,8 @@ class ImageList(MutableSequence['CoverArtImage']):
         if previous_images and settings['remove_images_from_tags']:
             index_by_type = {image.normalized_types(): i for i, image in enumerate(exported)}
             for prev_image in previous_images:
+                # Filter on is_front_image() first so normalized_types() is only
+                # computed for images that can actually be candidates.
                 if only_one_front and not prev_image.is_front_image():
                     continue
                 types = prev_image.normalized_types()

--- a/test/formats/coverart.py
+++ b/test/formats/coverart.py
@@ -163,6 +163,23 @@ class CommonCoverArtTests:
             config.setting['save_images_to_tags'] = False
             config.setting['save_images_to_files'] = True
             config.setting['remove_images_from_tags'] = True
+            # A new image is available to be saved to an external file.
+            new_image = CoverArtImage(data=self.jpegdata, types=['front'])
+            metadata = save_and_load_metadata(self.format_registry, self.filename, Metadata(images=[new_image]))
+            self.assertEqual(0, len(metadata.images))
+
+        @skipUnlessTestfile
+        def test_cover_art_removed_from_tags_and_original_kept_for_export(self):
+            # remove_images_from_tags must never delete the only copy of the
+            # cover art: with no new replacement, the existing tagged image
+            # itself becomes the one to be saved to an external file, so
+            # removal from tags still proceeds (the export is handled by
+            # File._save_images, exercised separately in test_imagelist.py).
+            image = CoverArtImage(data=self.pngdata, types=['front'])
+            file_save_image(self.format_registry, self.filename, image)
+            config.setting['save_images_to_tags'] = False
+            config.setting['save_images_to_files'] = True
+            config.setting['remove_images_from_tags'] = True
             metadata = save_and_load_metadata(self.format_registry, self.filename, Metadata())
             self.assertEqual(0, len(metadata.images))
 

--- a/test/formats/coverart.py
+++ b/test/formats/coverart.py
@@ -148,6 +148,36 @@ class CommonCoverArtTests:
             metadata = load_metadata(self.format_registry, self.filename)
             self.assertEqual(image, metadata.images[0])
 
+        @skipUnlessTestfile
+        def test_cover_art_not_removed_from_tags_by_default(self):
+            image = CoverArtImage(data=self.pngdata, types=['front'])
+            file_save_image(self.format_registry, self.filename, image)
+            config.setting['save_images_to_tags'] = False
+            metadata = save_and_load_metadata(self.format_registry, self.filename, Metadata())
+            self.assertEqual(image, metadata.images[0])
+
+        @skipUnlessTestfile
+        def test_cover_art_remove_images_from_tags(self):
+            image = CoverArtImage(data=self.pngdata, types=['front'])
+            file_save_image(self.format_registry, self.filename, image)
+            config.setting['save_images_to_tags'] = False
+            config.setting['save_images_to_files'] = True
+            config.setting['remove_images_from_tags'] = True
+            metadata = save_and_load_metadata(self.format_registry, self.filename, Metadata())
+            self.assertEqual(0, len(metadata.images))
+
+        @skipUnlessTestfile
+        def test_cover_art_remove_images_from_tags_requires_save_to_files(self):
+            # remove_images_from_tags must never delete the only copy of the
+            # cover art, so it is ignored while save_images_to_files is disabled.
+            image = CoverArtImage(data=self.pngdata, types=['front'])
+            file_save_image(self.format_registry, self.filename, image)
+            config.setting['save_images_to_tags'] = False
+            config.setting['save_images_to_files'] = False
+            config.setting['remove_images_from_tags'] = True
+            metadata = save_and_load_metadata(self.format_registry, self.filename, Metadata())
+            self.assertEqual(image, metadata.images[0])
+
         def _cover_metadata(self):
             imgdata = self.jpegdata
             metadata = Metadata()

--- a/test/test_coverart_details_option.py
+++ b/test/test_coverart_details_option.py
@@ -48,6 +48,7 @@ class _DummyThumb:
         self.current_pixmap_key: int | None = None
         self._visible: bool = True
         self._tooltip: str = ""
+        self.marked_for_removal: bool = False
 
     def setVisible(self, visible: bool) -> None:  # noqa: N802
         self._visible = visible
@@ -94,6 +95,7 @@ class _DummyButton:
 class CoverArtBoxLite:
     def __init__(self) -> None:
         self.item = None
+        self._removal_predicted = False
         self.cover_art_label = _DummyLabel()
         self.cover_art_info_label = _DummyLabel()
         self.orig_cover_art_label = _DummyLabel()
@@ -103,6 +105,7 @@ class CoverArtBoxLite:
         self.orig_cover_art = _DummyThumb()
         # Bind helpers from real implementation
         self._first_image_info_lines = CoverArtBox._first_image_info_lines  # type: ignore[assignment]
+        self._format_info_text = CoverArtBox._format_info_text  # type: ignore[assignment]
 
     def isHidden(self) -> bool:  # noqa: N802
         return False

--- a/test/test_coverart_removal_display.py
+++ b/test/test_coverart_removal_display.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""Tests for consistent display of cover art marked for removal from tags."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PyQt6 import (
+    QtCore,
+    QtGui,
+)
+
+from picard.config import get_config
+from picard.util.imagelist import ImageList
+from picard.util.lrucache import LRUCache
+
+import pytest
+
+from picard.ui.coverartbox import CoverArtBox
+from picard.ui.infodialog.dialog import ArtworkRow
+
+
+def _png_bytes() -> bytes:
+    image = QtGui.QImage(10, 10, QtGui.QImage.Format.Format_RGB32)
+    image.fill(QtGui.QColor('blue'))
+    data = QtCore.QByteArray()
+    buffer = QtCore.QBuffer(data)
+    buffer.open(QtCore.QIODevice.OpenModeFlag.WriteOnly)
+    image.save(buffer, 'PNG')
+    buffer.close()
+    return bytes(data)
+
+
+class FakeImage:
+    external_file_coverart = None
+    width = 100
+    height = 100
+
+    def __init__(self, data: bytes = b'') -> None:
+        self._data = data
+
+    @property
+    def data(self) -> bytes:
+        return self._data
+
+    def types_as_string(self) -> str:
+        return "front"
+
+    def is_front_image(self) -> bool:
+        return True
+
+    def normalized_types(self) -> tuple[str, ...]:
+        return ('front',)
+
+
+# --- ArtworkRow "New Exported" fallback -------------------------------------
+
+
+def test_artwork_row_uses_external_file_coverart() -> None:
+    image = FakeImage()
+    external = FakeImage()
+    image.external_file_coverart = external
+    row = ArtworkRow(new_image=image)
+    assert row.new_external_image is external
+
+
+def test_artwork_row_no_fallback_by_default() -> None:
+    row = ArtworkRow(new_image=FakeImage())
+    assert row.new_external_image is None
+
+
+def test_artwork_row_falls_back_to_image_when_removal_predicted() -> None:
+    image = FakeImage()
+    row = ArtworkRow(new_image=image, external_fallback=True)
+    assert row.new_external_image is image
+
+
+def test_artwork_row_prefers_external_over_fallback() -> None:
+    image = FakeImage()
+    external = FakeImage()
+    image.external_file_coverart = external
+    row = ArtworkRow(new_image=image, external_fallback=True)
+    assert row.new_external_image is external
+
+
+def test_artwork_row_falls_back_to_orig_image_when_no_new_image() -> None:
+    """When no new replacement was fetched, the originally tagged image
+    itself is what gets exported to a file instead of being lost."""
+    orig_image = FakeImage()
+    row = ArtworkRow(orig_image=orig_image, new_image=None, external_fallback=True)
+    assert row.new_external_image is orig_image
+
+
+def test_artwork_row_no_orig_fallback_without_removal_predicted() -> None:
+    orig_image = FakeImage()
+    row = ArtworkRow(orig_image=orig_image, new_image=None, external_fallback=False)
+    assert row.new_external_image is None
+
+
+# --- CoverArtThumbnail removal overlay ---------------------------------------
+
+
+@pytest.fixture
+def thumbnail(qapp, monkeypatch):
+    from PyQt6 import QtWidgets
+
+    mock_tagger = MagicMock()
+    mock_tagger.primaryScreen.return_value.devicePixelRatio.return_value = 1.0
+    monkeypatch.setattr(
+        'picard.ui.coverartbox.coverartthumbnail.tagger_instance',
+        lambda: mock_tagger,
+    )
+    from picard.ui.coverartbox.coverartthumbnail import CoverArtThumbnail
+
+    parent = QtWidgets.QWidget()
+    thumb = CoverArtThumbnail(pixmap_cache=LRUCache(10), parent=parent)
+    yield thumb
+    parent.deleteLater()
+
+
+def test_thumbnail_removal_overlay_changes_pixmap(thumbnail) -> None:
+    image = FakeImage(_png_bytes())
+    thumbnail.set_data([image], force=True)
+    unmarked = thumbnail.pixmap().toImage()
+    key = thumbnail.current_pixmap_key
+
+    thumbnail.set_marked_for_removal(True)
+    marked = thumbnail.pixmap().toImage()
+    assert marked != unmarked
+    # Marking must not change image identity used to compare thumbnails
+    assert thumbnail.current_pixmap_key == key
+
+    thumbnail.set_marked_for_removal(False)
+    assert thumbnail.pixmap().toImage() == unmarked
+
+
+def test_thumbnail_removal_overlay_kept_on_new_data(thumbnail) -> None:
+    thumbnail.set_marked_for_removal(True)
+    image = FakeImage(_png_bytes())
+    thumbnail.set_data([image], force=True)
+    marked = thumbnail.pixmap().toImage()
+
+    thumbnail.set_marked_for_removal(False)
+    assert thumbnail.pixmap().toImage() != marked
+
+
+# --- CoverArtBox marking logic -----------------------------------------------
+
+
+class _RemovalThumb:
+    def __init__(self) -> None:
+        self.data: list[object] | None = None
+        self.marked_for_removal = False
+        self.related_images: list[object] = []
+
+    def set_metadata(self, metadata) -> None:
+        if metadata is not None and metadata.images:
+            self.data = list(metadata.images)
+        else:
+            self.data = None
+
+    def set_marked_for_removal(self, marked_for_removal) -> None:
+        self.marked_for_removal = bool(marked_for_removal)
+
+    def __eq__(self, other) -> bool:
+        return self.data == other.data
+
+
+class _RemovalBox:
+    update_metadata = CoverArtBox.update_metadata
+
+    def __init__(self, item) -> None:
+        self.item = item
+        self.cover_art = _RemovalThumb()
+        self.orig_cover_art = _RemovalThumb()
+
+    def update_display(self, force: bool = False) -> None:
+        pass
+
+
+def _make_item(new_images: list[object], orig_images: list[object]):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(images=ImageList(new_images)),
+        orig_metadata=SimpleNamespace(images=ImageList(orig_images)),
+    )
+
+
+@pytest.fixture
+def removal_settings():
+    config = get_config()
+    config.setting['save_images_to_files'] = True
+    config.setting['remove_images_from_tags'] = True
+    config.setting['save_images_to_tags'] = False
+    config.setting['embed_only_one_front_image'] = False
+    return config
+
+
+def test_update_metadata_marks_single_view(removal_settings) -> None:
+    image = FakeImage()
+    box = _RemovalBox(_make_item([image], [image]))
+    box.update_metadata()
+    assert box._removal_predicted
+    assert box.orig_cover_art.marked_for_removal
+    # The exported copy is shown as its own unmarked panel, even though its
+    # data is identical to the original tagged image
+    assert not box.cover_art.marked_for_removal
+
+
+def test_update_metadata_marks_only_orig_when_images_differ(removal_settings) -> None:
+    box = _RemovalBox(_make_item([FakeImage()], [FakeImage()]))
+    box.update_metadata()
+    assert box._removal_predicted
+    assert box.orig_cover_art.marked_for_removal
+    assert not box.cover_art.marked_for_removal
+
+
+def test_update_metadata_unmarks_when_removal_disabled(removal_settings) -> None:
+    image = FakeImage()
+    box = _RemovalBox(_make_item([image], [image]))
+    box.update_metadata()
+    assert box.orig_cover_art.marked_for_removal
+
+    # Regression: stale marking must be cleared when prediction no longer holds
+    removal_settings.setting['remove_images_from_tags'] = False
+    box.update_metadata()
+    assert not box._removal_predicted
+    assert not box.cover_art.marked_for_removal
+    assert not box.orig_cover_art.marked_for_removal
+
+
+def test_update_metadata_no_removal_without_orig_images(removal_settings) -> None:
+    box = _RemovalBox(_make_item([FakeImage()], []))
+    box.update_metadata()
+    assert not box._removal_predicted
+    assert not box.cover_art.marked_for_removal

--- a/test/test_coverart_removal_display.py
+++ b/test/test_coverart_removal_display.py
@@ -185,6 +185,7 @@ class _RemovalThumb:
 
 
 class _RemovalBox:
+    _REMOVAL_SETTINGS = CoverArtBox._REMOVAL_SETTINGS
     update_metadata = CoverArtBox.update_metadata
 
     def __init__(self, item) -> None:
@@ -271,3 +272,37 @@ def test_update_metadata_keeps_showing_exported_image_after_save(removal_setting
     assert not box._removal_predicted
     assert box.cover_art.data == [image]
     assert box.orig_cover_art.data is None
+
+
+def test_setting_changed_triggers_update_metadata(removal_settings, monkeypatch) -> None:
+    """Changing remove_images_from_tags via the config signal must trigger
+    update_metadata so the cover art box refreshes without re-selecting."""
+    config = get_config()
+    image = FakeImage()
+    box = _RemovalBox(_make_item([image], [image]))
+    box.update_metadata()
+    assert box._removal_predicted
+
+    # Simulate the signal path: connect _on_setting_changed and fire it
+    from picard.ui.coverartbox import CoverArtBox
+
+    call_log = []
+    original_update = box.update_metadata
+
+    def tracking_update():
+        call_log.append('update_metadata')
+        original_update()
+
+    box.update_metadata = tracking_update
+    on_setting_changed = CoverArtBox._on_setting_changed.__get__(box, type(box))
+
+    # Disabling the option should trigger an update
+    config.setting['remove_images_from_tags'] = False
+    on_setting_changed('remove_images_from_tags', True, False)
+    assert 'update_metadata' in call_log
+    assert not box._removal_predicted
+
+    # An unrelated setting should not trigger an update
+    call_log.clear()
+    on_setting_changed('some_other_setting', None, None)
+    assert call_log == []

--- a/test/test_coverart_removal_display.py
+++ b/test/test_coverart_removal_display.py
@@ -256,6 +256,14 @@ def test_update_metadata_no_removal_without_orig_images(removal_settings) -> Non
     assert not box.cover_art.marked_for_removal
 
 
+def test_update_metadata_no_removal_when_saving_to_tags(removal_settings) -> None:
+    removal_settings.setting['save_images_to_tags'] = True
+    box = _RemovalBox(_make_item([], [FakeImage()]))
+    box.update_metadata()
+    assert not box._removal_predicted
+    assert not box.orig_cover_art.marked_for_removal
+
+
 def test_update_metadata_no_removal_for_file_in_cluster(removal_settings) -> None:
     """Files in a cluster (left pane) should not show the removal indicator.
     The warning should only appear once the file is matched to a track."""

--- a/test/test_coverart_removal_display.py
+++ b/test/test_coverart_removal_display.py
@@ -191,6 +191,7 @@ class _RemovalBox:
         self.item = item
         self.cover_art = _RemovalThumb()
         self.orig_cover_art = _RemovalThumb()
+        self._exported_images = None
 
     def update_display(self, force: bool = False) -> None:
         pass
@@ -251,3 +252,22 @@ def test_update_metadata_no_removal_without_orig_images(removal_settings) -> Non
     box.update_metadata()
     assert not box._removal_predicted
     assert not box.cover_art.marked_for_removal
+
+
+def test_update_metadata_keeps_showing_exported_image_after_save(removal_settings) -> None:
+    """Once a save has cleared orig_metadata.images (see File._saving_finished),
+    cover_art must keep showing the image that was exported instead of falling
+    back to nothing, since neither metadata nor orig_metadata reference it
+    anymore."""
+    image = FakeImage()
+    box = _RemovalBox(_make_item([], [image]))
+    box.update_metadata()
+    assert box._removal_predicted
+    assert box.cover_art.data == [image]
+
+    # Simulate the save completing: orig_metadata.images is now empty too.
+    box.item = _make_item([], [])
+    box.update_metadata()
+    assert not box._removal_predicted
+    assert box.cover_art.data == [image]
+    assert box.orig_cover_art.data is None

--- a/test/test_coverart_removal_display.py
+++ b/test/test_coverart_removal_display.py
@@ -28,6 +28,7 @@ from PyQt6 import (
     QtGui,
 )
 
+from picard.cluster import Cluster
 from picard.config import get_config
 from picard.util.imagelist import ImageList
 from picard.util.lrucache import LRUCache
@@ -253,6 +254,19 @@ def test_update_metadata_no_removal_without_orig_images(removal_settings) -> Non
     box.update_metadata()
     assert not box._removal_predicted
     assert not box.cover_art.marked_for_removal
+
+
+def test_update_metadata_no_removal_for_file_in_cluster(removal_settings) -> None:
+    """Files in a cluster (left pane) should not show the removal indicator.
+    The warning should only appear once the file is matched to a track."""
+    image = FakeImage()
+    item = _make_item([image], [image])
+    # Simulate a File whose parent_item is a Cluster
+    item.parent_item = Cluster("Test Cluster")
+    box = _RemovalBox(item)
+    box.update_metadata()
+    assert not box._removal_predicted
+    assert not box.orig_cover_art.marked_for_removal
 
 
 def test_update_metadata_keeps_showing_exported_image_after_save(removal_settings) -> None:

--- a/test/test_coverartbox_info.py
+++ b/test/test_coverartbox_info.py
@@ -52,6 +52,7 @@ class _DummyThumb:
         self.current_pixmap_key: int | None = None
         self._visible: bool = True
         self._tooltip: str = ""
+        self.marked_for_removal: bool = False
 
     def setVisible(self, visible: bool) -> None:  # noqa: N802 (Qt-style API)
         self._visible = visible
@@ -64,6 +65,9 @@ class _DummyThumb:
 
     def toolTip(self) -> str:  # noqa: N802
         return self._tooltip
+
+    def __eq__(self, other: object) -> bool:
+        return self.current_pixmap_key == getattr(other, 'current_pixmap_key', None)
 
 
 class _DummyLabel:
@@ -98,6 +102,7 @@ class _DummyButton:
 class CoverArtBoxLite:
     def __init__(self) -> None:
         self.item = None
+        self._removal_predicted = False
         self.cover_art_label = _DummyLabel()
         self.cover_art_info_label = _DummyLabel()
         self.orig_cover_art_label = _DummyLabel()
@@ -107,6 +112,7 @@ class CoverArtBoxLite:
         self.orig_cover_art = _DummyThumb()
         # Reuse real implementation helpers
         self._first_image_info_lines = CoverArtBox._first_image_info_lines  # type: ignore[assignment]
+        self._format_info_text = CoverArtBox._format_info_text  # type: ignore[assignment]
 
     def isHidden(self) -> bool:  # noqa: N802
         return False
@@ -294,3 +300,83 @@ def test_update_display_both_visible_headers_and_info(cover_art_box: CoverArtBox
     assert not cover_art_box.orig_cover_art_info_label.isVisible()
     assert cover_art_box.cover_art_info_label.text() == ""
     assert cover_art_box.orig_cover_art_info_label.text() == ""
+
+
+def test_update_display_marked_for_removal_tooltip(cover_art_box: CoverArtBox) -> None:
+    from picard.config import get_config
+
+    get_config().setting['show_cover_art_details'] = True
+
+    img_new = DummyImage("Front", 2000, 10, 10, "image/png")
+    img_orig = DummyImage("Back", 3000, 20, 20, "image/jpeg")
+    cover_art_box.cover_art.related_images = [img_new]
+    cover_art_box.orig_cover_art.related_images = [img_orig]
+    cover_art_box.cover_art.data = [_ImgLikeNew()]
+    cover_art_box.orig_cover_art.data = [_ImgLike()]
+    cover_art_box.cover_art.current_pixmap_key = 1
+    cover_art_box.orig_cover_art.current_pixmap_key = 2
+    cover_art_box._removal_predicted = True
+    cover_art_box.orig_cover_art.marked_for_removal = True
+
+    cover_art_box.show()
+    cover_art_box.update_display(force=True)
+
+    # Tooltip of the marked thumbnail explains the removal, and its info
+    # label is styled with a red strikethrough; the unmarked one stays plain
+    assert "removed from tags" in cover_art_box.orig_cover_art.toolTip()
+    assert "removed from tags" not in cover_art_box.cover_art.toolTip()
+    assert 'line-through' in cover_art_box.orig_cover_art_info_label.text()
+    assert 'line-through' not in cover_art_box.cover_art_info_label.text()
+
+
+def test_update_display_shows_export_panel_when_identical_to_original(cover_art_box: CoverArtBox) -> None:
+    """When nothing new was fetched, the image being removed from tags is
+    still the one exported to a file: both panels must stay visible and
+    only the original (tags) panel gets the removal styling."""
+    img = DummyImage("Front", 2000, 10, 10, "image/png")
+    cover_art_box.cover_art.related_images = [img]
+    cover_art_box.orig_cover_art.related_images = [img]
+    cover_art_box.cover_art.data = [_ImgLike()]
+    cover_art_box.orig_cover_art.data = [_ImgLike()]
+    cover_art_box.cover_art.current_pixmap_key = 1
+    cover_art_box.orig_cover_art.current_pixmap_key = 1
+    cover_art_box._removal_predicted = True
+    cover_art_box.orig_cover_art.marked_for_removal = True
+
+    cover_art_box.show()
+    cover_art_box.update_display(force=True)
+
+    assert cover_art_box.orig_cover_art.isVisible()
+    assert cover_art_box.cover_art_label.text() == "Saved to File"
+    assert cover_art_box.orig_cover_art_label.text() == "Original Cover Art"
+    assert "removed from tags" not in cover_art_box.cover_art.toolTip()
+    assert "removed from tags" in cover_art_box.orig_cover_art.toolTip()
+
+
+def test_update_display_no_data_does_not_crash(cover_art_box: CoverArtBoxLite, monkeypatch) -> None:
+    """Regression: update_display() must not crash on the real CoverArtThumbnail
+    when no item is selected yet (both thumbnails have data=None), since its
+    __eq__ calls len() on data (see startup crash after PICARD-3380 changes)."""
+    from unittest.mock import MagicMock
+
+    from PyQt6 import QtWidgets
+
+    mock_tagger = MagicMock()
+    mock_tagger.primaryScreen.return_value.devicePixelRatio.return_value = 1.0
+    monkeypatch.setattr(
+        'picard.ui.coverartbox.coverartthumbnail.tagger_instance',
+        lambda: mock_tagger,
+    )
+    from picard.util.lrucache import LRUCache
+
+    from picard.ui.coverartbox.coverartthumbnail import CoverArtThumbnail
+
+    parent = QtWidgets.QWidget()
+    try:
+        cache = LRUCache(10)
+        cover_art_box.cover_art = CoverArtThumbnail(pixmap_cache=cache, parent=parent)
+        cover_art_box.orig_cover_art = CoverArtThumbnail(pixmap_cache=cache, parent=parent)
+
+        cover_art_box.update_display(force=True)
+    finally:
+        parent.deleteLater()

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -579,8 +579,8 @@ class FileUpdateTest(PicardTestCase):
 
     def test_same_image(self):
         image = create_image(b'a')
-        self.file.metadata.images = [image]
-        self.file.orig_metadata.images = [image]
+        self.file.metadata.images = ImageList([image])
+        self.file.orig_metadata.images = ImageList([image])
         self.file.state = File.State.NORMAL
 
         self.file.update(signal=False)
@@ -598,8 +598,8 @@ class FileUpdateTest(PicardTestCase):
 
     def test_same_image_changed_state(self):
         image = create_image(b'a')
-        self.file.metadata.images = [image]
-        self.file.orig_metadata.images = [image]
+        self.file.metadata.images = ImageList([image])
+        self.file.orig_metadata.images = ImageList([image])
         self.file.state = File.State.CHANGED
 
         self.file.update(signal=False)
@@ -609,8 +609,8 @@ class FileUpdateTest(PicardTestCase):
     def test_changed_image(self):
         old_image = create_image(b'a')
         new_image = create_image(b'b')
-        self.file.metadata.images = [new_image]
-        self.file.orig_metadata.images = [old_image]
+        self.file.metadata.images = ImageList([new_image])
+        self.file.orig_metadata.images = ImageList([old_image])
         self.file.state = File.State.NORMAL
 
         self.file.update(signal=False)

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -45,6 +45,7 @@ from picard.tags import (
     calculated_tag_names,
     file_info_tag_names,
 )
+from picard.util.imagelist import ImageList
 
 
 class FileTest(PicardTestCase):
@@ -781,6 +782,103 @@ class FileUpdateTest(PicardTestCase):
             self.assertEqual('val' + info, metadata[info])
         self.assertEqual('valb', metadata['b'])
         self.assertNotIn('a', metadata)
+
+
+class FileSavingFinishedImagesTest(PicardTestCase):
+    """Regression tests for PICARD-3380: orig_metadata.images must reflect
+    what actually ended up embedded in tags after a save, not just whatever
+    self.metadata.images happened to contain (see ImageList)."""
+
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+        self.file = FakeMp3File('somepath/somefile.mp3')
+        self.tagger.files[self.file.filename] = self.file
+        self.set_config_values(
+            {
+                'clear_existing_tags': False,
+                'preserve_images': False,
+                'embed_only_one_front_image': False,
+                'enabled_plugins': [],
+            }
+        )
+
+    def _finish_saving(self):
+        self.file._saving_finished(result=self.file.filename)
+
+    def test_removed_from_tags_with_no_replacement(self):
+        """No new image was fetched, only the previously tagged image kept
+        for external export: tags end up empty, orig_metadata must match."""
+        image = create_image(b'a', types=['front'], support_types=True)
+        self.file.orig_metadata.images = ImageList([image])
+        self.file.metadata.copy(self.file.orig_metadata)
+        self.set_config_values(
+            {
+                'save_images_to_tags': False,
+                'save_images_to_files': True,
+                'remove_images_from_tags': True,
+            }
+        )
+
+        self._finish_saving()
+
+        self.assertEqual(0, len(self.file.orig_metadata.images))
+
+    def test_not_removed_when_remove_disabled(self):
+        """Without remove_images_from_tags, an untouched embedded image must
+        remain reflected in orig_metadata after saving."""
+        image = create_image(b'a', types=['front'], support_types=True)
+        self.file.orig_metadata.images = ImageList([image])
+        self.file.metadata.copy(self.file.orig_metadata)
+        self.set_config_values(
+            {
+                'save_images_to_tags': False,
+                'save_images_to_files': True,
+                'remove_images_from_tags': False,
+            }
+        )
+
+        self._finish_saving()
+
+        self.assertEqual([image], list(self.file.orig_metadata.images))
+
+    def test_replaced_image_reflected_after_save(self):
+        """A new embedded image replaces the old one in orig_metadata."""
+        old_image = create_image(b'a', types=['front'], support_types=True)
+        new_image = create_image(b'b', types=['front'], support_types=True)
+        self.file.orig_metadata.images = ImageList([old_image])
+        self.file.metadata.images = ImageList([new_image])
+        self.set_config_values(
+            {
+                'save_images_to_tags': True,
+                'save_images_to_files': False,
+                'remove_images_from_tags': False,
+            }
+        )
+
+        self._finish_saving()
+
+        self.assertEqual([new_image], list(self.file.orig_metadata.images))
+
+    def test_metadata_images_changed_emitted_on_removal(self):
+        """The removal must be signalled even though self.metadata.images
+        never differed from self.orig_metadata.images before saving."""
+        image = create_image(b'a', types=['front'], support_types=True)
+        self.file.orig_metadata.images = ImageList([image])
+        self.file.metadata.copy(self.file.orig_metadata)
+        self.set_config_values(
+            {
+                'save_images_to_tags': False,
+                'save_images_to_files': True,
+                'remove_images_from_tags': True,
+            }
+        )
+        received = []
+        self.file.metadata_images_changed.connect(lambda: received.append(True))
+
+        self._finish_saving()
+
+        self.assertEqual([True], received)
 
 
 class FileCopyMetadataTest(PicardTestCase):

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -334,6 +334,43 @@ class ImageListTest(PicardTestCase):
         with self.assertRaises(KeyError):
             next(to_be_saved(settings))
 
+    def test_to_be_saved_to_tags_with_previous_images(self):
+        """A "never replace with smaller" rejection only excludes the image
+        from tags, it stays available for external file saving."""
+        self.set_config_values(
+            {
+                'dont_replace_with_smaller_cover': True,
+                'dont_replace_cover_of_types': False,
+                'dont_replace_included_types': [],
+            }
+        )
+        settings = {
+            "save_images_to_tags": True,
+            "embed_only_one_front_image": False,
+        }
+        previous_image = self.images['b']  # front, larger by default (same size here)
+        previous_image.width = 1000
+        previous_image.height = 1000
+        previous_images = ImageList([previous_image])
+
+        smaller_front = self.images['c']
+        smaller_front.width = 500
+        smaller_front.height = 500
+        self.imagelist.append(smaller_front)
+
+        # rejected for tags because it is smaller than the previous front image
+        self.assertEqual(list(self.imagelist.to_be_saved_to_tags(settings, previous_images)), [])
+        # still available for saving to an external file
+        self.assertEqual(
+            list(
+                self.imagelist.to_be_saved_to_files({"save_images_to_files": True, "save_only_one_front_image": False})
+            ),
+            [smaller_front],
+        )
+
+        # without previous_images, no per-file filtering happens
+        self.assertEqual(list(self.imagelist.to_be_saved_to_tags(settings)), [smaller_front])
+
     def test_to_be_saved_to_files(self):
         def to_be_saved(settings):
             return self.imagelist.to_be_saved_to_files(settings=settings)
@@ -376,6 +413,71 @@ class ImageListTest(PicardTestCase):
         del settings["save_images_to_files"]
         with self.assertRaises(KeyError):
             next(to_be_saved(settings))
+
+    def test_should_remove_images_from_tags_requires_something_to_export(self):
+        """Never report tags-removal as intended unless an image will
+        actually be saved to an external file, to avoid deleting cover art
+        without keeping it anywhere (see PICARD-3380)."""
+        settings = {
+            "remove_images_from_tags": True,
+            "save_images_to_files": True,
+            "save_only_one_front_image": False,
+        }
+        # nothing in the list to export: must not report removal as safe
+        self.assertFalse(self.imagelist.should_remove_images_from_tags(settings))
+
+        # an image is available to export: removal is safe
+        self.imagelist.append(self.images['a'])
+        self.assertTrue(self.imagelist.should_remove_images_from_tags(settings))
+
+        # explicitly disabled by user
+        settings["remove_images_from_tags"] = False
+        self.assertFalse(self.imagelist.should_remove_images_from_tags(settings))
+
+        # not saving to files at all: nothing will be kept
+        settings["remove_images_from_tags"] = True
+        settings["save_images_to_files"] = False
+        self.assertFalse(self.imagelist.should_remove_images_from_tags(settings))
+
+    def test_to_be_saved_to_files_keeps_higher_quality_previous_image(self):
+        """When tags are about to be cleared, a previously tagged image is
+        exported to disk instead of being lost, unless a same-or-better
+        replacement is already being exported (see PICARD-3380)."""
+
+        def front_image(name, width, height):
+            image = CoverArtImage(
+                url='file://' + name,
+                data=create_fake_png(name.encode('utf-8')),
+                types=['front'],
+                support_types=True,
+            )
+            image.width = width
+            image.height = height
+            return image
+
+        settings = {
+            "remove_images_from_tags": True,
+            "save_images_to_files": True,
+            "save_only_one_front_image": False,
+        }
+        previous_front = front_image('previous', 1000, 1000)
+        previous_images = ImageList([previous_front])
+
+        # no new image at all: the previous (tagged) image is preserved
+        self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [previous_front])
+
+        # new replacement is smaller: the previous, bigger image is used instead
+        smaller_front = front_image('smaller', 500, 500)
+        self.imagelist.append(smaller_front)
+        self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [previous_front])
+
+        # new replacement is bigger: it is exported, the previous one is not duplicated
+        bigger_front = front_image('bigger', 2000, 2000)
+        self.imagelist = ImageList([bigger_front])
+        self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [bigger_front])
+
+        # without previous_images, nothing extra is added
+        self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings)), [bigger_front])
 
     def test_strip_front_images(self):
         self.imagelist.append(self.images['a'])

--- a/test/test_ui_options_cover.py
+++ b/test/test_ui_options_cover.py
@@ -34,15 +34,16 @@ def cover_options_page(qapp, patch_tagger_instance):
     return page
 
 
-def test_force_remove_images_false(cover_options_page):
-    # remove_images_from_tags is checked, but save_images_to_files is not
+def test_save_preserves_remove_even_without_save_to_files(cover_options_page):
+    # The checkbox state is persisted as-is; the runtime guards against
+    # removing images when save_images_to_files is disabled.
     cover_options_page.ui.save_images_to_files.setChecked(False)
     cover_options_page.ui.remove_images_from_tags.setChecked(True)
     cover_options_page.save()
 
     config = get_config()
     assert config.setting['save_images_to_files'] is False
-    assert config.setting['remove_images_from_tags'] is False
+    assert config.setting['remove_images_from_tags'] is True
 
 
 def test_save_keep_remove_images_true(cover_options_page):
@@ -62,15 +63,23 @@ def test_embed_and_remove_are_mutually_exclusive(cover_options_page):
     cover_options_page.ui.remove_images_from_tags.setChecked(True)
     assert cover_options_page.ui.remove_images_from_tags.isEnabled()
 
-    # Enabling embed disables and unchecks remove, regardless of prior state
+    # Enabling embed disables remove but preserves the checked state,
+    # so it's restored when embedding is turned off again.
     cover_options_page.ui.save_images_to_tags.setChecked(True)
     assert not cover_options_page.ui.remove_images_from_tags.isEnabled()
-    assert not cover_options_page.ui.remove_images_from_tags.isChecked()
+    assert cover_options_page.ui.remove_images_from_tags.isChecked()
 
+    # Saving with embed active persists the checkbox state (True), since
+    # the runtime code already guards against the incompatible combination.
     cover_options_page.save()
     config = get_config()
     assert config.setting['save_images_to_tags'] is True
-    assert config.setting['remove_images_from_tags'] is False
+    assert config.setting['remove_images_from_tags'] is True
+
+    # Turning embed off re-enables the checkbox with its prior state intact
+    cover_options_page.ui.save_images_to_tags.setChecked(False)
+    assert cover_options_page.ui.remove_images_from_tags.isEnabled()
+    assert cover_options_page.ui.remove_images_from_tags.isChecked()
 
 
 def test_load_disables_remove_when_embed_enabled(cover_options_page):

--- a/test/test_ui_options_cover.py
+++ b/test/test_ui_options_cover.py
@@ -53,6 +53,7 @@ def test_force_remove_images_false(cover_options_page):
 
 
 def test_save_keep_remove_images_true(cover_options_page):
+    cover_options_page.ui.save_images_to_tags.setChecked(False)
     cover_options_page.ui.save_images_to_files.setChecked(True)
     cover_options_page.ui.remove_images_from_tags.setChecked(True)
     cover_options_page.save()
@@ -60,3 +61,28 @@ def test_save_keep_remove_images_true(cover_options_page):
     config = get_config()
     assert config.setting['save_images_to_files'] is True
     assert config.setting['remove_images_from_tags'] is True
+
+
+def test_embed_and_remove_are_mutually_exclusive(cover_options_page):
+    cover_options_page.ui.save_images_to_files.setChecked(True)
+    cover_options_page.ui.save_images_to_tags.setChecked(False)
+    cover_options_page.ui.remove_images_from_tags.setChecked(True)
+    assert cover_options_page.ui.remove_images_from_tags.isEnabled()
+
+    # Enabling embed disables and unchecks remove, regardless of prior state
+    cover_options_page.ui.save_images_to_tags.setChecked(True)
+    assert not cover_options_page.ui.remove_images_from_tags.isEnabled()
+    assert not cover_options_page.ui.remove_images_from_tags.isChecked()
+
+    cover_options_page.save()
+    config = get_config()
+    assert config.setting['save_images_to_tags'] is True
+    assert config.setting['remove_images_from_tags'] is False
+
+
+def test_load_disables_remove_when_embed_enabled(cover_options_page):
+    cover_options_page.ui.save_images_to_tags.setChecked(True)
+    assert not cover_options_page.ui.remove_images_from_tags.isEnabled()
+
+    cover_options_page.ui.save_images_to_tags.setChecked(False)
+    assert cover_options_page.ui.remove_images_from_tags.isEnabled()

--- a/test/test_ui_options_cover.py
+++ b/test/test_ui_options_cover.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 The MusicBrainz Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from unittest.mock import MagicMock
+
+from picard.config import get_config
+
+import pytest
+
+from picard.ui.options.cover import CoverOptionsPage
+
+
+@pytest.fixture(autouse=True)
+def _patch_tagger_instance(monkeypatch):
+    import picard.ui.options as options_module
+
+    monkeypatch.setattr(options_module, 'tagger_instance', lambda: MagicMock())
+
+
+def test_save_forces_remove_images_from_tags_false_when_save_to_files_disabled():
+    page = CoverOptionsPage()
+    page.load()
+
+    # remove_images_from_tags is checked, but save_images_to_files is not
+    page.ui.save_images_to_files.setChecked(False)
+    page.ui.remove_images_from_tags.setChecked(True)
+    page.save()
+
+    config = get_config()
+    assert config.setting['save_images_to_files'] is False
+    assert config.setting['remove_images_from_tags'] is False
+
+
+def test_save_keeps_remove_images_from_tags_true_when_save_to_files_enabled():
+    page = CoverOptionsPage()
+    page.load()
+
+    page.ui.save_images_to_files.setChecked(True)
+    page.ui.remove_images_from_tags.setChecked(True)
+    page.save()
+
+    config = get_config()
+    assert config.setting['save_images_to_files'] is True
+    assert config.setting['remove_images_from_tags'] is True

--- a/test/test_ui_options_cover.py
+++ b/test/test_ui_options_cover.py
@@ -18,24 +18,17 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from test.picardtestcase import MockTagger
-
 from picard.config import get_config
 
 import pytest
 
-import picard.ui.options as options_module
 from picard.ui.options.cover import CoverOptionsPage
 
 
-@pytest.fixture(autouse=True)
-def _patch_tagger_instance(monkeypatch):
-    tagger = MockTagger()
-    monkeypatch.setattr(options_module, 'tagger_instance', lambda: tagger)
-
-
 @pytest.fixture()
-def cover_options_page(qapp):
+def cover_options_page(qapp, patch_tagger_instance):
+    patch_tagger_instance('picard.ui.options')
+
     page = CoverOptionsPage()
     page.load()
     return page

--- a/test/test_ui_options_cover.py
+++ b/test/test_ui_options_cover.py
@@ -18,43 +18,44 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from unittest.mock import MagicMock
+from test.picardtestcase import MockTagger
 
 from picard.config import get_config
 
 import pytest
 
+import picard.ui.options as options_module
 from picard.ui.options.cover import CoverOptionsPage
 
 
 @pytest.fixture(autouse=True)
 def _patch_tagger_instance(monkeypatch):
-    import picard.ui.options as options_module
+    tagger = MockTagger()
+    monkeypatch.setattr(options_module, 'tagger_instance', lambda: tagger)
 
-    monkeypatch.setattr(options_module, 'tagger_instance', lambda: MagicMock())
 
-
-def test_save_forces_remove_images_from_tags_false_when_save_to_files_disabled():
+@pytest.fixture()
+def cover_options_page(qapp):
     page = CoverOptionsPage()
     page.load()
+    return page
 
+
+def test_force_remove_images_false(cover_options_page):
     # remove_images_from_tags is checked, but save_images_to_files is not
-    page.ui.save_images_to_files.setChecked(False)
-    page.ui.remove_images_from_tags.setChecked(True)
-    page.save()
+    cover_options_page.ui.save_images_to_files.setChecked(False)
+    cover_options_page.ui.remove_images_from_tags.setChecked(True)
+    cover_options_page.save()
 
     config = get_config()
     assert config.setting['save_images_to_files'] is False
     assert config.setting['remove_images_from_tags'] is False
 
 
-def test_save_keeps_remove_images_from_tags_true_when_save_to_files_enabled():
-    page = CoverOptionsPage()
-    page.load()
-
-    page.ui.save_images_to_files.setChecked(True)
-    page.ui.remove_images_from_tags.setChecked(True)
-    page.save()
+def test_save_keep_remove_images_true(cover_options_page):
+    cover_options_page.ui.save_images_to_files.setChecked(True)
+    cover_options_page.ui.remove_images_from_tags.setChecked(True)
+    cover_options_page.save()
 
     config = get_config()
     assert config.setting['save_images_to_files'] is True

--- a/test/test_vorbis_sanitize_dates.py
+++ b/test/test_vorbis_sanitize_dates.py
@@ -171,6 +171,7 @@ def test_vorbis_save_respects_date_sanitization_setting(
     md['date'] = input_date
 
     vorbis_file = OggVorbisFile.__new__(OggVorbisFile)
+    vorbis_file.orig_metadata = Metadata()
 
     # Act
     vorbis_file._save('dummy.ogg', md)

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -136,6 +136,9 @@
       </item>
       <item>
        <widget class="QCheckBox" name="remove_images_from_tags">
+        <property name="toolTip">
+         <string>Delete cover images embedded in tags when saving</string>
+        </property>
         <property name="text">
          <string>Remove cover images from tags</string>
         </property>

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -134,6 +134,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="remove_images_from_tags">
+        <property name="text">
+         <string>Remove cover images from tags</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/ui/options_cover.ui
+++ b/ui/options_cover.ui
@@ -137,7 +137,7 @@
       <item>
        <widget class="QCheckBox" name="remove_images_from_tags">
         <property name="toolTip">
-         <string>Delete cover images embedded in tags when saving</string>
+         <string>When saving, remove cover images embedded in tags. Images will only be removed if they are also being saved as separate files.</string>
         </property>
         <property name="text">
          <string>Remove cover images from tags</string>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

**Describe this change in 1-2 sentences**:

This commit adds a new option to the Picard UI to remove cover images from tags for users that only wish to use external cover art.

The option is guarded by "Save cover images as separate files" so tagged artwork is saved to an external file before being removed from the tags.

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3380
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

There is currently not a way to automatically remove cover art from tags for users that wish to exclusively use external cover images.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Add a new option to the Picard UI to "Remove cover images from tags" when being saved to a separate file (so erroneous removal is potentially less destructive).

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->

* UI insertion
* Tagging syntax
* Tests

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

Not tested across all tag formats, only id3 and vorbis.