### PR TITLE
resources/compile: Modernize script and use atomic write pattern

### DIFF
--- a/resources/compile.py
+++ b/resources/compile.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # Picard, the next-generation MusicBrainz tagger
 #
 # Copyright (C) 2006 Lukáš Lalinský
-# Copyright (C) 2013-2014, 2018, 2020 Laurent Monin
+# Copyright (C) 2013-2014, 2018, 2020, 2026 Laurent Monin
 # Copyright (C) 2014 Shadab Zafar
 # Copyright (C) 2016 Sambhav Kothari
 # Copyright (C) 2022 Philipp Wolfer
@@ -24,44 +23,60 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from distutils import log
-from distutils.spawn import (
-    DistutilsExecError,
-    spawn,
-)
-import os.path
+import logging
+import os
+from pathlib import Path
 from shutil import which
+import subprocess
+import sys
+import tempfile
 
-from setuptools.modified import newer
+
+log = logging.getLogger(__name__)
 
 
 def fix_qtcore_import(path):
-    with open(path, 'r') as f:
-        data = f.read()
-    data = data.replace('PySide6', 'PyQt6')
-    with open(path, 'w') as f:
-        f.write(data)
+    data = path.read_text()
+    data = data.replace('from PySide6', 'from PyQt6')
+    path.write_text(data)
+
+
+def find_rcc():
+    """Find the Qt6 rcc binary."""
+    rcc = 'rcc'
+    for path in (
+        '/usr/lib64/qt6/libexec',
+        '/usr/lib/qt6/libexec',
+    ):
+        rcc_path = which(rcc, path=path)
+        if rcc_path:
+            return rcc_path
+    return which(rcc)
 
 
 def main():
-    scriptdir = os.path.dirname(os.path.abspath(__file__))
-    topdir = os.path.abspath(os.path.join(scriptdir, ".."))
-    pyfile = os.path.join(topdir, "picard", "resources.py")
-    qrcfile = os.path.join(topdir, "resources", "picard.qrc")
-    if newer(qrcfile, pyfile):
-        rcc = 'rcc'
-        rcc_path = which(rcc, path='/usr/lib64/qt6/libexec/') or which(rcc, path='/usr/lib/qt6/libexec/') or which(rcc)
-        if rcc_path is None:
-            log.error("%s command not found, cannot build resource file !", rcc)
-        else:
-            cmd = [rcc_path, '-g', 'python', '-o', pyfile, qrcfile]
-            try:
-                spawn(cmd, search_path=0)
-                fix_qtcore_import(pyfile)
-            except DistutilsExecError as e:
-                log.error(e)
+    topdir = Path(__file__).resolve().parent.parent
+    pyfile = topdir / "picard" / "resources.py"
+    qrcfile = topdir / "resources" / "picard.qrc"
+    rcc_path = find_rcc()
+    if rcc_path is None:
+        log.error("rcc command not found, cannot build resource file!")
+        sys.exit(1)
+    if not pyfile.exists() or qrcfile.stat().st_mtime > pyfile.stat().st_mtime:
+        log.info("Using rcc: %s", rcc_path)
+        fd, tmp_name = tempfile.mkstemp(dir=pyfile.parent, suffix='.tmp')
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            cmd = [rcc_path, '-g', 'python', '-o', str(tmp_path), str(qrcfile)]
+            subprocess.check_call(cmd)
+            fix_qtcore_import(tmp_path)
+            tmp_path.replace(pyfile)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
 
 if __name__ == "__main__":
-    log.set_verbosity(1)
+    logging.basicConfig(level=logging.INFO)
     main()


### PR DESCRIPTION
## Summary

* This is a...
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Modernize `resources/compile.py` by removing deprecated distutils usage, switching to pathlib and subprocess, and using an atomic write pattern so `resources.py` is never left in a partial state.

## Problem

* `resources/compile.py` relied on `distutils` (deprecated, removed from stdlib in Python 3.12) and used fragile file writing that could leave `resources.py` corrupted if the build was interrupted.

## Solution

- Replace `distutils.log` and `distutils.spawn` with `logging` and `subprocess`
- Replace `setuptools.modified.newer` with a simple `os.path.getmtime` comparison
- Use `pathlib.Path` for path handling
- Extract `find_rcc()` function for clearer rcc binary search (covers RHEL lib64, Debian lib, and system PATH)
- Check for rcc availability early, before checking timestamps
- Log which rcc binary is being used
- Have rcc write to a temp file, fix the PySide6 import there, then atomically rename to the target
- Remove the unnecessary `coding: utf-8` declaration

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used as a coding assistant for suggestions and reviewing the implementation.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)