### PR TITLE
Fix skipped tests and add patch_tagger_instance fixture

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -145,3 +145,32 @@ def _install_defaulting_config(monkeypatch):
 
     # Yield control to test session
     yield
+
+
+@pytest.fixture()
+def patch_tagger_instance(monkeypatch):
+    """Patch ``tagger_instance`` in one or more modules to return a shared MockTagger.
+
+    Usage in a test::
+
+        def test_something(patch_tagger_instance):
+            patch_tagger_instance('picard.ui.options')
+            ...
+
+    Returns a callable that accepts module path strings.  The underlying
+    mock tagger is available as the ``tagger`` attribute on the callable.
+    """
+    from test.picardtestcase import MockTagger
+
+    tagger = MockTagger()
+
+    def _patch(*modules):
+        for module_path in modules:
+            import importlib
+
+            module = importlib.import_module(module_path)
+            monkeypatch.setattr(module, 'tagger_instance', lambda: tagger)
+        return tagger
+
+    _patch.tagger = tagger
+    return _patch

--- a/test/test_coverart_details_option.py
+++ b/test/test_coverart_details_option.py
@@ -122,11 +122,11 @@ def test_option_default() -> None:
     assert opt.default is False
 
 
-@pytest.mark.skip(reason="This test fails if ran in parallel")
-def test_options_page_load_and_save() -> None:
-    from picard.ui.options.cover import CoverOptionsPage
+def test_options_page_load_and_save(patch_tagger_instance) -> None:
+    patch_tagger_instance('picard.ui.options')
+    from picard.ui.options.interface_cover_art_box import InterfaceCoverArtBoxOptionsPage
 
-    page = CoverOptionsPage()
+    page = InterfaceCoverArtBoxOptionsPage()
     page.load()
     config = get_config()
     # Default is False
@@ -221,14 +221,17 @@ def _set_details_config(
     config.setting['show_cover_art_details_mimetype'] = mime_on
 
 
-@pytest.mark.skip(reason="This test fails if ran in parallel")
-def test_options_page_children_enable_disable_and_save(_restore_cover_details_options: None) -> None:
-    from picard.ui.options.cover import CoverOptionsPage
+def test_options_page_children_enable_disable_and_save(
+    patch_tagger_instance,
+    _restore_cover_details_options: None,
+) -> None:
+    patch_tagger_instance('picard.ui.options')
+    from picard.ui.options.interface_cover_art_box import InterfaceCoverArtBoxOptionsPage
 
     # Ensure parent starts unchecked for this test
     get_config().setting['show_cover_art_details'] = False
 
-    page = CoverOptionsPage()
+    page = InterfaceCoverArtBoxOptionsPage()
     page.load()
     # Initially parent unchecked, children should be disabled (greyed out)
     assert page.ui.cb_show_cover_art_details.isChecked() is False

--- a/test/test_custom_columns.py
+++ b/test/test_custom_columns.py
@@ -24,6 +24,7 @@ from unittest.mock import Mock
 from weakref import ref
 
 from picard.metadata import Metadata
+import picard.script  # noqa: F401 - Ensure built-in script functions are registered
 
 import pytest
 
@@ -260,9 +261,8 @@ def test_callable_column_handles_exceptions() -> None:
     assert col.provider.evaluate(fake_item) == ""
 
 
-# TODO: Skip due to upstream global state interference with ScriptParser functions when full suite runs.
-# Does not impact live usage; scripts load functions correctly in app context.
-@pytest.mark.skip(reason="Temporarily skipped pending upstream global state investigation")
+# Previously skipped due to test-ordering sensitivity: ScriptParser functions
+# require `picard.script` to be imported for registration (see import above).
 def test_script_column_with_complex_expression(fake_item: _FakeItem) -> None:
     """Test script column with complex expressions."""
     script = "$if(%artist%,%artist% by %album%,Unknown)"


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add a reusable `patch_tagger_instance` pytest fixture and fix two skipped tests that were using the wrong options page class.

## Problem

Two tests in `test_coverart_details_option.py` were permanently skipped:
- `test_options_page_load_and_save`
- `test_options_page_children_enable_disable_and_save`

They had two bugs:
1. They instantiated `CoverOptionsPage` but referenced widgets (`cb_show_cover_art_details` etc.) that live on `InterfaceCoverArtBoxOptionsPage`.
2. They did not patch `tagger_instance`, causing `AttributeError` when `OptionsPage.__init__` tries to access the Tagger singleton.

## Solution

1. Add a `patch_tagger_instance` fixture to `test/conftest.py` that patches `tagger_instance` in specified modules using the project's existing `MockTagger` (with `spec=Tagger`). This provides a consistent, reusable pattern for pytest-style tests that need to instantiate widgets depending on the tagger.

2. Fix the two tests: use `InterfaceCoverArtBoxOptionsPage` (correct page) and the new fixture. Remove `@pytest.mark.skip`.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Fixture design and test diagnosis done with AI assistance.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
