### PR TITLE
PICARD-3385: add tags for called folk dances

### DIFF
--- a/picard/const/tags.py
+++ b/picard/const/tags.py
@@ -335,6 +335,164 @@ ALL_TAGS = TagVars(
         is_from_mb=False,
     ),
     TagVar(
+        'dance_caller',
+        shortdesc=N_('Caller'),
+        longdesc=N_('The name of the dance caller(s) heard in the track.'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_choreographer',
+        shortdesc=N_('Dance Choreographer'),
+        longdesc=N_('The name of the author(s) of the danc(es) being called in the track for called folk dances.'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+        is_multi_value=True,
+    ),
+    TagVar(
+        'dance_choreography',
+        shortdesc=N_('Dance Choreography'),
+        longdesc=N_(
+            'The moves of the dance as text for called folk dances. This should not include the dance title, author, or other information covered by other tags.'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_crooked',
+        shortdesc=N_('Crooked'),
+        longdesc=N_('Whether a traditional called folk dance tune is "crooked" (ie. not in perfect dance form).'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_form',
+        shortdesc=N_('Dance Form'),
+        longdesc=N_(
+            'The form of a called dance with no particular format, eg. "contra" or "square dance" or "duple minor improper contra".'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_intro',
+        shortdesc=N_('Intro Beats'),
+        longdesc=N_('The number of intro beats before the dance or any potatoes for called folk dances.'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_issong',
+        shortdesc=N_('Has Vocals'),
+        longdesc=N_(
+            'Whether the track is a song (has sung vocals other than the caller) or a tune (instrumental only) for traditional music forms that make this distinction.'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_license',
+        shortdesc=N_('Dance License'),
+        longdesc=N_(
+            'Like the license field except relating to the choreography of the dance being called for called folk dances.'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_potatoes',
+        shortdesc=N_('Potatoes'),
+        longdesc=N_('The number of "potatoes" (syncronization beats played before some traditional folk dances).'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_roles',
+        shortdesc=N_('Dance Roles'),
+        longdesc=N_(
+            'The role terms used for calls in a called folk dance, eg. "Larks/Robins" or "Leads/Follows" or "Positional".'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_start',
+        shortdesc=N_('Dance Start Time'),
+        longdesc=N_('The start time (in milliseconds) of the first time through the dance in a called folk dance.'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+    ),
+    TagVar(
+        'dance_times',
+        shortdesc=N_('Dance Times'),
+        longdesc=N_(
+            'The number of complete times through the dance excluding any intro, outro, or potatoes for a called folk dance. The exact definition will depend on the type of dance.'
+        ),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+        is_multi_value=True,
+    ),
+    TagVar(
+        'dance_title',
+        shortdesc=N_('Dance Title'),
+        longdesc=N_('The name of the dance(es) being called for called folk dances.'),
+        doc_links=(
+            DocumentLink(
+                N_('I-D: Metadata for Called Folk Dances'),
+                'https://datatracker.ietf.org/doc/draft-swhited-contra-tags/',
+            ),
+        ),
+        is_multi_value=True,
+    ),
+    TagVar(
         'datatrack',
         shortdesc=N_('Data Track'),
         longdesc=N_('Set to 1 if the track is a "data track", otherwise empty.'),

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -137,6 +137,18 @@ class VCommentFile(File):
             'musicbrainz_releasetrackid': 'musicbrainz_trackid',
             'musicbrainz_trackid': 'musicbrainz_recordingid',
             'waveformatextensible_channel_mask': '~waveformatextensible_channel_mask',
+            'dance:caller': 'dance_caller',
+            'dance:choreographer': 'dance_choreographer',
+            'dance:choreography': 'dance_choreography',
+            'dance:crooked': 'dance_crooked',
+            'dance:form': 'dance_form',
+            'dance:intro': 'dance_intro',
+            'dance:issong': 'dance_song',
+            'dance:license': 'dance_license',
+            'dance:potatoes': 'dance_potatoes',
+            'dance:roles': 'dance_roles',
+            'dance:start': 'dance_start',
+            'dance:titles': 'dance_titles',
         }
     )
     __rtranslate = MappingProxyType({v: k for k, v in __translate.items()})

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -137,18 +137,6 @@ class VCommentFile(File):
             'musicbrainz_releasetrackid': 'musicbrainz_trackid',
             'musicbrainz_trackid': 'musicbrainz_recordingid',
             'waveformatextensible_channel_mask': '~waveformatextensible_channel_mask',
-            'dance:caller': 'dance_caller',
-            'dance:choreographer': 'dance_choreographer',
-            'dance:choreography': 'dance_choreography',
-            'dance:crooked': 'dance_crooked',
-            'dance:form': 'dance_form',
-            'dance:intro': 'dance_intro',
-            'dance:issong': 'dance_song',
-            'dance:license': 'dance_license',
-            'dance:potatoes': 'dance_potatoes',
-            'dance:roles': 'dance_roles',
-            'dance:start': 'dance_start',
-            'dance:titles': 'dance_titles',
         }
     )
     __rtranslate = MappingProxyType({v: k for k, v in __translate.items()})


### PR DESCRIPTION
## Summary

[1]: https://datatracker.ietf.org/doc/draft-swhited-contra-tags/


* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

This patch adds tags for traditional called folk dances from the IETF Internet-Draft (I-D) [draft-swhited-contra-tags-04][1]. It also supports mapping these tags to Vorbis Comment namespaces as recommended in the document when saving a file that uses Vorbis Comments.

* JIRA ticket (_optional_): PICARD-3385



## Solution

This is a relatively simple patch adding the various tags from the document linked above to the tags list found at `picard/const/tags.py`. In addition it adds translations to the format the document recommends for Vorbis Comments to `picard/formats/vorbis.py`. That said, it may be worth removing this second part and updating the document to not make this distinction as I don't see that it provides any value (I simply did this originally because I was told this is how Vorbis tags should be namespaced, but most other tags in more common use don't seem to do this, so we could likely change this and drop this part of the commit, I would be happy to get opinions here).



## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

I don't believe this requires specific updates to the documentation, but if there is a page that exhaustively lists tags like this somewhere that I'm missing I am happy to submit a patch there as well. Thanks!