### PR TITLE
PICARD-3388: Add interface colors API to Plugin v3

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -1203,6 +1203,118 @@ def enable(api):
 
 ---
 
+## Interface Colors
+
+Plugins can register their own configurable colors and access Picard's core
+interface colors. Plugin colors appear in the Interface Colors options page,
+grouped under the plugin's name.
+
+### `api.is_dark_theme`
+
+Property that returns whether the current UI theme is dark.
+
+```python
+if api.is_dark_theme:
+    api.logger.info("Running in dark mode")
+```
+
+### `api.register_color(name, title, light_value=None, dark_value=None)`
+
+Register a configurable color for the plugin.
+
+**Parameters:**
+- `name` — Simple identifier (alphanumeric and underscores, e.g., `'highlight'`)
+- `title` — User-visible label (use `api.tr()` for translation)
+- `light_value` — Color for light theme (hex string or CSS color name)
+- `dark_value` — Color for dark theme (hex string or CSS color name)
+
+At least one of `light_value`/`dark_value` must be provided. If only one is
+given, the other defaults to the same value.
+
+Colors are automatically unregistered when the plugin is disabled.
+
+```python
+def enable(api):
+    api.register_color(
+        'highlight',
+        title=api.tr('colors.highlight', "Highlight color"),
+        light_value='#FFDD00',
+        dark_value='#AA9900',
+    )
+    api.register_color(
+        'warning_text',
+        title=api.tr('colors.warning', "Warning text"),
+        light_value='darkorange',
+    )
+```
+
+### `api.get_plugin_color(name)` / `api.get_plugin_qcolor(name)`
+
+Read a plugin-registered color.
+
+```python
+color_hex = api.get_plugin_color('highlight')  # Returns '#ffdd00'
+qcolor = api.get_plugin_qcolor('highlight')  # Returns QColor
+```
+
+### `api.get_color(name)` / `api.get_qcolor(name)`
+
+Read a core Picard interface color (read-only). Useful for matching your
+plugin's UI to Picard's look.
+
+**Available core color keys:**
+- `entity_error`, `entity_pending`, `entity_saved` — Entity states
+- `log_debug`, `log_error`, `log_info`, `log_warning` — Log view
+- `tagstatus_added`, `tagstatus_changed`, `tagstatus_removed` — Tag states
+- `profile_hl_bg`, `profile_hl_fg` — Profile highlighting
+- `row_highlight`, `first_cover_hl` — Miscellaneous highlights
+- `syntax_hl_*` — Script syntax highlighting
+
+```python
+error_color = api.get_color('entity_error')  # Returns '#c80000'
+qcolor = api.get_qcolor('tagstatus_added')  # Returns QColor
+```
+
+### `api.unregister_color(name)` / `api.unregister_all_colors()`
+
+Manually unregister colors. Normally not needed since colors are
+automatically cleaned up on plugin disable.
+
+### Complete Example
+
+```python
+from picard.plugin3.api import PluginApi
+
+
+def enable(api: PluginApi):
+    # Register custom colors for this plugin
+    api.register_color(
+        'match_highlight',
+        title=api.tr('colors.match_hl', "Match highlight"),
+        light_value='#E6FFE6',
+        dark_value='#1A3D1A',
+    )
+    api.register_color(
+        'no_match',
+        title=api.tr('colors.no_match', "No match indicator"),
+        light_value='#FFE6E6',
+        dark_value='#3D1A1A',
+    )
+    api.register_track_metadata_processor(process_track)
+
+
+def process_track(api, album, metadata, track, release):
+    # Read plugin's own color
+    highlight = api.get_plugin_color('match_highlight')
+    # Read core color for consistency
+    saved_color = api.get_color('entity_saved')
+    # Adapt to theme
+    if api.is_dark_theme:
+        ...
+```
+
+---
+
 ## Album Background Task Management
 
 Plugins can track asynchronous operations (like web requests) without blocking album loading.

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -39,6 +39,7 @@ from typing import (
 )
 
 from PyQt6.QtCore import QLocale
+from PyQt6.QtGui import QColor
 
 from picard import log
 from picard.album import Album
@@ -1721,8 +1722,12 @@ class PluginApi:
         """
         if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
             raise ValueError(f"Invalid color name '{name}': must be alphanumeric with underscores")
+        if light_value is not None and not QColor(light_value).isValid():
+            raise ValueError(f"register_color('{name}'): invalid light_value '{light_value}'")
+        if dark_value is not None and not QColor(dark_value).isValid():
+            raise ValueError(f"register_color('{name}'): invalid dark_value '{dark_value}'")
         if light_value is None and dark_value is None:
-            raise ValueError(f"register_color('{name}'): at least one of light_value or dark_value must be provided")
+            raise ValueError(f"register_color('{name}'): no valid color values provided")
         if light_value is None:
             light_value = dark_value
         if dark_value is None:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -118,6 +118,12 @@ from picard.webservice import (
 )
 from picard.webservice.api_helpers import MBAPIHelper
 
+from picard.ui.colors import (
+    ColorDescription,
+    interface_colors,
+    register_color as _register_color,
+    unregister_color as _unregister_color,
+)
 from picard.ui.options import OptionsPage as _OptionsPage
 
 
@@ -295,6 +301,7 @@ class PluginApi:
         self._plugin_dir: Path = plugin_dir
         self._qt_translator: PluginTranslator | None = None
         self._mb_api: MBAPIHelper | None = None
+        self._registered_colors: list[str] = []
 
     @staticmethod
     def _get_caller_info(frame_depth=2):
@@ -1657,6 +1664,153 @@ class PluginApi:
         # The options page needs a unique name if no name was given
         self._set_class_name_and_title(page_class)
         return register_options_page(page_class)
+
+    # Interface colors API
+
+    def _color_key(self, name: str) -> str:
+        """Return the internal namespaced key for a plugin color."""
+        return f'plugin:{self._manifest.uuid}:{name}'
+
+    @property
+    def is_dark_theme(self) -> bool:
+        """Whether the current UI theme is dark.
+
+        Example::
+
+            def enable(api):
+                if api.is_dark_theme:
+                    api.logger.info("Running in dark mode")
+        """
+        return interface_colors.dark_theme
+
+    def register_color(
+        self,
+        name: str,
+        title: str,
+        light_value: str | None = None,
+        dark_value: str | None = None,
+    ) -> None:
+        """Register a configurable color for this plugin.
+
+        The color appears in the Interface Colors options page, grouped
+        under the plugin's name. Users can customize it like any other
+        interface color.
+
+        Args:
+            name: Simple identifier (alphanumeric and underscores only,
+                  e.g., 'highlight', 'error_text').
+            title: User-visible label. Use api.tr() for translation.
+            light_value: Color value for light theme (hex string or CSS
+                         color name, e.g., '#FF0000' or 'red').
+            dark_value: Color value for dark theme.
+
+        At least one of light_value/dark_value must be provided. If only
+        one is given, the other defaults to the same value.
+
+        Colors are automatically unregistered when the plugin is disabled.
+
+        Example::
+
+            def enable(api):
+                api.register_color(
+                    'highlight',
+                    title=api.tr('colors.highlight', "Highlight color"),
+                    light_value='#FFDD00',
+                    dark_value='#AA9900',
+                )
+        """
+        if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
+            raise ValueError(f"Invalid color name '{name}': must be alphanumeric with underscores")
+        if light_value is None and dark_value is None:
+            raise ValueError(f"register_color('{name}'): at least one of light_value or dark_value must be provided")
+        if light_value is None:
+            light_value = dark_value
+        if dark_value is None:
+            dark_value = light_value
+
+        key = self._color_key(name)
+        group = self._manifest.name_i18n()
+        description = ColorDescription(title=title, group=group)
+
+        _register_color(('light',), key, light_value, description=description)
+        _register_color(('dark',), key, dark_value, description=description)
+
+        # Make the color immediately available in the active instance
+        interface_colors.set_default_color(key)
+
+        self._registered_colors.append(key)
+
+    def unregister_color(self, name: str) -> None:
+        """Unregister a plugin color by name.
+
+        Args:
+            name: The same name used in register_color().
+        """
+        key = self._color_key(name)
+        _unregister_color(key)
+        if key in self._registered_colors:
+            self._registered_colors.remove(key)
+
+    def unregister_all_colors(self) -> None:
+        """Unregister all colors registered by this plugin."""
+        for key in list(self._registered_colors):
+            _unregister_color(key)
+        self._registered_colors.clear()
+
+    def get_plugin_color(self, name: str) -> str:
+        """Get the current hex color value for a plugin-registered color.
+
+        Args:
+            name: The name used in register_color().
+
+        Returns:
+            Hex color string (e.g., '#ff0000').
+
+        Example::
+
+            color = api.get_plugin_color('highlight')
+        """
+        return interface_colors.get_color(self._color_key(name))
+
+    def get_plugin_qcolor(self, name: str):
+        """Get a QColor for a plugin-registered color.
+
+        Args:
+            name: The name used in register_color().
+
+        Returns:
+            A QColor instance.
+        """
+        return interface_colors.get_qcolor(self._color_key(name))
+
+    def get_color(self, name: str) -> str:
+        """Get the current hex color value for a core interface color.
+
+        This provides read-only access to Picard's built-in interface
+        colors, allowing plugins to style their UI consistently.
+
+        Args:
+            name: Core color key (e.g., 'entity_error', 'tagstatus_added').
+
+        Returns:
+            Hex color string (e.g., '#c80000').
+
+        Example::
+
+            error_color = api.get_color('entity_error')
+        """
+        return interface_colors.get_color(name)
+
+    def get_qcolor(self, name: str):
+        """Get a QColor for a core interface color.
+
+        Args:
+            name: Core color key (e.g., 'entity_error', 'tagstatus_added').
+
+        Returns:
+            A QColor instance.
+        """
+        return interface_colors.get_qcolor(name)
 
     # Album task management for plugins
     def add_album_task(

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -752,6 +752,7 @@ class Plugin:
         for name, api in list(PluginApi._instances.items()):
             if api._plugin_module is self._module:
                 api._remove_qt_translator()
+                api.unregister_all_colors()
                 profile_groups_remove_group(api._api_config.section_name)
                 del PluginApi._instances[name]
                 # Remove from cache (entries for this module and submodules)

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -70,10 +70,17 @@ _COLOR_DESCRIPTIONS = {
 _DEFAULT_COLORS: dict[str, dict] = defaultdict(dict)
 
 
+def _color_to_string(qcolor):
+    """Convert a QColor to a string, preserving alpha only when not fully opaque."""
+    if qcolor.alpha() == 255:
+        return qcolor.name()
+    return qcolor.name(QtGui.QColor.NameFormat.HexArgb)
+
+
 class DefaultColor:
     def __init__(self, value, description):
         qcolor = QtGui.QColor(value)
-        self.value = qcolor.name()
+        self.value = _color_to_string(qcolor)
         self.description = description
 
 
@@ -220,7 +227,7 @@ class InterfaceColors:
             qcolor = QtGui.QColor(color_value)
             if not qcolor.isValid():
                 qcolor = QtGui.QColor(self.default_colors[color_key].value)
-            self._colors[color_key] = qcolor.name()
+            self._colors[color_key] = _color_to_string(qcolor)
         else:
             raise UnknownColorException("Unknown color key: %s" % color_key)
 

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -77,10 +77,25 @@ class DefaultColor:
         self.description = description
 
 
-def register_color(themes, name, value):
-    description = _COLOR_DESCRIPTIONS.get(name, "FIXME: color desc for %s" % name)
+def register_color(themes, name, value, description=None):
+    if description is None:
+        description = _COLOR_DESCRIPTIONS.get(name, "FIXME: color desc for %s" % name)
+    else:
+        _COLOR_DESCRIPTIONS[name] = description
     for theme_name in themes:
         _DEFAULT_COLORS[theme_name][name] = DefaultColor(value, description)
+
+
+def unregister_color(name):
+    """Remove a color from the registry.
+
+    Removes the color from descriptions, default colors (both themes),
+    and the active InterfaceColors instance.
+    """
+    _COLOR_DESCRIPTIONS.pop(name, None)
+    _DEFAULT_COLORS['light'].pop(name, None)
+    _DEFAULT_COLORS['dark'].pop(name, None)
+    interface_colors._colors.pop(name, None)
 
 
 _DARK = ('dark',)

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -38,7 +38,10 @@ from picard.i18n import (
 )
 from picard.util import icontheme
 
-from picard.ui.colors import interface_colors
+from picard.ui.colors import (
+    _color_to_string,
+    interface_colors,
+)
 from picard.ui.forms.ui_options_interface_colors import (
     Ui_InterfaceColorsOptionsPage,
 )
@@ -52,6 +55,8 @@ from picard.ui.util import changes_require_restart_warning
 class ColorButton(QtWidgets.QPushButton):
     color_changed = QtCore.pyqtSignal(str)
 
+    _checkerboard = None
+
     def __init__(self, initial_color=None, parent=None):
         super().__init__('    ', parent=parent)
         # On macOS the style override in picard.ui.theme breaks styling these
@@ -63,24 +68,48 @@ class ColorButton(QtWidgets.QPushButton):
             color = QtGui.QColor('black')
         self.color = color
         self.clicked.connect(self.open_color_dialog)
-        self.update_color()
+
+    @classmethod
+    def _get_checkerboard(cls):
+        """Create a cached checkerboard pixmap for alpha visualization."""
+        if cls._checkerboard is None:
+            size = 8
+            pixmap = QtGui.QPixmap(size * 2, size * 2)
+            painter = QtGui.QPainter(pixmap)
+            painter.fillRect(0, 0, size, size, QtGui.QColor(204, 204, 204))
+            painter.fillRect(size, 0, size, size, QtGui.QColor(255, 255, 255))
+            painter.fillRect(0, size, size, size, QtGui.QColor(255, 255, 255))
+            painter.fillRect(size, size, size, size, QtGui.QColor(204, 204, 204))
+            painter.end()
+            cls._checkerboard = pixmap
+        return cls._checkerboard
+
+    def paintEvent(self, event):
+        painter = QtGui.QPainter(self)
+        rect = self.rect()
+        if self.color.alpha() < 255:
+            # Draw checkerboard behind semi-transparent color
+            painter.drawTiledPixmap(rect, self._get_checkerboard())
+        painter.fillRect(rect, self.color)
+        painter.end()
 
     def update_color(self, qcolor=None):
         if qcolor is not None:
             self.color = qcolor
-        self.setStyleSheet("QPushButton { background-color: %s; }" % self.color.name())
+        self.update()
 
     def open_color_dialog(self):
         new_color = QtWidgets.QColorDialog.getColor(
             self.color,
             title=_("Choose a color"),
             parent=self.parent(),
+            options=QtWidgets.QColorDialog.ColorDialogOption.ShowAlphaChannel,
         )
 
         if new_color.isValid():
             self.color = new_color
             self.update_color()
-            self.color_changed.emit(self.color.name())
+            self.color_changed.emit(_color_to_string(self.color))
 
 
 def delete_items_of_layout(layout):

--- a/test/plugins3/test_api_colors.py
+++ b/test/plugins3/test_api_colors.py
@@ -227,3 +227,46 @@ class TestUnregisterColor(PicardTestCase):
     def test_unregister_nonexistent_is_safe(self):
         """Test that unregistering a non-existent color doesn't raise."""
         unregister_color('totally_fake_color_key')
+
+
+class TestColorAlphaSupport(PicardTestCase):
+    """Test that colors with alpha are properly stored and retrieved."""
+
+    def test_opaque_color_stored_as_rrggbb(self):
+        """Opaque colors are stored as #RRGGBB (6 digits)."""
+        from picard.ui.colors import _color_to_string
+
+        c = QColor('#FF0000')
+        self.assertEqual(_color_to_string(c), '#ff0000')
+
+    def test_alpha_color_stored_as_aarrggbb(self):
+        """Colors with alpha < 255 are stored as #AARRGGBB (8 digits)."""
+        from picard.ui.colors import _color_to_string
+
+        c = QColor('#80FF0000')
+        self.assertEqual(_color_to_string(c), '#80ff0000')
+
+    def test_register_color_with_alpha(self):
+        """Plugin can register a color with alpha."""
+        from pathlib import Path
+        from unittest.mock import Mock
+
+        from test.plugins3.helpers import load_plugin_manifest
+
+        from picard.plugin3.api import PluginApi
+
+        api = PluginApi(load_plugin_manifest('example'), Mock(), Mock(), Path(''))
+        api.register_color('semi_transparent', title="Semi", light_value='#80FF0000')
+        color = api.get_plugin_color('semi_transparent')
+        self.assertEqual(color, '#80ff0000')
+        qcolor = api.get_plugin_qcolor('semi_transparent')
+        self.assertEqual(qcolor.alpha(), 128)
+        self.assertEqual(qcolor.red(), 255)
+        api.unregister_all_colors()
+
+    def test_shorthand_normalized_to_rrggbb(self):
+        """Shorthand #RGB input is normalized to #RRGGBB."""
+        from picard.ui.colors import _color_to_string
+
+        c = QColor('#ABC')
+        self.assertEqual(_color_to_string(c), '#aabbcc')

--- a/test/plugins3/test_api_colors.py
+++ b/test/plugins3/test_api_colors.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from PyQt6.QtGui import QColor
+
+from test.picardtestcase import PicardTestCase
+from test.plugins3.helpers import load_plugin_manifest
+
+from picard.plugin3.api import PluginApi
+
+from picard.ui.colors import (
+    _COLOR_DESCRIPTIONS,
+    _DEFAULT_COLORS,
+    UnknownColorException,
+    interface_colors,
+    unregister_color,
+)
+
+
+class TestPluginApiColors(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.api = PluginApi(load_plugin_manifest('example'), Mock(), Mock(), Path(''))
+        # Clean up any colors registered by this test
+        self._registered_keys = []
+
+    def tearDown(self):
+        # Ensure cleanup of any registered colors
+        self.api.unregister_all_colors()
+        super().tearDown()
+
+    def test_register_color_both_values(self):
+        """Test registering a color with both light and dark values."""
+        self.api.register_color(
+            'test_color',
+            title="Test Color",
+            light_value='#FF0000',
+            dark_value='#AA0000',
+        )
+        key = self.api._color_key('test_color')
+        self.assertIn(key, _DEFAULT_COLORS['light'])
+        self.assertIn(key, _DEFAULT_COLORS['dark'])
+        self.assertEqual(_DEFAULT_COLORS['light'][key].value, '#ff0000')
+        self.assertEqual(_DEFAULT_COLORS['dark'][key].value, '#aa0000')
+
+    def test_register_color_light_only(self):
+        """Test registering with only light_value sets dark to same."""
+        self.api.register_color(
+            'light_only',
+            title="Light Only",
+            light_value='#00FF00',
+        )
+        key = self.api._color_key('light_only')
+        self.assertIn(key, _DEFAULT_COLORS['light'])
+        self.assertIn(key, _DEFAULT_COLORS['dark'])
+        self.assertEqual(_DEFAULT_COLORS['light'][key].value, '#00ff00')
+        self.assertEqual(_DEFAULT_COLORS['dark'][key].value, '#00ff00')
+
+    def test_register_color_dark_only(self):
+        """Test registering with only dark_value sets light to same."""
+        self.api.register_color(
+            'dark_only',
+            title="Dark Only",
+            dark_value='#0000FF',
+        )
+        key = self.api._color_key('dark_only')
+        self.assertIn(key, _DEFAULT_COLORS['light'])
+        self.assertIn(key, _DEFAULT_COLORS['dark'])
+        self.assertEqual(_DEFAULT_COLORS['light'][key].value, '#0000ff')
+        self.assertEqual(_DEFAULT_COLORS['dark'][key].value, '#0000ff')
+
+    def test_register_color_no_values_raises(self):
+        """Test that registering without any value raises ValueError."""
+        with self.assertRaises(ValueError):
+            self.api.register_color('bad_color', title="Bad")
+
+    def test_register_color_invalid_name_raises(self):
+        """Test that invalid color names are rejected."""
+        with self.assertRaises(ValueError):
+            self.api.register_color('invalid:name', title="Bad", light_value='red')
+        with self.assertRaises(ValueError):
+            self.api.register_color('invalid.name', title="Bad", light_value='red')
+        with self.assertRaises(ValueError):
+            self.api.register_color('', title="Bad", light_value='red')
+        with self.assertRaises(ValueError):
+            self.api.register_color('123start', title="Bad", light_value='red')
+
+    def test_register_color_valid_names(self):
+        """Test that valid color names are accepted."""
+        self.api.register_color('simple', title="Simple", light_value='red')
+        self.api.register_color('with_underscore', title="Underscored", light_value='blue')
+        self.api.register_color('_leading', title="Leading", light_value='green')
+        self.api.register_color('CamelCase', title="Camel", light_value='yellow')
+
+    def test_register_color_description_group(self):
+        """Test that the color description uses the plugin's manifest name as group."""
+        self.api.register_color('grouped', title="My Color", light_value='#123456')
+        key = self.api._color_key('grouped')
+        self.assertIn(key, _COLOR_DESCRIPTIONS)
+        desc = _COLOR_DESCRIPTIONS[key]
+        self.assertEqual(desc.title, "My Color")
+        self.assertEqual(desc.group, self.api.manifest.name_i18n())
+
+    def test_get_plugin_color(self):
+        """Test reading a plugin-registered color."""
+        self.api.register_color('my_color', title="My Color", light_value='#ABCDEF')
+        color = self.api.get_plugin_color('my_color')
+        self.assertEqual(color, '#abcdef')
+
+    def test_get_plugin_qcolor(self):
+        """Test reading a plugin-registered color as QColor."""
+        self.api.register_color('my_color', title="My Color", light_value='#FF8800')
+        qcolor = self.api.get_plugin_qcolor('my_color')
+        self.assertIsInstance(qcolor, QColor)
+        self.assertEqual(qcolor.name(), '#ff8800')
+
+    def test_get_plugin_color_unknown_raises(self):
+        """Test that reading an unregistered plugin color raises."""
+        with self.assertRaises(UnknownColorException):
+            self.api.get_plugin_color('nonexistent')
+
+    def test_get_color_core(self):
+        """Test reading a core interface color."""
+        color = self.api.get_color('entity_error')
+        self.assertEqual(color, interface_colors.get_color('entity_error'))
+
+    def test_get_qcolor_core(self):
+        """Test reading a core interface color as QColor."""
+        qcolor = self.api.get_qcolor('entity_error')
+        self.assertIsInstance(qcolor, QColor)
+        self.assertEqual(qcolor.name(), interface_colors.get_color('entity_error'))
+
+    def test_get_color_unknown_raises(self):
+        """Test that reading an unknown core color raises."""
+        with self.assertRaises(UnknownColorException):
+            self.api.get_color('totally_nonexistent_color')
+
+    def test_is_dark_theme(self):
+        """Test is_dark_theme property."""
+        self.assertIsInstance(self.api.is_dark_theme, bool)
+
+    def test_unregister_color(self):
+        """Test unregistering a single color."""
+        self.api.register_color('temp', title="Temp", light_value='#111111')
+        key = self.api._color_key('temp')
+        self.assertIn(key, _DEFAULT_COLORS['light'])
+        self.api.unregister_color('temp')
+        self.assertNotIn(key, _DEFAULT_COLORS['light'])
+        self.assertNotIn(key, _DEFAULT_COLORS['dark'])
+        self.assertNotIn(key, _COLOR_DESCRIPTIONS)
+
+    def test_unregister_all_colors(self):
+        """Test unregistering all plugin colors at once."""
+        self.api.register_color('color_a', title="A", light_value='#111111')
+        self.api.register_color('color_b', title="B", light_value='#222222')
+        key_a = self.api._color_key('color_a')
+        key_b = self.api._color_key('color_b')
+        self.assertIn(key_a, _DEFAULT_COLORS['light'])
+        self.assertIn(key_b, _DEFAULT_COLORS['light'])
+        self.api.unregister_all_colors()
+        self.assertNotIn(key_a, _DEFAULT_COLORS['light'])
+        self.assertNotIn(key_b, _DEFAULT_COLORS['light'])
+        self.assertEqual(self.api._registered_colors, [])
+
+    def test_color_namespace_isolation(self):
+        """Test that plugin colors cannot collide with core colors."""
+        # Register a plugin color with same name as a core color
+        self.api.register_color('entity_error', title="Plugin Error", light_value='#FFFFFF')
+        # Plugin color is namespaced differently
+        plugin_color = self.api.get_plugin_color('entity_error')
+        core_color = self.api.get_color('entity_error')
+        # They should be different because the plugin one is #FFFFFF
+        self.assertEqual(plugin_color, '#ffffff')
+        self.assertNotEqual(plugin_color, core_color)
+
+    def test_register_color_named_css_color(self):
+        """Test registering with CSS named colors."""
+        self.api.register_color('named', title="Named", light_value='red', dark_value='darkred')
+        color_light = _DEFAULT_COLORS['light'][self.api._color_key('named')].value
+        color_dark = _DEFAULT_COLORS['dark'][self.api._color_key('named')].value
+        self.assertEqual(color_light, QColor('red').name())
+        self.assertEqual(color_dark, QColor('darkred').name())
+
+
+class TestUnregisterColor(PicardTestCase):
+    """Test the module-level unregister_color function."""
+
+    def test_unregister_existing_color(self):
+        """Test unregistering a dynamically added color."""
+        from picard.ui.colors import (
+            ColorDescription,
+            register_color,
+        )
+
+        register_color(
+            ('light', 'dark'),
+            'test_dynamic',
+            '#AABBCC',
+            description=ColorDescription(title="Test", group="Test"),
+        )
+        self.assertIn('test_dynamic', _DEFAULT_COLORS['light'])
+        unregister_color('test_dynamic')
+        self.assertNotIn('test_dynamic', _DEFAULT_COLORS['light'])
+        self.assertNotIn('test_dynamic', _DEFAULT_COLORS['dark'])
+        self.assertNotIn('test_dynamic', _COLOR_DESCRIPTIONS)
+
+    def test_unregister_nonexistent_is_safe(self):
+        """Test that unregistering a non-existent color doesn't raise."""
+        unregister_color('totally_fake_color_key')

--- a/test/plugins3/test_api_colors.py
+++ b/test/plugins3/test_api_colors.py
@@ -201,6 +201,21 @@ class TestPluginApiColors(PicardTestCase):
         self.assertEqual(color_light, QColor('red').name())
         self.assertEqual(color_dark, QColor('darkred').name())
 
+    def test_register_color_invalid_light_raises(self):
+        """Test that invalid light_value raises ValueError."""
+        with self.assertRaises(ValueError):
+            self.api.register_color('bad', title="Bad", light_value='notacolor', dark_value='#00FF00')
+
+    def test_register_color_invalid_dark_raises(self):
+        """Test that invalid dark_value raises ValueError."""
+        with self.assertRaises(ValueError):
+            self.api.register_color('bad', title="Bad", light_value='#FF0000', dark_value='xyz')
+
+    def test_register_color_both_invalid_raises(self):
+        """Test that both values invalid raises ValueError."""
+        with self.assertRaises(ValueError):
+            self.api.register_color('bad', title="Bad", light_value='nope', dark_value='alsonope')
+
 
 class TestUnregisterColor(PicardTestCase):
     """Test the module-level unregister_color function."""


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Add interface colors API to Plugin v3, allowing plugins to register
their own configurable colors and read Picard's core interface colors.

## Problem

* JIRA ticket: PICARD-3388

Plugins that create custom UI (options pages, dialogs) have no way to:
- Register their own user-configurable colors
- Read Picard's core interface colors for consistent styling
- Know whether the current theme is dark or light

This forces plugins to hardcode colors that may not adapt to the user's
theme.

## Solution

Add new methods to `PluginApi`:

- `register_color(name, title, light_value, dark_value)` — register a
  plugin-specific color that automatically appears in the Interface
  Colors options page, grouped under the plugin's name
- `get_plugin_color(name)` / `get_plugin_qcolor(name)` — read own colors
- `get_color(name)` / `get_qcolor(name)` — read core interface colors
- `is_dark_theme` — property for theme awareness
- `unregister_color(name)` / `unregister_all_colors()` — manual cleanup
  (automatic on plugin disable)

Plugin colors are internally namespaced as `plugin:<uuid>:<name>` to
prevent collisions with core colors or other plugins. They are persisted
in the same config keys as core colors, so user customizations survive
plugin disable/re-enable cycles.

Infrastructure changes:
- `picard/ui/colors.py`: added `unregister_color()` and updated
  `register_color()` to accept an optional `description` parameter
- `picard/plugin3/plugin.py`: cleanup on disable

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used for API design discussion, implementation, test development,
and documentation writing.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
