### PR TITLE
PICARD-3387: Use TagVar for plugin-registered script variables

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -819,6 +819,11 @@ def enable(api):
 - `is_multi_value`: Whether this variable can hold multiple values
   (default: `False`).
 
+**Raises**: `ValueError` if:
+- The variable name is invalid (must use only letters, digits, underscores).
+- The same base name is already registered with a different hidden status
+  (e.g., registering `_foo` when `foo` is already registered, or vice versa).
+
 ---
 
 #### `unregister_script_variable(name)`

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -771,9 +771,15 @@ def enable(api):
 
 ---
 
-#### `register_script_variable(name, documentation=None)`
+#### `register_script_variable(name, documentation=None, title=None, is_multi_value=False)`
 
-Register a variable name for script autocomplete.
+Register a variable name for script autocomplete and tag dropdowns.
+
+Registered variables become available in:
+- The script editor autocomplete (`%variable_name%`)
+- The edit tag dialog dropdown (for non-hidden variables)
+- The tag list editor in options pages (for non-hidden variables)
+- The scripting documentation panel
 
 If the same variable name has already been registered by this plugin, the
 existing entry is replaced (no duplicate is created). This allows plugins to
@@ -781,15 +787,37 @@ safely re-register variables without needing to unregister first.
 
 ```python
 def enable(api):
+    # Regular variable — appears in tag dropdowns and scripts
     api.register_script_variable(
         "my_plugin_var",
         documentation="A custom variable from my plugin",
+        title="My Variable",
+    )
+
+    # Hidden variable — available in scripts only, not in tag dropdowns
+    api.register_script_variable(
+        "_my_hidden_var",
+        documentation="A computed value for use in scripts",
+    )
+
+    # Multi-value variable
+    api.register_script_variable(
+        "my_list_var",
+        documentation="A variable that can hold multiple values",
+        is_multi_value=True,
     )
 ```
 
 **Parameters**:
-- `name`: Variable name (without % symbols)
-- `documentation`: Optional help text for the variable
+- `name`: The variable name as it appears between `%` symbols in scripts.
+  Names starting with `_` are treated as hidden variables (they won't appear
+  in tag dropdowns but are available in scripts).
+- `documentation`: Optional help text shown in the scripting documentation panel.
+- `title`: Optional display title for the metadata box (e.g., "Caller"). If
+  provided, the tag shows this human-readable title instead of the raw name in
+  the UI.
+- `is_multi_value`: Whether this variable can hold multiple values
+  (default: `False`).
 
 ---
 

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -18,28 +18,19 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from picard.i18n import _
 from picard.plugin import ExtensionPoint
 from picard.script.variable_pattern import VARIABLE_NAME_FULLMATCH_RE
 from picard.tags import script_variable_tag_names
+from picard.tags.tagvar import TagVar
 
 
 if TYPE_CHECKING:
     from picard.plugin3.api_impl import PluginApi
 
 
-@dataclass(frozen=True)
-class PluginVariable:
-    name: str
-    documentation: str
-    plugin_name: str
-    title: str | None = None
-
-
-ext_point_script_variables = ExtensionPoint[PluginVariable](label='script_variables')
+ext_point_script_variables = ExtensionPoint[TagVar](label='script_variables')
 
 
 def _check_if_duplicate_variable_name(name: str) -> str | None:
@@ -49,7 +40,10 @@ def _check_if_duplicate_variable_name(name: str) -> str | None:
 
     for var in ext_point_script_variables:
         if name == var.name:
-            sources.append(f'"{var.plugin_name}"')
+            if var.plugin_id:
+                sources.append(f'"{var.plugin_id}"')
+            else:
+                sources.append('"Unknown"')
 
     return ', '.join(sources) if sources else None
 
@@ -80,7 +74,7 @@ def register_script_variable(
     api : PluginApi, optional
         The plugin API instance
     title : str, optional
-        Display title for the metadata box (e.g., "Pinned Tags").
+        Display title for the metadata box (e.g., "Caller").
         If provided, the tag will show this title instead of the raw name.
 
     Examples
@@ -97,25 +91,22 @@ def register_script_variable(
 
     if api:
         module_name = api.module_path
+        plugin_id = api.plugin_id
     else:
         module_name = 'unknown'
-
-    plugin_name = api.manifest.name_i18n() if api else _("Unknown Plugin")
-    plugin_documentation = documentation or ""
-    if plugin_documentation and plugin_name:
-        plugin_documentation += "\n\n"
-    if plugin_name:
-        plugin_documentation += _("Plugin: %s") % plugin_name
+        plugin_id = None
 
     # Remove any existing entry with the same name from this plugin to avoid duplicates
     ext_point_script_variables.unregister(module_name, lambda item: item.name == name)
     ext_point_script_variables.register(
         module_name,
-        PluginVariable(
+        TagVar(
             name=name,
-            documentation=plugin_documentation,
-            plugin_name=plugin_name,
-            title=title,
+            shortdesc=title,
+            longdesc=documentation,
+            is_from_mb=False,
+            is_populated_by_picard=False,
+            plugin_id=plugin_id,
         ),
     )
 
@@ -170,7 +161,7 @@ def get_plugin_variable_documentation(name: str) -> str | None:
     """
     for var in ext_point_script_variables:
         if var.name == name:
-            return var.documentation
+            return var._longdesc
     return None
 
 
@@ -189,5 +180,5 @@ def get_plugin_variable_title(name: str) -> str | None:
     """
     for var in ext_point_script_variables:
         if var.name == name:
-            return var.title
+            return var._shortdesc
     return None

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -20,9 +20,9 @@
 
 from typing import TYPE_CHECKING
 
+from picard.const.tags import ALL_TAGS
 from picard.plugin import ExtensionPoint
 from picard.script.variable_pattern import VARIABLE_NAME_FULLMATCH_RE
-from picard.tags import script_variable_tag_names
 from picard.tags.tagvar import TagVar
 
 
@@ -35,7 +35,9 @@ ext_point_script_variables = ExtensionPoint[TagVar](label='script_variables')
 
 def _check_if_duplicate_variable_name(name: str) -> str | None:
     sources = []
-    if name in set(script_variable_tag_names()):
+    # Check against built-in system variables only (not plugin-registered ones)
+    builtin_names = {tagvar.script_name() for tagvar in ALL_TAGS if tagvar.is_script_variable}
+    if name in builtin_names:
         sources.append("System Variables")
 
     for var in ext_point_script_variables:

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -119,6 +119,12 @@ def register_script_variable(
             longdesc=documentation,
             is_hidden=is_hidden,
             is_multi_value=is_multi_value,
+            # Locked attributes for plugin-registered variables
+            is_preserved=False,
+            is_script_variable=True,
+            is_tag=True,
+            is_calculated=False,
+            is_file_info=False,
             is_from_mb=False,
             is_populated_by_picard=False,
             plugin_id=plugin_id,

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -113,8 +113,21 @@ def register_script_variable(
         module_name = 'unknown'
         plugin_id = None
 
+    # Reject registering the same base name with a different is_hidden status.
+    # A plugin cannot register both 'foo' and '_foo' — the base name must be unique.
+    for var in ext_point_script_variables:
+        if var.name == name and var.is_hidden != is_hidden:
+            prefix = '_' if is_hidden else ''
+            existing_prefix = '_' if var.is_hidden else ''
+            msg = (
+                f"Cannot register '{prefix}{name}': "
+                f"'{existing_prefix}{name}' is already registered "
+                f"with different hidden status."
+            )
+            raise ValueError(msg)
+
     # Remove any existing entry with the same name from this plugin to avoid duplicates
-    ext_point_script_variables.unregister(module_name, lambda item: item.name == name and item.is_hidden == is_hidden)
+    ext_point_script_variables.unregister(module_name, lambda item: item.name == name)
     ext_point_script_variables.register(
         module_name,
         TagVar(
@@ -166,7 +179,7 @@ def get_plugin_variable_documentation(name: str) -> str | None:
     Parameters
     ----------
     name : str
-        The variable name
+        The variable name (bare name without prefix)
 
     Returns
     -------
@@ -185,7 +198,7 @@ def get_plugin_variable_title(name: str) -> str | None:
     Parameters
     ----------
     name : str
-        The variable name
+        The variable name (bare name without prefix)
 
     Returns
     -------

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -160,17 +160,6 @@ def unregister_all_script_variables(api: 'PluginApi') -> None:
     ext_point_script_variables.unregister(api.module_path, lambda item: True)
 
 
-def get_plugin_variable_names() -> set[str]:
-    """Get all plugin-provided variable names.
-
-    Returns
-    -------
-    set[str]
-        Set of variable names provided by plugins
-    """
-    return {var.name for var in ext_point_script_variables}
-
-
 def get_plugin_variable_documentation(name: str) -> str | None:
     """Get documentation for a plugin-provided variable.
 

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -109,9 +109,11 @@ def register_script_variable(
     if api:
         module_name = api.module_path
         plugin_id = api.plugin_id
+        plugin_name = api.manifest.name_i18n()
     else:
         module_name = 'unknown'
         plugin_id = None
+        plugin_name = None
 
     # Reject registering the same base name with a different is_hidden status.
     # A plugin cannot register both 'foo' and '_foo' — the base name must be unique.
@@ -145,6 +147,7 @@ def register_script_variable(
             is_from_mb=False,
             is_populated_by_picard=False,
             plugin_id=plugin_id,
+            plugin_name=plugin_name,
         ),
     )
 
@@ -171,25 +174,6 @@ def unregister_all_script_variables(api: 'PluginApi') -> None:
         The plugin API instance (identifies which plugin's registrations to remove)
     """
     ext_point_script_variables.unregister(api.module_path, lambda item: True)
-
-
-def get_plugin_variable_documentation(name: str) -> str | None:
-    """Get documentation for a plugin-provided variable.
-
-    Parameters
-    ----------
-    name : str
-        The variable name (bare name without prefix)
-
-    Returns
-    -------
-    str or None
-        Documentation string if available, None otherwise
-    """
-    for var in ext_point_script_variables:
-        if var.script_name() == name:
-            return var._longdesc
-    return None
 
 
 def get_plugin_variable_title(name: str) -> str | None:

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -60,7 +60,12 @@ def _is_valid_plugin_variable_name(name: str | None) -> bool:
 
 
 def register_script_variable(
-    name: str, documentation: str | None = None, api: 'PluginApi | None' = None, title: str | None = None
+    name: str,
+    documentation: str | None = None,
+    api: 'PluginApi | None' = None,
+    title: str | None = None,
+    is_hidden: bool = False,
+    is_multi_value: bool = False,
 ) -> None:
     """Register a variable that plugins can provide for script completion.
 
@@ -78,6 +83,12 @@ def register_script_variable(
     title : str, optional
         Display title for the metadata box (e.g., "Caller").
         If provided, the tag will show this title instead of the raw name.
+    is_hidden : bool, optional
+        Whether this is a hidden variable (prefixed with ~ in tag names,
+        _ in scripts). Hidden variables don't appear in tag dropdowns.
+        Default: False.
+    is_multi_value : bool, optional
+        Whether this variable can hold multiple values. Default: False.
 
     Examples
     --------
@@ -106,6 +117,8 @@ def register_script_variable(
             name=name,
             shortdesc=title,
             longdesc=documentation,
+            is_hidden=is_hidden,
+            is_multi_value=is_multi_value,
             is_from_mb=False,
             is_populated_by_picard=False,
             plugin_id=plugin_id,

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -114,7 +114,7 @@ def register_script_variable(
         plugin_id = None
 
     # Remove any existing entry with the same name from this plugin to avoid duplicates
-    ext_point_script_variables.unregister(module_name, lambda item: item.name == name)
+    ext_point_script_variables.unregister(module_name, lambda item: item.name == name and item.is_hidden == is_hidden)
     ext_point_script_variables.register(
         module_name,
         TagVar(

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -126,7 +126,7 @@ def register_script_variable(
             # Locked attributes for plugin-registered variables
             is_preserved=False,
             is_script_variable=True,
-            is_tag=True,
+            is_tag=not is_hidden,
             is_calculated=False,
             is_file_info=False,
             is_from_mb=False,

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -98,6 +98,12 @@ def register_script_variable(
         msg = "Invalid script variable name; use letters, digits, underscores."
         raise ValueError(msg)
 
+    # Backward compatibility: plugins may register hidden variables using the
+    # script syntax prefix "_". Normalize to bare name + is_hidden=True.
+    if name.startswith('_'):
+        name = name[1:]
+        is_hidden = True
+
     duplicate = _check_if_duplicate_variable_name(name)
     if api and duplicate:
         api.logger.warning("Tag '%s' also found in %s.", name, duplicate)

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -187,7 +187,7 @@ def get_plugin_variable_documentation(name: str) -> str | None:
         Documentation string if available, None otherwise
     """
     for var in ext_point_script_variables:
-        if var.name == name:
+        if var.script_name() == name:
             return var._longdesc
     return None
 
@@ -206,6 +206,6 @@ def get_plugin_variable_title(name: str) -> str | None:
         Display title if available, None otherwise
     """
     for var in ext_point_script_variables:
-        if var.name == name:
+        if var.script_name() == name:
             return var._shortdesc
     return None

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -64,7 +64,6 @@ def register_script_variable(
     documentation: str | None = None,
     api: 'PluginApi | None' = None,
     title: str | None = None,
-    is_hidden: bool = False,
     is_multi_value: bool = False,
 ) -> None:
     """Register a variable that plugins can provide for script completion.
@@ -75,7 +74,9 @@ def register_script_variable(
     Parameters
     ----------
     name : str
-        The variable name (without % symbols)
+        The variable name as it appears between percent signs in scripts.
+        Names starting with ``_`` are treated as hidden variables (they won't
+        appear in tag dropdowns but are available in scripts).
     documentation : str, optional
         Optional documentation for the variable
     api : PluginApi, optional
@@ -83,26 +84,23 @@ def register_script_variable(
     title : str, optional
         Display title for the metadata box (e.g., "Caller").
         If provided, the tag will show this title instead of the raw name.
-    is_hidden : bool, optional
-        Whether this is a hidden variable (prefixed with ~ in tag names,
-        _ in scripts). Hidden variables don't appear in tag dropdowns.
-        Default: False.
     is_multi_value : bool, optional
         Whether this variable can hold multiple values. Default: False.
 
     Examples
     --------
     >>> register_script_variable("my_plugin_var", "A custom variable from my plugin", title="My Variable")
+    >>> register_script_variable("_my_hidden_var", "A hidden variable only for scripts")
     """
-    if not _is_valid_plugin_variable_name(name):
-        msg = "Invalid script variable name; use letters, digits, underscores."
-        raise ValueError(msg)
-
-    # Backward compatibility: plugins may register hidden variables using the
-    # script syntax prefix "_". Normalize to bare name + is_hidden=True.
+    # Determine hidden status from name prefix: names starting with _ are hidden.
+    is_hidden = False
     if name.startswith('_'):
         name = name[1:]
         is_hidden = True
+
+    if not _is_valid_plugin_variable_name(name):
+        msg = "Invalid script variable name; use letters, digits, underscores."
+        raise ValueError(msg)
 
     duplicate = _check_if_duplicate_variable_name(name)
     if api and duplicate:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1371,20 +1371,19 @@ class PluginApi:
         name: str,
         documentation: str | None = None,
         title: str | None = None,
-        is_hidden: bool = False,
         is_multi_value: bool = False,
     ) -> None:
         """Register a variable name for script autocomplete.
 
         Args:
-            name: The variable name without the surrounding ``%`` symbols.
+            name: The variable name as it appears between ``%`` symbols in
+                scripts. Names starting with ``_`` are treated as hidden
+                variables (they won't appear in tag dropdowns but are
+                available in scripts).
             documentation: Optional help text shown for the variable.
             title: Optional display title for the metadata box (e.g.,
                 "Caller"). If provided, the tag shows this title
                 instead of the raw name.
-            is_hidden: Whether this is a hidden variable (prefixed with
-                ``~`` in tag names, ``_`` in scripts). Hidden variables
-                don't appear in tag dropdowns. Default: False.
             is_multi_value: Whether this variable can hold multiple
                 values. Default: False.
 
@@ -1395,13 +1394,18 @@ class PluginApi:
                     documentation="A custom variable from my plugin",
                     title="My Variable",
                 )
+
+                # Hidden variable (only available in scripts):
+                api.register_script_variable(
+                    "_my_hidden_var",
+                    documentation="A hidden variable",
+                )
         """
         return register_script_variable(
             name,
             documentation,
             self,
             title=title,
-            is_hidden=is_hidden,
             is_multi_value=is_multi_value,
         )
 

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1366,15 +1366,27 @@ class PluginApi:
         """
         return register_script_function(function, name, eval_args, check_argcount, documentation, signature)
 
-    def register_script_variable(self, name: str, documentation: str | None = None, title: str | None = None) -> None:
+    def register_script_variable(
+        self,
+        name: str,
+        documentation: str | None = None,
+        title: str | None = None,
+        is_hidden: bool = False,
+        is_multi_value: bool = False,
+    ) -> None:
         """Register a variable name for script autocomplete.
 
         Args:
             name: The variable name without the surrounding ``%`` symbols.
             documentation: Optional help text shown for the variable.
             title: Optional display title for the metadata box (e.g.,
-                "Pinned Tags"). If provided, the tag shows this title
+                "Caller"). If provided, the tag shows this title
                 instead of the raw name.
+            is_hidden: Whether this is a hidden variable (prefixed with
+                ``~`` in tag names, ``_`` in scripts). Hidden variables
+                don't appear in tag dropdowns. Default: False.
+            is_multi_value: Whether this variable can hold multiple
+                values. Default: False.
 
         Example:
             def enable(api):
@@ -1384,7 +1396,14 @@ class PluginApi:
                     title="My Variable",
                 )
         """
-        return register_script_variable(name, documentation, self, title=title)
+        return register_script_variable(
+            name,
+            documentation,
+            self,
+            title=title,
+            is_hidden=is_hidden,
+            is_multi_value=is_multi_value,
+        )
 
     def unregister_script_variable(self, name: str) -> None:
         """Unregister a single script variable previously registered by this plugin.

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -31,9 +31,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections.abc import Iterator
 import re
 
 from picard.const.tags import ALL_TAGS
+from picard.tags.tagvar import TagVar
 
 
 RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
@@ -86,15 +88,17 @@ def parse_subtag(name):
     return lang, desc
 
 
-def tag_names():
-    """Tag names available for user assignment: built-in tags + plugin-provided tags."""
+def _all_tag_vars() -> Iterator[TagVar]:
     # Inline import to avoid circular dependency: script_variables imports from this module.
     from picard.extension_points.script_variables import ext_point_script_variables
 
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag)
-    for var in ext_point_script_variables:
-        if var.is_tag and not var.is_hidden:
-            yield var.name
+    yield from ALL_TAGS
+    yield from ext_point_script_variables
+
+
+def tag_names():
+    """Tag names available for user assignment: built-in tags + plugin-provided tags."""
+    yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
 def visible_tag_names():
@@ -130,13 +134,7 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
-    # Inline import to avoid circular dependency: script_variables imports from this module.
-    from picard.extension_points.script_variables import ext_point_script_variables
-
-    yield from (tagvar.script_name() for tagvar in ALL_TAGS if tagvar.is_script_variable)
-    for var in ext_point_script_variables:
-        if var.is_script_variable:
-            yield var.script_name()
+    yield from (var.script_name() for var in _all_tag_vars() if var.is_script_variable)
 
 
 def display_tag_name(name):

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -101,14 +101,6 @@ def tag_names():
     yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
-def visible_tag_names():
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag and not tv.is_hidden)
-
-
-def hidden_tag_names():
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag and tv.is_hidden)
-
-
 def filterable_tag_names():
     yield from ALL_TAGS.names(selector=lambda tv: tv.is_filterable)
 

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -87,7 +87,14 @@ def parse_subtag(name):
 
 
 def tag_names():
+    """Tag names available for user assignment: built-in tags + plugin-provided tags."""
+    # Inline import to avoid circular dependency: script_variables imports from this module.
+    from picard.extension_points.script_variables import ext_point_script_variables
+
     yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag)
+    for var in ext_point_script_variables:
+        if var.is_tag and not var.is_hidden:
+            yield var.name
 
 
 def visible_tag_names():
@@ -123,7 +130,13 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
+    # Inline import to avoid circular dependency: script_variables imports from this module.
+    from picard.extension_points.script_variables import ext_point_script_variables
+
     yield from (tagvar.script_name() for tagvar in ALL_TAGS if tagvar.is_script_variable)
+    for var in ext_point_script_variables:
+        if var.is_script_variable:
+            yield var.script_name()
 
 
 def display_tag_name(name):

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -88,7 +88,7 @@ def parse_subtag(name):
     return lang, desc
 
 
-def _all_tag_vars() -> Iterator[TagVar]:
+def all_tag_vars() -> Iterator[TagVar]:
     # Inline import to avoid circular dependency: script_variables imports from this module.
     from picard.extension_points.script_variables import ext_point_script_variables
 
@@ -98,7 +98,7 @@ def _all_tag_vars() -> Iterator[TagVar]:
 
 def tag_names():
     """Tag names available for user assignment: built-in tags + plugin-provided tags."""
-    yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
+    yield from (var.name for var in all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
 def filterable_tag_names():
@@ -126,7 +126,7 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
-    yield from (var.script_name() for var in _all_tag_vars() if var.is_script_variable)
+    yield from (var.script_name() for var in all_tag_vars() if var.is_script_variable)
 
 
 def display_tag_name(name):

--- a/picard/tags/docs.py
+++ b/picard/tags/docs.py
@@ -21,7 +21,6 @@
 
 from picard.const.tags import ALL_TAGS
 from picard.i18n import gettext as _
-from picard.tags import all_tag_vars
 from picard.tags.tagvar import (
     TEXT_NO_DESCRIPTION,
     TagVar,
@@ -48,7 +47,17 @@ def _get_tagvar_item(tagname):
     else:
         tagdesc = None
 
-    item = next((var for var in all_tag_vars() if var.name == tagname.lstrip('~_')), None)
+    # O(1) lookup for built-in tags
+    item = ALL_TAGS.tagvar_from_name(tagname)
+
+    # Linear scan for plugin variables (typically very few)
+    if not item:
+        # Inline import to avoid circular dependency: script_variables imports from this module.
+        from picard.extension_points.script_variables import ext_point_script_variables
+
+        bare_name = tagname.lstrip('~_')
+        item = next((var for var in ext_point_script_variables if var.name == bare_name), None)
+
     if item:
         return item.script_name(), item, tagdesc
     return tagname, None, None

--- a/picard/tags/docs.py
+++ b/picard/tags/docs.py
@@ -20,38 +20,47 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from picard.const.tags import ALL_TAGS
-from picard.extension_points.script_variables import get_plugin_variable_documentation
 from picard.i18n import gettext as _
+from picard.tags import all_tag_vars
 from picard.tags.tagvar import (
     TEXT_NO_DESCRIPTION,
+    TagVar,
     _markdown,
 )
 
 
 def display_tag_tooltip(tagname):
-    name, tagdesc, _search_name, item = ALL_TAGS.item_from_name(tagname)
+    name, item, tagdesc = _get_tagvar_item(tagname)
     content = ALL_TAGS.tooltip_content(item) if item else None
-    return _finalize_content(name, content, tagdesc)
+    return _finalize_tooltip_content(name, content, tagdesc)
 
 
-def display_tag_full_description(tagname):
-    name, tagdesc, _search_name, item = ALL_TAGS.item_from_name(tagname)
+def display_tag_full_description(item: TagVar) -> str:
     content = ALL_TAGS.full_description_content(item) if item else None
-    return _finalize_content(name, content, tagdesc)
-
-
-def display_plugin_tag_full_description(name, description):
-    content = _markdown(description or _(TEXT_NO_DESCRIPTION))
-    return _format_display(name, content, '')
-
-
-def _finalize_content(name, content, tagdesc):
     if not content:
-        content = _markdown(get_plugin_variable_documentation(name) or _(TEXT_NO_DESCRIPTION))
-    return _format_display(name, content, tagdesc)
+        content = _markdown(_(TEXT_NO_DESCRIPTION))
+    return content
 
 
-def _format_display(name, content, tagdesc):
+def _get_tagvar_item(tagname):
+    if ':' in tagname:
+        tagname, tagdesc = tagname.split(':', 1)
+    else:
+        tagdesc = None
+
+    item = next((var for var in all_tag_vars() if var.name == tagname.lstrip('~_')), None)
+    if item:
+        return item.script_name(), item, tagdesc
+    return tagname, None, None
+
+
+def _finalize_tooltip_content(name, content, tagdesc=None):
+    if not content:
+        content = _markdown(_(TEXT_NO_DESCRIPTION))
+    return _format_tooltip(name, content, tagdesc)
+
+
+def _format_tooltip(name, content, tagdesc=None):
     fmt_tagdesc = _("<p><em>%{name}%</em> [{tagdesc}]</p>{content}")
     fmt_normal = _("<p><em>%{name}%</em></p>{content}")
     fmt = fmt_tagdesc if tagdesc else fmt_normal

--- a/picard/tags/docs.py
+++ b/picard/tags/docs.py
@@ -55,7 +55,7 @@ def _get_tagvar_item(tagname):
         # Inline import to avoid circular dependency: script_variables imports from this module.
         from picard.extension_points.script_variables import ext_point_script_variables
 
-        bare_name = tagname.lstrip('~_')
+        bare_name = tagname[1:] if tagname[:1] in ('~', '_') else tagname
         item = next((var for var in ext_point_script_variables if var.name == bare_name), None)
 
     if item:

--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -103,6 +103,7 @@ class TagVar:
         see_also=None,
         related_options=None,
         doc_links=None,
+        plugin_id=None,
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
@@ -126,6 +127,7 @@ class TagVar:
         see_also: an iterable containing ids of related tags
         related_options: an iterable containing the related option settings (see picard/options.py)
         doc_links: an iterable containing links to external documentation (DocumentLink tuples)
+        plugin_id: the plugin module id that registered this tag (str or None, default: None)
         """
         self.name = name
         self._shortdesc = shortdesc
@@ -144,6 +146,7 @@ class TagVar:
         self.see_also = see_also
         self.related_options = related_options
         self.doc_links = doc_links
+        self.plugin_id = plugin_id
 
     @property
     def shortdesc(self):

--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -131,6 +131,7 @@ class TagVar:
         related_options: an iterable containing the related option settings (see picard/options.py)
         doc_links: an iterable containing links to external documentation (DocumentLink tuples)
         plugin_id: the plugin module id that registered this tag (str or None, default: None)
+        plugin_name: the display name of the plugin that registered this tag (str or None, default: None)
         """
         self.name = name
         self._shortdesc = shortdesc

--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -60,6 +60,7 @@ class Section(IntEnum):
     options = 2
     links = 3
     see_also = 4
+    plugin_info = 5
 
 
 SectionInfo = namedtuple('SectionInfo', ('title', 'tagvar_func'))
@@ -68,6 +69,7 @@ SECTIONS = {
     Section.options: SectionInfo(N_('Option Settings'), 'related_options_titles'),
     Section.links: SectionInfo(N_('Links'), 'links'),
     Section.see_also: SectionInfo(N_('See Also'), 'see_alsos'),
+    Section.plugin_info: SectionInfo(N_('Plugin'), 'plugin_info'),
 }
 
 TEXT_NO_DESCRIPTION = N_('No description available.')
@@ -104,6 +106,7 @@ class TagVar:
         related_options=None,
         doc_links=None,
         plugin_id=None,
+        plugin_name=None,
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
@@ -147,6 +150,7 @@ class TagVar:
         self.related_options = related_options
         self.doc_links = doc_links
         self.plugin_id = plugin_id
+        self.plugin_name = plugin_name
 
     @property
     def shortdesc(self):
@@ -262,7 +266,7 @@ class TagVars(MutableSequence):
         return self.item_from_name(name).item
 
     def script_name_from_name(self, name):
-        tagname, tagdesc, search_name, item = self.item_from_name(name)
+        item = self.tagvar_from_name(name)
         if item:
             return str(item)
         return None
@@ -306,6 +310,11 @@ class TagVars(MutableSequence):
             if self.script_name_from_name(tag):
                 yield f'<a href="#{tag}">%{tag}%</a>'
 
+    def plugin_info(self, item: TagVar):
+        if not item.plugin_name:
+            return
+        yield item.plugin_name
+
     def _base_description(self, item: TagVar):
         return _markdown(_(item.longdesc) if item.longdesc else _(TEXT_NO_DESCRIPTION))
 
@@ -328,7 +337,7 @@ class TagVars(MutableSequence):
 
     def tooltip_content(self, item: TagVar):
         content = self._base_description(item)
-        content += self._add_sections(item, (Section.notes,))
+        content += self._add_sections(item, (Section.notes, Section.plugin_info))
         return content
 
     def full_description_content(self, item: TagVar):
@@ -339,12 +348,7 @@ class TagVars(MutableSequence):
             content += _markdown(_(item.additionaldesc))
 
         # Append additional sections as required
-        include_sections = (
-            Section.notes,
-            Section.options,
-            Section.links,
-            Section.see_also,
-        )
+        include_sections = (Section.notes, Section.options, Section.links, Section.see_also, Section.plugin_info)
         content += self._add_sections(item, include_sections)
 
         return content

--- a/picard/ui/widgets/completion_provider.py
+++ b/picard/ui/widgets/completion_provider.py
@@ -21,7 +21,6 @@
 """Completion choices provider for script completion."""
 
 from collections.abc import (
-    Callable,
     Iterable,
     Iterator,
 )
@@ -49,15 +48,12 @@ class CompletionChoicesProvider:
 
     Attributes
     ----------
-    _get_plugin_variable_names : Callable[[], set[str]]
-        Function that returns a set of plugin variable names.
     _user_script_scanner : UserScriptScanner | None
         User script scanner for extracting variables from user scripts.
     """
 
     def __init__(
         self,
-        get_plugin_variable_names: Callable[[], set[str]],
         user_script_scanner: UserScriptScanner | None = None,
     ):
         """Initialize the completion choices provider.
@@ -69,7 +65,6 @@ class CompletionChoicesProvider:
         user_script_scanner : UserScriptScanner | None
             Optional user script scanner for extracting variables from user scripts.
         """
-        self._get_plugin_variable_names = get_plugin_variable_names
         self._user_script_scanner = user_script_scanner
 
     def build_choices(
@@ -105,7 +100,6 @@ class CompletionChoicesProvider:
         - TAG_NAME_ARG: Returns variable names without formatting
         - DEFAULT/VARIABLE: Returns variable names with % prefix and suffix
         """
-        plugin_variables = self._get_plugin_variable_names()
         builtin_variables = set(builtin_variables)
 
         # Get user script variables if scanner is available
@@ -116,7 +110,7 @@ class CompletionChoicesProvider:
                 if cached_variables is not None:
                     user_script_variables = cached_variables
 
-        all_variables = list(builtin_variables | user_defined_variables | plugin_variables | user_script_variables)
+        all_variables = list(builtin_variables | user_defined_variables | user_script_variables)
         all_variables.sort(key=lambda x: (-usage_counts.get(x, 0), x))
 
         if mode in (CompletionMode.DEFAULT, CompletionMode.FUNCTION_NAME):

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -153,6 +153,9 @@ class TagsDocumentationPage(DocumentationPage):
             tag_title = f'<a id="{tag_name}"><code>%{tag_name}%</code></a>'
             return f'<dt>{tag_title}</dt><dd>{tag_desc}</dd>'
 
+        tagger = tagger_instance()
+        manager = tagger.get_plugin_manager() if tagger else None
+
         tags: list[DocItem] = []
 
         # Process system-defined tags and variables
@@ -167,11 +170,16 @@ class TagsDocumentationPage(DocumentationPage):
 
         # Process plugin variables separately to allow plugin descriptions for duplicated variables.
         for var in ext_point_script_variables:
+            plugin_name = ''
+            if var.plugin_id and manager:
+                plugin = manager.plugin_id_to_plugin(var.plugin_id)
+                if plugin:
+                    plugin_name = plugin.name()
             tags.append(
                 DocItem(
-                    name=var.name,
-                    desc=display_plugin_tag_full_description(var.name, var.documentation),
-                    plugin=var.plugin_name,
+                    name=var.script_name(),
+                    desc=display_plugin_tag_full_description(var.script_name(), var._longdesc),
+                    plugin=plugin_name,
                 )
             )
 

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -34,17 +34,14 @@ from picard.const.tags import ALL_TAGS
 from picard.extension_points.script_variables import ext_point_script_variables
 from picard.i18n import gettext as _
 from picard.script import script_function_documentation_all
-from picard.tags.docs import (
-    display_plugin_tag_full_description,
-    display_tag_full_description,
-)
+from picard.tags.docs import display_tag_full_description
 from picard.util import get_url
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
 
 
-DocItem = namedtuple('DocItem', 'name desc plugin')
+DocItem = namedtuple('DocItem', 'name desc')
 
 DOCUMENTATION_HTML_TEMPLATE = '''
 <!DOCTYPE html>
@@ -149,48 +146,35 @@ class FunctionsDocumentationPage(DocumentationPage):
 
 class TagsDocumentationPage(DocumentationPage):
     def generate_html(self):
-        def process_tag(tag_name: str, tag_desc: str, plugin_name: str | None):
+        def process_tag(tag_name: str, tag_desc: str):
             tag_title = f'<a id="{tag_name}"><code>%{tag_name}%</code></a>'
-            if plugin_name:
-                plugin_label = _("Plugin: {plugin_name}").format(plugin_name=plugin_name)
-                tag_desc = f'{tag_desc}[{plugin_label}]'
             return f'<dt>{tag_title}</dt><dd>{tag_desc}</dd>'
-
-        tagger = tagger_instance()
-        manager = tagger.get_plugin_manager() if tagger else None
 
         tags: list[DocItem] = []
 
         # Process system-defined tags and variables
-        for tag_name in [tag.script_name() for tag in ALL_TAGS]:
+        for var in ALL_TAGS:
             tags.append(
                 DocItem(
-                    name=tag_name,
-                    desc=display_tag_full_description(tag_name),
-                    plugin=None,
+                    name=var.script_name(),
+                    desc=display_tag_full_description(var),
                 )
             )
 
         # Process plugin variables separately to allow plugin descriptions for duplicated variables.
         for var in ext_point_script_variables:
-            plugin_name = None
-            if var.plugin_id and manager:
-                plugin = manager.plugin_id_to_plugin(var.plugin_id)
-                if plugin:
-                    plugin_name = plugin.name()
             tags.append(
                 DocItem(
                     name=var.script_name(),
-                    desc=display_plugin_tag_full_description(var.script_name(), var._longdesc),
-                    plugin=plugin_name,
+                    desc=display_tag_full_description(var),
                 )
             )
 
         html = ''
         # Sort tags alphabetically regardless of whether they are hidden, with system tags shown
         # before plugin tags having the same name.
-        for tag in sorted(tags, key=lambda x: (x.name.lstrip('_'), x.plugin or '')):
-            html += process_tag(tag.name, tag.desc, tag.plugin)
+        for tag in sorted(tags, key=lambda x: x.name.lstrip('_')):
+            html += process_tag(tag.name, tag.desc)
 
         return html
 

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -149,8 +149,11 @@ class FunctionsDocumentationPage(DocumentationPage):
 
 class TagsDocumentationPage(DocumentationPage):
     def generate_html(self):
-        def process_tag(tag_name: str, tag_desc: str):
+        def process_tag(tag_name: str, tag_desc: str, plugin_name: str | None):
             tag_title = f'<a id="{tag_name}"><code>%{tag_name}%</code></a>'
+            if plugin_name:
+                plugin_label = _("Plugin: {plugin_name}").format(plugin_name=plugin_name)
+                tag_desc = f'{tag_desc}[{plugin_label}]'
             return f'<dt>{tag_title}</dt><dd>{tag_desc}</dd>'
 
         tagger = tagger_instance()
@@ -164,13 +167,13 @@ class TagsDocumentationPage(DocumentationPage):
                 DocItem(
                     name=tag_name,
                     desc=display_tag_full_description(tag_name),
-                    plugin='',
+                    plugin=None,
                 )
             )
 
         # Process plugin variables separately to allow plugin descriptions for duplicated variables.
         for var in ext_point_script_variables:
-            plugin_name = ''
+            plugin_name = None
             if var.plugin_id and manager:
                 plugin = manager.plugin_id_to_plugin(var.plugin_id)
                 if plugin:
@@ -186,8 +189,8 @@ class TagsDocumentationPage(DocumentationPage):
         html = ''
         # Sort tags alphabetically regardless of whether they are hidden, with system tags shown
         # before plugin tags having the same name.
-        for tag in sorted(tags, key=lambda x: f"{x.name.lstrip('_')}:{x.plugin}"):
-            html += process_tag(tag.name, tag.desc)
+        for tag in sorted(tags, key=lambda x: (x.name.lstrip('_'), x.plugin or '')):
+            html += process_tag(tag.name, tag.desc, tag.plugin)
 
         return html
 

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections.abc import Callable
 import contextlib
 import re
 import unicodedata
@@ -47,7 +46,6 @@ from PyQt6.QtWidgets import (
 
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
-from picard.extension_points.script_variables import get_plugin_variable_names
 from picard.i18n import gettext as _
 from picard.script import (
     ScriptFunctionDocError,
@@ -199,7 +197,6 @@ class ScriptCompleter(QCompleter):
         parser: ScriptParser | None = None,
         variable_extractor: VariableExtractor | None = None,
         context_detector: ContextDetector | None = None,
-        plugin_variable_provider: Callable[[], set[str]] | None = None,
         choices_provider: CompletionChoicesProvider | None = None,
         user_script_scanner: UserScriptScanner | None = None,
     ):
@@ -229,10 +226,7 @@ class ScriptCompleter(QCompleter):
         self.highlighted.connect(self.set_highlighted)
 
         # IOC for plugin variables and choices provider
-        self._plugin_variable_provider = plugin_variable_provider or get_plugin_variable_names
-        self._choices_provider = choices_provider or CompletionChoicesProvider(
-            self._plugin_variable_provider, self._user_script_scanner
-        )
+        self._choices_provider = choices_provider or CompletionChoicesProvider(self._user_script_scanner)
 
         # Initialize the model with initial choices
         self._model.setStringList(list(self.choices))

--- a/test/script_text_edit/test_completion_choices_provider.py
+++ b/test/script_text_edit/test_completion_choices_provider.py
@@ -25,9 +25,7 @@ to handle completion choices generation with proper ordering, mode handling,
 deduplication, and error handling.
 """
 
-from collections.abc import Callable
 from unittest.mock import (
-    Mock,
     patch,
 )
 
@@ -38,15 +36,9 @@ from picard.ui.widgets.context_detector import CompletionMode
 
 
 @pytest.fixture
-def mock_plugin_provider() -> Mock:
-    """Create a mock plugin variable provider."""
-    return Mock(return_value={'plugin_var1', 'plugin_var2', 'plugin_var3'})
-
-
-@pytest.fixture
-def choices_provider(mock_plugin_provider: Mock) -> CompletionChoicesProvider:
+def choices_provider() -> CompletionChoicesProvider:
     """Create a CompletionChoicesProvider instance for testing."""
-    return CompletionChoicesProvider(mock_plugin_provider)
+    return CompletionChoicesProvider()
 
 
 @pytest.fixture
@@ -71,30 +63,6 @@ def sample_builtin_variables() -> list[str]:
 def sample_user_variables() -> set[str]:
     """Sample user-defined variables for testing."""
     return {'user_var1', 'user_var2', 'artist'}  # 'artist' overlaps with builtin
-
-
-class TestCompletionChoicesProviderInitialization:
-    """Test CompletionChoicesProvider initialization."""
-
-    def test_initialization_with_provider(self, mock_plugin_provider: Callable[[], set[str]]) -> None:
-        """Test initialization with plugin provider."""
-        provider = CompletionChoicesProvider(mock_plugin_provider)
-        assert provider._get_plugin_variable_names is mock_plugin_provider
-
-    def test_plugin_provider_integration(self, mock_plugin_provider: Callable[[], set[str]]) -> None:
-        """Test that plugin provider is integrated correctly."""
-        # Create a fresh provider to avoid calls during fixture creation
-        provider = CompletionChoicesProvider(mock_plugin_provider)
-
-        # Test that plugin variables are included in the results
-        choices = list(provider.build_choices(CompletionMode.VARIABLE, set(), [], {}))
-
-        # Should include plugin variables
-        plugin_choices = [choice for choice in choices if 'plugin_var' in choice]
-        assert len(plugin_choices) > 0
-        assert any('plugin_var1' in choice for choice in choices)
-        assert any('plugin_var2' in choice for choice in choices)
-        assert any('plugin_var3' in choice for choice in choices)
 
 
 class TestCompletionChoicesProviderOrdering:
@@ -127,11 +95,8 @@ class TestCompletionChoicesProviderOrdering:
             'artist',  # 5 uses
             'user_var1',  # 4 uses
             'album',  # 3 uses
-            'plugin_var1',  # 2 uses
             'title',  # 1 use
             'date',  # 0 uses
-            'plugin_var2',  # 0 uses
-            'plugin_var3',  # 0 uses
             'user_var2',  # 0 uses
         ]
 
@@ -249,9 +214,6 @@ class TestCompletionChoicesProviderModes:
             'date',
             'user_var1',
             'user_var2',
-            'plugin_var1',
-            'plugin_var2',
-            'plugin_var3',
         }
         actual_names = set(choices)
         assert actual_names == expected_names
@@ -282,30 +244,6 @@ class TestCompletionChoicesProviderModes:
 class TestCompletionChoicesProviderDeduplication:
     """Test deduplication across builtin/plugin/user variables."""
 
-    def test_deduplication_builtin_plugin_overlap(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test deduplication when builtin and plugin variables overlap."""
-        # Mock plugin provider to return overlapping variables
-        choices_provider._get_plugin_variable_names.return_value = {'artist', 'plugin_var'}  # type: ignore
-
-        choices = list(
-            choices_provider.build_choices(
-                CompletionMode.VARIABLE,
-                set(),
-                ['artist', 'album'],
-                {},
-            )
-        )
-
-        # Should not have duplicates
-        var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        assert len(var_names) == len(set(var_names))
-        assert 'artist' in var_names
-        assert 'album' in var_names
-        assert 'plugin_var' in var_names
-
     def test_deduplication_user_builtin_overlap(
         self,
         choices_provider: CompletionChoicesProvider,
@@ -323,26 +261,6 @@ class TestCompletionChoicesProviderDeduplication:
         var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
         assert len(var_names) == len(set(var_names))
         assert var_names.count('artist') == 1  # Should appear only once
-
-    def test_deduplication_user_plugin_overlap(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test deduplication when user and plugin variables overlap."""
-        choices_provider._get_plugin_variable_names.return_value = {'plugin_var', 'user_var'}  # type: ignore
-
-        choices = list(
-            choices_provider.build_choices(
-                CompletionMode.VARIABLE,
-                {'user_var', 'other_user_var'},
-                [],
-                {},
-            )
-        )
-
-        var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        assert len(var_names) == len(set(var_names))
-        assert var_names.count('user_var') == 1  # Should appear only once
 
     def test_stable_output_with_equal_weights(
         self,
@@ -379,8 +297,6 @@ class TestCompletionChoicesProviderErrorHandling:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling when plugin provider returns empty set."""
-        choices_provider._get_plugin_variable_names.return_value = set()  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
@@ -394,40 +310,6 @@ class TestCompletionChoicesProviderErrorHandling:
         assert 'user_var' in var_names
         assert 'builtin_var' in var_names
         # No plugin variables should be present
-
-    def test_plugin_provider_raises_exception(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test handling when plugin provider raises exception."""
-        choices_provider._get_plugin_variable_names.side_effect = RuntimeError("Plugin error")  # type: ignore
-
-        with pytest.raises(RuntimeError, match="Plugin error"):
-            list(
-                choices_provider.build_choices(
-                    CompletionMode.VARIABLE,
-                    {'user_var'},
-                    ['builtin_var'],
-                    {},
-                )
-            )
-
-    def test_plugin_provider_returns_none(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test handling when plugin provider returns None."""
-        choices_provider._get_plugin_variable_names.return_value = None  # type: ignore
-
-        with pytest.raises(TypeError):
-            list(
-                choices_provider.build_choices(
-                    CompletionMode.VARIABLE,
-                    {'user_var'},
-                    ['builtin_var'],
-                    {},
-                )
-            )
 
     def test_empty_inputs(
         self,
@@ -445,8 +327,7 @@ class TestCompletionChoicesProviderErrorHandling:
 
         # Should only contain plugin variables
         var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        expected_plugin_vars = {'plugin_var1', 'plugin_var2', 'plugin_var3'}
-        assert set(var_names) == expected_plugin_vars
+        assert set(var_names) == set()
 
 
 class TestCompletionChoicesProviderEdgeCases:
@@ -457,12 +338,10 @@ class TestCompletionChoicesProviderEdgeCases:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling of unicode variable names."""
-        choices_provider._get_plugin_variable_names.return_value = {'var_ñ', 'var_中文'}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {'var_ñ', 'var_中文'},
                 [],
                 {},
             )
@@ -477,12 +356,10 @@ class TestCompletionChoicesProviderEdgeCases:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling of variable names with colons."""
-        choices_provider._get_plugin_variable_names.return_value = {'tag:artist', 'tag:album'}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {'tag:artist', 'tag:album'},
                 [],
                 {},
             )
@@ -498,12 +375,10 @@ class TestCompletionChoicesProviderEdgeCases:
     ) -> None:
         """Test handling of very long variable names."""
         long_name = 'a' * 1000
-        choices_provider._get_plugin_variable_names.return_value = {long_name}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {long_name},
                 [],
                 {},
             )

--- a/test/script_text_edit/test_completion_provider_user_scripts.py
+++ b/test/script_text_edit/test_completion_provider_user_scripts.py
@@ -34,12 +34,6 @@ from picard.ui.widgets.user_script_scanner import UserScriptScanner
 
 
 @pytest.fixture
-def mock_plugin_provider():
-    """Create a mock plugin variable provider."""
-    return Mock(return_value={'plugin_var1', 'plugin_var2'})
-
-
-@pytest.fixture
 def mock_user_script_scanner():
     """Create a mock user script scanner."""
     scanner = Mock(spec=UserScriptScanner)
@@ -48,28 +42,26 @@ def mock_user_script_scanner():
 
 
 @pytest.fixture
-def choices_provider_with_scanner(mock_plugin_provider, mock_user_script_scanner):
+def choices_provider_with_scanner(mock_user_script_scanner):
     """Create a CompletionChoicesProvider with user script scanner."""
-    return CompletionChoicesProvider(mock_plugin_provider, mock_user_script_scanner)
+    return CompletionChoicesProvider(mock_user_script_scanner)
 
 
 @pytest.fixture
-def choices_provider_without_scanner(mock_plugin_provider):
+def choices_provider_without_scanner():
     """Create a CompletionChoicesProvider without user script scanner."""
-    return CompletionChoicesProvider(mock_plugin_provider)
+    return CompletionChoicesProvider()
 
 
-def test_initialization_with_user_script_scanner(mock_plugin_provider, mock_user_script_scanner):
+def test_initialization_with_user_script_scanner(mock_user_script_scanner):
     """Test initialization with user script scanner."""
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_user_script_scanner)
-    assert provider._get_plugin_variable_names is mock_plugin_provider
+    provider = CompletionChoicesProvider(mock_user_script_scanner)
     assert provider._user_script_scanner is mock_user_script_scanner
 
 
-def test_initialization_without_user_script_scanner(mock_plugin_provider):
+def test_initialization_without_user_script_scanner():
     """Test initialization without user script scanner."""
-    provider = CompletionChoicesProvider(mock_plugin_provider)
-    assert provider._get_plugin_variable_names is mock_plugin_provider
+    provider = CompletionChoicesProvider()
     assert provider._user_script_scanner is None
 
 
@@ -89,8 +81,6 @@ def test_build_choices_includes_user_script_variables(choices_provider_with_scan
     assert '%user_script_var2%' in choices
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
-    assert '%plugin_var2%' in choices
 
 
 def test_build_choices_without_user_script_scanner(choices_provider_without_scanner):
@@ -109,8 +99,6 @@ def test_build_choices_without_user_script_scanner(choices_provider_without_scan
     assert '%user_script_var2%' not in choices
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
-    assert '%plugin_var2%' in choices
 
 
 def test_build_choices_deduplication_with_user_scripts(choices_provider_with_scanner):
@@ -183,18 +171,16 @@ def test_build_choices_tag_name_arg_mode_with_user_scripts(choices_provider_with
         'user_script_var2',
         'user_defined_var',
         'builtin_var',
-        'plugin_var1',
-        'plugin_var2',
     }
     actual_names = set(choices)
     assert actual_names == expected_names
 
 
-def test_build_choices_user_script_scanner_exception(mock_plugin_provider):
+def test_build_choices_user_script_scanner_exception():
     """Test handling when user script scanner raises exception."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.side_effect = AttributeError("Scanner error")
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     # Should not raise exception
     choices = list(
@@ -209,14 +195,13 @@ def test_build_choices_user_script_scanner_exception(mock_plugin_provider):
     # Should still include other variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
 
 
-def test_build_choices_user_script_scanner_returns_none(mock_plugin_provider):
+def test_build_choices_user_script_scanner_returns_none():
     """Test handling when user script scanner returns None."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = None
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     # Should not raise exception
     choices = list(
@@ -231,14 +216,13 @@ def test_build_choices_user_script_scanner_returns_none(mock_plugin_provider):
     # Should still include other variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
 
 
-def test_build_choices_empty_user_script_variables(mock_plugin_provider):
+def test_build_choices_empty_user_script_variables():
     """Test handling when user script scanner returns empty set."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = set()
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(
@@ -252,15 +236,14 @@ def test_build_choices_empty_user_script_variables(mock_plugin_provider):
     # Should include other variables but not user script variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
     assert '%user_script_var1%' not in choices
 
 
-def test_build_choices_unicode_user_script_variables(mock_plugin_provider):
+def test_build_choices_unicode_user_script_variables():
     """Test handling of unicode user script variable names."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = {'var_ñ', 'var_中文'}
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(
@@ -275,12 +258,12 @@ def test_build_choices_unicode_user_script_variables(mock_plugin_provider):
     assert '%var_中文%' in choices
 
 
-def test_build_choices_very_long_user_script_variables(mock_plugin_provider):
+def test_build_choices_very_long_user_script_variables():
     """Test handling of very long user script variable names."""
     long_name = 'a' * 1000
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = {long_name}
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(

--- a/test/script_text_edit/test_script_completer_ioc.py
+++ b/test/script_text_edit/test_script_completer_ioc.py
@@ -25,7 +25,6 @@ that injected dependencies are used correctly and model reuse works
 as expected.
 """
 
-from collections.abc import Callable
 from unittest.mock import Mock
 
 from picard.script.parser import ScriptParser
@@ -66,13 +65,6 @@ def mock_context_detector() -> Mock:
 
 
 @pytest.fixture
-def mock_plugin_variable_provider() -> Callable[[], set[str]]:
-    """Create a mock plugin variable provider."""
-    provider = Mock(return_value={'plugin_var1', 'plugin_var2'})
-    return provider
-
-
-@pytest.fixture
 def mock_choices_provider() -> Mock:
     """Create a mock CompletionChoicesProvider."""
     provider = Mock(spec=CompletionChoicesProvider)
@@ -86,7 +78,6 @@ def script_completer_with_injections(
     mock_parser: Mock,
     mock_variable_extractor: Mock,
     mock_context_detector: Mock,
-    mock_plugin_variable_provider: Callable[[], set[str]],
     mock_choices_provider: Mock,
 ) -> ScriptCompleter:
     """Create a ScriptCompleter with all dependencies injected."""
@@ -94,7 +85,6 @@ def script_completer_with_injections(
         parser=mock_parser,
         variable_extractor=mock_variable_extractor,
         context_detector=mock_context_detector,
-        plugin_variable_provider=mock_plugin_variable_provider,
         choices_provider=mock_choices_provider,
     )
 
@@ -126,14 +116,6 @@ class TestScriptCompleterDependencyInjection:
         """Test that injected context detector is used."""
         assert script_completer_with_injections._context_detector is mock_context_detector
 
-    def test_uses_injected_plugin_provider(
-        self,
-        script_completer_with_injections: ScriptCompleter,
-        mock_plugin_variable_provider: Callable[[], set[str]],
-    ) -> None:
-        """Test that injected plugin provider is used."""
-        assert script_completer_with_injections._plugin_variable_provider is mock_plugin_variable_provider
-
     def test_uses_injected_choices_provider(
         self,
         script_completer_with_injections: ScriptCompleter,
@@ -150,7 +132,6 @@ class TestScriptCompleterDependencyInjection:
         assert isinstance(completer._parser, ScriptParser)
         assert isinstance(completer._variable_extractor, VariableExtractor)
         assert isinstance(completer._context_detector, ContextDetector)
-        assert completer._plugin_variable_provider is not None
         assert isinstance(completer._choices_provider, CompletionChoicesProvider)
 
     def test_variable_extractor_uses_injected_parser(
@@ -351,11 +332,7 @@ class TestScriptCompleterIntegration:
         # Should get choices for the context
         assert isinstance(choices, list)
 
-    def test_plugin_provider_integration(
-        self,
-        script_completer_with_injections: ScriptCompleter,
-        mock_plugin_variable_provider: Callable[[], set[str]],
-    ) -> None:
+    def test_plugin_provider_integration(self, script_completer_with_injections: ScriptCompleter) -> None:
         """Test integration between completer and plugin provider."""
         # Generate choices
         choices = list(script_completer_with_injections.choices)
@@ -392,7 +369,6 @@ class TestScriptCompleterEdgeCases:
             parser=None,
             variable_extractor=None,
             context_detector=None,
-            plugin_variable_provider=None,
             choices_provider=None,
         )
 
@@ -400,7 +376,6 @@ class TestScriptCompleterEdgeCases:
         assert completer._parser is not None
         assert completer._variable_extractor is not None
         assert completer._context_detector is not None
-        assert completer._plugin_variable_provider is not None
         assert completer._choices_provider is not None
 
     def test_handles_empty_script_content(

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -293,6 +293,19 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         else:
             self.fail("Variable not found in extension point")
 
+    def test_register_script_variable_underscore_prefix_normalized(self):
+        """Names starting with _ should be normalized to is_hidden=True with stripped name."""
+        register_script_variable('_hidden_by_prefix', 'docs')
+        self.assertIn('hidden_by_prefix', get_plugin_variable_names())
+        self.assertNotIn('_hidden_by_prefix', get_plugin_variable_names())
+        for var in self.ext_point:
+            if var.name == 'hidden_by_prefix':
+                self.assertTrue(var.is_hidden)
+                self.assertEqual('_hidden_by_prefix', var.script_name())
+                break
+        else:
+            self.fail("Variable not found in extension point")
+
     def test_register_script_variable_deduplication(self):
         """Registering the same variable twice from the same plugin should update, not duplicate."""
         api = self._make_api()

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -33,7 +33,6 @@ from picard.extension_points import (
     unset_plugin_uuid,
 )
 from picard.extension_points.script_variables import (
-    get_plugin_variable_documentation,
     register_script_variable,
     unregister_all_script_variables,
     unregister_script_variable,
@@ -250,8 +249,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
-        self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
         var = self._get_tagvar_by_name('my_var1')
+        self.assertEqual('some docs', var._longdesc)
         self.assertTrue(var.is_tag)
         self.assertFalse(var.is_hidden)
         self.assertFalse(var.is_multi_value)
@@ -259,15 +258,18 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
         self.assertEqual({'my_var1'}, self._registered_variable_names())
-        self.assertIsNone(get_plugin_variable_documentation('my_var1'))
+        var = self._get_tagvar_by_name('my_var1')
+        self.assertIsNone(var._longdesc)
 
     def test_register_script_variable_with_api(self):
         api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
-        self.assertEqual('Some docs', get_plugin_variable_documentation('my_var1'))
-        self.assertIsNone(get_plugin_variable_documentation('my_var2'))
+        var1 = self._get_tagvar_by_name('my_var1')
+        self.assertEqual('Some docs', var1._longdesc)
+        var2 = self._get_tagvar_by_name('my_var2')
+        self.assertIsNone(var2._longdesc)
 
     def test_register_script_variable_invalid_name(self):
         with self.assertRaises(ValueError):
@@ -305,7 +307,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertFalse(var.is_hidden)
-        self.assertEqual('Non-hidden docs', get_plugin_variable_documentation('my_var'))
+        self.assertEqual('Non-hidden docs', var._longdesc)
 
     def test_register_same_name_hidden_then_non_hidden_rejected(self):
         """Registering non-hidden after hidden with same base name should be rejected."""
@@ -317,7 +319,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original hidden registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertTrue(var.is_hidden)
-        self.assertEqual('Hidden docs', get_plugin_variable_documentation('_my_var'))
+        self.assertEqual('Hidden docs', var._longdesc)
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""
@@ -331,7 +333,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var', 'First docs', api)
         register_script_variable('my_var', 'Updated docs', api)
         self.assertEqual({'my_var'}, self._registered_variable_names())
-        self.assertEqual('Updated docs', get_plugin_variable_documentation('my_var'))
+        var = self._get_tagvar_by_name('my_var')
+        self.assertEqual('Updated docs', var._longdesc)
 
     def test_register_same_variable_different_plugins(self):
         """Same variable name from different plugins should both be kept."""
@@ -340,7 +343,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from plugin1', api1)
         register_script_variable('shared_var', 'Docs from plugin2', api2)
         self.assertEqual({'shared_var'}, self._registered_variable_names())
-        self.assertEqual('Docs from plugin1', get_plugin_variable_documentation('shared_var'))
+        var = self._get_tagvar_by_name('shared_var')
+        self.assertEqual('Docs from plugin1', var._longdesc)
 
     def test_unregister_script_variable(self):
         """Unregistering a single variable should remove only that variable."""
@@ -383,7 +387,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from p2', api2)
         unregister_script_variable('shared_var', api1)
         self.assertEqual({'shared_var'}, self._registered_variable_names())
-        self.assertEqual('Docs from p2', get_plugin_variable_documentation('shared_var'))
+        var = self._get_tagvar_by_name('shared_var')
+        self.assertEqual('Docs from p2', var._longdesc)
 
     def test_extension_point_unregister_with_match(self):
         """ExtensionPoint.unregister should remove only items matching the callable."""

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -317,7 +317,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original hidden registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertTrue(var.is_hidden)
-        self.assertEqual('Hidden docs', get_plugin_variable_documentation('my_var'))
+        self.assertEqual('Hidden docs', get_plugin_variable_documentation('_my_var'))
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -260,6 +260,11 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         with self.assertRaises(ValueError):
             register_script_variable('my-var1')
 
+    def test_register_script_variable_underscore_only(self):
+        """Registering just '_' should fail validation (empty name after stripping)."""
+        with self.assertRaises(ValueError):
+            register_script_variable('_')
+
     def test_register_script_variable_plugin_id(self):
         """Registered TagVar should carry the plugin_id from the API."""
         api = self._make_api()
@@ -272,8 +277,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
             self.fail("Variable not found in extension point")
 
     def test_register_script_variable_is_hidden(self):
-        """is_hidden parameter should be passed through to the TagVar."""
-        register_script_variable('hidden_var', 'docs', is_hidden=True)
+        """Names starting with _ should be registered as hidden variables."""
+        register_script_variable('_hidden_var', 'docs')
         for var in self.ext_point:
             if var.name == 'hidden_var':
                 self.assertTrue(var.is_hidden)
@@ -289,19 +294,6 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         for var in self.ext_point:
             if var.name == 'multi_var':
                 self.assertTrue(var.is_multi_value)
-                break
-        else:
-            self.fail("Variable not found in extension point")
-
-    def test_register_script_variable_underscore_prefix_normalized(self):
-        """Names starting with _ should be normalized to is_hidden=True with stripped name."""
-        register_script_variable('_hidden_by_prefix', 'docs')
-        self.assertIn('hidden_by_prefix', get_plugin_variable_names())
-        self.assertNotIn('_hidden_by_prefix', get_plugin_variable_names())
-        for var in self.ext_point:
-            if var.name == 'hidden_by_prefix':
-                self.assertTrue(var.is_hidden)
-                self.assertEqual('_hidden_by_prefix', var.script_name())
                 break
         else:
             self.fail("Variable not found in extension point")

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -240,11 +240,11 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
     def _registered_variable_names(self):
         return set(var.name for var in self.ext_point)
 
-    def _get_tagvar_by_name(self, name) -> TagVar:
+    def _get_tagvar_by_name(self, name, is_hidden=None) -> TagVar:
         for var in self.ext_point:
-            if var.name == name:
+            if var.name == name and (is_hidden is None or var.is_hidden == is_hidden):
                 return var
-        raise ValueError(f'Variable "{name}" not found in extension point')
+        raise ValueError(f'Variable "{name}" (is_hidden={is_hidden}) not found in extension point')
 
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
@@ -293,6 +293,31 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         self.assertFalse(var.is_tag)
         self.assertEqual('~hidden_var', str(var))
         self.assertEqual('_hidden_var', var.script_name())
+
+    def test_register_same_name_hidden_and_non_hidden(self):
+        """Registering the same base name as both hidden and non-hidden should be rejected."""
+        api = self._make_api()
+        register_script_variable('my_var', 'Non-hidden docs', api)
+
+        with self.assertRaises(ValueError, msg="Cannot register '_my_var'"):
+            register_script_variable('_my_var', 'Hidden docs', api)
+
+        # Original registration should remain unchanged
+        var = self._get_tagvar_by_name('my_var')
+        self.assertFalse(var.is_hidden)
+        self.assertEqual('Non-hidden docs', get_plugin_variable_documentation('my_var'))
+
+    def test_register_same_name_hidden_then_non_hidden_rejected(self):
+        """Registering non-hidden after hidden with same base name should be rejected."""
+        register_script_variable('_my_var', 'Hidden docs')
+
+        with self.assertRaises(ValueError, msg="Cannot register 'my_var'"):
+            register_script_variable('my_var', 'Non-hidden docs')
+
+        # Original hidden registration should remain unchanged
+        var = self._get_tagvar_by_name('my_var')
+        self.assertTrue(var.is_hidden)
+        self.assertEqual('Hidden docs', get_plugin_variable_documentation('my_var'))
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -233,6 +233,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api = MagicMock()
         api._plugin_module.__name__ = module
         api.module_path = module
+        api.plugin_id = module.split('.')[-1]
         api.manifest.name_i18n.return_value = name
         return api
 
@@ -240,24 +241,57 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
-        self.assertEqual('some docs\n\nPlugin: Unknown Plugin', get_plugin_variable_documentation('my_var1'))
+        self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
         self.assertEqual({'my_var1'}, get_plugin_variable_names())
-        self.assertEqual('Plugin: Unknown Plugin', get_plugin_variable_documentation('my_var1'))
+        self.assertIsNone(get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_with_api(self):
         api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
         self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
-        self.assertEqual('Some docs\n\nPlugin: Test Plugin', get_plugin_variable_documentation('my_var1'))
-        self.assertEqual('Plugin: Test Plugin', get_plugin_variable_documentation('my_var2'))
+        self.assertEqual('Some docs', get_plugin_variable_documentation('my_var1'))
+        self.assertIsNone(get_plugin_variable_documentation('my_var2'))
 
     def test_register_script_variable_invalid_name(self):
         with self.assertRaises(ValueError):
             register_script_variable('my-var1')
+
+    def test_register_script_variable_plugin_id(self):
+        """Registered TagVar should carry the plugin_id from the API."""
+        api = self._make_api()
+        register_script_variable('my_var', 'docs', api)
+        for var in self.ext_point:
+            if var.name == 'my_var':
+                self.assertEqual('testplugin', var.plugin_id)
+                break
+        else:
+            self.fail("Variable not found in extension point")
+
+    def test_register_script_variable_is_hidden(self):
+        """is_hidden parameter should be passed through to the TagVar."""
+        register_script_variable('hidden_var', 'docs', is_hidden=True)
+        for var in self.ext_point:
+            if var.name == 'hidden_var':
+                self.assertTrue(var.is_hidden)
+                self.assertEqual('~hidden_var', str(var))
+                self.assertEqual('_hidden_var', var.script_name())
+                break
+        else:
+            self.fail("Variable not found in extension point")
+
+    def test_register_script_variable_is_multi_value(self):
+        """is_multi_value parameter should be passed through to the TagVar."""
+        register_script_variable('multi_var', 'docs', is_multi_value=True)
+        for var in self.ext_point:
+            if var.name == 'multi_var':
+                self.assertTrue(var.is_multi_value)
+                break
+        else:
+            self.fail("Variable not found in extension point")
 
     def test_register_script_variable_deduplication(self):
         """Registering the same variable twice from the same plugin should update, not duplicate."""
@@ -265,7 +299,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var', 'First docs', api)
         register_script_variable('my_var', 'Updated docs', api)
         self.assertEqual({'my_var'}, get_plugin_variable_names())
-        self.assertEqual('Updated docs\n\nPlugin: Test Plugin', get_plugin_variable_documentation('my_var'))
+        self.assertEqual('Updated docs', get_plugin_variable_documentation('my_var'))
 
     def test_register_same_variable_different_plugins(self):
         """Same variable name from different plugins should both be kept."""
@@ -274,7 +308,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from plugin1', api1)
         register_script_variable('shared_var', 'Docs from plugin2', api2)
         self.assertEqual({'shared_var'}, get_plugin_variable_names())
-        self.assertEqual('Docs from plugin1\n\nPlugin: Plugin One', get_plugin_variable_documentation('shared_var'))
+        self.assertEqual('Docs from plugin1', get_plugin_variable_documentation('shared_var'))
 
     def test_unregister_script_variable(self):
         """Unregistering a single variable should remove only that variable."""
@@ -317,7 +351,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from p2', api2)
         unregister_script_variable('shared_var', api1)
         self.assertEqual({'shared_var'}, get_plugin_variable_names())
-        self.assertEqual('Docs from p2\n\nPlugin: Plugin Two', get_plugin_variable_documentation('shared_var'))
+        self.assertEqual('Docs from p2', get_plugin_variable_documentation('shared_var'))
 
     def test_extension_point_unregister_with_match(self):
         """ExtensionPoint.unregister should remove only items matching the callable."""

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -34,7 +34,6 @@ from picard.extension_points import (
 )
 from picard.extension_points.script_variables import (
     get_plugin_variable_documentation,
-    get_plugin_variable_names,
     register_script_variable,
     unregister_all_script_variables,
     unregister_script_variable,
@@ -237,22 +236,25 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api.manifest.name_i18n.return_value = name
         return api
 
+    def _registered_variable_names(self):
+        return set(var.name for var in self.ext_point)
+
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
-        self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
-        self.assertEqual({'my_var1'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1'}, self._registered_variable_names())
         self.assertIsNone(get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_with_api(self):
         api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
-        self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('Some docs', get_plugin_variable_documentation('my_var1'))
         self.assertIsNone(get_plugin_variable_documentation('my_var2'))
 
@@ -303,7 +305,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api = self._make_api()
         register_script_variable('my_var', 'First docs', api)
         register_script_variable('my_var', 'Updated docs', api)
-        self.assertEqual({'my_var'}, get_plugin_variable_names())
+        self.assertEqual({'my_var'}, self._registered_variable_names())
         self.assertEqual('Updated docs', get_plugin_variable_documentation('my_var'))
 
     def test_register_same_variable_different_plugins(self):
@@ -312,7 +314,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api2 = self._make_api('picard.plugins.plugin2', 'Plugin Two')
         register_script_variable('shared_var', 'Docs from plugin1', api1)
         register_script_variable('shared_var', 'Docs from plugin2', api2)
-        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual({'shared_var'}, self._registered_variable_names())
         self.assertEqual('Docs from plugin1', get_plugin_variable_documentation('shared_var'))
 
     def test_unregister_script_variable(self):
@@ -320,9 +322,9 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api = self._make_api()
         register_script_variable('var1', 'Docs 1', api)
         register_script_variable('var2', 'Docs 2', api)
-        self.assertEqual({'var1', 'var2'}, get_plugin_variable_names())
+        self.assertEqual({'var1', 'var2'}, self._registered_variable_names())
         unregister_script_variable('var1', api)
-        self.assertEqual({'var2'}, get_plugin_variable_names())
+        self.assertEqual({'var2'}, self._registered_variable_names())
 
     def test_unregister_script_variable_nonexistent(self):
         """Unregistering a variable that doesn't exist should not raise."""
@@ -335,9 +337,9 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('var1', 'Docs 1', api)
         register_script_variable('var2', 'Docs 2', api)
         register_script_variable('var3', 'Docs 3', api)
-        self.assertEqual({'var1', 'var2', 'var3'}, get_plugin_variable_names())
+        self.assertEqual({'var1', 'var2', 'var3'}, self._registered_variable_names())
         unregister_all_script_variables(api)
-        self.assertEqual(set(), get_plugin_variable_names())
+        self.assertEqual(set(), self._registered_variable_names())
 
     def test_unregister_all_does_not_affect_other_plugins(self):
         """Unregistering all variables from one plugin should not affect another."""
@@ -346,7 +348,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('var_from_p1', 'Docs', api1)
         register_script_variable('var_from_p2', 'Docs', api2)
         unregister_all_script_variables(api1)
-        self.assertEqual({'var_from_p2'}, get_plugin_variable_names())
+        self.assertEqual({'var_from_p2'}, self._registered_variable_names())
 
     def test_unregister_does_not_affect_other_plugins(self):
         """Unregistering a variable name should only remove it from the calling plugin."""
@@ -355,7 +357,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from p1', api1)
         register_script_variable('shared_var', 'Docs from p2', api2)
         unregister_script_variable('shared_var', api1)
-        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual({'shared_var'}, self._registered_variable_names())
         self.assertEqual('Docs from p2', get_plugin_variable_documentation('shared_var'))
 
     def test_extension_point_unregister_with_match(self):

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -40,6 +40,7 @@ from picard.extension_points.script_variables import (
 )
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.plugin import Plugin
+from picard.tags.tagvar import TagVar
 
 
 def create_mock_plugin(uuid, plugin_id='testplugin') -> Plugin:
@@ -220,7 +221,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         super().setUp()
         patcher_ep = patch(
             'picard.extension_points.script_variables.ext_point_script_variables',
-            ExtensionPoint(label='test_variables'),
+            ExtensionPoint[TagVar](label='test_variables'),
         )
         patcher_config = patch('picard.extension_points.get_config', return_value=None)
         self.ext_point = patcher_ep.start()
@@ -239,11 +240,21 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
     def _registered_variable_names(self):
         return set(var.name for var in self.ext_point)
 
+    def _get_tagvar_by_name(self, name) -> TagVar:
+        for var in self.ext_point:
+            if var.name == name:
+                return var
+        raise ValueError(f'Variable "{name}" not found in extension point')
+
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
+        var = self._get_tagvar_by_name('my_var1')
+        self.assertTrue(var.is_tag)
+        self.assertFalse(var.is_hidden)
+        self.assertFalse(var.is_multi_value)
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
@@ -271,34 +282,23 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         """Registered TagVar should carry the plugin_id from the API."""
         api = self._make_api()
         register_script_variable('my_var', 'docs', api)
-        for var in self.ext_point:
-            if var.name == 'my_var':
-                self.assertEqual('testplugin', var.plugin_id)
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('my_var')
+        self.assertEqual('testplugin', var.plugin_id)
 
     def test_register_script_variable_is_hidden(self):
         """Names starting with _ should be registered as hidden variables."""
         register_script_variable('_hidden_var', 'docs')
-        for var in self.ext_point:
-            if var.name == 'hidden_var':
-                self.assertTrue(var.is_hidden)
-                self.assertEqual('~hidden_var', str(var))
-                self.assertEqual('_hidden_var', var.script_name())
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('hidden_var')
+        self.assertTrue(var.is_hidden)
+        self.assertFalse(var.is_tag)
+        self.assertEqual('~hidden_var', str(var))
+        self.assertEqual('_hidden_var', var.script_name())
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""
         register_script_variable('multi_var', 'docs', is_multi_value=True)
-        for var in self.ext_point:
-            if var.name == 'multi_var':
-                self.assertTrue(var.is_multi_value)
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('multi_var')
+        self.assertTrue(var.is_multi_value)
 
     def test_register_script_variable_deduplication(self):
         """Registering the same variable twice from the same plugin should update, not duplicate."""

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -26,10 +26,7 @@ import unittest.mock as mock
 
 from test.picardtestcase import PicardTestCase
 
-from picard.const import (
-    DOCS_SERVER_URL,
-    PICARD_URLS,
-)
+from picard.const import PICARD_URLS
 from picard.const.tags import ALL_TAGS
 from picard.options import (
     Option,
@@ -515,54 +512,78 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(display_tag_tooltip('performer'), result)
 
     def test_display_tag_full_description(self):
+        item = TagVar(name='my_var', longdesc='The tag description.')
+
+        # Tag with description only
+        expected = "<p>The tag description.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+
+        # Multi-value tag with description only
+        item.is_multi_value = True
+        expected = "<p>The tag description.</p><p><strong>Notes:</strong> multi-value variable.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.is_multi_value = False
+
         # Tag with option setting only
-        if ('setting', 'use_genres') not in Option.registry:
-            Option('setting', 'use_genres', None, title='Use genres from MusicBrainz')
-        result = (
-            '<p><em>%genre%</em></p><p>The specified genre information from MusicBrainz.</p><p><strong>Notes:</strong> multi-value '
-            'variable.</p><p><strong>Option Settings:</strong> Use genres from MusicBrainz.</p>'
-        )
-        self.assertEqual(display_tag_full_description('genre'), result)
+        Option('setting', 'my_script_var_opt', None, title='Option description')
+        item.related_options = ('my_script_var_opt',)
+        expected = "<p>The tag description.</p><p><strong>Option Settings:</strong> Option description.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.related_options = None
 
-        # Tag with link only
-        result = (
-            '<p><em>%barcode%</em></p><p>The barcode assigned to the release.</p>'
-            "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/Barcode'>Barcode in MusicBrainz documentation</a>; "
-            "<a href='{server}en/latest/appendices/tag_mapping.html#id6'>Barcode mapping in Picard documentation</a>.</p>"
-        ).format(server=DOCS_SERVER_URL)
-        self.assertEqual(display_tag_full_description('barcode'), result)
+        # Tag with plugin info
+        item.plugin_name = "My Plugin"
+        expected = "<p>The tag description.</p><p><strong>Plugin:</strong> My Plugin.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.plugin_name = None
 
-        # Hidden tag with notes only.
-        result = (
-            '<p><em>%_sample_rate%</em></p><p>The sample rate of the audio file.</p>'
-            '<p><strong>Notes:</strong> preserved read-only; info from audio file; not provided from MusicBrainz data.</p>'
+        # Tag with doc links
+        item.doc_links = (
+            DocumentLink('Link 1', 'https://example.com'),
+            DocumentLink('Link 2', 'https://example.com/foo'),
         )
-        self.assertEqual(display_tag_full_description('_sample_rate'), result)
+        expected = "<p>The tag description.</p><p><strong>Links:</strong> <a href='https://example.com'>Link 1</a>; <a href='https://example.com/foo'>Link 2</a>.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.doc_links = None
+
+        # Tag with see also references
+        item.see_also = ('artist', 'albumartist')
+        expected = '<p>The tag description.</p><p><strong>See Also:</strong> <a href="#artist">%artist%</a>; <a href="#albumartist">%albumartist%</a>.</p>'
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.see_also = None
 
         # Tag with complex markdown (list items) and notes.
+        item.is_hidden = True
+        item.is_multi_value = True
+        item._longdesc = """Description of **My Var**:
+
+- Foo
+- Bar
+        """
         result = (
             (
-                '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:</p>\n'
+                '<p>Description of <strong>My Var</strong>:</p>\n'
                 '<ul>\n'
-                '<li>vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;<em>vocal</em>&quot;, '
-                '&quot;<em>guest guitar</em>&quot;, &quot;<em>solo violin</em>&quot;, etc.</li>\n'
-                '<li>the orchestra for the associated release or recording, where &quot;type&quot; is &quot;<em>orchestra</em>&quot;</li>\n'
-                '<li>the concert master for the associated release or recording, where &quot;type&quot; is &quot;<em>concertmaster</em>&quot;</li>\n'
-                '</ul>'
-                '<p><strong>Notes:</strong> multi-value variable.</p>'
+                '<li>Foo</li>\n'
+                '<li>Bar</li>\n'
+                '</ul><p><strong>Notes:</strong> multi-value variable.</p>'
             )
             if markdown is not None
             else (
-                '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
-                '<br /><br />'
-                '- vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;*vocal*&quot;, '
-                '&quot;*guest guitar*&quot;, &quot;*solo violin*&quot;, etc.<br />'
-                '- the orchestra for the associated release or recording, where &quot;type&quot; is &quot;*orchestra*&quot;<br />'
-                '- the concert master for the associated release or recording, where &quot;type&quot; is &quot;*concertmaster*&quot;</p>'
+                '<p>Description of **My Var**:<br /><br />'
+                '- Foo<br />'
+                '- Bar</p>'
                 '<p><strong>Notes:</strong> multi-value variable.</p>'
             )
         )
-        self.assertEqual(display_tag_full_description('performer'), result)
+        self.assertEqual(display_tag_full_description(item), result)
+        item.is_hidden = False
+        item.is_multi_value = False
+
+        # Tag with no description
+        item._longdesc = None
+        expected = '<p>my_var</p>'
+        self.assertEqual(display_tag_full_description(item), expected)
 
 
 class UtilTagsOptionsTest(PicardTestCase):

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -39,13 +39,11 @@ from picard.profile import profile_groups_add_setting
 from picard.tags import (
     display_tag_name,
     filterable_tag_names,
-    hidden_tag_names,
     parse_comment_tag,
     parse_subtag,
     preserved_tag_names,
     script_variable_tag_names,
     tag_names,
-    visible_tag_names,
 )
 from picard.tags.docs import (
     display_tag_full_description,
@@ -617,20 +615,6 @@ class TagsGeneratorTest(PicardTestCase):
 
         for tag in tags:
             self.assertTrue(ALL_TAGS.tagvar_from_name(tag).is_tag)
-
-    def test_all_visible_tags(self):
-        tags = list(visible_tag_names())
-        self.assertTrue(len(tags) > 0)
-
-        for tag in tags:
-            self.assertFalse(ALL_TAGS.tagvar_from_name(tag).is_hidden)
-
-    def test_all_hidden_tags(self):
-        tags = list(hidden_tag_names())
-        self.assertTrue(len(tags) > 0)
-
-        for tag in tags:
-            self.assertTrue(ALL_TAGS.tagvar_from_name(tag).is_hidden)
 
     def test_all_preserved_tags(self):
         tags = list(preserved_tag_names())


### PR DESCRIPTION
## Summary
* This is a…
  * Bug fix
  * Feature addition
  * Refactoring
* **Describe this change in 1-2 sentences**: Replace `PluginVariable` with `TagVar` in the script variables extension point, giving plugin-registered variables the same capabilities as built-in tags. This makes `tag_names()` include plugin variables, fixing autocomplete in tag dropdowns and restoring plugin attribution in the scripting documentation.

## Problem
* JIRA ticket: [PICARD-3387](https://tickets.metabrainz.org/browse/PICARD-3387)

When a plugin registers custom tags using `api.register_script_variable()`, those tags appear in the script editor autocomplete but do NOT appear in:
* The edit tag dialog dropdown (metadata box)
* The tag list editor autocomplete (options pages)

The root cause is that `tag_names()` only queries `ALL_TAGS` (the static built-in registry), while plugin variables lived in a separate `ExtensionPoint[PluginVariable]` dataclass that was only consumed by the script editor.

## Solution

Instead of maintaining a separate `PluginVariable` dataclass, plugin-registered variables now use `TagVar` instances stored in the `ExtensionPoint`. This allows:

1. **`tag_names()` extended** to yield from both `ALL_TAGS` and `ext_point_script_variables` — all UI consumers of `tag_names()` (edit tag dialog, tag list editor) automatically get plugin variables.
2. **Full TagVar capabilities** for plugin variables: `is_hidden`, `is_multi_value`, proper `script_name()` formatting, tooltip/documentation support.
3. **Plugin attribution via `plugin_id`** — resolved to a display name at render time via the plugin manager. The scripting documentation panel shows `[Plugin: <name>]` for plugin-registered variables, consistent with how script functions handle attribution.
4. **New API parameters** — `register_script_variable()` now accepts `title` and `is_multi_value`. Hidden status is derived from the `_` prefix convention (names starting with `_` are hidden).
5. **Unified iteration** — A single `_all_tag_vars()` helper iterates both built-in and plugin TagVars, simplifying `tag_names()`, `script_variable_tag_names()`, and the `CompletionProvider`.
6. **Simplified CompletionProvider** — Plugin variables flow through the standard tag iteration path; no separate `get_plugin_variable_names` callable injection needed.
7. **Registration restriction** — A plugin cannot register the same base name as both hidden and non-hidden (e.g., both `foo` and `_foo`). Raises `ValueError` if attempted. This keeps lookup functions simple (name-only matching).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:
* Significant use (e.g. code structure, tests development, etc.)

Investigation, implementation, and testing developed with AI assistance. Design decisions made collaboratively with human review.

## Action

Additional actions required:
* Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)

The plugin v3 API docs (`docs/PLUGINSV3/API.md`) have been updated in this PR to document the `title`, `is_multi_value` parameters, the `_` prefix convention, and the `ValueError` raised for conflicting registrations.
