### PR TITLE
Add hidden variable check to `TagVar` definition

### DIFF
--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -127,6 +127,10 @@ class TagVar:
         related_options: an iterable containing the related option settings (see picard/options.py)
         doc_links: an iterable containing links to external documentation (DocumentLink tuples)
         """
+        if name.startswith('_') and not is_hidden:
+            is_hidden = True
+            name = name[1:]  # to preserve tags starting with multiple underscores
+
         self.name = name
         self._shortdesc = shortdesc
         self._longdesc = longdesc

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -108,6 +108,11 @@ class TagVarTest(PicardTestCase):
         tv = TagVar('name', is_hidden=True)
         self.assertEqual(tv.script_name(), '_name')
 
+    def test_hidden_script_name_without_is_hidden(self):
+        tv = TagVar('_name', is_hidden=False)
+        self.assertEqual(tv.name, 'name')
+        self.assertEqual(tv.script_name(), '_name')
+
     def test_basic_notes(self):
         see_also = (
             'a',


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

It was possible to initialize a TagVar with a name beginning with an underscore and not have it marked as a hidden variable.

* JIRA ticket (_optional_): PICARD-XXX


## Solution

Add a check when initializing a `TagVar` instance to automatically remove a leading underscore and set the `is_hidden` attribute to True.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
