### PR TITLE
Extend plugin i18n plural forms

### DIFF
--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -106,6 +106,7 @@ from picard.log import LoggerFunc
 from picard.metadata import Metadata
 from picard.plugin3.i18n import (
     PluginTranslator,
+    Plural,
     get_plural_form,
 )
 from picard.plugin3.manifest import PluginManifest
@@ -464,7 +465,7 @@ class PluginApi:
 
     def _is_plural_dict(self, d: dict) -> bool:
         """Check if dict is a plural forms dict (has keys like 'one', 'other', etc.)."""
-        plural_keys = {'zero', 'one', 'two', 'few', 'many', 'other'}
+        plural_keys = set(e.value for e in Plural)
         return bool(d.keys() & plural_keys)
 
     def _load_translations(self) -> None:
@@ -795,12 +796,12 @@ class PluginApi:
             locale = self.get_locale()
             plural_form = get_plural_form(locale, n)
 
-            def get_plural_translation(trans: Any, plural_form: str) -> str | None:
+            def get_plural_translation(trans: Any, plural_form: Plural) -> str | None:
                 if isinstance(trans, dict):
-                    if plural_form in trans:
-                        return trans[plural_form]
-                    elif 'other' in trans:
-                        return trans['other']
+                    if plural_form.value in trans:
+                        return trans[plural_form.value]
+                    elif Plural.OTHER.value in trans:
+                        return trans[Plural.OTHER.value]
                 return None
 
             # Try exact locale match

--- a/picard/plugin3/i18n.py
+++ b/picard/plugin3/i18n.py
@@ -69,6 +69,180 @@ class PluginTranslator(QTranslator):
         return None
 
 
+def _plural_english(n: int) -> str:
+    return 'one' if n == 1 else 'other'
+
+
+def _plural_french(n: int) -> str:
+    return 'one' if n in {0, 1} else 'other'
+
+
+def _plural_polish(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
+        return 'few'
+    return 'many'
+
+
+def _plural_russian(n: int) -> str:
+    if n % 10 == 1 and n % 100 != 11:
+        return 'one'
+    if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
+        return 'few'
+    return 'many'
+
+
+def _plural_arabic(n: int) -> str:
+    if n == 0:
+        return 'zero'
+    if n == 1:
+        return 'one'
+    if n == 2:
+        return 'two'
+    if 3 <= n % 100 <= 10:
+        return 'few'
+    if 11 <= n % 100 <= 99:
+        return 'many'
+    return 'other'
+
+
+def _plural_hebrew(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if n == 2:
+        return 'two'
+    return 'other'
+
+
+def _plural_czech(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if 2 <= n <= 4:
+        return 'few'
+    return 'other'
+
+
+def _plural_romanian(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if n == 0 or (n != 1 and 1 <= n % 100 <= 19):
+        return 'few'
+    return 'other'
+
+
+def _plural_croatian(n: int) -> str:
+    if n % 10 == 1 and n % 100 != 11:
+        return 'one'
+    if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
+        return 'few'
+    return 'other'
+
+
+def _plural_catalan(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if n != 0 and n % 1_000_000 == 0:
+        return 'many'
+    return 'other'
+
+
+def _plural_lithuanian(n: int) -> str:
+    if n % 10 == 1 and not 11 <= n % 100 <= 19:
+        return 'one'
+    if 2 <= n % 10 <= 9 and not 11 <= n % 100 <= 19:
+        return 'few'
+    return 'other'
+
+
+def _plural_other(n: int) -> str:
+    return 'other'
+
+
+def _plural_icelandic(n: int) -> str:
+    if n % 10 == 1 and n % 100 != 11:
+        return 'one'
+    return 'other'
+
+
+def _plural_irish(n: int) -> str:
+    if n == 1:
+        return 'one'
+    if n == 2:
+        return 'two'
+    if n in {3, 4, 5, 6}:
+        return 'few'
+    if n in {7, 8, 9, 10}:
+        return 'many'
+    return 'other'
+
+
+def _plural_welsh(n: int) -> str:
+    if n == 0:
+        return 'zero'
+    if n == 1:
+        return 'one'
+    if n == 2:
+        return 'two'
+    if n == 3:
+        return 'few'
+    if n == 6:
+        return 'many'
+    return 'other'
+
+
+_PLURAL_RULES = {
+    # English, German, Spanish, Italian, Portuguese, etc.
+    'en': _plural_english,
+    'de': _plural_english,
+    'es': _plural_english,
+    'it': _plural_english,
+    'pt': _plural_english,
+    'nl': _plural_english,
+    'sv': _plural_english,
+    'da': _plural_english,
+    'no': _plural_english,
+    'fi': _plural_english,
+    # French, Punjabi (0 and 1 are singular)
+    'fr': _plural_french,
+    'pa': _plural_french,
+    # Polish
+    'pl': _plural_polish,
+    # Russian, Ukrainian
+    'ru': _plural_russian,
+    'uk': _plural_russian,
+    # Arabic
+    'ar': _plural_arabic,
+    # Hebrew
+    'he': _plural_hebrew,
+    # Czech, Slovak
+    'cs': _plural_czech,
+    'sk': _plural_czech,
+    # Romanian
+    'ro': _plural_romanian,
+    # Croatian, Bosnian, Serbian
+    'hr': _plural_croatian,
+    'bs': _plural_croatian,
+    'sr': _plural_croatian,
+    # Catalan
+    'ca': _plural_catalan,
+    # Lithuanian
+    'lt': _plural_lithuanian,
+    # Japanese, Korean, Malay, Vietnamese, Chinese
+    'ja': _plural_other,
+    'ko': _plural_other,
+    'ms': _plural_other,
+    'vi': _plural_other,
+    'zh': _plural_other,
+    # Icelandic
+    'is': _plural_icelandic,
+    # Irish
+    'ga': _plural_irish,
+    # Welsh
+    'cy': _plural_welsh,
+}
+
+
 def get_plural_form(locale: str, n: int) -> str:
     """Get CLDR plural form for a number in a given locale.
 
@@ -80,128 +254,4 @@ def get_plural_form(locale: str, n: int) -> str:
         One of: 'zero', 'one', 'two', 'few', 'many', 'other'
     """
     lang = locale.split('_')[0]
-
-    # English, German, Spanish, Italian, Portuguese, etc.
-    if lang in {'en', 'de', 'es', 'it', 'pt', 'nl', 'sv', 'da', 'no', 'fi'}:
-        return 'one' if n == 1 else 'other'
-
-    # French, Punjabi (0 and 1 are singular)
-    if lang in {'fr', 'pa'}:
-        return 'one' if n in {0, 1} else 'other'
-
-    # Polish
-    if lang == 'pl':
-        if n == 1:
-            return 'one'
-        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-            return 'few'
-        return 'many'
-
-    # Russian, Ukrainian
-    if lang in {'ru', 'uk'}:
-        if n % 10 == 1 and n % 100 != 11:
-            return 'one'
-        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-            return 'few'
-        return 'many'
-
-    # Arabic
-    if lang == 'ar':
-        if n == 0:
-            return 'zero'
-        if n == 1:
-            return 'one'
-        if n == 2:
-            return 'two'
-        if 3 <= n % 100 <= 10:
-            return 'few'
-        if 11 <= n % 100 <= 99:
-            return 'many'
-        return 'other'
-
-    # Hebrew
-    if lang == 'he':
-        if n == 1:
-            return 'one'
-        if n == 2:
-            return 'two'
-        return 'other'
-
-    # Czech, Slovak
-    if lang in {'cs', 'sk'}:
-        if n == 1:
-            return 'one'
-        if 2 <= n <= 4:
-            return 'few'
-        return 'other'
-
-    # Romanian (also: mo)  — one/few/other
-    if lang == 'ro':
-        if n == 1:
-            return 'one'
-        if n == 0 or (n != 1 and 1 <= n % 100 <= 19):
-            return 'few'
-        return 'other'
-
-    # Croatian (also: bs, sr) — one/few/other
-    if lang in {'hr', 'bs', 'sr'}:
-        if n % 10 == 1 and n % 100 != 11:
-            return 'one'
-        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-            return 'few'
-        return 'other'
-
-    # Catalan — one/many/other
-    if lang == 'ca':
-        if n == 1:
-            return 'one'
-        if n != 0 and n % 1_000_000 == 0:
-            return 'many'
-        return 'other'
-
-    # Lithuanian
-    if lang == 'lt':
-        if n % 10 == 1 and not 11 <= n % 100 <= 19:
-            return 'one'
-        if 2 <= n % 10 <= 9 and not 11 <= n % 100 <= 19:
-            return 'few'
-        return 'other'
-
-    # Japanese, Korean, Malay, Vietnamese, Chinese
-    if lang in {'ja', 'ko', 'ms', 'vi', 'zh'}:
-        return 'other'
-
-    # Icelandic
-    if lang == 'is':
-        if n % 10 == 1 and n % 100 != 11:
-            return 'one'
-        return 'other'
-
-    # Irish
-    if lang == 'ga':
-        if n == 1:
-            return 'one'
-        if n == 2:
-            return 'two'
-        if n in {3, 4, 5, 6}:
-            return 'few'
-        if n in {7, 8, 9, 10}:
-            return 'many'
-        return 'other'
-
-    # Welsh
-    if lang == 'cy':
-        if n == 0:
-            return 'zero'
-        if n == 1:
-            return 'one'
-        if n == 2:
-            return 'two'
-        if n == 3:
-            return 'few'
-        if n == 6:
-            return 'many'
-        return 'other'
-
-    # Default to English rules
-    return 'one' if n == 1 else 'other'
+    return _PLURAL_RULES.get(lang, _plural_english)(n)

--- a/picard/plugin3/i18n.py
+++ b/picard/plugin3/i18n.py
@@ -18,6 +18,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from enum import Enum
+
 from PyQt6.QtCore import QTranslator
 
 
@@ -69,126 +71,135 @@ class PluginTranslator(QTranslator):
         return None
 
 
-def _plural_english(n: int) -> str:
-    return 'one' if n == 1 else 'other'
+class Plural(Enum):
+    ZERO = 'zero'
+    ONE = 'one'
+    TWO = 'two'
+    FEW = 'few'
+    MANY = 'many'
+    OTHER = 'other'
 
 
-def _plural_french(n: int) -> str:
-    return 'one' if n in {0, 1} else 'other'
+def _plural_english(n: int) -> Plural:
+    return Plural.ONE if n == 1 else Plural.OTHER
 
 
-def _plural_polish(n: int) -> str:
+def _plural_french(n: int) -> Plural:
+    return Plural.ONE if n in {0, 1} else Plural.OTHER
+
+
+def _plural_polish(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-        return 'few'
-    return 'many'
+        return Plural.FEW
+    return Plural.MANY
 
 
-def _plural_russian(n: int) -> str:
+def _plural_russian(n: int) -> Plural:
     if n % 10 == 1 and n % 100 != 11:
-        return 'one'
+        return Plural.ONE
     if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-        return 'few'
-    return 'many'
+        return Plural.FEW
+    return Plural.MANY
 
 
-def _plural_arabic(n: int) -> str:
+def _plural_arabic(n: int) -> Plural:
     if n == 0:
-        return 'zero'
+        return Plural.ZERO
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n == 2:
-        return 'two'
+        return Plural.TWO
     if 3 <= n % 100 <= 10:
-        return 'few'
+        return Plural.FEW
     if 11 <= n % 100 <= 99:
-        return 'many'
-    return 'other'
+        return Plural.MANY
+    return Plural.OTHER
 
 
-def _plural_hebrew(n: int) -> str:
+def _plural_hebrew(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n == 2:
-        return 'two'
-    return 'other'
+        return Plural.TWO
+    return Plural.OTHER
 
 
-def _plural_czech(n: int) -> str:
+def _plural_czech(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if 2 <= n <= 4:
-        return 'few'
-    return 'other'
+        return Plural.FEW
+    return Plural.OTHER
 
 
-def _plural_romanian(n: int) -> str:
+def _plural_romanian(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n == 0 or (n != 1 and 1 <= n % 100 <= 19):
-        return 'few'
-    return 'other'
+        return Plural.FEW
+    return Plural.OTHER
 
 
-def _plural_croatian(n: int) -> str:
+def _plural_croatian(n: int) -> Plural:
     if n % 10 == 1 and n % 100 != 11:
-        return 'one'
+        return Plural.ONE
     if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
-        return 'few'
-    return 'other'
+        return Plural.FEW
+    return Plural.OTHER
 
 
-def _plural_catalan(n: int) -> str:
+def _plural_catalan(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n != 0 and n % 1_000_000 == 0:
-        return 'many'
-    return 'other'
+        return Plural.MANY
+    return Plural.OTHER
 
 
-def _plural_lithuanian(n: int) -> str:
+def _plural_lithuanian(n: int) -> Plural:
     if n % 10 == 1 and not 11 <= n % 100 <= 19:
-        return 'one'
+        return Plural.ONE
     if 2 <= n % 10 <= 9 and not 11 <= n % 100 <= 19:
-        return 'few'
-    return 'other'
+        return Plural.FEW
+    return Plural.OTHER
 
 
-def _plural_other(n: int) -> str:
-    return 'other'
+def _plural_other(n: int) -> Plural:
+    return Plural.OTHER
 
 
-def _plural_icelandic(n: int) -> str:
+def _plural_icelandic(n: int) -> Plural:
     if n % 10 == 1 and n % 100 != 11:
-        return 'one'
-    return 'other'
+        return Plural.ONE
+    return Plural.OTHER
 
 
-def _plural_irish(n: int) -> str:
+def _plural_irish(n: int) -> Plural:
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n == 2:
-        return 'two'
+        return Plural.TWO
     if n in {3, 4, 5, 6}:
-        return 'few'
+        return Plural.FEW
     if n in {7, 8, 9, 10}:
-        return 'many'
-    return 'other'
+        return Plural.MANY
+    return Plural.OTHER
 
 
-def _plural_welsh(n: int) -> str:
+def _plural_welsh(n: int) -> Plural:
     if n == 0:
-        return 'zero'
+        return Plural.ZERO
     if n == 1:
-        return 'one'
+        return Plural.ONE
     if n == 2:
-        return 'two'
+        return Plural.TWO
     if n == 3:
-        return 'few'
+        return Plural.FEW
     if n == 6:
-        return 'many'
-    return 'other'
+        return Plural.MANY
+    return Plural.OTHER
 
 
 _PLURAL_RULES = {
@@ -243,7 +254,7 @@ _PLURAL_RULES = {
 }
 
 
-def get_plural_form(locale: str, n: int) -> str:
+def get_plural_form(locale: str, n: int) -> Plural:
     """Get CLDR plural form for a number in a given locale.
 
     Args:
@@ -251,7 +262,7 @@ def get_plural_form(locale: str, n: int) -> str:
         n: Number to get plural form for
 
     Returns:
-        One of: 'zero', 'one', 'two', 'few', 'many', 'other'
+        Plural enum value
     """
     lang = locale.split('_')[0]
     return _PLURAL_RULES.get(lang, _plural_english)(n)

--- a/picard/plugin3/i18n.py
+++ b/picard/plugin3/i18n.py
@@ -135,6 +135,30 @@ def get_plural_form(locale: str, n: int) -> str:
             return 'few'
         return 'other'
 
+    # Romanian (also: mo)  — one/few/other
+    if lang == 'ro':
+        if n == 1:
+            return 'one'
+        if n == 0 or (n != 1 and 1 <= n % 100 <= 19):
+            return 'few'
+        return 'other'
+
+    # Croatian (also: bs, sr) — one/few/other
+    if lang in {'hr', 'bs', 'sr'}:
+        if n % 10 == 1 and n % 100 != 11:
+            return 'one'
+        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
+            return 'few'
+        return 'other'
+
+    # Catalan — one/many/other
+    if lang == 'ca':
+        if n == 1:
+            return 'one'
+        if n != 0 and n % 1_000_000 == 0:
+            return 'many'
+        return 'other'
+
     # Lithuanian
     if lang == 'lt':
         if n % 10 == 1 and not 11 <= n % 100 <= 19:

--- a/picard/plugin3/i18n.py
+++ b/picard/plugin3/i18n.py
@@ -137,9 +137,9 @@ def get_plural_form(locale: str, n: int) -> str:
 
     # Lithuanian
     if lang == 'lt':
-        if n % 10 == 1 and n % 100 not in range(11, 20):
+        if n % 10 == 1 and not 11 <= n % 100 <= 19:
             return 'one'
-        if n % 10 in range(2, 10) and n % 100 not in range(11, 20):
+        if 2 <= n % 10 <= 9 and not 11 <= n % 100 <= 19:
             return 'few'
         return 'other'
 

--- a/picard/plugin3/i18n.py
+++ b/picard/plugin3/i18n.py
@@ -82,26 +82,26 @@ def get_plural_form(locale: str, n: int) -> str:
     lang = locale.split('_')[0]
 
     # English, German, Spanish, Italian, Portuguese, etc.
-    if lang in ('en', 'de', 'es', 'it', 'pt', 'nl', 'sv', 'da', 'no', 'fi'):
+    if lang in {'en', 'de', 'es', 'it', 'pt', 'nl', 'sv', 'da', 'no', 'fi'}:
         return 'one' if n == 1 else 'other'
 
-    # French (0 and 1 are singular)
-    if lang == 'fr':
-        return 'one' if n in (0, 1) else 'other'
+    # French, Punjabi (0 and 1 are singular)
+    if lang in {'fr', 'pa'}:
+        return 'one' if n in {0, 1} else 'other'
 
     # Polish
     if lang == 'pl':
         if n == 1:
             return 'one'
-        if n % 10 in (2, 3, 4) and n % 100 not in (12, 13, 14):
+        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
             return 'few'
         return 'many'
 
     # Russian, Ukrainian
-    if lang in ('ru', 'uk'):
+    if lang in {'ru', 'uk'}:
         if n % 10 == 1 and n % 100 != 11:
             return 'one'
-        if n % 10 in (2, 3, 4) and n % 100 not in (12, 13, 14):
+        if n % 10 in {2, 3, 4} and n % 100 not in {12, 13, 14}:
             return 'few'
         return 'many'
 
@@ -119,12 +119,64 @@ def get_plural_form(locale: str, n: int) -> str:
             return 'many'
         return 'other'
 
+    # Hebrew
+    if lang == 'he':
+        if n == 1:
+            return 'one'
+        if n == 2:
+            return 'two'
+        return 'other'
+
     # Czech, Slovak
-    if lang in ('cs', 'sk'):
+    if lang in {'cs', 'sk'}:
         if n == 1:
             return 'one'
         if 2 <= n <= 4:
             return 'few'
+        return 'other'
+
+    # Lithuanian
+    if lang == 'lt':
+        if n % 10 == 1 and n % 100 not in range(11, 20):
+            return 'one'
+        if n % 10 in range(2, 10) and n % 100 not in range(11, 20):
+            return 'few'
+        return 'other'
+
+    # Japanese, Korean, Malay, Vietnamese, Chinese
+    if lang in {'ja', 'ko', 'ms', 'vi', 'zh'}:
+        return 'other'
+
+    # Icelandic
+    if lang == 'is':
+        if n % 10 == 1 and n % 100 != 11:
+            return 'one'
+        return 'other'
+
+    # Irish
+    if lang == 'ga':
+        if n == 1:
+            return 'one'
+        if n == 2:
+            return 'two'
+        if n in {3, 4, 5, 6}:
+            return 'few'
+        if n in {7, 8, 9, 10}:
+            return 'many'
+        return 'other'
+
+    # Welsh
+    if lang == 'cy':
+        if n == 0:
+            return 'zero'
+        if n == 1:
+            return 'one'
+        if n == 2:
+            return 'two'
+        if n == 3:
+            return 'few'
+        if n == 6:
+            return 'many'
         return 'other'
 
     # Default to English rules

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -22,7 +22,10 @@ from typing import ClassVar
 
 from test.picardtestcase import PicardTestCase
 
-from picard.plugin3.i18n import get_plural_form
+from picard.plugin3.i18n import (
+    Plural,
+    get_plural_form,
+)
 
 
 class TestPluralRules(PicardTestCase):
@@ -35,156 +38,156 @@ class TestPluralRules(PicardTestCase):
     PLURAL_RULES_TEST_DATA: ClassVar[dict] = {
         # English (also: de, es, it, pt, nl, sv, da, no, fi) — one/other
         'en': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'other'),
-            (5, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.OTHER),
+            (5, Plural.OTHER),
         ],
-        # French (also: pa) — one/other, 0 and 1 are 'one'
+        # French (also: pa) — one/other, 0 and 1 are Plural.ONE
         'fr': [
-            (0, 'one'),
-            (1, 'one'),
-            (2, 'other'),
+            (0, Plural.ONE),
+            (1, Plural.ONE),
+            (2, Plural.OTHER),
         ],
         # Polish — one/few/many
         'pl': [
-            (1, 'one'),
-            (2, 'few'),
-            (3, 'few'),
-            (4, 'few'),
-            (5, 'many'),
-            (10, 'many'),
-            (22, 'few'),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (3, Plural.FEW),
+            (4, Plural.FEW),
+            (5, Plural.MANY),
+            (10, Plural.MANY),
+            (22, Plural.FEW),
         ],
         # Russian (also: uk) — one/few/many
         'ru': [
-            (1, 'one'),
-            (2, 'few'),
-            (5, 'many'),
-            (21, 'one'),
-            (22, 'few'),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (5, Plural.MANY),
+            (21, Plural.ONE),
+            (22, Plural.FEW),
         ],
         # Arabic — zero/one/two/few/many/other
         'ar': [
-            (0, 'zero'),
-            (1, 'one'),
-            (2, 'two'),
-            (3, 'few'),
-            (11, 'many'),
-            (100, 'other'),
+            (0, Plural.ZERO),
+            (1, Plural.ONE),
+            (2, Plural.TWO),
+            (3, Plural.FEW),
+            (11, Plural.MANY),
+            (100, Plural.OTHER),
         ],
         # Czech (also: sk) — one/few/other
         'cs': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'few'),
-            (4, 'few'),
-            (5, 'other'),
-            (100, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (4, Plural.FEW),
+            (5, Plural.OTHER),
+            (100, Plural.OTHER),
         ],
         # Romanian — one/few/other
         'ro': [
-            (0, 'few'),
-            (1, 'one'),
-            (2, 'few'),
-            (12, 'few'),
-            (19, 'few'),
-            (20, 'other'),
-            (100, 'other'),
-            (101, 'few'),
-            (119, 'few'),
-            (120, 'other'),
+            (0, Plural.FEW),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (12, Plural.FEW),
+            (19, Plural.FEW),
+            (20, Plural.OTHER),
+            (100, Plural.OTHER),
+            (101, Plural.FEW),
+            (119, Plural.FEW),
+            (120, Plural.OTHER),
         ],
         # Croatian (also: bs, sr) — one/few/other
         'hr': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'few'),
-            (4, 'few'),
-            (5, 'other'),
-            (11, 'other'),
-            (12, 'other'),
-            (21, 'one'),
-            (22, 'few'),
-            (25, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (4, Plural.FEW),
+            (5, Plural.OTHER),
+            (11, Plural.OTHER),
+            (12, Plural.OTHER),
+            (21, Plural.ONE),
+            (22, Plural.FEW),
+            (25, Plural.OTHER),
         ],
         # Catalan — one/many/other
         'ca': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'other'),
-            (5, 'other'),
-            (1_000_000, 'many'),
-            (2_000_000, 'many'),
-            (1_000, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.OTHER),
+            (5, Plural.OTHER),
+            (1_000_000, Plural.MANY),
+            (2_000_000, Plural.MANY),
+            (1_000, Plural.OTHER),
         ],
         # Hebrew — one/two/other
         'he': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'two'),
-            (5, 'other'),
-            (100, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.TWO),
+            (5, Plural.OTHER),
+            (100, Plural.OTHER),
         ],
         # Lithuanian — one/few/other
         'lt': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'few'),
-            (9, 'few'),
-            (10, 'other'),
-            (11, 'other'),
-            (19, 'other'),
-            (21, 'one'),
-            (22, 'few'),
-            (29, 'few'),
-            (100, 'other'),
-            (101, 'one'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.FEW),
+            (9, Plural.FEW),
+            (10, Plural.OTHER),
+            (11, Plural.OTHER),
+            (19, Plural.OTHER),
+            (21, Plural.ONE),
+            (22, Plural.FEW),
+            (29, Plural.FEW),
+            (100, Plural.OTHER),
+            (101, Plural.ONE),
         ],
         # Japanese (also: ko, ms, vi, zh) — other only
         'ja': [
-            (0, 'other'),
-            (1, 'other'),
-            (5, 'other'),
-            (100, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.OTHER),
+            (5, Plural.OTHER),
+            (100, Plural.OTHER),
         ],
         # Icelandic — one/other
         'is': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'other'),
-            (10, 'other'),
-            (11, 'other'),
-            (21, 'one'),
-            (101, 'one'),
-            (111, 'other'),
-            (131, 'one'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.OTHER),
+            (10, Plural.OTHER),
+            (11, Plural.OTHER),
+            (21, Plural.ONE),
+            (101, Plural.ONE),
+            (111, Plural.OTHER),
+            (131, Plural.ONE),
         ],
         # Irish — one/two/few/many/other
         'ga': [
-            (0, 'other'),
-            (1, 'one'),
-            (2, 'two'),
-            (3, 'few'),
-            (6, 'few'),
-            (7, 'many'),
-            (10, 'many'),
-            (11, 'other'),
-            (100, 'other'),
+            (0, Plural.OTHER),
+            (1, Plural.ONE),
+            (2, Plural.TWO),
+            (3, Plural.FEW),
+            (6, Plural.FEW),
+            (7, Plural.MANY),
+            (10, Plural.MANY),
+            (11, Plural.OTHER),
+            (100, Plural.OTHER),
         ],
         # Welsh — zero/one/two/few/many/other
         'cy': [
-            (0, 'zero'),
-            (1, 'one'),
-            (2, 'two'),
-            (3, 'few'),
-            (4, 'other'),
-            (5, 'other'),
-            (6, 'many'),
-            (7, 'other'),
-            (10, 'other'),
-            (11, 'other'),
-            (100, 'other'),
+            (0, Plural.ZERO),
+            (1, Plural.ONE),
+            (2, Plural.TWO),
+            (3, Plural.FEW),
+            (4, Plural.OTHER),
+            (5, Plural.OTHER),
+            (6, Plural.MANY),
+            (7, Plural.OTHER),
+            (10, Plural.OTHER),
+            (11, Plural.OTHER),
+            (100, Plural.OTHER),
         ],
     }
 
@@ -197,11 +200,11 @@ class TestPluralRules(PicardTestCase):
 
     def test_unknown_locale_defaults_to_english(self):
         """Test unknown locale falls back to English rules."""
-        self.assertEqual(get_plural_form('xx', 1), 'one')
-        self.assertEqual(get_plural_form('xx', 2), 'other')
+        self.assertEqual(get_plural_form('xx', 1), Plural.ONE)
+        self.assertEqual(get_plural_form('xx', 2), Plural.OTHER)
 
     def test_locale_with_region(self):
         """Test that region suffix is stripped correctly."""
-        self.assertEqual(get_plural_form('en_US', 1), 'one')
-        self.assertEqual(get_plural_form('fr_CA', 0), 'one')
-        self.assertEqual(get_plural_form('zh_TW', 5), 'other')
+        self.assertEqual(get_plural_form('en_US', 1), Plural.ONE)
+        self.assertEqual(get_plural_form('fr_CA', 0), Plural.ONE)
+        self.assertEqual(get_plural_form('zh_TW', 5), Plural.OTHER)

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -82,6 +82,42 @@ class TestPluralRules(PicardTestCase):
             (5, 'other'),
             (100, 'other'),
         ],
+        # Romanian — one/few/other
+        'ro': [
+            (0, 'few'),
+            (1, 'one'),
+            (2, 'few'),
+            (12, 'few'),
+            (19, 'few'),
+            (20, 'other'),
+            (100, 'other'),
+            (101, 'few'),
+            (119, 'few'),
+            (120, 'other'),
+        ],
+        # Croatian (also: bs, sr) — one/few/other
+        'hr': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'few'),
+            (4, 'few'),
+            (5, 'other'),
+            (11, 'other'),
+            (12, 'other'),
+            (21, 'one'),
+            (22, 'few'),
+            (25, 'other'),
+        ],
+        # Catalan — one/many/other
+        'ca': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'other'),
+            (5, 'other'),
+            (1_000_000, 'many'),
+            (2_000_000, 'many'),
+            (1_000, 'other'),
+        ],
         # Hebrew — one/two/other
         'he': [
             (0, 'other'),

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -61,15 +61,6 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('fr', 1), 'one')
         self.assertEqual(get_plural_form('fr', 2), 'other')
 
-    # def test_spanish_plural_rules(self):
-    #     """Test French plural rules (one/other, many for full millions)."""
-    #     self.assertEqual(get_plural_form('es', 0), 'other')
-    #     self.assertEqual(get_plural_form('es', 1), 'one')
-    #     self.assertEqual(get_plural_form('es', 2), 'other')
-    #     self.assertEqual(get_plural_form('es', 5), 'other')
-    #     self.assertEqual(get_plural_form('es', 1_000_000), 'many')
-    #     self.assertEqual(get_plural_form('es', 2_000_000), 'many')
-
     def test_arabic_plural_rules(self):
         """Test Arabic plural rules (zero/one/two/few/many/other)."""
         self.assertEqual(get_plural_form('ar', 0), 'zero')

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -18,142 +18,154 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from typing import ClassVar
+
 from test.picardtestcase import PicardTestCase
 
 from picard.plugin3.i18n import get_plural_form
 
 
 class TestPluralRules(PicardTestCase):
-    def test_english_plural_rules(self):
-        """Test English plural rules (one/other)."""
-        self.assertEqual(get_plural_form('en', 0), 'other')
-        self.assertEqual(get_plural_form('en', 1), 'one')
-        self.assertEqual(get_plural_form('en', 2), 'other')
-        self.assertEqual(get_plural_form('en', 5), 'other')
+    """Test CLDR plural rules for get_plural_form().
 
-    def test_german_plural_rules(self):
-        """Test German plural rules (same as English)."""
-        self.assertEqual(get_plural_form('de', 0), 'other')
-        self.assertEqual(get_plural_form('de', 1), 'one')
-        self.assertEqual(get_plural_form('de', 2), 'other')
+    Each entry in PLURAL_RULES_TEST_DATA maps a locale to a list of
+    (n, expected_form) pairs covering the rule boundaries.
+    """
 
-    def test_polish_plural_rules(self):
-        """Test Polish plural rules (one/few/many/other)."""
-        self.assertEqual(get_plural_form('pl', 1), 'one')
-        self.assertEqual(get_plural_form('pl', 2), 'few')
-        self.assertEqual(get_plural_form('pl', 3), 'few')
-        self.assertEqual(get_plural_form('pl', 4), 'few')
-        self.assertEqual(get_plural_form('pl', 5), 'many')
-        self.assertEqual(get_plural_form('pl', 10), 'many')
-        self.assertEqual(get_plural_form('pl', 22), 'few')
+    PLURAL_RULES_TEST_DATA: ClassVar[dict] = {
+        # English (also: de, es, it, pt, nl, sv, da, no, fi) — one/other
+        'en': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'other'),
+            (5, 'other'),
+        ],
+        # French (also: pa) — one/other, 0 and 1 are 'one'
+        'fr': [
+            (0, 'one'),
+            (1, 'one'),
+            (2, 'other'),
+        ],
+        # Polish — one/few/many
+        'pl': [
+            (1, 'one'),
+            (2, 'few'),
+            (3, 'few'),
+            (4, 'few'),
+            (5, 'many'),
+            (10, 'many'),
+            (22, 'few'),
+        ],
+        # Russian (also: uk) — one/few/many
+        'ru': [
+            (1, 'one'),
+            (2, 'few'),
+            (5, 'many'),
+            (21, 'one'),
+            (22, 'few'),
+        ],
+        # Arabic — zero/one/two/few/many/other
+        'ar': [
+            (0, 'zero'),
+            (1, 'one'),
+            (2, 'two'),
+            (3, 'few'),
+            (11, 'many'),
+            (100, 'other'),
+        ],
+        # Czech (also: sk) — one/few/other
+        'cs': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'few'),
+            (4, 'few'),
+            (5, 'other'),
+            (100, 'other'),
+        ],
+        # Hebrew — one/two/other
+        'he': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'two'),
+            (5, 'other'),
+            (100, 'other'),
+        ],
+        # Lithuanian — one/few/other
+        'lt': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'few'),
+            (9, 'few'),
+            (10, 'other'),
+            (11, 'other'),
+            (19, 'other'),
+            (21, 'one'),
+            (22, 'few'),
+            (29, 'few'),
+            (100, 'other'),
+            (101, 'one'),
+        ],
+        # Japanese (also: ko, ms, vi, zh) — other only
+        'ja': [
+            (0, 'other'),
+            (1, 'other'),
+            (5, 'other'),
+            (100, 'other'),
+        ],
+        # Icelandic — one/other
+        'is': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'other'),
+            (10, 'other'),
+            (11, 'other'),
+            (21, 'one'),
+            (101, 'one'),
+            (111, 'other'),
+            (131, 'one'),
+        ],
+        # Irish — one/two/few/many/other
+        'ga': [
+            (0, 'other'),
+            (1, 'one'),
+            (2, 'two'),
+            (3, 'few'),
+            (6, 'few'),
+            (7, 'many'),
+            (10, 'many'),
+            (11, 'other'),
+            (100, 'other'),
+        ],
+        # Welsh — zero/one/two/few/many/other
+        'cy': [
+            (0, 'zero'),
+            (1, 'one'),
+            (2, 'two'),
+            (3, 'few'),
+            (4, 'other'),
+            (5, 'other'),
+            (6, 'many'),
+            (7, 'other'),
+            (10, 'other'),
+            (11, 'other'),
+            (100, 'other'),
+        ],
+    }
 
-    def test_russian_plural_rules(self):
-        """Test Russian plural rules (one/few/many/other)."""
-        self.assertEqual(get_plural_form('ru', 1), 'one')
-        self.assertEqual(get_plural_form('ru', 2), 'few')
-        self.assertEqual(get_plural_form('ru', 5), 'many')
-        self.assertEqual(get_plural_form('ru', 21), 'one')
-        self.assertEqual(get_plural_form('ru', 22), 'few')
-
-    def test_french_plural_rules(self):
-        """Test French plural rules (one/other, 0 and 1 are 'one')."""
-        self.assertEqual(get_plural_form('fr', 0), 'one')
-        self.assertEqual(get_plural_form('fr', 1), 'one')
-        self.assertEqual(get_plural_form('fr', 2), 'other')
-
-    def test_punjabi_plural_rules(self):
-        """Test Punjabi plural rules (same as French: 0 and 1 are 'one')."""
-        self.assertEqual(get_plural_form('pa', 0), 'one')
-        self.assertEqual(get_plural_form('pa', 1), 'one')
-        self.assertEqual(get_plural_form('pa', 2), 'other')
-
-    def test_arabic_plural_rules(self):
-        """Test Arabic plural rules (zero/one/two/few/many/other)."""
-        self.assertEqual(get_plural_form('ar', 0), 'zero')
-        self.assertEqual(get_plural_form('ar', 1), 'one')
-        self.assertEqual(get_plural_form('ar', 2), 'two')
-        self.assertEqual(get_plural_form('ar', 3), 'few')
-        self.assertEqual(get_plural_form('ar', 11), 'many')
-        self.assertEqual(get_plural_form('ar', 100), 'other')
-
-    def test_czech_plural_rules(self):
-        """Test Czech plural rules (one/few/other)."""
-        self.assertEqual(get_plural_form('cs', 0), 'other')
-        self.assertEqual(get_plural_form('cs', 1), 'one')
-        self.assertEqual(get_plural_form('cs', 2), 'few')
-        self.assertEqual(get_plural_form('cs', 4), 'few')
-        self.assertEqual(get_plural_form('cs', 5), 'other')
-        self.assertEqual(get_plural_form('cs', 100), 'other')
-
-    def test_hebrew_plural_rules(self):
-        """Test Hebrew plural rules (one/two/other)."""
-        self.assertEqual(get_plural_form('he', 0), 'other')
-        self.assertEqual(get_plural_form('he', 1), 'one')
-        self.assertEqual(get_plural_form('he', 2), 'two')
-        self.assertEqual(get_plural_form('he', 5), 'other')
-        self.assertEqual(get_plural_form('he', 100), 'other')
-
-    def test_lithuanian_plural_rules(self):
-        """Test Lithuanian plural rules (one/few/other)."""
-        self.assertEqual(get_plural_form('lt', 0), 'other')
-        self.assertEqual(get_plural_form('lt', 1), 'one')
-        self.assertEqual(get_plural_form('lt', 2), 'few')
-        self.assertEqual(get_plural_form('lt', 9), 'few')
-        self.assertEqual(get_plural_form('lt', 10), 'other')
-        self.assertEqual(get_plural_form('lt', 11), 'other')
-        self.assertEqual(get_plural_form('lt', 19), 'other')
-        self.assertEqual(get_plural_form('lt', 21), 'one')
-        self.assertEqual(get_plural_form('lt', 22), 'few')
-        self.assertEqual(get_plural_form('lt', 29), 'few')
-        self.assertEqual(get_plural_form('lt', 100), 'other')
-        self.assertEqual(get_plural_form('lt', 101), 'one')
-
-    def test_japanese_plural_rules(self):
-        """Test Japanese plural rules (other)."""
-        self.assertEqual(get_plural_form('ja', 0), 'other')
-        self.assertEqual(get_plural_form('ja', 1), 'other')
-        self.assertEqual(get_plural_form('ja', 5), 'other')
-        self.assertEqual(get_plural_form('ja', 100), 'other')
-
-    def test_icelandic_plural_rules(self):
-        """Test Icelandic plural rules (one/other)."""
-        self.assertEqual(get_plural_form('is', 0), 'other')
-        self.assertEqual(get_plural_form('is', 1), 'one')
-        self.assertEqual(get_plural_form('is', 2), 'other')
-        self.assertEqual(get_plural_form('is', 10), 'other')
-        self.assertEqual(get_plural_form('is', 11), 'other')
-        self.assertEqual(get_plural_form('is', 21), 'one')
-        self.assertEqual(get_plural_form('is', 101), 'one')
-        self.assertEqual(get_plural_form('is', 111), 'other')
-        self.assertEqual(get_plural_form('is', 131), 'one')
-
-    def test_irish_plural_rules(self):
-        """Test Irish plural rules (one/two/few/many/other)."""
-        self.assertEqual(get_plural_form('ga', 0), 'other')
-        self.assertEqual(get_plural_form('ga', 1), 'one')
-        self.assertEqual(get_plural_form('ga', 2), 'two')
-        self.assertEqual(get_plural_form('ga', 3), 'few')
-        self.assertEqual(get_plural_form('ga', 6), 'few')
-        self.assertEqual(get_plural_form('ga', 7), 'many')
-        self.assertEqual(get_plural_form('ga', 10), 'many')
-        self.assertEqual(get_plural_form('ga', 11), 'other')
-        self.assertEqual(get_plural_form('ga', 100), 'other')
-
-    def test_welsh_plural_rules(self):
-        """Test Welsh plural rules (zero/one/two/few/many/other)."""
-        self.assertEqual(get_plural_form('cy', 0), 'zero')
-        self.assertEqual(get_plural_form('cy', 1), 'one')
-        self.assertEqual(get_plural_form('cy', 2), 'two')
-        self.assertEqual(get_plural_form('cy', 3), 'few')
-        self.assertEqual(get_plural_form('cy', 4), 'other')
-        self.assertEqual(get_plural_form('cy', 5), 'other')
-        self.assertEqual(get_plural_form('cy', 6), 'many')
-        self.assertEqual(get_plural_form('cy', 7), 'other')
-        self.assertEqual(get_plural_form('cy', 10), 'other')
-        self.assertEqual(get_plural_form('cy', 11), 'other')
-        self.assertEqual(get_plural_form('cy', 100), 'other')
+    def test_plural_rules(self):
+        """Test plural form rules for all supported locales."""
+        for locale, cases in self.PLURAL_RULES_TEST_DATA.items():
+            for n, expected in cases:
+                with self.subTest(locale=locale, n=n):
+                    self.assertEqual(get_plural_form(locale, n), expected)
 
     def test_unknown_locale_defaults_to_english(self):
         """Test unknown locale falls back to English rules."""
         self.assertEqual(get_plural_form('xx', 1), 'one')
         self.assertEqual(get_plural_form('xx', 2), 'other')
+
+    def test_locale_with_region(self):
+        """Test that region suffix is stripped correctly."""
+        self.assertEqual(get_plural_form('en_US', 1), 'one')
+        self.assertEqual(get_plural_form('fr_CA', 0), 'one')
+        self.assertEqual(get_plural_form('zh_TW', 5), 'other')

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -89,7 +89,7 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('cs', 100), 'other')
 
     def test_hebrew_plural_rules(self):
-        """Test Japanese plural rules (one/two/other)."""
+        """Test Hebrew plural rules (one/two/other)."""
         self.assertEqual(get_plural_form('he', 0), 'other')
         self.assertEqual(get_plural_form('he', 1), 'one')
         self.assertEqual(get_plural_form('he', 2), 'two')

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -61,6 +61,12 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('fr', 1), 'one')
         self.assertEqual(get_plural_form('fr', 2), 'other')
 
+    def test_punjabi_plural_rules(self):
+        """Test Punjabi plural rules (same as French: 0 and 1 are 'one')."""
+        self.assertEqual(get_plural_form('pa', 0), 'one')
+        self.assertEqual(get_plural_form('pa', 1), 'one')
+        self.assertEqual(get_plural_form('pa', 2), 'other')
+
     def test_arabic_plural_rules(self):
         """Test Arabic plural rules (zero/one/two/few/many/other)."""
         self.assertEqual(get_plural_form('ar', 0), 'zero')
@@ -88,7 +94,7 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('he', 100), 'other')
 
     def test_lithuanian_plural_rules(self):
-        """Test Lithuanian plural rules (one/few/many/other)."""
+        """Test Lithuanian plural rules (one/few/other)."""
         self.assertEqual(get_plural_form('lt', 0), 'other')
         self.assertEqual(get_plural_form('lt', 1), 'one')
         self.assertEqual(get_plural_form('lt', 2), 'few')
@@ -125,6 +131,7 @@ class TestPluralRules(PicardTestCase):
         """Test Irish plural rules (one/two/few/many/other)."""
         self.assertEqual(get_plural_form('ga', 0), 'other')
         self.assertEqual(get_plural_form('ga', 1), 'one')
+        self.assertEqual(get_plural_form('ga', 2), 'two')
         self.assertEqual(get_plural_form('ga', 3), 'few')
         self.assertEqual(get_plural_form('ga', 6), 'few')
         self.assertEqual(get_plural_form('ga', 7), 'many')

--- a/test/plugins3/test_plural_rules.py
+++ b/test/plugins3/test_plural_rules.py
@@ -61,6 +61,15 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('fr', 1), 'one')
         self.assertEqual(get_plural_form('fr', 2), 'other')
 
+    # def test_spanish_plural_rules(self):
+    #     """Test French plural rules (one/other, many for full millions)."""
+    #     self.assertEqual(get_plural_form('es', 0), 'other')
+    #     self.assertEqual(get_plural_form('es', 1), 'one')
+    #     self.assertEqual(get_plural_form('es', 2), 'other')
+    #     self.assertEqual(get_plural_form('es', 5), 'other')
+    #     self.assertEqual(get_plural_form('es', 1_000_000), 'many')
+    #     self.assertEqual(get_plural_form('es', 2_000_000), 'many')
+
     def test_arabic_plural_rules(self):
         """Test Arabic plural rules (zero/one/two/few/many/other)."""
         self.assertEqual(get_plural_form('ar', 0), 'zero')
@@ -69,6 +78,82 @@ class TestPluralRules(PicardTestCase):
         self.assertEqual(get_plural_form('ar', 3), 'few')
         self.assertEqual(get_plural_form('ar', 11), 'many')
         self.assertEqual(get_plural_form('ar', 100), 'other')
+
+    def test_czech_plural_rules(self):
+        """Test Czech plural rules (one/few/other)."""
+        self.assertEqual(get_plural_form('cs', 0), 'other')
+        self.assertEqual(get_plural_form('cs', 1), 'one')
+        self.assertEqual(get_plural_form('cs', 2), 'few')
+        self.assertEqual(get_plural_form('cs', 4), 'few')
+        self.assertEqual(get_plural_form('cs', 5), 'other')
+        self.assertEqual(get_plural_form('cs', 100), 'other')
+
+    def test_hebrew_plural_rules(self):
+        """Test Japanese plural rules (one/two/other)."""
+        self.assertEqual(get_plural_form('he', 0), 'other')
+        self.assertEqual(get_plural_form('he', 1), 'one')
+        self.assertEqual(get_plural_form('he', 2), 'two')
+        self.assertEqual(get_plural_form('he', 5), 'other')
+        self.assertEqual(get_plural_form('he', 100), 'other')
+
+    def test_lithuanian_plural_rules(self):
+        """Test Lithuanian plural rules (one/few/many/other)."""
+        self.assertEqual(get_plural_form('lt', 0), 'other')
+        self.assertEqual(get_plural_form('lt', 1), 'one')
+        self.assertEqual(get_plural_form('lt', 2), 'few')
+        self.assertEqual(get_plural_form('lt', 9), 'few')
+        self.assertEqual(get_plural_form('lt', 10), 'other')
+        self.assertEqual(get_plural_form('lt', 11), 'other')
+        self.assertEqual(get_plural_form('lt', 19), 'other')
+        self.assertEqual(get_plural_form('lt', 21), 'one')
+        self.assertEqual(get_plural_form('lt', 22), 'few')
+        self.assertEqual(get_plural_form('lt', 29), 'few')
+        self.assertEqual(get_plural_form('lt', 100), 'other')
+        self.assertEqual(get_plural_form('lt', 101), 'one')
+
+    def test_japanese_plural_rules(self):
+        """Test Japanese plural rules (other)."""
+        self.assertEqual(get_plural_form('ja', 0), 'other')
+        self.assertEqual(get_plural_form('ja', 1), 'other')
+        self.assertEqual(get_plural_form('ja', 5), 'other')
+        self.assertEqual(get_plural_form('ja', 100), 'other')
+
+    def test_icelandic_plural_rules(self):
+        """Test Icelandic plural rules (one/other)."""
+        self.assertEqual(get_plural_form('is', 0), 'other')
+        self.assertEqual(get_plural_form('is', 1), 'one')
+        self.assertEqual(get_plural_form('is', 2), 'other')
+        self.assertEqual(get_plural_form('is', 10), 'other')
+        self.assertEqual(get_plural_form('is', 11), 'other')
+        self.assertEqual(get_plural_form('is', 21), 'one')
+        self.assertEqual(get_plural_form('is', 101), 'one')
+        self.assertEqual(get_plural_form('is', 111), 'other')
+        self.assertEqual(get_plural_form('is', 131), 'one')
+
+    def test_irish_plural_rules(self):
+        """Test Irish plural rules (one/two/few/many/other)."""
+        self.assertEqual(get_plural_form('ga', 0), 'other')
+        self.assertEqual(get_plural_form('ga', 1), 'one')
+        self.assertEqual(get_plural_form('ga', 3), 'few')
+        self.assertEqual(get_plural_form('ga', 6), 'few')
+        self.assertEqual(get_plural_form('ga', 7), 'many')
+        self.assertEqual(get_plural_form('ga', 10), 'many')
+        self.assertEqual(get_plural_form('ga', 11), 'other')
+        self.assertEqual(get_plural_form('ga', 100), 'other')
+
+    def test_welsh_plural_rules(self):
+        """Test Welsh plural rules (zero/one/two/few/many/other)."""
+        self.assertEqual(get_plural_form('cy', 0), 'zero')
+        self.assertEqual(get_plural_form('cy', 1), 'one')
+        self.assertEqual(get_plural_form('cy', 2), 'two')
+        self.assertEqual(get_plural_form('cy', 3), 'few')
+        self.assertEqual(get_plural_form('cy', 4), 'other')
+        self.assertEqual(get_plural_form('cy', 5), 'other')
+        self.assertEqual(get_plural_form('cy', 6), 'many')
+        self.assertEqual(get_plural_form('cy', 7), 'other')
+        self.assertEqual(get_plural_form('cy', 10), 'other')
+        self.assertEqual(get_plural_form('cy', 11), 'other')
+        self.assertEqual(get_plural_form('cy', 100), 'other')
 
     def test_unknown_locale_defaults_to_english(self):
         """Test unknown locale falls back to English rules."""


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Add additional plural forms for the plugin translations, based on actually used languages and the Unicode definition: https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html

Note: I did some research of getting the rules from a library instead of defining them ourselves. The two options seem to be using PyICU or Babel. Both add some significant dependency. I had some hope Qt6 might be able to provide the info, but it doesn't. I think we are better off shipping the rules ourselves (and extend if needed). 

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Define additional rules for Hebrew, Lithuanian, Japanese, Korean, Maylay, Vietnamese, Chinese, Icelandic, Irish, Welsh, Punjabi with tests.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
