### PR TITLE
PICARD-2109: Add 'prefer release group cover art' option to setup wizard

### DIFF
--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -30,6 +30,8 @@ from picard.config import (
 )
 from picard.const import PLUGINS_BACKGROUND_CHECK_DELAY
 from picard.const.sys import IS_WIN
+from picard.coverart.providers.caa import CoverArtProviderCaa
+from picard.coverart.providers.caa_release_group import CoverArtProviderCaaReleaseGroup
 from picard.i18n import gettext as _
 from picard.util import (
     get_url,
@@ -273,6 +275,15 @@ class CoverArtPage(SetupWizardPage):
         )
         layout.addWidget(self.save_to_files_checkbox)
 
+        self.prefer_release_group_checkbox = WizardCheckbox(
+            _("Prefer release group cover art"),
+            _(
+                "Use the album's main cover art instead of edition-specific artwork. "
+                "This usually provides higher quality images but may not match your exact release."
+            ),
+        )
+        layout.addWidget(self.prefer_release_group_checkbox)
+
         layout.addStretch()
         hint = QtWidgets.QLabel(
             _("You can change these later under Options \N{RIGHTWARDS ARROW} Options \N{RIGHTWARDS ARROW} Cover Art.")
@@ -284,10 +295,71 @@ class CoverArtPage(SetupWizardPage):
         config = get_config()
         self.embed_checkbox.set_checked(config.setting['save_images_to_tags'])
         self.save_to_files_checkbox.set_checked(config.setting['save_images_to_files'])
+        self.prefer_release_group_checkbox.set_checked(self._is_release_group_preferred(config.setting['ca_providers']))
 
     def save_settings(self, config: Config) -> None:
         config.setting['save_images_to_tags'] = self.embed_checkbox.is_checked()
         config.setting['save_images_to_files'] = self.save_to_files_checkbox.is_checked()
+        config.setting['ca_providers'] = self._reorder_release_group_provider(
+            config.setting['ca_providers'],
+            prefer_release_group=self.prefer_release_group_checkbox.is_checked(),
+        )
+
+    @staticmethod
+    def _is_release_group_preferred(ca_providers: list[tuple[str, bool]]) -> bool:
+        """Check if CaaReleaseGroup is enabled and ordered before Cover Art Archive."""
+        rg_position = None
+        caa_position = None
+        for position, (name, enabled) in enumerate(ca_providers):
+            if name == CoverArtProviderCaaReleaseGroup.NAME:
+                if not enabled:
+                    return False
+                rg_position = position
+            elif name == CoverArtProviderCaa.NAME:
+                caa_position = position
+        if rg_position is None or caa_position is None:
+            return False
+        return rg_position < caa_position
+
+    @staticmethod
+    def _reorder_release_group_provider(
+        ca_providers: list[tuple[str, bool]],
+        prefer_release_group: bool,
+    ) -> list[tuple[str, bool]]:
+        """Reorder CaaReleaseGroup relative to Cover Art Archive.
+
+        If prefer_release_group is True, place it just before CAA and enable it.
+        Otherwise, place it just after CAA (preserving its enabled state).
+        Only the position of CaaReleaseGroup is changed; all other providers
+        keep their relative order.
+        """
+        providers = list(ca_providers)
+        rg_index = None
+        rg_enabled = False
+        caa_index = None
+        for i, (name, enabled) in enumerate(providers):
+            if name == CoverArtProviderCaaReleaseGroup.NAME:
+                rg_index = i
+                rg_enabled = enabled
+            elif name == CoverArtProviderCaa.NAME:
+                caa_index = i
+
+        if rg_index is None or caa_index is None:
+            return providers
+
+        if prefer_release_group:
+            rg_enabled = True
+
+        # Remove RG from its current position
+        del providers[rg_index]
+
+        # Find CAA's new index after removal
+        caa_index = next(i for i, (name, _) in enumerate(providers) if name == CoverArtProviderCaa.NAME)
+
+        # Insert before or after CAA
+        insert_index = caa_index if prefer_release_group else caa_index + 1
+        providers.insert(insert_index, (CoverArtProviderCaaReleaseGroup.NAME, rg_enabled))
+        return providers
 
 
 class UpdatesPage(SetupWizardPage):


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Adds a "Prefer release group cover art" checkbox to the Cover Art page of the
first-use setup wizard, allowing new users to easily opt into using release group
artwork (typically higher quality) over release-specific artwork.

## Problem

* JIRA ticket: PICARD-2109

There is a disconnect between the imagery most casual users want (usually the
highest resolution digital artwork) and the default behavior of fetching
release-specific cover art. The CAA Release Group provider gives better results
for most users, but discovering and configuring it requires navigating the full
options dialog.

## Solution

Extend the existing `CoverArtPage` in the setup wizard with a third checkbox:
"Prefer release group cover art". When checked, the `CaaReleaseGroup` provider
is moved before `Cover Art Archive` in the provider list and enabled. When
unchecked, it is placed after `Cover Art Archive` (preserving its enabled state).
The order of all other providers is preserved.

The checkbox state on page load reflects the current configuration (whether
`CaaReleaseGroup` is both enabled and ordered before `Cover Art Archive`).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Code was developed by an AI assistant with human review and direction.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
