### PR TITLE
PICARD-2109: Use CaaReleaseGroup by default

### DIFF
--- a/picard/const/defaults.py
+++ b/picard/const/defaults.py
@@ -94,9 +94,9 @@ DEFAULT_DRIVES = get_default_cdrom_drives()
 
 DEFAULT_CA_NEVER_REPLACE_TYPES = ('front',)
 DEFAULT_CA_PROVIDERS = [
+    ('CaaReleaseGroup', True),
     ('Cover Art Archive', True),
     ('UrlRelationships', True),
-    ('CaaReleaseGroup', True),
     ('Local', False),
 ]
 DEFAULT_COVER_IMAGE_FILENAME = 'cover'


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2109
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Now that PR #3357 adds the choice on startup to choose whether to prefer the RG cover or not, we can also default the RG cover to be preferred and thus fully resolve PICARD-2109.

Casual users often want to tag their releases with high quality artwork for the album (usually the highest res digital square image). This is best fulfilled by the CaaReleaseGroup cover art provider.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Change order of default cover art providers to prefer CAA-RG over CAA


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
