### PR TITLE
PICARD-2442: Runtime theme switching without restart

### DIFF
--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -171,3 +171,4 @@ class DebugOpt(DebugOptEnum):
     TIMINGS = 10, N_('Timings'), N_('Log timing information for operations affecting UI responsiveness')
     ISRC = 11, N_('ISRC'), N_('Log ISRC processing, submission, and lookup details')
     RATECONTROL = 12, N_('Rate Control'), N_('Log request throttling, congestion window, and backoff details')
+    THEME = 13, N_('Theme'), N_('Log theme switching diagnostics, palette colors, and color scheme details')

--- a/picard/ui/aboutdialog.py
+++ b/picard/ui/aboutdialog.py
@@ -63,6 +63,7 @@ class AboutDialog(PicardDialog, SingletonDialog):
         self.ui.setupUi(self)
         self._apply_styling()
         self._update_content()
+        theme.theme_changed.connect(self._apply_styling)
 
     def _apply_styling(self):
         """Apply accent color and visual styling to the dialog."""

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -157,9 +157,11 @@ class InterfaceColors:
 
         Call this after a theme switch to pick up the correct color set
         (dark or light) and any user customizations.
+        Emits colors_changed to notify all consumers.
         """
         self.set_default_colors()
         self.load_from_config()
+        theme.colors_changed.emit()
 
     def set_default_color(self, color_key):
         color_value = self.default_colors[color_key].value
@@ -237,9 +239,7 @@ class InterfaceColors:
 interface_colors = InterfaceColors()
 
 # Reload colors automatically when the theme changes at runtime.
-# After reload, also emit colors_changed to notify color consumers.
 theme.theme_changed.connect(interface_colors.reload)
-theme.theme_changed.connect(theme.colors_changed)
 
 
 # Theme-aware validation indicator colors.

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -152,6 +152,15 @@ class InterfaceColors:
         for color_key in self.default_colors:
             self.set_default_color(color_key)
 
+    def reload(self):
+        """Reload colors for the current theme from config.
+
+        Call this after a theme switch to pick up the correct color set
+        (dark or light) and any user customizations.
+        """
+        self.set_default_colors()
+        self.load_from_config()
+
     def set_default_color(self, color_key):
         color_value = self.default_colors[color_key].value
         self.set_color(color_key, color_value)

--- a/picard/ui/colors.py
+++ b/picard/ui/colors.py
@@ -236,6 +236,11 @@ class InterfaceColors:
 
 interface_colors = InterfaceColors()
 
+# Reload colors automatically when the theme changes at runtime.
+# After reload, also emit colors_changed to notify color consumers.
+theme.theme_changed.connect(interface_colors.reload)
+theme.theme_changed.connect(theme.colors_changed)
+
 
 # Theme-aware validation indicator colors.
 # These are not user-configurable; they are standard UX patterns

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -43,6 +43,7 @@ from picard.ui import PicardDialog
 from picard.ui.colors import interface_colors
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
+from picard.ui.theme import theme
 from picard.ui.util import font_scaled_size
 
 
@@ -200,12 +201,12 @@ class InstallPluginDialog(PicardDialog):
         self.tab_widget.addTab(local_widget, _("Local"))
 
         # Warning label
-        # TODO: color baked in at construction, won't update on runtime theme switch.
         self.warning_label = QtWidgets.QLabel()
-        self.warning_label.setStyleSheet("color: %s; font-weight: bold;" % interface_colors.get_color('log_warning'))
+        self._apply_warning_style()
         self.warning_label.setWordWrap(True)
         self.warning_label.hide()
         layout.addWidget(self.warning_label)
+        theme.colors_changed.connect(self._apply_warning_style)
 
         # Progress bar
         self.progress_bar = QtWidgets.QProgressBar()
@@ -238,6 +239,10 @@ class InstallPluginDialog(PicardDialog):
         self.tab_widget.currentChanged.connect(self._validate_input)
         self._load_registry_plugins()
         self._validate_input()
+
+    def _apply_warning_style(self):
+        """Apply warning color stylesheet from current interface colors."""
+        self.warning_label.setStyleSheet("color: %s; font-weight: bold;" % interface_colors.get_color('log_warning'))
 
     def _validate_input(self):
         """Validate input and update UI."""

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -200,6 +200,7 @@ class InstallPluginDialog(PicardDialog):
         self.tab_widget.addTab(local_widget, _("Local"))
 
         # Warning label
+        # TODO: color baked in at construction, won't update on runtime theme switch.
         self.warning_label = QtWidgets.QLabel()
         self.warning_label.setStyleSheet("color: %s; font-weight: bold;" % interface_colors.get_color('log_warning'))
         self.warning_label.setWordWrap(True)

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -145,29 +145,7 @@ class MainPanel(QtWidgets.QSplitter):
             view.itemSelectionChanged.connect(partial(_view_update_selection, view))
 
         TreeItem.window = window
-        TreeItem.base_color = self.palette().base().color()
-        TreeItem.text_color = self.palette().text().color()
-        TreeItem.text_color_secondary = (
-            self.palette().brush(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text).color()
-        )
-        TrackItem.track_colors = defaultdict(
-            lambda: TreeItem.text_color,
-            {
-                File.State.NORMAL: interface_colors.get_qcolor('entity_saved'),
-                File.State.CHANGED: TreeItem.text_color,
-                File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
-                File.State.ERROR: interface_colors.get_qcolor('entity_error'),
-            },
-        )
-        FileItem.file_colors = defaultdict(
-            lambda: TreeItem.text_color,
-            {
-                File.State.NORMAL: TreeItem.text_color,
-                File.State.CHANGED: TreeItem.text_color,
-                File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
-                File.State.ERROR: interface_colors.get_qcolor('entity_error'),
-            },
-        )
+        self._refresh_colors()
 
         theme.colors_changed.connect(self._refresh_colors)
 

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -89,6 +89,7 @@ from picard.ui.match_icons import (
     match_pending_icons,
     similarity_to_level,
 )
+from picard.ui.theme import theme
 
 
 def get_match_color(similarity, basecolor):
@@ -167,6 +168,36 @@ class MainPanel(QtWidgets.QSplitter):
                 File.State.ERROR: interface_colors.get_qcolor('entity_error'),
             },
         )
+
+        theme.colors_changed.connect(self._refresh_colors)
+
+    def _refresh_colors(self):
+        """Refresh cached color attributes after a theme or color change."""
+        TreeItem.base_color = self.palette().base().color()
+        TreeItem.text_color = self.palette().text().color()
+        TreeItem.text_color_secondary = (
+            self.palette().brush(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text).color()
+        )
+        TrackItem.track_colors = defaultdict(
+            lambda: TreeItem.text_color,
+            {
+                File.State.NORMAL: interface_colors.get_qcolor('entity_saved'),
+                File.State.CHANGED: TreeItem.text_color,
+                File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
+                File.State.ERROR: interface_colors.get_qcolor('entity_error'),
+            },
+        )
+        FileItem.file_colors = defaultdict(
+            lambda: TreeItem.text_color,
+            {
+                File.State.NORMAL: TreeItem.text_color,
+                File.State.CHANGED: TreeItem.text_color,
+                File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
+                File.State.ERROR: interface_colors.get_qcolor('entity_error'),
+            },
+        )
+        for view in self._views:
+            view.viewport().update()
 
     def set_processing(self, processing=True):
         self._ignore_selection_changes = processing

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -103,6 +103,23 @@ def get_match_color(similarity, basecolor):
     )
 
 
+def _refresh_item_colors(view):
+    """Recompute foreground and background colors for all items in a view.
+
+    Called after a theme or color change to update baked-in item colors
+    that were set via setBackground()/setForeground().
+    """
+    for i in range(view.topLevelItemCount()):
+        _refresh_item_colors_recursive(view.topLevelItem(i))
+
+
+def _refresh_item_colors_recursive(item):
+    """Recursively refresh theme-dependent visuals for all items."""
+    item.refresh_theme()
+    for i in range(item.childCount()):
+        _refresh_item_colors_recursive(item.child(i))
+
+
 class MainPanel(QtWidgets.QSplitter):
     def __init__(self, window, parent=None):
         super().__init__(parent=parent)
@@ -175,6 +192,7 @@ class MainPanel(QtWidgets.QSplitter):
             },
         )
         for view in self._views:
+            _refresh_item_colors(view)
             view.viewport().update()
 
     def set_processing(self, processing=True):
@@ -396,6 +414,11 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         # gets implemented by sub classes
         pass
 
+    # Subclasses override this to refresh theme-dependent visuals
+    # (colors, icons, etc.) after a theme or color change.
+    def refresh_theme(self):
+        pass
+
     def setText(self, column, text):
         self._sortkeys[column] = None
         return super().setText(column, text)
@@ -597,8 +620,6 @@ class TrackItem(TreeItem):
         if num_linked_files == 1:
             file = track.files[0]
             file.ui_item = self
-            color = TrackItem.track_colors[file.state]
-            bgcolor = get_match_color(file.similarity, TreeItem.base_color)
             icon, icon_tooltip = FileItem.decide_file_icon_info(file)
             self.takeChildren()
             self.setExpanded(False)
@@ -612,11 +633,6 @@ class TrackItem(TreeItem):
                 icon_tooltip = ngettext('%i matched file', '%i matched files', num_linked_files) % num_linked_files
             self.setToolTip(fingerprint_column, "")
             self.setIcon(fingerprint_column, QtGui.QIcon())
-            if track.ignored_for_completeness():
-                color = TreeItem.text_color_secondary
-            else:
-                color = TreeItem.text_color
-            bgcolor = get_match_color(1, TreeItem.base_color)
             if track.is_video():
                 icon = TrackItem.icon_video
             elif track.is_data():
@@ -650,11 +666,32 @@ class TrackItem(TreeItem):
         else:
             self.setIcon(self.columns.status_icon_column, icon)
             self.setToolTip(self.columns.status_icon_column, icon_tooltip)
+        color, bgcolor = self._item_colors()
         self.update_colums_text(color=color, bgcolor=bgcolor)
         if update_selection and self.isSelected():
             TreeItem.window.panel.update_current_view()
         if update_album:
             self.parent().update(update_tracks=False, update_selection=update_selection)
+
+    def refresh_theme(self):
+        if self.obj:
+            color, bgcolor = self._item_colors()
+            self.update_colums_text(color=color, bgcolor=bgcolor)
+
+    def _item_colors(self):
+        """Return (foreground, background) colors for this track item."""
+        track = self.obj
+        if track.num_linked_files == 1:
+            file = track.files[0]
+            color = TrackItem.track_colors[file.state]
+            bgcolor = get_match_color(file.similarity, TreeItem.base_color)
+        else:
+            if track.ignored_for_completeness():
+                color = TreeItem.text_color_secondary
+            else:
+                color = TreeItem.text_color
+            bgcolor = get_match_color(1, TreeItem.base_color)
+        return color, bgcolor
 
 
 class FileItem(TreeItem):
@@ -669,14 +706,25 @@ class FileItem(TreeItem):
         self.setToolTip(fingerprint_column, fingerprint_tooltip)
         self.setIcon(fingerprint_column, fingerprint_icon)
 
-        color = FileItem.file_colors[file.state]
-        bgcolor = get_match_color(file.similarity, TreeItem.base_color)
+        color, bgcolor = self._item_colors()
         self.update_colums_text(color=color, bgcolor=bgcolor)
         if update_selection and self.isSelected():
             TreeItem.window.panel.update_current_view()
         parent = self.parent()
         if isinstance(parent, TrackItem) and update_track:
             parent.update(update_files=False, update_selection=update_selection)
+
+    def refresh_theme(self):
+        if self.obj:
+            color, bgcolor = self._item_colors()
+            self.update_colums_text(color=color, bgcolor=bgcolor)
+
+    def _item_colors(self):
+        """Return (foreground, background) colors for this file item."""
+        file = self.obj
+        color = FileItem.file_colors[file.state]
+        bgcolor = get_match_color(file.similarity, TreeItem.base_color)
+        return color, bgcolor
 
     @staticmethod
     def decide_file_icon_info(file):

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -53,6 +53,7 @@ from picard.ui.logviewmodel import (
     LogItemDelegate,
     LogItemModel,
 )
+from picard.ui.theme import theme
 from picard.ui.util import FileDialog
 
 
@@ -80,6 +81,12 @@ class LogHighlighter(QtGui.QSyntaxHighlighter):
     def __init__(self, document):
         super().__init__(document)
         self._formats = self._build_formats()
+        theme.colors_changed.connect(self._refresh_colors)
+
+    def _refresh_colors(self):
+        """Rebuild formats with current colors and rehighlight."""
+        self._formats = self._build_formats()
+        self.rehighlight()
 
     def _build_formats(self):
         error_color = interface_colors.get_qcolor('log_error')

--- a/picard/ui/logviewmodel.py
+++ b/picard/ui/logviewmodel.py
@@ -29,6 +29,7 @@ from PyQt6.QtCore import Qt
 from picard import log
 
 from picard.ui.colors import interface_colors
+from picard.ui.theme import theme
 
 
 LevelRole = Qt.ItemDataRole.UserRole + 1
@@ -50,6 +51,7 @@ class LogItemModel(QtCore.QAbstractListModel):
         self._color_cache = {}
         self._compact_view = False
         self.refresh_colors()
+        theme.colors_changed.connect(self.refresh_colors)
 
     @property
     def compact_view(self):

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -230,6 +230,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.toolbar = None
         self.player = None
+        self.plugin_updates_button = None
         self.status_indicators = []
         if DesktopStatusIndicator:
             self.ready_for_display.connect(self._setup_desktop_status_indicator)
@@ -367,12 +368,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _update_statusbar_plugin_icon(self):
         """Swap the plugin updates icon for the current theme."""
-        if hasattr(self, 'plugin_updates_button'):
-            if theme.is_dark_theme:
-                icon = QtGui.QIcon(":/images/plugin-dark.png")
-            else:
-                icon = QtGui.QIcon(":/images/plugin.png")
-            self.plugin_updates_button.setIcon(icon)
+        if not self.plugin_updates_button:
+            return
+        if theme.is_dark_theme:
+            icon = QtGui.QIcon(":/images/plugin-dark.png")
+        else:
+            icon = QtGui.QIcon(":/images/plugin.png")
+        self.plugin_updates_button.setIcon(icon)
 
     def _setup_player(self):
         # Local import: player depends on QtMultimedia which is an optional runtime dependency

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -338,6 +338,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _setup_debug_shortcuts(self):
         """Set up keyboard shortcuts for development/debugging."""
         shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Shift+D"), self)
+        shortcut.setContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
         shortcut.activated.connect(self._toggle_theme)
 
     def _toggle_theme(self):

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -181,7 +181,10 @@ from picard.ui.statusindicator import (
     ProgressStatus,
 )
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
-from picard.ui.theme import theme
+from picard.ui.theme import (
+    UiTheme,
+    theme,
+)
 from picard.ui.tutorial import TutorialManager
 from picard.ui.util import (
     FileDialog,
@@ -328,6 +331,20 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         # Initially set the plugin updates available status in the status bar.
         self._update_statusbar_plugin_updates_available()
+
+        self._setup_debug_shortcuts()
+
+    def _setup_debug_shortcuts(self):
+        """Set up keyboard shortcuts for development/debugging."""
+        shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Shift+D"), self)
+        shortcut.activated.connect(self._toggle_theme)
+
+    def _toggle_theme(self):
+        """Toggle between dark and light theme at runtime (debug helper)."""
+        app = QtWidgets.QApplication.instance()
+        new_theme = UiTheme.LIGHT if theme.is_dark_theme else UiTheme.DARK
+        log.debug("Toggling theme to %s", new_theme.value)
+        theme.apply_theme(app, new_theme)
 
     def _setup_player(self):
         # Local import: player depends on QtMultimedia which is an optional runtime dependency

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -181,10 +181,7 @@ from picard.ui.statusindicator import (
     ProgressStatus,
 )
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
-from picard.ui.theme import (
-    UiTheme,
-    theme,
-)
+from picard.ui.theme import theme
 from picard.ui.tutorial import TutorialManager
 from picard.ui.util import (
     FileDialog,
@@ -334,20 +331,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._update_statusbar_plugin_updates_available()
 
         theme.theme_changed.connect(self._on_theme_changed)
-        self._setup_debug_shortcuts()
-
-    def _setup_debug_shortcuts(self):
-        """Set up keyboard shortcuts for development/debugging."""
-        shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Shift+D"), self)
-        shortcut.setContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
-        shortcut.activated.connect(self._toggle_theme)
-
-    def _toggle_theme(self):
-        """Toggle between dark and light theme at runtime (debug helper)."""
-        app = QtWidgets.QApplication.instance()
-        new_theme = UiTheme.LIGHT if theme.is_dark_theme else UiTheme.DARK
-        log.debug("Toggling theme to %s", new_theme.value)
-        theme.apply_theme(app, new_theme)
 
     def _on_theme_changed(self):
         """Update theme-dependent icons and stylesheets after a theme switch."""

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -353,6 +353,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """Update theme-dependent icons and stylesheets after a theme switch."""
         self._update_toolbar_theme()
         self._update_statusbar_plugin_icon()
+        self.metadata_box.update()
 
     def _update_toolbar_theme(self):
         """Refresh toolbar extension button icon and stylesheet for current theme."""

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -332,6 +332,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         # Initially set the plugin updates available status in the status bar.
         self._update_statusbar_plugin_updates_available()
 
+        theme.theme_changed.connect(self._on_theme_changed)
         self._setup_debug_shortcuts()
 
     def _setup_debug_shortcuts(self):
@@ -345,6 +346,32 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         new_theme = UiTheme.LIGHT if theme.is_dark_theme else UiTheme.DARK
         log.debug("Toggling theme to %s", new_theme.value)
         theme.apply_theme(app, new_theme)
+
+    def _on_theme_changed(self):
+        """Update theme-dependent icons and stylesheets after a theme switch."""
+        self._update_toolbar_theme()
+        self._update_statusbar_plugin_icon()
+
+    def _update_toolbar_theme(self):
+        """Refresh toolbar extension button icon and stylesheet for current theme."""
+        if not self.toolbar:
+            return
+        if theme.is_dark_theme:
+            self._apply_toolbar_extension_button_dark_theme_styling(self.toolbar)
+        else:
+            self.toolbar.setStyleSheet("")
+            ext_button = self.toolbar.findChild(QtWidgets.QToolButton, 'qt_toolbar_ext_button')
+            if ext_button:
+                ext_button.setIcon(QtGui.QIcon())
+
+    def _update_statusbar_plugin_icon(self):
+        """Swap the plugin updates icon for the current theme."""
+        if hasattr(self, 'plugin_updates_button'):
+            if theme.is_dark_theme:
+                icon = QtGui.QIcon(":/images/plugin-dark.png")
+            else:
+                icon = QtGui.QIcon(":/images/plugin.png")
+            self.plugin_updates_button.setIcon(icon)
 
     def _setup_player(self):
         # Local import: player depends on QtMultimedia which is an optional runtime dependency

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -113,6 +113,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     tags_compatibility_id3,
     tags_compatibility_wave,
 )
+from picard.ui.theme import theme as _theme
 
 
 if TYPE_CHECKING:
@@ -386,6 +387,8 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         # Set initial selection after plugin refresh
         if self.default_item:
             self.ui.pages_tree.setCurrentItem(self.default_item)  # this will call switch_page
+
+        _theme.colors_changed.connect(self.highlight_enabled_profile_options)
 
         if DebugOpt.TIMINGS.enabled:
             log.debug("OptionsDialog: total __init__ in %.1f ms", (time.perf_counter_ns() - _init_t0) / 1_000_000)

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -54,6 +54,7 @@ from picard.ui.theme import (
     AVAILABLE_UI_THEMES,
     OS_SUPPORTS_THEMES,
     UiTheme,
+    theme,
 )
 from picard.ui.util import (
     FileDialog,
@@ -108,11 +109,11 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.starting_directory_browse.setIcon(icon)
 
         self.ui.ui_theme.clear()
-        for theme in AVAILABLE_UI_THEMES:
-            label = self._UI_THEME_LABELS[theme]['label']
-            desc = self._UI_THEME_LABELS[theme]['desc']
-            self.ui.ui_theme.addItem(_(label), theme)
-            idx = self.ui.ui_theme.findData(theme)
+        for ui_theme in AVAILABLE_UI_THEMES:
+            label = self._UI_THEME_LABELS[ui_theme]['label']
+            desc = self._UI_THEME_LABELS[ui_theme]['desc']
+            self.ui.ui_theme.addItem(_(label), ui_theme)
+            idx = self.ui.ui_theme.findData(ui_theme)
             self.ui.ui_theme.setItemData(idx, _(desc), QtCore.Qt.ItemDataRole.ToolTipRole)
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(UiTheme.DEFAULT))
 
@@ -184,8 +185,13 @@ class InterfaceOptionsPage(OptionsPage):
         warnings = []
         notes = []
         if new_theme_setting != config.setting['ui_theme']:
-            warnings.append(_("You have changed the application theme."))
             config.setting['ui_theme'] = new_theme_setting
+            # Apply the theme change live
+            wanted_theme = UiTheme(new_theme_setting)
+            app = self.tagger
+            if wanted_theme == UiTheme.DEFAULT:
+                wanted_theme = theme.get_system_theme(app)
+            theme.apply_theme(app, wanted_theme)
         if new_language != config.setting['ui_language']:
             config.setting['ui_language'] = new_language
             warnings.append(_("You have changed the interface language."))

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -177,9 +177,8 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.starting_directory.setChecked(config.setting['starting_directory'])
         self.ui.starting_directory_path.setText(config.setting['starting_directory_path'])
         current_theme = UiTheme(config.setting['ui_theme'])
-        self.ui.ui_theme.blockSignals(True)
-        self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(current_theme))
-        self.ui.ui_theme.blockSignals(False)
+        with QtCore.QSignalBlocker(self.ui.ui_theme):
+            self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(current_theme))
 
         # re-enable the multi-selection warning
         self.ui.allow_multi_dirs_selection.blockSignals(False)

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -153,11 +153,9 @@ class InterfaceOptionsPage(OptionsPage):
         selected_theme = self.ui.ui_theme.itemData(index)
         if selected_theme is None:
             return
-        wanted_theme = selected_theme
-        app = self.tagger
-        if wanted_theme == UiTheme.DEFAULT:
-            wanted_theme = theme.get_system_theme(app)
-        theme.apply_theme(app, wanted_theme)
+        if selected_theme == UiTheme.DEFAULT:
+            selected_theme = theme.get_system_theme(self.tagger)
+        theme.apply_theme(self.tagger, selected_theme)
 
     def load(self):
         # Don't display the multi-selection warning when loading values.

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -116,6 +116,7 @@ class InterfaceOptionsPage(OptionsPage):
             idx = self.ui.ui_theme.findData(ui_theme)
             self.ui.ui_theme.setItemData(idx, _(desc), QtCore.Qt.ItemDataRole.ToolTipRole)
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(UiTheme.DEFAULT))
+        self.ui.ui_theme.currentIndexChanged.connect(self._on_theme_changed)
 
         self.ui.ui_language.addItem(_("System default"), '')
         language_list = [(lang[0], lang[1], gettext_constants(lang[2])) for lang in UI_LANGUAGES]
@@ -147,6 +148,17 @@ class InterfaceOptionsPage(OptionsPage):
         self.reset_tutorial_button.clicked.connect(self._reset_tutorial)
         self.ui.vboxlayout1.addWidget(self.reset_tutorial_button)
 
+    def _on_theme_changed(self, index):
+        """Apply the theme immediately when the user selects it."""
+        selected_theme = self.ui.ui_theme.itemData(index)
+        if selected_theme is None:
+            return
+        wanted_theme = selected_theme
+        app = self.tagger
+        if wanted_theme == UiTheme.DEFAULT:
+            wanted_theme = theme.get_system_theme(app)
+        theme.apply_theme(app, wanted_theme)
+
     def load(self):
         # Don't display the multi-selection warning when loading values.
         # This is required because loading a different option profile could trigger the warning.
@@ -165,7 +177,9 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.starting_directory.setChecked(config.setting['starting_directory'])
         self.ui.starting_directory_path.setText(config.setting['starting_directory_path'])
         current_theme = UiTheme(config.setting['ui_theme'])
+        self.ui.ui_theme.blockSignals(True)
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(current_theme))
+        self.ui.ui_theme.blockSignals(False)
 
         # re-enable the multi-selection warning
         self.ui.allow_multi_dirs_selection.blockSignals(False)
@@ -186,12 +200,6 @@ class InterfaceOptionsPage(OptionsPage):
         notes = []
         if new_theme_setting != config.setting['ui_theme']:
             config.setting['ui_theme'] = new_theme_setting
-            # Apply the theme change live
-            wanted_theme = UiTheme(new_theme_setting)
-            app = self.tagger
-            if wanted_theme == UiTheme.DEFAULT:
-                wanted_theme = theme.get_system_theme(app)
-            theme.apply_theme(app, wanted_theme)
         if new_language != config.setting['ui_language']:
             config.setting['ui_language'] = new_language
             warnings.append(_("You have changed the interface language."))

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -44,7 +44,7 @@ from picard.ui.options import (
     OptionsPage,
     PageOptionConfigs,
 )
-from picard.ui.util import changes_require_restart_warning
+from picard.ui.theme import theme
 
 
 class ColorButton(QtWidgets.QPushButton):
@@ -174,7 +174,8 @@ class InterfaceColorsOptionsPage(OptionsPage):
 
     def save(self):
         if interface_colors.save_to_config():
-            changes_require_restart_warning(self, warnings=[_("You have changed the interface colors.")])
+            # Emit colors_changed to notify all consumers to refresh
+            theme.colors_changed.emit()
 
     def restore_defaults(self):
         interface_colors.set_default_colors()

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -36,7 +36,10 @@ from picard.i18n import (
 )
 from picard.util import icontheme
 
-from picard.ui.colors import interface_colors
+from picard.ui.colors import (
+    InterfaceColors,
+    interface_colors,
+)
 from picard.ui.forms.ui_options_interface_colors import (
     Ui_InterfaceColorsOptionsPage,
 )
@@ -112,29 +115,43 @@ class InterfaceColorsOptionsPage(OptionsPage):
         super().__init__(parent=parent)
         self.ui = Ui_InterfaceColorsOptionsPage()
         self.ui.setupUi(self)
-        self.new_colors = {}
+        # Local working copies — edits here don't affect the global
+        # interface_colors until save() is called.
+        self._colors_light = InterfaceColors(dark_theme=False)
+        self._colors_dark = InterfaceColors(dark_theme=True)
         self.colors_list = QtWidgets.QVBoxLayout()
         self.ui.colors.setLayout(self.colors_list)
+
+    @property
+    def _current_colors(self):
+        """Return the working color set for the active theme."""
+        if theme.is_dark_theme:
+            return self._colors_dark
+        return self._colors_light
 
     def update_color_selectors(self):
         if self.colors_list:
             delete_items_of_layout(self.colors_list)
 
+        colors = self._current_colors
+
         def color_changed(color_key, color_value):
-            interface_colors.set_color(color_key, color_value)
+            colors.set_color(color_key, color_value)
 
         def restore_default_color(color_key, color_button):
-            interface_colors.set_default_color(color_key)
-            color_button.update_color(interface_colors.get_qcolor(color_key))
+            colors.set_default_color(color_key)
+            color_button.update_color(colors.get_qcolor(color_key))
 
-        def colors():
-            for color_key, color_value in interface_colors.get_colors().items():
-                group = interface_colors.get_color_group(color_key)
-                title = interface_colors.get_color_title(color_key)
+        def iter_colors():
+            for color_key, color_value in colors.get_colors().items():
+                group = colors.get_color_group(color_key)
+                title = colors.get_color_title(color_key)
                 yield color_key, color_value, title, group
 
         prev_group = None
-        for color_key, color_value, title, group in sorted(colors(), key=lambda c: (sort_key(c[3]), sort_key(c[2]))):
+        for color_key, color_value, title, group in sorted(
+            iter_colors(), key=lambda c: (sort_key(c[3]), sort_key(c[2]))
+        ):
             if prev_group != group:
                 groupbox = QtWidgets.QGroupBox(group)
                 self.colors_list.addWidget(groupbox)
@@ -169,16 +186,19 @@ class InterfaceColorsOptionsPage(OptionsPage):
         self.colors_list.addItem(spacerItem1)
 
     def load(self):
-        interface_colors.load_from_config()
+        self._colors_light.load_from_config()
+        self._colors_dark.load_from_config()
         self.update_color_selectors()
 
     def save(self):
-        if interface_colors.save_to_config():
-            # Emit colors_changed to notify all consumers to refresh
-            theme.colors_changed.emit()
+        light_changed = self._colors_light.save_to_config()
+        dark_changed = self._colors_dark.save_to_config()
+        if light_changed or dark_changed:
+            # Reload the global instance and notify consumers
+            interface_colors.reload()
 
     def restore_defaults(self):
-        interface_colors.set_default_colors()
+        self._current_colors.set_default_colors()
         self.update_color_selectors()
 
 

--- a/picard/ui/options/interface_colors.py
+++ b/picard/ui/options/interface_colors.py
@@ -121,6 +121,7 @@ class InterfaceColorsOptionsPage(OptionsPage):
         self._colors_dark = InterfaceColors(dark_theme=True)
         self.colors_list = QtWidgets.QVBoxLayout()
         self.ui.colors.setLayout(self.colors_list)
+        theme.theme_changed.connect(self._on_theme_changed)
 
     @property
     def _current_colors(self):
@@ -128,6 +129,11 @@ class InterfaceColorsOptionsPage(OptionsPage):
         if theme.is_dark_theme:
             return self._colors_dark
         return self._colors_light
+
+    def _on_theme_changed(self):
+        """Switch displayed colors when theme changes at runtime."""
+        if self.loaded:
+            self.update_color_selectors()
 
     def update_color_selectors(self):
         if self.colors_list:

--- a/picard/ui/scripteditor/utils.py
+++ b/picard/ui/scripteditor/utils.py
@@ -25,6 +25,8 @@ from PyQt6.QtGui import QPalette
 
 from picard.i18n import gettext as _
 
+from picard.ui.theme import theme
+
 
 def confirmation_dialog(parent, message):
     """Displays a confirmation dialog.
@@ -52,30 +54,34 @@ def synchronize_vertical_scrollbars(widgets):
     Args:
         widgets (list): List of QListView widgets to synchronize
     """
+
     # Set highlight colors for selected list items
-    # TODO: these colors are baked in at construction time and won't update
-    # on runtime theme switches while this dialog is open.
-    example_style = widgets[0].palette()
-    highlight_bg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.Highlight)
-    highlight_fg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText)
-    stylesheet = (
-        "QListView::item:selected { color: "
-        + highlight_fg.name()
-        + "; background-color: "
-        + highlight_bg.name()
-        + "; }"
-    )
+    def _apply_highlight_stylesheet():
+        example_style = widgets[0].palette()
+        highlight_bg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.Highlight)
+        highlight_fg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText)
+        stylesheet = (
+            "QListView::item:selected { color: "
+            + highlight_fg.name()
+            + "; background-color: "
+            + highlight_bg.name()
+            + "; }"
+        )
+        for widget in widgets:
+            widget.setStyleSheet(stylesheet)
+
+    _apply_highlight_stylesheet()
+    theme.theme_changed.connect(_apply_highlight_stylesheet)
 
     def _sync_scrollbar_vert(widget, value):
         widget.blockSignals(True)
         widget.verticalScrollBar().setValue(value)
         widget.blockSignals(False)
 
-    widgets = set(widgets)
-    for widget in widgets:
-        for other in widgets - {widget}:
+    widget_set = set(widgets)
+    for widget in widget_set:
+        for other in widget_set - {widget}:
             widget.verticalScrollBar().valueChanged.connect(partial(_sync_scrollbar_vert, other))
-        widget.setStyleSheet(stylesheet)
 
 
 def populate_script_selection_combo_box(naming_scripts, selected_script_id, combo_box):

--- a/picard/ui/scripteditor/utils.py
+++ b/picard/ui/scripteditor/utils.py
@@ -53,6 +53,8 @@ def synchronize_vertical_scrollbars(widgets):
         widgets (list): List of QListView widgets to synchronize
     """
     # Set highlight colors for selected list items
+    # TODO: these colors are baked in at construction time and won't update
+    # on runtime theme switches while this dialog is open.
     example_style = widgets[0].palette()
     highlight_bg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.Highlight)
     highlight_fg = example_style.color(QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText)

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -49,6 +49,7 @@ class WizardCheckbox(QtWidgets.QWidget):
         style = QtWidgets.QApplication.style()
         assert style
 
+        # TODO: hover color baked in at construction, won't update on runtime theme switch.
         palette = self.palette()
         highlight = palette.color(QtGui.QPalette.ColorRole.Highlight)
         hover_bg = QtGui.QColor(

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -39,6 +39,8 @@ from picard.util import (
 )
 from picard.util.readthedocs import ReadTheDocs
 
+from picard.ui.theme import theme
+
 
 class WizardCheckbox(QtWidgets.QWidget):
     toggled = QtCore.pyqtSignal(bool)
@@ -49,22 +51,9 @@ class WizardCheckbox(QtWidgets.QWidget):
         style = QtWidgets.QApplication.style()
         assert style
 
-        # TODO: hover color baked in at construction, won't update on runtime theme switch.
-        palette = self.palette()
-        highlight = palette.color(QtGui.QPalette.ColorRole.Highlight)
-        hover_bg = QtGui.QColor(
-            highlight.red(),
-            highlight.green(),
-            highlight.blue(),
-            80,
-        )
-
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_StyledBackground, True)
-        self.setStyleSheet(f"""
-            WizardCheckbox:hover {{
-                background-color: {hover_bg.name(QtGui.QColor.NameFormat.HexArgb)};
-            }}
-        """)
+        self._apply_hover_style()
+        theme.theme_changed.connect(self._apply_hover_style)
 
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -90,6 +79,16 @@ class WizardCheckbox(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Policy.Minimum,
         )
         self._inner_layout.addWidget(hint)
+
+    def _apply_hover_style(self):
+        """Apply hover background color from the current palette."""
+        highlight = self.palette().color(QtGui.QPalette.ColorRole.Highlight)
+        hover_bg = QtGui.QColor(highlight.red(), highlight.green(), highlight.blue(), 80)
+        self.setStyleSheet(f"""
+            WizardCheckbox:hover {{
+                background-color: {hover_bg.name(QtGui.QColor.NameFormat.HexArgb)};
+            }}
+        """)
 
     def add_extra_widget(self, widget: QtWidgets.QWidget) -> None:
         self._inner_layout.addWidget(widget)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -216,6 +216,7 @@ class BaseTheme(QtCore.QObject):
         self._loaded_config_theme: UiTheme = UiTheme.DEFAULT
         self._applied_theme: UiTheme = UiTheme.DEFAULT
         self._accent_color: QtGui.QColor | None = None
+        self._accent_color_is_system: bool = False
         self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
@@ -238,6 +239,7 @@ class BaseTheme(QtCore.QObject):
         system_accent_color = self.get_system_accent_color()
         if system_accent_color:
             self._accent_color = system_accent_color
+            self._accent_color_is_system = True
 
         # Apply dark/light theme based on configuration or system settings
         if wanted_theme == UiTheme.DEFAULT:
@@ -283,6 +285,9 @@ class BaseTheme(QtCore.QObject):
         between dark and light themes.  Emits theme_changed after the
         palette has been updated.
         """
+        # setColorScheme tells Qt which color scheme we want. On Linux this
+        # is unreliable for native widgets but still needed so that
+        # style.standardPalette() returns the correct base palette.
         qt_color_scheme = QtCore.Qt.ColorScheme.Dark if ui_theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
         set_color_scheme(qt_color_scheme)
         # Get a fresh base palette from the style (preferred) or create a new one
@@ -290,7 +295,7 @@ class BaseTheme(QtCore.QObject):
         palette = style.standardPalette() if style else QtGui.QPalette()
         if ui_theme == UiTheme.DARK:
             apply_dark_theme_to_palette(palette)
-        if self._accent_color:
+        if self._accent_color and self._accent_color_is_system:
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)
         # Force all widgets to refresh their style and repaint.

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -233,19 +233,19 @@ class BaseTheme(QtCore.QObject):
             'QGroupBox::title { /* PICARD-1206, Qt bug workaround */ }',
         )
 
+        # Determine the system accent color before applying the theme,
+        # so apply_theme() can include it in the palette.
+        system_accent_color = self.get_system_accent_color()
+        if system_accent_color:
+            self._accent_color = system_accent_color
+
         # Apply dark/light theme based on configuration or system settings
         if wanted_theme == UiTheme.DEFAULT:
             wanted_theme = self.get_system_theme(app)
         self.apply_theme(app, wanted_theme)
 
-        # Get the system accent color, if available, and apply if to the palette
-        system_accent_color = self.get_system_accent_color()
-        if system_accent_color:
-            self._accent_color = system_accent_color
-            palette = app.palette()
-            apply_accent_color_to_palette(palette, self._accent_color)
-            app.setPalette(palette)
-        else:
+        # If no system accent color was found, use whatever the palette provides
+        if not self._accent_color:
             self._accent_color = get_accent_color_from_palette(app.palette())
 
         if self._accent_color:
@@ -276,14 +276,23 @@ class BaseTheme(QtCore.QObject):
     def get_system_accent_color(self) -> QtGui.QColor | None:
         return None
 
-    def apply_theme(self, app: QtWidgets.QApplication, theme: UiTheme) -> None:
-        qt_color_theme = QtCore.Qt.ColorScheme.Dark if theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
-        set_color_scheme(qt_color_theme)
-        if theme == UiTheme.DARK:
-            palette = app.palette()
+    def apply_theme(self, app: QtWidgets.QApplication, ui_theme: UiTheme) -> None:
+        """Apply a theme to the application.
+
+        This method is safe to call multiple times at runtime to switch
+        between dark and light themes.
+        """
+        qt_color_scheme = QtCore.Qt.ColorScheme.Dark if ui_theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
+        set_color_scheme(qt_color_scheme)
+        # Get a fresh base palette from the style (preferred) or create a new one
+        style = app.style()
+        palette = style.standardPalette() if style else QtGui.QPalette()
+        if ui_theme == UiTheme.DARK:
             apply_dark_theme_to_palette(palette)
-            app.setPalette(palette)
-        self._applied_theme = theme
+        if self._accent_color:
+            apply_accent_color_to_palette(palette, self._accent_color)
+        app.setPalette(palette)
+        self._applied_theme = ui_theme
 
     @property
     def is_dark_theme(self) -> bool:
@@ -350,14 +359,14 @@ class MacTheme(BaseTheme):
         else:
             return UiTheme.LIGHT
 
-    def apply_theme(self, app: QtWidgets.QApplication, theme: UiTheme) -> None:
-        super().apply_theme(app, theme)
+    def apply_theme(self, app: QtWidgets.QApplication, ui_theme: UiTheme) -> None:
+        super().apply_theme(app, ui_theme)
 
         # MacOS uses a NSAppearance object to change the current application appearance
         # We call this even if UiTheme is the default, preventing MacOS from switching on-the-fly
         if OS_SUPPORTS_THEMES and AppKit:
             try:
-                if theme == UiTheme.DARK:
+                if ui_theme == UiTheme.DARK:
                     appearance = AppKit.NSAppearance._darkAquaAppearance()
                 else:
                     appearance = AppKit.NSAppearance._aquaAppearance()

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -274,6 +274,7 @@ class BaseTheme(QtCore.QObject):
         self._applied_theme: UiTheme = UiTheme.DEFAULT
         self._accent_color: QtGui.QColor | None = None
         self._accent_color_is_system: bool = False
+        self._applying_theme: bool = False
         self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
@@ -327,6 +328,8 @@ class BaseTheme(QtCore.QObject):
             self._log_setup_diagnostics(app)
 
     def _on_color_scheme_changed(self, color_scheme: QtCore.Qt.ColorScheme) -> None:
+        if self._applying_theme:
+            return
         log.debug_if(
             DebugOpt.THEME,
             "Theme: system colorSchemeChanged signal received: %s",
@@ -413,6 +416,7 @@ class BaseTheme(QtCore.QObject):
         """
         if ui_theme == self._applied_theme:
             return
+        self._applying_theme = True
         # setColorScheme tells Qt which color scheme we want. On Linux this
         # is unreliable for native widgets but still needed so that
         # style.standardPalette() returns the correct base palette.
@@ -440,6 +444,7 @@ class BaseTheme(QtCore.QObject):
                 style.polish(widget)
                 QtWidgets.QWidget.update(widget)
         self._applied_theme = ui_theme
+        self._applying_theme = False
         self.theme_changed.emit()
 
     @property

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -277,7 +277,6 @@ class BaseTheme(QtCore.QObject):
         self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
-        self._app = app
         config = get_config()
         wanted_theme = UiTheme(config.setting['ui_theme'])
         self._loaded_config_theme = wanted_theme
@@ -333,7 +332,8 @@ class BaseTheme(QtCore.QObject):
         if wanted_theme == UiTheme.DEFAULT:
             ui_theme = UiTheme.from_color_scheme(color_scheme)
             if ui_theme != self._applied_theme:
-                self.apply_theme(self._app, ui_theme)
+                app = QtWidgets.QApplication.instance()
+                self.apply_theme(app, ui_theme)
 
     def _log_setup_diagnostics(self, app: QtWidgets.QApplication) -> None:
         """Log detailed theme diagnostics at startup."""

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -240,21 +240,20 @@ def apply_light_theme_to_palette(palette: QtGui.QPalette) -> None:
 
 def get_accent_color_from_palette(palette: QtGui.QPalette) -> QtGui.QColor:
     """Returns the accent color from the palette."""
-    if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
-        color_role = QtGui.QPalette.ColorRole.Accent
-    else:
-        color_role = QtGui.QPalette.ColorRole.Highlight
-    return palette.color(QtGui.QPalette.ColorGroup.Active, color_role)
+    return palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
 
 
 def apply_accent_color_to_palette(palette: QtGui.QPalette, accent_color: QtGui.QColor) -> None:
     """Updates the palette to use the accent color."""
     palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight, accent_color)
+    palette.setColor(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.Highlight, accent_color)
     accent_text_color = QtCore.Qt.GlobalColor.white if accent_color.lightness() < 160 else QtCore.Qt.GlobalColor.black
     palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.HighlightedText, accent_text_color)
+    palette.setColor(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.HighlightedText, accent_text_color)
     # Accent is available since Qt 6.6
     if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
         palette.setColor(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Accent, accent_color)
+        palette.setColor(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.Accent, accent_color)
 
     link_color = QtGui.QColor()
     link_color.setHsl(accent_color.hue(), accent_color.saturation(), 160, accent_color.alpha())
@@ -302,11 +301,6 @@ class BaseTheme(QtCore.QObject):
             self._accent_color = system_accent_color
             self._accent_color_is_system = True
 
-        # Apply dark/light theme based on configuration or system settings
-        if wanted_theme == UiTheme.DEFAULT:
-            wanted_theme = self.get_system_theme(app)
-        self.apply_theme(app, wanted_theme)
-
         # If no system accent color was found, use whatever the palette provides
         if not self._accent_color:
             self._accent_color = get_accent_color_from_palette(app.palette())
@@ -315,6 +309,11 @@ class BaseTheme(QtCore.QObject):
             accent_color_str = self._accent_color.name(QtGui.QColor.NameFormat.HexArgb)
         else:
             accent_color_str = "None"
+
+        # Apply dark/light theme based on configuration or system settings
+        if wanted_theme == UiTheme.DEFAULT:
+            wanted_theme = self.get_system_theme(app)
+        self.apply_theme(app, wanted_theme)
 
         log.debug(
             "Theme (%s): config=%s applied=%s accent_color=%s",

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -155,7 +155,7 @@ else:
 class MacOverrideStyle(QtWidgets.QProxyStyle):
     """Override the default style to fix some platform specific issues"""
 
-    def styleHint(self, hint, option, widget, returnData):
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
         # This is disabled on macOS, but prevents collapsing tree view items easily with
         # left arrow key. Enable this consistently on all platforms.
         # See https://tickets.metabrainz.org/browse/PICARD-2417
@@ -356,6 +356,7 @@ class BaseTheme(QtCore.QObject):
         text_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Text)
         style_hints = get_style_hints()
         color_scheme_supported = style_hints is not None
+        app_style = app.style()
         if color_scheme_supported and hasattr(style_hints, 'colorScheme'):
             current_scheme = style_hints.colorScheme().name
         else:
@@ -364,7 +365,7 @@ class BaseTheme(QtCore.QObject):
             "Theme diagnostics: style=%s platform=%s "
             "color_scheme_supported=%s current_scheme=%s "
             "accent_color_is_system=%s",
-            app.style().objectName() if app.style() else "None",
+            app_style.objectName() if app_style else "None",
             QtGui.QGuiApplication.platformName(),
             color_scheme_supported,
             current_scheme,
@@ -468,6 +469,7 @@ class WindowsTheme(BaseTheme):
     """Windows dark mode theme detection."""
 
     def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
+        assert winreg, "winreg is required on Windows"
         try:
             with winreg.OpenKey(
                 winreg.HKEY_CURRENT_USER,
@@ -480,6 +482,7 @@ class WindowsTheme(BaseTheme):
             return UiTheme.LIGHT
 
     def get_system_accent_color(self) -> QtGui.QColor | None:
+        assert winreg, "winreg is required on Windows"
         try:
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\DWM") as key:
                 accent_color_dword = winreg.QueryValueEx(key, "ColorizationColor")[0]

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -325,35 +325,7 @@ class BaseTheme(QtCore.QObject):
         )
 
         if DebugOpt.THEME.enabled:
-            palette = app.palette()
-            base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
-            highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
-            window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
-            text_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Text)
-            style_hints = get_style_hints()
-            color_scheme_supported = style_hints is not None
-            if color_scheme_supported and hasattr(style_hints, 'colorScheme'):
-                current_scheme = style_hints.colorScheme().name
-            else:
-                current_scheme = "N/A"
-            log.debug(
-                "Theme diagnostics: style=%s platform=%s "
-                "color_scheme_supported=%s current_scheme=%s "
-                "accent_color_is_system=%s",
-                app.style().objectName() if app.style() else "None",
-                QtGui.QGuiApplication.platformName(),
-                color_scheme_supported,
-                current_scheme,
-                self._accent_color_is_system,
-            )
-            log.debug(
-                "Theme palette: base=%s (lightness=%d) window=%s text=%s highlight=%s",
-                base_color.name(),
-                base_color.lightness(),
-                window_color.name(),
-                text_color.name(),
-                highlight_color.name(),
-            )
+            self._log_setup_diagnostics(app)
 
     def _on_color_scheme_changed(self, color_scheme: QtCore.Qt.ColorScheme) -> None:
         config = get_config()
@@ -362,6 +334,50 @@ class BaseTheme(QtCore.QObject):
             ui_theme = UiTheme.from_color_scheme(color_scheme)
             if ui_theme != self._applied_theme:
                 self.apply_theme(self._app, ui_theme)
+
+    def _log_setup_diagnostics(self, app: QtWidgets.QApplication) -> None:
+        """Log detailed theme diagnostics at startup."""
+        palette = app.palette()
+        base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+        highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+        window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
+        text_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Text)
+        style_hints = get_style_hints()
+        color_scheme_supported = style_hints is not None
+        if color_scheme_supported and hasattr(style_hints, 'colorScheme'):
+            current_scheme = style_hints.colorScheme().name
+        else:
+            current_scheme = "N/A"
+        log.debug(
+            "Theme diagnostics: style=%s platform=%s "
+            "color_scheme_supported=%s current_scheme=%s "
+            "accent_color_is_system=%s",
+            app.style().objectName() if app.style() else "None",
+            QtGui.QGuiApplication.platformName(),
+            color_scheme_supported,
+            current_scheme,
+            self._accent_color_is_system,
+        )
+        log.debug(
+            "Theme palette: base=%s (lightness=%d) window=%s text=%s highlight=%s",
+            base_color.name(),
+            base_color.lightness(),
+            window_color.name(),
+            text_color.name(),
+            highlight_color.name(),
+        )
+
+    def _log_apply_theme_diagnostics(self, palette: QtGui.QPalette, ui_theme: UiTheme) -> None:
+        """Log palette info after theme application."""
+        base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+        highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+        log.debug(
+            "Theme apply_theme: target=%s base=%s (lightness=%d) highlight=%s",
+            ui_theme.value,
+            base_color.name(),
+            base_color.lightness(),
+            highlight_color.name(),
+        )
 
     def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
         # Iterate through all registered strategies
@@ -403,15 +419,7 @@ class BaseTheme(QtCore.QObject):
         app.setPalette(palette)
 
         if DebugOpt.THEME.enabled:
-            base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
-            highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
-            log.debug(
-                "Theme apply_theme: target=%s base=%s (lightness=%d) highlight=%s",
-                ui_theme.value,
-                base_color.name(),
-                base_color.lightness(),
-                highlight_color.name(),
-            )
+            self._log_apply_theme_diagnostics(palette, ui_theme)
         # Force all widgets to refresh their style and repaint.
         # Unpolish + polish forces the style to recompute, and update()
         # schedules a repaint. Use QWidget.update() directly to avoid

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -117,6 +117,15 @@ class UiTheme(Enum):
     def _missing_(cls, value):
         return cls.DEFAULT
 
+    @classmethod
+    def from_color_scheme(cls, color_scheme: QtCore.Qt.ColorScheme) -> 'UiTheme':
+        """Convert a Qt ColorScheme to a UiTheme."""
+        return cls.DARK if color_scheme == QtCore.Qt.ColorScheme.Dark else cls.LIGHT
+
+    def to_color_scheme(self) -> QtCore.Qt.ColorScheme:
+        """Convert to a Qt ColorScheme."""
+        return QtCore.Qt.ColorScheme.Dark if self == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
+
 
 def get_style_hints() -> QtGui.QStyleHints | None:
     """Get style hints from QGuiApplication, returning None if unavailable."""
@@ -350,7 +359,7 @@ class BaseTheme(QtCore.QObject):
         config = get_config()
         wanted_theme = UiTheme(config.setting['ui_theme'])
         if wanted_theme == UiTheme.DEFAULT:
-            ui_theme = UiTheme.DARK if color_scheme == QtCore.Qt.ColorScheme.Dark else UiTheme.LIGHT
+            ui_theme = UiTheme.from_color_scheme(color_scheme)
             if ui_theme != self._applied_theme:
                 self.apply_theme(self._app, ui_theme)
 
@@ -379,8 +388,7 @@ class BaseTheme(QtCore.QObject):
         # setColorScheme tells Qt which color scheme we want. On Linux this
         # is unreliable for native widgets but still needed so that
         # style.standardPalette() returns the correct base palette.
-        qt_color_scheme = QtCore.Qt.ColorScheme.Dark if ui_theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
-        set_color_scheme(qt_color_scheme)
+        set_color_scheme(ui_theme.to_color_scheme())
         # Get a fresh base palette from the style (preferred) or create a new one
         style = app.style()
         palette = style.standardPalette() if style else QtGui.QPalette()

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -280,7 +280,8 @@ class BaseTheme(QtCore.QObject):
         """Apply a theme to the application.
 
         This method is safe to call multiple times at runtime to switch
-        between dark and light themes.
+        between dark and light themes.  Emits theme_changed after the
+        palette has been updated.
         """
         qt_color_scheme = QtCore.Qt.ColorScheme.Dark if ui_theme == UiTheme.DARK else QtCore.Qt.ColorScheme.Light
         set_color_scheme(qt_color_scheme)
@@ -293,6 +294,7 @@ class BaseTheme(QtCore.QObject):
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)
         self._applied_theme = ui_theme
+        self.theme_changed.emit()
 
     @property
     def is_dark_theme(self) -> bool:

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -156,24 +156,24 @@ class MacOverrideStyle(QtWidgets.QProxyStyle):
         return super().styleHint(hint, option, widget, returnData)
 
 
-def apply_dark_palette_colors(palette: QtGui.QPalette) -> None:
-    """Apply dark palette colors to the given palette."""
-    for key, value in DARK_PALETTE_COLORS.items():
+def _apply_palette_colors(palette: QtGui.QPalette, colors: dict) -> None:
+    """Apply a set of color definitions to the given palette."""
+    for key, value in colors.items():
         if isinstance(key, tuple):
             group, role = key
             palette.setColor(group, role, value)
         else:
             palette.setColor(key, value)
+
+
+def apply_dark_palette_colors(palette: QtGui.QPalette) -> None:
+    """Apply dark palette colors to the given palette."""
+    _apply_palette_colors(palette, DARK_PALETTE_COLORS)
 
 
 def apply_light_palette_colors(palette: QtGui.QPalette) -> None:
     """Apply light palette colors to the given palette."""
-    for key, value in LIGHT_PALETTE_COLORS.items():
-        if isinstance(key, tuple):
-            group, role = key
-            palette.setColor(group, role, value)
-        else:
-            palette.setColor(key, value)
+    _apply_palette_colors(palette, LIGHT_PALETTE_COLORS)
 
 
 def set_color_scheme(color_scheme: QtCore.Qt.ColorScheme) -> None:
@@ -394,8 +394,7 @@ class BaseTheme(QtCore.QObject):
         # Unpolish + polish forces the style to recompute, and update()
         # schedules a repaint. Use QWidget.update() directly to avoid
         # calling overridden update() methods with different signatures.
-        if hasattr(app, 'allWidgets'):
-            style = app.style()
+        if style and hasattr(app, 'allWidgets'):
             for widget in app.allWidgets():
                 style.unpolish(widget)
                 style.polish(widget)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -37,6 +37,7 @@ from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
+from picard.debug_opts import DebugOpt
 
 from picard.ui.theme_detect import get_linux_dark_mode_strategies
 
@@ -310,6 +311,37 @@ class BaseTheme(QtCore.QObject):
             accent_color_str,
         )
 
+        if DebugOpt.THEME.enabled:
+            palette = app.palette()
+            base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+            highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+            window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
+            text_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Text)
+            style_hints = get_style_hints()
+            color_scheme_supported = style_hints is not None
+            if color_scheme_supported and hasattr(style_hints, 'colorScheme'):
+                current_scheme = style_hints.colorScheme().name
+            else:
+                current_scheme = "N/A"
+            log.debug(
+                "Theme diagnostics: style=%s platform=%s "
+                "color_scheme_supported=%s current_scheme=%s "
+                "accent_color_is_system=%s",
+                app.style().objectName() if app.style() else "None",
+                QtGui.QGuiApplication.platformName(),
+                color_scheme_supported,
+                current_scheme,
+                self._accent_color_is_system,
+            )
+            log.debug(
+                "Theme palette: base=%s (lightness=%d) window=%s text=%s highlight=%s",
+                base_color.name(),
+                base_color.lightness(),
+                window_color.name(),
+                text_color.name(),
+                highlight_color.name(),
+            )
+
     def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
         # Iterate through all registered strategies
         if any(strategy() for strategy in self._dark_mode_strategies):
@@ -347,6 +379,17 @@ class BaseTheme(QtCore.QObject):
         if self._accent_color and self._accent_color_is_system:
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)
+
+        if DebugOpt.THEME.enabled:
+            base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+            highlight_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Highlight)
+            log.debug(
+                "Theme apply_theme: target=%s base=%s (lightness=%d) highlight=%s",
+                ui_theme.value,
+                base_color.name(),
+                base_color.lightness(),
+                highlight_color.name(),
+            )
         # Force all widgets to refresh their style and repaint.
         # Unpolish + polish forces the style to recompute, and update()
         # schedules a repaint. Use QWidget.update() directly to avoid

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -293,6 +293,16 @@ class BaseTheme(QtCore.QObject):
         if self._accent_color:
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)
+        # Force all widgets to refresh their style and repaint.
+        # Unpolish + polish forces the style to recompute, and update()
+        # schedules a repaint. Use QWidget.update() directly to avoid
+        # calling overridden update() methods with different signatures.
+        if hasattr(app, 'allWidgets'):
+            style = app.style()
+            for widget in app.allWidgets():
+                style.unpolish(widget)
+                style.polish(widget)
+                QtWidgets.QWidget.update(widget)
         self._applied_theme = ui_theme
         self.theme_changed.emit()
 

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -351,7 +351,8 @@ class BaseTheme(QtCore.QObject):
         wanted_theme = UiTheme(config.setting['ui_theme'])
         if wanted_theme == UiTheme.DEFAULT:
             ui_theme = UiTheme.DARK if color_scheme == QtCore.Qt.ColorScheme.Dark else UiTheme.LIGHT
-            self.apply_theme(self._app, ui_theme)
+            if ui_theme != self._applied_theme:
+                self.apply_theme(self._app, ui_theme)
 
     def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
         # Iterate through all registered strategies

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -277,6 +277,7 @@ class BaseTheme(QtCore.QObject):
         self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
+        self._app = app
         config = get_config()
         wanted_theme = UiTheme(config.setting['ui_theme'])
         self._loaded_config_theme = wanted_theme
@@ -344,8 +345,7 @@ class BaseTheme(QtCore.QObject):
                     "Theme: applying system theme change to %s",
                     ui_theme.value,
                 )
-                app = QtWidgets.QApplication.instance()
-                self.apply_theme(app, ui_theme)
+                self.apply_theme(self._app, ui_theme)
 
     def _log_setup_diagnostics(self, app: QtWidgets.QApplication) -> None:
         """Log detailed theme diagnostics at startup."""

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -268,6 +268,7 @@ class BaseTheme(QtCore.QObject):
         self._dark_mode_strategies: list[Callable[[], bool]] = []
 
     def setup(self, app: QtWidgets.QApplication) -> None:
+        self._app = app
         config = get_config()
         wanted_theme = UiTheme(config.setting['ui_theme'])
         self._loaded_config_theme = wanted_theme
@@ -281,6 +282,9 @@ class BaseTheme(QtCore.QObject):
         app.setStyleSheet(
             'QGroupBox::title { /* PICARD-1206, Qt bug workaround */ }',
         )
+
+        if style_hints := get_style_hints():
+            style_hints.colorSchemeChanged.connect(self._on_color_scheme_changed)
 
         # Determine the system accent color before applying the theme,
         # so apply_theme() can include it in the palette.
@@ -341,6 +345,13 @@ class BaseTheme(QtCore.QObject):
                 text_color.name(),
                 highlight_color.name(),
             )
+
+    def _on_color_scheme_changed(self, color_scheme: QtCore.Qt.ColorScheme) -> None:
+        config = get_config()
+        wanted_theme = UiTheme(config.setting['ui_theme'])
+        if wanted_theme == UiTheme.DEFAULT:
+            ui_theme = UiTheme.DARK if color_scheme == QtCore.Qt.ColorScheme.Dark else UiTheme.LIGHT
+            self.apply_theme(self._app, ui_theme)
 
     def get_system_theme(self, app: QtWidgets.QApplication) -> Literal[UiTheme.DARK, UiTheme.LIGHT]:
         # Iterate through all registered strategies

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -396,7 +396,7 @@ class BaseTheme(QtCore.QObject):
             apply_dark_theme_to_palette(palette)
         else:
             apply_light_theme_to_palette(palette)
-        if self._accent_color and self._accent_color_is_system:
+        if self._accent_color:
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)
 

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -327,11 +327,21 @@ class BaseTheme(QtCore.QObject):
             self._log_setup_diagnostics(app)
 
     def _on_color_scheme_changed(self, color_scheme: QtCore.Qt.ColorScheme) -> None:
+        log.debug_if(
+            DebugOpt.THEME,
+            "Theme: system colorSchemeChanged signal received: %s",
+            color_scheme.name,
+        )
         config = get_config()
         wanted_theme = UiTheme(config.setting['ui_theme'])
         if wanted_theme == UiTheme.DEFAULT:
             ui_theme = UiTheme.from_color_scheme(color_scheme)
             if ui_theme != self._applied_theme:
+                log.debug_if(
+                    DebugOpt.THEME,
+                    "Theme: applying system theme change to %s",
+                    ui_theme.value,
+                )
                 app = QtWidgets.QApplication.instance()
                 self.apply_theme(app, ui_theme)
 

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -385,6 +385,8 @@ class BaseTheme(QtCore.QObject):
         between dark and light themes.  Emits theme_changed after the
         palette has been updated.
         """
+        if ui_theme == self._applied_theme:
+            return
         # setColorScheme tells Qt which color scheme we want. On Linux this
         # is unreliable for native widgets but still needed so that
         # style.standardPalette() returns the correct base palette.

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -64,6 +64,27 @@ DARK_PALETTE_COLORS = {
     (QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.HighlightedText): QtCore.Qt.GlobalColor.white,
 }
 
+# Light palette colors matching Fusion's standard light appearance.
+# Used as a fallback when setColorScheme does not take effect (e.g., Linux
+# without QT_PLATFORM_THEME=gnome) and standardPalette() remains dark.
+LIGHT_BG_COLOR = QtGui.QColor(239, 239, 239)
+
+LIGHT_PALETTE_COLORS = {
+    QtGui.QPalette.ColorRole.Window: LIGHT_BG_COLOR,
+    QtGui.QPalette.ColorRole.WindowText: QtCore.Qt.GlobalColor.black,
+    QtGui.QPalette.ColorRole.Base: QtCore.Qt.GlobalColor.white,
+    QtGui.QPalette.ColorRole.AlternateBase: LIGHT_BG_COLOR,
+    QtGui.QPalette.ColorRole.ToolTipBase: QtGui.QColor(255, 255, 220),
+    QtGui.QPalette.ColorRole.ToolTipText: QtCore.Qt.GlobalColor.black,
+    QtGui.QPalette.ColorRole.Text: QtCore.Qt.GlobalColor.black,
+    QtGui.QPalette.ColorRole.Button: LIGHT_BG_COLOR,
+    QtGui.QPalette.ColorRole.ButtonText: QtCore.Qt.GlobalColor.black,
+    QtGui.QPalette.ColorRole.BrightText: QtCore.Qt.GlobalColor.red,
+    (QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text): QtCore.Qt.GlobalColor.darkGray,
+    (QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.ButtonText): QtCore.Qt.GlobalColor.darkGray,
+    (QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Base): LIGHT_BG_COLOR,
+}
+
 
 OS_SUPPORTS_THEMES = True
 AppKit = None
@@ -144,6 +165,16 @@ def apply_dark_palette_colors(palette: QtGui.QPalette) -> None:
             palette.setColor(key, value)
 
 
+def apply_light_palette_colors(palette: QtGui.QPalette) -> None:
+    """Apply light palette colors to the given palette."""
+    for key, value in LIGHT_PALETTE_COLORS.items():
+        if isinstance(key, tuple):
+            group, role = key
+            palette.setColor(group, role, value)
+        else:
+            palette.setColor(key, value)
+
+
 def set_color_scheme(color_scheme: QtCore.Qt.ColorScheme) -> None:
     """Set the color scheme using style hints if available.
 
@@ -179,6 +210,22 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
     # colors to the palette.
     if not palette_is_dark(palette):
         apply_dark_palette_colors(palette)
+
+
+def apply_light_theme_to_palette(palette: QtGui.QPalette) -> None:
+    """Apply light theme colors to the given palette.
+
+    The function applies a lightness check on the existing palette's base color. Only
+    if the base color appears to be dark, light colors are applied to the palette.
+
+    Args:
+        palette: The palette to apply light colors to
+    """
+    # If setColorScheme worked, standardPalette() already returns a light palette.
+    # But if it didn't (e.g., Linux without proper platform theme integration),
+    # the palette may still be dark. Explicitly apply light colors in that case.
+    if palette_is_dark(palette):
+        apply_light_palette_colors(palette)
 
 
 def get_accent_color_from_palette(palette: QtGui.QPalette) -> QtGui.QColor:
@@ -295,6 +342,8 @@ class BaseTheme(QtCore.QObject):
         palette = style.standardPalette() if style else QtGui.QPalette()
         if ui_theme == UiTheme.DARK:
             apply_dark_theme_to_palette(palette)
+        else:
+            apply_light_theme_to_palette(palette)
         if self._accent_color and self._accent_color_is_system:
             apply_accent_color_to_palette(palette, self._accent_color)
         app.setPalette(palette)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -204,8 +204,15 @@ def apply_accent_color_to_palette(palette: QtGui.QPalette, accent_color: QtGui.Q
     palette.setColor(QtGui.QPalette.ColorRole.Link, link_color)
 
 
-class BaseTheme:
+class BaseTheme(QtCore.QObject):
+    # Emitted after a full theme switch (dark↔light). Implies colors also changed.
+    theme_changed = QtCore.pyqtSignal()
+
+    # Emitted when interface colors change without a full theme switch.
+    colors_changed = QtCore.pyqtSignal()
+
     def __init__(self):
+        super().__init__()
         self._loaded_config_theme: UiTheme = UiTheme.DEFAULT
         self._applied_theme: UiTheme = UiTheme.DEFAULT
         self._accent_color: QtGui.QColor | None = None

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -19,6 +19,7 @@
 
 
 from collections import namedtuple
+from contextlib import contextmanager
 
 from PyQt6 import (
     QtCore,
@@ -98,7 +99,18 @@ class HtmlBrowser(QtWidgets.QTextBrowser):
         theme.colors_changed.connect(self._apply_html)
 
     def _apply_html(self):
-        self.setHtml(htmldoc(self._html, self._rtl))
+        with self._preserve_scrollbar_position():
+            self.setHtml(htmldoc(self._html, self._rtl))
+
+    @contextmanager
+    def _preserve_scrollbar_position(self):
+        scrollbar = self.verticalScrollBar()
+        if not scrollbar:
+            yield
+            return
+        position = scrollbar.sliderPosition()
+        yield
+        scrollbar.setSliderPosition(position)
 
 
 class DocumentationPage(QtWidgets.QWidget):

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -36,6 +36,7 @@ from picard.util import get_url
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
+from picard.ui.theme import theme
 
 
 DocItem = namedtuple('DocItem', 'name desc')
@@ -85,14 +86,19 @@ def htmldoc(html, rtl):
 class HtmlBrowser(QtWidgets.QTextBrowser):
     def __init__(self, html, rtl, parent=None):
         super().__init__(parent=parent)
-
+        self._html = html
+        self._rtl = rtl
         self.setEnabled(True)
         self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.setObjectName('func_browser')
         self.setOpenLinks(True)
         self.setOpenExternalLinks(True)
-        self.setHtml(htmldoc(html, rtl))
+        self._apply_html()
         self.show()
+        theme.colors_changed.connect(self._apply_html)
+
+    def _apply_html(self):
+        self.setHtml(htmldoc(self._html, self._rtl))
 
 
 class DocumentationPage(QtWidgets.QWidget):

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -61,6 +61,7 @@ from picard.tags.docs import display_tag_tooltip
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
+from picard.ui.theme import theme
 from picard.ui.widgets.completion_provider import CompletionChoicesProvider
 from picard.ui.widgets.context_detector import (
     TAG_NAME_FIRST_ARG_FUNCTIONS,
@@ -108,15 +109,7 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     def __init__(self, document):
         super().__init__(document)
 
-        self.textcharformats = {
-            'escape': HighlightFormat(fg_color='syntax_hl_escape'),
-            'func': HighlightFormat(fg_color='syntax_hl_func', bold=True),
-            'noop': HighlightFormat(fg_color='syntax_hl_noop', bold=True, italic=True),
-            'special': HighlightFormat(fg_color='syntax_hl_special'),
-            'unicode': HighlightFormat(fg_color='syntax_hl_unicode'),
-            'unknown_func': HighlightFormat(fg_color='syntax_hl_error', italic=True),
-            'var': HighlightFormat(fg_color='syntax_hl_var'),
-        }
+        self._build_formats()
 
         self.rules = list(self.func_rules())
         self.rules.extend(
@@ -128,6 +121,24 @@ class TaggerScriptSyntaxHighlighter(QtGui.QSyntaxHighlighter):
                 HighlightRule('special', r"(?<!\\)[(),]"),
             )
         )
+
+        theme.colors_changed.connect(self._refresh_colors)
+
+    def _build_formats(self):
+        self.textcharformats = {
+            'escape': HighlightFormat(fg_color='syntax_hl_escape'),
+            'func': HighlightFormat(fg_color='syntax_hl_func', bold=True),
+            'noop': HighlightFormat(fg_color='syntax_hl_noop', bold=True, italic=True),
+            'special': HighlightFormat(fg_color='syntax_hl_special'),
+            'unicode': HighlightFormat(fg_color='syntax_hl_unicode'),
+            'unknown_func': HighlightFormat(fg_color='syntax_hl_error', italic=True),
+            'var': HighlightFormat(fg_color='syntax_hl_var'),
+        }
+
+    def _refresh_colors(self):
+        """Rebuild highlight formats with current colors and rehighlight."""
+        self._build_formats()
+        self.rehighlight()
 
     def func_rules(self):
         for func_name in script_function_names():

--- a/test/test_interface_colors.py
+++ b/test/test_interface_colors.py
@@ -93,3 +93,21 @@ class InterfaceColorsTest(PicardTestCase):
         colors = InterfaceColors(dark_theme=False)
         colors.reload()
         self.assertEqual(colors.get_color('entity_error'), '#112233')
+
+    def test_theme_changed_triggers_reload(self):
+        """Test that theme.theme_changed signal triggers interface_colors reload."""
+        from picard.ui.theme import theme
+
+        # Set distinct colors in dark config
+        config.setting['interface_colors_dark'] = {'entity_error': '#aabbcc'}
+        # Simulate a theme switch by emitting theme_changed
+        # (normally apply_theme would set is_dark_theme first, but we can
+        #  just verify the signal connection works by checking reload was called)
+        original_dark = interface_colors._dark_theme
+        interface_colors._dark_theme = True
+        theme.theme_changed.emit()
+        dark_error = interface_colors.get_color('entity_error')
+        self.assertEqual(dark_error, '#aabbcc')
+        # Restore
+        interface_colors._dark_theme = original_dark
+        interface_colors.reload()

--- a/test/test_interface_colors.py
+++ b/test/test_interface_colors.py
@@ -70,3 +70,26 @@ class InterfaceColorsTest(PicardTestCase):
 
     def test_interface_colors_default(self):
         self.assertIsInstance(interface_colors, InterfaceColors)
+
+    def test_reload_switches_color_set(self):
+        """Test that reload() picks up colors for the current theme."""
+        # Create instance for light theme
+        colors = InterfaceColors(dark_theme=False)
+        colors.load_from_config()
+        light_log_debug = colors.get_color('log_debug')
+
+        # Switch to dark theme and reload
+        colors._dark_theme = True
+        colors.reload()
+        dark_log_debug = colors.get_color('log_debug')
+
+        # Dark and light should differ for log_debug
+        self.assertNotEqual(light_log_debug, dark_log_debug)
+
+    def test_reload_loads_user_config(self):
+        """Test that reload() loads user customizations from config."""
+        # Set a known value in config first
+        config.setting['interface_colors'] = {'entity_error': '#112233'}
+        colors = InterfaceColors(dark_theme=False)
+        colors.reload()
+        self.assertEqual(colors.get_color('entity_error'), '#112233')

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -387,10 +387,10 @@ def assert_palette_not_dark(palette, expected_colors):
 @pytest.mark.parametrize(
     ("already_dark_theme", "system_theme", "expect_dark_palette"),
     [
-        (True, theme_mod.UiTheme.DARK, False),  # Already dark, detection dark: do NOT override
-        (True, theme_mod.UiTheme.LIGHT, False),  # Already dark, detection light: do NOT override
-        (False, theme_mod.UiTheme.DARK, True),  # Not dark, detection dark: override
-        (False, theme_mod.UiTheme.LIGHT, False),  # Not dark, detection light: do NOT override
+        (True, theme_mod.UiTheme.DARK, True),  # System dark: apply dark palette
+        (True, theme_mod.UiTheme.LIGHT, False),  # System light: use fresh light palette
+        (False, theme_mod.UiTheme.DARK, True),  # System dark: apply dark palette
+        (False, theme_mod.UiTheme.LIGHT, False),  # System light: use fresh light palette
     ],
 )
 def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, system_theme, expect_dark_palette):
@@ -416,10 +416,10 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, system_theme,
     if expect_dark_palette:
         assert_palette_matches_expected(palette, EXPECTED_DARK_PALETTE_COLORS)
     else:
-        # The Window color should remain the unique color if not overridden
-        window_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Window)
-        assert window_color == QtGui.QColor(123, 123, 123), (
-            f"Palette should not be overridden, got {window_color.getRgb()}"
+        # For light theme, verify the palette is NOT dark.
+        base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+        assert base_color.lightness() >= 128, (
+            f"Light theme should produce a light palette, got base lightness {base_color.lightness()}"
         )
 
 

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -329,7 +329,7 @@ EXPECTED_DARK_PALETTE_COLORS = {
     (
         QtGui.QPalette.ColorGroup.Inactive,
         QtGui.QPalette.ColorRole.Highlight,
-    ): QtGui.QColor(51, 51, 51),
+    ): QtGui.QColor(235, 116, 59),
     (
         QtGui.QPalette.ColorGroup.Inactive,
         QtGui.QPalette.ColorRole.HighlightedText,
@@ -402,9 +402,11 @@ def test_linux_dark_theme_palette(monkeypatch, already_dark_theme, system_theme,
     config_mock = MagicMock()
     config_mock.setting = {"ui_theme": "default"}
     monkeypatch.setattr(theme_mod, "get_config", lambda: config_mock)
+    monkeypatch.setattr(theme_mod, "palette_is_dark", lambda palette: not expect_dark_palette)
     # Patch get_system_theme to return dark_mode
     theme = theme_mod.BaseTheme()
     theme.get_system_theme = lambda app: system_theme
+    theme.get_system_accent_color = lambda: QtGui.QColor(235, 116, 59)
 
     # Mock QGuiApplication.styleHints() to return None to force manual fallback
     monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: None)
@@ -436,6 +438,7 @@ def test_windows_dark_theme_palette(monkeypatch, apps_use_light_theme, expected_
     monkeypatch.setattr(theme_mod, "IS_WIN", True)
     monkeypatch.setattr(theme_mod, "IS_MACOS", False)
     monkeypatch.setattr(theme_mod, "IS_HAIKU", False)
+    monkeypatch.setattr(theme_mod, "palette_is_dark", lambda palette: not expected_dark)
 
     # Patch winreg
     winreg_mock = types.SimpleNamespace()
@@ -472,6 +475,7 @@ def test_windows_dark_theme_palette(monkeypatch, apps_use_light_theme, expected_
     monkeypatch.setattr(theme_mod, "get_config", lambda: config_mock)
     # Instantiate WindowsTheme and run setup
     theme = theme_mod.WindowsTheme()
+    theme.get_system_accent_color = lambda: QtGui.QColor(235, 116, 59)
     # Force manual fallback for palette changes
     monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: None)
     app = DummyApp()

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -327,18 +327,21 @@ class TestGenericTheme:
     """Generic theme behavior."""
 
     def test_apply_theme_light(self, mock_palette):
-        """Test WindowsTheme uses apply_dark_theme_to_palette in update_palette."""
+        """Test that light theme does not apply dark palette colors."""
         app = MagicMock()
         app.palette.return_value = mock_palette
+        app.style.return_value.standardPalette.return_value = mock_palette
         theme = theme_mod.GenericTheme()
 
         with (
             patch("picard.ui.theme.set_color_scheme") as mock_set_color_scheme,
-            patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply,
+            patch("picard.ui.theme.apply_dark_theme_to_palette") as mock_apply_dark,
+            patch("picard.ui.theme.apply_light_theme_to_palette") as mock_apply_light,
         ):
             theme.apply_theme(app, theme_mod.UiTheme.LIGHT)
             mock_set_color_scheme.assert_called_once()
-            mock_apply.assert_not_called()
+            mock_apply_dark.assert_not_called()
+            mock_apply_light.assert_called_once_with(mock_palette)
 
     def test_apply_theme_dark(self, mock_palette):
         """Test WindowsTheme uses apply_dark_theme_to_palette in update_palette."""

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -190,10 +190,7 @@ class TestGetAccentColorFromPalette:
     def test_get_accent_color_from_palette(self):
         palette = QtGui.QPalette()
         accent_color = QtGui.QColor(40, 10, 40)
-        if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
-            palette.setColor(QtGui.QPalette.ColorRole.Accent, accent_color)
-        else:
-            palette.setColor(QtGui.QPalette.ColorRole.Highlight, accent_color)
+        palette.setColor(QtGui.QPalette.ColorRole.Highlight, accent_color)
 
         new_accent_color = theme_mod.get_accent_color_from_palette(palette)
         assert new_accent_color == accent_color

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -63,6 +63,7 @@ def mock_app():
     """Create a mock app for testing."""
     app = MagicMock()
     app.palette.return_value = QtGui.QPalette()
+    app.style.return_value.standardPalette.return_value = QtGui.QPalette()
     return app
 
 
@@ -343,6 +344,7 @@ class TestGenericTheme:
         """Test WindowsTheme uses apply_dark_theme_to_palette in update_palette."""
         app = MagicMock()
         app.palette.return_value = mock_palette
+        app.style.return_value.standardPalette.return_value = mock_palette
         theme = theme_mod.WindowsTheme()
 
         with (
@@ -529,6 +531,7 @@ class TestLinuxDarkModeDetection:
         palette = QtGui.QPalette()
         palette.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(0, 0, 0))
         mock_app.palette.return_value = palette
+        mock_app.style.return_value.standardPalette.return_value = palette
 
         with (
             patch.object(theme_mod, "get_config", return_value=config_mock),


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences:**

Enable runtime dark/light theme switching and interface color changes without requiring a restart.

## Problem

* JIRA ticket: [PICARD-2442](https://tickets.metabrainz.org/browse/PICARD-2442)

Currently switching theme (dark/light) or modifying interface colors requires restarting Picard. This is a poor UX especially when experimenting with colors or when the system theme changes.

Also related: [PICARD-2160](https://tickets.metabrainz.org/browse/PICARD-2160) (macOS dark mode switching not updating list elements).

## Solution

Infrastructure:
* Make `BaseTheme` a `QObject` with `theme_changed` and `colors_changed` signals
* Make `apply_theme()` re-entrant (starts from fresh `standardPalette()`, handles both directions)
* Add `InterfaceColors.reload()` to switch color sets after theme change
* Emit signals after palette update, auto-reload interface colors
* Force `unpolish`/`polish`/`update` on all widgets for immediate visual refresh
* Add `UiTheme.from_color_scheme()` and `to_color_scheme()` helpers
* Skip redundant `apply_theme` on system color scheme change
* Allow system style changes if `ui_theme` is "default"

Widget fixes:
* Log view: connect existing `refresh_colors()` to signal
* MainPanel tree: refresh cached class-level color attributes
* Syntax highlighter: rebuild `HighlightFormat` objects and rehighlight
* Toolbar: swap dark/light icon variants and extension button stylesheet
* Options dialog: regenerate profile highlight stylesheets
* About dialog: re-apply styling on theme change
* Cover art box: already dynamic (reads colors at paint time, no change needed)

Options pages:
* Theme change in Interface options now applies live
* Color changes emit `colors_changed` instead of showing restart warning
* Use `QSignalBlocker` context manager for theme combo

Debug:
* `Ctrl+Shift+D` shortcut toggles theme at runtime for testing
* `--debug-opts=theme` for theme switching diagnostics

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Further testing on macOS and Windows
* [ ] Plugin API for theme awareness (separate PR, see [PICARD-3388](https://tickets.metabrainz.org/browse/PICARD-3388))
