### PR TITLE
PICARD-3393: Isolate processor errors so one failing plugin does not block others

### DIFF
--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -37,6 +37,7 @@ from collections.abc import (
     Callable,
     Iterator,
 )
+from contextlib import contextmanager
 from functools import partial
 from typing import (
     Generic,
@@ -44,6 +45,7 @@ from typing import (
     TypeVar,
 )
 
+from picard import log
 from picard.config import (
     Option,
     get_config,
@@ -150,6 +152,30 @@ class PluginFunctions(Generic[P, R]):
         yield from sorted(self.functions, key=lambda i: self.get_priority(i), reverse=True)
 
     def run(self, *args: P.args, **kwargs: P.kwargs) -> None:
-        """Execute registered functions with passed parameters honouring priority"""
+        """Execute registered functions with passed parameters honouring priority.
+
+        Exceptions in individual functions are logged and do not prevent
+        remaining functions from running.
+        """
         for function in self._get_functions():
-            function(*args, **kwargs)
+            with _log_processor_error(str(self.functions.label), function):
+                function(*args, **kwargs)
+
+
+@contextmanager
+def _log_processor_error(label: str, function: Callable):
+    """Context manager that catches and logs exceptions from a processor function.
+
+    This ensures that a single failing processor does not prevent subsequent
+    processors from running.
+    """
+    try:
+        yield
+    except Exception:
+        log.error(
+            "Error in %s (%s.%s):",
+            label,
+            getattr(function, '__module__', '?'),
+            getattr(function, '__name__', function),
+            exc_info=True,
+        )

--- a/test/test_plugin_functions.py
+++ b/test/test_plugin_functions.py
@@ -1,0 +1,156 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from unittest.mock import patch
+
+from test.picardtestcase import PicardTestCase
+
+from picard.plugin import (
+    PluginFunctions,
+    _log_processor_error,
+)
+
+
+class TestLogProcessorError(PicardTestCase):
+    """Tests for the _log_processor_error context manager."""
+
+    @patch('picard.plugin.log')
+    def test_logs_exception_with_module_and_name(self, mock_log):
+        def bad_func():
+            raise ValueError("something went wrong")
+
+        with _log_processor_error('track_metadata_processors', bad_func):
+            bad_func()
+
+        mock_log.error.assert_called_once()
+        args = mock_log.error.call_args
+        formatted = args[0][0] % args[0][1:]
+        self.assertIn('track_metadata_processors', formatted)
+        self.assertIn('bad_func', formatted)
+        self.assertTrue(args[1].get('exc_info'))
+
+    @patch('picard.plugin.log')
+    def test_no_log_on_success(self, mock_log):
+        with _log_processor_error('album_metadata_processors', lambda: None):
+            pass
+
+        mock_log.error.assert_not_called()
+
+    def test_does_not_catch_keyboard_interrupt(self):
+        """SystemExit and KeyboardInterrupt must propagate."""
+        with self.assertRaises(KeyboardInterrupt):
+            with _log_processor_error('track_metadata_processors', lambda: None):
+                raise KeyboardInterrupt
+
+
+class TestPluginFunctionsRun(PicardTestCase):
+    """Tests for PluginFunctions.run() error isolation (PICARD-3393)."""
+
+    def setUp(self):
+        super().setUp()
+        self.set_config_values(setting={'plugins3_exec_order': {}})
+        self.pf = PluginFunctions(label='track_metadata_processors')
+
+    def test_run_executes_all_functions(self):
+        results = []
+
+        def func_a(x):
+            results.append('a')
+
+        def func_b(x):
+            results.append('b')
+
+        self.pf.register('test_module', func_a)
+        self.pf.register('test_module', func_b)
+        self.pf.run('arg')
+        self.assertEqual(results, ['a', 'b'])
+
+    def test_run_continues_after_exception(self):
+        """A failing function must not prevent subsequent functions from running."""
+        results = []
+
+        def func_good_before(x):
+            results.append('before')
+
+        def func_bad(x):
+            raise TypeError("wrong number of arguments")
+
+        def func_good_after(x):
+            results.append('after')
+
+        self.pf.register('test_module', func_good_before)
+        self.pf.register('test_module', func_bad)
+        self.pf.register('test_module', func_good_after)
+        self.pf.run('arg')
+        self.assertEqual(results, ['before', 'after'])
+
+    @patch('picard.plugin.log')
+    def test_run_logs_exception(self, mock_log):
+        """A failing function should be logged with an error."""
+
+        def func_bad(x):
+            raise ValueError("something went wrong")
+
+        self.pf.register('test_module', func_bad)
+        self.pf.run('arg')
+        mock_log.error.assert_called_once()
+        args = mock_log.error.call_args
+        self.assertTrue(args[1].get('exc_info'))
+
+    def test_run_with_no_functions(self):
+        """run() with no registered functions should be a no-op."""
+        self.pf.run('arg')  # Should not raise
+
+    def test_run_multiple_failures_all_logged(self):
+        """Multiple failing functions should all be logged independently."""
+        results = []
+
+        def func_bad_1(x):
+            raise TypeError("bad 1")
+
+        def func_good(x):
+            results.append('good')
+
+        def func_bad_2(x):
+            raise RuntimeError("bad 2")
+
+        self.pf.register('test_module', func_bad_1)
+        self.pf.register('test_module', func_good)
+        self.pf.register('test_module', func_bad_2)
+
+        with patch('picard.plugin.log') as mock_log:
+            self.pf.run('arg')
+
+        self.assertEqual(results, ['good'])
+        self.assertEqual(mock_log.error.call_count, 2)
+
+    def test_run_works_for_non_metadata_processors(self):
+        """Error isolation works for all processor types, not just metadata."""
+        pf = PluginFunctions(label='file_post_load_processors')
+        results = []
+
+        def func_bad(f):
+            raise RuntimeError("plugin crash")
+
+        def func_good(f):
+            results.append('loaded')
+
+        pf.register('test_module', func_bad)
+        pf.register('test_module', func_good)
+        pf.run('file')
+        self.assertEqual(results, ['loaded'])


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Wrap each function call in `PluginFunctions.run()` with a context manager that catches and logs exceptions per-function, so a single broken plugin does not prevent all subsequent processors from running.

## Problem

* JIRA ticket: [PICARD-3393](https://tickets.metabrainz.org/browse/PICARD-3393)

`PluginFunctions.run()` iterates over registered processors without per-function error handling. If any function raises (e.g. a plugin with an incorrect signature), the loop aborts and all remaining processors are skipped. This means one broken plugin silently breaks every other plugin in the chain.

## Solution

- Added a `_log_processor_error` context manager that catches `Exception` (not `BaseException`, so `KeyboardInterrupt`/`SystemExit` still propagate), logs the error with `exc_info=True`, and identifies the failing function via `module.name`.
- `run()` now wraps each function call with this context manager.
- Added tests covering error isolation, logging, and non-suppression of fatal exceptions.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

Implementation and tests developed with AI assistance (Kiro CLI), with human review and direction on design decisions.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)