### PR TITLE
PICARD-3394: ListenQueue: Avoid unnecessary file writes and clean up queue file

### DIFF
--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -310,10 +310,11 @@ class ListenQueue:
 
     def _clear_listen_queue_file(self):
         queue_file = self.get_listen_queue_file_path()
-        try:
-            queue_file.unlink(missing_ok=True)
-        except OSError as e:
-            log.debug("Failed to remove listen queue file %s: %s", queue_file, e)
+        with self._lock.lock_for_write():
+            try:
+                queue_file.unlink(missing_ok=True)
+            except OSError as e:
+                log.debug("Failed to remove listen queue file %s: %s", queue_file, e)
 
 
 def from_json(obj: dict):

--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -306,6 +306,14 @@ class ListenQueue:
     def _on_listen_queue_drained(self):
         log.debug("All queued listens submitted successfully")
         self._timer.stop()
+        self._clear_listen_queue_file()
+
+    def _clear_listen_queue_file(self):
+        queue_file = self.get_listen_queue_file_path()
+        try:
+            queue_file.unlink(missing_ok=True)
+        except OSError as e:
+            log.debug("Failed to remove listen queue file %s: %s", queue_file, e)
 
 
 def from_json(obj: dict):

--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -201,6 +201,8 @@ class ListenQueue:
                     self._queue = []
 
     def save(self):
+        if not self._queue:
+            return
         queue_file = self.get_listen_queue_file_path()
         log.debug("Saving listen queue to %s", queue_file)
         with open(queue_file, 'w') as f:

--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -257,11 +257,11 @@ class ListenQueue:
             log.debug('ListenBrainz batch submission successful: data=%s', data)
             self._remove_from_queue(batch)
             # Check whether there is more data in the queue and directly submit the next
-            # batch. Otherwise suspend the submission timer.
+            # batch. Otherwise stop the submission timer.
             if self._queue:
                 self.submit_batch()
             else:
-                self._suspend_submission()
+                self._on_listen_queue_drained()
 
     def _submit(self, submission: ListenSubmission, callback: ReplyHandler):
         config = get_config()
@@ -301,8 +301,8 @@ class ListenQueue:
             log.debug("Batch listen submission scheduled to run in %d seconds", SUBMISSION_INTERVAL_SECONDS)
             self._timer.start(SUBMISSION_INTERVAL_SECONDS * 1000)
 
-    def _suspend_submission(self):
-        log.debug("Batch listen submission suspended")
+    def _on_listen_queue_drained(self):
+        log.debug("All queued listens submitted successfully")
         self._timer.stop()
 
 

--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -186,10 +186,10 @@ class ListenQueue:
         self._timer.timeout.connect(self.submit_batch)
 
     def load(self):
-        cache_file = self.get_cache_file_path()
-        if cache_file.exists():
-            log.debug("Loading listen queue from %s", cache_file)
-            with open(cache_file) as f:
+        queue_file = self.get_listen_queue_file_path()
+        if queue_file.exists():
+            log.debug("Loading listen queue from %s", queue_file)
+            with open(queue_file) as f:
                 try:
                     with self._lock.lock_for_write():
                         self._queue = json.load(f, object_hook=from_json)
@@ -201,9 +201,9 @@ class ListenQueue:
                     self._queue = []
 
     def save(self):
-        cache_file = self.get_cache_file_path()
-        log.debug("Saving listen queue to %s", cache_file)
-        with open(cache_file, 'w') as f:
+        queue_file = self.get_listen_queue_file_path()
+        log.debug("Saving listen queue to %s", queue_file)
+        with open(queue_file, 'w') as f:
             with self._lock.lock_for_write():
                 data = [asdict(p) for p in self._queue]
                 json.dump(data, f)
@@ -293,7 +293,7 @@ class ListenQueue:
                     batch,
                 )
 
-    def get_cache_file_path(self) -> Path:
+    def get_listen_queue_file_path(self) -> Path:
         return Path(cache_folder()) / "listenbrainz-queue.json"
 
     def _schedule_submission(self):

--- a/test/test_player_listenbrainz.py
+++ b/test/test_player_listenbrainz.py
@@ -16,6 +16,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import json
 from unittest.mock import Mock
 
 from PyQt6.QtNetwork import (
@@ -106,23 +107,53 @@ class TestListenQueue(PicardTestCase):
     def setUp(self):
         super().setUp()
         self.set_config_values({"listenbrainz_token": "test_token"})
+        self.lbapi = FakeListenBrainzAPIHelper()
+        self.queue = ListenQueue(self.lbapi)
+        self.queue_file = self.queue.get_listen_queue_file_path()
+        self.queue_file.parent.mkdir(parents=True, exist_ok=True)
+        self.queue_file.unlink(missing_ok=True)
+
+    def _queue_with_pending_listen(self):
+        self.lbapi = FakeListenBrainzAPIHelper(
+            status_code=401, error=QNetworkReply.NetworkError.AuthenticationRequiredError
+        )
+        self.queue = ListenQueue(self.lbapi)
+        payload = ListenPayload(track_metadata=TrackMetadata(artist_name="Test", track_name="Song"))
+        self.queue.add(payload)
+        return payload
 
     def test_add(self):
-        lbapi = FakeListenBrainzAPIHelper()
-        queue = ListenQueue(lbapi)
-        queue._on_submit_listen_response = Mock()
+        self.queue._on_submit_listen_response = Mock()
         payload = ListenPayload(track_metadata=TrackMetadata(artist_name="", track_name=""))
-        queue.add(payload)
-        lbapi.submit_listen.assert_called_once()
-        args = lbapi.submit_listen.call_args.args
+        self.queue.add(payload)
+        self.lbapi.submit_listen.assert_called_once()
+        args = self.lbapi.submit_listen.call_args.args
         self.assertEqual(args[0], "test_token")
         self.assertEqual(args[1], ListenSubmission(ListenType.SINGLE, [payload]))
-        queue._on_submit_listen_response.assert_called_once()
-        self.assertEqual([], queue._queue)
+        self.queue._on_submit_listen_response.assert_called_once()
+        self.assertEqual([], self.queue._queue)
 
     def test_add_failure(self):
-        lbapi = FakeListenBrainzAPIHelper(status_code=401, error=QNetworkReply.NetworkError.AuthenticationRequiredError)
-        queue = ListenQueue(lbapi)
-        payload = ListenPayload(track_metadata=TrackMetadata(artist_name="", track_name=""))
-        queue.add(payload)
-        self.assertEqual([payload], queue._queue)
+        self._queue_with_pending_listen()
+        self.assertEqual(1, len(self.queue._queue))
+
+    def test_save_does_not_create_file_when_queue_empty(self):
+        self.queue.save()
+        self.assertFalse(self.queue_file.exists())
+
+    def test_save_writes_non_empty_queue(self):
+        self._queue_with_pending_listen()
+        self.queue.save()
+        self.assertTrue(self.queue_file.exists())
+        with open(self.queue_file) as f:
+            data = json.load(f)
+        self.assertEqual(len(data), 1)
+
+    def test_queue_file_removed_after_successful_submission(self):
+        self._queue_with_pending_listen()
+        self.queue.save()
+        self.assertTrue(self.queue_file.exists())
+        # Simulate successful submission draining the queue
+        self.queue._queue.clear()
+        self.queue._on_listen_queue_drained()
+        self.assertFalse(self.queue_file.exists())


### PR DESCRIPTION
<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Refactor `ListenQueue` to avoid unnecessary file writes on shutdown and properly clean up the queue file after successful submission.

## Problem

* JIRA ticket: [PICARD-3394](https://tickets.metabrainz.org/browse/PICARD-3394)

On every Picard shutdown, `ListenQueue.save()` writes the queue to disk unconditionally — even when nothing was played and the queue is empty. Additionally, after previously-failed listens are successfully submitted mid-session, the stale queue file is never cleaned up until the next exit.

## Solution

- Rename `get_cache_file_path` → `get_listen_queue_file_path` (it's not a cache, it persists pending listens)
- Rename `_suspend_submission` → `_on_listen_queue_drained` (clearer intent)
- `save()` skips writing when the queue is empty
- After all queued listens are successfully submitted, the queue file is removed
- File deletion is guarded by the write lock to prevent races
- Added tests covering the save and cleanup behavior

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI assisted with code suggestions.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
