### PR TITLE
PICARD-2442: Fix switching UI theme to Default having no effect until restart

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -397,8 +397,31 @@ class BaseTheme(QtCore.QObject):
         if any(strategy() for strategy in self._dark_mode_strategies):
             return UiTheme.DARK
 
-        if palette_is_dark(app.palette()):
-            log.debug("No system dark mode detected, but palette is already dark.")
+        # Ask Qt directly for the OS color scheme when available (Qt 6.5+).
+        # Unlike app.palette(), this reflects the operating system setting and
+        # is not affected by any palette Picard applied at runtime.
+        # get_style_hints() only returns non-None when setColorScheme (Qt 6.8+)
+        # is present, which implies colorScheme() (Qt 6.5+) is available too.
+        style_hints = get_style_hints()
+        if style_hints is not None:
+            color_scheme = style_hints.colorScheme()
+            if color_scheme == QtCore.Qt.ColorScheme.Dark:
+                log.debug("System color scheme reported as dark.")
+                return UiTheme.DARK
+            if color_scheme == QtCore.Qt.ColorScheme.Light:
+                log.debug("System color scheme reported as light.")
+                return UiTheme.LIGHT
+            # Unknown/unspecified: fall through to the palette-based heuristic.
+
+        # Fallback for platforms/Qt versions without a usable color scheme hint.
+        # Use the style's standard palette rather than the live application
+        # palette: app.palette() may have been overridden by a runtime theme
+        # switch (e.g. the user selected Dark and then switched back to
+        # Default), which would otherwise make us misdetect the system theme.
+        style = app.style()
+        reference_palette = style.standardPalette() if style else app.palette()
+        if palette_is_dark(reference_palette):
+            log.debug("No system dark mode detected, but standard palette is dark.")
             return UiTheme.DARK
 
         log.debug("No system dark mode detected, defaulting to light mode.")

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -384,6 +384,114 @@ def assert_palette_not_dark(palette, expected_colors):
             )
 
 
+def _make_light_standard_palette():
+    """A light palette as a style's standardPalette() would report on a light OS."""
+    palette = QtGui.QPalette()
+    palette.setColor(
+        QtGui.QPalette.ColorGroup.Active,
+        QtGui.QPalette.ColorRole.Base,
+        QtGui.QColor(255, 255, 255),
+    )
+    return palette
+
+
+class _StyleWithStandardPalette:
+    """Minimal style stub exposing a fixed standardPalette()."""
+
+    def __init__(self, standard_palette):
+        self._standard_palette = standard_palette
+
+    def standardPalette(self):
+        return self._standard_palette
+
+
+class _AppWithStyle(DummyApp):
+    """DummyApp variant whose style() returns a style with a standardPalette().
+
+    Models the real runtime state: the live application palette may have been
+    overridden (e.g. dark, after the user picked the Dark theme), while the
+    style's standard palette still reflects the true OS theme.
+    """
+
+    def __init__(self, live_dark, standard_palette):
+        super().__init__(already_dark_theme=live_dark)
+        self._style = _StyleWithStandardPalette(standard_palette)
+
+    def style(self):
+        return self._style
+
+
+def test_get_system_theme_ignores_runtime_applied_dark_palette(monkeypatch):
+    """Regression test for PICARD-2442 dynamic theme switch bug.
+
+    Reproduces the scenario reported by rdswift: on a system whose real theme
+    is light, switching the UI theme option from "Dark" back to "Default" had
+    no effect until restart.
+
+    Root cause: ``get_system_theme()`` used to fall back to
+    ``palette_is_dark(app.palette())`` when no OS dark-mode strategy reported
+    dark. That live palette reflects whatever theme Picard applied at runtime.
+    After the user manually selected the Dark theme, ``app.palette()`` is dark,
+    so the old code wrongly reported the system theme as DARK, and
+    ``apply_theme(DARK)`` then early-returned because dark was already applied,
+    so nothing repainted.
+
+    ``get_system_theme()`` must report the real OS theme (LIGHT here),
+    independent of whatever palette Picard has applied at runtime.
+    """
+    # Force the style-hints path off so we exercise the standard-palette fallback.
+    monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: None)
+
+    theme = theme_mod.GenericTheme()
+    # No OS dark-mode strategy reports dark (system default is light).
+    theme._dark_mode_strategies = [lambda: False]
+
+    # Live palette is dark (Picard applied Dark at runtime), but the style's
+    # standard palette still reflects the true OS theme (light).
+    app = _AppWithStyle(live_dark=True, standard_palette=_make_light_standard_palette())
+    assert theme_mod.palette_is_dark(app.palette())
+    assert not theme_mod.palette_is_dark(app.style().standardPalette())
+
+    detected = theme.get_system_theme(app)
+
+    assert detected == theme_mod.UiTheme.LIGHT, (
+        "get_system_theme must report the real OS theme (light) and not be "
+        "fooled by a dark palette that Picard applied at runtime"
+    )
+
+
+def test_get_system_theme_uses_style_hints_color_scheme(monkeypatch):
+    """When available, get_system_theme should trust the OS color scheme hint.
+
+    Even if the live application palette is dark (runtime override), a light OS
+    color scheme must be reported as LIGHT.
+    """
+
+    class _StyleHints:
+        def __init__(self, scheme):
+            self._scheme = scheme
+
+        def setColorScheme(self, scheme):  # presence gates get_style_hints()
+            self._scheme = scheme
+
+        def colorScheme(self):
+            return self._scheme
+
+    monkeypatch.setattr(
+        QtGui.QGuiApplication,
+        "styleHints",
+        lambda: _StyleHints(QtCore.Qt.ColorScheme.Light),
+    )
+
+    theme = theme_mod.GenericTheme()
+    theme._dark_mode_strategies = [lambda: False]
+
+    # Live palette is dark, but the OS reports a light scheme.
+    app = _AppWithStyle(live_dark=True, standard_palette=_make_light_standard_palette())
+
+    assert theme.get_system_theme(app) == theme_mod.UiTheme.LIGHT
+
+
 @pytest.mark.parametrize(
     ("already_dark_theme", "system_theme", "expect_dark_palette"),
     [


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

  Fix the runtime theme switcher so that selecting **Default** actually takes
  effect immediately when the previously applied theme was Dark (or Light),
  instead of only after a restart.

## Problem

* JIRA ticket (_optional_): PICARD-2442

Reported by rdswift (running from source on Linux): switching from **Light** or
**Dark** to **Default** had no visible effect until Picard was restarted.
Switching between Light/Dark, or from Default to Light/Dark, worked fine.

Root cause: `BaseTheme.get_system_theme()` resolved the system theme from the
live application palette via `palette_is_dark(app.palette())`. At runtime that
palette reflects whatever theme Picard last applied, not the operating system
setting. After the user selected **Dark** and then switched back to **Default**,
`app.palette()` was dark, so `get_system_theme()` incorrectly returned `DARK`.
`apply_theme(DARK)` then early-returned (because dark was already applied) and
nothing repainted.

This matches the reported log line:

```
ui/theme.get_system_theme: No system dark mode detected, but palette is already dark.
```

The palette heuristic is only reliable at startup, before Picard has overridden
the application palette.

## Solution

`get_system_theme()` now determines the OS theme independently of any palette
Picard applied at runtime:

* Prefer `QStyleHints.colorScheme()` when available (Qt 6.5+), which reports the
  operating system color scheme directly.
* Otherwise fall back to the style's `standardPalette()` rather than the live
  `app.palette()`, so a runtime theme override no longer skews detection.

The OS-specific dark-mode detection strategies (freedesktop portal, GNOME, KDE,
XFCE, LXQt) remain the first and highest-priority signal and are unchanged.

Added regression tests covering both detection paths:

* `test_get_system_theme_ignores_runtime_applied_dark_palette` — reproduces
  rdswift's scenario (light OS, dark runtime palette, no strategy reporting
  dark) and asserts `LIGHT` is returned.
* `test_get_system_theme_uses_style_hints_color_scheme` — verifies the color
  scheme hint is trusted over a dark runtime palette.

`pytest test/test_theme.py` passes (48 tests); `ruff format`, `ruff check`, and
`ty check` are clean on the changed files.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Investigation of the root cause, the fix in `get_system_theme()`, and the
regression tests were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
