### PR TITLE
plugins3: List new local-source branches without requiring a restart

### DIFF
--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -43,6 +43,7 @@ from picard.const.appdirs import cache_folder
 from picard.git.backend import GitRefType
 from picard.git.factory import git_backend
 from picard.git.ops import GitOperations
+from picard.git.utils import is_local_path
 from picard.plugin3.manager.clean import PluginCleanupManager
 from picard.plugin3.manager.errors import (  # noqa: F401
     PluginAlreadyInstalledError,
@@ -231,6 +232,21 @@ class PluginManager(QObject):
                     repo_path = plugin.local_path
                     break
 
+        # When reusing an installed plugin's repository whose source is a local
+        # filesystem path, refresh it from its origin before listing refs.
+        # Plugins are installed as single-branch clones, so on its own the
+        # installed copy only knows about the originally installed branch;
+        # branches or tags added to the source repository afterwards would not
+        # appear in the ref selector until the next restart. A fetch from a
+        # local origin is a cheap on-disk operation (no network), so it is safe
+        # to do synchronously here. Remote origins are intentionally skipped:
+        # they are refreshed asynchronously via refresh_all_plugin_refs(), and a
+        # synchronous network fetch on dialog open would be undesirable. Fetch
+        # failures (missing origin, etc.) are non-fatal: we then list whatever
+        # refs the existing clone already has.
+        if repo_path and is_local_path(url):
+            self._refresh_repo_from_origin(repo_path)
+
         remote_refs = GitOperations.fetch_remote_refs(url, use_callbacks=True, repo_path=repo_path)
         if not remote_refs:
             return None
@@ -274,6 +290,25 @@ class PluginManager(QObject):
         }
 
         return result
+
+    def _refresh_repo_from_origin(self, repo_path):
+        """Fetch all refs (branches and tags) from a repository's origin.
+
+        Best-effort: any failure (no origin remote, unreachable source, etc.)
+        is logged and swallowed so callers can fall back to the refs already
+        present in the repository.
+        """
+
+        def fetch_refs(repo):
+            backend = git_backend()
+            callbacks = backend.create_remote_callbacks()
+            for remote in repo.get_remotes():
+                repo.fetch_remote_with_tags(remote, None, callbacks._callbacks)
+
+        try:
+            self._with_plugin_repo(repo_path, fetch_refs)
+        except Exception as e:
+            log.debug("Failed to refresh refs from origin for %s: %s", repo_path, e)
 
     def get_plugin_refs_info(self, identifier):
         """Get plugin refs information from identifier.

--- a/test/plugins3/test_manager.py
+++ b/test/plugins3/test_manager.py
@@ -1030,3 +1030,69 @@ class TestPluginErrors(PicardTestCase):
 
             # Should not be added twice
             self.assertEqual(len(manager._plugin_dirs), initial_count)
+
+
+class TestFetchAllGitRefsLocalSource(PicardTestCase):
+    """Regression tests for listing refs of plugins installed from a local repo.
+
+    Plugins are installed as single-branch clones. fetch_all_git_refs() reuses
+    that clone to list refs. A branch created in the local source repository
+    after installation must still show up in the ref selector, not only after
+    the next restart.
+    """
+
+    def _clone_single_branch(self, source_path, target_path, branch):
+        """Clone source_path into target_path checking out a single branch."""
+        backend = git_backend()
+        repo = backend.clone_repository(source_path.as_uri(), target_path, checkout_branch=branch)
+        repo.free()
+
+    def test_branch_added_to_source_after_install_is_listed(self):
+        """A branch created in the local source after install is listed."""
+        skip_if_no_git_backend()
+
+        from test.plugins3.helpers import (
+            backend_create_branch,
+            create_git_repo_with_backend,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+
+            # rdswift's local copy of the repo (the install source), on 'main'.
+            source_path = tmp / 'source'
+            create_git_repo_with_backend(source_path, {'MANIFEST.toml': 'name = "Test"\n'})
+
+            # Picard's installed copy: a single-branch clone of the source.
+            clone_path = tmp / 'clone'
+            self._clone_single_branch(source_path, clone_path, 'main')
+
+            # After installation, a new branch is created in the SOURCE repo.
+            backend_create_branch(source_path, 'feature-x')
+
+            # Register an installed plugin pointing at the source URL with the
+            # single-branch clone as its local path.
+            manager = _create_manager()
+            plugin = MockPlugin(uuid='local-src-uuid', local_path=clone_path)
+            manager._plugins = [plugin]
+            manager._save_plugin_metadata(
+                PluginMetadata(
+                    name='Test',
+                    url=str(source_path),
+                    ref='main',
+                    commit='',
+                    uuid='local-src-uuid',
+                )
+            )
+
+            refs = manager.fetch_all_git_refs(str(source_path))
+
+            self.assertIsNotNone(refs)
+            branch_names = {b['name'] for b in refs['branches']}
+            self.assertIn('main', branch_names)
+            self.assertIn(
+                'feature-x',
+                branch_names,
+                "A branch created in the local source repository after install "
+                "must be listed without requiring a restart",
+            )


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

  When a plugin is installed from a local git repository, branches (or tags)
  created in that source repo after installation now show up in the ref
  selector immediately, instead of only after restarting Picard.

## Problem

* JIRA ticket (_optional_): PICARD-XXX (to be created)

Reported by rdswift while developing a plugin against a local clone of its
repository: after using **Reinstall** and selecting a local branch, creating a
*new* branch in the local source repo and reopening the installer showed the
new branch missing. It reappeared only after Picard was restarted.

Root cause: plugins are installed as **single-branch clones**
(`_sync_plugin_source` → `PluginSourceGit.sync(single_branch=True)`).
`PluginManager.fetch_all_git_refs()` reuses that clone (`plugin.local_path`)
to populate the ref selector and reads its references directly, **without
fetching from origin first** (`Pygit2Backend.fetch_remote_refs` with a
`repo_path` just enumerates the existing repo). Consequently a branch added to
the source repository after installation never existed in the clone, so it was
absent from the Branches tab until a restart repopulated state.

This was originally described as a language-related issue, but the trigger was
simply the **restart** forced by changing the UI language — it reproduces on
any restart and is not related to translations.

## Solution

When the reused repository's source is a **local filesystem path**, refresh it
from its `origin` before listing refs, so newly created branches and tags
become visible. Key points:

* Scoped to local sources via the existing `is_local_path()` helper. A fetch
  from a local origin is a cheap on-disk operation (no network), so it is safe
  to do synchronously on dialog open.
* **Remote** origins are intentionally left untouched: they are already
  refreshed asynchronously via `refresh_all_plugin_refs()`, and adding a
  synchronous network fetch on dialog open would be undesirable.
* The refresh is best-effort — on any failure (no `origin`, unreachable
  source, etc.) we fall back to listing whatever refs the clone already has.

The new `_refresh_repo_from_origin()` helper mirrors the existing fetch pattern
already used by `refresh_all_plugin_refs()`.

Added an end-to-end regression test (`TestFetchAllGitRefsLocalSource`) that:
installs from a local repo (single-branch clone), creates a new branch in the
source afterwards, and asserts `fetch_all_git_refs()` lists it. The test fails
without the fix (`'feature-x' not found in {'main'}`) and passes with it.

Verification: `pytest test/plugins3/ test/test_git.py` → 655 passed, 2 skipped;
`ruff format`, `ruff check` clean on the changed files. `ty check` shows only
the same pre-existing `callbacks._callbacks` diagnostic already present in
`refresh_all_plugin_refs()`.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Investigation of the root cause, the fix in `fetch_all_git_refs()`, and the
regression test were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

A JIRA ticket still needs to be created and the PR title/branch updated with the
`PICARD-XXXX:` prefix once it exists.
