### PR TITLE
PICARD-3396: Offer "Use track relationships" as an opt-in in the first-run setup wizard

### DIFF
--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -431,6 +431,45 @@ class UpdatesPage(SetupWizardPage):
             ReadTheDocs.update_documentation_items()
 
 
+class MetadataPage(SetupWizardPage):
+    """Page for configuring additional metadata options."""
+
+    def __init__(self, parent: QtWidgets.QWizard | None = None):
+        super().__init__(parent)
+        self.setTitle(_("Additional Metadata"))
+        self.setSubTitle(_("Choose whether Picard should fetch extra details about each track."))
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.track_ars_checkbox = WizardCheckbox(
+            _("Fetch detailed track relationships (performers, composers, and more)"),
+            _(
+                "For every track, Picard will also download extra credits such as the "
+                "musicians who performed on it, the composer and lyricist, and related "
+                "works. This gives you much richer tags.\n\n"
+                "It is turned off by default because it downloads more data from the "
+                "MusicBrainz servers, which makes loading albums a little slower and adds "
+                "load to the servers. Enable it if you want the most complete tags and "
+                "don't mind the extra loading time."
+            ),
+        )
+        layout.addWidget(self.track_ars_checkbox)
+
+        layout.addStretch()
+        hint = QtWidgets.QLabel(
+            _("You can change this later under Options \N{RIGHTWARDS ARROW} Options \N{RIGHTWARDS ARROW} Metadata.")
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+    def initializePage(self) -> None:
+        config = get_config()
+        self.track_ars_checkbox.set_checked(config.setting['track_ars'])
+
+    def save_settings(self, config: Config) -> None:
+        config.setting['track_ars'] = self.track_ars_checkbox.is_checked()
+
+
 class SetupWizard(QtWidgets.QWizard):
     """First-run setup wizard for new Picard users."""
 
@@ -438,6 +477,7 @@ class SetupWizard(QtWidgets.QWizard):
         WelcomePage,
         FileOrganizationPage,
         CoverArtPage,
+        MetadataPage,
         UpdatesPage,
     )
 

--- a/test/test_setupwizard.py
+++ b/test/test_setupwizard.py
@@ -1,0 +1,49 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+from test.picardtestcase import PicardTestCase
+
+from picard.config import get_config
+
+from picard.ui.setupwizard import (
+    MetadataPage,
+    SetupWizard,
+)
+
+
+class TestSetupWizardMetadataPage(PicardTestCase):
+    def test_metadata_page_registered(self):
+        self.assertIn(MetadataPage, SetupWizard.PAGES)
+
+    def test_initialize_reflects_config_disabled(self, *args):
+        self._check_roundtrip(initial=False)
+
+    def test_initialize_reflects_config_enabled(self, *args):
+        self._check_roundtrip(initial=True)
+
+    def _check_roundtrip(self, initial):
+        self.set_config_values(setting={'track_ars': initial})
+        config = get_config()
+        page = MetadataPage()
+        try:
+            page.initializePage()
+            self.assertEqual(page.track_ars_checkbox.is_checked(), initial)
+
+            # Toggle and save; config should reflect the new value.
+            page.track_ars_checkbox.set_checked(not initial)
+            page.save_settings(config)
+            self.assertEqual(config.setting['track_ars'], not initial)
+        finally:
+            page.deleteLater()


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add an "Additional Metadata" page to the
  first-run setup wizard that exposes the "Use track relationships" option (`track_ars`)
  as an opt-in, with a plain-language explanation of what it does and why it is off by
  default.

## Problem

* JIRA ticket: PICARD-3396

The `track_ars` ("Use track and release relationships") option is disabled by default.
Enabling it yields much richer per-track metadata (performers, composers, lyricists,
related works), but most users never discover it because it is buried in
Options → Metadata. New users in particular have no easy way to make an informed choice
about it during initial setup.

## Solution

Add a new `MetadataPage` to the setup wizard (`picard/ui/setupwizard.py`), placed between
the Cover Art and Updates pages. It presents a single opt-in `WizardCheckbox` for
`track_ars` with a short, user-facing description that explains:

* what it does — richer per-track credits (performers, composer, lyricist, related works);
* why it is off by default — it downloads more data from the MusicBrainz servers, which
  makes loading albums a little slower and adds some server load.

No internals (API `inc=` parameters, relationship types, infrastructure) are exposed.
The checkbox defaults to the current `track_ars` value (so existing settings are
respected), persists the choice back to `track_ars`, and the setting remains changeable
later under Options → Metadata. The page follows the existing wizard patterns
(`SetupWizardPage`, `initializePage()`/`save_settings()`, `WizardCheckbox`).

Note: release-level relationships (`release_ars`) are already enabled by default and so
are intentionally not surfaced in the wizard; only the track-level opt-in is offered.

A regression test (`test/test_setupwizard.py`) verifies the page is registered in
`SetupWizard.PAGES` and that the config round-trips in both directions.

Verification: `ruff format`, `ruff check`, and `ty check` are clean (no new diagnostics),
and the new tests pass.

<img width="617" height="512" alt="image" src="https://github.com/user-attachments/assets/0ceb90f5-55e0-48ff-94cb-e8dd53b2db2d" />


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The wizard page, user-facing wording, and regression test were drafted with AI
assistance (following the existing wizard patterns), then reviewed and verified by the
author. The decision to enable this as an opt-in was informed by a server-side impact
analysis of enabling track relationships.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
