### PR TITLE
PICARD-700: Add albumartists tag

### DIFF
--- a/picard/const/tags.py
+++ b/picard/const/tags.py
@@ -82,9 +82,24 @@ ALL_TAGS = TagVars(
             'The artists primarily credited on the release. These could be either "standardized" or '
             '"as credited" depending on whether the "Use standardized artist names" metadata option is enabled.'
         ),
+        is_multi_value=True,
+        see_also=('albumartist', '_albumartists'),
+    ),
+    TagVar(
+        'albumartists',
+        shortdesc=N_('Album Artists'),
+        longdesc=N_(
+            'The artists primarily credited on the release. These could be either "standardized" or '
+            '"as credited" depending on whether the "Use standardized artist names" metadata option is enabled.'
+        ),
+        additionaldesc=N_(
+            'This hidden variable is retained for backward compatibility with existing scripts. '
+            'It is never written to files; use the "albumartists" tag instead.'
+        ),
         is_hidden=True,
         is_tag=False,
         is_multi_value=True,
+        see_also=('albumartists',),
     ),
     TagVar(
         'albumartists_countries',

--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -183,6 +183,7 @@ class ASFFile(File):
             'djmixer': 'WM/DJMixer',
             'mixer': 'WM/Mixer',
             'artists': 'WM/ARTISTS',
+            'albumartists': 'WM/ALBUMARTISTS',
             'director': 'WM/Director',
             'work': 'WM/Work',
             'website': 'WM/AuthorURL',

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -227,6 +227,7 @@ class ID3File(File):
             'ASIN': 'asin',
             'MusicMagic Fingerprint': 'musicip_fingerprint',
             'ARTISTS': 'artists',
+            'ALBUMARTISTS': 'albumartists',
             'DIRECTOR': 'director',
             'WORK': 'work',
             'Writer': 'writer',

--- a/picard/formats/mp4.py
+++ b/picard/formats/mp4.py
@@ -160,6 +160,7 @@ class MP4File(File):
             '----:com.apple.iTunes:SCRIPT': 'script',
             '----:com.apple.iTunes:LANGUAGE': 'language',
             '----:com.apple.iTunes:ARTISTS': 'artists',
+            '----:com.apple.iTunes:ALBUMARTISTS': 'albumartists',
             '----:com.apple.iTunes:WORK': 'work',
             '----:com.apple.iTunes:initialkey': 'key',
             '----:com.apple.iTunes:iTunes_CDDB_1': 'itunes_cddb_1',

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -701,6 +701,7 @@ def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = F
     if release:
         m['musicbrainz_albumartistid'] = ids
         m['albumartist'] = credits.name
+        m['albumartists'] = credits.names
         m['albumartistsort'] = credits.sort_name
         m['~albumartists'] = credits.names
         m['~albumartists_sort'] = credits.sort_names

--- a/test/formats/test_asf.py
+++ b/test/formats/test_asf.py
@@ -28,11 +28,13 @@ from test.picardtestcase import (
 )
 
 from picard.formats import asf
+from picard.metadata import Metadata
 
 from .common import (
     CommonTests,
     load_metadata,
     load_raw,
+    save_and_load_metadata,
     save_metadata,
     save_raw,
     skipUnlessTestfile,
@@ -53,6 +55,12 @@ class CommonAsfTests:
             self.assertTrue(fmt.supports_tag('lyrics:lead'))
             for tag in self.replaygain_tags.keys():
                 self.assertTrue(fmt.supports_tag(tag))
+
+        @skipUnlessTestfile
+        def test_albumartists(self):
+            metadata = Metadata({'albumartists': ['Artist1', 'Artist2']})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual(loaded_metadata.getall('albumartists'), ['Artist1', 'Artist2'])
 
         @skipUnlessTestfile
         def test_ci_tags_preserve_case(self):

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -349,6 +349,14 @@ class CommonId3Tests:
             self.assertNotIn('TXXX:Work', raw_metadata)
             self.assertIn('TXXX:WORK', raw_metadata)
 
+        @skipUnlessTestfile
+        def test_albumartists_txxx(self):
+            metadata = Metadata({'albumartists': ['Artist1', 'Artist2']})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual(loaded_metadata.getall('albumartists'), ['Artist1', 'Artist2'])
+            raw_metadata = load_raw(self.filename)
+            self.assertIn('TXXX:ALBUMARTISTS', raw_metadata)
+
         def test_preserve_unchanged_tags_v23(self):
             config.setting['write_id3v23'] = True
             self.test_preserve_unchanged_tags()

--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -103,6 +103,12 @@ class CommonMP4Tests:
             self.assertNotIn('foo', new_metadata)
 
         @skipUnlessTestfile
+        def test_albumartists(self):
+            metadata = Metadata({'albumartists': ['Artist1', 'Artist2']})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual(loaded_metadata.getall('albumartists'), ['Artist1', 'Artist2'])
+
+        @skipUnlessTestfile
         def test_invalid_track_and_discnumber(self):
             metadata = Metadata(
                 {

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -104,6 +104,12 @@ class CommonVorbisTests:
             self._test_unsupported_tags(tags)
 
         @skipUnlessTestfile
+        def test_albumartists(self):
+            metadata = Metadata({'albumartists': ['Artist1', 'Artist2']})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertEqual(loaded_metadata.getall('albumartists'), ['Artist1', 'Artist2'])
+
+        @skipUnlessTestfile
         def test_invalid_metadata_block_picture_nobase64(self):
             metadata = {'metadata_block_picture': 'notbase64'}
             save_raw(self.filename, metadata)

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -119,6 +119,7 @@ class ReleaseTest(MBJSONTest):
         release_to_metadata(self.json_doc, m, a)
         self.assertEqual(m['album'], 'The Dark Side of the Moon')
         self.assertEqual(m['albumartist'], 'Pink Floyd')
+        self.assertEqual(m['albumartists'], 'Pink Floyd')
         self.assertEqual(m['albumartistsort'], 'Pink Floyd')
         self.assertEqual(m['asin'], 'b123')
         self.assertEqual(m['barcode'], '123')
@@ -172,6 +173,7 @@ class ReleaseTest(MBJSONTest):
         release_to_metadata(self.json_doc, m, a)
         self.assertEqual(m['album'], 'The Dark Side of the Moon')
         self.assertEqual(m['albumartist'], 'Pink Floyd')
+        self.assertEqual(m['albumartists'], 'Pink Floyd')
         self.assertEqual(m['albumartistsort'], 'Pink Floyd')
         self.assertEqual(m['asin'], 'b123')
         self.assertEqual(m['barcode'], '123')
@@ -485,6 +487,7 @@ class RecordingMultiArtistsTest1(MBJSONTest):
         self.assertEqual('Ed Sheeran feat. Meek Mill & A Boogie Wit da Hoodie', m['albumartist'])
         self.assertEqual('Sheeran, Ed feat. Meek Mill & Boogie Wit da Hoodie, A', m['albumartistsort'])
         self.assertEqual(['Ed Sheeran', 'Meek Mill', 'A Boogie Wit da Hoodie'], m.getall('~albumartists'))
+        self.assertEqual(m.getall('~albumartists'), m.getall('albumartists'))
         self.assertEqual(['Sheeran, Ed', 'Meek Mill', 'Boogie Wit da Hoodie, A'], m.getall('~albumartists_sort'))
         self.assertEqual(['GB', 'US', 'US'], m.getall('~albumartists_countries'))
         self.assertEqual(


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Adds a first-class, multi-valued `albumartists` tag, written to files by
default, mirroring the existing `artists` tag for track artists.

## Problem

* JIRA ticket: PICARD-700

Picard already exposes the individual album artists internally as the hidden
`~albumartists` variable, but never writes them to files. This means albums
with multiple album artists can only be stored as the joined `albumartist`
string, which cannot be reliably split back into individual artists.

Several players read a dedicated `ALBUMARTISTS` tag and recommend writing it:

* Kodi reads `ALBUMARTISTS` (Vorbis/ID3/APE/MP4); its wiki tells users to add a
  script to write it because Picard does not do so yet.
* Navidrome maps `albumartists` directly and prefers it over splitting the
  singular `albumartist` string.
* Jellyfin reads it when the "Prefer nonstandard artists tag" library option is
  enabled (otherwise it splits the singular tag).

## Solution

Promotes `albumartists` to a real, multi-valued written tag, populated by
default just like `artists`. Tag mapping follows the existing `artists` tag:

* Vorbis (FLAC/Ogg): `ALBUMARTISTS` (native)
* ID3 (MP3): `TXXX:ALBUMARTISTS`
* MP4: `----:com.apple.iTunes:ALBUMARTISTS`
* ASF/WMA: `WM/ALBUMARTISTS`

The hidden `~albumartists` variable is kept for backward compatibility with
existing scripts using `%_albumartists%`. It is never written to files, so it
cannot drift out of sync with the new tag.

Scope note: only the plural `albumartists` (names) is added. No plural sort tag,
since sorting uses the singular `ALBUMARTISTSORT` and there are no consumers for
a plural one. Per-artist IDs are already covered by `MUSICBRAINZ_ALBUMARTISTID`.

Open question: for ASF/WMA I used `WM/ALBUMARTISTS` (all caps) to match the
existing `WM/ARTISTS`. The sibling official attributes use PascalCase
(`WM/AlbumArtist`, `WM/AlbumArtistSortOrder`), so `WM/AlbumArtists` would also
be defensible — happy to change it if preferred.

Tests cover round-trip for all four formats. The full test suite passes.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI assistance was used to investigate the existing tag handling, design the
backward-compatible approach for `~albumartists`, implement the format mappings
and tests, and verify against downstream player behaviour. All changes were
reviewed by the author.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
