### PR TITLE
PICARD-2442: Fix theme switch to Default staying on the last applied theme

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -381,6 +381,17 @@ class Tagger(QtWidgets.QApplication):
 
         # log interesting environment variables
         log.debug("Qt Env.: %s", " ".join("%s=%r" % (k, v) for k, v in os.environ.items() if k.startswith('QT_')))
+        desktop_env_vars = (
+            'XDG_CURRENT_DESKTOP',
+            'XDG_SESSION_DESKTOP',
+            'XDG_SESSION_TYPE',
+            'DESKTOP_SESSION',
+            'KDE_FULL_SESSION',
+        )
+        log.debug(
+            "Desktop Env.: %s",
+            " ".join("%s=%r" % (k, os.environ[k]) for k in desktop_env_vars if k in os.environ),
+        )
 
     def _init_gettext(self, config, localedir):
         """Initialize gettext"""

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -275,6 +275,13 @@ class BaseTheme(QtCore.QObject):
         self._accent_color_is_system: bool = False
         self._applying_theme: bool = False
         self._dark_mode_strategies: list[Callable[[], bool]] = []
+        # The OS color scheme as reported by Qt's style hints, captured at
+        # setup *before* Picard ever calls setColorScheme(). Calling
+        # setColorScheme() (done by apply_theme) mutates what colorScheme()
+        # subsequently returns, so we must not read it back to detect the OS
+        # theme once a runtime theme switch happened. Refreshed on genuine OS
+        # changes via the colorSchemeChanged signal.
+        self._system_color_scheme: QtCore.Qt.ColorScheme | None = None
 
     def setup(self, app: QtWidgets.QApplication) -> None:
         self._app = app
@@ -293,6 +300,10 @@ class BaseTheme(QtCore.QObject):
         )
 
         if style_hints := get_style_hints():
+            # Capture the OS color scheme now, before apply_theme() calls
+            # setColorScheme() below and thereby overwrites what colorScheme()
+            # reports. This cached value is what get_system_theme() trusts.
+            self._system_color_scheme = style_hints.colorScheme()
             style_hints.colorSchemeChanged.connect(self._on_color_scheme_changed)
 
         # Determine the system accent color before applying the theme,
@@ -330,6 +341,12 @@ class BaseTheme(QtCore.QObject):
     def _on_color_scheme_changed(self, color_scheme: QtCore.Qt.ColorScheme) -> None:
         if self._applying_theme:
             return
+        # This fired outside of our own apply_theme() (Qt delivers the echo
+        # from our setColorScheme() synchronously, while _applying_theme is
+        # still set, so it is filtered above). Treat it as a genuine OS change
+        # and refresh the cached OS scheme so get_system_theme() keeps tracking
+        # the operating system.
+        self._system_color_scheme = color_scheme
         log.debug_if(
             DebugOpt.THEME,
             "Theme: system colorSchemeChanged signal received: %s",
@@ -397,14 +414,15 @@ class BaseTheme(QtCore.QObject):
         if any(strategy() for strategy in self._dark_mode_strategies):
             return UiTheme.DARK
 
-        # Ask Qt directly for the OS color scheme when available (Qt 6.5+).
-        # Unlike app.palette(), this reflects the operating system setting and
-        # is not affected by any palette Picard applied at runtime.
-        # get_style_hints() only returns non-None when setColorScheme (Qt 6.8+)
-        # is present, which implies colorScheme() (Qt 6.5+) is available too.
-        style_hints = get_style_hints()
-        if style_hints is not None:
-            color_scheme = style_hints.colorScheme()
+        # Use the OS color scheme captured at setup (and refreshed on genuine
+        # OS changes via colorSchemeChanged), NOT the live colorScheme().
+        # Picard calls setColorScheme() when applying a theme, which overwrites
+        # what colorScheme() reports; reading it back here would make us detect
+        # the *last applied* theme rather than the operating system's theme.
+        # See PICARD-2442: switching Dark -> Default used to stay dark because
+        # the live colorScheme() still reported the Dark value Picard had set.
+        color_scheme = self._system_color_scheme
+        if color_scheme is not None:
             if color_scheme == QtCore.Qt.ColorScheme.Dark:
                 log.debug("System color scheme reported as dark.")
                 return UiTheme.DARK

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -461,7 +461,7 @@ def test_get_system_theme_ignores_runtime_applied_dark_palette(monkeypatch):
 
 
 def test_get_system_theme_uses_style_hints_color_scheme(monkeypatch):
-    """When available, get_system_theme should trust the OS color scheme hint.
+    """When available, get_system_theme should trust the cached OS color scheme.
 
     Even if the live application palette is dark (runtime override), a light OS
     color scheme must be reported as LIGHT.
@@ -485,11 +485,100 @@ def test_get_system_theme_uses_style_hints_color_scheme(monkeypatch):
 
     theme = theme_mod.GenericTheme()
     theme._dark_mode_strategies = [lambda: False]
+    # setup() would capture this; set it directly for this focused unit test.
+    theme._system_color_scheme = QtCore.Qt.ColorScheme.Light
 
     # Live palette is dark, but the OS reports a light scheme.
     app = _AppWithStyle(live_dark=True, standard_palette=_make_light_standard_palette())
 
     assert theme.get_system_theme(app) == theme_mod.UiTheme.LIGHT
+
+
+def test_get_system_theme_ignores_color_scheme_polluted_by_apply_theme(monkeypatch):
+    """Regression test for PICARD-2442 follow-up (rdswift report).
+
+    Reproduces: on a light system, select the Dark theme, then switch the
+    option back to "Default". The display wrongly stayed dark until restart.
+
+    Root cause: ``apply_theme()`` calls ``setColorScheme()``, which mutates
+    what ``QStyleHints.colorScheme()`` subsequently returns. ``get_system_theme()``
+    then read that polluted live value back and reported DARK, so
+    ``apply_theme(DARK)`` early-returned and nothing switched back to light.
+
+    The fix caches the OS color scheme captured at setup (before any
+    ``setColorScheme()`` call) and refreshes it only on genuine OS changes, so
+    ``get_system_theme()`` keeps reporting the true OS theme (LIGHT here).
+    """
+
+    class _StyleHints:
+        """Models real Qt: setColorScheme() changes what colorScheme() returns."""
+
+        colorSchemeChanged = MagicMock()
+
+        def __init__(self, scheme):
+            self._scheme = scheme
+
+        def setColorScheme(self, scheme):
+            self._scheme = scheme
+
+        def colorScheme(self):
+            return self._scheme
+
+    # OS theme is light.
+    style_hints = _StyleHints(QtCore.Qt.ColorScheme.Light)
+    monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: style_hints)
+
+    theme = theme_mod.GenericTheme()
+    theme._dark_mode_strategies = [lambda: False]
+
+    # Simulate the capture that setup() performs before applying any theme.
+    theme._system_color_scheme = style_hints.colorScheme()
+
+    app = _AppWithStyle(live_dark=False, standard_palette=_make_light_standard_palette())
+
+    # User selects Dark: apply_theme() calls setColorScheme(Dark), polluting
+    # the live colorScheme() value.
+    theme.apply_theme(app, theme_mod.UiTheme.DARK)
+    assert style_hints.colorScheme() == QtCore.Qt.ColorScheme.Dark
+
+    # User switches back to Default: get_system_theme() must still report the
+    # true OS theme (light), not the polluted Dark value.
+    assert theme.get_system_theme(app) == theme_mod.UiTheme.LIGHT
+
+
+def test_on_color_scheme_changed_refreshes_cached_os_scheme(monkeypatch):
+    """A genuine OS color scheme change must update the cached OS scheme.
+
+    Ensures get_system_theme() continues to track the OS after the user
+    changes their desktop theme while Picard is running.
+    """
+
+    class _StyleHints:
+        colorSchemeChanged = MagicMock()
+
+        def __init__(self, scheme):
+            self._scheme = scheme
+
+        def setColorScheme(self, scheme):
+            self._scheme = scheme
+
+        def colorScheme(self):
+            return self._scheme
+
+    style_hints = _StyleHints(QtCore.Qt.ColorScheme.Light)
+    monkeypatch.setattr(QtGui.QGuiApplication, "styleHints", lambda: style_hints)
+
+    theme = theme_mod.GenericTheme()
+    theme._dark_mode_strategies = [lambda: False]
+    theme._system_color_scheme = QtCore.Qt.ColorScheme.Light
+    theme._app = _AppWithStyle(live_dark=False, standard_palette=_make_light_standard_palette())
+
+    # OS switches to dark: the signal fires outside of apply_theme().
+    theme._applying_theme = False
+    theme._on_color_scheme_changed(QtCore.Qt.ColorScheme.Dark)
+
+    assert theme._system_color_scheme == QtCore.Qt.ColorScheme.Dark
+    assert theme.get_system_theme(theme._app) == theme_mod.UiTheme.DARK
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Switching the UI theme option from Dark (or Light) back to Default had no effect until restart on Qt 6.8+. This makes the switch take effect immediately.

## Problem

* JIRA ticket: PICARD-2442

Follow-up to dfd21e3 (PICARD-2442). @rdswift reported the issue was still
reproducible on the current master (Linux Mint / X-Cinnamon, Qt 6.11, `qt5ct`
platform theme): starting on the light system theme, selecting **Dark**, then
switching back to **Default** left the UI stuck on dark until the next restart.

His debug log showed `get_system_theme()` reporting the system scheme as
*dark* right after a Dark theme had been applied, even though the OS theme was
light — so `apply_theme()` early-returned and nothing switched back.

Root cause: `apply_theme()` calls `QStyleHints.setColorScheme()`, which mutates
what `QStyleHints.colorScheme()` subsequently returns. When the option is set to
Default, `get_system_theme()` read `colorScheme()` back to detect the OS theme,
but it now reported the *last theme Picard applied* rather than the operating
system's theme. A restart cleared this, which is why it only worked after
restarting.

This only affects Qt 6.8+ (where `setColorScheme` exists); on older Qt the
runtime theme-switching path is not used.

## Solution

Capture the OS color scheme once at setup, **before** Picard ever calls
`setColorScheme()`, and refresh it only on genuine `colorSchemeChanged` signals.
`get_system_theme()` now trusts this cached value instead of the live,
pollutable `colorScheme()`.

The self-triggered `colorSchemeChanged` echo from our own `setColorScheme()`
call is delivered synchronously (verified with a standalone script on Qt
6.11/xcb), so it is already filtered by the existing `_applying_theme` guard and
does not re-pollute the cache.

Includes regression tests covering the pollution scenario (Dark → Default) and
continued tracking of genuine runtime OS color-scheme changes.

A separate commit adds the desktop/session environment variables
(`XDG_CURRENT_DESKTOP`, etc.) to the startup debug log, since the dark-mode
detection strategies depend on them and they make theme issues easier to
diagnose from a user's log (this is what pinpointed the X-Cinnamon case).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The root-cause analysis, the fix, the regression tests, and a standalone
verification script (used to confirm the `setColorScheme`/`colorScheme`
pollution and that the signal echo is synchronous) were developed with
significant AI assistance, reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
