### PR TITLE
Use QSignalBlocker context manager consistently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,25 @@ class MyWidget(QWidget):
         self.value_changed.emit("new value")
 ```
 
+Use the `QSignalBlocker` context manager to suppress signals temporarily,
+rather than manual `blockSignals(True)`/`blockSignals(False)` calls. It is
+exception-safe (signals are always unblocked, even if an exception is raised)
+and more concise.
+
+```python
+from PyQt6.QtCore import QSignalBlocker
+
+
+# ❌ Manual, not exception-safe
+widget.blockSignals(True)
+widget.setChecked(True)
+widget.blockSignals(False)
+
+# ✅ Context manager
+with QSignalBlocker(widget):
+    widget.setChecked(True)
+```
+
 ### Readability
 - Use descriptive names
 - Comment complex logic

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -296,9 +296,8 @@ class InstallPluginDialog(PicardDialog):
             self.local_ref_edit.clear()
             self.no_git_checkbox.setEnabled(False)
             # Block signals to avoid re-triggering _validate_local_path
-            self.no_git_checkbox.blockSignals(True)
-            self.no_git_checkbox.setChecked(False)
-            self.no_git_checkbox.blockSignals(False)
+            with QtCore.QSignalBlocker(self.no_git_checkbox):
+                self.no_git_checkbox.setChecked(False)
             self.local_status_label.setStyleSheet("color: %s;" % interface_colors.get_color('log_warning'))
             self.local_status_label.setText(
                 _(

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -1055,14 +1055,13 @@ class AttachedProfilesDialog(PicardDialog):
     def _on_selection_changed(self) -> None:
         if not self.ui.profile_list.selectedItems():
             # Never allow empty selection
-            self.ui.profile_list.blockSignals(True)
-            if len(self._last_selection) == 1:
-                self._last_selection[0].setSelected(True)
-            else:
-                first = self.ui.profile_list.topLevelItem(0)
-                first.setSelected(True)
-                self._last_selection = [first]
-            self.ui.profile_list.blockSignals(False)
+            with QtCore.QSignalBlocker(self.ui.profile_list):
+                if len(self._last_selection) == 1:
+                    self._last_selection[0].setSelected(True)
+                else:
+                    first = self.ui.profile_list.topLevelItem(0)
+                    first.setSelected(True)
+                    self._last_selection = [first]
             return
         self._last_selection = list(self.ui.profile_list.selectedItems())
         self._populate_settings_tree()
@@ -1156,9 +1155,8 @@ class AttachedProfilesDialog(PicardDialog):
         correct_state = self._compute_check_state(pkey, selected_ids)
         self._check_states[pkey] = correct_state
         if item.checkState(0) != correct_state:
-            self.ui.settings_tree.blockSignals(True)
-            item.setCheckState(0, correct_state)
-            self.ui.settings_tree.blockSignals(False)
+            with QtCore.QSignalBlocker(self.ui.settings_tree):
+                item.setCheckState(0, correct_state)
         item.setToolTip(0, self._build_tooltip(pkey))
         self._update_profile_markers(pkey)
         self.profile_page.update_config_overrides()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -160,26 +160,22 @@ class InterfaceOptionsPage(OptionsPage):
     def load(self):
         # Don't display the multi-selection warning when loading values.
         # This is required because loading a different option profile could trigger the warning.
-        self.ui.allow_multi_dirs_selection.blockSignals(True)
-
-        config = get_config()
-        self.ui.toolbar_show_labels.setChecked(config.setting['toolbar_show_labels'])
-        self.ui.allow_multi_dirs_selection.setChecked(config.setting['allow_multi_dirs_selection'])
-        self.ui.show_menu_icons.setChecked(config.setting['show_menu_icons'])
-        self.ui.new_user_dialog.setChecked(config.setting['show_new_user_dialog'])
-        self.ui.quit_confirmation.setChecked(config.setting['quit_confirmation'])
-        self.ui.file_save_warning.setChecked(config.setting['file_save_warning'])
-        current_ui_language = config.setting['ui_language']
-        self.ui.ui_language.setCurrentIndex(self.ui.ui_language.findData(current_ui_language))
-        self.ui.filebrowser_horizontal_autoscroll.setChecked(config.setting['filebrowser_horizontal_autoscroll'])
-        self.ui.starting_directory.setChecked(config.setting['starting_directory'])
-        self.ui.starting_directory_path.setText(config.setting['starting_directory_path'])
-        current_theme = UiTheme(config.setting['ui_theme'])
-        with QtCore.QSignalBlocker(self.ui.ui_theme):
-            self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(current_theme))
-
-        # re-enable the multi-selection warning
-        self.ui.allow_multi_dirs_selection.blockSignals(False)
+        with QtCore.QSignalBlocker(self.ui.allow_multi_dirs_selection):
+            config = get_config()
+            self.ui.toolbar_show_labels.setChecked(config.setting['toolbar_show_labels'])
+            self.ui.allow_multi_dirs_selection.setChecked(config.setting['allow_multi_dirs_selection'])
+            self.ui.show_menu_icons.setChecked(config.setting['show_menu_icons'])
+            self.ui.new_user_dialog.setChecked(config.setting['show_new_user_dialog'])
+            self.ui.quit_confirmation.setChecked(config.setting['quit_confirmation'])
+            self.ui.file_save_warning.setChecked(config.setting['file_save_warning'])
+            current_ui_language = config.setting['ui_language']
+            self.ui.ui_language.setCurrentIndex(self.ui.ui_language.findData(current_ui_language))
+            self.ui.filebrowser_horizontal_autoscroll.setChecked(config.setting['filebrowser_horizontal_autoscroll'])
+            self.ui.starting_directory.setChecked(config.setting['starting_directory'])
+            self.ui.starting_directory_path.setText(config.setting['starting_directory_path'])
+            current_theme = UiTheme(config.setting['ui_theme'])
+            with QtCore.QSignalBlocker(self.ui.ui_theme):
+                self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(current_theme))
 
     def save(self):
         config = get_config()

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -609,9 +609,8 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
             idx (int): New index position
         """
         widget = self.ui.preset_naming_scripts
-        widget.blockSignals(True)
-        widget.setCurrentIndex(idx)
-        widget.blockSignals(False)
+        with QtCore.QSignalBlocker(widget):
+            widget.setCurrentIndex(idx)
         self.selected_script_index = idx
         self.signal_index_changed.emit()
 
@@ -838,9 +837,8 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         if confirmation_dialog(self, _("Are you sure that you want to delete the script?")):
             widget = self.ui.preset_naming_scripts
             idx = widget.currentIndex()
-            widget.blockSignals(True)
-            widget.removeItem(idx)
-            widget.blockSignals(False)
+            with QtCore.QSignalBlocker(widget):
+                widget.removeItem(idx)
             if idx >= widget.count():
                 idx = widget.count() - 1
             self._set_combobox_index(idx)

--- a/picard/ui/scripteditor/examples.py
+++ b/picard/ui/scripteditor/examples.py
@@ -22,6 +22,8 @@ from html import escape
 import os.path
 import random
 
+from PyQt6.QtCore import QSignalBlocker
+
 from picard.config import get_config
 from picard.file import File
 from picard.i18n import gettext as _
@@ -169,9 +171,8 @@ class ScriptEditorExamples:
         """
         if source.currentRow() != current_row:
             current_row = source.currentRow()
-            target.blockSignals(True)
-            target.setCurrentRow(current_row)
-            target.blockSignals(False)
+            with QSignalBlocker(target):
+                target.setCurrentRow(current_row)
 
     @classmethod
     def get_notes_text(cls):

--- a/picard/ui/scripteditor/utils.py
+++ b/picard/ui/scripteditor/utils.py
@@ -21,6 +21,7 @@
 from functools import partial
 
 from PyQt6 import QtWidgets
+from PyQt6.QtCore import QSignalBlocker
 from PyQt6.QtGui import QPalette
 
 from picard.i18n import gettext as _
@@ -74,9 +75,8 @@ def synchronize_vertical_scrollbars(widgets):
     theme.theme_changed.connect(_apply_highlight_stylesheet)
 
     def _sync_scrollbar_vert(widget, value):
-        widget.blockSignals(True)
-        widget.verticalScrollBar().setValue(value)
-        widget.blockSignals(False)
+        with QSignalBlocker(widget):
+            widget.verticalScrollBar().setValue(value)
 
     widget_set = set(widgets)
     for widget in widget_set:
@@ -95,20 +95,19 @@ def populate_script_selection_combo_box(naming_scripts, selected_script_id, comb
     Returns:
         int: The index of the currently selected script
     """
-    combo_box.blockSignals(True)
-    combo_box.clear()
+    with QSignalBlocker(combo_box):
+        combo_box.clear()
 
-    def _add_and_check(idx, count, title, item):
-        combo_box.addItem(title, item)
-        if item['id'] == selected_script_id:
-            idx = count
-        return idx
+        def _add_and_check(idx, count, title, item):
+            combo_box.addItem(title, item)
+            if item['id'] == selected_script_id:
+                idx = count
+            return idx
 
-    idx = 0
-    count = -1
-    for count, (_id, naming_script) in enumerate(sorted(naming_scripts.items(), key=lambda item: item[1]['title'])):
-        idx = _add_and_check(idx, count, naming_script['title'], naming_script)
+        idx = 0
+        count = -1
+        for count, (_id, naming_script) in enumerate(sorted(naming_scripts.items(), key=lambda item: item[1]['title'])):
+            idx = _add_and_check(idx, count, naming_script['title'], naming_script)
 
-    combo_box.setCurrentIndex(idx)
-    combo_box.blockSignals(False)
+        combo_box.setCurrentIndex(idx)
     return idx


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other

Replace all manual `blockSignals(True)`/`blockSignals(False)` pairs with
the `QSignalBlocker` context manager. This is exception-safe (signals are
always unblocked even if an exception occurs) and more concise.

9 occurrences across 6 files converted. Zero `blockSignals` calls remain.

## AI Usage

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)
