### PR TITLE
PICARD-3397: Dynamic language switching (no restart required)

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -206,7 +206,7 @@ class Album(MetadataItem):
         if discid:
             self._discids.add(discid)
         self._after_load_callbacks: list[tuple[Callable[[], Any], bool]] = []
-        self.unmatched_files = Cluster(_("Unmatched Files"), special=True, related_album=self, hide_if_empty=True)
+        self.unmatched_files = Cluster(N_("Unmatched Files"), special=True, related_album=self, hide_if_empty=True)
         self.unmatched_files.metadata_images_changed.connect(self.update_metadata_images)
         self.status = AlbumStatus.NONE
         self._album_artists = []

--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -349,7 +349,10 @@ class Cluster(FileList):
 
     def column(self, column: str) -> str:
         if column == 'title':
-            return '%s (%d)' % (self.metadata['album'], len(self.files))
+            name = self.metadata['album']
+            if self.special:
+                name = _(name)
+            return '%s (%d)' % (name, len(self.files))
         elif self.special and column in {'~length', 'album', 'covercount'}:
             return ''
         elif column == '~length':
@@ -513,7 +516,7 @@ class UnclusteredFiles(Cluster):
     """Special cluster for 'Unmatched Files' which have not been clustered."""
 
     def __init__(self):
-        super().__init__(_("Unclustered Files"), special=True)
+        super().__init__(N_("Unclustered Files"), special=True)
 
     def add_files(self, files, new_album=True):
         super().add_files(files, new_album=new_album)
@@ -552,7 +555,7 @@ class ClusterList(list, Item):
 
     def __init__(self, name=None):
         if not name:
-            self._name = _('Clusters')
+            self._name = N_('Clusters')
         else:
             self._name = name
         super().__init__()
@@ -567,7 +570,7 @@ class ClusterList(list, Item):
 
     def column(self, column: str) -> str:
         if column == 'title':
-            return '%s (%d)' % (self._name, len(self))
+            return '%s (%d)' % (_(self._name), len(self))
         else:
             return ''
 

--- a/picard/i18n/__init__.py
+++ b/picard/i18n/__init__.py
@@ -21,6 +21,11 @@
 
 from collections.abc import Callable
 
+from PyQt6.QtCore import (
+    QObject,
+    pyqtSignal,
+)
+
 from picard.i18n.collate import (
     setup_collator,
     sort_key,
@@ -38,6 +43,21 @@ from picard.i18n.gettext import (
 )
 
 
+class _I18nSignals(QObject):
+    """Signals emitted by the i18n subsystem."""
+
+    # Emitted after the UI language has been switched at runtime.
+    language_changed = pyqtSignal()
+
+
+_signals = _I18nSignals()
+language_changed = _signals.language_changed
+
+
+# Store the localedir used at startup so switch_language() can reuse it.
+_localedir: str | None = None
+
+
 __all__ = [
     'N_',
     '_',
@@ -45,14 +65,18 @@ __all__ = [
     'gettext_attributes',
     'gettext_constants',
     'gettext_countries',
+    'language_changed',
     'ngettext',
     'pgettext_attributes',
     'setup_i18n',
     'sort_key',
+    'switch_language',
 ]
 
 
 def setup_i18n(localedir: str | None, ui_language: str | None = None, logger: Callable | None = None):
+    global _localedir
+    _localedir = localedir
     logger = _init_logger(logger)
 
     # Setup gettext translations
@@ -60,6 +84,30 @@ def setup_i18n(localedir: str | None, ui_language: str | None = None, logger: Ca
 
     # Setup collator
     setup_collator(logger)
+
+
+def switch_language(ui_language: str | None, logger: Callable | None = None):
+    """Switch the UI language at runtime.
+
+    Reloads gettext translations, refreshes the collator, and emits
+    the language_changed signal so UI components can retranslate.
+
+    Args:
+        ui_language: The new language code (e.g. 'de', 'fr', 'ja'),
+                     or empty string / None for system default.
+        logger: Optional logging callable.
+    """
+    logger = _init_logger(logger)
+    logger("Switching UI language to: %r", ui_language)
+
+    # Reload gettext translations
+    setup_gettext(_localedir, ui_language or None, logger)
+
+    # Refresh collator for new locale
+    setup_collator(logger)
+
+    # Notify all connected UI components
+    language_changed.emit()
 
 
 def _init_logger(logger: Callable | None) -> Callable:

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -287,3 +287,68 @@ def gettext_countries(message: str) -> str:
 
 def gettext_constants(message: str) -> str:
     return _translation['constants'].gettext(message)
+
+
+# Dev utility: trace all gettext calls to a file.
+# Usage: from picard.i18n.gettext import enable_trace; enable_trace()
+# Zero overhead when not enabled (functions remain unwrapped).
+_trace_file = None
+
+
+def _make_traced(fn, domain):
+    """Wrap a gettext function to log source → result to the trace file."""
+
+    def traced(*args, **kwargs):
+        result = fn(*args, **kwargs)
+        source = args[0] if args else ''
+        locale_name = QLocale().name()
+        _trace_file.write(f"{locale_name} [{domain}]: {source!r} → {result!r}\n")
+        _trace_file.flush()
+        return result
+
+    traced.__wrapped__ = fn
+    return traced
+
+
+def enable_trace(path):
+    """Enable tracing of all gettext calls to a file.
+
+    Patches the module-level gettext functions to log every call.
+    """
+    global _trace_file, gettext, ngettext, gettext_attributes, pgettext_attributes
+    global gettext_countries, gettext_constants, _
+    _trace_file = open(path, 'w', encoding='utf-8')
+    gettext = _make_traced(gettext, 'main')
+    _ = gettext
+    ngettext = _make_traced(ngettext, 'main')
+    gettext_attributes = _make_traced(gettext_attributes, 'attributes')
+    pgettext_attributes = _make_traced(pgettext_attributes, 'attributes')
+    gettext_countries = _make_traced(gettext_countries, 'countries')
+    gettext_constants = _make_traced(gettext_constants, 'constants')
+
+
+def disable_trace():
+    """Disable tracing and restore original functions."""
+    global _trace_file, gettext, ngettext, gettext_attributes, pgettext_attributes
+    global gettext_countries, gettext_constants, _
+    if _trace_file:
+        _trace_file.close()
+        _trace_file = None
+    for name in (
+        'gettext',
+        'ngettext',
+        'gettext_attributes',
+        'pgettext_attributes',
+        'gettext_countries',
+        'gettext_constants',
+    ):
+        fn = globals()[name]
+        if hasattr(fn, '__wrapped__'):
+            globals()[name] = fn.__wrapped__
+    _ = gettext
+
+
+# Enable trace via env var: PICARD_I18N_TRACE=/path/to/trace.log
+_trace_path = os.environ.get('PICARD_I18N_TRACE')
+if _trace_path:
+    enable_trace(_trace_path)

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -289,49 +289,165 @@ def gettext_constants(message: str) -> str:
     return _translation['constants'].gettext(message)
 
 
-# Dev utility: trace all gettext calls to a file.
-# Usage: from picard.i18n.gettext import enable_trace; enable_trace()
+# Dev utility: trace all gettext calls to a file with caller location.
+# Purpose: detect strings that are translated at startup but NOT re-translated
+# after a language switch (i.e., missing dynamic retranslation code).
+#
+# Usage: PICARD_I18N_TRACE=/path/to/trace.log picard
+#
+# Log format: PREFIX CALLER_FILE:LINE SOURCE_STRING
+#   - "n:" prefix means N_() was called (string marked for extraction only)
+#   - "LANG:" prefix means _() was called (actual translation lookup)
+#
+# On exit, a report is appended listing strings that were translated in one
+# locale phase but not in the subsequent phase (missing retranslation).
+# Strings without an available translation (untranslated) are excluded from
+# the report since those are a Weblate issue, not a code issue.
+#
 # Zero overhead when not enabled (functions remain unwrapped).
+
 _trace_file = None
+_trace_phases = []  # list of (locale, set_of_strings)
+_trace_current_locale = None
+_trace_current_strings = None
+_trace_has_translation = set()  # strings that have a known translation (source != result)
 
 
-def _make_traced(fn, domain):
-    """Wrap a gettext function to log source → result to the trace file."""
+def _trace_switch_phase(locale):
+    """Track locale phases for the exit report."""
+    global _trace_current_locale, _trace_current_strings
+    if locale != _trace_current_locale:
+        if _trace_current_locale is not None and _trace_current_strings:
+            _trace_phases.append((_trace_current_locale, _trace_current_strings))
+        _trace_current_locale = locale
+        _trace_current_strings = set()
+
+
+def _make_traced(fn, domain, prefix_fn):
+    """Wrap a gettext function to log every call with caller location."""
+    import traceback
 
     def traced(*args, **kwargs):
         result = fn(*args, **kwargs)
         source = args[0] if args else ''
-        locale_name = QLocale().name()
-        _trace_file.write(f"{locale_name} [{domain}]: {source!r} → {result!r}\n")
-        _trace_file.flush()
+        if source:
+            locale = QLocale().name()
+            prefix = prefix_fn()
+            stack = traceback.extract_stack(limit=3)
+            if stack:
+                frame = stack[0]
+                caller = f"{frame.filename}:{frame.lineno}"
+            else:
+                caller = "??:0"
+            _trace_file.write(f"{prefix} {caller} {source!r}\n")
+            _trace_file.flush()
+            # Track for exit report
+            _trace_switch_phase(locale)
+            if _trace_current_strings is not None:
+                _trace_current_strings.add(source)
+            # Track if this string actually has a translation
+            if source != result:
+                _trace_has_translation.add(source)
         return result
 
     traced.__wrapped__ = fn
     return traced
 
 
+def _make_traced_n(fn):
+    """Wrap N_() to log with 'n:' prefix."""
+    import traceback
+
+    def traced(message):
+        result = fn(message)
+        if message:
+            stack = traceback.extract_stack(limit=3)
+            if stack:
+                frame = stack[0]
+                caller = f"{frame.filename}:{frame.lineno}"
+            else:
+                caller = "??:0"
+            _trace_file.write(f"n: {caller} {message!r}\n")
+            _trace_file.flush()
+        return result
+
+    traced.__wrapped__ = fn
+    return traced
+
+
+def _trace_exit_report():
+    """Write exit report: strings missing retranslation after locale switch."""
+    global _trace_current_locale, _trace_current_strings
+    if not _trace_file:
+        return
+    # Flush the last phase
+    if _trace_current_locale and _trace_current_strings:
+        _trace_phases.append((_trace_current_locale, _trace_current_strings))
+
+    if len(_trace_phases) < 2:
+        _trace_file.write("\n=== NO LANGUAGE SWITCH DETECTED ===\n")
+        _trace_file.flush()
+        return
+
+    _trace_file.write("\n=== EXIT REPORT: MISSING RETRANSLATION ===\n")
+    _trace_file.write("(Only strings with known translations are shown.\n")
+    _trace_file.write(" Untranslated strings are a Weblate issue, not a code issue.)\n\n")
+
+    for i in range(len(_trace_phases) - 1):
+        prev_locale, prev_strings = _trace_phases[i]
+        next_locale, next_strings = _trace_phases[i + 1]
+        # Strings in prev phase but not in next phase
+        missing = prev_strings - next_strings
+        # Only report strings that have a known translation (source != result at some point)
+        missing_with_translation = missing & _trace_has_translation
+        if missing_with_translation:
+            _trace_file.write(
+                f"--- Strings translated in {prev_locale} but NOT re-translated in {next_locale} "
+                f"({len(missing_with_translation)} strings) ---\n"
+            )
+            for s in sorted(missing_with_translation):
+                _trace_file.write(f"  {s!r}\n")
+            _trace_file.write("\n")
+
+    _trace_file.flush()
+
+
 def enable_trace(path):
     """Enable tracing of all gettext calls to a file.
 
-    Patches the module-level gettext functions to log every call.
+    Patches the module-level gettext functions to log every call with
+    the caller's file and line number. N_() calls are prefixed with "n:",
+    _() calls with the current locale (e.g. "fr_FR:").
+
+    On exit, appends a report of strings missing retranslation.
     """
     global _trace_file, gettext, ngettext, gettext_attributes, pgettext_attributes
-    global gettext_countries, gettext_constants, _
+    global gettext_countries, gettext_constants, _, N_
+
+    import atexit
+
     _trace_file = open(path, 'w', encoding='utf-8')
-    gettext = _make_traced(gettext, 'main')
+    atexit.register(_trace_exit_report)
+
+    def _locale_prefix():
+        return QLocale().name() + ':'
+
+    gettext = _make_traced(gettext, 'main', _locale_prefix)
     _ = gettext
-    ngettext = _make_traced(ngettext, 'main')
-    gettext_attributes = _make_traced(gettext_attributes, 'attributes')
-    pgettext_attributes = _make_traced(pgettext_attributes, 'attributes')
-    gettext_countries = _make_traced(gettext_countries, 'countries')
-    gettext_constants = _make_traced(gettext_constants, 'constants')
+    ngettext = _make_traced(ngettext, 'main', _locale_prefix)
+    gettext_attributes = _make_traced(gettext_attributes, 'attributes', _locale_prefix)
+    pgettext_attributes = _make_traced(pgettext_attributes, 'attributes', _locale_prefix)
+    gettext_countries = _make_traced(gettext_countries, 'countries', _locale_prefix)
+    gettext_constants = _make_traced(gettext_constants, 'constants', _locale_prefix)
+    N_ = _make_traced_n(N_)
 
 
 def disable_trace():
     """Disable tracing and restore original functions."""
     global _trace_file, gettext, ngettext, gettext_attributes, pgettext_attributes
-    global gettext_countries, gettext_constants, _
+    global gettext_countries, gettext_constants, _, N_
     if _trace_file:
+        _trace_exit_report()
         _trace_file.close()
         _trace_file = None
     for name in (
@@ -341,6 +457,7 @@ def disable_trace():
         'pgettext_attributes',
         'gettext_countries',
         'gettext_constants',
+        'N_',
     ):
         fn = globals()[name]
         if hasattr(fn, '__wrapped__'):

--- a/picard/i18n/qt.py
+++ b/picard/i18n/qt.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 from PyQt6 import QtCore
 
 from picard import log
+from picard.i18n import language_changed
 
 
 if TYPE_CHECKING:
@@ -58,6 +59,7 @@ class Translators:
     def __init__(self, tagger: 'Tagger'):
         self.tagger = tagger
         self.tagger._qt_translators_updated.connect(self.reinstall)
+        language_changed.connect(self.reload_default_translators)
         self._translators = []
         self._changed = False
         self.add_default_translators()
@@ -73,6 +75,27 @@ class Translators:
             self._changed = True
         else:
             log.debug("Qt locale %s not available", locale.name())
+
+    def reload_default_translators(self) -> None:
+        """Reload the Qt base translators for the current QLocale.
+
+        Called when the UI language changes at runtime.  Removes the old
+        Qt base translator(s) and loads a new one matching the new locale,
+        then triggers a reinstall of all translators.
+        """
+        # Remove existing Qt base translators
+        for t in self._translators[:]:
+            if t.sort_index == TRANSLATOR_PRIORITY_QT_BASE:
+                if t.installed:
+                    self.tagger.removeTranslator(t.instance)
+                self._translators.remove(t)
+
+        # Load new Qt base translator for current locale
+        self.add_default_translators()
+
+        # Force reinstall even if add_default_translators didn't find a translation
+        self._changed = True
+        self.reinstall()
 
     def add_translator(self, translator: QtCore.QTranslator) -> None:
         plugin_id = getattr(translator, 'plugin_id', '')

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -280,6 +280,7 @@ class PluginApi:
     _instances: ClassVar[dict[str, 'PluginApi']] = {}  # Maps module name -> PluginApi instance
     _module_cache: ClassVar[dict[str, 'PluginApi']] = {}  # Maps module name -> PluginApi instance (for faster lookup)
     _deprecation_warnings_emitted: ClassVar[set[tuple[str, str, int]]] = set()  # Track emitted deprecation warnings
+    _language_changed_connected: ClassVar[bool] = False
 
     def __init__(self, manifest: PluginManifest, tagger: 'Tagger', module: types.ModuleType, plugin_dir: Path) -> None:
         self._tagger: Tagger = tagger
@@ -296,6 +297,12 @@ class PluginApi:
         self._plugin_dir: Path = plugin_dir
         self._qt_translator: PluginTranslator | None = None
         self._mb_api: MBAPIHelper | None = None
+
+        if not PluginApi._language_changed_connected:
+            from picard.i18n import language_changed
+
+            language_changed.connect(PluginApi._on_language_changed)
+            PluginApi._language_changed_connected = True
 
     @staticmethod
     def _get_caller_info(frame_depth=2):
@@ -508,6 +515,17 @@ class PluginApi:
                 )
                 return True
         return False
+
+    @classmethod
+    def _on_language_changed(cls) -> None:
+        """Reload translations for all active plugins when UI language changes."""
+        for api in cls._instances.values():
+            # Reload translation files for the new locale
+            api._translations.clear()
+            api._load_translations()
+            # Update Qt translator locale
+            if api._qt_translator:
+                api._qt_translator._current_locale = api.get_locale()
 
     @property
     def tagger(self) -> 'Tagger':

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -151,14 +151,14 @@ class CoverArtBox(QtWidgets.QGroupBox):
         config = get_config()
         config.setting.setting_changed.connect(self._on_setting_changed)
         # Apply initial translation
-        self._retranslate()
+        self._retranslate_ui()
 
     def changeEvent(self, event):
         if event.type() == QtCore.QEvent.Type.LanguageChange:
-            self._retranslate()
+            self._retranslate_ui()
         super().changeEvent(event)
 
-    def _retranslate(self):
+    def _retranslate_ui(self):
         """Retranslate static UI strings after a language change."""
         self.show_details_button.setText(_(self._source_show_details_text))
 

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -131,7 +131,8 @@ class CoverArtBox(QtWidgets.QGroupBox):
             QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
         )
         self.orig_cover_art_info_label.setWordWrap(True)
-        self.show_details_button = QtWidgets.QPushButton(N_('Show more details'), self)
+        self._source_show_details_text = N_('Show more details')
+        self.show_details_button = QtWidgets.QPushButton(_(self._source_show_details_text), self)
         self.show_details_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(_("Ctrl+Shift+I")), self, self.show_cover_art_info
         )
@@ -159,14 +160,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
 
     def _retranslate(self):
         """Retranslate static UI strings after a language change."""
-        from picard.ui.mainwindow.actions import _retranslate_action_property
-
-        _retranslate_action_property(
-            self.show_details_button,
-            'text',
-            self.show_details_button.text,
-            self.show_details_button.setText,
-        )
+        self.show_details_button.setText(_(self._source_show_details_text))
 
     def _on_setting_changed(self, name, old_value, new_value):
         if name in self._REMOVAL_SETTINGS:

--- a/picard/ui/coverartbox/__init__.py
+++ b/picard/ui/coverartbox/__init__.py
@@ -61,7 +61,10 @@ from picard.coverart.setters import (
     CoverArtSetter,
     CoverArtSetterMode,
 )
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.metadata import Metadata
 from picard.util import (
     bytes2human,
@@ -128,7 +131,7 @@ class CoverArtBox(QtWidgets.QGroupBox):
             QtCore.Qt.AlignmentFlag.AlignTop | QtCore.Qt.AlignmentFlag.AlignHCenter
         )
         self.orig_cover_art_info_label.setWordWrap(True)
-        self.show_details_button = QtWidgets.QPushButton(_('Show more details'), self)
+        self.show_details_button = QtWidgets.QPushButton(N_('Show more details'), self)
         self.show_details_shortcut = QtGui.QShortcut(
             QtGui.QKeySequence(_("Ctrl+Shift+I")), self, self.show_cover_art_info
         )
@@ -146,6 +149,24 @@ class CoverArtBox(QtWidgets.QGroupBox):
         self.show_details_button.clicked.connect(self.show_cover_art_info)
         config = get_config()
         config.setting.setting_changed.connect(self._on_setting_changed)
+        # Apply initial translation
+        self._retranslate()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate()
+        super().changeEvent(event)
+
+    def _retranslate(self):
+        """Retranslate static UI strings after a language change."""
+        from picard.ui.mainwindow.actions import _retranslate_action_property
+
+        _retranslate_action_property(
+            self.show_details_button,
+            'text',
+            self.show_details_button.text,
+            self.show_details_button.setText,
+        )
 
     def _on_setting_changed(self, name, old_value, new_value):
         if name in self._REMOVAL_SETTINGS:

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -38,7 +38,7 @@ from PyQt6 import (
 from picard import tagger_instance
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
-from picard.i18n import gettext as _
+from picard.i18n import N_
 from picard.util import find_existing_path
 from picard.util.macos import (
     extend_root_volume_path,
@@ -52,24 +52,42 @@ class FileBrowser(QtWidgets.QTreeView):
         self.tagger = tagger_instance()
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setDragEnabled(True)
-        self.load_selected_files_action = QtGui.QAction(_("&Load selected files"), self)
+        self.load_selected_files_action = QtGui.QAction(N_("&Load selected files"), self)
         self.load_selected_files_action.triggered.connect(self.load_selected_files)
         self.addAction(self.load_selected_files_action)
-        self.move_files_here_action = QtGui.QAction(_("&Move tagged files here"), self)
+        self.move_files_here_action = QtGui.QAction(N_("&Move tagged files here"), self)
         self.move_files_here_action.triggered.connect(self.move_files_here)
         self.addAction(self.move_files_here_action)
-        self.toggle_hidden_action = QtGui.QAction(_("Show &hidden files"), self)
+        self.toggle_hidden_action = QtGui.QAction(N_("Show &hidden files"), self)
         self.toggle_hidden_action.setCheckable(True)
         config = get_config()
         self.toggle_hidden_action.setChecked(config.persist['show_hidden_files'])
         self.toggle_hidden_action.toggled.connect(self.show_hidden)
         self.addAction(self.toggle_hidden_action)
-        self.set_as_starting_directory_action = QtGui.QAction(_("&Set as starting directory"), self)
+        self.set_as_starting_directory_action = QtGui.QAction(N_("&Set as starting directory"), self)
         self.set_as_starting_directory_action.triggered.connect(self.set_as_starting_directory)
         self.addAction(self.set_as_starting_directory_action)
         self.doubleClicked.connect(self.load_file_for_item)
         self.focused = False
         self.tagger.format_registry.formats_changed.connect(self._update_name_filters)
+        self._retranslate()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate()
+        super().changeEvent(event)
+
+    def _retranslate(self):
+        """Retranslate action labels after a language change."""
+        from picard.ui.mainwindow.actions import _retranslate_action_property
+
+        for action in (
+            self.load_selected_files_action,
+            self.move_files_here_action,
+            self.toggle_hidden_action,
+            self.set_as_starting_directory_action,
+        ):
+            _retranslate_action_property(action, 'text', action.text, action.setText)
 
     def showEvent(self, event):
         if not self.model():

--- a/picard/ui/filebrowser.py
+++ b/picard/ui/filebrowser.py
@@ -45,6 +45,8 @@ from picard.util.macos import (
     strip_root_volume_path,
 )
 
+from picard.ui.translatable import TranslatableAction
+
 
 class FileBrowser(QtWidgets.QTreeView):
     def __init__(self, parent=None):
@@ -52,42 +54,39 @@ class FileBrowser(QtWidgets.QTreeView):
         self.tagger = tagger_instance()
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
         self.setDragEnabled(True)
-        self.load_selected_files_action = QtGui.QAction(N_("&Load selected files"), self)
+        self.load_selected_files_action = TranslatableAction(N_("&Load selected files"), self)
         self.load_selected_files_action.triggered.connect(self.load_selected_files)
         self.addAction(self.load_selected_files_action)
-        self.move_files_here_action = QtGui.QAction(N_("&Move tagged files here"), self)
+        self.move_files_here_action = TranslatableAction(N_("&Move tagged files here"), self)
         self.move_files_here_action.triggered.connect(self.move_files_here)
         self.addAction(self.move_files_here_action)
-        self.toggle_hidden_action = QtGui.QAction(N_("Show &hidden files"), self)
+        self.toggle_hidden_action = TranslatableAction(N_("Show &hidden files"), self)
         self.toggle_hidden_action.setCheckable(True)
         config = get_config()
         self.toggle_hidden_action.setChecked(config.persist['show_hidden_files'])
         self.toggle_hidden_action.toggled.connect(self.show_hidden)
         self.addAction(self.toggle_hidden_action)
-        self.set_as_starting_directory_action = QtGui.QAction(N_("&Set as starting directory"), self)
+        self.set_as_starting_directory_action = TranslatableAction(N_("&Set as starting directory"), self)
         self.set_as_starting_directory_action.triggered.connect(self.set_as_starting_directory)
         self.addAction(self.set_as_starting_directory_action)
         self.doubleClicked.connect(self.load_file_for_item)
         self.focused = False
         self.tagger.format_registry.formats_changed.connect(self._update_name_filters)
-        self._retranslate()
 
     def changeEvent(self, event):
         if event.type() == QtCore.QEvent.Type.LanguageChange:
-            self._retranslate()
+            self._retranslate_ui()
         super().changeEvent(event)
 
-    def _retranslate(self):
+    def _retranslate_ui(self):
         """Retranslate action labels after a language change."""
-        from picard.ui.mainwindow.actions import _retranslate_action_property
-
         for action in (
             self.load_selected_files_action,
             self.move_files_here_action,
             self.toggle_hidden_action,
             self.set_as_starting_directory_action,
         ):
-            _retranslate_action_property(action, 'text', action.text, action.setText)
+            action.retranslateUi()
 
     def showEvent(self, event):
         if not self.model():

--- a/picard/ui/filter.py
+++ b/picard/ui/filter.py
@@ -74,12 +74,18 @@ class Filter(QtWidgets.QWidget):
 
         # filter input
         self.filter_query_box = QtWidgets.QLineEdit(self)
-        self.filter_query_box.setPlaceholderText(_("Type to filter…"))
+        self._source_placeholder = N_("Type to filter…")
+        self.filter_query_box.setPlaceholderText(_(self._source_placeholder))
         self.filter_query_box.setClearButtonEnabled(True)
         self.filter_query_box.textChanged.connect(self._query_changed)
         layout.addWidget(self.filter_query_box)
 
         self.initializing = False
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self.filter_query_box.setPlaceholderText(_(self._source_placeholder))
+        super().changeEvent(event)
 
     def _get_saved_selected_filters(self):
         config = get_config()

--- a/picard/ui/infostatus.py
+++ b/picard/ui/infostatus.py
@@ -64,8 +64,12 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self.stop_button.setIconSize(self._size)
         self.stop_button.setIcon(self.stop_button.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserStop))
         self.stop_button.setEnabled(False)
-        self.stop_button.setToolTip(_("Stop all pending network requests"))
         self.stop_button.clicked.connect(self.stop_requested.emit)
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._init_tooltips()
+        super().changeEvent(event)
 
     def _create_icons(self):
         self.icon_eta = QtGui.QIcon(":/images/22x22/hourglass.png")
@@ -90,6 +94,7 @@ class InfoStatus(QtWidgets.QWidget, Ui_InfoStatus):
         self.pending_files_icon.setToolTip(t4)
         self.pending_requests_value.setToolTip(t5)
         self.pending_requests_icon.setToolTip(t5)
+        self.stop_button.setToolTip(_("Stop all pending network requests"))
 
     def update(self, progress_status):
         self.set_files(progress_status.files)

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -333,6 +333,11 @@ class FileTreeView(BaseTreeView):
     def default_drop_target(self):
         return self.tagger.unclustered_files
 
+    def _retranslate_ui(self):
+        super()._retranslate_ui()
+        self.unmatched_files.update()
+        self.clusters.update()
+
 
 class AlbumTreeView(BaseTreeView):
     NAME = N_("Album view")

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -78,7 +78,10 @@ from picard.extension_points.item_actions import (
     ext_point_track_actions,
 )
 from picard.file import File
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.script import iter_tagging_scripts_from_tuples
 from picard.track import (
     NonAlbumTrack,
@@ -103,6 +106,7 @@ from picard.ui.itemviews.custom_columns.shared import get_recognized_view_column
 from picard.ui.itemviews.events import header_events
 from picard.ui.ratingwidget import RatingWidget
 from picard.ui.scriptsmenu import ScriptsMenu
+from picard.ui.translatable import TranslatableAction
 from picard.ui.util import menu_builder
 from picard.ui.widgets.configurablecolumnsheader import ConfigurableColumnsHeader
 
@@ -199,17 +203,30 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
         self.setSortingEnabled(True)
 
-        self.expand_all_action = QtGui.QAction(_("&Expand all"), self)
+        self.expand_all_action = TranslatableAction(N_("&Expand all"), self)
         self.expand_all_action.triggered.connect(self.expandAll)
-        self.collapse_all_action = QtGui.QAction(_("&Collapse all"), self)
+        self.collapse_all_action = TranslatableAction(N_("&Collapse all"), self)
         self.collapse_all_action.triggered.connect(self.collapseAll)
-        self.select_all_action = QtGui.QAction(_("Select &all"), self)
+        self.select_all_action = TranslatableAction(N_("Select &all"), self)
         self.select_all_action.triggered.connect(self.selectAll)
         self.select_all_action.setShortcut(QtGui.QKeySequence(_("Ctrl+A")))
         self.doubleClicked.connect(self.activate_item)
         self.setUniformRowHeights(True)
 
         self.icon_plugins = icontheme.lookup('applications-system', icontheme.ICON_SIZE_MENU)
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate tree view actions and accessible properties."""
+        self.setAccessibleName(_(self.NAME))
+        self.setAccessibleDescription(_(self.DESCRIPTION))
+        self.expand_all_action.retranslateUi()
+        self.collapse_all_action.retranslateUi()
+        self.select_all_action.retranslateUi()
 
     def contextMenuEvent(self, event):
         item = self.itemAt(event.pos())

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -57,6 +57,7 @@ from picard.ui.logviewmodel import (
     LogItemModel,
 )
 from picard.ui.theme import theme
+from picard.ui.translatable import TranslatableAction
 from picard.ui.util import FileDialog
 
 
@@ -171,18 +172,20 @@ class LogViewDialog(PicardDialog):
         self.list_view.activated.connect(self._show_detail)
         self.vbox.addWidget(self.list_view)
 
-        view_detail_action = QtGui.QAction(
-            QtGui.QIcon.fromTheme("document-properties"), _("&View detail…"), self.list_view
+        view_detail_action = TranslatableAction(
+            QtGui.QIcon.fromTheme("document-properties"), N_("&View detail…"), self.list_view
         )
         view_detail_action.triggered.connect(self._show_detail)
         self.list_view.addAction(view_detail_action)
 
-        copy_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-copy"), _("&Copy"), self.list_view)
+        copy_action = TranslatableAction(QtGui.QIcon.fromTheme("edit-copy"), N_("&Copy"), self.list_view)
         copy_action.setShortcut(QtGui.QKeySequence.StandardKey.Copy)
         copy_action.triggered.connect(self._copy_selection)
         self.list_view.addAction(copy_action)
 
-        select_all_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-select-all"), _("Select &all"), self.list_view)
+        select_all_action = TranslatableAction(
+            QtGui.QIcon.fromTheme("edit-select-all"), N_("Select &all"), self.list_view
+        )
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self._select_all)
         self.list_view.addAction(select_all_action)
@@ -195,6 +198,10 @@ class LogViewDialog(PicardDialog):
     def _retranslate_ui(self):
         """Retranslate window title after a language change."""
         self.set_window_title(_(self._source_title))
+        # Retranslate context menu actions
+        for action in self.list_view.actions():
+            if hasattr(action, 'retranslateUi'):
+                action.retranslateUi()
 
     def _show_context_menu(self, pos):
         menu = QtWidgets.QMenu(self.list_view)
@@ -364,16 +371,18 @@ class LogView(LogViewCommon):
         self._delegate = LogItemDelegate(parent=self.list_view)
         self.list_view.setItemDelegate(self._delegate)
 
-        clear_log_action = QtGui.QAction(QtGui.QIcon.fromTheme("edit-clear"), _("Clear &log…"), self.list_view)
-        clear_log_action.triggered.connect(self._clear_log_do)
-        self.list_view.addAction(clear_log_action)
+        self._clear_log_action = TranslatableAction(
+            QtGui.QIcon.fromTheme("edit-clear"), N_("Clear &log…"), self.list_view
+        )
+        self._clear_log_action.triggered.connect(self._clear_log_do)
+        self.list_view.addAction(self._clear_log_action)
 
-        self._regex_action = QtGui.QAction(_("&Regex filter"), self.list_view)
+        self._regex_action = TranslatableAction(N_("&Regex filter"), self.list_view)
         self._regex_action.setCheckable(True)
         self._regex_action.toggled.connect(self._on_regex_toggled)
         self.list_view.addAction(self._regex_action)
 
-        self._compact_view_action = QtGui.QAction(_("&Compact view"), self.list_view)
+        self._compact_view_action = TranslatableAction(N_("&Compact view"), self.list_view)
         self._compact_view_action.setCheckable(True)
         self._compact_view_action.setChecked(False)
         self._compact_view_action.toggled.connect(self._on_compact_view_toggled)
@@ -382,29 +391,31 @@ class LogView(LogViewCommon):
         self.hbox = QtWidgets.QHBoxLayout()
         self.vbox.addLayout(self.hbox)
 
-        self.help_button = QtWidgets.QPushButton(QtGui.QIcon.fromTheme("help-contents"), _("Help"))
+        self._source_help_text = N_("Help")
+        self.help_button = QtWidgets.QPushButton(QtGui.QIcon.fromTheme("help-contents"), _(self._source_help_text))
         self.help_button.setAutoDefault(False)
         self.help_button.clicked.connect(self.show_help)
         self.hbox.addWidget(self.help_button)
 
         self.verbosity_menu_button = QtWidgets.QPushButton()
         self.verbosity_menu_button.setAutoDefault(False)
-        self.verbosity_menu_button.setAccessibleName(_("Verbosity"))
-        self.verbosity_menu_button.setToolTip(
-            _(
-                "Changes the logging verbosity level for the current session. "
-                "The default level configured in Options will be restored on next startup."
-            )
+        self._source_verbosity_accessible = N_("Verbosity")
+        self.verbosity_menu_button.setAccessibleName(_(self._source_verbosity_accessible))
+        self._source_verbosity_tooltip = N_(
+            "Changes the logging verbosity level for the current session. "
+            "The default level configured in Options will be restored on next startup."
         )
+        self.verbosity_menu_button.setToolTip(_(self._source_verbosity_tooltip))
         self.hbox.addWidget(self.verbosity_menu_button)
 
         self.verbosity_menu = VerbosityMenu()
         self.verbosity_menu.verbosity_changed.connect(self._verbosity_changed)
         self.verbosity_menu_button.setMenu(self.verbosity_menu)
 
-        self.debug_opts_menu_button = QtWidgets.QPushButton(_("Debug Options"))
+        self._source_debug_opts_text = N_("Debug Options")
+        self.debug_opts_menu_button = QtWidgets.QPushButton(_(self._source_debug_opts_text))
         self.debug_opts_menu_button.setAutoDefault(False)
-        self.debug_opts_menu_button.setAccessibleName(_("Debug Options"))
+        self.debug_opts_menu_button.setAccessibleName(_(self._source_debug_opts_text))
         self.hbox.addWidget(self.debug_opts_menu_button)
 
         self.debug_opts_menu = DebugOptsMenu()
@@ -414,7 +425,8 @@ class LogView(LogViewCommon):
 
         # filter input with embedded clear button
         self.filter_input = QtWidgets.QLineEdit()
-        self.filter_input.setPlaceholderText(_("Filter"))
+        self._source_filter_text = N_("Filter")
+        self.filter_input.setPlaceholderText(_(self._source_filter_text))
         self.filter_input.setClearButtonEnabled(True)
         self.filter_input.textChanged.connect(self._on_filter_changed)
         self.filter_input.returnPressed.connect(self._on_filter_return)
@@ -422,14 +434,15 @@ class LogView(LogViewCommon):
 
         # filter toggle button
         self.filter_button = QtWidgets.QToolButton()
-        self.filter_button.setText(_("Filter"))
+        self.filter_button.setText(_(self._source_filter_text))
         self.filter_button.setCheckable(True)
         self.filter_button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly)
         self.filter_button.toggled.connect(self._on_filter_toggled)
         self.hbox.addWidget(self.filter_button)
 
         # save as
-        self.save_log_as_button = QtWidgets.QPushButton(_("Save As…"))
+        self._source_save_as_text = N_("Save As…")
+        self.save_log_as_button = QtWidgets.QPushButton(_(self._source_save_as_text))
         self.save_log_as_button.setAutoDefault(False)
         self.hbox.addWidget(self.save_log_as_button)
         self.save_log_as_button.clicked.connect(self._save_log_as_do)
@@ -441,6 +454,25 @@ class LogView(LogViewCommon):
         self._model.rowsInserted.connect(self._update_status)
         self._model.modelReset.connect(self._update_status)
         self._update_status()
+
+    def _retranslate_ui(self):
+        """Retranslate LogView-specific UI elements."""
+        super()._retranslate_ui()
+        # Actions
+        self._clear_log_action.retranslateUi()
+        self._regex_action.retranslateUi()
+        self._compact_view_action.retranslateUi()
+        # Buttons
+        self.help_button.setText(_(self._source_help_text))
+        self.verbosity_menu_button.setAccessibleName(_(self._source_verbosity_accessible))
+        self.verbosity_menu_button.setToolTip(_(self._source_verbosity_tooltip))
+        self.debug_opts_menu_button.setText(_(self._source_debug_opts_text))
+        self.debug_opts_menu_button.setAccessibleName(_(self._source_debug_opts_text))
+        self.filter_input.setPlaceholderText(_(self._source_filter_text))
+        self.filter_button.setText(_(self._source_filter_text))
+        self.save_log_as_button.setText(_(self._source_save_as_text))
+        # Refresh verbosity button text
+        self._set_verbosity(self.verbosity)
 
     def _update_status(self):
         if self._status_label is None:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -39,7 +39,10 @@ from PyQt6 import (
 
 from picard import log
 from picard.debug_opts import DebugOpt
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.util import reconnect
 
 from picard.ui import (
@@ -153,7 +156,8 @@ class LogViewDialog(PicardDialog):
     def __init__(self, title, parent=None):
         super().__init__(parent=parent)
         self.setWindowFlags(QtCore.Qt.WindowType.Window)
-        self.set_window_title(title)
+        self._source_title = title
+        self.set_window_title(_(title))
         self.vbox = QtWidgets.QVBoxLayout()
         self.setLayout(self.vbox)
         self.list_view = QtWidgets.QListView()
@@ -182,6 +186,15 @@ class LogViewDialog(PicardDialog):
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self._select_all)
         self.list_view.addAction(select_all_action)
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate window title after a language change."""
+        self.set_window_title(_(self._source_title))
 
     def _show_context_menu(self, pos):
         menu = QtWidgets.QMenu(self.list_view)
@@ -337,7 +350,7 @@ class DebugOptsMenu(QtWidgets.QMenu):
 
 class LogView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.main_tail, _("Log View"), parent=parent)
+        super().__init__(log.main_tail, N_("Log View"), parent=parent)
         self.verbosity = log.get_effective_level()
         self._status_label = None
         self.help_url = '/appendices/log_viewer.html'
@@ -552,4 +565,4 @@ class LogView(LogViewCommon):
 
 class HistoryView(LogViewCommon):
     def __init__(self, parent=None):
-        super().__init__(log.history_tail, _("Activity History"), parent=parent)
+        super().__init__(log.history_tail, N_("Activity History"), parent=parent)

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -331,6 +331,10 @@ class VerbosityMenu(QtWidgets.QMenu):
     def set_verbosity(self, level):
         self.action_map[level].setChecked(True)
 
+    def retranslateUi(self):
+        for level, feat in log.levels_features.items():
+            self.action_map[level].setText(_(feat.name))
+
 
 class DebugOptsMenu(QtWidgets.QMenu):
     def __init__(self, parent=None):
@@ -343,6 +347,11 @@ class DebugOptsMenu(QtWidgets.QMenu):
             action.triggered.connect(partial(self.debug_opt_changed, debug_opt))
             self.addAction(action)
             self.action_map[debug_opt] = action
+
+    def retranslateUi(self):
+        for debug_opt, action in self.action_map.items():
+            action.setText(_(debug_opt.title))
+            action.setToolTip(_(debug_opt.description))
 
     def debug_opt_changed(self, debug_opt, checked):
         debug_opt.enabled = checked
@@ -471,6 +480,9 @@ class LogView(LogViewCommon):
         self.filter_input.setPlaceholderText(_(self._source_filter_text))
         self.filter_button.setText(_(self._source_filter_text))
         self.save_log_as_button.setText(_(self._source_save_as_text))
+        # Menus
+        self.verbosity_menu.retranslateUi()
+        self.debug_opts_menu.retranslateUi()
         # Refresh verbosity button text
         self._set_verbosity(self.verbosity)
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -163,7 +163,6 @@ from picard.ui.logview import (
 )
 from picard.ui.mainwindow.actions import (
     create_actions,
-    retranslate_actions,
 )
 from picard.ui.metadatabox import MetadataBox
 from picard.ui.newuserdialog import NewUserDialog
@@ -353,9 +352,12 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _retranslate_ui(self):
         """Retranslate all UI elements after a language change."""
-        retranslate_actions(self.action_map)
-        self._retranslate_menus()
+        from picard.ui.translatable import retranslate_all
+
+        # Retranslate all Translatable* instances (actions, menus, buttons)
+        retranslate_all()
         self._retranslate_window()
+        self._retranslate_search_toolbar()
         # Create event once for propagation to child widgets
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
         # Refresh column headers in tree views and propagate event
@@ -369,8 +371,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             QtCore.QCoreApplication.sendEvent(widget, event)
         if hasattr(self, 'player_toolbar'):
             QtCore.QCoreApplication.sendEvent(self.player_toolbar, event)
-        # Retranslate search toolbar
-        self._retranslate_search_toolbar()
 
     def _retranslate_search_toolbar(self):
         """Retranslate search toolbar title and combo items."""
@@ -388,15 +388,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         listen_port = getattr(self, '_listen_port', None)
         if listen_port:
             self.listening_label.setText(_("Listening on port %(port)d") % {"port": listen_port})
-
-    def _retranslate_menus(self):
-        """Retranslate menu titles after a language change."""
-        for action in self.menuBar().actions():
-            menu = action.menu()
-            if menu and hasattr(menu, 'retranslateUi'):
-                menu.retranslateUi()
-        for menu in self._translatable_submenus:
-            menu.retranslateUi()
 
     def _update_toolbar_theme(self):
         """Refresh toolbar extension button icon and stylesheet for current theme."""
@@ -1161,18 +1152,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         )
 
         # Collect submenus that need retranslation (not in the menu bar directly)
-        self._translatable_submenus = [
-            self.file_naming_scripts_menu,
-            self.profile_quick_selector_menu,
-            self.quick_settings_menu,
-            self.cd_lookup_menu,
-            self.recent_sessions_menu,
-        ]
-
         self._menus_created = True
-
-        # Apply initial translation to menu titles
-        self._retranslate_menus()
 
     def update_toolbar_style(self):
         config = get_config()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -353,6 +353,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         retranslate_actions(self.action_map)
         self._retranslate_menus()
         self._retranslate_window()
+        # Refresh column headers in tree views (columns store untranslated
+        # titles via N_() and _set_header_labels applies _() lazily)
+        for view in self.panel._views:
+            view._set_header_labels()
 
     def _retranslate_window(self):
         """Retranslate window title and statusbar elements."""

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -360,7 +360,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             view._set_header_labels()
         # Propagate LanguageChange event to persistent child widgets
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
-        for widget in (self.metadata_box, self.cover_art_box, self.file_browser):
+        for widget in (self.metadata_box, self.cover_art_box, self.file_browser, self._infostatus):
             QtCore.QCoreApplication.sendEvent(widget, event)
         # Retranslate search toolbar
         self._retranslate_search_toolbar()
@@ -690,6 +690,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """Creates a new status bar."""
         self.statusBar().showMessage(N_("Ready"))
         infostatus = InfoStatus(self)
+        self._infostatus = infostatus
         self._progress = infostatus.get_progress
         self.listening_label = QtWidgets.QLabel()
         self.listening_label.setStyleSheet("QLabel { margin: 0 4px 0 4px; }")

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -350,6 +350,25 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def _retranslate_ui(self):
         """Retranslate all UI elements after a language change."""
         retranslate_actions(self.action_map)
+        self._retranslate_menus()
+
+    def _retranslate_menus(self):
+        """Retranslate menu titles after a language change.
+
+        Uses the same pattern as retranslate_actions: on first call captures
+        the untranslated source title from each menu's menuAction, then applies
+        _() on every call.
+        """
+        from picard.ui.mainwindow.actions import _retranslate_action_property
+
+        for action in self.menuBar().actions():
+            menu = action.menu()
+            if menu:
+                _retranslate_action_property(action, 'text', action.text, action.setText)
+        # Also retranslate submenus not directly in the menu bar
+        for menu in self._translatable_submenus:
+            action = menu.menuAction()
+            _retranslate_action_property(action, 'text', action.text, action.setText)
 
     def _update_toolbar_theme(self):
         """Refresh toolbar extension button icon and stylesheet for current theme."""
@@ -816,7 +835,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         retranslate_actions(self.action_map)
 
     def _create_cd_lookup_menu(self):
-        menu = QtWidgets.QMenu(_("Lookup &CD…"))
+        menu = QtWidgets.QMenu(N_("Lookup &CD…"))
         menu.setIcon(icontheme.lookup('media-optical'))
         self.cd_lookup_menu = menu
         self._init_cd_lookup_menu()
@@ -826,7 +845,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         The menu content is populated from the persisted recent sessions list.
         """
-        self.recent_sessions_menu = QtWidgets.QMenu(_("Recent Sessions"))
+        self.recent_sessions_menu = QtWidgets.QMenu(N_("Recent Sessions"))
         self.recent_sessions_menu.setIcon(icontheme.lookup('document-open-recent'))
         self._populate_recent_sessions_menu()
         return self.recent_sessions_menu
@@ -1002,7 +1021,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             menu_builder(menu, self.action_map, *args)
 
         add_menu(
-            _("&File"),
+            N_("&File"),
             MainAction.ADD_DIRECTORY,
             MainAction.ADD_FILES,
             MainAction.CLOSE_WINDOW if self.show_close_window else None,
@@ -1026,7 +1045,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         )
 
         add_menu(
-            _("&Edit"),
+            N_("&Edit"),
             MainAction.CUT,
             MainAction.PASTE,
             '-',
@@ -1035,7 +1054,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         )
 
         add_menu(
-            _("&View"),
+            N_("&View"),
             MainAction.SHOW_FILE_BROWSER,
             MainAction.SHOW_METADATA_VIEW,
             MainAction.SHOW_COVER_ART,
@@ -1046,24 +1065,24 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.PLAYER_TOOLBAR_TOGGLE if self.player else None,
         )
 
-        self.file_naming_scripts_menu = QtWidgets.QMenu(_("File naming &scripts"))
+        self.file_naming_scripts_menu = QtWidgets.QMenu(N_("File naming &scripts"))
         self.file_naming_scripts_menu.setIcon(icontheme.lookup('document-open'))
         self._script_actions = []
         self._make_script_selector_menu()
         self.file_naming_scripts_menu.addSeparator()
         self.file_naming_scripts_menu.addAction(self.action_map[MainAction.SHOW_SCRIPT_EDITOR])
 
-        self.profile_quick_selector_menu = QtWidgets.QMenu(_("&Profiles"))
+        self.profile_quick_selector_menu = QtWidgets.QMenu(N_("&Profiles"))
         self.profile_quick_selector_menu.setIcon(
             self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_FileDialogDetailedView)
         )
         self._make_profile_selector_menu()
 
-        self.quick_settings_menu = QtWidgets.QMenu(_("&Quick settings"))
+        self.quick_settings_menu = QtWidgets.QMenu(N_("&Quick settings"))
         self.quick_settings_menu.setIcon(icontheme.lookup('applications-system'))
         self._make_quick_settings_menu()
 
-        self.options_menu = self.menuBar().addMenu(_("&Options"))
+        self.options_menu = self.menuBar().addMenu(N_("&Options"))
         menu_builder(
             self.options_menu,
             self.action_map,
@@ -1074,7 +1093,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         )
 
         add_menu(
-            _("&Tools"),
+            N_("&Tools"),
             MainAction.REFRESH,
             self.cd_lookup_menu,
             MainAction.AUTOTAG,
@@ -1089,14 +1108,14 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.OPEN_COLLECTION_IN_BROWSER,
         )
 
-        self.plugin_tools_menu = self.menuBar().addMenu(_("&Plugin Tools"))
+        self.plugin_tools_menu = self.menuBar().addMenu(N_("&Plugin Tools"))
         self.plugin_tools_menu.menuAction().setVisible(False)
         self._make_plugin_tools_menu()
 
         self.menuBar().addSeparator()
 
         add_menu(
-            _("&Help"),
+            N_("&Help"),
             MainAction.HELP,
             '-',
             MainAction.VIEW_HISTORY,
@@ -1112,7 +1131,19 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.ABOUT,
         )
 
+        # Collect submenus that need retranslation (not in the menu bar directly)
+        self._translatable_submenus = [
+            self.file_naming_scripts_menu,
+            self.profile_quick_selector_menu,
+            self.quick_settings_menu,
+            self.cd_lookup_menu,
+            self.recent_sessions_menu,
+        ]
+
         self._menus_created = True
+
+        # Apply initial translation to menu titles
+        self._retranslate_menus()
 
     def update_toolbar_style(self):
         config = get_config()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -364,6 +364,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
         for widget in (self.metadata_box, self.cover_art_box, self.file_browser, self._infostatus):
             QtCore.QCoreApplication.sendEvent(widget, event)
+        for view in self.panel._views:
+            QtCore.QCoreApplication.sendEvent(view.filter_box, event)
         if hasattr(self, 'player_toolbar'):
             QtCore.QCoreApplication.sendEvent(self.player_toolbar, event)
         # Retranslate search toolbar

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -356,17 +356,17 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         retranslate_actions(self.action_map)
         self._retranslate_menus()
         self._retranslate_window()
-        # Refresh column headers in tree views (columns store untranslated
-        # titles via N_() and _set_header_labels applies _() lazily)
+        # Create event once for propagation to child widgets
+        event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
+        # Refresh column headers in tree views and propagate event
         for view in self.panel._views:
             view._set_header_labels()
             view.viewport().update()
-        # Propagate LanguageChange event to persistent child widgets
-        event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
+            QtCore.QCoreApplication.sendEvent(view, event)
+            QtCore.QCoreApplication.sendEvent(view.filter_box, event)
+        # Propagate LanguageChange event to other persistent child widgets
         for widget in (self.metadata_box, self.cover_art_box, self.file_browser, self._infostatus):
             QtCore.QCoreApplication.sendEvent(widget, event)
-        for view in self.panel._views:
-            QtCore.QCoreApplication.sendEvent(view.filter_box, event)
         if hasattr(self, 'player_toolbar'):
             QtCore.QCoreApplication.sendEvent(self.player_toolbar, event)
         # Retranslate search toolbar

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -273,7 +273,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 func.on_exit()
 
     def setupUi(self):
-        self.setWindowTitle(_("MusicBrainz Picard"))
+        self.setWindowTitle(N_("MusicBrainz Picard"))
 
         self.show_close_window = IS_MACOS
 
@@ -281,6 +281,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._create_statusbar()
         self._create_toolbar()
         self._create_menus()
+        self._retranslate_window()
 
         if IS_MACOS:
             self.setUnifiedTitleAndToolBarOnMac(True)
@@ -351,6 +352,26 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         """Retranslate all UI elements after a language change."""
         retranslate_actions(self.action_map)
         self._retranslate_menus()
+        self._retranslate_window()
+
+    def _retranslate_window(self):
+        """Retranslate window title and statusbar elements."""
+        # Window title
+        source = self.property('_source_windowTitle')
+        if source is None:
+            source = self.windowTitle()
+            self.setProperty('_source_windowTitle', source)
+        self.setWindowTitle(_(source))
+
+        # Statusbar tooltips
+        for widget in (self.listening_label, self.plugin_updates_button):
+            source = widget.property('_source_toolTip')
+            if source is None:
+                source = widget.toolTip()
+                if not source:
+                    continue
+                widget.setProperty('_source_toolTip', source)
+            widget.setToolTip(_(source))
 
     def _retranslate_menus(self):
         """Retranslate menu titles after a language change.
@@ -641,7 +662,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_statusbar(self):
         """Creates a new status bar."""
-        self.statusBar().showMessage(_("Ready"))
+        self.statusBar().showMessage(N_("Ready"))
         infostatus = InfoStatus(self)
         self._progress = infostatus.get_progress
         self.listening_label = QtWidgets.QLabel()
@@ -649,7 +670,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.listening_label.setVisible(False)
         self.listening_label.setToolTip(
             "<qt/>"
-            + _(
+            + N_(
                 "Picard listens on this port to integrate with your browser. When "
                 "you \"Search\" or \"Open in Browser\" from Picard, clicking the "
                 "\"Tagger\" button on the web page loads the release into Picard."
@@ -668,7 +689,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.plugin_updates_button.setStyleSheet("QToolButton { border: none; }")
         self.plugin_updates_button.setVisible(False)
         self.plugin_updates_button.setToolTip(
-            _("There are updates available for installed plugins. Click to open the plugin manager.")
+            N_("There are updates available for installed plugins. Click to open the plugin manager.")
         )
         self.plugin_updates_button.clicked.connect(partial(self.show_options, page='plugins'))
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -360,6 +360,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         # titles via N_() and _set_header_labels applies _() lazily)
         for view in self.panel._views:
             view._set_header_labels()
+            view.viewport().update()
         # Propagate LanguageChange event to persistent child widgets
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
         for widget in (self.metadata_box, self.cover_art_box, self.file_browser, self._infostatus):

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -360,7 +360,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             view._set_header_labels()
         # Propagate LanguageChange event to persistent child widgets
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
-        for widget in (self.metadata_box, self.cover_art_box):
+        for widget in (self.metadata_box, self.cover_art_box, self.file_browser):
             QtCore.QCoreApplication.sendEvent(widget, event)
         # Retranslate search toolbar
         self._retranslate_search_toolbar()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -161,7 +161,10 @@ from picard.ui.logview import (
     HistoryView,
     LogView,
 )
-from picard.ui.mainwindow.actions import create_actions
+from picard.ui.mainwindow.actions import (
+    create_actions,
+    retranslate_actions,
+)
 from picard.ui.metadatabox import MetadataBox
 from picard.ui.newuserdialog import NewUserDialog
 from picard.ui.options.dialog import OptionsDialog
@@ -337,6 +340,16 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._update_toolbar_theme()
         self._update_statusbar_plugin_icon()
         self.metadata_box.update()
+
+    def changeEvent(self, event):
+        """Handle change events, particularly LanguageChange for dynamic translation."""
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate all UI elements after a language change."""
+        retranslate_actions(self.action_map)
 
     def _update_toolbar_theme(self):
         """Refresh toolbar extension button icon and stylesheet for current theme."""
@@ -800,6 +813,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_actions(self):
         self.action_map = dict(create_actions(self))
+        retranslate_actions(self.action_map)
 
     def _create_cd_lookup_menu(self):
         menu = QtWidgets.QMenu(_("Lookup &CD…"))

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -399,6 +399,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 widget.setProperty('_source_toolTip', source)
             widget.setToolTip(_(source))
 
+        # Listening label text (if port is active)
+        listen_port = getattr(self, '_listen_port', None)
+        if listen_port:
+            self.listening_label.setText(_("Listening on port %(port)d") % {"port": listen_port})
+
     def _retranslate_menus(self):
         """Retranslate menu titles after a language change.
 
@@ -743,6 +748,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             indicator.update(progress_status)
 
     def _update_statusbar_listen_port(self, listen_port):
+        self._listen_port = listen_port
         if listen_port:
             self.listening_label.setVisible(True)
             self.listening_label.setText(_("Listening on port %(port)d") % {"port": listen_port})

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -886,7 +886,6 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_actions(self):
         self.action_map = dict(create_actions(self))
-        retranslate_actions(self.action_map)
 
     def _create_cd_lookup_menu(self):
         menu = QtWidgets.QMenu(N_("Lookup &CD…"))

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -1041,7 +1041,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_menus(self):
         def add_menu(menu_title, *args):
-            menu = TranslatableMenu(menu_title)
+            menu = TranslatableMenu(menu_title, self.menuBar())
             self.menuBar().addMenu(menu)
             menu.setSeparatorsCollapsible(True)
             menu_builder(menu, self.action_map, *args)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -364,6 +364,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
         for widget in (self.metadata_box, self.cover_art_box, self.file_browser, self._infostatus):
             QtCore.QCoreApplication.sendEvent(widget, event)
+        if hasattr(self, 'player_toolbar'):
+            QtCore.QCoreApplication.sendEvent(self.player_toolbar, event)
         # Retranslate search toolbar
         self._retranslate_search_toolbar()
 

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -357,6 +357,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         # titles via N_() and _set_header_labels applies _() lazily)
         for view in self.panel._views:
             view._set_header_labels()
+        # Propagate LanguageChange event to persistent child widgets
+        event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
+        for widget in (self.metadata_box, self.cover_art_box):
+            QtCore.QCoreApplication.sendEvent(widget, event)
 
     def _retranslate_window(self):
         """Retranslate window title and statusbar elements."""

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -185,6 +185,7 @@ from picard.ui.statusindicator import (
 )
 from picard.ui.tagsfromfilenames import TagsFromFileNamesDialog
 from picard.ui.theme import theme
+from picard.ui.translatable import TranslatableMenu
 from picard.ui.tutorial import TutorialManager
 from picard.ui.util import (
     FileDialog,
@@ -273,7 +274,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 func.on_exit()
 
     def setupUi(self):
-        self.setWindowTitle(N_("MusicBrainz Picard"))
+        self._source_window_title = N_("MusicBrainz Picard")
+        self.setWindowTitle(self._source_window_title)
 
         self.show_close_window = IS_MACOS
 
@@ -367,37 +369,15 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _retranslate_search_toolbar(self):
         """Retranslate search toolbar title and combo items."""
-        from picard.ui.mainwindow.actions import _retranslate_action_property
-
-        # Toolbar title (shown in View menu as toggle action)
-        toggle_action = self.search_toolbar.toggleViewAction()
-        _retranslate_action_property(toggle_action, 'text', toggle_action.text, toggle_action.setText)
-        # Combo box items
-        for i in range(self.search_combo.count()):
-            source = self.search_combo.property(f'_source_item_{i}')
-            if source is None:
-                source = self.search_combo.itemText(i)
-                self.search_combo.setProperty(f'_source_item_{i}', source)
+        self.search_toolbar.setWindowTitle(_(self._search_toolbar_title))
+        for i, source in enumerate(self._search_combo_sources):
             self.search_combo.setItemText(i, _(source))
 
     def _retranslate_window(self):
         """Retranslate window title and statusbar elements."""
-        # Window title
-        source = self.property('_source_windowTitle')
-        if source is None:
-            source = self.windowTitle()
-            self.setProperty('_source_windowTitle', source)
-        self.setWindowTitle(_(source))
-
-        # Statusbar tooltips
-        for widget in (self.listening_label, self.plugin_updates_button):
-            source = widget.property('_source_toolTip')
-            if source is None:
-                source = widget.toolTip()
-                if not source:
-                    continue
-                widget.setProperty('_source_toolTip', source)
-            widget.setToolTip(_(source))
+        self.setWindowTitle(_(self._source_window_title))
+        self.listening_label.setToolTip("<qt/>" + _(self._source_listening_tooltip))
+        self.plugin_updates_button.setToolTip(_(self._source_plugin_updates_tooltip))
 
         # Listening label text (if port is active)
         listen_port = getattr(self, '_listen_port', None)
@@ -405,22 +385,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             self.listening_label.setText(_("Listening on port %(port)d") % {"port": listen_port})
 
     def _retranslate_menus(self):
-        """Retranslate menu titles after a language change.
-
-        Uses the same pattern as retranslate_actions: on first call captures
-        the untranslated source title from each menu's menuAction, then applies
-        _() on every call.
-        """
-        from picard.ui.mainwindow.actions import _retranslate_action_property
-
+        """Retranslate menu titles after a language change."""
         for action in self.menuBar().actions():
             menu = action.menu()
-            if menu:
-                _retranslate_action_property(action, 'text', action.text, action.setText)
-        # Also retranslate submenus not directly in the menu bar
+            if menu and hasattr(menu, 'retranslateUi'):
+                menu.retranslateUi()
         for menu in self._translatable_submenus:
-            action = menu.menuAction()
-            _retranslate_action_property(action, 'text', action.text, action.setText)
+            menu.retranslateUi()
 
     def _update_toolbar_theme(self):
         """Refresh toolbar extension button icon and stylesheet for current theme."""
@@ -700,13 +671,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.listening_label = QtWidgets.QLabel()
         self.listening_label.setStyleSheet("QLabel { margin: 0 4px 0 4px; }")
         self.listening_label.setVisible(False)
-        self.listening_label.setToolTip(
-            "<qt/>"
-            + N_(
-                "Picard listens on this port to integrate with your browser. When "
-                "you \"Search\" or \"Open in Browser\" from Picard, clicking the "
-                "\"Tagger\" button on the web page loads the release into Picard."
-            )
+        self._source_listening_tooltip = N_(
+            "Picard listens on this port to integrate with your browser. When "
+            "you \"Search\" or \"Open in Browser\" from Picard, clicking the "
+            "\"Tagger\" button on the web page loads the release into Picard."
         )
 
         if theme.is_dark_theme:
@@ -720,8 +688,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.plugin_updates_button.setIconSize(QtCore.QSize(16, 16))
         self.plugin_updates_button.setStyleSheet("QToolButton { border: none; }")
         self.plugin_updates_button.setVisible(False)
-        self.plugin_updates_button.setToolTip(
-            N_("There are updates available for installed plugins. Click to open the plugin manager.")
+        self._source_plugin_updates_tooltip = N_(
+            "There are updates available for installed plugins. Click to open the plugin manager."
         )
         self.plugin_updates_button.clicked.connect(partial(self.show_options, page='plugins'))
 
@@ -888,7 +856,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.action_map = dict(create_actions(self))
 
     def _create_cd_lookup_menu(self):
-        menu = QtWidgets.QMenu(N_("Lookup &CD…"))
+        menu = TranslatableMenu(N_("Lookup &CD…"))
         menu.setIcon(icontheme.lookup('media-optical'))
         self.cd_lookup_menu = menu
         self._init_cd_lookup_menu()
@@ -898,7 +866,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         The menu content is populated from the persisted recent sessions list.
         """
-        self.recent_sessions_menu = QtWidgets.QMenu(N_("Recent Sessions"))
+        self.recent_sessions_menu = TranslatableMenu(N_("Recent Sessions"))
         self.recent_sessions_menu.setIcon(icontheme.lookup('document-open-recent'))
         self._populate_recent_sessions_menu()
         return self.recent_sessions_menu
@@ -1069,7 +1037,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_menus(self):
         def add_menu(menu_title, *args):
-            menu = self.menuBar().addMenu(menu_title)
+            menu = TranslatableMenu(menu_title)
+            self.menuBar().addMenu(menu)
             menu.setSeparatorsCollapsible(True)
             menu_builder(menu, self.action_map, *args)
 
@@ -1118,24 +1087,25 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.PLAYER_TOOLBAR_TOGGLE if self.player else None,
         )
 
-        self.file_naming_scripts_menu = QtWidgets.QMenu(N_("File naming &scripts"))
+        self.file_naming_scripts_menu = TranslatableMenu(N_("File naming &scripts"))
         self.file_naming_scripts_menu.setIcon(icontheme.lookup('document-open'))
         self._script_actions = []
         self._make_script_selector_menu()
         self.file_naming_scripts_menu.addSeparator()
         self.file_naming_scripts_menu.addAction(self.action_map[MainAction.SHOW_SCRIPT_EDITOR])
 
-        self.profile_quick_selector_menu = QtWidgets.QMenu(N_("&Profiles"))
+        self.profile_quick_selector_menu = TranslatableMenu(N_("&Profiles"))
         self.profile_quick_selector_menu.setIcon(
             self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_FileDialogDetailedView)
         )
         self._make_profile_selector_menu()
 
-        self.quick_settings_menu = QtWidgets.QMenu(N_("&Quick settings"))
+        self.quick_settings_menu = TranslatableMenu(N_("&Quick settings"))
         self.quick_settings_menu.setIcon(icontheme.lookup('applications-system'))
         self._make_quick_settings_menu()
 
-        self.options_menu = self.menuBar().addMenu(N_("&Options"))
+        self.options_menu = TranslatableMenu(N_("&Options"))
+        self.menuBar().addMenu(self.options_menu)
         menu_builder(
             self.options_menu,
             self.action_map,
@@ -1161,7 +1131,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
             MainAction.OPEN_COLLECTION_IN_BROWSER,
         )
 
-        self.plugin_tools_menu = self.menuBar().addMenu(N_("&Plugin Tools"))
+        self.plugin_tools_menu = TranslatableMenu(N_("&Plugin Tools"))
+        self.menuBar().addMenu(self.plugin_tools_menu)
         self.plugin_tools_menu.menuAction().setVisible(False)
         self._make_plugin_tools_menu()
 
@@ -1296,7 +1267,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_search_toolbar(self):
         config = get_config()
-        self.search_toolbar = toolbar = self.addToolBar(N_("Search"))
+        self._search_toolbar_title = N_("Search")
+        self.search_toolbar = toolbar = self.addToolBar(self._search_toolbar_title)
         self.action_map[MainAction.SEARCH_TOOLBAR_TOGGLE] = self.search_toolbar.toggleViewAction()
         toolbar.setObjectName('search_toolbar')
         if self._is_wayland:
@@ -1307,9 +1279,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         search_panel = QtWidgets.QWidget(toolbar)
         hbox = QtWidgets.QHBoxLayout(search_panel)
         self.search_combo = QtWidgets.QComboBox(search_panel)
-        self.search_combo.addItem(N_("Album"), 'album')
-        self.search_combo.addItem(N_("Artist"), 'artist')
-        self.search_combo.addItem(N_("Track"), 'track')
+        self._search_combo_sources = [N_("Album"), N_("Artist"), N_("Track")]
+        self.search_combo.addItem(self._search_combo_sources[0], 'album')
+        self.search_combo.addItem(self._search_combo_sources[1], 'artist')
+        self.search_combo.addItem(self._search_combo_sources[2], 'track')
         hbox.addWidget(self.search_combo, 0)
         self.search_edit = QtWidgets.QLineEdit(search_panel)
         self.search_edit.setClearButtonEnabled(True)

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -282,6 +282,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self._create_toolbar()
         self._create_menus()
         self._retranslate_window()
+        self._retranslate_search_toolbar()
 
         if IS_MACOS:
             self.setUnifiedTitleAndToolBarOnMac(True)
@@ -361,6 +362,23 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
         for widget in (self.metadata_box, self.cover_art_box):
             QtCore.QCoreApplication.sendEvent(widget, event)
+        # Retranslate search toolbar
+        self._retranslate_search_toolbar()
+
+    def _retranslate_search_toolbar(self):
+        """Retranslate search toolbar title and combo items."""
+        from picard.ui.mainwindow.actions import _retranslate_action_property
+
+        # Toolbar title (shown in View menu as toggle action)
+        toggle_action = self.search_toolbar.toggleViewAction()
+        _retranslate_action_property(toggle_action, 'text', toggle_action.text, toggle_action.setText)
+        # Combo box items
+        for i in range(self.search_combo.count()):
+            source = self.search_combo.property(f'_source_item_{i}')
+            if source is None:
+                source = self.search_combo.itemText(i)
+                self.search_combo.setProperty(f'_source_item_{i}', source)
+            self.search_combo.setItemText(i, _(source))
 
     def _retranslate_window(self):
         """Retranslate window title and statusbar elements."""
@@ -1272,7 +1290,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
     def _create_search_toolbar(self):
         config = get_config()
-        self.search_toolbar = toolbar = self.addToolBar(_("Search"))
+        self.search_toolbar = toolbar = self.addToolBar(N_("Search"))
         self.action_map[MainAction.SEARCH_TOOLBAR_TOGGLE] = self.search_toolbar.toggleViewAction()
         toolbar.setObjectName('search_toolbar')
         if self._is_wayland:
@@ -1283,9 +1301,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         search_panel = QtWidgets.QWidget(toolbar)
         hbox = QtWidgets.QHBoxLayout(search_panel)
         self.search_combo = QtWidgets.QComboBox(search_panel)
-        self.search_combo.addItem(_("Album"), 'album')
-        self.search_combo.addItem(_("Artist"), 'artist')
-        self.search_combo.addItem(_("Track"), 'track')
+        self.search_combo.addItem(N_("Album"), 'album')
+        self.search_combo.addItem(N_("Artist"), 'artist')
+        self.search_combo.addItem(N_("Track"), 'track')
         hbox.addWidget(self.search_combo, 0)
         self.search_edit = QtWidgets.QLineEdit(search_panel)
         self.search_edit.setClearButtonEnabled(True)

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -62,6 +62,7 @@ from picard.i18n import (
 from picard.util import icontheme
 
 from picard.ui.enums import MainAction
+from picard.ui.translatable_action import TranslatableAction
 
 
 _actions_functions = {}
@@ -81,23 +82,10 @@ def create_actions(parent):
 
 
 def retranslate_actions(action_map):
-    """Retranslate all actions in the action map.
-
-    On the first call, captures the untranslated source strings from each
-    action (text, statusTip, toolTip, iconText) into Qt dynamic properties.
-    On every call (including the first), applies _() to produce the
-    translated strings.
-
-    This must be called once after action creation to apply the initial
-    translation, and again on each language change.
-    """
+    """Retranslate all TranslatableAction instances in the action map."""
     for action in action_map.values():
-        if action is None:
-            continue
-        _retranslate_action_property(action, 'text', action.text, action.setText)
-        _retranslate_action_property(action, 'statusTip', action.statusTip, action.setStatusTip)
-        _retranslate_action_property(action, 'toolTip', action.toolTip, action.setToolTip)
-        _retranslate_action_property(action, 'iconText', action.iconText, action.setIconText)
+        if action is not None and hasattr(action, 'retranslateUi'):
+            action.retranslateUi()
 
 
 def _retranslate_action_property(action, prop_name, getter, setter):
@@ -119,7 +107,7 @@ def _retranslate_action_property(action, prop_name, getter, setter):
 
 @add_action(MainAction.OPTIONS)
 def _create_options_action(parent):
-    action = QtGui.QAction(icontheme.lookup('preferences-desktop'), N_("&Options…"), parent)
+    action = TranslatableAction(icontheme.lookup('preferences-desktop'), N_("&Options…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.PreferencesRole)
     action.triggered.connect(parent.show_options)
     return action
@@ -127,7 +115,7 @@ def _create_options_action(parent):
 
 @add_action(MainAction.SHOW_SCRIPT_EDITOR)
 def _create_show_script_editor_action(parent):
-    action = QtGui.QAction(N_("&Edit scripts…"))
+    action = TranslatableAction(N_("&Edit scripts…"))
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+S")))
     action.triggered.connect(parent.open_file_naming_script_editor)
     return action
@@ -135,7 +123,7 @@ def _create_show_script_editor_action(parent):
 
 @add_action(MainAction.CUT)
 def _create_cut_action(parent):
-    action = QtGui.QAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), N_("&Cut"), parent)
+    action = TranslatableAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), N_("&Cut"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.Cut)
     action.setEnabled(False)
     action.triggered.connect(parent.cut)
@@ -144,7 +132,7 @@ def _create_cut_action(parent):
 
 @add_action(MainAction.PASTE)
 def _create_paste_action(parent):
-    action = QtGui.QAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), N_("&Paste"), parent)
+    action = TranslatableAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), N_("&Paste"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.Paste)
     action.setEnabled(False)
     action.triggered.connect(parent.paste)
@@ -153,7 +141,7 @@ def _create_paste_action(parent):
 
 @add_action(MainAction.HELP)
 def _create_help_action(parent):
-    action = QtGui.QAction(N_("&Help…"), parent)
+    action = TranslatableAction(N_("&Help…"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.HelpContents)
     action.triggered.connect(parent.show_help)
     return action
@@ -161,7 +149,7 @@ def _create_help_action(parent):
 
 @add_action(MainAction.ABOUT)
 def _create_about_action(parent):
-    action = QtGui.QAction(N_("&About…"), parent)
+    action = TranslatableAction(N_("&About…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.AboutRole)
     action.triggered.connect(parent.show_about)
     return action
@@ -169,28 +157,28 @@ def _create_about_action(parent):
 
 @add_action(MainAction.DONATE)
 def _create_donate_action(parent):
-    action = QtGui.QAction(N_("&Donate…"), parent)
+    action = TranslatableAction(N_("&Donate…"), parent)
     action.triggered.connect(parent.open_donation_page)
     return action
 
 
 @add_action(MainAction.REPORT_BUG)
 def _create_report_bug_action(parent):
-    action = QtGui.QAction(N_("&Report a Bug…"), parent)
+    action = TranslatableAction(N_("&Report a Bug…"), parent)
     action.triggered.connect(parent.open_bug_report)
     return action
 
 
 @add_action(MainAction.SUPPORT_FORUM)
 def _create_support_forum_action(parent):
-    action = QtGui.QAction(N_("&Support Forum…"), parent)
+    action = TranslatableAction(N_("&Support Forum…"), parent)
     action.triggered.connect(parent.open_support_forum)
     return action
 
 
 @add_action(MainAction.ADD_FILES)
 def _create_add_files_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-open'), N_("&Add Files…"), parent)
+    action = TranslatableAction(icontheme.lookup('document-open'), N_("&Add Files…"), parent)
     action.setStatusTip(N_("Add files to the tagger"))
     # TR: Keyboard shortcut for "Add Files…"
     action.setShortcut(QtGui.QKeySequence.StandardKey.Open)
@@ -200,7 +188,7 @@ def _create_add_files_action(parent):
 
 @add_action(MainAction.ADD_DIRECTORY)
 def _create_add_directory_action(parent):
-    action = QtGui.QAction(icontheme.lookup('folder'), N_("Add Fold&er…"), parent)
+    action = TranslatableAction(icontheme.lookup('folder'), N_("Add Fold&er…"), parent)
     action.setStatusTip(N_("Add a folder to the tagger"))
     # TR: Keyboard shortcut for "Add Directory…"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+E")))
@@ -211,7 +199,7 @@ def _create_add_directory_action(parent):
 @add_action(MainAction.CLOSE_WINDOW)
 def _create_close_window_action(parent):
     if parent.show_close_window:
-        action = QtGui.QAction(N_("Close Window"), parent)
+        action = TranslatableAction(N_("Close Window"), parent)
         action.setShortcut(QtGui.QKeySequence(_("Ctrl+W")))
         action.triggered.connect(parent.close_active_window)
     else:
@@ -221,7 +209,7 @@ def _create_close_window_action(parent):
 
 @add_action(MainAction.SAVE)
 def _create_save_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), N_("&Save"), parent)
+    action = TranslatableAction(icontheme.lookup('document-save'), N_("&Save"), parent)
     action.setStatusTip(N_("Save selected files"))
     # TR: Keyboard shortcut for "Save"
     action.setShortcut(QtGui.QKeySequence.StandardKey.Save)
@@ -233,7 +221,7 @@ def _create_save_action(parent):
 @add_action(MainAction.TRASH)
 def _create_trash_action(parent):
     icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TrashIcon)
-    action = QtGui.QAction(icon, N_("Move to &trash"), parent)
+    action = TranslatableAction(icon, N_("Move to &trash"), parent)
     action.setStatusTip(N_("Move files to trash"))
     action.setShortcut(QtGui.QKeySequence(_("Shift+Del")))
     action.setEnabled(False)
@@ -243,7 +231,7 @@ def _create_trash_action(parent):
 
 @add_action(MainAction.SUBMIT_ACOUSTID)
 def _create_submit_acoustid_action(parent):
-    action = QtGui.QAction(icontheme.lookup('acoustid-fingerprinter'), N_("S&ubmit AcoustIDs"), parent)
+    action = TranslatableAction(icontheme.lookup('acoustid-fingerprinter'), N_("S&ubmit AcoustIDs"), parent)
     action.setStatusTip(N_("Submit acoustic fingerprints"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_submit_acoustid)
@@ -252,7 +240,7 @@ def _create_submit_acoustid_action(parent):
 
 @add_action(MainAction.SUBMIT_ISRC)
 def _create_submit_isrc_action(parent):
-    action = QtGui.QAction(icontheme.lookup('isrc-submit'), N_("Submit &ISRCs"), parent)
+    action = TranslatableAction(icontheme.lookup('isrc-submit'), N_("Submit &ISRCs"), parent)
     action.setStatusTip(N_("Submit ISRCs to MusicBrainz"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_submit_isrc)
@@ -261,7 +249,7 @@ def _create_submit_isrc_action(parent):
 
 @add_action(MainAction.EXIT)
 def _create_exit_action(parent):
-    action = QtGui.QAction(N_("E&xit"), parent)
+    action = TranslatableAction(N_("E&xit"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.QuitRole)
     # TR: Keyboard shortcut for "Exit"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Q")))
@@ -271,7 +259,7 @@ def _create_exit_action(parent):
 
 @add_action(MainAction.REMOVE)
 def _create_remove_action(parent):
-    action = QtGui.QAction(icontheme.lookup('list-remove'), N_("&Remove"), parent)
+    action = TranslatableAction(icontheme.lookup('list-remove'), N_("&Remove"), parent)
     action.setStatusTip(N_("Remove selected files/albums"))
     action.setEnabled(False)
     action.triggered.connect(parent.remove_selected_objects)
@@ -280,7 +268,7 @@ def _create_remove_action(parent):
 
 @add_action(MainAction.BROWSER_LOOKUP)
 def _create_browser_lookup_action(parent):
-    action = QtGui.QAction(icontheme.lookup('lookup-musicbrainz'), N_("Lookup in &Browser"), parent)
+    action = TranslatableAction(icontheme.lookup('lookup-musicbrainz'), N_("Lookup in &Browser"), parent)
     action.setStatusTip(N_("Lookup selected item on MusicBrainz website"))
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Lookup in Browser"
@@ -291,7 +279,7 @@ def _create_browser_lookup_action(parent):
 
 @add_action(MainAction.LOOKUP_ISRC)
 def _create_lookup_isrc_action(parent):
-    action = QtGui.QAction(N_("Lookup by &ISRC"), parent)
+    action = TranslatableAction(N_("Lookup by &ISRC"), parent)
     action.setStatusTip(N_("Lookup selected item by ISRC"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_lookup_isrc)
@@ -301,7 +289,7 @@ def _create_lookup_isrc_action(parent):
 @add_action(MainAction.SUBMIT_CLUSTER)
 def _create_submit_cluster_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(N_("Submit cluster as release…"), parent)
+        action = TranslatableAction(N_("Submit cluster as release…"), parent)
         action.setStatusTip(N_("Submit cluster as a new release to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(parent.submit_cluster)
@@ -313,7 +301,7 @@ def _create_submit_cluster_action(parent):
 @add_action(MainAction.SUBMIT_FILE_AS_RECORDING)
 def _create_submit_file_as_recording_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(N_("Submit file as standalone recording…"), parent)
+        action = TranslatableAction(N_("Submit file as standalone recording…"), parent)
         action.setStatusTip(N_("Submit file as a new recording to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(parent.submit_file)
@@ -325,7 +313,7 @@ def _create_submit_file_as_recording_action(parent):
 @add_action(MainAction.SUBMIT_FILE_AS_RELEASE)
 def _create_submit_file_as_release_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(N_("Submit file as release…"), parent)
+        action = TranslatableAction(N_("Submit file as release…"), parent)
         action.setStatusTip(N_("Submit file as a new release to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(partial(parent.submit_file, as_release=True))
@@ -336,7 +324,7 @@ def _create_submit_file_as_release_action(parent):
 
 @add_action(MainAction.SIMILAR_ITEMS_SEARCH)
 def _create_similar_items_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar items…"), parent)
+    action = TranslatableAction(icontheme.lookup('system-search'), N_("Search for similar items…"), parent)
     action.setIconText(N_("Similar items"))
     action.setStatusTip(N_("View similar releases or recordings and optionally choose a different one"))
     action.setEnabled(False)
@@ -347,7 +335,7 @@ def _create_similar_items_search_action(parent):
 
 @add_action(MainAction.ALBUM_SEARCH)
 def _create_album_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar albums…"), parent)
+    action = TranslatableAction(icontheme.lookup('system-search'), N_("Search for similar albums…"), parent)
     action.setStatusTip(N_("View similar releases and optionally choose a different release"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+T")))
@@ -357,7 +345,7 @@ def _create_album_search_action(parent):
 
 @add_action(MainAction.TRACK_SEARCH)
 def _create_track_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar tracks…"), parent)
+    action = TranslatableAction(icontheme.lookup('system-search'), N_("Search for similar tracks…"), parent)
     action.setStatusTip(N_("View similar tracks and optionally choose a different release"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+T")))
@@ -367,7 +355,7 @@ def _create_track_search_action(parent):
 
 @add_action(MainAction.ALBUM_OTHER_VERSIONS)
 def _create_album_other_versions_action(parent):
-    action = QtGui.QAction(N_("Show &other album versions…"), parent)
+    action = TranslatableAction(N_("Show &other album versions…"), parent)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+O")))
     action.triggered.connect(parent.show_album_other_versions)
     return action
@@ -376,7 +364,7 @@ def _create_album_other_versions_action(parent):
 @add_action(MainAction.SHOW_FILE_BROWSER)
 def _create_show_file_browser_action(parent):
     config = get_config()
-    action = QtGui.QAction(N_("File &Browser"), parent)
+    action = TranslatableAction(N_("File &Browser"), parent)
     action.setCheckable(True)
     if config.persist['view_file_browser']:
         action.setChecked(True)
@@ -388,7 +376,7 @@ def _create_show_file_browser_action(parent):
 @add_action(MainAction.SHOW_METADATA_VIEW)
 def _create_show_metadata_view_action(parent):
     config = get_config()
-    action = QtGui.QAction(N_("&Metadata"), parent)
+    action = TranslatableAction(N_("&Metadata"), parent)
     action.setCheckable(True)
     if config.persist['view_metadata_view']:
         action.setChecked(True)
@@ -400,7 +388,7 @@ def _create_show_metadata_view_action(parent):
 @add_action(MainAction.SHOW_COVER_ART)
 def _create_show_cover_art_action(parent):
     config = get_config()
-    action = QtGui.QAction(N_("&Cover Art"), parent)
+    action = TranslatableAction(N_("&Cover Art"), parent)
     action.setCheckable(True)
     if config.persist['view_cover_art']:
         action.setChecked(True)
@@ -412,7 +400,7 @@ def _create_show_cover_art_action(parent):
 @add_action(MainAction.SHOW_TOOLBAR)
 def _create_show_toolbar_action(parent):
     config = get_config()
-    action = QtGui.QAction(N_("&Actions"), parent)
+    action = TranslatableAction(N_("&Actions"), parent)
     action.setCheckable(True)
     if config.persist['view_toolbar']:
         action.setChecked(True)
@@ -423,7 +411,7 @@ def _create_show_toolbar_action(parent):
 @add_action(MainAction.SHOW_FILTERBAR)
 def _create_filter_bar_action(parent):
     config = get_config()
-    action = QtGui.QAction(N_("Filter Items"), parent)
+    action = TranslatableAction(N_("Filter Items"), parent)
     action.setStatusTip(N_("Toggle filtering of items based on specific tag values."))
     action.setCheckable(True)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+F")))
@@ -435,7 +423,7 @@ def _create_filter_bar_action(parent):
 
 @add_action(MainAction.SEARCH)
 def _create_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search"), parent)
+    action = TranslatableAction(icontheme.lookup('system-search'), N_("Search"), parent)
     action.setEnabled(False)
     action.triggered.connect(parent.search)
     return action
@@ -443,7 +431,7 @@ def _create_search_action(parent):
 
 @add_action(MainAction.CD_LOOKUP)
 def _create_cd_lookup_action(parent):
-    action = QtGui.QAction(icontheme.lookup('media-optical'), N_("Lookup &CD…"), parent)
+    action = TranslatableAction(icontheme.lookup('media-optical'), N_("Lookup &CD…"), parent)
     action.setStatusTip(N_("Lookup the details of the CD in your drive"))
     # TR: Keyboard shortcut for "Lookup CD"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+K")))
@@ -453,7 +441,7 @@ def _create_cd_lookup_action(parent):
 
 @add_action(MainAction.DISCID_FROM_LOGFILE)
 def _lookup_discid_from_logfile_action(parent):
-    action = QtGui.QAction(icontheme.lookup('file-disc'), N_("Lookup CD &log file…"), parent)
+    action = TranslatableAction(icontheme.lookup('file-disc'), N_("Lookup CD &log file…"), parent)
     action.setStatusTip(N_("Lookup release from a CD ripping log file"))
     action.setEnabled(True)
     action.triggered.connect(parent.tagger.lookup_discid_from_logfile)
@@ -462,7 +450,7 @@ def _lookup_discid_from_logfile_action(parent):
 
 @add_action(MainAction.DISCID_FROM_TAGS)
 def _lookup_discid_from_tags_action(parent):
-    action = QtGui.QAction(icontheme.lookup('media-optical-disc-id'), N_("Lookup TOC &tag…"), parent)
+    action = TranslatableAction(icontheme.lookup('media-optical-disc-id'), N_("Lookup TOC &tag…"), parent)
     action.setStatusTip(N_("Lookup release via disc identifiers from track tags"))
     action.setEnabled(False)
     action.triggered.connect(parent.lookup_discid_from_tags)
@@ -471,7 +459,7 @@ def _lookup_discid_from_tags_action(parent):
 
 @add_action(MainAction.ANALYZE)
 def _create_analyze_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-analyze'), N_("&Scan"), parent)
+    action = TranslatableAction(icontheme.lookup('picard-analyze'), N_("&Scan"), parent)
     action.setStatusTip(
         N_("Use AcoustID audio fingerprint to identify the files by the actual music, even if they have no metadata")
     )
@@ -485,7 +473,7 @@ def _create_analyze_action(parent):
 
 @add_action(MainAction.GENERATE_FINGERPRINTS)
 def _create_generate_fingerprints_action(parent):
-    action = QtGui.QAction(icontheme.lookup('fingerprint'), N_("&Generate AcoustID Fingerprints"), parent)
+    action = TranslatableAction(icontheme.lookup('fingerprint'), N_("&Generate AcoustID Fingerprints"), parent)
     action.setIconText(N_("Generate Fingerprints"))
     action.setStatusTip(N_("Generate the AcoustID audio fingerprints for the selected files without doing a lookup"))
     action.setEnabled(False)
@@ -497,7 +485,7 @@ def _create_generate_fingerprints_action(parent):
 
 @add_action(MainAction.CLUSTER)
 def _create_cluster_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-cluster'), N_("Cl&uster"), parent)
+    action = TranslatableAction(icontheme.lookup('picard-cluster'), N_("Cl&uster"), parent)
     action.setStatusTip(N_("Cluster files into album clusters"))
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Cluster"
@@ -508,7 +496,7 @@ def _create_cluster_action(parent):
 
 @add_action(MainAction.AUTOTAG)
 def _create_autotag_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-auto-tag'), N_("&Lookup"), parent)
+    action = TranslatableAction(icontheme.lookup('picard-auto-tag'), N_("&Lookup"), parent)
     tip = N_("Lookup selected items in MusicBrainz")
     action.setToolTip(tip)
     action.setStatusTip(tip)
@@ -521,7 +509,7 @@ def _create_autotag_action(parent):
 
 @add_action(MainAction.VIEW_INFO)
 def _create_view_info_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-edit-tags'), N_("&Info…"), parent)
+    action = TranslatableAction(icontheme.lookup('picard-edit-tags'), N_("&Info…"), parent)
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Info"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+I")))
@@ -531,7 +519,7 @@ def _create_view_info_action(parent):
 
 @add_action(MainAction.REFRESH)
 def _create_refresh_action(parent):
-    action = QtGui.QAction(icontheme.lookup('view-refresh', icontheme.ICON_SIZE_MENU), N_("&Refresh"), parent)
+    action = TranslatableAction(icontheme.lookup('view-refresh', icontheme.ICON_SIZE_MENU), N_("&Refresh"), parent)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+R")))
     action.triggered.connect(parent.refresh)
     return action
@@ -539,7 +527,7 @@ def _create_refresh_action(parent):
 
 @add_action(MainAction.TAGS_FROM_FILENAMES)
 def _create_tags_from_filenames_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-tags-from-filename'), N_("Tags From &File Names…"), parent)
+    action = TranslatableAction(icontheme.lookup('picard-tags-from-filename'), N_("Tags From &File Names…"), parent)
     action.setIconText(N_("Parse File Names…"))
     action.setToolTip(N_("Set tags based on the file names"))
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+T")))
@@ -550,7 +538,7 @@ def _create_tags_from_filenames_action(parent):
 
 @add_action(MainAction.OPEN_COLLECTION_IN_BROWSER)
 def _create_open_collection_in_browser_action(parent):
-    action = QtGui.QAction(N_("&Open My Collections in Browser"), parent)
+    action = TranslatableAction(N_("&Open My Collections in Browser"), parent)
     action.setEnabled(parent.tagger.webservice.oauth_manager.is_logged_in())
     action.triggered.connect(parent.open_collection_in_browser)
     return action
@@ -558,7 +546,7 @@ def _create_open_collection_in_browser_action(parent):
 
 @add_action(MainAction.VIEW_LOG)
 def _create_view_log_action(parent):
-    action = QtGui.QAction(N_("View &Error/Debug Log"), parent)
+    action = TranslatableAction(N_("View &Error/Debug Log"), parent)
     # TR: Keyboard shortcut for "View Error/Debug Log"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+G")))
     action.triggered.connect(parent.show_log)
@@ -567,7 +555,7 @@ def _create_view_log_action(parent):
 
 @add_action(MainAction.VIEW_HISTORY)
 def _create_view_history_action(parent):
-    action = QtGui.QAction(N_("View Activity &History"), parent)
+    action = TranslatableAction(N_("View Activity &History"), parent)
     # TR: Keyboard shortcut for "View Activity History"
     # On macOS ⌘+H is a system shortcut to hide the window. Use ⌘+Shift+H instead.
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+H") if IS_MACOS else _("Ctrl+H")))
@@ -577,7 +565,7 @@ def _create_view_history_action(parent):
 
 @add_action(MainAction.PLAY)
 def _create_play_file_action(parent):
-    action = QtGui.QAction(icontheme.lookup('play'), N_("&Play"), parent)
+    action = TranslatableAction(icontheme.lookup('play'), N_("&Play"), parent)
     action.setStatusTip(N_("Play selected files"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+P")))
@@ -587,7 +575,7 @@ def _create_play_file_action(parent):
 
 @add_action(MainAction.PLAY_FILE_EXTERNAL)
 def _create_play_file_external_action(parent):
-    action = QtGui.QAction(icontheme.lookup('play-music'), N_("Open in System &Media Player"), parent)
+    action = TranslatableAction(icontheme.lookup('play-music'), N_("Open in System &Media Player"), parent)
     action.setStatusTip(N_("Play the file in your default media player"))
     action.setEnabled(False)
     action.triggered.connect(parent.play_file_external)
@@ -596,7 +584,9 @@ def _create_play_file_external_action(parent):
 
 @add_action(MainAction.OPEN_FOLDER)
 def _create_open_folder_action(parent):
-    action = QtGui.QAction(icontheme.lookup('folder', icontheme.ICON_SIZE_MENU), N_("Open Containing &Folder"), parent)
+    action = TranslatableAction(
+        icontheme.lookup('folder', icontheme.ICON_SIZE_MENU), N_("Open Containing &Folder"), parent
+    )
     action.setStatusTip(N_("Open the containing folder in your file explorer"))
     action.setEnabled(False)
     action.triggered.connect(parent.open_folder)
@@ -606,7 +596,7 @@ def _create_open_folder_action(parent):
 @add_action(MainAction.CHECK_UPDATE)
 def _create_check_update_action(parent):
     if parent.tagger.autoupdate_enabled:
-        action = QtGui.QAction(N_("&Check for Update…"), parent)
+        action = TranslatableAction(N_("&Check for Update…"), parent)
         action.setMenuRole(QtGui.QAction.MenuRole.ApplicationSpecificRole)
         action.triggered.connect(parent.do_update_check)
     else:
@@ -616,7 +606,7 @@ def _create_check_update_action(parent):
 
 @add_action(MainAction.SHOW_SETUP_WIZARD)
 def _create_show_setup_wizard_action(parent):
-    action = QtGui.QAction(N_("Show Setup &Wizard…"), parent)
+    action = TranslatableAction(N_("Show Setup &Wizard…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.ApplicationSpecificRole)
     action.triggered.connect(partial(parent.show_setup_wizard, True))
     return action
@@ -624,7 +614,7 @@ def _create_show_setup_wizard_action(parent):
 
 @add_action(MainAction.SAVE_SESSION_AS)
 def _create_save_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), N_("Save Session &As…"), parent)
+    action = TranslatableAction(icontheme.lookup('document-save'), N_("Save Session &As…"), parent)
     action.setStatusTip(N_("Save the current session to a new file"))
     action.triggered.connect(parent.save_session_as)
     return action
@@ -632,7 +622,7 @@ def _create_save_session_action(parent):
 
 @add_action(MainAction.SAVE_SESSION)
 def _create_quick_save_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), N_("&Save Session"), parent)
+    action = TranslatableAction(icontheme.lookup('document-save'), N_("&Save Session"), parent)
     action.setStatusTip(N_("Save the current session to the last used file"))
     action.triggered.connect(parent.quick_save_session)
     return action
@@ -640,7 +630,7 @@ def _create_quick_save_session_action(parent):
 
 @add_action(MainAction.LOAD_SESSION)
 def _create_load_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-open'), N_("&Load Session…"), parent)
+    action = TranslatableAction(icontheme.lookup('document-open'), N_("&Load Session…"), parent)
     action.setStatusTip(N_("Load a session file"))
     action.triggered.connect(parent.load_session)
     return action
@@ -648,7 +638,7 @@ def _create_load_session_action(parent):
 
 @add_action(MainAction.NEW_SESSION)
 def _create_close_session_action(parent):
-    action = QtGui.QAction(N_("&New Session"), parent)
+    action = TranslatableAction(N_("&New Session"), parent)
     action.setStatusTip(N_("Close the current session"))
     action.triggered.connect(parent.close_session)
     return action
@@ -656,7 +646,7 @@ def _create_close_session_action(parent):
 
 @add_action(MainAction.CLEAR_RECENT_SESSIONS)
 def _create_clear_recent_sessions_action(parent):
-    action = QtGui.QAction(N_("Clear Recent Sessions"), parent)
+    action = TranslatableAction(N_("Clear Recent Sessions"), parent)
     action.setStatusTip(N_("Clear all recent session entries"))
     action.triggered.connect(parent.clear_recent_sessions)
     return action

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -88,23 +88,6 @@ def retranslate_actions(action_map):
             action.retranslateUi()
 
 
-def _retranslate_action_property(action, prop_name, getter, setter):
-    """Retranslate a single property of an action.
-
-    On first call, saves the current (untranslated) value as the source.
-    On every call, translates the source and applies it.
-    """
-    source_prop = f'_source_{prop_name}'
-    source = action.property(source_prop)
-    if source is None:
-        # First call: capture the untranslated source string
-        source = getter()
-        if not source:
-            return
-        action.setProperty(source_prop, source)
-    setter(_(source))
-
-
 @add_action(MainAction.OPTIONS)
 def _create_options_action(parent):
     action = TranslatableAction(icontheme.lookup('preferences-desktop'), N_("&Options…"), parent)

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -55,7 +55,10 @@ from PyQt6 import (
 from picard.browser import addrelease
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.util import icontheme
 
 from picard.ui.enums import MainAction
@@ -77,9 +80,46 @@ def create_actions(parent):
         yield (action_name, action(parent))
 
 
+def retranslate_actions(action_map):
+    """Retranslate all actions in the action map.
+
+    On the first call, captures the untranslated source strings from each
+    action (text, statusTip, toolTip, iconText) into Qt dynamic properties.
+    On every call (including the first), applies _() to produce the
+    translated strings.
+
+    This must be called once after action creation to apply the initial
+    translation, and again on each language change.
+    """
+    for action in action_map.values():
+        if action is None:
+            continue
+        _retranslate_action_property(action, 'text', action.text, action.setText)
+        _retranslate_action_property(action, 'statusTip', action.statusTip, action.setStatusTip)
+        _retranslate_action_property(action, 'toolTip', action.toolTip, action.setToolTip)
+        _retranslate_action_property(action, 'iconText', action.iconText, action.setIconText)
+
+
+def _retranslate_action_property(action, prop_name, getter, setter):
+    """Retranslate a single property of an action.
+
+    On first call, saves the current (untranslated) value as the source.
+    On every call, translates the source and applies it.
+    """
+    source_prop = f'_source_{prop_name}'
+    source = action.property(source_prop)
+    if source is None:
+        # First call: capture the untranslated source string
+        source = getter()
+        if not source:
+            return
+        action.setProperty(source_prop, source)
+    setter(_(source))
+
+
 @add_action(MainAction.OPTIONS)
 def _create_options_action(parent):
-    action = QtGui.QAction(icontheme.lookup('preferences-desktop'), _("&Options…"), parent)
+    action = QtGui.QAction(icontheme.lookup('preferences-desktop'), N_("&Options…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.PreferencesRole)
     action.triggered.connect(parent.show_options)
     return action
@@ -87,7 +127,7 @@ def _create_options_action(parent):
 
 @add_action(MainAction.SHOW_SCRIPT_EDITOR)
 def _create_show_script_editor_action(parent):
-    action = QtGui.QAction(_("&Edit scripts…"))
+    action = QtGui.QAction(N_("&Edit scripts…"))
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+S")))
     action.triggered.connect(parent.open_file_naming_script_editor)
     return action
@@ -95,7 +135,7 @@ def _create_show_script_editor_action(parent):
 
 @add_action(MainAction.CUT)
 def _create_cut_action(parent):
-    action = QtGui.QAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), _("&Cut"), parent)
+    action = QtGui.QAction(icontheme.lookup('edit-cut', icontheme.ICON_SIZE_MENU), N_("&Cut"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.Cut)
     action.setEnabled(False)
     action.triggered.connect(parent.cut)
@@ -104,7 +144,7 @@ def _create_cut_action(parent):
 
 @add_action(MainAction.PASTE)
 def _create_paste_action(parent):
-    action = QtGui.QAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), _("&Paste"), parent)
+    action = QtGui.QAction(icontheme.lookup('edit-paste', icontheme.ICON_SIZE_MENU), N_("&Paste"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.Paste)
     action.setEnabled(False)
     action.triggered.connect(parent.paste)
@@ -113,7 +153,7 @@ def _create_paste_action(parent):
 
 @add_action(MainAction.HELP)
 def _create_help_action(parent):
-    action = QtGui.QAction(_("&Help…"), parent)
+    action = QtGui.QAction(N_("&Help…"), parent)
     action.setShortcut(QtGui.QKeySequence.StandardKey.HelpContents)
     action.triggered.connect(parent.show_help)
     return action
@@ -121,7 +161,7 @@ def _create_help_action(parent):
 
 @add_action(MainAction.ABOUT)
 def _create_about_action(parent):
-    action = QtGui.QAction(_("&About…"), parent)
+    action = QtGui.QAction(N_("&About…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.AboutRole)
     action.triggered.connect(parent.show_about)
     return action
@@ -129,29 +169,29 @@ def _create_about_action(parent):
 
 @add_action(MainAction.DONATE)
 def _create_donate_action(parent):
-    action = QtGui.QAction(_("&Donate…"), parent)
+    action = QtGui.QAction(N_("&Donate…"), parent)
     action.triggered.connect(parent.open_donation_page)
     return action
 
 
 @add_action(MainAction.REPORT_BUG)
 def _create_report_bug_action(parent):
-    action = QtGui.QAction(_("&Report a Bug…"), parent)
+    action = QtGui.QAction(N_("&Report a Bug…"), parent)
     action.triggered.connect(parent.open_bug_report)
     return action
 
 
 @add_action(MainAction.SUPPORT_FORUM)
 def _create_support_forum_action(parent):
-    action = QtGui.QAction(_("&Support Forum…"), parent)
+    action = QtGui.QAction(N_("&Support Forum…"), parent)
     action.triggered.connect(parent.open_support_forum)
     return action
 
 
 @add_action(MainAction.ADD_FILES)
 def _create_add_files_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-open'), _("&Add Files…"), parent)
-    action.setStatusTip(_("Add files to the tagger"))
+    action = QtGui.QAction(icontheme.lookup('document-open'), N_("&Add Files…"), parent)
+    action.setStatusTip(N_("Add files to the tagger"))
     # TR: Keyboard shortcut for "Add Files…"
     action.setShortcut(QtGui.QKeySequence.StandardKey.Open)
     action.triggered.connect(parent.add_files)
@@ -160,8 +200,8 @@ def _create_add_files_action(parent):
 
 @add_action(MainAction.ADD_DIRECTORY)
 def _create_add_directory_action(parent):
-    action = QtGui.QAction(icontheme.lookup('folder'), _("Add Fold&er…"), parent)
-    action.setStatusTip(_("Add a folder to the tagger"))
+    action = QtGui.QAction(icontheme.lookup('folder'), N_("Add Fold&er…"), parent)
+    action.setStatusTip(N_("Add a folder to the tagger"))
     # TR: Keyboard shortcut for "Add Directory…"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+E")))
     action.triggered.connect(parent.add_directory)
@@ -171,7 +211,7 @@ def _create_add_directory_action(parent):
 @add_action(MainAction.CLOSE_WINDOW)
 def _create_close_window_action(parent):
     if parent.show_close_window:
-        action = QtGui.QAction(_("Close Window"), parent)
+        action = QtGui.QAction(N_("Close Window"), parent)
         action.setShortcut(QtGui.QKeySequence(_("Ctrl+W")))
         action.triggered.connect(parent.close_active_window)
     else:
@@ -181,8 +221,8 @@ def _create_close_window_action(parent):
 
 @add_action(MainAction.SAVE)
 def _create_save_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), _("&Save"), parent)
-    action.setStatusTip(_("Save selected files"))
+    action = QtGui.QAction(icontheme.lookup('document-save'), N_("&Save"), parent)
+    action.setStatusTip(N_("Save selected files"))
     # TR: Keyboard shortcut for "Save"
     action.setShortcut(QtGui.QKeySequence.StandardKey.Save)
     action.setEnabled(False)
@@ -193,8 +233,8 @@ def _create_save_action(parent):
 @add_action(MainAction.TRASH)
 def _create_trash_action(parent):
     icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TrashIcon)
-    action = QtGui.QAction(icon, _("Move to &trash"), parent)
-    action.setStatusTip(_("Move files to trash"))
+    action = QtGui.QAction(icon, N_("Move to &trash"), parent)
+    action.setStatusTip(N_("Move files to trash"))
     action.setShortcut(QtGui.QKeySequence(_("Shift+Del")))
     action.setEnabled(False)
     action.triggered.connect(parent.trash_files)
@@ -203,8 +243,8 @@ def _create_trash_action(parent):
 
 @add_action(MainAction.SUBMIT_ACOUSTID)
 def _create_submit_acoustid_action(parent):
-    action = QtGui.QAction(icontheme.lookup('acoustid-fingerprinter'), _("S&ubmit AcoustIDs"), parent)
-    action.setStatusTip(_("Submit acoustic fingerprints"))
+    action = QtGui.QAction(icontheme.lookup('acoustid-fingerprinter'), N_("S&ubmit AcoustIDs"), parent)
+    action.setStatusTip(N_("Submit acoustic fingerprints"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_submit_acoustid)
     return action
@@ -212,8 +252,8 @@ def _create_submit_acoustid_action(parent):
 
 @add_action(MainAction.SUBMIT_ISRC)
 def _create_submit_isrc_action(parent):
-    action = QtGui.QAction(icontheme.lookup('isrc-submit'), _("Submit &ISRCs"), parent)
-    action.setStatusTip(_("Submit ISRCs to MusicBrainz"))
+    action = QtGui.QAction(icontheme.lookup('isrc-submit'), N_("Submit &ISRCs"), parent)
+    action.setStatusTip(N_("Submit ISRCs to MusicBrainz"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_submit_isrc)
     return action
@@ -221,7 +261,7 @@ def _create_submit_isrc_action(parent):
 
 @add_action(MainAction.EXIT)
 def _create_exit_action(parent):
-    action = QtGui.QAction(_("E&xit"), parent)
+    action = QtGui.QAction(N_("E&xit"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.QuitRole)
     # TR: Keyboard shortcut for "Exit"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Q")))
@@ -231,8 +271,8 @@ def _create_exit_action(parent):
 
 @add_action(MainAction.REMOVE)
 def _create_remove_action(parent):
-    action = QtGui.QAction(icontheme.lookup('list-remove'), _("&Remove"), parent)
-    action.setStatusTip(_("Remove selected files/albums"))
+    action = QtGui.QAction(icontheme.lookup('list-remove'), N_("&Remove"), parent)
+    action.setStatusTip(N_("Remove selected files/albums"))
     action.setEnabled(False)
     action.triggered.connect(parent.remove_selected_objects)
     return action
@@ -240,8 +280,8 @@ def _create_remove_action(parent):
 
 @add_action(MainAction.BROWSER_LOOKUP)
 def _create_browser_lookup_action(parent):
-    action = QtGui.QAction(icontheme.lookup('lookup-musicbrainz'), _("Lookup in &Browser"), parent)
-    action.setStatusTip(_("Lookup selected item on MusicBrainz website"))
+    action = QtGui.QAction(icontheme.lookup('lookup-musicbrainz'), N_("Lookup in &Browser"), parent)
+    action.setStatusTip(N_("Lookup selected item on MusicBrainz website"))
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Lookup in Browser"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+L")))
@@ -251,8 +291,8 @@ def _create_browser_lookup_action(parent):
 
 @add_action(MainAction.LOOKUP_ISRC)
 def _create_lookup_isrc_action(parent):
-    action = QtGui.QAction(_("Lookup by &ISRC"), parent)
-    action.setStatusTip(_("Lookup selected item by ISRC"))
+    action = QtGui.QAction(N_("Lookup by &ISRC"), parent)
+    action.setStatusTip(N_("Lookup selected item by ISRC"))
     action.setEnabled(False)
     action.triggered.connect(parent._on_lookup_isrc)
     return action
@@ -261,8 +301,8 @@ def _create_lookup_isrc_action(parent):
 @add_action(MainAction.SUBMIT_CLUSTER)
 def _create_submit_cluster_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(_("Submit cluster as release…"), parent)
-        action.setStatusTip(_("Submit cluster as a new release to MusicBrainz"))
+        action = QtGui.QAction(N_("Submit cluster as release…"), parent)
+        action.setStatusTip(N_("Submit cluster as a new release to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(parent.submit_cluster)
     else:
@@ -273,8 +313,8 @@ def _create_submit_cluster_action(parent):
 @add_action(MainAction.SUBMIT_FILE_AS_RECORDING)
 def _create_submit_file_as_recording_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(_("Submit file as standalone recording…"), parent)
-        action.setStatusTip(_("Submit file as a new recording to MusicBrainz"))
+        action = QtGui.QAction(N_("Submit file as standalone recording…"), parent)
+        action.setStatusTip(N_("Submit file as a new recording to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(parent.submit_file)
     else:
@@ -285,8 +325,8 @@ def _create_submit_file_as_recording_action(parent):
 @add_action(MainAction.SUBMIT_FILE_AS_RELEASE)
 def _create_submit_file_as_release_action(parent):
     if addrelease.is_available():
-        action = QtGui.QAction(_("Submit file as release…"), parent)
-        action.setStatusTip(_("Submit file as a new release to MusicBrainz"))
+        action = QtGui.QAction(N_("Submit file as release…"), parent)
+        action.setStatusTip(N_("Submit file as a new release to MusicBrainz"))
         action.setEnabled(False)
         action.triggered.connect(partial(parent.submit_file, as_release=True))
     else:
@@ -296,9 +336,9 @@ def _create_submit_file_as_release_action(parent):
 
 @add_action(MainAction.SIMILAR_ITEMS_SEARCH)
 def _create_similar_items_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), _("Search for similar items…"), parent)
-    action.setIconText(_("Similar items"))
-    action.setStatusTip(_("View similar releases or recordings and optionally choose a different one"))
+    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar items…"), parent)
+    action.setIconText(N_("Similar items"))
+    action.setStatusTip(N_("View similar releases or recordings and optionally choose a different one"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+T")))
     action.triggered.connect(parent.show_similar_items_search)
@@ -307,8 +347,8 @@ def _create_similar_items_search_action(parent):
 
 @add_action(MainAction.ALBUM_SEARCH)
 def _create_album_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), _("Search for similar albums…"), parent)
-    action.setStatusTip(_("View similar releases and optionally choose a different release"))
+    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar albums…"), parent)
+    action.setStatusTip(N_("View similar releases and optionally choose a different release"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+T")))
     action.triggered.connect(parent.show_more_albums)
@@ -317,8 +357,8 @@ def _create_album_search_action(parent):
 
 @add_action(MainAction.TRACK_SEARCH)
 def _create_track_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), _("Search for similar tracks…"), parent)
-    action.setStatusTip(_("View similar tracks and optionally choose a different release"))
+    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search for similar tracks…"), parent)
+    action.setStatusTip(N_("View similar tracks and optionally choose a different release"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+T")))
     action.triggered.connect(parent.show_more_tracks)
@@ -327,7 +367,7 @@ def _create_track_search_action(parent):
 
 @add_action(MainAction.ALBUM_OTHER_VERSIONS)
 def _create_album_other_versions_action(parent):
-    action = QtGui.QAction(_("Show &other album versions…"), parent)
+    action = QtGui.QAction(N_("Show &other album versions…"), parent)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+O")))
     action.triggered.connect(parent.show_album_other_versions)
     return action
@@ -336,7 +376,7 @@ def _create_album_other_versions_action(parent):
 @add_action(MainAction.SHOW_FILE_BROWSER)
 def _create_show_file_browser_action(parent):
     config = get_config()
-    action = QtGui.QAction(_("File &Browser"), parent)
+    action = QtGui.QAction(N_("File &Browser"), parent)
     action.setCheckable(True)
     if config.persist['view_file_browser']:
         action.setChecked(True)
@@ -348,7 +388,7 @@ def _create_show_file_browser_action(parent):
 @add_action(MainAction.SHOW_METADATA_VIEW)
 def _create_show_metadata_view_action(parent):
     config = get_config()
-    action = QtGui.QAction(_("&Metadata"), parent)
+    action = QtGui.QAction(N_("&Metadata"), parent)
     action.setCheckable(True)
     if config.persist['view_metadata_view']:
         action.setChecked(True)
@@ -360,7 +400,7 @@ def _create_show_metadata_view_action(parent):
 @add_action(MainAction.SHOW_COVER_ART)
 def _create_show_cover_art_action(parent):
     config = get_config()
-    action = QtGui.QAction(_("&Cover Art"), parent)
+    action = QtGui.QAction(N_("&Cover Art"), parent)
     action.setCheckable(True)
     if config.persist['view_cover_art']:
         action.setChecked(True)
@@ -372,7 +412,7 @@ def _create_show_cover_art_action(parent):
 @add_action(MainAction.SHOW_TOOLBAR)
 def _create_show_toolbar_action(parent):
     config = get_config()
-    action = QtGui.QAction(_("&Actions"), parent)
+    action = QtGui.QAction(N_("&Actions"), parent)
     action.setCheckable(True)
     if config.persist['view_toolbar']:
         action.setChecked(True)
@@ -383,8 +423,8 @@ def _create_show_toolbar_action(parent):
 @add_action(MainAction.SHOW_FILTERBAR)
 def _create_filter_bar_action(parent):
     config = get_config()
-    action = QtGui.QAction(_("Filter Items"), parent)
-    action.setStatusTip(_("Toggle filtering of items based on specific tag values."))
+    action = QtGui.QAction(N_("Filter Items"), parent)
+    action.setStatusTip(N_("Toggle filtering of items based on specific tag values."))
     action.setCheckable(True)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+F")))
     if config.persist['view_filterbar']:
@@ -395,7 +435,7 @@ def _create_filter_bar_action(parent):
 
 @add_action(MainAction.SEARCH)
 def _create_search_action(parent):
-    action = QtGui.QAction(icontheme.lookup('system-search'), _("Search"), parent)
+    action = QtGui.QAction(icontheme.lookup('system-search'), N_("Search"), parent)
     action.setEnabled(False)
     action.triggered.connect(parent.search)
     return action
@@ -403,8 +443,8 @@ def _create_search_action(parent):
 
 @add_action(MainAction.CD_LOOKUP)
 def _create_cd_lookup_action(parent):
-    action = QtGui.QAction(icontheme.lookup('media-optical'), _("Lookup &CD…"), parent)
-    action.setStatusTip(_("Lookup the details of the CD in your drive"))
+    action = QtGui.QAction(icontheme.lookup('media-optical'), N_("Lookup &CD…"), parent)
+    action.setStatusTip(N_("Lookup the details of the CD in your drive"))
     # TR: Keyboard shortcut for "Lookup CD"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+K")))
     action.triggered.connect(parent.lookup_cd)
@@ -413,8 +453,8 @@ def _create_cd_lookup_action(parent):
 
 @add_action(MainAction.DISCID_FROM_LOGFILE)
 def _lookup_discid_from_logfile_action(parent):
-    action = QtGui.QAction(icontheme.lookup('file-disc'), _("Lookup CD &log file…"), parent)
-    action.setStatusTip(_("Lookup release from a CD ripping log file"))
+    action = QtGui.QAction(icontheme.lookup('file-disc'), N_("Lookup CD &log file…"), parent)
+    action.setStatusTip(N_("Lookup release from a CD ripping log file"))
     action.setEnabled(True)
     action.triggered.connect(parent.tagger.lookup_discid_from_logfile)
     return action
@@ -422,8 +462,8 @@ def _lookup_discid_from_logfile_action(parent):
 
 @add_action(MainAction.DISCID_FROM_TAGS)
 def _lookup_discid_from_tags_action(parent):
-    action = QtGui.QAction(icontheme.lookup('media-optical-disc-id'), _("Lookup TOC &tag…"), parent)
-    action.setStatusTip(_("Lookup release via disc identifiers from track tags"))
+    action = QtGui.QAction(icontheme.lookup('media-optical-disc-id'), N_("Lookup TOC &tag…"), parent)
+    action.setStatusTip(N_("Lookup release via disc identifiers from track tags"))
     action.setEnabled(False)
     action.triggered.connect(parent.lookup_discid_from_tags)
     return action
@@ -431,12 +471,12 @@ def _lookup_discid_from_tags_action(parent):
 
 @add_action(MainAction.ANALYZE)
 def _create_analyze_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-analyze'), _("&Scan"), parent)
+    action = QtGui.QAction(icontheme.lookup('picard-analyze'), N_("&Scan"), parent)
     action.setStatusTip(
-        _("Use AcoustID audio fingerprint to identify the files by the actual music, even if they have no metadata")
+        N_("Use AcoustID audio fingerprint to identify the files by the actual music, even if they have no metadata")
     )
     action.setEnabled(False)
-    action.setToolTip(_("Identify the file using its AcoustID audio fingerprint"))
+    action.setToolTip(N_("Identify the file using its AcoustID audio fingerprint"))
     # TR: Keyboard shortcut for "Analyze"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Y")))
     action.triggered.connect(parent.analyze)
@@ -445,11 +485,11 @@ def _create_analyze_action(parent):
 
 @add_action(MainAction.GENERATE_FINGERPRINTS)
 def _create_generate_fingerprints_action(parent):
-    action = QtGui.QAction(icontheme.lookup('fingerprint'), _("&Generate AcoustID Fingerprints"), parent)
-    action.setIconText(_("Generate Fingerprints"))
-    action.setStatusTip(_("Generate the AcoustID audio fingerprints for the selected files without doing a lookup"))
+    action = QtGui.QAction(icontheme.lookup('fingerprint'), N_("&Generate AcoustID Fingerprints"), parent)
+    action.setIconText(N_("Generate Fingerprints"))
+    action.setStatusTip(N_("Generate the AcoustID audio fingerprints for the selected files without doing a lookup"))
     action.setEnabled(False)
-    action.setToolTip(_("Generate the AcoustID audio fingerprints for the selected files"))
+    action.setToolTip(N_("Generate the AcoustID audio fingerprints for the selected files"))
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+Y")))
     action.triggered.connect(parent.generate_fingerprints)
     return action
@@ -457,8 +497,8 @@ def _create_generate_fingerprints_action(parent):
 
 @add_action(MainAction.CLUSTER)
 def _create_cluster_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-cluster'), _("Cl&uster"), parent)
-    action.setStatusTip(_("Cluster files into album clusters"))
+    action = QtGui.QAction(icontheme.lookup('picard-cluster'), N_("Cl&uster"), parent)
+    action.setStatusTip(N_("Cluster files into album clusters"))
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Cluster"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+U")))
@@ -468,8 +508,8 @@ def _create_cluster_action(parent):
 
 @add_action(MainAction.AUTOTAG)
 def _create_autotag_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-auto-tag'), _("&Lookup"), parent)
-    tip = _("Lookup selected items in MusicBrainz")
+    action = QtGui.QAction(icontheme.lookup('picard-auto-tag'), N_("&Lookup"), parent)
+    tip = N_("Lookup selected items in MusicBrainz")
     action.setToolTip(tip)
     action.setStatusTip(tip)
     action.setEnabled(False)
@@ -481,7 +521,7 @@ def _create_autotag_action(parent):
 
 @add_action(MainAction.VIEW_INFO)
 def _create_view_info_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-edit-tags'), _("&Info…"), parent)
+    action = QtGui.QAction(icontheme.lookup('picard-edit-tags'), N_("&Info…"), parent)
     action.setEnabled(False)
     # TR: Keyboard shortcut for "Info"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+I")))
@@ -491,7 +531,7 @@ def _create_view_info_action(parent):
 
 @add_action(MainAction.REFRESH)
 def _create_refresh_action(parent):
-    action = QtGui.QAction(icontheme.lookup('view-refresh', icontheme.ICON_SIZE_MENU), _("&Refresh"), parent)
+    action = QtGui.QAction(icontheme.lookup('view-refresh', icontheme.ICON_SIZE_MENU), N_("&Refresh"), parent)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+R")))
     action.triggered.connect(parent.refresh)
     return action
@@ -499,9 +539,9 @@ def _create_refresh_action(parent):
 
 @add_action(MainAction.TAGS_FROM_FILENAMES)
 def _create_tags_from_filenames_action(parent):
-    action = QtGui.QAction(icontheme.lookup('picard-tags-from-filename'), _("Tags From &File Names…"), parent)
-    action.setIconText(_("Parse File Names…"))
-    action.setToolTip(_("Set tags based on the file names"))
+    action = QtGui.QAction(icontheme.lookup('picard-tags-from-filename'), N_("Tags From &File Names…"), parent)
+    action.setIconText(N_("Parse File Names…"))
+    action.setToolTip(N_("Set tags based on the file names"))
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+T")))
     action.setEnabled(False)
     action.triggered.connect(parent.open_tags_from_filenames)
@@ -510,7 +550,7 @@ def _create_tags_from_filenames_action(parent):
 
 @add_action(MainAction.OPEN_COLLECTION_IN_BROWSER)
 def _create_open_collection_in_browser_action(parent):
-    action = QtGui.QAction(_("&Open My Collections in Browser"), parent)
+    action = QtGui.QAction(N_("&Open My Collections in Browser"), parent)
     action.setEnabled(parent.tagger.webservice.oauth_manager.is_logged_in())
     action.triggered.connect(parent.open_collection_in_browser)
     return action
@@ -518,7 +558,7 @@ def _create_open_collection_in_browser_action(parent):
 
 @add_action(MainAction.VIEW_LOG)
 def _create_view_log_action(parent):
-    action = QtGui.QAction(_("View &Error/Debug Log"), parent)
+    action = QtGui.QAction(N_("View &Error/Debug Log"), parent)
     # TR: Keyboard shortcut for "View Error/Debug Log"
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+G")))
     action.triggered.connect(parent.show_log)
@@ -527,7 +567,7 @@ def _create_view_log_action(parent):
 
 @add_action(MainAction.VIEW_HISTORY)
 def _create_view_history_action(parent):
-    action = QtGui.QAction(_("View Activity &History"), parent)
+    action = QtGui.QAction(N_("View Activity &History"), parent)
     # TR: Keyboard shortcut for "View Activity History"
     # On macOS ⌘+H is a system shortcut to hide the window. Use ⌘+Shift+H instead.
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+H") if IS_MACOS else _("Ctrl+H")))
@@ -537,8 +577,8 @@ def _create_view_history_action(parent):
 
 @add_action(MainAction.PLAY)
 def _create_play_file_action(parent):
-    action = QtGui.QAction(icontheme.lookup('play'), _("&Play"), parent)
-    action.setStatusTip(_("Play selected files"))
+    action = QtGui.QAction(icontheme.lookup('play'), N_("&Play"), parent)
+    action.setStatusTip(N_("Play selected files"))
     action.setEnabled(False)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+P")))
     action.triggered.connect(parent.play)
@@ -547,8 +587,8 @@ def _create_play_file_action(parent):
 
 @add_action(MainAction.PLAY_FILE_EXTERNAL)
 def _create_play_file_external_action(parent):
-    action = QtGui.QAction(icontheme.lookup('play-music'), _("Open in System &Media Player"), parent)
-    action.setStatusTip(_("Play the file in your default media player"))
+    action = QtGui.QAction(icontheme.lookup('play-music'), N_("Open in System &Media Player"), parent)
+    action.setStatusTip(N_("Play the file in your default media player"))
     action.setEnabled(False)
     action.triggered.connect(parent.play_file_external)
     return action
@@ -556,8 +596,8 @@ def _create_play_file_external_action(parent):
 
 @add_action(MainAction.OPEN_FOLDER)
 def _create_open_folder_action(parent):
-    action = QtGui.QAction(icontheme.lookup('folder', icontheme.ICON_SIZE_MENU), _("Open Containing &Folder"), parent)
-    action.setStatusTip(_("Open the containing folder in your file explorer"))
+    action = QtGui.QAction(icontheme.lookup('folder', icontheme.ICON_SIZE_MENU), N_("Open Containing &Folder"), parent)
+    action.setStatusTip(N_("Open the containing folder in your file explorer"))
     action.setEnabled(False)
     action.triggered.connect(parent.open_folder)
     return action
@@ -566,7 +606,7 @@ def _create_open_folder_action(parent):
 @add_action(MainAction.CHECK_UPDATE)
 def _create_check_update_action(parent):
     if parent.tagger.autoupdate_enabled:
-        action = QtGui.QAction(_("&Check for Update…"), parent)
+        action = QtGui.QAction(N_("&Check for Update…"), parent)
         action.setMenuRole(QtGui.QAction.MenuRole.ApplicationSpecificRole)
         action.triggered.connect(parent.do_update_check)
     else:
@@ -576,7 +616,7 @@ def _create_check_update_action(parent):
 
 @add_action(MainAction.SHOW_SETUP_WIZARD)
 def _create_show_setup_wizard_action(parent):
-    action = QtGui.QAction(_("Show Setup &Wizard…"), parent)
+    action = QtGui.QAction(N_("Show Setup &Wizard…"), parent)
     action.setMenuRole(QtGui.QAction.MenuRole.ApplicationSpecificRole)
     action.triggered.connect(partial(parent.show_setup_wizard, True))
     return action
@@ -584,39 +624,39 @@ def _create_show_setup_wizard_action(parent):
 
 @add_action(MainAction.SAVE_SESSION_AS)
 def _create_save_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), _("Save Session &As…"), parent)
-    action.setStatusTip(_("Save the current session to a new file"))
+    action = QtGui.QAction(icontheme.lookup('document-save'), N_("Save Session &As…"), parent)
+    action.setStatusTip(N_("Save the current session to a new file"))
     action.triggered.connect(parent.save_session_as)
     return action
 
 
 @add_action(MainAction.SAVE_SESSION)
 def _create_quick_save_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-save'), _("&Save Session"), parent)
-    action.setStatusTip(_("Save the current session to the last used file"))
+    action = QtGui.QAction(icontheme.lookup('document-save'), N_("&Save Session"), parent)
+    action.setStatusTip(N_("Save the current session to the last used file"))
     action.triggered.connect(parent.quick_save_session)
     return action
 
 
 @add_action(MainAction.LOAD_SESSION)
 def _create_load_session_action(parent):
-    action = QtGui.QAction(icontheme.lookup('document-open'), _("&Load Session…"), parent)
-    action.setStatusTip(_("Load a session file"))
+    action = QtGui.QAction(icontheme.lookup('document-open'), N_("&Load Session…"), parent)
+    action.setStatusTip(N_("Load a session file"))
     action.triggered.connect(parent.load_session)
     return action
 
 
 @add_action(MainAction.NEW_SESSION)
 def _create_close_session_action(parent):
-    action = QtGui.QAction(_("&New Session"), parent)
-    action.setStatusTip(_("Close the current session"))
+    action = QtGui.QAction(N_("&New Session"), parent)
+    action.setStatusTip(N_("Close the current session"))
     action.triggered.connect(parent.close_session)
     return action
 
 
 @add_action(MainAction.CLEAR_RECENT_SESSIONS)
 def _create_clear_recent_sessions_action(parent):
-    action = QtGui.QAction(_("Clear Recent Sessions"), parent)
-    action.setStatusTip(_("Clear all recent session entries"))
+    action = QtGui.QAction(N_("Clear Recent Sessions"), parent)
+    action.setStatusTip(N_("Clear all recent session entries"))
     action.triggered.connect(parent.clear_recent_sessions)
     return action

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -62,7 +62,7 @@ from picard.i18n import (
 from picard.util import icontheme
 
 from picard.ui.enums import MainAction
-from picard.ui.translatable_action import TranslatableAction
+from picard.ui.translatable import TranslatableAction
 
 
 _actions_functions = {}

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -310,10 +310,11 @@ class MetadataBox(QtWidgets.QTableWidget):
             plugin_manager.plugin_state_changed.connect(self._on_plugin_changed)
 
         # Table widget configuration
-        self.setAccessibleName(_("metadata view"))
-        self.setAccessibleDescription(_("Displays original and new tags for the selected files"))
+        self.setAccessibleName(N_("metadata view"))
+        self.setAccessibleDescription(N_("Displays original and new tags for the selected files"))
         self.setColumnCount(3)
-        self.setHorizontalHeaderLabels((_("Tag"), _("Original Value"), _("New Value")))
+        self._source_header_labels = (N_("Tag"), N_("Original Value"), N_("New Value"))
+        self.setHorizontalHeaderLabels(self._source_header_labels)
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.horizontalHeader().setSectionsClickable(False)
@@ -337,9 +338,9 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.editing = None  # the QTableWidgetItem being edited
 
         # Actions and shortcuts
-        self.add_tag_action = QtGui.QAction(_("Add New Tag…"), self)
+        self.add_tag_action = QtGui.QAction(N_("Add New Tag…"), self)
         self.add_tag_action.triggered.connect(partial(self._edit_tag, ""))
-        self.changes_first_action = QtGui.QAction(_("Show Changes First"), self)
+        self.changes_first_action = QtGui.QAction(N_("Show Changes First"), self)
         self.changes_first_action.setCheckable(True)
         self.changes_first_action.setChecked(config.persist['show_changes_first'])
         self.changes_first_action.toggled.connect(self._toggle_changes_first)
@@ -377,6 +378,36 @@ class MetadataBox(QtWidgets.QTableWidget):
             self.MIMETYPE_TEXT,
             encode_func=lambda tag_diff: tag_diff.to_tsv().encode('utf-8'),
             decode_func=lambda target, mimedata: target._paste_from_text(mimedata),
+        )
+        # Apply initial translation for N_() strings
+        self._retranslate()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate()
+        super().changeEvent(event)
+
+    def _retranslate(self):
+        """Retranslate static UI strings after a language change.
+
+        Uses the same capture-on-first-call pattern: the source is the
+        untranslated N_() string initially set on the widget. It gets
+        captured into a property, then _() is applied on every call.
+        """
+        from picard.ui.mainwindow.actions import _retranslate_action_property
+
+        # Header labels
+        for i, label in enumerate(self._source_header_labels):
+            self.horizontalHeaderItem(i).setText(_(label))
+        # Accessible name/description
+        _retranslate_action_property(self, 'accessibleName', self.accessibleName, self.setAccessibleName)
+        _retranslate_action_property(
+            self, 'accessibleDescription', self.accessibleDescription, self.setAccessibleDescription
+        )
+        # Actions
+        _retranslate_action_property(self.add_tag_action, 'text', self.add_tag_action.text, self.add_tag_action.setText)
+        _retranslate_action_property(
+            self.changes_first_action, 'text', self.changes_first_action.text, self.changes_first_action.setText
         )
 
     def _on_setting_changed(self, name, old_value, new_value):

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -88,6 +88,7 @@ from picard.ui.metadatabox.tagdiffhtml import (
     compute_diff,
     highlight_full,
 )
+from picard.ui.translatable import TranslatableAction
 
 
 # Custom data role for storing diff HTML on table items
@@ -310,11 +311,13 @@ class MetadataBox(QtWidgets.QTableWidget):
             plugin_manager.plugin_state_changed.connect(self._on_plugin_changed)
 
         # Table widget configuration
-        self.setAccessibleName(N_("metadata view"))
-        self.setAccessibleDescription(N_("Displays original and new tags for the selected files"))
+        self._source_accessible_name = N_("metadata view")
+        self._source_accessible_description = N_("Displays original and new tags for the selected files")
+        self.setAccessibleName(_(self._source_accessible_name))
+        self.setAccessibleDescription(_(self._source_accessible_description))
         self.setColumnCount(3)
         self._source_header_labels = (N_("Tag"), N_("Original Value"), N_("New Value"))
-        self.setHorizontalHeaderLabels(self._source_header_labels)
+        self.setHorizontalHeaderLabels([_(label) for label in self._source_header_labels])
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.horizontalHeader().setSectionsClickable(False)
@@ -338,9 +341,9 @@ class MetadataBox(QtWidgets.QTableWidget):
         self.editing = None  # the QTableWidgetItem being edited
 
         # Actions and shortcuts
-        self.add_tag_action = QtGui.QAction(N_("Add New Tag…"), self)
+        self.add_tag_action = TranslatableAction(N_("Add New Tag…"), self)
         self.add_tag_action.triggered.connect(partial(self._edit_tag, ""))
-        self.changes_first_action = QtGui.QAction(N_("Show Changes First"), self)
+        self.changes_first_action = TranslatableAction(N_("Show Changes First"), self)
         self.changes_first_action.setCheckable(True)
         self.changes_first_action.setChecked(config.persist['show_changes_first'])
         self.changes_first_action.toggled.connect(self._toggle_changes_first)
@@ -388,27 +391,16 @@ class MetadataBox(QtWidgets.QTableWidget):
         super().changeEvent(event)
 
     def _retranslate(self):
-        """Retranslate static UI strings after a language change.
-
-        Uses the same capture-on-first-call pattern: the source is the
-        untranslated N_() string initially set on the widget. It gets
-        captured into a property, then _() is applied on every call.
-        """
-        from picard.ui.mainwindow.actions import _retranslate_action_property
-
+        """Retranslate static UI strings after a language change."""
         # Header labels
         for i, label in enumerate(self._source_header_labels):
             self.horizontalHeaderItem(i).setText(_(label))
         # Accessible name/description
-        _retranslate_action_property(self, 'accessibleName', self.accessibleName, self.setAccessibleName)
-        _retranslate_action_property(
-            self, 'accessibleDescription', self.accessibleDescription, self.setAccessibleDescription
-        )
+        self.setAccessibleName(_(self._source_accessible_name))
+        self.setAccessibleDescription(_(self._source_accessible_description))
         # Actions
-        _retranslate_action_property(self.add_tag_action, 'text', self.add_tag_action.text, self.add_tag_action.setText)
-        _retranslate_action_property(
-            self.changes_first_action, 'text', self.changes_first_action.text, self.changes_first_action.setText
-        )
+        self.add_tag_action.retranslateUi()
+        self.changes_first_action.retranslateUi()
 
     def _on_setting_changed(self, name, old_value, new_value):
         settings_to_watch = {

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -383,14 +383,14 @@ class MetadataBox(QtWidgets.QTableWidget):
             decode_func=lambda target, mimedata: target._paste_from_text(mimedata),
         )
         # Apply initial translation for N_() strings
-        self._retranslate()
+        self._retranslate_ui()
 
     def changeEvent(self, event):
         if event.type() == QtCore.QEvent.Type.LanguageChange:
-            self._retranslate()
+            self._retranslate_ui()
         super().changeEvent(event)
 
-    def _retranslate(self):
+    def _retranslate_ui(self):
         """Retranslate static UI strings after a language change."""
         # Header labels
         for i, label in enumerate(self._source_header_labels):

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -862,6 +862,31 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             url = 'doc_options'  # key in PICARD_DOCS_URLS
         return url
 
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate()
+        super().changeEvent(event)
+
+    def _retranslate(self):
+        """Retranslate the options dialog after a language change."""
+        # Retranslate the auto-generated form (window title, labels, etc.)
+        self.ui.retranslateUi(self)
+        # Retranslate page titles in the tree
+        for item, PageCls in self.item_to_page.items():
+            item.setText(0, PageCls.display_title())
+        # Retranslate the currently visible page's form if it has retranslateUi
+        current_page = self._get_current_page()
+        if current_page and hasattr(current_page, 'ui') and hasattr(current_page.ui, 'retranslateUi'):
+            current_page.ui.retranslateUi(current_page)
+
+    def _get_current_page(self):
+        """Return the currently visible options page instance, or None."""
+        items = self.ui.pages_tree.selectedItems()
+        if items and items[0] in self.item_to_page:
+            page_cls = self.item_to_page[items[0]]
+            return self._page_instances.get(page_cls.NAME)
+        return None
+
     def accept(self):
         for page in self.loaded_pages:
             try:

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -876,8 +876,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             item.setText(0, PageCls.display_title())
         # Retranslate the currently visible page's form if it has retranslateUi
         current_page = self._get_current_page()
-        if current_page and hasattr(current_page, 'ui') and hasattr(current_page.ui, 'retranslateUi'):
-            current_page.ui.retranslateUi(current_page)
+        if current_page:
+            if hasattr(current_page, 'ui') and hasattr(current_page.ui, 'retranslateUi'):
+                current_page.ui.retranslateUi(current_page)
+            # Propagate LanguageChange to custom child widgets within the page
+            event = QtCore.QEvent(QtCore.QEvent.Type.LanguageChange)
+            QtCore.QCoreApplication.sendEvent(current_page, event)
 
     def _get_current_page(self):
         """Return the currently visible options page instance, or None."""

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -114,6 +114,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     tags_compatibility_wave,
 )
 from picard.ui.theme import theme as _theme
+from picard.ui.translatable import TranslatablePushButton
 
 
 if TYPE_CHECKING:
@@ -306,14 +307,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         profile_help_button.clicked.connect(self._show_profile_help)
         profile_layout.addWidget(profile_help_button)
 
-        self.ui.reset_all_button = QtWidgets.QPushButton(_("&Restore all Defaults"))
-        self.ui.reset_all_button.setToolTip(_("Reset all of Picard's settings"))
-        self.ui.reset_button = QtWidgets.QPushButton(_("Restore &Defaults"))
-        self.ui.reset_button.setToolTip(_("Reset all settings for current option page"))
+        self.ui.reset_all_button = TranslatablePushButton(N_("&Restore all Defaults"))
+        self.ui.reset_all_button.setToolTip(N_("Reset all of Picard's settings"))
+        self.ui.reset_button = TranslatablePushButton(N_("Restore &Defaults"))
+        self.ui.reset_button.setToolTip(N_("Reset all settings for current option page"))
 
         # Buttons
-        ok = QtWidgets.QPushButton(_("Make It So!"))
-        self.ui.buttonbox.addButton(ok, QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        self._ok_button = TranslatablePushButton(N_("Make It So!"))
+        self.ui.buttonbox.addButton(self._ok_button, QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Help)
         self.ui.buttonbox.addButton(self.ui.reset_all_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)
@@ -871,6 +872,10 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         """Retranslate the options dialog after a language change."""
         # Retranslate the auto-generated form (window title, labels, etc.)
         self.ui.retranslateUi(self)
+        # Retranslate dialog buttons
+        self._ok_button.retranslateUi()
+        self.ui.reset_all_button.retranslateUi()
+        self.ui.reset_button.retranslateUi()
         # Retranslate page titles in the tree
         for item, PageCls in self.item_to_page.items():
             item.setText(0, PageCls.display_title())

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -872,10 +872,6 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         """Retranslate the options dialog after a language change."""
         # Retranslate the auto-generated form (window title, labels, etc.)
         self.ui.retranslateUi(self)
-        # Retranslate dialog buttons
-        self._ok_button.retranslateUi()
-        self.ui.reset_all_button.retranslateUi()
-        self.ui.reset_button.retranslateUi()
         # Retranslate page titles in the tree
         for item, PageCls in self.item_to_page.items():
             item.setText(0, PageCls.display_title())

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -129,6 +129,7 @@ class InterfaceOptionsPage(OptionsPage):
             else:
                 name = translation
             self.ui.ui_language.addItem(name, lang_code)
+        self.ui.ui_language.currentIndexChanged.connect(self._on_language_changed)
         self.ui.starting_directory.toggled.connect(self.ui.starting_directory_path.setEnabled)
         self.ui.starting_directory.toggled.connect(self.ui.starting_directory_browse.setEnabled)
         self.ui.starting_directory_browse.clicked.connect(self.starting_directory_browse)
@@ -156,10 +157,32 @@ class InterfaceOptionsPage(OptionsPage):
             selected_theme = theme.get_system_theme(self.tagger)
         theme.apply_theme(self.tagger, selected_theme)
 
+    def _on_language_changed(self, index):
+        """Apply the language immediately when the user selects it."""
+        selected_language = self.ui.ui_language.itemData(index)
+        if selected_language is None:
+            return
+        switch_language(selected_language or None, log.debug)
+
+    def _revert_language(self):
+        """Revert to the saved language if the dialog is cancelled."""
+        config = get_config()
+        saved_language = config.setting['ui_language']
+        switch_language(saved_language or None, log.debug)
+
+    def _dialog_rejected(self):
+        """Handle dialog cancellation by reverting live-previewed changes."""
+        self._revert_language()
+
     def load(self):
         # Don't display the multi-selection warning when loading values.
         # This is required because loading a different option profile could trigger the warning.
         self.ui.allow_multi_dirs_selection.blockSignals(True)
+
+        # Revert live-previewed changes if the dialog is cancelled
+        if not hasattr(self, '_reject_connected'):
+            self.dialog.rejected.connect(self._dialog_rejected)
+            self._reject_connected = True
 
         config = get_config()
         self.ui.toolbar_show_labels.setChecked(config.setting['toolbar_show_labels'])
@@ -169,7 +192,8 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.quit_confirmation.setChecked(config.setting['quit_confirmation'])
         self.ui.file_save_warning.setChecked(config.setting['file_save_warning'])
         current_ui_language = config.setting['ui_language']
-        self.ui.ui_language.setCurrentIndex(self.ui.ui_language.findData(current_ui_language))
+        with QtCore.QSignalBlocker(self.ui.ui_language):
+            self.ui.ui_language.setCurrentIndex(self.ui.ui_language.findData(current_ui_language))
         self.ui.filebrowser_horizontal_autoscroll.setChecked(config.setting['filebrowser_horizontal_autoscroll'])
         self.ui.starting_directory.setChecked(config.setting['starting_directory'])
         self.ui.starting_directory_path.setText(config.setting['starting_directory_path'])
@@ -196,7 +220,6 @@ class InterfaceOptionsPage(OptionsPage):
             config.setting['ui_theme'] = new_theme_setting
         if new_language != config.setting['ui_language']:
             config.setting['ui_language'] = new_language
-            switch_language(new_language or None, log.debug)
             ReadTheDocs.update_documentation_items()
 
         config.setting['filebrowser_horizontal_autoscroll'] = self.ui.filebrowser_horizontal_autoscroll.isChecked()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -34,6 +34,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import log
 from picard.config import get_config
 from picard.const.languages import UI_LANGUAGES
 from picard.extension_points.options_pages import register_options_page
@@ -42,6 +43,7 @@ from picard.i18n import (
     gettext as _,
     gettext_constants,
     sort_key,
+    switch_language,
 )
 from picard.util.readthedocs import ReadTheDocs
 
@@ -56,10 +58,7 @@ from picard.ui.theme import (
     UiTheme,
     theme,
 )
-from picard.ui.util import (
-    FileDialog,
-    changes_require_restart_warning,
-)
+from picard.ui.util import FileDialog
 
 
 class InterfaceOptionsPage(OptionsPage):
@@ -193,15 +192,12 @@ class InterfaceOptionsPage(OptionsPage):
         self.tagger.window.update_toolbar_style()
         new_theme_setting = str(self.ui.ui_theme.itemData(self.ui.ui_theme.currentIndex()))
         new_language = self.ui.ui_language.itemData(self.ui.ui_language.currentIndex())
-        warnings = []
-        notes = []
         if new_theme_setting != config.setting['ui_theme']:
             config.setting['ui_theme'] = new_theme_setting
         if new_language != config.setting['ui_language']:
             config.setting['ui_language'] = new_language
-            warnings.append(_("You have changed the interface language."))
+            switch_language(new_language or None, log.debug)
             ReadTheDocs.update_documentation_items()
-        changes_require_restart_warning(self, warnings=warnings, notes=notes)
 
         config.setting['filebrowser_horizontal_autoscroll'] = self.ui.filebrowser_horizontal_autoscroll.isChecked()
         config.setting['starting_directory'] = self.ui.starting_directory.isChecked()

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -117,18 +117,7 @@ class InterfaceOptionsPage(OptionsPage):
         self.ui.ui_theme.setCurrentIndex(self.ui.ui_theme.findData(UiTheme.DEFAULT))
         self.ui.ui_theme.currentIndexChanged.connect(self._on_theme_changed)
 
-        self.ui.ui_language.addItem(_("System default"), '')
-        language_list = [(lang[0], lang[1], gettext_constants(lang[2])) for lang in UI_LANGUAGES]
-
-        def fcmp(x):
-            return sort_key(x[2])
-
-        for lang_code, native, translation in sorted(language_list, key=fcmp):
-            if native and native != translation:
-                name = '%s (%s)' % (translation, native)
-            else:
-                name = translation
-            self.ui.ui_language.addItem(name, lang_code)
+        self._populate_language_combo()
         self.ui.ui_language.currentIndexChanged.connect(self._on_language_changed)
         self.ui.starting_directory.toggled.connect(self.ui.starting_directory_path.setEnabled)
         self.ui.starting_directory.toggled.connect(self.ui.starting_directory_browse.setEnabled)
@@ -173,6 +162,33 @@ class InterfaceOptionsPage(OptionsPage):
     def _dialog_rejected(self):
         """Handle dialog cancellation by reverting live-previewed changes."""
         self._revert_language()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate the language combo items."""
+        current_data = self.ui.ui_language.currentData()
+        with QtCore.QSignalBlocker(self.ui.ui_language):
+            self._populate_language_combo()
+            idx = self.ui.ui_language.findData(current_data)
+            if idx >= 0:
+                self.ui.ui_language.setCurrentIndex(idx)
+
+    def _populate_language_combo(self):
+        """Populate the language combo with translated names."""
+        self.ui.ui_language.clear()
+        self.ui.ui_language.addItem(_("System default"), '')
+        language_list = [(lang[0], lang[1], gettext_constants(lang[2])) for lang in UI_LANGUAGES]
+
+        for lang_code, native, translation in sorted(language_list, key=lambda x: sort_key(x[2])):
+            if native and native != translation:
+                name = '%s (%s)' % (translation, native)
+            else:
+                name = translation
+            self.ui.ui_language.addItem(name, lang_code)
 
     def load(self):
         # Don't display the multi-selection warning when loading values.

--- a/picard/ui/player/toolbar.py
+++ b/picard/ui/player/toolbar.py
@@ -44,6 +44,7 @@ from .player import (
     Player,
 )
 
+from picard.ui.translatable import TranslatableAction
 from picard.ui.util import get_text_width
 from picard.ui.widgets import (
     ClickableSlider,
@@ -54,7 +55,8 @@ from picard.ui.widgets import (
 
 class PlayerToolbar(QtWidgets.QToolBar):
     def __init__(self, player: Player, parent=None):
-        super().__init__(_("Player"), parent=parent)
+        self._source_toolbar_title = N_("Player")
+        super().__init__(self._source_toolbar_title, parent=parent)
         self.setObjectName('player_toolbar')
         self.setAllowedAreas(
             QtCore.Qt.ToolBarArea.TopToolBarArea
@@ -65,18 +67,16 @@ class PlayerToolbar(QtWidgets.QToolBar):
         self.player = player
         self.player.playback_state_changed.connect(self.playback_state_changed)
 
-        self.play_action = QtGui.QAction(icontheme.lookup('play'), _("Play"), self)
-        play_tip = _("Play selected files")
-        self.play_action.setToolTip(play_tip)
-        self.play_action.setStatusTip(play_tip)
+        self.play_action = TranslatableAction(icontheme.lookup('play'), N_("Play"), self)
+        self.play_action.setToolTip(N_("Play selected files"))
+        self.play_action.setStatusTip(N_("Play selected files"))
         self.play_action.setEnabled(False)
         self.play_action.triggered.connect(self.play)
         self.player.playback_available.connect(self.play_action.setEnabled)
 
-        self.pause_action = QtGui.QAction(icontheme.lookup('pause'), _("Pause"), self)
-        pause_tip = _("Pause or resume current playback")
-        self.pause_action.setToolTip(pause_tip)
-        self.pause_action.setStatusTip(pause_tip)
+        self.pause_action = TranslatableAction(icontheme.lookup('pause'), N_("Pause"), self)
+        self.pause_action.setToolTip(N_("Pause or resume current playback"))
+        self.pause_action.setStatusTip(N_("Pause or resume current playback"))
         self.pause_action.setCheckable(True)
         self.pause_action.setChecked(False)
         self.pause_action.setEnabled(False)
@@ -125,6 +125,19 @@ class PlayerToolbar(QtWidgets.QToolBar):
     def play(self):
         self.player.play()
         self.pause_action.setChecked(False)
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate toolbar elements after a language change."""
+        self.setWindowTitle(_(self._source_toolbar_title))
+        self.play_action.retranslateUi()
+        self.pause_action.retranslateUi()
+        self.volume_button._retranslate_ui()
+        self.playback_rate_button._retranslate_ui()
 
     def setToolButtonStyle(self, style):
         super().setToolButtonStyle(style)
@@ -236,6 +249,8 @@ class PlaybackRateButton(QtWidgets.QToolButton):
         self._is_updating = IgnoreUpdatesContext()
         self.popover_position = 'bottom'
         self._rate_fmt = N_("%1.1f ×")
+        self._source_tooltip = N_("Change playback speed")
+        self._source_popover_title = N_("Playback speed")
         style = self.style()
         assert style is not None
         button_margin = style.pixelMetric(QtWidgets.QStyle.PixelMetric.PM_ButtonMargin)
@@ -243,13 +258,18 @@ class PlaybackRateButton(QtWidgets.QToolButton):
         self.setMinimumWidth(min_width + (2 * button_margin) + 2)
         self.set_playback_rate(playback_rate)
         self.clicked.connect(self.show_popover)
-        tooltip = _("Change playback speed")
-        self.setToolTip(tooltip)
-        self.setStatusTip(tooltip)
+        self.setToolTip(_(self._source_tooltip))
+        self.setStatusTip(_(self._source_tooltip))
+
+    def _retranslate_ui(self):
+        """Retranslate tooltip and update displayed rate text."""
+        self.setToolTip(_(self._source_tooltip))
+        self.setStatusTip(_(self._source_tooltip))
+        self.set_playback_rate(self._playback_rate)
 
     def show_popover(self):
         slider_value = self._playback_rate * self.multiplier
-        popover = SliderPopover(self, self.popover_position, _("Playback speed"), slider_value)
+        popover = SliderPopover(self, self.popover_position, _(self._source_popover_title), slider_value)
         # In 0.1 steps from 0.5 to 1.5
         popover.slider.setMinimum(int(MIN_PLAYBACK_RATE * self.multiplier))
         popover.slider.setMaximum(int(MAX_PLAYBACK_RATE * self.multiplier))
@@ -298,6 +318,8 @@ class VolumeControlButton(QtWidgets.QToolButton):
         self.popover_position = 'bottom'
         self._step = 3
         self._volume_fmt = N_("%d%%")
+        self._source_tooltip = N_("Change audio volume")
+        self._source_popover_title = N_("Audio volume")
         self.set_volume(volume)
         style = self.style()
         assert style is not None
@@ -305,33 +327,38 @@ class VolumeControlButton(QtWidgets.QToolButton):
         min_width = get_text_width(self.font(), _(self._volume_fmt) % 888)
         self.setMinimumWidth(min_width + (2 * button_margin) + 2)
         self.clicked.connect(self.show_popover)
-        tooltip = _("Change audio volume")
-        self.setToolTip(tooltip)
-        self.setStatusTip(tooltip)
+        self.setToolTip(_(self._source_tooltip))
+        self.setStatusTip(_(self._source_tooltip))
 
         # Register global volume up / down keyboard shortcuts
-        self.volume_up_action = QtGui.QAction(_('Volume up'), self)
-        volume_up_tip = _("Increase audio volume")
-        self.volume_up_action.setToolTip(volume_up_tip)
-        self.volume_up_action.setStatusTip(volume_up_tip)
+        self.volume_up_action = TranslatableAction(N_('Volume up'), self)
+        self.volume_up_action.setToolTip(N_("Increase audio volume"))
+        self.volume_up_action.setStatusTip(N_("Increase audio volume"))
         self.volume_up_action.setEnabled(True)
         self.volume_up_action.setShortcutContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
         self.volume_up_action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift++")))
         self.volume_up_action.triggered.connect(self.volume_up)
         self.addAction(self.volume_up_action)
 
-        self.volume_down_action = QtGui.QAction(_('Volume down'), self)
-        volume_down_tip = _("Decrease audio volume")
-        self.volume_down_action.setToolTip(volume_down_tip)
-        self.volume_down_action.setStatusTip(volume_down_tip)
+        self.volume_down_action = TranslatableAction(N_('Volume down'), self)
+        self.volume_down_action.setToolTip(N_("Decrease audio volume"))
+        self.volume_down_action.setStatusTip(N_("Decrease audio volume"))
         self.volume_up_action.setEnabled(True)
         self.volume_down_action.setShortcutContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
         self.volume_down_action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+-")))
         self.volume_down_action.triggered.connect(self.volume_down)
         self.addAction(self.volume_down_action)
 
+    def _retranslate_ui(self):
+        """Retranslate tooltip and volume actions."""
+        self.setToolTip(_(self._source_tooltip))
+        self.setStatusTip(_(self._source_tooltip))
+        self.volume_up_action.retranslateUi()
+        self.volume_down_action.retranslateUi()
+        self._set_volume(self._volume, signal=False)
+
     def show_popover(self):
-        popover = SliderPopover(self, self.popover_position, _("Audio volume"), self._volume)
+        popover = SliderPopover(self, self.popover_position, _(self._source_popover_title), self._volume)
         popover.slider.setMinimum(0)
         popover.slider.setMaximum(100)
         popover.slider.setPageStep(self._step)

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -77,6 +77,10 @@ from picard.ui.options.scripting import (
     OptionsCheckError,
     ScriptCheckError,
 )
+from picard.ui.translatable import (
+    TranslatableAction,
+    TranslatableMenu,
+)
 from picard.ui.util import set_widget_fixed_width_for_text
 from picard.ui.widgets.scriptdocumentation import ScriptingDocumentationWidget
 
@@ -238,76 +242,79 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         main_menu = QtWidgets.QMenuBar()
 
         # File menu settings
-        file_menu = main_menu.addMenu(_("&File"))
+        file_menu = TranslatableMenu(N_("&File"))
+        main_menu.addMenu(file_menu)
         file_menu.setToolTipsVisible(True)
 
-        self.import_action = QtGui.QAction(_("&Import a script file"), self)
-        self.import_action.setToolTip(_("Import a file as a new script"))
+        self.import_action = TranslatableAction(N_("&Import a script file"), self)
+        self.import_action.setToolTip(N_("Import a file as a new script"))
         self.import_action.setIcon(icontheme.lookup('document-open'))
         self.import_action.triggered.connect(self.import_script)
         file_menu.addAction(self.import_action)
 
-        self.export_action = QtGui.QAction(_("&Export a script file"), self)
-        self.export_action.setToolTip(_("Export the script to a file"))
+        self.export_action = TranslatableAction(N_("&Export a script file"), self)
+        self.export_action.setToolTip(N_("Export the script to a file"))
         self.export_action.setIcon(icontheme.lookup('document-save'))
         self.export_action.triggered.connect(self.export_script)
         file_menu.addAction(self.export_action)
 
-        self.reset_action = QtGui.QAction(_("&Reset all scripts"), self)
-        self.reset_action.setToolTip(_("Reset all scripts to the saved values"))
+        self.reset_action = TranslatableAction(N_("&Reset all scripts"), self)
+        self.reset_action.setToolTip(N_("Reset all scripts to the saved values"))
         self.reset_action.setIcon(icontheme.lookup('view-refresh'))
         self.reset_action.triggered.connect(self.reload_from_config)
         file_menu.addAction(self.reset_action)
 
-        self.save_action = QtGui.QAction(_("&Save and exit"), self)
-        self.save_action.setToolTip(_("Save changes to the script settings and exit"))
+        self.save_action = TranslatableAction(N_("&Save and exit"), self)
+        self.save_action.setToolTip(N_("Save changes to the script settings and exit"))
         self.save_action.setIcon(icontheme.lookup('document-save'))
         self.save_action.triggered.connect(self.make_it_so)
         file_menu.addAction(self.save_action)
 
-        self.close_action = QtGui.QAction(_("E&xit without saving"), self)
-        self.close_action.setToolTip(_("Close the script editor without saving changes"))
+        self.close_action = TranslatableAction(N_("E&xit without saving"), self)
+        self.close_action.setToolTip(N_("Close the script editor without saving changes"))
         self.close_action.triggered.connect(self.close)
         file_menu.addAction(self.close_action)
 
         # Script menu settings
-        script_menu = main_menu.addMenu(_("&Script"))
+        script_menu = TranslatableMenu(N_("&Script"))
+        main_menu.addMenu(script_menu)
         script_menu.setToolTipsVisible(True)
 
-        self.details_action = QtGui.QAction(_("View/Edit Script &Metadata"), self)
-        self.details_action.setToolTip(_("Display the details for the script"))
+        self.details_action = TranslatableAction(N_("View/Edit Script &Metadata"), self)
+        self.details_action.setToolTip(N_("Display the details for the script"))
         self.details_action.triggered.connect(self.view_script_details)
         self.details_action.setShortcut(QtGui.QKeySequence(_("Ctrl+M")))
         script_menu.addAction(self.details_action)
 
-        self.add_action = QtWidgets.QMenu(_("Add a &new script"))
+        self.add_action = TranslatableMenu(N_("Add a &new script"))
         self.add_action.setIcon(icontheme.lookup('add-item'))
         self.make_script_template_selector_menu()
         script_menu.addMenu(self.add_action)
 
-        self.copy_action = QtGui.QAction(_("&Copy the current script"), self)
-        self.copy_action.setToolTip(_("Save a copy of the script as a new script"))
+        self.copy_action = TranslatableAction(N_("&Copy the current script"), self)
+        self.copy_action.setToolTip(N_("Save a copy of the script as a new script"))
         self.copy_action.setIcon(icontheme.lookup('edit-copy'))
         self.copy_action.triggered.connect(self.copy_script)
         script_menu.addAction(self.copy_action)
 
-        self.delete_action = QtGui.QAction(_("&Delete the current script"), self)
-        self.delete_action.setToolTip(_("Delete the script"))
+        self.delete_action = TranslatableAction(N_("&Delete the current script"), self)
+        self.delete_action.setToolTip(N_("Delete the script"))
         self.delete_action.setIcon(icontheme.lookup('list-remove'))
         self.delete_action.triggered.connect(self.delete_script)
         script_menu.addAction(self.delete_action)
 
-        self.reset_current_script_action = QtGui.QAction(_("Rese&t current script"), self)
-        self.reset_current_script_action.setToolTip(_("Discard changes and reset to the last saved version"))
+        self.reset_current_script_action = TranslatableAction(N_("Rese&t current script"), self)
+        self.reset_current_script_action.setToolTip(N_("Discard changes and reset to the last saved version"))
         self.reset_current_script_action.setIcon(icontheme.lookup('view-refresh'))
         self.reset_current_script_action.triggered.connect(self.revert_script)
         script_menu.addAction(self.reset_current_script_action)
 
         # Display menu settings
-        display_menu = main_menu.addMenu(_("&View"))
+        display_menu = TranslatableMenu(N_("&View"))
+        main_menu.addMenu(display_menu)
         display_menu.setToolTipsVisible(True)
 
-        self.examples_action = QtGui.QAction(_("&Reload random example files"), self)
+        self.examples_action = TranslatableAction(N_("&Reload random example files"), self)
         self.examples_action.setToolTip(self.examples.get_tooltip_text())
         self.examples_action.setIcon(icontheme.lookup('view-refresh'))
         self.examples_action.triggered.connect(self.update_example_files)
@@ -316,8 +323,8 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         display_menu.addAction(self.ui.file_naming_format.wordwrap_action)
         display_menu.addAction(self.ui.file_naming_format.show_tooltips_action)
 
-        self.docs_action = QtGui.QAction(_("&Show documentation"), self)
-        self.docs_action.setToolTip(_("View the scripting documentation in a sidebar"))
+        self.docs_action = TranslatableAction(N_("&Show documentation"), self)
+        self.docs_action.setToolTip(N_("View the scripting documentation in a sidebar"))
         self.docs_action.triggered.connect(self.toggle_documentation)
         self.docs_action.setShortcut(QtGui.QKeySequence(_("Ctrl+H")))
         self.docs_action.setCheckable(True)
@@ -325,20 +332,57 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         display_menu.addAction(self.docs_action)
 
         # Help menu settings
-        help_menu = main_menu.addMenu(_("&Help"))
+        help_menu = TranslatableMenu(N_("&Help"))
+        main_menu.addMenu(help_menu)
         help_menu.setToolTipsVisible(True)
 
-        self.help_action = QtGui.QAction(_("&Help…"), self)
+        self.help_action = TranslatableAction(N_("&Help…"), self)
         self.help_action.setShortcut(QtGui.QKeySequence.StandardKey.HelpContents)
         self.help_action.triggered.connect(self.show_help)
         help_menu.addAction(self.help_action)
 
-        self.scripting_docs_action = QtGui.QAction(_("&Scripting documentation…"), self)
-        self.scripting_docs_action.setToolTip(_("Open the scripting documentation in your browser"))
+        self.scripting_docs_action = TranslatableAction(N_("&Scripting documentation…"), self)
+        self.scripting_docs_action.setToolTip(N_("Open the scripting documentation in your browser"))
         self.scripting_docs_action.triggered.connect(self.docs_browser)
         help_menu.addAction(self.scripting_docs_action)
 
+        self._translatable_menus = [file_menu, script_menu, display_menu, help_menu]
+        self._translatable_actions = [
+            self.import_action,
+            self.export_action,
+            self.reset_action,
+            self.save_action,
+            self.close_action,
+            self.details_action,
+            self.copy_action,
+            self.delete_action,
+            self.reset_current_script_action,
+            self.examples_action,
+            self.docs_action,
+            self.help_action,
+            self.scripting_docs_action,
+        ]
         self.ui.layout_for_menubar.addWidget(main_menu)
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            self.ui.retranslateUi(self)
+            self._retranslate_ui()
+        super().changeEvent(event)
+
+    def _retranslate_ui(self):
+        """Retranslate programmatic UI elements after a language change."""
+        # Menus
+        for menu in self._translatable_menus:
+            menu.retranslateUi()
+        self.add_action.retranslateUi()
+        # Actions
+        for action in self._translatable_actions:
+            action.retranslateUi()
+        # Rebuild template selector (uses live _() calls)
+        self.make_script_template_selector_menu()
+        # Window title
+        self.set_window_title(self.display_title())
 
     def make_script_template_selector_menu(self):
         """Update the sub-menu of available file naming script templates."""

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -379,6 +379,9 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         # Actions
         for action in self._translatable_actions:
             action.retranslateUi()
+        # Script text edit actions
+        self.ui.file_naming_format.wordwrap_action.retranslateUi()
+        self.ui.file_naming_format.show_tooltips_action.retranslateUi()
         # Rebuild template selector (uses live _() calls)
         self.make_script_template_selector_menu()
         # Window title

--- a/picard/ui/translatable.py
+++ b/picard/ui/translatable.py
@@ -17,7 +17,10 @@
 
 
 from PyQt6.QtGui import QAction
-from PyQt6.QtWidgets import QMenu
+from PyQt6.QtWidgets import (
+    QMenu,
+    QPushButton,
+)
 
 from picard.i18n import gettext as _
 
@@ -96,3 +99,36 @@ class TranslatableMenu(QMenu):
         """Re-apply _() to the stored source title."""
         if self._source_title:
             super().setTitle(_(self._source_title))
+
+
+class TranslatablePushButton(QPushButton):
+    """QPushButton subclass that supports dynamic retranslation.
+
+    The text passed to the constructor or setText() is treated as an
+    untranslated source string (as marked with N_() at the call site).
+    The source is stored and _() is applied immediately.
+
+    Call retranslateUi() after a language change to re-apply _().
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._source_text = self.text()
+        self._source_tool_tip = ''
+        if self._source_text:
+            super().setText(_(self._source_text))
+
+    def setText(self, text):
+        self._source_text = text
+        super().setText(_(text) if text else '')
+
+    def setToolTip(self, text):
+        self._source_tool_tip = text
+        super().setToolTip(_(text) if text else '')
+
+    def retranslateUi(self):
+        """Re-apply _() to stored source strings."""
+        if self._source_text:
+            super().setText(_(self._source_text))
+        if self._source_tool_tip:
+            super().setToolTip(_(self._source_tool_tip))

--- a/picard/ui/translatable.py
+++ b/picard/ui/translatable.py
@@ -17,6 +17,7 @@
 
 
 from PyQt6.QtGui import QAction
+from PyQt6.QtWidgets import QMenu
 
 from picard.i18n import gettext as _
 
@@ -69,3 +70,29 @@ class TranslatableAction(QAction):
             super().setStatusTip(_(self._source_status_tip))
         if self._source_icon_text:
             super().setIconText(_(self._source_icon_text))
+
+
+class TranslatableMenu(QMenu):
+    """QMenu subclass that supports dynamic retranslation of its title.
+
+    The title passed to the constructor or setTitle() is treated as an
+    untranslated source string (as marked with N_() at the call site).
+    The source is stored and _() is applied immediately.
+
+    Call retranslateUi() after a language change to re-apply _().
+    """
+
+    def __init__(self, title='', parent=None):
+        super().__init__(title, parent)
+        self._source_title = self.title()
+        if self._source_title:
+            super().setTitle(_(self._source_title))
+
+    def setTitle(self, title):
+        self._source_title = title
+        super().setTitle(_(title) if title else '')
+
+    def retranslateUi(self):
+        """Re-apply _() to the stored source title."""
+        if self._source_title:
+            super().setTitle(_(self._source_title))

--- a/picard/ui/translatable.py
+++ b/picard/ui/translatable.py
@@ -25,6 +25,24 @@ from PyQt6.QtWidgets import (
 from picard.i18n import gettext as _
 
 
+# Global registry of all translatable widget instances.
+# Uses destroyed signal for cleanup instead of weakrefs (Qt objects
+# may have their C++ side deleted while Python reference is alive).
+_registry = set()
+
+
+def _register(widget):
+    """Register a translatable widget and connect cleanup on destroy."""
+    _registry.add(widget)
+    widget.destroyed.connect(lambda: _registry.discard(widget))
+
+
+def retranslate_all():
+    """Retranslate all live Translatable* instances in the registry."""
+    for widget in list(_registry):
+        widget.retranslateUi()
+
+
 class TranslatableAction(QAction):
     """QAction subclass that supports dynamic retranslation.
 
@@ -32,8 +50,7 @@ class TranslatableAction(QAction):
     as untranslated source text (as marked with N_() at the call site).
     The source is stored and _() is applied immediately.
 
-    Call retranslateUi() after a language change to re-apply _() to all
-    stored source strings.
+    Instances are auto-registered and retranslated by retranslate_all().
     """
 
     def __init__(self, *args, **kwargs):
@@ -46,6 +63,7 @@ class TranslatableAction(QAction):
         self._source_icon_text = ''
         if self._source_text:
             super().setText(_(self._source_text))
+        _register(self)
 
     def setText(self, text):
         self._source_text = text
@@ -82,7 +100,7 @@ class TranslatableMenu(QMenu):
     untranslated source string (as marked with N_() at the call site).
     The source is stored and _() is applied immediately.
 
-    Call retranslateUi() after a language change to re-apply _().
+    Instances are auto-registered and retranslated by retranslate_all().
     """
 
     def __init__(self, title='', parent=None):
@@ -90,6 +108,7 @@ class TranslatableMenu(QMenu):
         self._source_title = self.title()
         if self._source_title:
             super().setTitle(_(self._source_title))
+        _register(self)
 
     def setTitle(self, title):
         self._source_title = title
@@ -108,7 +127,7 @@ class TranslatablePushButton(QPushButton):
     untranslated source string (as marked with N_() at the call site).
     The source is stored and _() is applied immediately.
 
-    Call retranslateUi() after a language change to re-apply _().
+    Instances are auto-registered and retranslated by retranslate_all().
     """
 
     def __init__(self, *args, **kwargs):
@@ -117,6 +136,7 @@ class TranslatablePushButton(QPushButton):
         self._source_tool_tip = ''
         if self._source_text:
             super().setText(_(self._source_text))
+        _register(self)
 
     def setText(self, text):
         self._source_text = text

--- a/picard/ui/translatable_action.py
+++ b/picard/ui/translatable_action.py
@@ -1,0 +1,60 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from PyQt6.QtGui import QAction
+
+from picard.i18n import gettext as _
+
+
+class TranslatableAction(QAction):
+    """QAction subclass that supports dynamic retranslation.
+
+    All text set via setText(), setToolTip(), and setStatusTip() is treated
+    as untranslated source text (as marked with N_() at the call site).
+    The source is stored and _() is applied immediately.
+
+    Call retranslateUi() after a language change to re-apply _() to all
+    stored source strings.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._source_text = ''
+        self._source_tool_tip = ''
+        self._source_status_tip = ''
+
+    def setText(self, text):
+        self._source_text = text
+        super().setText(_(text) if text else '')
+
+    def setToolTip(self, text):
+        self._source_tool_tip = text
+        super().setToolTip(_(text) if text else '')
+
+    def setStatusTip(self, text):
+        self._source_status_tip = text
+        super().setStatusTip(_(text) if text else '')
+
+    def retranslateUi(self):
+        """Re-apply _() to all stored source strings."""
+        if self._source_text:
+            super().setText(_(self._source_text))
+        if self._source_tool_tip:
+            super().setToolTip(_(self._source_tool_tip))
+        if self._source_status_tip:
+            super().setStatusTip(_(self._source_status_tip))

--- a/picard/ui/translatable_action.py
+++ b/picard/ui/translatable_action.py
@@ -34,9 +34,14 @@ class TranslatableAction(QAction):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._source_text = ''
+        # Capture any text set via the constructor (PyQt6 sets it at C++ level,
+        # bypassing our setText override). Store source and apply _().
+        self._source_text = self.text()
         self._source_tool_tip = ''
         self._source_status_tip = ''
+        self._source_icon_text = ''
+        if self._source_text:
+            super().setText(_(self._source_text))
 
     def setText(self, text):
         self._source_text = text
@@ -50,6 +55,10 @@ class TranslatableAction(QAction):
         self._source_status_tip = text
         super().setStatusTip(_(text) if text else '')
 
+    def setIconText(self, text):
+        self._source_icon_text = text
+        super().setIconText(_(text) if text else '')
+
     def retranslateUi(self):
         """Re-apply _() to all stored source strings."""
         if self._source_text:
@@ -58,3 +67,5 @@ class TranslatableAction(QAction):
             super().setToolTip(_(self._source_tool_tip))
         if self._source_status_tip:
             super().setStatusTip(_(self._source_status_tip))
+        if self._source_icon_text:
+            super().setIconText(_(self._source_icon_text))

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -32,7 +32,10 @@ from picard import (
     tagger_instance,
 )
 from picard.config import get_config
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.metadata import (
     album_metadata_processors,
     track_metadata_processors,
@@ -144,7 +147,8 @@ class PluginListWidget(QtWidgets.QWidget):
 
         # Create tree widget
         self.tree_widget = QtWidgets.QTreeWidget()
-        self.tree_widget.setHeaderLabels([_("Enabled"), _("Plugin"), _("Version"), _("New Version")])
+        self._source_header_labels = [N_("Enabled"), N_("Plugin"), N_("Version"), N_("New Version")]
+        self.tree_widget.setHeaderLabels([_(h) for h in self._source_header_labels])
         self.tree_widget.setRootIsDecorated(False)
         self.tree_widget.setAlternatingRowColors(True)
         self.tree_widget.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
@@ -195,6 +199,12 @@ class PluginListWidget(QtWidgets.QWidget):
 
         # Don't load cached update status during initialization to avoid any network activity
         # It will be loaded when actually needed during populate_plugins()
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            for i, label in enumerate(self._source_header_labels):
+                self.tree_widget.headerItem().setText(i, _(label))
+        super().changeEvent(event)
 
     def populate_plugins(self, plugins):
         """Populate the widget with plugins."""

--- a/picard/ui/widgets/preferencelistwidget.py
+++ b/picard/ui/widgets/preferencelistwidget.py
@@ -84,19 +84,28 @@ class PreferenceListWidget(QtWidgets.QWidget):
 
         buttons_layout.addStretch()
         if self._ordered:
-            self._up_btn = self._make_button(buttons_layout, ":/images/16x16/go-up.png", _("Move up"))
-            self._down_btn = self._make_button(buttons_layout, ":/images/16x16/go-down.png", _("Move down"))
-        self._remove_btn = self._make_button(buttons_layout, ":/images/16x16/list-remove.png", _("Remove"))
+            self._up_btn = self._make_button(buttons_layout, ":/images/16x16/go-up.png", N_("Move up"))
+            self._down_btn = self._make_button(buttons_layout, ":/images/16x16/go-down.png", N_("Move down"))
+        self._remove_btn = self._make_button(buttons_layout, ":/images/16x16/list-remove.png", N_("Remove"))
 
         layout.addLayout(buttons_layout)
 
     def _make_button(self, layout, icon_path, tooltip) -> QtWidgets.QToolButton:
         btn = QtWidgets.QToolButton(self)
         btn.setIcon(QtGui.QIcon(icon_path))
-        btn.setToolTip(tooltip)
-        btn.setAccessibleDescription(tooltip)
+        btn._source_tooltip = tooltip
+        btn.setToolTip(_(tooltip))
+        btn.setAccessibleDescription(_(tooltip))
         layout.addWidget(btn)
         return btn
+
+    def changeEvent(self, event):
+        if event.type() == QtCore.QEvent.Type.LanguageChange:
+            for btn in (self._remove_btn, getattr(self, '_up_btn', None), getattr(self, '_down_btn', None)):
+                if btn and hasattr(btn, '_source_tooltip'):
+                    btn.setToolTip(_(btn._source_tooltip))
+                    btn.setAccessibleDescription(_(btn._source_tooltip))
+        super().changeEvent(event)
 
     def _connect_signals(self) -> None:
         self._add_combo.activated.connect(self._on_combo_activated)

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -31,7 +31,6 @@ from PyQt6 import (
 )
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import (
-    QAction,
     QCursor,
     QKeySequence,
     QTextCursor,
@@ -44,7 +43,10 @@ from PyQt6.QtWidgets import (
 
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
-from picard.i18n import gettext as _
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 from picard.script import (
     ScriptFunctionDocError,
     ScriptFunctionDocUnknownFunctionError,
@@ -62,6 +64,7 @@ from picard.tags.docs import display_tag_tooltip
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
 from picard.ui.theme import theme
+from picard.ui.translatable import TranslatableAction
 from picard.ui.widgets.completion_provider import CompletionChoicesProvider
 from picard.ui.widgets.context_detector import (
     TAG_NAME_FIRST_ARG_FUNCTIONS,
@@ -425,8 +428,8 @@ class ScriptTextEdit(QTextEdit):
         self.setFontFamily(FONT_FAMILY_MONOSPACE)
         self.setMouseTracking(True)
         self.setAcceptRichText(False)
-        self.wordwrap_action = QAction(_("&Word wrap script"), self)
-        self.wordwrap_action.setToolTip(_("Word wrap long lines in the editor"))
+        self.wordwrap_action = TranslatableAction(N_("&Word wrap script"), self)
+        self.wordwrap_action.setToolTip(N_("Word wrap long lines in the editor"))
         self.wordwrap_action.triggered.connect(self.update_wordwrap)
         self.wordwrap_action.setShortcut(QKeySequence(_("Ctrl+Shift+W")))
         self.wordwrap_action.setCheckable(True)
@@ -434,8 +437,8 @@ class ScriptTextEdit(QTextEdit):
         self.update_wordwrap()
         self.addAction(self.wordwrap_action)
         self._show_tooltips = config.persist['script_editor_tooltips']
-        self.show_tooltips_action = QAction(_("Show help &tooltips"), self)
-        self.show_tooltips_action.setToolTip(_("Show tooltips for script elements"))
+        self.show_tooltips_action = TranslatableAction(N_("Show help &tooltips"), self)
+        self.show_tooltips_action.setToolTip(N_("Show tooltips for script elements"))
         self.show_tooltips_action.triggered.connect(self.update_show_tooltips)
         self.show_tooltips_action.setShortcut(QKeySequence(_("Ctrl+Shift+T")))
         self.show_tooltips_action.setCheckable(True)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -34,10 +34,12 @@ from picard.i18n import (
     gettext as _,
     gettext_constants,
     gettext_countries,
+    language_changed,
     ngettext,
     pgettext_attributes,
     setup_i18n,
     sort_key,
+    switch_language,
 )
 from picard.i18n.gettext import (
     _bcp47_to_locale,
@@ -190,3 +192,47 @@ class TestBcp47ToLocale(PicardTestCase):
     def test_numeric_region(self):
         # UN M.49 numeric region codes (3 digits)
         self.assertEqual('es_419', _bcp47_to_locale('es-419'))
+
+
+class TestSwitchLanguage(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        setup_i18n(localedir, 'en')
+
+    def tearDown(self):
+        setup_i18n(None, 'C')
+
+    @unittest.skipUnless(
+        os.path.exists(os.path.join(localedir, 'de')),
+        'Test requires locales to be built with "python setup.py build_locales"',
+    )
+    def test_switch_language_changes_translations(self):
+        self.assertEqual('Country', _('Country'))
+        switch_language('de')
+        self.assertEqual('Land', _('Country'))
+
+    @unittest.skipUnless(
+        os.path.exists(os.path.join(localedir, 'fr')),
+        'Test requires locales to be built with "python setup.py build_locales"',
+    )
+    def test_switch_language_emits_signal(self):
+        received = []
+        language_changed.connect(lambda: received.append(True))
+        switch_language('fr')
+        self.assertEqual([True], received)
+
+    def test_switch_language_empty_string_uses_system(self):
+        # Switching to empty string should not raise
+        switch_language('')
+        # _() should still work (returns untranslated or system-translated)
+        self.assertIsInstance(_('Country'), str)
+
+    @unittest.skipUnless(
+        os.path.exists(os.path.join(localedir, 'de')),
+        'Test requires locales to be built with "python setup.py build_locales"',
+    )
+    def test_switch_language_multiple_times(self):
+        switch_language('de')
+        self.assertEqual('Land', _('Country'))
+        switch_language('en')
+        self.assertEqual('Country', _('Country'))

--- a/test/test_ui_translatable.py
+++ b/test/test_ui_translatable.py
@@ -1,0 +1,142 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def translatable_action(qapp):
+    from picard.ui.translatable import TranslatableAction
+
+    return TranslatableAction
+
+
+@pytest.fixture()
+def translatable_menu(qapp):
+    from picard.ui.translatable import TranslatableMenu
+
+    return TranslatableMenu
+
+
+class TestTranslatableAction:
+    def test_constructor_stores_source_text(self, translatable_action):
+        action = translatable_action("Save")
+        assert action._source_text == "Save"
+
+    def test_constructor_translates_text(self, translatable_action):
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            action = translatable_action("Save")
+        assert action.text() == "[Save]"
+
+    def test_set_text_stores_source(self, translatable_action):
+        action = translatable_action()
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            action.setText("Open")
+        assert action._source_text == "Open"
+        assert action.text() == "[Open]"
+
+    def test_set_tool_tip_stores_source(self, translatable_action):
+        action = translatable_action()
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            action.setToolTip("Save the file")
+        assert action._source_tool_tip == "Save the file"
+        assert action.toolTip() == "[Save the file]"
+
+    def test_set_status_tip_stores_source(self, translatable_action):
+        action = translatable_action()
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            action.setStatusTip("Ready")
+        assert action._source_status_tip == "Ready"
+        assert action.statusTip() == "[Ready]"
+
+    def test_set_icon_text_stores_source(self, translatable_action):
+        action = translatable_action()
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            action.setIconText("Save...")
+        assert action._source_icon_text == "Save..."
+        assert action.iconText() == "[Save...]"
+
+    def test_retranslate_ui_updates_all(self, translatable_action):
+        action = translatable_action("Save")
+        action.setToolTip("Save the file")
+        action.setStatusTip("Ready")
+        action.setIconText("Save...")
+
+        # Simulate language change
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'<{x}>'):
+            action.retranslateUi()
+
+        assert action.text() == "<Save>"
+        assert action.toolTip() == "<Save the file>"
+        assert action.statusTip() == "<Ready>"
+        assert action.iconText() == "<Save...>"
+
+    def test_set_text_overwrites_previous_source(self, translatable_action):
+        action = translatable_action("A")
+        action.setText("B")
+        assert action._source_text == "B"
+
+    def test_empty_text_not_translated(self, translatable_action):
+        action = translatable_action()
+        assert action._source_text == ""
+        assert action.text() == ""
+
+    def test_retranslate_ui_skips_empty(self, translatable_action):
+        action = translatable_action()
+        with patch('picard.ui.translatable._') as mock_gettext:
+            action.retranslateUi()
+        mock_gettext.assert_not_called()
+
+
+class TestTranslatableMenu:
+    def test_constructor_stores_source_title(self, translatable_menu):
+        menu = translatable_menu("File")
+        assert menu._source_title == "File"
+
+    def test_constructor_translates_title(self, translatable_menu):
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            menu = translatable_menu("File")
+        assert menu.title() == "[File]"
+
+    def test_set_title_stores_source(self, translatable_menu):
+        menu = translatable_menu()
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'[{x}]'):
+            menu.setTitle("Edit")
+        assert menu._source_title == "Edit"
+        assert menu.title() == "[Edit]"
+
+    def test_retranslate_ui_updates_title(self, translatable_menu):
+        menu = translatable_menu("File")
+
+        with patch('picard.ui.translatable._', side_effect=lambda x: f'<{x}>'):
+            menu.retranslateUi()
+
+        assert menu.title() == "<File>"
+
+    def test_empty_title_not_translated(self, translatable_menu):
+        menu = translatable_menu()
+        assert menu._source_title == ""
+        assert menu.title() == ""
+
+    def test_retranslate_ui_skips_empty(self, translatable_menu):
+        menu = translatable_menu()
+        with patch('picard.ui.translatable._') as mock_gettext:
+            menu.retranslateUi()
+        mock_gettext.assert_not_called()


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Switch UI language instantly without restarting Picard, following the same live-preview pattern as dynamic theme switching. Introduces `Translatable*` widget subclasses with an auto-registry for clean, scalable retranslation.

## Problem

* JIRA ticket: PICARD-3397

Changing the UI language requires restarting Picard. This is inconsistent with theme switching (which is instant) and creates friction for users trying different languages.

The codebase was built over 25 years assuming language changes only on restart — translated strings are cached in actions, menus, toolbars, and tree items at creation time.

## Solution

### Why this is complex

1. **gettext vs Qt `tr()`** — Picard uses Python gettext `_()`, not Qt's `tr()`. Switching gettext catalogs doesn't fire any Qt event. We bridge via `installTranslator()` which triggers Qt's `LanguageChange` event propagation to all top-level windows.

2. **Cached strings everywhere** — Actions, menus, toolbar items, statusbar tooltips, tree item labels all stored translated text at creation time. Each needed migration to store the source string for lazy retranslation.

3. **Plugin translations** — Plugins load translation files only for the locale active at enable time. Dynamic switching requires reloading plugin translation files and updating the Qt translator locale.

4. **Qt event propagation** — Qt only posts `LanguageChange` to top-level windows, not child widgets. Persistent child widgets need manual event propagation (future improvement: connect to a signal instead).

### Architecture

- **`TranslatableAction`**, **`TranslatableMenu`**, **`TranslatablePushButton`** (`picard/ui/translatable.py`) — Store source strings, apply `_()` on construction, provide `retranslateUi()`. Auto-register in a global set with cleanup via Qt's `destroyed` signal. `retranslate_all()` retranslates every live instance in one call.

- **`switch_language()`** + **`language_changed`** signal (`picard/i18n/__init__.py`) — Reloads gettext catalogs, Qt base translators, and plugin translations.

- **`changeEvent()`** pattern — Each top-level window catches `LanguageChange`, calls `retranslateUi()` (for `.ui` forms) + `_retranslate_ui()` (for programmatic elements). The naming avoids collision with generated code and allows coexistence when migrating to `.ui` files.

- **Dev trace utility** (`PICARD_I18N_TRACE=/path/to/file`) — Logs all `N_()`/`_()` calls with caller file:line. On exit, generates a report identifying strings missing retranslation (excluding untranslated strings which are a Weblate issue).

### What is covered

- Main window: all actions, menus, toolbars, statusbar, column headers, window title, search toolbar
- Options dialog: buttons, page titles, language combo, current page form
- Script editor: full menu bar + actions
- Log/History views: window titles, buttons, context menu actions, verbosity/debug menus
- Player toolbar: play/pause actions, volume/playback rate buttons
- File browser, MetadataBox, CoverArtBox, InfoStatus, Filter bars
- Tree view items (Clusters, Unclustered Files), accessible names
- Plugin translations (reload on language switch)

### Known limitations (future work)

- Options pages not currently visible don't retranslate until visited
- Some tooltips set on-demand (cover art details) retranslate on next display
- Could replace manual event propagation with direct signal connection for cleaner architecture

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [x] Primarily AI developed
* [ ] Other (please specify below)

AI-assisted development using Kiro CLI. All architectural decisions, code review, and testing performed by human. The AI implemented the changes under human direction, with iterative feedback on patterns and approach.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other: This is an experimental draft — architecture review and broader testing welcome before merging.
