### PR TITLE
PICARD-3398: Handle cancelled OAuth in browser integration

### DIFF
--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -245,25 +245,38 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             self._response(400, 'Missing parameter "token".')
 
+    _OAUTH_CALLBACK_PARAMS = frozenset(('code', 'error'))
+
     def _auth(self, args):
-        if 'code' in args and args['code']:
-            tagger = tagger_instance()
-            oauth_manager = tagger.webservice.oauth_manager
-            try:
-                state = args.get('state', [''])[0]
-                callback = oauth_manager.verify_state(state)
-            except OAuthInvalidStateError:
-                self._response(400, 'Invalid "state" parameter.')
-                return
+        if not args.keys() & self._OAUTH_CALLBACK_PARAMS:
+            self._response(400, 'Invalid OAuth callback parameters.')
+            return
+
+        def qs_value(key):
+            return args.get(key, [''])[0]
+
+        tagger = tagger_instance()
+        oauth_manager = tagger.webservice.oauth_manager
+        try:
+            callback = oauth_manager.verify_state(qs_value('state'))
+        except OAuthInvalidStateError:
+            self._response(400, 'Invalid "state" parameter.')
+            return
+
+        code = qs_value('code')
+        if code:
             to_main(
                 oauth_manager.exchange_authorization_code,
-                authorization_code=args['code'][0],
+                authorization_code=code,
                 scopes='profile tag rating collection submit_isrc submit_barcode',
                 callback=callback,
             )
             self._response(200, "Authentication successful, you can close this window now.", 'text/html')
         else:
-            self._response(400, 'Missing parameter "code".')
+            error_msg = qs_value('error_description') or qs_value('error')
+            log.info("%s: Authorization denied: %s", LOG_PREFIX, error_msg)
+            to_main(callback, successful=False, error_msg=error_msg)
+            self._response(200, "Authentication cancelled, you can close this window now.", 'text/html')
 
     def _response(self, code, content='', content_type='text/plain'):
         self.server_version = SERVER_VERSION

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -19,6 +19,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+from io import BytesIO
 from unittest.mock import (
     MagicMock,
     Mock,
@@ -32,7 +33,11 @@ from urllib.parse import (
 from test.picardtestcase import PicardTestCase
 
 from picard.browser.filelookup import FileLookup
-from picard.browser.server import clean_header
+from picard.browser.server import (
+    RequestHandler,
+    clean_header,
+)
+from picard.oauth import OAuthInvalidStateError
 from picard.util import webbrowser2
 
 
@@ -256,3 +261,92 @@ class BrowserIntegrationTest(PicardTestCase):
     def test_clean_header(self):
         bad_header = "foo\nSome-Header: bar"
         self.assertEqual("fooSome-Header bar", clean_header(bad_header))
+
+
+class RequestHandlerAuthTest(PicardTestCase):
+    """Tests for PICARD-3398: Pending request stuck if authentication gets cancelled."""
+
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({'server_host': 'musicbrainz.org'})
+        self.callback = MagicMock()
+        self.oauth_manager = MagicMock()
+        self.oauth_manager.verify_state.return_value = self.callback
+        self.tagger.webservice.oauth_manager = self.oauth_manager
+        self.patch_tagger_instance('picard.browser.server')
+
+    def _make_handler(self, path):
+        """Create a RequestHandler instance without starting a real HTTP server."""
+        handler = RequestHandler.__new__(RequestHandler)
+        handler.server_version = 'Test'
+        handler.sys_version = ''
+        handler.path = path
+        handler.headers = {'origin': None}
+        handler.wfile = BytesIO()
+        handler.requestline = f'GET {path} HTTP/1.1'
+        handler.command = 'GET'
+        handler.request_version = 'HTTP/1.1'
+        handler.responses = {}
+        handler.client_address = ('127.0.0.1', 0)
+        return handler
+
+    @patch('picard.browser.server.to_main')
+    def test_auth_cancelled_calls_callback(self, mock_to_main):
+        """When auth is cancelled (error=access_denied), the callback should be
+        called with successful=False so pending requests are released."""
+        handler = self._make_handler('/auth?error=access_denied&state=valid_state')
+
+        handler._handle_get()
+
+        self.oauth_manager.verify_state.assert_called_once_with('valid_state')
+        mock_to_main.assert_called_once_with(self.callback, successful=False, error_msg='access_denied')
+
+    @patch('picard.browser.server.to_main')
+    def test_auth_cancelled_with_error_description(self, mock_to_main):
+        """When auth error includes error_description, it should be in the callback."""
+        handler = self._make_handler(
+            '/auth?error=access_denied&error_description=The+user+denied+the+request&state=valid_state'
+        )
+
+        handler._handle_get()
+
+        mock_to_main.assert_called_once_with(self.callback, successful=False, error_msg='The user denied the request')
+
+    @patch('picard.browser.server.to_main')
+    def test_auth_success_still_works(self, mock_to_main):
+        """Ensure normal auth success flow is not broken."""
+        handler = self._make_handler('/auth?code=auth_code_123&state=valid_state')
+
+        handler._handle_get()
+
+        self.oauth_manager.verify_state.assert_called_once_with('valid_state')
+        mock_to_main.assert_called_once()
+        self.callback.assert_not_called()
+
+    def test_auth_invalid_state(self):
+        """An invalid state should return 400 regardless of code or error."""
+        self.oauth_manager.verify_state.side_effect = OAuthInvalidStateError()
+        for path in (
+            '/auth?code=auth_code_123&state=bad',
+            '/auth?error=access_denied&state=bad',
+        ):
+            with self.subTest(path=path):
+                self.oauth_manager.verify_state.reset_mock()
+                handler = self._make_handler(path)
+
+                handler._handle_get()
+
+                self.oauth_manager.verify_state.assert_called_once_with('bad')
+                self.callback.assert_not_called()
+                response = handler.wfile.getvalue()
+                self.assertIn(b'400', response)
+
+    def test_auth_no_code_no_error(self):
+        """When auth has neither code nor error, return 400."""
+        handler = self._make_handler('/auth?state=valid_state')
+
+        handler._handle_get()
+
+        response = handler.wfile.getvalue()
+        self.assertIn(b'400', response)
+        self.assertIn(b'Invalid OAuth callback', response)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Handle the OAuth `error` parameter in the browser integration `/auth` endpoint so that cancelled authentication properly releases pending requests instead of leaving them stuck.

## Problem

* JIRA ticket: PICARD-3398

When a release loading requires authentication and the user cancels the OAuth flow in the browser, MusicBrainz redirects to `/auth?error=access_denied&state=xxx`. The handler only checked for the `code` parameter — if missing, it returned HTTP 400 without invoking the state callback. This left pending requests permanently stuck in "loading album information" state, with no way to recover (reload fails, removing and re-adding the release also fails).

## Solution

The `_auth` method now handles the `error` query parameter from the OAuth redirect. When present, it verifies the state token, retrieves the associated callback, and invokes it with `successful=False` and the error message. This triggers the normal failure path (`on_mb_authorization_finished` → `discard_authorized_requests`), which releases the stuck requests.

Also refactored `_auth` to extract the shared state verification logic, eliminating code duplication between the success and error paths.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used for drafting the initial implementation and tests, with manual review and refinement.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
