### PR TITLE
PICARD-3400: Use consistent OAuth scopes for browser-integration login

### DIFF
--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -49,6 +49,7 @@ from picard.config import get_config
 from picard.const import (
     BROWSER_INTEGRATION_LOCALIP,
     BROWSER_INTEGRATION_MAX_PORT,
+    METABRAINZ_OAUTH_SCOPES,
 )
 from picard.oauth import OAuthInvalidStateError
 from picard.util import mbid_validate
@@ -268,7 +269,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             to_main(
                 oauth_manager.exchange_authorization_code,
                 authorization_code=code,
-                scopes='profile tag rating collection submit_isrc submit_barcode',
+                scopes=METABRAINZ_OAUTH_SCOPES,
                 callback=callback,
             )
             self._response(200, "Authentication successful, you can close this window now.", 'text/html')

--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -53,6 +53,17 @@ FPCALC_NAMES = ['fpcalc', 'pyfpcalc']
 METABRAINZ_OAUTH_HOST = 'metabrainz.org'
 METABRAINZ_OAUTH_CLIENT_ID = 'CF9xgQn5Rmwx125oGjx19NE9'
 METABRAINZ_OAUTH_CLIENT_SECRET = 'mebs_7qJdRZp5LQx63NNo3S3du1ghwIie7XtLl5esNoyUDlObmnWk'
+# OAuth scopes Picard requests. Must be the same for both the authorization
+# request and the authorization-code exchange, otherwise the resulting token
+# will not carry the expected permissions.
+METABRAINZ_OAUTH_SCOPES = (
+    'profile'
+    ' musicbrainz:tag'
+    ' musicbrainz:rating'
+    ' musicbrainz:collection'
+    ' musicbrainz:submit_isrc'
+    ' musicbrainz:submit_barcode'
+)
 
 # Cover art archive URL
 CAA_URL = 'https://coverartarchive.org'

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -104,6 +104,7 @@ from picard.config import (
 from picard.config_upgrade import run_config_upgrades
 from picard.const import (
     BROWSER_INTEGRATION_LOCALHOST,
+    METABRAINZ_OAUTH_SCOPES,
     USER_DIR,
 )
 from picard.const.appdirs import (
@@ -665,7 +666,7 @@ class Tagger(QtWidgets.QApplication):
 
     def mb_login(self, callback, parent=None):
         oauth_manager = self.webservice.oauth_manager
-        scopes = 'profile musicbrainz:tag musicbrainz:rating musicbrainz:collection musicbrainz:submit_isrc musicbrainz:submit_barcode'
+        scopes = METABRAINZ_OAUTH_SCOPES
         authorization_url = oauth_manager.get_authorization_url(
             scopes, partial(self.on_mb_authorization_finished, callback)
         )

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -37,6 +37,7 @@ from picard.browser.server import (
     RequestHandler,
     clean_header,
 )
+from picard.const import METABRAINZ_OAUTH_SCOPES
 from picard.oauth import OAuthInvalidStateError
 from picard.util import webbrowser2
 
@@ -322,6 +323,11 @@ class RequestHandlerAuthTest(PicardTestCase):
         self.oauth_manager.verify_state.assert_called_once_with('valid_state')
         mock_to_main.assert_called_once()
         self.callback.assert_not_called()
+        # The code exchange must request the same prefixed scopes as the
+        # authorization request; a mismatch yields a token without the
+        # expected permissions (e.g. collection access fails with 401).
+        self.assertEqual(mock_to_main.call_args.kwargs['scopes'], METABRAINZ_OAUTH_SCOPES)
+        self.assertIn('musicbrainz:collection', mock_to_main.call_args.kwargs['scopes'])
 
     def test_auth_invalid_state(self):
         """An invalid state should return 400 regardless of code or error."""


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Fix the browser-integration OAuth login exchanging the authorization code with
the wrong (unprefixed) scopes, which left the token without the requested
permissions so collections failed to load with HTTP 401 right after login.

## Problem

* JIRA ticket: PICARD-3400

After logging in to MusicBrainz via the browser integration flow, Picard
immediately re-prompted for authentication and failed to load collections:

```
E: Network request error for https://musicbrainz.org/ws/2/collection ->
   AuthenticationRequiredError (HTTP 401)
I: MusicBrainz authentication declined
E: Error loading collections: Authorization required
```

Picard requests OAuth scopes in two places and they had drifted apart:

- `picard/tagger.py` (`mb_login`, the authorization request) used the current
  `musicbrainz:`-prefixed scopes.
- `picard/browser/server.py` (the `/auth` callback that exchanges the
  authorization code) still used the old, unprefixed scopes
  (`profile tag rating collection submit_isrc submit_barcode`).

`OAuthManager.on_exchange_authorization_code_finished()` persists the scopes
passed to `exchange_authorization_code()` together with the refresh token, so
the stored token was associated with the wrong scope set and authorized
requests such as `GET /ws/2/collection` returned HTTP 401.

The server migrated scope names to the `musicbrainz:` prefix; PICARD-2772
updated the scopes in `tagger.py` but did not update `browser/server.py`.

## Solution

Define the requested scopes once as `METABRAINZ_OAUTH_SCOPES` (in
`picard/const`) and use it in both the authorization request
(`tagger.mb_login`) and the authorization-code exchange (`browser/server._auth`)
so the two paths can no longer drift. Added a regression test asserting the
`/auth` code exchange requests the shared, prefixed scopes (including
`musicbrainz:collection`).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to diagnose the scope mismatch from runtime logs, implement the
shared constant and regression test, with manual review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
