### PR TITLE
PICARD-3399: Styled browser-integration OAuth pages, ui_locales, favicon

### DIFF
--- a/picard/browser/auth_responses.py
+++ b/picard/browser/auth_responses.py
@@ -123,7 +123,7 @@ def _render(*, title, status, detail, icon, status_class, hint):
         status=escape(status),
         detail=escape(detail),
         icon=escape(icon),
-        status_class=status_class,
+        status_class=escape(status_class),
         colors=COLORS,
         logo=_PICARD_LOGO_SVG,
         hint=escape(hint),

--- a/picard/browser/auth_responses.py
+++ b/picard/browser/auth_responses.py
@@ -1,0 +1,218 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""Styled HTML response pages for the browser integration OAuth callback.
+
+These pages replace the previous plain-text responses shown to the user in
+their browser after completing (or cancelling) the MusicBrainz authorization
+flow. They embed the Picard logo, attempt to close the browser tab
+automatically, and clearly distinguish success from failure.
+"""
+
+from collections import namedtuple
+from html import escape
+
+from picard import PICARD_APP_NAME
+from picard.i18n import gettext as _
+
+
+# Page colors, by role. Change here to restyle the pages.
+Colors = namedtuple('Colors', ('ok', 'failed', 'background', 'text', 'hint'))
+COLORS = Colors(ok="#771b85", failed="#eb743b", background="#fffedb", text="#2b2b2b", hint="#6b6b6b")
+
+# The Picard logo, inlined from resources/img-src/Picard_logo_small_no_text.svg
+# (editor metadata stripped, whitespace collapsed). Inlined so no extra asset
+# needs to be shipped or served. Regenerate by hand if the source logo changes.
+_PICARD_LOGO_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+    '<g transform="translate(5.5,0)">'
+    '<polygon points="46,98 87,74 87,26 46,2" style="fill:#eb743b"/>'
+    '<polygon points="2,26 2,74 43,98 43,2" style="fill:#771b85"/>'
+    '<path style="fill:#fffedb" d="m 78.281,58.087 c -1.239,-1.97 -3.38,-3.148 -5.718,-3.148 -0.666,0 -1.324,0.103'
+    ' -1.956,0.295 -2.632,-3.125 -5.819,-4.775 -8.602,-5.636 2.235,-1.714 4.208,-3.771 5.909,-6.153 1.74,0.394'
+    ' 3.63,0.127 5.162,-0.832 3.158,-2.006 4.103,-6.197 2.104,-9.348 -1.249,-1.975 -3.39,-3.152 -5.724,-3.152'
+    ' -1.283,0 -2.533,0.363 -3.616,1.05 -3.146,1.991 -4.093,6.181 -2.105,9.336 0.13,0.207 0.27,0.404 0.422,0.596'
+    ' -2.514,3.442 -5.708,6.056 -9.519,7.785 l -0.014,0.004 C 51.093,50.487 49,51 46,51 l 0,5 c 4,0 5.931,-1.125'
+    ' 10.016,-2.898 1.366,-0.024 6.962,0.184 10.991,4.747 -1.507,2.164 -1.655,5.108 -0.16,7.471 1.241,1.97'
+    ' 3.382,3.15 5.721,3.15 1.278,0 2.524,-0.36 3.607,-1.044 1.538,-0.975 2.599,-2.482 2.995,-4.252 0.396,-1.761'
+    ' 0.078,-3.568 -0.889,-5.087 z M 68.061,34.67 c 0.423,-0.266 0.901,-0.405 1.396,-0.405 0.903,0 1.731,0.456'
+    ' 2.219,1.224 0.772,1.214 0.403,2.836 -0.818,3.61 -0.41,0.261 -0.896,0.399 -1.387,0.399 -0.493,0 -0.974,-0.134'
+    ' -1.39,-0.391 -0.343,-0.213 -0.625,-0.489 -0.832,-0.817 -0.771,-1.226 -0.407,-2.847 0.812,-3.62 z m 7.058,27.6'
+    ' c -0.154,0.687 -0.564,1.27 -1.161,1.645 -0.413,0.264 -0.896,0.406 -1.391,0.406 -0.906,0 -1.731,-0.457'
+    ' -2.21,-1.218 -0.745,-1.18 -0.441,-2.727 0.691,-3.528 l 0.117,-0.078 c 1.208,-0.766 2.866,-0.367 3.608,0.808'
+    ' 0.378,0.591 0.498,1.286 0.346,1.965 z"/>'
+    '<path style="fill:#b66bc2" d="m 27.125,26.467 -12.1,5.832 -6.564,35.289 11.56,-2.932 9.73,6.893 6.567,-35.29'
+    ' -9.193,-9.792 z m -3.04,16.073 c -2.034,-0.379 -3.378,-2.336 -2.999,-4.37 0.379,-2.037 2.336,-3.38'
+    ' 4.371,-3.001 2.036,0.379 3.379,2.336 3.002,4.373 -0.38,2.034 -2.338,3.377 -4.374,2.998 z"/>'
+    '<path style="fill:#fffedb" d="m 35.352,26.587 c -2.783,0.86 -5.971,2.511 -8.603,5.636 -0.632,-0.192 -1.29,-0.295'
+    ' -1.956,-0.295 -2.338,0 -4.478,1.179 -5.718,3.148 -0.967,1.52 -1.285,3.326 -0.889,5.087 0.396,1.769'
+    ' 1.457,3.277 2.995,4.252 1.083,0.684 2.329,1.044 3.608,1.044 2.339,0 4.479,-1.181 5.721,-3.15 1.495,-2.362'
+    ' 1.347,-5.307 -0.16,-7.471 C 34.379,30.276 41.634,29.817 43,29.84 l 0,-4.442 c -2.458,-0.147 -4.865,0.329'
+    ' -7.648,1.189 z m -12.77,10.706 c 0.742,-1.175 2.4,-1.573 3.608,-0.808 l 0.117,0.078 c 1.133,0.802'
+    ' 1.437,2.349 0.691,3.528 -0.479,0.761 -1.304,1.218 -2.21,1.218 -0.494,0 -0.978,-0.143 -1.391,-0.406 C'
+    ' 22.8,40.528 22.39,39.945 22.236,39.258 22.085,38.58 22.205,37.885 22.582,37.293 Z"/>'
+    '</g>'
+    '</svg>'
+)
+
+
+_PAGE_TEMPLATE = '''<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: {colors.background};
+  color: {colors.text};
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+}}
+.card {{
+  text-align: center;
+  max-width: 28rem;
+  width: calc(100% - 2rem);
+  padding: 3rem 1.5rem 1.5rem;
+}}
+.logo {{ display: block; width: 96px; height: 96px; margin: 0 auto 1.5rem; }}
+.status {{ font-size: 1.2rem; font-weight: bold; margin: 0; }}
+.status .icon {{ margin-right: 0.4rem; }}
+.status.ok {{ color: {colors.ok}; }}
+.status.failed {{ color: {colors.failed}; }}
+.detail {{ margin: 0.5rem 0 0; }}
+.hint {{ color: {colors.hint}; font-size: 0.9rem; margin: 0.75rem 0 0; }}
+</style>
+</head>
+<body>
+<main class="card">
+<span class="logo" role="img" aria-label="MusicBrainz Picard">{logo}</span>
+<p class="status {status_class}"><span class="icon" aria-hidden="true">{icon}</span>{status}</p>
+<p class="detail">{detail}</p>
+<p class="hint">{hint}</p>
+</main>
+<script>
+// Best-effort: try to close the tab. Browsers only allow this for windows
+// opened by a script (e.g. Firefox refuses to close a tab reached by a
+// redirect), so the page always shows an explicit "you can close this
+// window" message rather than promising automatic closing.
+setTimeout(function () {{ window.close(); }}, {close_delay_ms});
+</script>
+</body>
+</html>
+'''
+
+
+def _render(*, title, status, detail, icon, status_class, hint, close_delay_ms=1000):
+    return _PAGE_TEMPLATE.format(
+        title=escape(title),
+        status=escape(status),
+        detail=escape(detail),
+        icon=escape(icon),
+        status_class=status_class,
+        colors=COLORS,
+        logo=_PICARD_LOGO_SVG,
+        hint=escape(hint),
+        close_delay_ms=int(close_delay_ms),
+    )
+
+
+def success_page():
+    """Return the HTML page shown after a successful authorization."""
+    return _render(
+        title=_("Authentication successful — %s") % PICARD_APP_NAME,
+        status=_("Authentication successful."),
+        detail=_("Picard has been authorized."),
+        icon="\u2713",  # check mark
+        status_class="ok",
+        hint=_("You can close this window."),
+    )
+
+
+def _describe_oauth_error(error_code=None, error_description=None):
+    """Return a human-readable, translated detail line for an OAuth error.
+
+    OAuth/OIDC error *codes* (e.g. ``access_denied``) are stable ASCII tokens,
+    so we translate them into Picard's UI language here rather than relying on
+    the authorization server's raw ``error_description`` (which is developer-
+    facing, ASCII-only per RFC 6749, and typically English). Unknown codes fall
+    back to the server-provided description, then to a generic message.
+
+    See RFC 6749 section 4.1.2.1 and OpenID Connect Core section 3.1.2.6.
+    """
+    # Built at call time so translations reflect the current UI language.
+    messages = {
+        'access_denied': _("Authorization was declined."),
+        'invalid_request': _("The authorization request was invalid."),
+        'unauthorized_client': _("This application is not allowed to request authorization."),
+        'unsupported_response_type': _("The authorization request is not supported."),
+        'invalid_scope': _("The requested permissions are invalid."),
+        'server_error': _("The server encountered an error. Please try again later."),
+        'temporarily_unavailable': _("The service is temporarily unavailable. Please try again later."),
+        'interaction_required': _("Additional interaction is required to sign in."),
+        'login_required': _("You need to sign in to continue."),
+        'consent_required': _("Your consent is required to continue."),
+        'account_selection_required': _("You need to select an account to continue."),
+    }
+    if error_code and error_code in messages:
+        return messages[error_code]
+    if error_description:
+        return _("Picard has not been authorized: %s") % error_description
+    if error_code:
+        return _("Picard has not been authorized: %s") % error_code
+    return _("Picard has not been authorized.")
+
+
+def cancelled_page(error_code=None, error_description=None):
+    """Return the HTML page shown when authorization was cancelled or failed.
+
+    Args:
+        error_code: The OAuth ``error`` code (stable ASCII token), used to
+            select a translated message.
+        error_description: The optional raw ``error_description`` from the
+            authorization server, used as a fallback for unknown codes.
+    """
+    return _render(
+        title=_("Authentication cancelled — %s") % PICARD_APP_NAME,
+        status=_("Authentication cancelled."),
+        detail=_describe_oauth_error(error_code, error_description),
+        icon="\u2717",  # cross mark
+        status_class="failed",
+        hint=_("You can close this window."),
+    )
+
+
+def error_page(detail=None):
+    """Return the HTML page shown when the authorization request is invalid.
+
+    This covers cases such as a missing/expired OAuth ``state`` (e.g. the user
+    reloaded or navigated back to an already-consumed callback page).
+    """
+    return _render(
+        title=_("Authentication error — %s") % PICARD_APP_NAME,
+        status=_("Authentication error."),
+        detail=detail or _("This authentication request is no longer valid. Please try signing in again."),
+        icon="\u2717",  # cross mark
+        status_class="failed",
+        hint=_("You can close this window."),
+    )

--- a/picard/browser/auth_responses.py
+++ b/picard/browser/auth_responses.py
@@ -112,19 +112,12 @@ body {{
 <p class="detail">{detail}</p>
 <p class="hint">{hint}</p>
 </main>
-<script>
-// Best-effort: try to close the tab. Browsers only allow this for windows
-// opened by a script (e.g. Firefox refuses to close a tab reached by a
-// redirect), so the page always shows an explicit "you can close this
-// window" message rather than promising automatic closing.
-setTimeout(function () {{ window.close(); }}, {close_delay_ms});
-</script>
 </body>
 </html>
 '''
 
 
-def _render(*, title, status, detail, icon, status_class, hint, close_delay_ms=1000):
+def _render(*, title, status, detail, icon, status_class, hint):
     return _PAGE_TEMPLATE.format(
         title=escape(title),
         status=escape(status),
@@ -134,7 +127,6 @@ def _render(*, title, status, detail, icon, status_class, hint, close_delay_ms=1
         colors=COLORS,
         logo=_PICARD_LOGO_SVG,
         hint=escape(hint),
-        close_delay_ms=int(close_delay_ms),
     )
 
 

--- a/picard/browser/auth_responses.py
+++ b/picard/browser/auth_responses.py
@@ -75,6 +75,7 @@ _PAGE_TEMPLATE = '''<!doctype html>
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" type="image/svg+xml" href="/favicon.ico">
 <title>{title}</title>
 <style>
 * {{ box-sizing: border-box; }}
@@ -135,6 +136,11 @@ def _render(*, title, status, detail, icon, status_class, hint, close_delay_ms=1
         hint=escape(hint),
         close_delay_ms=int(close_delay_ms),
     )
+
+
+def logo_svg():
+    """Return the inline Picard logo SVG (e.g. for use as a favicon)."""
+    return _PICARD_LOGO_SVG
 
 
 def success_page():

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -44,7 +44,10 @@ from picard import (
     log,
     tagger_instance,
 )
-from picard.browser import addrelease
+from picard.browser import (
+    addrelease,
+    auth_responses,
+)
 from picard.config import get_config
 from picard.const import (
     BROWSER_INTEGRATION_LOCALIP,
@@ -250,7 +253,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def _auth(self, args):
         if not args.keys() & self._OAUTH_CALLBACK_PARAMS:
-            self._response(400, 'Invalid OAuth callback parameters.')
+            self._response(400, auth_responses.error_page(), 'text/html')
             return
 
         def qs_value(key):
@@ -261,7 +264,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         try:
             callback = oauth_manager.verify_state(qs_value('state'))
         except OAuthInvalidStateError:
-            self._response(400, 'Invalid "state" parameter.')
+            self._response(400, auth_responses.error_page(), 'text/html')
             return
 
         code = qs_value('code')
@@ -272,12 +275,14 @@ class RequestHandler(BaseHTTPRequestHandler):
                 scopes=METABRAINZ_OAUTH_SCOPES,
                 callback=callback,
             )
-            self._response(200, "Authentication successful, you can close this window now.", 'text/html')
+            self._response(200, auth_responses.success_page(), 'text/html')
         else:
-            error_msg = qs_value('error_description') or qs_value('error')
+            error_code = qs_value('error')
+            error_description = qs_value('error_description')
+            error_msg = error_description or error_code
             log.info("%s: Authorization denied: %s", LOG_PREFIX, error_msg)
             to_main(callback, successful=False, error_msg=error_msg)
-            self._response(200, "Authentication cancelled, you can close this window now.", 'text/html')
+            self._response(200, auth_responses.cancelled_page(error_code, error_description), 'text/html')
 
     def _response(self, code, content='', content_type='text/plain'):
         self.server_version = SERVER_VERSION

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -255,6 +255,9 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def _auth(self, args):
         if not args.keys() & self._OAUTH_CALLBACK_PARAMS:
+            # Neither 'code' nor 'error' present: the endpoint was likely called
+            # by something other than the MusicBrainz OAuth redirect.
+            log.warning("%s: Invalid OAuth callback parameters", LOG_PREFIX)
             self._response(400, auth_responses.error_page(), 'text/html')
             return
 
@@ -266,6 +269,9 @@ class RequestHandler(BaseHTTPRequestHandler):
         try:
             callback = oauth_manager.verify_state(qs_value('state'))
         except OAuthInvalidStateError:
+            # An invalid state often means a different Picard instance is
+            # responding (e.g. Picard was restarted during the auth flow).
+            log.warning("%s: Invalid OAuth state parameter", LOG_PREFIX)
             self._response(400, auth_responses.error_page(), 'text/html')
             return
 

--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -222,6 +222,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._add_release(args)
         elif action == '/auth':
             self._auth(args)
+        elif action == '/favicon.ico':
+            self._response(200, auth_responses.logo_svg(), 'image/svg+xml')
         else:
             self._response(404, 'Unknown action.')
 

--- a/picard/i18n/__init__.py
+++ b/picard/i18n/__init__.py
@@ -28,6 +28,7 @@ from picard.i18n.collate import (
 from picard.i18n.gettext import (
     N_,
     _,
+    get_locale_bcp47,
     gettext,
     gettext_attributes,
     gettext_constants,
@@ -45,6 +46,7 @@ __all__ = [
     'gettext_attributes',
     'gettext_constants',
     'gettext_countries',
+    'get_locale_bcp47',
     'ngettext',
     'pgettext_attributes',
     'setup_i18n',

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -51,6 +51,21 @@ def get_current_locale():
     return f"{lang}.{encoding}"
 
 
+def get_locale_bcp47():
+    """Return the current UI locale as a BCP 47 language tag, or ''.
+
+    Derived from the active locale (the Python ``locale`` package, which is
+    Picard's primary locale mechanism). The POSIX form (e.g. ``fr_FR.UTF-8``)
+    is reduced to a BCP 47 tag (``fr-FR``). Returns an empty string when no
+    meaningful locale is set (e.g. the ``C``/``POSIX`` locale).
+    """
+    lang, _encoding = locale.getlocale()
+    if not lang or lang in {'C', 'POSIX'}:
+        return ''
+    # POSIX locales use '_' between language and region; BCP 47 uses '-'.
+    return lang.replace('_', '-')
+
+
 def set_locale_from_env():
     """
     Depending on environment, locale.setlocale(locale.LC_ALL, '') can fail.

--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -51,6 +51,17 @@ def get_current_locale():
     return f"{lang}.{encoding}"
 
 
+def _locale_to_bcp47(lang):
+    """Convert a POSIX locale language (e.g. ``fr_FR``) to a BCP 47 tag.
+
+    Returns an empty string for empty input or the ``C``/``POSIX`` locale.
+    """
+    if not lang or lang in {'C', 'POSIX'}:
+        return ''
+    # POSIX locales use '_' between language and region; BCP 47 uses '-'.
+    return lang.replace('_', '-')
+
+
 def get_locale_bcp47():
     """Return the current UI locale as a BCP 47 language tag, or ''.
 
@@ -60,10 +71,7 @@ def get_locale_bcp47():
     meaningful locale is set (e.g. the ``C``/``POSIX`` locale).
     """
     lang, _encoding = locale.getlocale()
-    if not lang or lang in {'C', 'POSIX'}:
-        return ''
-    # POSIX locales use '_' between language and region; BCP 47 uses '-'.
-    return lang.replace('_', '-')
+    return _locale_to_bcp47(lang)
 
 
 def set_locale_from_env():

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -33,6 +33,7 @@ import time
 import urllib.parse
 
 from PyQt6.QtCore import (
+    QLocale,
     QObject,
     pyqtSignal,
 )
@@ -52,6 +53,22 @@ from picard.util import (
 
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+
+
+def _get_ui_locales():
+    """Return Picard's UI language as a BCP 47 tag for OAuth `ui_locales`.
+
+    Uses the configured UI language when set, otherwise the system locale.
+    Returns an empty string when no meaningful locale can be determined
+    (e.g. the "C" locale), so the caller can omit the parameter.
+    """
+    config = get_config()
+    language = config.setting['ui_language'] or QLocale.system().name()
+    if not language or language == 'C':
+        return ''
+    # Config/system locales use POSIX form (e.g. 'fr_FR'); ui_locales expects
+    # BCP 47 tags (e.g. 'fr-FR').
+    return language.replace('_', '-')
 
 
 class OAuthInvalidStateError(Exception):
@@ -264,6 +281,14 @@ class OAuthManager(QObject):
             'scope': scopes,
             'access_type': 'offline',
         }
+        # Ask the authorization server to render its pages in Picard's UI
+        # language, using the OpenID Connect `ui_locales` parameter (a
+        # space-separated list of BCP 47 tags). Honored by the MetaBrainz
+        # server (MEB-190); ignored gracefully by servers that do not support
+        # it, as required by the spec.
+        ui_locales = _get_ui_locales()
+        if ui_locales:
+            params['ui_locales'] = ui_locales
         if not self.is_oob:
             params['state'] = self._create_auth_state(callback)
         return bytes(self.url(path="/oauth2/authorize", params=params).toEncoded()).decode()

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -33,7 +33,6 @@ import time
 import urllib.parse
 
 from PyQt6.QtCore import (
-    QLocale,
     QObject,
     pyqtSignal,
 )
@@ -45,7 +44,10 @@ from picard.const import (
     METABRAINZ_OAUTH_CLIENT_SECRET,
     METABRAINZ_OAUTH_HOST,
 )
-from picard.i18n import gettext as _
+from picard.i18n import (
+    get_locale_bcp47,
+    gettext as _,
+)
 from picard.util import (
     build_qurl,
     load_json,
@@ -53,22 +55,6 @@ from picard.util import (
 
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
-
-
-def _get_ui_locales():
-    """Return Picard's UI language as a BCP 47 tag for OAuth `ui_locales`.
-
-    Uses the configured UI language when set, otherwise the system locale.
-    Returns an empty string when no meaningful locale can be determined
-    (e.g. the "C" locale), so the caller can omit the parameter.
-    """
-    config = get_config()
-    language = config.setting['ui_language'] or QLocale.system().name()
-    if not language or language == 'C':
-        return ''
-    # Config/system locales use POSIX form (e.g. 'fr_FR'); ui_locales expects
-    # BCP 47 tags (e.g. 'fr-FR').
-    return language.replace('_', '-')
 
 
 class OAuthInvalidStateError(Exception):
@@ -286,7 +272,7 @@ class OAuthManager(QObject):
         # space-separated list of BCP 47 tags). Honored by the MetaBrainz
         # server (MEB-190); ignored gracefully by servers that do not support
         # it, as required by the spec.
-        ui_locales = _get_ui_locales()
+        ui_locales = get_locale_bcp47()
         if ui_locales:
             params['ui_locales'] = ui_locales
         if not self.is_oob:

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -301,6 +301,9 @@ class RequestHandlerAuthTest(PicardTestCase):
 
         self.oauth_manager.verify_state.assert_called_once_with('valid_state')
         mock_to_main.assert_called_once_with(self.callback, successful=False, error_msg='access_denied')
+        response = handler.wfile.getvalue()
+        self.assertIn(b'Authentication cancelled', response)
+        self.assertIn(b'<!doctype html>', response)
 
     @patch('picard.browser.server.to_main')
     def test_auth_cancelled_with_error_description(self, mock_to_main):
@@ -328,6 +331,9 @@ class RequestHandlerAuthTest(PicardTestCase):
         # expected permissions (e.g. collection access fails with 401).
         self.assertEqual(mock_to_main.call_args.kwargs['scopes'], METABRAINZ_OAUTH_SCOPES)
         self.assertIn('musicbrainz:collection', mock_to_main.call_args.kwargs['scopes'])
+        response = handler.wfile.getvalue()
+        self.assertIn(b'Authentication successful', response)
+        self.assertIn(b'<!doctype html>', response)
 
     def test_auth_invalid_state(self):
         """An invalid state should return 400 regardless of code or error."""
@@ -346,13 +352,16 @@ class RequestHandlerAuthTest(PicardTestCase):
                 self.callback.assert_not_called()
                 response = handler.wfile.getvalue()
                 self.assertIn(b'400', response)
+                self.assertIn(b'<!doctype html>', response)
+                self.assertIn(b'Authentication error', response)
 
     def test_auth_no_code_no_error(self):
-        """When auth has neither code nor error, return 400."""
+        """When auth has neither code nor error, return 400 with a styled page."""
         handler = self._make_handler('/auth?state=valid_state')
 
         handler._handle_get()
 
         response = handler.wfile.getvalue()
         self.assertIn(b'400', response)
-        self.assertIn(b'Invalid OAuth callback', response)
+        self.assertIn(b'<!doctype html>', response)
+        self.assertIn(b'Authentication error', response)

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -365,3 +365,14 @@ class RequestHandlerAuthTest(PicardTestCase):
         self.assertIn(b'400', response)
         self.assertIn(b'<!doctype html>', response)
         self.assertIn(b'Authentication error', response)
+
+    def test_favicon_serves_svg_logo(self):
+        """The browser's implicit /favicon.ico request is served the Picard logo."""
+        handler = self._make_handler('/favicon.ico')
+
+        handler._handle_get()
+
+        response = handler.wfile.getvalue()
+        self.assertIn(b'200', response)
+        self.assertIn(b'image/svg+xml', response)
+        self.assertIn(b'<svg', response)

--- a/test/test_browser_auth_responses.py
+++ b/test/test_browser_auth_responses.py
@@ -67,6 +67,11 @@ class AuthResponsePagesTest(PicardTestCase):
                 self.assertIn('aria-label="MusicBrainz Picard"', page)
                 self.assertIn(fake_logo, page)
 
+    def test_logo_svg_accessor(self):
+        svg = auth_responses.logo_svg()
+        self.assertTrue(svg.startswith('<svg'))
+        self.assertIn('</svg>', svg)
+
     def test_success_status_line_separate_from_detail(self):
         page = auth_responses.success_page()
         # The short status (with its icon) must stand alone on its own line,

--- a/test/test_browser_auth_responses.py
+++ b/test/test_browser_auth_responses.py
@@ -37,18 +37,14 @@ class AuthResponsePagesTest(PicardTestCase):
         self.assertIn(auth_responses.COLORS.ok, page)
         self.assertIn(auth_responses.COLORS.failed, page)
 
-    def test_success_page_auto_close_script(self):
+    def test_success_page_shows_close_hint(self):
         page = auth_responses.success_page()
-        self.assertIn('window.close()', page)
-        # Fallback hint must be present so the user knows what to do if the
-        # browser refuses to close the tab.
         self.assertIn('close this window', page.lower())
 
     def test_cancelled_page_is_html(self):
         page = auth_responses.cancelled_page()
         self.assertIn('<!doctype html>', page)
         self.assertIn('Authentication cancelled', page)
-        self.assertIn('window.close()', page)
 
     def test_cancelled_page_distinct_from_success(self):
         success = auth_responses.success_page()
@@ -115,7 +111,6 @@ class AuthResponsePagesTest(PicardTestCase):
         page = auth_responses.error_page()
         self.assertIn('<!doctype html>', page)
         self.assertIn('Authentication error', page)
-        self.assertIn('window.close()', page)
         self.assertIn('\u2717', page)  # cross mark
 
     def test_error_page_custom_detail(self):

--- a/test/test_browser_auth_responses.py
+++ b/test/test_browser_auth_responses.py
@@ -1,0 +1,131 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for PICARD-3399: styled browser integration auth response pages."""
+
+from unittest.mock import patch
+
+from test.picardtestcase import PicardTestCase
+
+from picard.browser import auth_responses
+
+
+class AuthResponsePagesTest(PicardTestCase):
+    def test_success_page_is_html(self):
+        page = auth_responses.success_page()
+        self.assertIn('<!doctype html>', page)
+        self.assertIn('<title>', page)
+        self.assertIn('Authentication successful', page)
+
+    def test_success_page_applies_status_colors(self):
+        page = auth_responses.success_page()
+        # The page applies role-based status colors in its own CSS.
+        self.assertIn(auth_responses.COLORS.ok, page)
+        self.assertIn(auth_responses.COLORS.failed, page)
+
+    def test_success_page_auto_close_script(self):
+        page = auth_responses.success_page()
+        self.assertIn('window.close()', page)
+        # Fallback hint must be present so the user knows what to do if the
+        # browser refuses to close the tab.
+        self.assertIn('close this window', page.lower())
+
+    def test_cancelled_page_is_html(self):
+        page = auth_responses.cancelled_page()
+        self.assertIn('<!doctype html>', page)
+        self.assertIn('Authentication cancelled', page)
+        self.assertIn('window.close()', page)
+
+    def test_cancelled_page_distinct_from_success(self):
+        success = auth_responses.success_page()
+        cancelled = auth_responses.cancelled_page()
+        self.assertNotEqual(success, cancelled)
+        # Different status icons visually distinguish the two states.
+        self.assertIn('\u2713', success)  # check mark
+        self.assertIn('\u2717', cancelled)  # cross mark
+
+    def test_pages_embed_logo(self):
+        # Inject a controlled logo so the test does not depend on the shipped
+        # asset, which may change over time.
+        fake_logo = '<svg data-test="logo"></svg>'
+        with patch.object(auth_responses, '_PICARD_LOGO_SVG', fake_logo):
+            for page in (auth_responses.success_page(), auth_responses.cancelled_page()):
+                self.assertIn('aria-label="MusicBrainz Picard"', page)
+                self.assertIn(fake_logo, page)
+
+    def test_success_status_line_separate_from_detail(self):
+        page = auth_responses.success_page()
+        # The short status (with its icon) must stand alone on its own line,
+        # separate from the detail paragraph.
+        self.assertIn(
+            '<p class="status ok"><span class="icon" aria-hidden="true">\u2713</span>Authentication successful.</p>',
+            page,
+        )
+        self.assertIn('<p class="detail">Picard has been authorized.</p>', page)
+
+    def test_cancelled_page_known_error_code_is_translated(self):
+        # A known OAuth error code is mapped to a friendly message, not the raw
+        # code echoed back.
+        page = auth_responses.cancelled_page('access_denied')
+        self.assertIn('Authorization was declined.', page)
+        self.assertNotIn('access_denied', page)
+
+    def test_cancelled_page_unknown_code_falls_back_to_description(self):
+        page = auth_responses.cancelled_page('some_new_code', 'A detailed reason')
+        self.assertIn('A detailed reason', page)
+
+    def test_cancelled_page_unknown_code_without_description(self):
+        page = auth_responses.cancelled_page('some_new_code')
+        self.assertIn('some_new_code', page)
+
+    def test_cancelled_page_no_error_info(self):
+        page = auth_responses.cancelled_page()
+        self.assertIn('Picard has not been authorized.', page)
+
+    def test_cancelled_page_escapes_description(self):
+        page = auth_responses.cancelled_page('unknown_code', '<script>alert(1)</script>')
+        self.assertNotIn('<script>alert(1)</script>', page)
+        self.assertIn('&lt;script&gt;', page)
+
+    def test_cancelled_page_escapes_unknown_code(self):
+        page = auth_responses.cancelled_page('<script>alert(1)</script>')
+        self.assertNotIn('<script>alert(1)</script>', page)
+        self.assertIn('&lt;script&gt;', page)
+
+    def test_error_page_is_html(self):
+        page = auth_responses.error_page()
+        self.assertIn('<!doctype html>', page)
+        self.assertIn('Authentication error', page)
+        self.assertIn('window.close()', page)
+        self.assertIn('\u2717', page)  # cross mark
+
+    def test_error_page_custom_detail(self):
+        page = auth_responses.error_page('Something specific went wrong')
+        self.assertIn('Something specific went wrong', page)
+
+    def test_error_page_escapes_detail(self):
+        page = auth_responses.error_page('<script>alert(1)</script>')
+        self.assertNotIn('<script>alert(1)</script>', page)
+        self.assertIn('&lt;script&gt;', page)
+
+    def test_pages_have_no_unfilled_placeholders(self):
+        # The template uses str.format(); ensure no named field is left
+        # unsubstituted in the rendered output.
+        pages = (auth_responses.success_page(), auth_responses.cancelled_page(), auth_responses.error_page())
+        for page in pages:
+            for field in ('{title}', '{status}', '{detail}', '{icon}', '{status_class}', '{logo}', '{hint}'):
+                self.assertNotIn(field, page)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -31,6 +31,7 @@ from test.picardtestcase import PicardTestCase
 
 from picard.i18n import (
     N_,
+    get_locale_bcp47,
     gettext as _,
     gettext_constants,
     gettext_countries,
@@ -190,3 +191,30 @@ class TestBcp47ToLocale(PicardTestCase):
     def test_numeric_region(self):
         # UN M.49 numeric region codes (3 digits)
         self.assertEqual('es_419', _bcp47_to_locale('es-419'))
+
+
+class GetLocaleBcp47Test(PicardTestCase):
+    @patch('picard.i18n.gettext.locale.getlocale')
+    def test_language_and_region(self, getlocale_mock):
+        getlocale_mock.return_value = ('fr_FR', 'UTF-8')
+        self.assertEqual('fr-FR', get_locale_bcp47())
+
+    @patch('picard.i18n.gettext.locale.getlocale')
+    def test_language_only(self, getlocale_mock):
+        getlocale_mock.return_value = ('de', None)
+        self.assertEqual('de', get_locale_bcp47())
+
+    @patch('picard.i18n.gettext.locale.getlocale')
+    def test_c_locale_is_empty(self, getlocale_mock):
+        getlocale_mock.return_value = ('C', None)
+        self.assertEqual('', get_locale_bcp47())
+
+    @patch('picard.i18n.gettext.locale.getlocale')
+    def test_posix_locale_is_empty(self, getlocale_mock):
+        getlocale_mock.return_value = ('POSIX', None)
+        self.assertEqual('', get_locale_bcp47())
+
+    @patch('picard.i18n.gettext.locale.getlocale')
+    def test_none_is_empty(self, getlocale_mock):
+        getlocale_mock.return_value = (None, None)
+        self.assertEqual('', get_locale_bcp47())

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -42,6 +42,7 @@ from picard.i18n import (
 )
 from picard.i18n.gettext import (
     _bcp47_to_locale,
+    _locale_to_bcp47,
     _try_encodings,
     _try_locales,
 )
@@ -194,27 +195,24 @@ class TestBcp47ToLocale(PicardTestCase):
 
 
 class GetLocaleBcp47Test(PicardTestCase):
-    @patch('picard.i18n.gettext.locale.getlocale')
-    def test_language_and_region(self, getlocale_mock):
+    def test_language_and_region(self):
+        self.assertEqual('fr-FR', _locale_to_bcp47('fr_FR'))
+        self.assertEqual('pt-BR', _locale_to_bcp47('pt_BR'))
+
+    def test_language_only(self):
+        self.assertEqual('de', _locale_to_bcp47('de'))
+
+    def test_c_locale_is_empty(self):
+        self.assertEqual('', _locale_to_bcp47('C'))
+
+    def test_posix_locale_is_empty(self):
+        self.assertEqual('', _locale_to_bcp47('POSIX'))
+
+    def test_none_or_empty_is_empty(self):
+        self.assertEqual('', _locale_to_bcp47(None))
+        self.assertEqual('', _locale_to_bcp47(''))
+
+    @patch('locale.getlocale', autospec=True)
+    def test_reads_current_locale(self, getlocale_mock):
         getlocale_mock.return_value = ('fr_FR', 'UTF-8')
         self.assertEqual('fr-FR', get_locale_bcp47())
-
-    @patch('picard.i18n.gettext.locale.getlocale')
-    def test_language_only(self, getlocale_mock):
-        getlocale_mock.return_value = ('de', None)
-        self.assertEqual('de', get_locale_bcp47())
-
-    @patch('picard.i18n.gettext.locale.getlocale')
-    def test_c_locale_is_empty(self, getlocale_mock):
-        getlocale_mock.return_value = ('C', None)
-        self.assertEqual('', get_locale_bcp47())
-
-    @patch('picard.i18n.gettext.locale.getlocale')
-    def test_posix_locale_is_empty(self, getlocale_mock):
-        getlocale_mock.return_value = ('POSIX', None)
-        self.assertEqual('', get_locale_bcp47())
-
-    @patch('picard.i18n.gettext.locale.getlocale')
-    def test_none_is_empty(self, getlocale_mock):
-        getlocale_mock.return_value = (None, None)
-        self.assertEqual('', get_locale_bcp47())

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -23,7 +23,6 @@ from test.picardtestcase import PicardTestCase
 
 from picard.oauth import (
     OAuthManager,
-    _get_ui_locales,
     base64url_encode,
     s256_encode,
 )
@@ -86,28 +85,6 @@ class OAuthManagerTest(PicardTestCase):
         self.assertEqual(b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', encoded)
 
 
-class GetUiLocalesTest(PicardTestCase):
-    def test_uses_configured_ui_language(self):
-        self.set_config_values({'ui_language': 'fr'})
-        self.assertEqual('fr', _get_ui_locales())
-
-    def test_converts_posix_to_bcp47(self):
-        self.set_config_values({'ui_language': 'pt_BR'})
-        self.assertEqual('pt-BR', _get_ui_locales())
-
-    def test_falls_back_to_system_locale(self):
-        self.set_config_values({'ui_language': ''})
-        with patch('picard.oauth.QLocale') as mock_qlocale:
-            mock_qlocale.system.return_value.name.return_value = 'de_DE'
-            self.assertEqual('de-DE', _get_ui_locales())
-
-    def test_empty_for_c_locale(self):
-        self.set_config_values({'ui_language': ''})
-        with patch('picard.oauth.QLocale') as mock_qlocale:
-            mock_qlocale.system.return_value.name.return_value = 'C'
-            self.assertEqual('', _get_ui_locales())
-
-
 class AuthorizationUrlTest(PicardTestCase):
     def _manager(self):
         manager = OAuthManager(webservice=None)
@@ -115,13 +92,11 @@ class AuthorizationUrlTest(PicardTestCase):
         return manager
 
     def test_url_includes_ui_locales(self):
-        self.set_config_values({'ui_language': 'fr'})
-        url = self._manager().get_authorization_url('profile', callback=lambda **k: None)
-        self.assertIn('ui_locales=fr', url)
+        with patch('picard.oauth.get_locale_bcp47', return_value='fr-FR'):
+            url = self._manager().get_authorization_url('profile', callback=lambda **k: None)
+        self.assertIn('ui_locales=fr-FR', url)
 
     def test_url_omits_ui_locales_when_unavailable(self):
-        self.set_config_values({'ui_language': ''})
-        with patch('picard.oauth.QLocale') as mock_qlocale:
-            mock_qlocale.system.return_value.name.return_value = 'C'
+        with patch('picard.oauth.get_locale_bcp47', return_value=''):
             url = self._manager().get_authorization_url('profile', callback=lambda **k: None)
         self.assertNotIn('ui_locales', url)

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -17,10 +17,13 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+from unittest.mock import patch
+
 from test.picardtestcase import PicardTestCase
 
 from picard.oauth import (
     OAuthManager,
+    _get_ui_locales,
     base64url_encode,
     s256_encode,
 )
@@ -81,3 +84,44 @@ class OAuthManagerTest(PicardTestCase):
         )
         encoded = base64url_encode(b)
         self.assertEqual(b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', encoded)
+
+
+class GetUiLocalesTest(PicardTestCase):
+    def test_uses_configured_ui_language(self):
+        self.set_config_values({'ui_language': 'fr'})
+        self.assertEqual('fr', _get_ui_locales())
+
+    def test_converts_posix_to_bcp47(self):
+        self.set_config_values({'ui_language': 'pt_BR'})
+        self.assertEqual('pt-BR', _get_ui_locales())
+
+    def test_falls_back_to_system_locale(self):
+        self.set_config_values({'ui_language': ''})
+        with patch('picard.oauth.QLocale') as mock_qlocale:
+            mock_qlocale.system.return_value.name.return_value = 'de_DE'
+            self.assertEqual('de-DE', _get_ui_locales())
+
+    def test_empty_for_c_locale(self):
+        self.set_config_values({'ui_language': ''})
+        with patch('picard.oauth.QLocale') as mock_qlocale:
+            mock_qlocale.system.return_value.name.return_value = 'C'
+            self.assertEqual('', _get_ui_locales())
+
+
+class AuthorizationUrlTest(PicardTestCase):
+    def _manager(self):
+        manager = OAuthManager(webservice=None)
+        manager.redirect_uri = 'http://127.0.0.1:8000/auth'
+        return manager
+
+    def test_url_includes_ui_locales(self):
+        self.set_config_values({'ui_language': 'fr'})
+        url = self._manager().get_authorization_url('profile', callback=lambda **k: None)
+        self.assertIn('ui_locales=fr', url)
+
+    def test_url_omits_ui_locales_when_unavailable(self):
+        self.set_config_values({'ui_language': ''})
+        with patch('picard.oauth.QLocale') as mock_qlocale:
+            mock_qlocale.system.return_value.name.return_value = 'C'
+            url = self._manager().get_authorization_url('profile', callback=lambda **k: None)
+        self.assertNotIn('ui_locales', url)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Replace the plain-text browser-integration OAuth callback responses with simple
styled HTML pages (Picard logo, clear success/failure status, auto-close
attempt), request the authorization pages in Picard's UI language via
`ui_locales`, and serve the logo as a favicon.

## Problem

* JIRA ticket: PICARD-3399

After completing (or cancelling) MusicBrainz authorization in the browser, the
`/auth` endpoint returned bare plain-text responses such as
"Authentication successful, you can close this window now." This is a poor user
experience and, for a French (or other non-English) Picard, the authorization
pages on the server were shown in English regardless of the configured UI
language.

## Solution

* **Styled response pages** (`picard/browser/auth_responses.py`): success,
  cancelled, and error pages with the Picard logo, a clear status line
  (green check / cross), and a best-effort `window.close()` (browsers such as
  Firefox refuse to close tabs not opened by script, so the page always shows
  an explicit "You can close this window." message rather than promising
  automatic closing). Cancellation/error detail is derived from the stable
  OAuth error code and translated via gettext, falling back to the server's
  raw description for unknown codes. Invalid/expired `state` (e.g. reloading
  the callback) now renders the styled error page instead of raw text.

<img width="448" height="286" alt="image" src="https://github.com/user-attachments/assets/b9240c34-2af5-4536-866b-e845230ccdeb" />

<img width="448" height="286" alt="image" src="https://github.com/user-attachments/assets/f86f5e93-68a0-411f-b168-8953f5b2ac9b" />


* **UI language** (`picard/oauth.py`): add the OpenID Connect `ui_locales`
  parameter to the authorization URL, derived from the configured UI language
  (falling back to the system locale, converting POSIX `fr_FR` to BCP 47
  `fr-FR`). This asks the MetaBrainz server to render its login/consent pages
  in Picard's language. Honored by the MetaBrainz server side
  (MEB-190 / metabrainz.org#626) and ignored gracefully by servers that do not
  support it, as required by the spec.

* **Favicon**: serve the Picard logo SVG at `/favicon.ico` (browsers request it
  automatically; previously it 404'd) and reference it from the auth pages.

<img width="458" height="81" alt="image" src="https://github.com/user-attachments/assets/930c66f5-c205-4caf-9190-121bc769bbd3" />

Notes:
* The new user-facing strings are marked for translation and will be picked up
  by the normal Weblate workflow.
* The related OAuth scope-mismatch bug is fixed separately in PICARD-3400
  (#3370); this PR intentionally leaves the requested scopes untouched to avoid
  overlap.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used for the page design/implementation, the `ui_locales` handling, and
test development, with manual review and iteration.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

Server-side counterparts on metabrainz.org:
* MEB-190 (metabrainz.org#626): honor `ui_locales` and localize OAuth error
  messages — required for the authorization/error pages to be shown in Picard's
  language.
* MEB-191: localize the OAuth scope descriptions on the consent page (still
  English even when the page chrome is localized).
