### PR TITLE
PICARD-3401: Do not submit ListenBrainz listens while disabled

### DIFF
--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -98,6 +98,10 @@ class ListenBrainzSubmissionService:
         self._current: PreparedSubmission | None = None
         self._lbapi = ListenBrainzAPIHelper(webservice)
         self._queue = ListenQueue(self._lbapi)
+        # Load any persisted queue so listens are not lost, but do not start
+        # submitting: submission is only scheduled once the service is enabled
+        # (see enable()). Otherwise queued listens would be submitted even when
+        # ListenBrainz submission is disabled in the settings.
         self._queue.load()
         tagger.register_cleanup(self._queue.save)
 
@@ -111,9 +115,15 @@ class ListenBrainzSubmissionService:
         self._player.playback_state_changed.connect(self.on_playback_state_changed)
         self._player.position_changed.connect(self.on_position_changed)
 
+        # Flush any listens queued from a previous session.
+        self._queue.start()
+
     def disable(self):
         if not self._enabled:
             return
+
+        # Stop submitting queued listens while disabled.
+        self._queue.stop()
 
         self._player.media_changed.disconnect(self.on_media_changed)
         self._player.playback_state_changed.disconnect(self.on_playback_state_changed)
@@ -195,10 +205,19 @@ class ListenQueue:
                         self._queue = json.load(f, object_hook=from_json)
                         if count := len(self._queue):
                             log.debug("Loaded %d listens from queue", count)
-                            self._schedule_submission()
                 except json.JSONDecodeError as e:
                     log.error("Failed to load listen queue: %s", e)
                     self._queue = []
+
+    def start(self):
+        """Start submitting queued listens (schedules a submission if the queue
+        is not empty). Called when ListenBrainz submission is enabled."""
+        self._schedule_submission()
+
+    def stop(self):
+        """Stop submitting queued listens. Called when ListenBrainz submission
+        is disabled; the queue itself is kept (and persisted) for later."""
+        self._timer.stop()
 
     def save(self):
         if not self._queue:

--- a/test/test_player_listenbrainz.py
+++ b/test/test_player_listenbrainz.py
@@ -35,6 +35,7 @@ from picard.webservice.api_helpers.listenbrainz import (
 )
 
 from picard.ui.player.listenbrainz import (
+    ListenBrainzSubmissionService,
     ListenQueue,
     PreparedSubmission,
 )
@@ -157,3 +158,72 @@ class TestListenQueue(PicardTestCase):
         self.queue._queue.clear()
         self.queue._on_listen_queue_drained()
         self.assertFalse(self.queue_file.exists())
+
+    def test_load_does_not_start_submission(self):
+        # A persisted, non-empty queue must be loaded but not submitted until
+        # the service is enabled; otherwise listens are submitted even when
+        # ListenBrainz submission is disabled in the settings.
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+        self.queue.save()
+
+        fresh = ListenQueue(self.lbapi)
+        fresh.load()
+
+        self.assertEqual(1, len(fresh._queue))
+        self.assertFalse(fresh._timer.isActive())
+
+    def test_start_submits_pending_queue(self):
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+
+        self.queue.start()
+
+        self.assertTrue(self.queue._timer.isActive())
+
+    def test_start_does_not_schedule_when_empty(self):
+        self.queue.start()
+        self.assertFalse(self.queue._timer.isActive())
+
+    def test_stop_halts_submission(self):
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+        self.queue.start()
+        self.assertTrue(self.queue._timer.isActive())
+
+        self.queue.stop()
+
+        self.assertFalse(self.queue._timer.isActive())
+
+
+class TestSubmissionServiceGating(PicardTestCase):
+    """Regression tests: queued listens must not be submitted while ListenBrainz
+    submission is disabled (submission is gated by enable()/disable())."""
+
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({"listenbrainz_token": "test_token"})
+        self.player = Mock()
+        self.webservice = Mock()
+        self.tagger = Mock()
+
+    def _make_service(self):
+        service = ListenBrainzSubmissionService(self.player, self.webservice, self.tagger)
+        service._lbapi = FakeListenBrainzAPIHelper()
+        service._queue._lbapi = service._lbapi
+        return service
+
+    def test_disabled_by_default_does_not_submit_pending_queue(self):
+        service = self._make_service()
+        # Simulate a queue restored from a previous session.
+        service._queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+
+        # Without enabling, nothing should be scheduled or submitted.
+        self.assertFalse(service._queue._timer.isActive())
+
+    def test_enable_starts_submission_disable_stops_it(self):
+        service = self._make_service()
+        service._queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+
+        service.enable()
+        self.assertTrue(service._queue._timer.isActive())
+
+        service.disable()
+        self.assertFalse(service._queue._timer.isActive())


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Stop Picard from submitting queued ListenBrainz listens when ListenBrainz
submission is disabled in the settings.

## Problem

* JIRA ticket: PICARD-3401

With ListenBrainz submission disabled, Picard still submitted queued listens on
startup and kept retrying every couple of minutes:

```
E: Network request error for https://api.listenbrainz.org/1/submit-listens
   -> AuthenticationRequiredError (HTTP 401)
E: ListenBrainz batch submission failed: ...
```

`ListenBrainzSubmissionService.__init__` loaded the persisted queue, and
`ListenQueue.load()` started the submission timer. That timer submitted queued
listens independently of the `listenbrainz_enabled` setting — the
`enable()`/`disable()` gating only connected/disconnected the player signals,
not the queue's submission timer.

## Solution

Load the persisted queue without starting submission, and gate submission on
the service state:

* `ListenQueue.load()` no longer schedules submission.
* Added `ListenQueue.start()` / `stop()`.
* `ListenBrainzSubmissionService.enable()` starts the queue (flushing any
  listens queued in a previous session); `disable()` stops it.

The queue is still loaded and persisted while disabled, so no listens are lost.

Added regression tests covering load-without-submit and the enable/disable
start/stop gating.

Note: an invalid token can still cause the batch submission to retry in a loop
*while enabled*; that separate robustness issue is tracked in its own ticket.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to diagnose the issue from runtime logs and implement the fix and
tests, with manual review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
