### PR TITLE
PICARD-3402: Stop ListenBrainz retry loop on permanent submission errors

### DIFF
--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -100,6 +100,14 @@ class ListenBrainzSubmissionService:
         self._queue = ListenQueue(self._lbapi)
         self._queue.load()
         tagger.register_cleanup(self._queue.save)
+        # Resume submitting queued listens when the token changes: a permanent
+        # auth failure (e.g. 401) suspends the retry timer, so fixing the token
+        # should give the queued listens another chance.
+        get_config().setting.setting_changed.connect(self._on_setting_changed)
+
+    def _on_setting_changed(self, name, old_value, new_value):
+        if name == 'listenbrainz_token':
+            self._queue.schedule_submission()
 
     def enable(self):
         if self._enabled:
@@ -195,7 +203,7 @@ class ListenQueue:
                         self._queue = json.load(f, object_hook=from_json)
                         if count := len(self._queue):
                             log.debug("Loaded %d listens from queue", count)
-                            self._schedule_submission()
+                            self.schedule_submission()
                 except json.JSONDecodeError as e:
                     log.error("Failed to load listen queue: %s", e)
                     self._queue = []
@@ -224,14 +232,18 @@ class ListenQueue:
     ):
         if error:
             status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
-            if not status_code or int(status_code) in {401, 429} or int(status_code) >= 500:
+            # Keep the listen queued regardless of the error, so it is not lost
+            # (e.g. a wrong token can be fixed later). Only schedule a retry for
+            # transient errors; for permanent ones the timer stays suspended
+            # until submission is retriggered (e.g. on a token change).
+            self._append(payload)
+            if _is_temporary_submission_error(status_code):
                 log.warning(
                     'Temporary ListenBrainz submission error (queued for retry): data=%s, error=%s', data, error
                 )
-                self._append(payload)
-                self._schedule_submission()
+                self.schedule_submission()
             else:
-                log.error('ListenBrainz submission failed: data=%s, error=%s', data, error)
+                log.error('ListenBrainz submission failed (queued, retry suspended): data=%s, error=%s', data, error)
         else:
             log.debug('ListenBrainz submission successful: data=%s', data)
 
@@ -254,7 +266,18 @@ class ListenQueue:
     ):
         self._submitting = False
         if error:
-            log.error('ListenBrainz batch submission failed: data=%s, error=%s', data, error)
+            status_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+            # The batch stays in the queue (it is only removed on success). For
+            # transient errors keep the timer running to retry; for permanent
+            # errors (e.g. an invalid token) suspend it to avoid an endless
+            # retry loop until submission is retriggered.
+            if _is_temporary_submission_error(status_code):
+                log.warning(
+                    'Temporary ListenBrainz batch submission error (will retry): data=%s, error=%s', data, error
+                )
+            else:
+                log.error('ListenBrainz batch submission failed, retry suspended: data=%s, error=%s', data, error)
+                self._timer.stop()
         else:
             log.debug('ListenBrainz batch submission successful: data=%s', data)
             self._remove_from_queue(batch)
@@ -298,7 +321,12 @@ class ListenQueue:
     def get_listen_queue_file_path(self) -> Path:
         return Path(cache_folder()) / "listenbrainz-queue.json"
 
-    def _schedule_submission(self):
+    def schedule_submission(self):
+        """Start the retry timer if there are queued listens to submit.
+
+        Safe to call at any time (e.g. after the user fixes their token) to
+        resume submitting listens that were queued after a failed attempt.
+        """
         if len(self._queue) > 0:
             log.debug("Batch listen submission scheduled to run in %d seconds", SUBMISSION_INTERVAL_SECONDS)
             self._timer.start(SUBMISSION_INTERVAL_SECONDS * 1000)
@@ -315,6 +343,20 @@ class ListenQueue:
                 queue_file.unlink(missing_ok=True)
             except OSError as e:
                 log.debug("Failed to remove listen queue file %s: %s", queue_file, e)
+
+
+def _is_temporary_submission_error(status_code) -> bool:
+    """Return True if a failed submission is worth retrying automatically.
+
+    Only rate limiting (429) and server errors (5xx) are treated as transient.
+    Everything else, notably 401 (an invalid user token), is permanent: an
+    automatic retry cannot succeed until the user fixes their configuration, so
+    the retry timer is suspended for those instead of looping.
+    """
+    if not status_code:
+        return False
+    status_code = int(status_code)
+    return status_code == 429 or status_code >= 500
 
 
 def from_json(obj: dict):

--- a/test/test_player_listenbrainz.py
+++ b/test/test_player_listenbrainz.py
@@ -17,7 +17,10 @@
 
 
 import json
-from unittest.mock import Mock
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 from PyQt6.QtNetwork import (
     QNetworkReply,
@@ -35,8 +38,10 @@ from picard.webservice.api_helpers.listenbrainz import (
 )
 
 from picard.ui.player.listenbrainz import (
+    ListenBrainzSubmissionService,
     ListenQueue,
     PreparedSubmission,
+    _is_temporary_submission_error,
 )
 
 
@@ -157,3 +162,102 @@ class TestListenQueue(PicardTestCase):
         self.queue._queue.clear()
         self.queue._on_listen_queue_drained()
         self.assertFalse(self.queue_file.exists())
+
+    def test_single_listen_permanent_error_keeps_listen_without_scheduling(self):
+        # A 401 must not drop the listen; it stays queued, but the retry timer
+        # is not scheduled (retrying cannot succeed until the token is fixed).
+        self.lbapi = FakeListenBrainzAPIHelper(
+            status_code=401, error=QNetworkReply.NetworkError.AuthenticationRequiredError
+        )
+        self.queue = ListenQueue(self.lbapi)
+        self.queue.add(ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B")))
+        self.assertEqual(1, len(self.queue._queue))
+        self.assertFalse(self.queue._timer.isActive())
+
+    def test_single_listen_temporary_error_keeps_listen_and_schedules(self):
+        self.lbapi = FakeListenBrainzAPIHelper(
+            status_code=503, error=QNetworkReply.NetworkError.ServiceUnavailableError
+        )
+        self.queue = ListenQueue(self.lbapi)
+        self.queue.add(ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B")))
+        self.assertEqual(1, len(self.queue._queue))
+        self.assertTrue(self.queue._timer.isActive())
+
+    def test_batch_permanent_error_keeps_queue_and_suspends_timer(self):
+        self.lbapi = FakeListenBrainzAPIHelper(
+            status_code=401, error=QNetworkReply.NetworkError.AuthenticationRequiredError
+        )
+        self.queue = ListenQueue(self.lbapi)
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+        self.queue._timer.start(1000)
+
+        self.queue.submit_batch()
+
+        self.assertEqual(1, len(self.queue._queue))  # not dropped
+        self.assertFalse(self.queue._timer.isActive())  # suspended
+
+    def test_batch_temporary_error_keeps_queue_and_timer(self):
+        self.lbapi = FakeListenBrainzAPIHelper(
+            status_code=503, error=QNetworkReply.NetworkError.ServiceUnavailableError
+        )
+        self.queue = ListenQueue(self.lbapi)
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+        self.queue._timer.start(1000)
+
+        self.queue.submit_batch()
+
+        self.assertEqual(1, len(self.queue._queue))
+        self.assertTrue(self.queue._timer.isActive())
+
+    def test_schedule_submission_starts_only_with_queued_listens(self):
+        self.assertFalse(self.queue._timer.isActive())
+        self.queue.schedule_submission()
+        self.assertFalse(self.queue._timer.isActive())  # empty queue: no timer
+
+        self.queue._queue = [ListenPayload(track_metadata=TrackMetadata(artist_name="A", track_name="B"))]
+        self.queue.schedule_submission()
+        self.assertTrue(self.queue._timer.isActive())
+
+
+class TestIsTemporarySubmissionError(PicardTestCase):
+    def test_transient_errors(self):
+        self.assertTrue(_is_temporary_submission_error(429))
+        self.assertTrue(_is_temporary_submission_error(500))
+        self.assertTrue(_is_temporary_submission_error(503))
+
+    def test_permanent_errors(self):
+        self.assertFalse(_is_temporary_submission_error(401))
+        self.assertFalse(_is_temporary_submission_error(400))
+        self.assertFalse(_is_temporary_submission_error(404))
+
+    def test_missing_status_is_permanent(self):
+        self.assertFalse(_is_temporary_submission_error(None))
+        self.assertFalse(_is_temporary_submission_error(0))
+
+
+class TestSubmissionServiceTokenRearm(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values({"listenbrainz_token": "test_token"})
+        self.player = Mock()
+        self.webservice = Mock()
+        self.tagger = Mock()
+
+    def _make_service(self):
+        # The service connects to config.setting.setting_changed in __init__;
+        # provide a config whose setting exposes that signal.
+        fake_config = Mock()
+        with patch('picard.ui.player.listenbrainz.get_config', return_value=fake_config):
+            service = ListenBrainzSubmissionService(self.player, self.webservice, self.tagger)
+        service._queue = Mock()
+        return service
+
+    def test_token_change_reschedules_submission(self):
+        service = self._make_service()
+        service._on_setting_changed('listenbrainz_token', 'old', 'new')
+        service._queue.schedule_submission.assert_called_once()
+
+    def test_other_setting_change_does_not_reschedule(self):
+        service = self._make_service()
+        service._on_setting_changed('some_other_setting', 'old', 'new')
+        service._queue.schedule_submission.assert_not_called()


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

Stop the ListenBrainz submission retry loop when the failure is permanent
(e.g. HTTP 401 from an invalid token), and resume submitting once the token is
fixed.

> Note: this branch builds on PICARD-3401 (#3372); it uses the queue
> start()/stop() lifecycle introduced there. Review/merge #3372 first.

## Problem

* JIRA ticket: PICARD-3402

With ListenBrainz submission enabled but an invalid user token, batch
submission failed with HTTP 401 and retried indefinitely every couple of
minutes, hammering the API:

```
E: ListenBrainz batch submission failed:
   data=b'{"code":401,"error":"Provided Authorization header is invalid."}'
```

`ListenQueue._on_submit_batch_response` only logged the error and left the
submission timer running, so a permanent failure never stopped retrying. The
single-listen handler also treated 401 as retryable.

## Solution

Add a helper `_is_temporary_submission_error()` that classifies only 429 (rate
limit) and 5xx (server error) as transient; everything else, notably 401, is
permanent.

* On a permanent batch error the retry timer is stopped (no more looping).
* The same classifier is applied to single-listen submissions, so 401 is no
  longer re-queued.
* **Recovery:** submission is re-armed when the `listenbrainz_token` setting
  changes (while enabled), so the queued listens are submitted again once the
  user fixes their token. Submission also resumes on re-enable or a newly
  queued listen.

Added tests for the classifier, the batch handler stopping on a permanent
error (and continuing on a transient one), and the token-change re-arm.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to diagnose the loop from runtime logs and implement the fix and
tests, with manual review.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [x] Other (please specify below)

Depends on / builds upon PICARD-3401 (#3372).
