### PR TITLE
PICARD-2844: Support language for lyrics tags, make language mandatory in comment tags with description

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -47,7 +47,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'beta', 9)
+PICARD_VERSION = Version(3, 0, 0, 'beta', 10)
 COPYRIGHT_YEARS = "2004-2026"
 
 

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -826,3 +826,42 @@ def clamp_browser_integration_port(settings):
         return max(BROWSER_INTEGRATION_MIN_PORT, min(BROWSER_INTEGRATION_MAX_PORT, int(value)))
 
     upgrade_option_value(settings, 'browser_integration_port', _clamp_port)
+
+
+@upgrade_settings('3.0.0b10')
+def upgrade_scripts_lyrics_comments(settings):
+    ASSIGNMENT_FUNCS = 'set|setmulti|copy|copymerge'
+    REMOVAL_FUNCS = 'unset|delete'
+    COPY_FUNCS = 'copy|copymerge'
+    RE_LYRICS_VAR = re.compile(r'%lyrics:([a-zA-Z0-9_:]+)%')
+    RE_LYRICS_ASSIGNMENT_FUNC = re.compile(rf'\$({ASSIGNMENT_FUNCS})\(lyrics:([a-zA-Z0-9_:]+),')
+    RE_LYRICS_REMOVAL_FUNC = re.compile(rf'\$({REMOVAL_FUNCS})\(lyrics:([a-zA-Z0-9_:]+)\)')
+    RE_LYRICS_COPY_FUNC = re.compile(rf'\$({COPY_FUNCS})\(([^,]*),lyrics:([a-zA-Z0-9_:]+)\)')
+    # Comments can already contain the language optionally, but need to be converted
+    # to the new double-colon syntax.
+    RE_COMMENTS_VAR = re.compile(r'%comment(?!:[a-zA-Z0-9_]{3}[^a-zA-Z0-9_]):([a-zA-Z0-9_:]+)%')
+    RE_COMMENTS_ASSIGNMENT_FUNC = re.compile(
+        rf'\$({ASSIGNMENT_FUNCS})\(comment(?!:[a-zA-Z0-9_]{{3}}[^a-zA-Z0-9_]):([a-zA-Z0-9_:]+),'
+    )
+    RE_COMMENTS_REMOVAL_FUNC = re.compile(
+        rf'\$({REMOVAL_FUNCS})\(comment(?!:[a-zA-Z0-9_]{{3}}[^a-zA-Z0-9_]):([a-zA-Z0-9_:]+)\)'
+    )
+    RE_COMMENTS_COPY_FUNC = re.compile(
+        rf'\$({COPY_FUNCS})\(([^,]*),comment(?!:[a-zA-Z0-9_]{{3}}[^a-zA-Z0-9_]):([a-zA-Z0-9_:]+)\)'
+    )
+
+    def convert_script(script):
+        script = RE_LYRICS_VAR.sub(r'%lyrics::\1%', script)
+        script = RE_LYRICS_ASSIGNMENT_FUNC.sub(r'$\1(lyrics::\2,', script)
+        script = RE_LYRICS_REMOVAL_FUNC.sub(r'$\1(lyrics::\2)', script)
+        script = RE_LYRICS_COPY_FUNC.sub(r'$\1(\2,lyrics::\3)', script)
+        script = RE_COMMENTS_VAR.sub(r'%comment::\1%', script)
+        script = RE_COMMENTS_ASSIGNMENT_FUNC.sub(r'$\1(comment::\2,', script)
+        script = RE_COMMENTS_REMOVAL_FUNC.sub(r'$\1(comment::\2)', script)
+        script = RE_COMMENTS_COPY_FUNC.sub(r'$\1(\2,comment::\3)', script)
+        return script
+
+    def convert_list_of_scripts(scripts):
+        return [(pos, name, enabled, convert_script(content)) for pos, name, enabled, content in scripts]
+
+    upgrade_option_value(settings, 'list_of_scripts', convert_list_of_scripts)

--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -71,8 +71,8 @@ from picard.formats.mutagenext import (
 from picard.i18n import N_
 from picard.metadata import Metadata
 from picard.tags import (
-    parse_comment_tag,
-    parse_subtag,
+    create_lang_desc_tag,
+    parse_lang_desc_tag,
 )
 from picard.util import (
     sanitize_date,
@@ -395,10 +395,8 @@ class ID3File(File):
                     # iTunes CDDB comment should be mapped to itunes_cddb_1 tag
                     if frame.desc == 'iTunes_CDDB_1':
                         name = 'itunes_cddb_1'
-                    elif frame.lang == 'eng':
-                        name = '%s:%s' % (name, frame.desc)
                     else:
-                        name = '%s:%s:%s' % (name, frame.lang, frame.desc)
+                        name = create_lang_desc_tag(name, frame.lang, frame.desc, default_language="eng")
                     metadata.add(name, text)
         else:
             metadata.add(name, frame)
@@ -460,9 +458,7 @@ class ID3File(File):
         """Process a USLT frame and add it to metadata.
         Handles unsynchronized lyrics, optionally with description.
         """
-        name = 'lyrics'
-        if frame.desc:
-            name += ':%s' % frame.desc
+        name = create_lang_desc_tag('lyrics', frame.lang, frame.desc)
         metadata.add(name, frame.text)
 
     def _load_sylt_frame(self, frame, metadata, config_params):
@@ -483,13 +479,7 @@ class ID3File(File):
                 config_params['filename'],
             )
             return
-        name = 'syncedlyrics'
-        if frame.lang:
-            name += ':%s' % frame.lang
-            if frame.desc:
-                name += ':%s' % frame.desc
-        elif frame.desc:
-            name += '::%s' % frame.desc
+        name = create_lang_desc_tag('syncedlyrics', frame.lang, frame.desc)
         lrc_lyrics = self._parse_sylt_text(frame.text, config_params['file_length'])
         metadata.add(name, lrc_lyrics)
 
@@ -797,7 +787,7 @@ class ID3File(File):
     def _save_comment_tag(self, tags, name, values, config_params):
         """Save comment tag to ID3 frames."""
         encoding = config_params['encoding']
-        (lang, desc) = parse_comment_tag(name)
+        (lang, desc) = parse_lang_desc_tag(name, default_language='eng')
         if desc.lower()[:4] == 'itun':
             tags.delall('COMM:' + desc)
             tags.add(id3.COMM(encoding=Id3Encoding.LATIN1, desc=desc, lang='eng', text=[v + '\x00' for v in values]))
@@ -807,17 +797,14 @@ class ID3File(File):
     def _save_lyrics_tag(self, tags, name, values, config_params):
         """Save lyrics tag to ID3 frames."""
         encoding = config_params['encoding']
-        if ':' in name:
-            desc = name.split(':', 1)[1]
-        else:
-            desc = ''
+        (lang, desc) = parse_lang_desc_tag(name)
         for value in values:
-            tags.add(id3.USLT(encoding=encoding, desc=desc, text=value))
+            tags.add(id3.USLT(encoding=encoding, lang=lang, desc=desc, text=value))
 
     def _save_synced_lyrics_tag(self, tags, name, values, config_params):
         """Save synchronized lyrics tag to ID3 frames."""
         encoding = config_params['encoding']
-        (lang, desc) = parse_subtag(name)
+        (lang, desc) = parse_lang_desc_tag(name)
         for value in values:
             sylt_lyrics = self._parse_lrc_text(value)
             # If the text does not contain any timestamps, the tag is not added
@@ -1022,24 +1009,21 @@ class ID3File(File):
 
     def _remove_comment_tag(self, tags, name):
         """Remove comment tag from ID3 frames."""
-        (lang, desc) = parse_comment_tag(name)
+        (lang, desc) = parse_lang_desc_tag(name, default_language='eng')
         for key, frame in list(tags.items()):
             if frame.FrameID == 'COMM' and frame.desc == desc and frame.lang == lang:
                 del tags[key]
 
     def _remove_lyrics_tag(self, tags, name):
         """Remove lyrics tag from ID3 frames."""
-        if ':' in name:
-            desc = name.split(':', 1)[1]
-        else:
-            desc = ''
+        (lang, desc) = parse_lang_desc_tag(name)
         for key, frame in list(tags.items()):
-            if frame.FrameID == 'USLT' and frame.desc == desc:
+            if frame.FrameID == 'USLT' and frame.desc == desc and frame.lang == lang:
                 del tags[key]
 
     def _remove_synced_lyrics_tag(self, tags, name):
         """Remove synchronized lyrics tag from ID3 frames."""
-        (lang, desc) = parse_subtag(name)
+        (lang, desc) = parse_lang_desc_tag(name)
         for key, frame in list(tags.items()):
             if frame.FrameID == 'SYLT' and frame.desc == desc and frame.lang == lang and frame.type == 1:
                 del tags[key]

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -52,7 +52,11 @@ def parse_lang_desc_tag(name: str, default_language: str = 'xxx') -> tuple[str, 
     else:
         lang = default_language
 
-    if len(split) > 2:
+    if len(lang) != 3:
+        # If language is not 3 chars, assume default and use remaining parts as description
+        lang = default_language
+        desc = ':'.join(split[1:])
+    elif len(split) > 2:
         desc = split[2]
     else:
         desc = ''

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -41,27 +41,41 @@ RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
 
 
 def parse_lang_desc_tag(name: str, default_language: str = 'xxx') -> tuple[str, str]:
-    """
-    Parses a tag name like "lyrics:XXX:desc", where XXX is the language.
-    If language is not set, the colons are still mandatory, and "eng" is
-    assumed by default.
-    """
-    split = name.split(':')
-    if len(split) > 1 and split[1]:
-        lang = split[1]
-    else:
-        lang = default_language
+    """Parse a tag name of the form ``name:lang:desc`` into ``(lang, desc)``.
 
-    if len(lang) != 3:
-        # If language is not 3 chars, assume default and use remaining parts as description
-        lang = default_language
-        desc = ':'.join(split[1:])
-    elif len(split) > 2:
-        desc = split[2]
-    else:
-        desc = ''
+    Both the language and description are optional, and the description may
+    itself contain colons::
 
-    return lang, desc
+        name            -> (default_language, '')
+        name:eng        -> ('eng', '')
+        name:eng:desc   -> ('eng', 'desc')
+        name::desc      -> (default_language, 'desc')
+        name:desc       -> (default_language, 'desc')
+
+    The language must be a 3-character code (an ID3 requirement). Anything else
+    in that position (e.g. a 2-character code, or a description that uses a
+    single colon) is treated as part of the description and ``default_language``
+    is used instead.
+    """
+    # str.partition(sep) returns (before, sep, after) and never raises: when the
+    # separator is absent, `after` is ''. Partition twice to peel off the two
+    # optional ":"-separated parts after the tag name, leaving any further colons
+    # in the description untouched. E.g. for "lyrics:eng:some:desc":
+    #
+    #   "lyrics:eng:some:desc".partition(':') -> ("lyrics", ":", "eng:some:desc")
+    #   "eng:some:desc".partition(':')        -> ("eng", ":", "some:desc")
+    _tag, _colon, lang_and_desc = name.partition(':')
+    language, _colon, description = lang_and_desc.partition(':')
+
+    if len(language) == 3:
+        # Valid language code followed by an optional description.
+        return language, description
+    if language:
+        # A non-empty but invalid code (e.g. "de"): treat the whole thing after
+        # the tag name, including its single colon, as the description.
+        return default_language, lang_and_desc
+    # Empty language ("name::desc"): the description is what follows.
+    return default_language, description
 
 
 def create_lang_desc_tag(name: str, language: str = 'xxx', description: str = '', default_language: str = 'xxx') -> str:

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -40,34 +40,7 @@ from picard.tags.tagvar import TagVar
 RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
 
 
-def parse_comment_tag(name):
-    """
-    Parses a tag name like "comment:XXX:desc", where XXX is the language.
-    If language is not set ("comment:desc") "eng" is assumed as default.
-    Returns a (lang, desc) tuple.
-    """
-    lang = 'eng'
-    desc = ''
-
-    split = name.split(':', 1)
-    if len(split) > 1:
-        desc = split[1]
-
-    match_ = RE_COMMENT_LANG.match(desc)
-    if match_:
-        lang = match_.group(1)
-        desc = desc[4:]
-        return lang, desc
-
-    # Special case for unspecified language + empty description
-    if desc == 'XXX':
-        lang = 'XXX'
-        desc = ''
-
-    return lang, desc
-
-
-def parse_subtag(name):
+def parse_lang_desc_tag(name: str, default_language: str = 'xxx') -> tuple[str, str]:
     """
     Parses a tag name like "lyrics:XXX:desc", where XXX is the language.
     If language is not set, the colons are still mandatory, and "eng" is
@@ -77,7 +50,7 @@ def parse_subtag(name):
     if len(split) > 1 and split[1]:
         lang = split[1]
     else:
-        lang = 'eng'
+        lang = default_language
 
     if len(split) > 2:
         desc = split[2]
@@ -85,6 +58,18 @@ def parse_subtag(name):
         desc = ''
 
     return lang, desc
+
+
+def create_lang_desc_tag(name: str, language: str = 'xxx', description: str = '', default_language: str = 'xxx') -> str:
+    name_parts = [name]
+    if language and language.lower() != default_language:
+        name_parts.append(language)
+    elif description:
+        # Add empty language part if description is also set
+        name_parts.append('')
+    if description:
+        name_parts.append(description)
+    return ':'.join(name_parts)
 
 
 def all_tag_vars() -> Iterator[TagVar]:

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -111,9 +111,9 @@ TAGS = {
     'barcode': 'Foo',
     'bpm': '80',
     'catalognumber': 'Foo',
-    'comment': 'Foo',
-    'comment:foo': 'Foo',
-    'comment:deu:foo': 'Foo',
+    'comment': 'Foo Comment',
+    'comment:foo': 'Foo Comment (foo)',
+    'comment:deu:foo': 'Foo Comment (deu)',
     'compilation': '1',
     'composer': 'Foo',
     'composersort': 'Foo',
@@ -381,12 +381,12 @@ class CommonTests:
         @skipUnlessTestfile
         def test_delete_tags_with_description(self):
             for key in (
-                'comment:foo',
-                'comment:de:foo',
+                'comment::foo',
+                'comment:deu:foo',
                 'performer:foo',
-                'lyrics:foo',
-                'comment:a*',
-                'comment:a[',
+                'lyrics::foo',
+                'comment::a*',
+                'comment::a[',
                 'performer:(x)',
                 'performer: Ä é ',
             ):
@@ -554,17 +554,17 @@ class CommonTests:
 
         @skipUnlessTestfile
         def test_lyrics_with_description(self):
-            metadata = Metadata({'lyrics:foó': 'bar'})
+            metadata = Metadata({'lyrics::foó': 'bar'})
             loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertEqual(metadata['lyrics:foó'], loaded_metadata['lyrics'])
+            self.assertEqual(metadata['lyrics::foó'], loaded_metadata['lyrics'])
 
         @skipUnlessTestfile
         def test_comments_with_description(self):
-            if not self.format.supports_tag('comment:foó'):
+            if not self.format.supports_tag('comment::foó'):
                 return
-            metadata = Metadata({'comment:foó': 'bar'})
+            metadata = Metadata({'comment::foó': 'bar'})
             loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertEqual(metadata['comment:foó'], loaded_metadata['comment:foó'])
+            self.assertEqual(metadata['comment::foó'], loaded_metadata['comment::foó'])
 
         @skipUnlessTestfile
         def test_invalid_track_and_discnumber(self):

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -429,6 +429,13 @@ class CommonId3Tests:
             self.assertEqual(metadata['lyrics:fra:foo'], loaded_metadata['lyrics:fra:foo'])
 
         @skipUnlessTestfile
+        def test_lyrics_with_description_containing_colon(self):
+            metadata = Metadata({'lyrics:eng:foo:bar': 'baz'})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertIn('lyrics:eng:foo:bar', loaded_metadata)
+            self.assertEqual(metadata['lyrics:eng:foo:bar'], loaded_metadata['lyrics:eng:foo:bar'])
+
+        @skipUnlessTestfile
         def test_syncedlyrics_preserve_language_and_description(self):
             metadata = Metadata({'syncedlyrics': '[00:00.000]<00:00.000>foo1'})
             metadata.add('syncedlyrics:deu:desc', '[00:00.000]<00:00.000>foo2')

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -200,18 +200,18 @@ class CommonId3Tests:
         @skipUnlessTestfile
         def test_comment_delete(self):
             metadata = Metadata(self.tags)
-            metadata['comment:bar'] = 'Foo'
+            metadata['comment::bar'] = 'Foo'
             metadata['comment:XXX:withlang'] = 'Foo'
             original_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            del metadata['comment:bar']
+            del metadata['comment::bar']
             del metadata['comment:XXX:withlang']
             new_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
 
-            self.assertIn('comment:foo', original_metadata)
-            self.assertIn('comment:bar', original_metadata)
+            self.assertIn('comment', original_metadata)
+            self.assertIn('comment::bar', original_metadata)
             self.assertIn('comment:XXX:withlang', original_metadata)
-            self.assertIn('comment:foo', new_metadata)
-            self.assertNotIn('comment:bar', new_metadata)
+            self.assertIn('comment', new_metadata)
+            self.assertNotIn('comment::bar', new_metadata)
             self.assertNotIn('comment:XXX:withlang', new_metadata)
 
         @skipUnlessTestfile
@@ -280,25 +280,25 @@ class CommonId3Tests:
             config.setting['clear_existing_tags'] = True
             iTunNORM = '00001E86 00001E86 0000A2A3 0000A2A3 000006A6 000006A6 000078FA 000078FA 00000211 00000211'
             metadata = Metadata()
-            metadata['comment:iTunNORM'] = iTunNORM
+            metadata['comment::iTunNORM'] = iTunNORM
             new_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertEqual(new_metadata['comment:iTunNORM'], iTunNORM)
+            self.assertEqual(new_metadata['comment::iTunNORM'], iTunNORM)
 
         @skipUnlessTestfile
         def test_delete_itun_tags(self):
             metadata = Metadata()
-            metadata['comment:iTunNORM'] = (
+            metadata['comment::iTunNORM'] = (
                 '00001E86 00001E86 0000A2A3 0000A2A3 000006A6 000006A6 000078FA 000078FA 00000211 00000211'
             )
-            metadata['comment:iTunPGAP'] = '1'
+            metadata['comment::iTunPGAP'] = '1'
             new_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertIn('comment:iTunNORM', new_metadata)
-            self.assertIn('comment:iTunPGAP', new_metadata)
-            del metadata['comment:iTunNORM']
-            del metadata['comment:iTunPGAP']
+            self.assertIn('comment::iTunNORM', new_metadata)
+            self.assertIn('comment::iTunPGAP', new_metadata)
+            del metadata['comment::iTunNORM']
+            del metadata['comment::iTunPGAP']
             new_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertNotIn('comment:iTunNORM', new_metadata)
-            self.assertNotIn('comment:iTunPGAP', new_metadata)
+            self.assertNotIn('comment::iTunNORM', new_metadata)
+            self.assertNotIn('comment::iTunPGAP', new_metadata)
 
         @skipUnlessTestfile
         def test_itunes_cddb_1_comm_frame(self):
@@ -318,7 +318,7 @@ class CommonId3Tests:
             self.assertEqual(loaded_metadata['itunes_cddb_1'], cddb_value)
 
             # Ensure it's not loaded as a comment tag
-            self.assertNotIn('comment:iTunes_CDDB_1', loaded_metadata)
+            self.assertNotIn('comment::iTunes_CDDB_1', loaded_metadata)
 
             # Now verify that saving the tag keeps it in COMM frame
             new_metadata = save_and_load_metadata(self.format_registry, self.filename, loaded_metadata)
@@ -408,10 +408,25 @@ class CommonId3Tests:
             self.assertNotIn('TXXX:REPLAYGAIN_ALBUM_PEAK', raw_metadata)
 
         @skipUnlessTestfile
-        def test_lyrics_with_description(self):
-            metadata = Metadata({'lyrics:foo': 'bar'})
+        def test_lyrics_with_language(self):
+            metadata = Metadata({'lyrics:jpn': 'bar'})
             loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertEqual(metadata['lyrics:foo'], loaded_metadata['lyrics:foo'])
+            self.assertIn('lyrics:jpn', loaded_metadata)
+            self.assertEqual(metadata['lyrics:jpn'], loaded_metadata['lyrics:jpn'])
+
+        @skipUnlessTestfile
+        def test_lyrics_with_description(self):
+            metadata = Metadata({'lyrics::foo': 'bar'})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertIn('lyrics::foo', loaded_metadata)
+            self.assertEqual(metadata['lyrics::foo'], loaded_metadata['lyrics::foo'])
+
+        @skipUnlessTestfile
+        def test_lyrics_with_language_and_description(self):
+            metadata = Metadata({'lyrics:fra:foo': 'bar'})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertIn('lyrics:fra:foo', loaded_metadata)
+            self.assertEqual(metadata['lyrics:fra:foo'], loaded_metadata['lyrics:fra:foo'])
 
         @skipUnlessTestfile
         def test_syncedlyrics_preserve_language_and_description(self):
@@ -420,10 +435,10 @@ class CommonId3Tests:
             metadata.add('syncedlyrics:ita', '[00:00.000]<00:00.000>foo3')
             metadata.add('syncedlyrics::desc', '[00:00.000]<00:00.000>foo4')
             loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-            self.assertEqual(metadata['syncedlyrics'], loaded_metadata['syncedlyrics:eng'])
+            self.assertEqual(metadata['syncedlyrics'], loaded_metadata['syncedlyrics'])
             self.assertEqual(metadata['syncedlyrics:deu:desc'], loaded_metadata['syncedlyrics:deu:desc'])
             self.assertEqual(metadata['syncedlyrics:ita'], loaded_metadata['syncedlyrics:ita'])
-            self.assertEqual(metadata['syncedlyrics::desc'], loaded_metadata['syncedlyrics:eng:desc'])
+            self.assertEqual(metadata['syncedlyrics::desc'], loaded_metadata['syncedlyrics::desc'])
 
         @skipUnlessTestfile
         def test_syncedlyrics_delete(self):

--- a/test/formats/test_id3_load.py
+++ b/test/formats/test_id3_load.py
@@ -107,26 +107,27 @@ class TestID3Load(PicardTestCase):
         frame.FrameID = 'USLT'
         frame.desc = 'Test Lyrics'
         frame.text = 'These are the lyrics.'
+        frame.lang = 'eng'
         metadata = Metadata()
         config_params = {}
         self.id3_file._load_uslt_frame(frame, metadata, config_params)
-        self.assertIn('lyrics:Test Lyrics', metadata)
-        self.assertEqual(metadata['lyrics:Test Lyrics'], 'These are the lyrics.')
+        self.assertIn('lyrics:eng:Test Lyrics', metadata)
+        self.assertEqual(metadata['lyrics:eng:Test Lyrics'], 'These are the lyrics.')
 
     def test_load_sylt_frame(self):
         frame = MagicMock(spec=SYLT)
         frame.FrameID = 'SYLT'
         frame.type = 1
         frame.format = 2
-        frame.lang = 'ENG'
+        frame.lang = 'eng'
         frame.desc = 'Test Lyrics'
         frame.text = [('These are the lyrics.', 0), ('etc.', 1000)]
         metadata = Metadata()
         config_params = {'file_length': 120, 'filename': 'test.mp3'}
         self.id3_file._load_sylt_frame(frame, metadata, config_params)
-        self.assertIn('syncedlyrics:ENG:Test Lyrics', metadata)
+        self.assertIn('syncedlyrics:eng:Test Lyrics', metadata)
         self.assertEqual(
-            metadata['syncedlyrics:ENG:Test Lyrics'], '[00:00.000]<00:00.000>These are the lyrics.<00:01.000>etc.'
+            metadata['syncedlyrics:eng:Test Lyrics'], '[00:00.000]<00:00.000>These are the lyrics.<00:01.000>etc.'
         )
 
     def test_load_sylt_frame_no_lang(self):
@@ -211,8 +212,8 @@ class TestID3Load(PicardTestCase):
         metadata = Metadata()
         config_params = {}
         self.id3_file._load_standard_text_frame(frame, metadata, config_params)
-        self.assertIn('comment:Test Comment', metadata)
-        self.assertEqual(metadata['comment:Test Comment'], 'This is a test comment.')
+        self.assertIn('comment::Test Comment', metadata)
+        self.assertEqual(metadata['comment::Test Comment'], 'This is a test comment.')
 
     def test_load_standard_text_frame_TALB(self):
         frame = MagicMock(spec=TALB)

--- a/test/test_config_upgrade_hooks.py
+++ b/test/test_config_upgrade_hooks.py
@@ -845,3 +845,45 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         settings = {'browser_integration_port': 8021}
         hooks.clamp_browser_integration_port(settings)
         self.assertEqual(8020, settings['browser_integration_port'])
+
+    def test_upgrade_scripts_lyrics_comments(self):
+        settings = {
+            'list_of_scripts': [
+                (0, 's1', True, ''),
+                (1, 's2', True, '%lyrics:somedescription%'),
+                (2, 's3', True, '%lyrics:some:description%'),
+                (3, 's4', False, '$set(lyrics:foo,bar)'),
+                (4, 's5', False, '%comment:fra:description%'),
+                (5, 's6', False, '%comment:fra%'),
+                (6, 's7', False, '%comment:description%'),
+                (7, 's8', True, '%comment:ab%'),
+                (8, 's9', True, '%comment:ab:moredescription%'),
+                (9, 's10', True, '$set(comment:fra:description,'),
+                (10, 's11', False, '$copy(comment:fra,'),
+                (11, 's12', False, '$unset(comment:description)'),
+                (12, 's13', True, '$setmulti(comment:ab,'),
+                (13, 's14', True, '$delete(comment:ab:moredescription)'),
+                (14, 's15', True, '$copy(comment:lyrics,lyrics:foo)'),
+                (15, 's16', True, '$copymerge(lyrics:foo,comment:lyrics)'),
+            ]
+        }
+        hooks.upgrade_scripts_lyrics_comments(settings)
+        expected_settings = [
+            (0, 's1', True, ''),
+            (1, 's2', True, '%lyrics::somedescription%'),
+            (2, 's3', True, '%lyrics::some:description%'),
+            (3, 's4', False, '$set(lyrics::foo,bar)'),
+            (4, 's5', False, '%comment:fra:description%'),
+            (5, 's6', False, '%comment:fra%'),
+            (6, 's7', False, '%comment::description%'),
+            (7, 's8', True, '%comment::ab%'),
+            (8, 's9', True, '%comment::ab:moredescription%'),
+            (9, 's10', True, '$set(comment:fra:description,'),
+            (10, 's11', False, '$copy(comment:fra,'),
+            (11, 's12', False, '$unset(comment::description)'),
+            (12, 's13', True, '$setmulti(comment::ab,'),
+            (13, 's14', True, '$delete(comment::ab:moredescription)'),
+            (14, 's15', True, '$copy(comment::lyrics,lyrics::foo)'),
+            (15, 's16', True, '$copymerge(lyrics::foo,comment::lyrics)'),
+        ]
+        self.assertEqual(expected_settings, settings['list_of_scripts'])

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -446,6 +446,10 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(parse_lang_desc_tag('lyrics:XXX'), ('XXX', ''))
         self.assertEqual(parse_lang_desc_tag('lyrics::foo', default_language='eng'), ('eng', 'foo'))
 
+    def test_parse_lang_desc_tag_invalid_language(self):
+        self.assertEqual(parse_lang_desc_tag('lyrics:de', default_language='eng'), ('eng', 'de'))
+        self.assertEqual(parse_lang_desc_tag('lyrics:toolong:foo', default_language='eng'), ('eng', 'toolong:foo'))
+
     def test_create_lang_desc_tag(self):
         self.assertEqual('comment', create_lang_desc_tag('comment'))
         self.assertEqual('comment:eng', create_lang_desc_tag('comment', language='eng'))

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -32,10 +32,10 @@ from picard.options import (
 )
 from picard.profile import profile_groups_add_setting
 from picard.tags import (
+    create_lang_desc_tag,
     display_tag_name,
     filterable_tag_names,
-    parse_comment_tag,
-    parse_subtag,
+    parse_lang_desc_tag,
     preserved_tag_names,
     script_variable_tag_names,
     tag_names,
@@ -440,17 +440,20 @@ class UtilTagsTest(PicardTestCase):
         # Empty tag
         self.assertEqual(display_tag_name(''), '')
 
-    def test_parse_comment_tag(self):
-        self.assertEqual(parse_comment_tag('comment:XXX:foo'), ('XXX', 'foo'))
-        self.assertEqual(parse_comment_tag('comment:foo'), ('eng', 'foo'))
-        self.assertEqual(parse_comment_tag('comment:XXX'), ('XXX', ''))
-        self.assertEqual(parse_comment_tag('comment'), ('eng', ''))
+    def test_parse_lang_desc_tag(self):
+        self.assertEqual(parse_lang_desc_tag('lyrics:eng'), ('eng', ''))
+        self.assertEqual(parse_lang_desc_tag('lyrics:XXX:foo'), ('XXX', 'foo'))
+        self.assertEqual(parse_lang_desc_tag('lyrics:XXX'), ('XXX', ''))
+        self.assertEqual(parse_lang_desc_tag('lyrics::foo', default_language='eng'), ('eng', 'foo'))
 
-    def test_parse_lyrics_tag(self):
-        self.assertEqual(parse_subtag('lyrics'), ('eng', ''))
-        self.assertEqual(parse_subtag('lyrics:XXX:foo'), ('XXX', 'foo'))
-        self.assertEqual(parse_subtag('lyrics:XXX'), ('XXX', ''))
-        self.assertEqual(parse_subtag('lyrics::foo'), ('eng', 'foo'))
+    def test_create_lang_desc_tag(self):
+        self.assertEqual('comment', create_lang_desc_tag('comment'))
+        self.assertEqual('comment:eng', create_lang_desc_tag('comment', language='eng'))
+        self.assertEqual('comment::foo', create_lang_desc_tag('comment', description='foo'))
+        self.assertEqual('lyrics:jpn:foo', create_lang_desc_tag('lyrics', language='jpn', description='foo'))
+        self.assertEqual(
+            'lyrics::foo', create_lang_desc_tag('lyrics', language='jpn', description='foo', default_language='jpn')
+        )
 
     def test_display_tag_tooltip(self):
         # Unknown tag

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -450,6 +450,12 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(parse_lang_desc_tag('lyrics:de', default_language='eng'), ('eng', 'de'))
         self.assertEqual(parse_lang_desc_tag('lyrics:toolong:foo', default_language='eng'), ('eng', 'toolong:foo'))
 
+    def test_parse_lang_desc_tag_description_with_colon(self):
+        # The description may itself contain colons and must be preserved in full.
+        self.assertEqual(parse_lang_desc_tag('lyrics:eng:a:b'), ('eng', 'a:b'))
+        self.assertEqual(parse_lang_desc_tag('lyrics::a:b', default_language='eng'), ('eng', 'a:b'))
+        self.assertEqual(parse_lang_desc_tag('comment:deu:foo:bar:baz'), ('deu', 'foo:bar:baz'))
+
     def test_create_lang_desc_tag(self):
         self.assertEqual('comment', create_lang_desc_tag('comment'))
         self.assertEqual('comment:eng', create_lang_desc_tag('comment', language='eng'))


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2844, PICARD-1877
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

This change makes the tags lyrics, syncedlyrics and comments consistent to follow the syntax `{tagname}:{lang}:{description}`. While both "lang" and "description" are optional, a missing language but non-empty description is indicated by a double colon like `comment::withdescription`.

The general syntax for language and description was already possible for syncedlyrics (since this was newly implemented specifically to follow this syntax) and in parts for comments. The PR applies the following changes:

- The `lyrics` tag did not support language at all, hence language set in ID3 tags was lost. This is a bug, see PICARD-1877.
- The `comment` tag supported both e.g. `comment:lang:description` and also just `comment:description`. Now the latter form gets stanardized to `comment::description` to avoid the ambiguity with only language.
- Unify the implementation for all of `comment`, `lyrics` and `syncedlyrics`



## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- Combine  helper functions `parse_subtag` and `parse_comment_tag` into `parse_lang_desc_tag` and use it for all three tags in the ID3 implementation
- Fix `parse_lang_desc_tag` to handle special cases:
  - Treat language code part with not exactly 3 letters (as required by ID3) as part of the description. This gives a fallback to cases that use a single colon
  - The description part could contain additional colons
- Add corresponding `create_lang_desc_tag`
- Added a migration to update scripts to add the double colon syntax for `lyrics` and `comment` tags.


## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
