### PR TITLE
PICARD-3403: Fix plugin git auth crash on pygit2 1.20+

### DIFF
--- a/picard/git/backend.py
+++ b/picard/git/backend.py
@@ -157,7 +157,14 @@ class GitObject:
 
 
 class GitRemoteCallbacks:
-    """Abstract remote callbacks for authentication"""
+    """Abstract remote callbacks for authentication.
+
+    Concrete backends store their native callbacks object in ``_callbacks``
+    (e.g. a ``pygit2.RemoteCallbacks`` instance).
+    """
+
+    #: Backend-specific native callbacks handle, populated by subclasses.
+    _callbacks: Any = None
 
 
 def _log_git_call(method_name: str, *args, **kwargs):

--- a/picard/git/backends/pygit2.py
+++ b/picard/git/backends/pygit2.py
@@ -350,6 +350,16 @@ class Pygit2Backend(GitBackend):
         if not HAS_PYGIT2:
             raise ImportError("pygit2 not available")
 
+    @staticmethod
+    def _raw(repo: GitRepository):
+        """Return the underlying pygit2 repository for a Pygit2Repository.
+
+        All repositories created by this backend are Pygit2Repository instances;
+        the assertion documents and enforces that invariant for the type checker.
+        """
+        assert isinstance(repo, Pygit2Repository)
+        return repo._repo
+
     def create_repository(self, path: Path) -> GitRepository:
         _log_git_call("create_repository", str(path))
         try:
@@ -366,7 +376,7 @@ class Pygit2Backend(GitBackend):
     def create_commit(
         self, repo: GitRepository, message: str, author_name: str = "Test", author_email: str = "test@example.com"
     ) -> str:
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
         index = pygit_repo.index
         index.add_all()
         index.write()
@@ -388,13 +398,13 @@ class Pygit2Backend(GitBackend):
         author_email: str = "test@example.com",
     ):
         _log_git_call("create_tag", tag_name, commit_id, message)
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
         author = pygit2.Signature(author_name, author_email)
         pygit_repo.create_tag(tag_name, commit_id, pygit2.GIT_OBJECT_COMMIT, author, message)
 
     def create_branch(self, repo: GitRepository, branch_name: str, commit_id: str):
         _log_git_call("create_branch", branch_name, commit_id)
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
         # Create branch reference pointing to the commit
         pygit_repo.create_reference(f'refs/heads/{branch_name}', commit_id)
 
@@ -402,7 +412,7 @@ class Pygit2Backend(GitBackend):
         self, repo: GitRepository, message: str, author_name: str = "Test", author_email: str = "test@example.com"
     ) -> str:
         try:
-            pygit_repo = repo._repo
+            pygit_repo = self._raw(repo)
             index = pygit_repo.index
             index.add_all()
             index.write()
@@ -426,17 +436,17 @@ class Pygit2Backend(GitBackend):
 
     def reset_hard(self, repo: GitRepository, commit_id: str):
         _log_git_call("reset_hard", commit_id)
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
         pygit_repo.reset(commit_id, pygit2.enums.ResetMode.HARD)
 
     def create_reference(self, repo: GitRepository, ref_name: str, commit_id: str):
         _log_git_call("create_reference", ref_name, commit_id)
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
         pygit_repo.create_reference(ref_name, commit_id)
 
     def set_head_detached(self, repo: GitRepository, commit_id: str):
         _log_git_call("set_head_detached", commit_id)
-        pygit_repo = repo._repo
+        pygit_repo = self._raw(repo)
 
         # To create a true detached HEAD, we need to make HEAD point directly to a commit
         # rather than to a branch reference

--- a/picard/git/backends/pygit2.py
+++ b/picard/git/backends/pygit2.py
@@ -68,12 +68,12 @@ class Pygit2RemoteCallbacks(GitRemoteCallbacks):
             return None
         self._attempted = True
 
-        if allowed_types & pygit2.GIT_CREDENTIAL_SSH_KEY:
+        if allowed_types & pygit2.enums.CredentialType.SSH_KEY:
             try:
                 return pygit2.Keypair('git', None, None, '')
             except (pygit2.GitError, OSError):
                 return None
-        elif allowed_types & pygit2.GIT_CREDENTIAL_USERPASS_PLAINTEXT:
+        elif allowed_types & pygit2.enums.CredentialType.USERPASS_PLAINTEXT:
             try:
                 return pygit2.Username('git')
             except (pygit2.GitError, OSError):

--- a/picard/git/backends/pygit2.py
+++ b/picard/git/backends/pygit2.py
@@ -89,9 +89,9 @@ class Pygit2Repository(GitRepository):
         status = self._repo.status()
         result = {}
         for filepath, flags in status.items():
-            if flags == pygit2.GIT_STATUS_CURRENT:
+            if flags == pygit2.enums.FileStatus.CURRENT:
                 result[filepath] = GitStatusFlag.CURRENT
-            elif flags == pygit2.GIT_STATUS_IGNORED:
+            elif flags == pygit2.enums.FileStatus.IGNORED:
                 result[filepath] = GitStatusFlag.IGNORED
             else:
                 # Any other status means the file is modified/added/deleted/untracked
@@ -117,7 +117,7 @@ class Pygit2Repository(GitRepository):
     def revparse_single(self, ref: str) -> GitObject:
         try:
             obj = self._repo.revparse_single(ref)
-            obj_type = GitObjectType.COMMIT if obj.type == pygit2.GIT_OBJECT_COMMIT else GitObjectType.TAG
+            obj_type = GitObjectType.COMMIT if obj.type == pygit2.enums.ObjectType.COMMIT else GitObjectType.TAG
             ret = GitObject(str(obj.id), obj_type)
             _log_git_call("revparse_single", ref, retval=ret)
             return ret
@@ -130,8 +130,8 @@ class Pygit2Repository(GitRepository):
 
     def peel_to_commit(self, obj: GitObject) -> GitObject:
         pygit_obj = self._repo.get(obj.id)
-        if pygit_obj.type == pygit2.GIT_OBJECT_TAG:
-            commit = pygit_obj.peel(pygit2.GIT_OBJECT_COMMIT)
+        if pygit_obj.type == pygit2.enums.ObjectType.TAG:
+            commit = pygit_obj.peel(pygit2.enums.ObjectType.COMMIT)
             ret = GitObject(str(commit.id), GitObjectType.COMMIT)
         else:
             ret = obj
@@ -268,11 +268,11 @@ class Pygit2Repository(GitRepository):
                     else:
                         # Remote reference
                         obj = repo.get(ref.oid)
-                    is_annotated = obj.type == pygit2.GIT_OBJECT_TAG
+                    is_annotated = obj.type == pygit2.enums.ObjectType.TAG
 
                     # For annotated tags, dereference to get the commit ID
                     if is_annotated:
-                        commit = obj.peel(pygit2.GIT_OBJECT_COMMIT)
+                        commit = obj.peel(pygit2.enums.ObjectType.COMMIT)
                         target = str(commit.id)
                     # For lightweight tags, target is already the commit ID
                 except Exception:
@@ -400,7 +400,7 @@ class Pygit2Backend(GitBackend):
         _log_git_call("create_tag", tag_name, commit_id, message)
         pygit_repo = self._raw(repo)
         author = pygit2.Signature(author_name, author_email)
-        pygit_repo.create_tag(tag_name, commit_id, pygit2.GIT_OBJECT_COMMIT, author, message)
+        pygit_repo.create_tag(tag_name, commit_id, pygit2.enums.ObjectType.COMMIT, author, message)
 
     def create_branch(self, repo: GitRepository, branch_name: str, commit_id: str):
         _log_git_call("create_branch", branch_name, commit_id)

--- a/test/plugins3/test_plugin.py
+++ b/test/plugins3/test_plugin.py
@@ -151,6 +151,34 @@ class TestGitRemoteCallbacks(PicardTestCase):
             callbacks._transfer_progress(mock_stats)
             mock_print.assert_not_called()
 
+    def test_git_remote_callbacks_credentials_credential_types(self):
+        """Regression test for PICARD-3403.
+
+        _credentials() must resolve credentials using the
+        pygit2.enums.CredentialType flag enum. The legacy pygit2.GIT_CREDENTIAL_*
+        module constants were removed in pygit2 1.20.0, so referencing them
+        raised AttributeError whenever git authentication was required.
+        """
+        if not has_git_backend():
+            self.skipTest('git backend not available')
+
+        # Inline import: pygit2 is an optional dependency and may be absent.
+        import pygit2
+        from pygit2.enums import CredentialType
+
+        backend = git_backend()
+
+        # SSH key credentials requested.
+        callbacks = backend.create_remote_callbacks()
+        result = callbacks._credentials('url', 'git', CredentialType.SSH_KEY)
+        self.assertIsInstance(result, pygit2.Keypair)
+
+        # Username/password credentials requested. Use fresh callbacks because
+        # the first attempt is remembered to avoid authentication loops.
+        callbacks = backend.create_remote_callbacks()
+        result = callbacks._credentials('url', 'git', CredentialType.USERPASS_PLAINTEXT)
+        self.assertIsInstance(result, pygit2.Username)
+
 
 class TestPluginSourceGitUpdate(PicardTestCase):
     def test_update_without_ref_uses_head(self):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: The pygit2 credentials callback referenced `pygit2.GIT_CREDENTIAL_*` constants that were removed in pygit2 1.20.0, causing an `AttributeError` whenever plugin git authentication was required. This switches to the `pygit2.enums.CredentialType` flag enum (and modernizes the other flat `GIT_*` constants along the way).

## Problem

* JIRA ticket: PICARD-3403

`picard/git/backends/pygit2.py`, in `Pygit2RemoteCallbacks._credentials()`, referenced the module-level constants `pygit2.GIT_CREDENTIAL_SSH_KEY` and `pygit2.GIT_CREDENTIAL_USERPASS_PLAINTEXT`.

These flat `GIT_*` constants were deprecated in pygit2 1.14.0 (when `pygit2.enums` was introduced) and **removed in pygit2 1.20.0** (per its CHANGELOG: *"Remove deprecated `pygit2.legacyenums` module and `GIT_*` constants, use `pygit2.enums` instead"*).

Since the project's own dependency pins resolve to pygit2 1.20.0 on Python 3.11+ (`uv.lock` / `requirements.txt`), the credentials callback raised `AttributeError: module 'pygit2' has no attribute 'GIT_CREDENTIAL_SSH_KEY'` whenever git authentication was required (e.g. installing or updating a plugin from an SSH or userpass-protected repository). Public HTTPS repositories don't trigger the callback, which is why it went unnoticed.

## Solution

The change is split into three focused commits:

1. **PICARD-3403 bug fix** — Replace the removed `pygit2.GIT_CREDENTIAL_*` constants with `pygit2.enums.CredentialType.SSH_KEY` / `.USERPASS_PLAINTEXT`. The enum has existed since pygit2 1.14.0 and is therefore available across the entire supported range (1.18.2 → 1.20.0), so no version guard is needed. Includes a regression test covering the SSH and userpass credential paths (verified to fail on the old code with the exact `AttributeError`, and pass after the fix).

2. **Static typing gaps in the pygit2 backend** — Resolve `ty` `unresolved-attribute` errors: add a typed `Pygit2Backend._raw()` helper that narrows `GitRepository` to the concrete `Pygit2Repository` before accessing the private `_repo` handle (replacing seven bare `repo._repo` accesses), and declare the opaque `_callbacks` handle on the abstract `GitRemoteCallbacks` base. No behavioural change.

3. **Modernize remaining `GIT_*` constants** — Replace the still-present `pygit2.GIT_OBJECT_*` and `pygit2.GIT_STATUS_*` constants with their `pygit2.enums` equivalents (`ObjectType.COMMIT/TAG`, `FileStatus.CURRENT/IGNORED`). These are not currently broken, but pygit2 recommends the enums and the flat names may be removed in a future release. Values are identical, and this matches the `pygit2.enums.ResetMode` usage already present in the file.

Verification: `ruff check`/`ruff format` clean; `ty` introduces no new diagnostics; all git backend tests pass (`test/test_git.py`, `test/plugins3/test_git.py`, `test/plugins3/test_plugin.py`), plus a functional smoke test of `get_status` / `revparse_single` / `peel_to_commit`.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to investigate the pygit2 CHANGELOG and version history to pin down when the constants were removed, to identify and narrow the typing gaps, and to draft the fix, the regression test, and this PR description. All changes were reviewed and verified against the test suite.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
