### PR TITLE
plugin3: Fix static typing gaps in the plugin subsystem

### DIFF
--- a/docs/PLUGINSV3/ROADMAP.md
+++ b/docs/PLUGINSV3/ROADMAP.md
@@ -194,10 +194,10 @@ This document outlines the development roadmap for Picard's Plugin v3 system. Th
 - ✅ Add `--yes` flag to skip confirmations
 - ✅ Return proper exit codes (ExitCode enum: SUCCESS, ERROR, NOT_FOUND, CANCELLED)
 - ✅ Add clear messages that changes require Picard restart
-- ✅ Create PluginOutput wrapper with color support
+- ✅ Create PluginCliOutput wrapper with color support
 
 **Files modified:**
-- `picard/plugin3/cli.py` - enhanced all methods with PluginOutput
+- `picard/plugin3/cli.py` - enhanced all methods with PluginCliOutput
 - `picard/plugin3/output.py` - created output wrapper with colors
 - `picard/tagger.py` - added --info argument
 

--- a/picard/cli/plugins.py
+++ b/picard/cli/plugins.py
@@ -217,7 +217,7 @@ def _run_plugins(args):
     from picard.git.factory import has_git_backend
     from picard.plugin3.cli import PluginCLI
     from picard.plugin3.manager import PluginManager
-    from picard.plugin3.output import PluginOutput
+    from picard.plugin3.output import PluginCliOutput
     from picard.util import cli
 
     # Check git backend
@@ -235,6 +235,6 @@ def _run_plugins(args):
     manager.add_directory(USER_PLUGIN_DIR, primary=True)
 
     # Create output
-    output = PluginOutput(color=False if is_color_disabled(args) else None)
+    output = PluginCliOutput(color=False if is_color_disabled(args) else None)
 
     return PluginCLI(manager, args, output=output).run()

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -153,6 +153,10 @@ Option('persist', 'cli_plugins_init', {})
 class PluginCLI(BaseCLI):
     """Command line interface for managing plugins."""
 
+    # PluginCLI always uses PluginCliOutput, which extends CliOutput with
+    # plugin/git-specific display methods (d_commit_old, d_commit_new, ...).
+    _out: PluginCliOutput
+
     def __init__(self, manager, args, output=None):
         super().__init__(args, output or PluginCliOutput())
         self._manager = manager
@@ -176,6 +180,8 @@ class PluginCLI(BaseCLI):
         self._manager._registry.fetch_registry(callback=callback)
 
         app = QtCore.QCoreApplication.instance()
+        if app is None:
+            raise RuntimeError('No QCoreApplication instance available')
         while not result['done']:
             app.processEvents()
 
@@ -454,7 +460,7 @@ class PluginCLI(BaseCLI):
                     self._out.info(f'  State: {plugin.state.value}')
 
                     # Version with git info
-                    metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else {}
+                    metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
                     if metadata:
                         git_ref = metadata.get_git_ref()
                         if git_ref.shortname and git_ref.target:
@@ -513,7 +519,7 @@ class PluginCLI(BaseCLI):
             return error
 
         is_enabled = plugin.uuid and plugin.uuid in self._manager._enabled_plugins
-        metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else {}
+        metadata = self._manager._get_plugin_metadata(plugin.uuid) if plugin.uuid else None
         is_local = is_local_plugin(metadata)
 
         local_marker = self._local_marker(metadata)
@@ -1768,6 +1774,8 @@ class PluginCLI(BaseCLI):
 
             # Process events until callback is called
             app = QtCore.QCoreApplication.instance()
+            if app is None:
+                raise RuntimeError('No QCoreApplication instance available')
             while not result['done']:
                 app.processEvents()
 

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -71,7 +71,7 @@ from picard.plugin3.manager import (
     PluginRefSwitchError,
 )
 from picard.plugin3.manifest import generate_manifest_template
-from picard.plugin3.output import PluginOutput
+from picard.plugin3.output import PluginCliOutput
 from picard.plugin3.plugin import (
     PluginAlreadyDisabledError,
     PluginAlreadyEnabledError,
@@ -154,7 +154,7 @@ class PluginCLI(BaseCLI):
     """Command line interface for managing plugins."""
 
     def __init__(self, manager, args, output=None):
-        super().__init__(args, output or PluginOutput())
+        super().__init__(args, output or PluginCliOutput())
         self._manager = manager
 
     def _ensure_registry(self):

--- a/picard/plugin3/output.py
+++ b/picard/plugin3/output.py
@@ -22,7 +22,7 @@
 from picard.cli.output import CliOutput
 
 
-class PluginOutput(CliOutput):
+class PluginCliOutput(CliOutput):
     """Output wrapper for plugin CLI commands.
 
     Extends CliOutput with display methods specific to plugin management

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -362,7 +362,7 @@ class PluginSourceGit(PluginSource):
         # Determine ref type for the resolved ref (non-relative refs only)
         if self.resolved_ref and not self._is_relative_ref(self.ref):
             git_ref = find_git_ref(repo, self.resolved_ref)
-            if git_ref:
+            if git_ref and git_ref.ref_type:
                 self.resolved_ref_type = git_ref.ref_type.value  # 'tag' or 'branch'
             else:
                 # If not found as branch or tag, assume it's a commit
@@ -693,6 +693,8 @@ class Plugin:
 
         module_file = self.local_path.joinpath('__init__.py')
         spec = importlib.util.spec_from_file_location(self.module_name, module_file)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not create import spec for plugin {self.plugin_id!r} at {module_file}")
         module = importlib.util.module_from_spec(spec)
         sys.modules[self.module_name] = module
         spec.loader.exec_module(module)
@@ -773,10 +775,11 @@ class Plugin:
     def name(self):
         """Returns translated plugin name if possible, else plugin_id"""
         try:
-            return self.manifest.name_i18n()
+            if self.manifest is not None:
+                return self.manifest.name_i18n()
         except Exception as e:
             log.error("Failed to get plugin %s's name: %s", self, e)
-            return str(self)
+        return str(self)
 
     def __str__(self):
         """Returns plugin id"""

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -33,7 +33,7 @@ from picard.plugin3.cli import PluginCLI
 from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.manifest import PluginManifest
-from picard.plugin3.output import PluginOutput
+from picard.plugin3.output import PluginCliOutput
 from picard.plugin3.plugin import (
     Plugin,
     PluginState,
@@ -145,8 +145,8 @@ def create_test_registry():
 
 
 def create_cli_output():
-    """Create PluginOutput with StringIO streams."""
-    return PluginOutput(stdout=StringIO(), stderr=StringIO(), color=False)
+    """Create PluginCliOutput with StringIO streams."""
+    return PluginCliOutput(stdout=StringIO(), stderr=StringIO(), color=False)
 
 
 class MockCliArgs(Mock):

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -58,7 +58,7 @@ from picard.plugin3.manager import (
     PluginMetadata,
 )
 from picard.plugin3.manager.update import UpdateResult
-from picard.plugin3.output import PluginOutput
+from picard.plugin3.output import PluginCliOutput
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.registry import (
     RegistryFetchError,
@@ -104,7 +104,7 @@ def create_mock_registry_plugin(data):
 def _make_cli(manager, args, **kwargs):
     """Create a PluginCLI with captured stderr output."""
     stderr = StringIO()
-    output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+    output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
     cli = PluginCLI(manager, args, output=output, **kwargs)
     return cli, stderr
 
@@ -216,13 +216,13 @@ class TestPluginCLI(PicardTestCase):
         """Test that color mode works correctly."""
         # Test with color enabled
         stdout_color = StringIO()
-        output_color = PluginOutput(stdout=stdout_color, stderr=StringIO(), color=True)
+        output_color = PluginCliOutput(stdout=stdout_color, stderr=StringIO(), color=True)
         output_color.success('test')
         self.assertIn('\033[32m', stdout_color.getvalue())
 
         # Test with color disabled
         stdout_no_color = StringIO()
-        output_no_color = PluginOutput(stdout=stdout_no_color, stderr=StringIO(), color=False)
+        output_no_color = PluginCliOutput(stdout=stdout_no_color, stderr=StringIO(), color=False)
         output_no_color.success('test')
         self.assertNotIn('\033[', stdout_no_color.getvalue())
 
@@ -888,7 +888,7 @@ class TestPluginCLIValidate(PicardTestCase):
             git_dir.mkdir()
 
             stderr = StringIO()
-            output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+            output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
             cli = PluginCLI(manager, args, output=output)
 
             result = cli._cmd_validate(tmpdir)
@@ -911,7 +911,7 @@ class TestPluginCLIValidate(PicardTestCase):
             manifest_path.write_text('name = "Test"\n')  # Missing required fields
 
             stderr = StringIO()
-            output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+            output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
             cli = PluginCLI(manager, args, output=output)
 
             result = cli._cmd_validate(tmpdir)
@@ -929,7 +929,7 @@ class TestPluginCLIValidate(PicardTestCase):
             plugin_dir = create_test_plugin_dir(tmpdir, 'test-plugin', add_git=True)
 
             stdout = StringIO()
-            output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+            output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
             cli = PluginCLI(manager, args, output=output)
 
             result = cli._cmd_validate(str(plugin_dir))
@@ -961,7 +961,7 @@ class TestPluginCLIValidate(PicardTestCase):
             plugin_dir = create_test_plugin_dir(tmpdir, 'test-plugin', manifest_content, add_git=True)
 
             stdout = StringIO()
-            output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+            output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
             cli = PluginCLI(manager, args, output=output)
 
             result = cli._cmd_validate(str(plugin_dir))
@@ -983,7 +983,7 @@ class TestPluginCLIManifest(PicardTestCase):
         args = MockCliArgs()
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(manager, args, output=output)
 
         result = cli._cmd_manifest(None)
@@ -1014,7 +1014,7 @@ class TestPluginCLIManifest(PicardTestCase):
             mock_plugin.local_path = plugin_dir
 
             stdout = StringIO()
-            output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+            output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
             cli = PluginCLI(manager, args, output=output)
             manager.find_plugin = Mock(return_value=mock_plugin)
 
@@ -1037,7 +1037,7 @@ class TestPluginCLIManifest(PicardTestCase):
             mock_plugin.local_path = plugin_dir
 
             stderr = StringIO()
-            output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+            output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
             cli = PluginCLI(manager, args, output=output)
             manager.find_plugin = Mock(return_value=mock_plugin)
 
@@ -1062,7 +1062,7 @@ class TestPluginCLIManifest(PicardTestCase):
             manifest_path.write_text(manifest_content)
 
             stdout = StringIO()
-            output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+            output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
             cli = PluginCLI(manager, args, output=output)
             manager.find_plugin = Mock(return_value=None)
 
@@ -1082,7 +1082,7 @@ class TestPluginCLIManifest(PicardTestCase):
             git_dir.mkdir()
 
             stderr = StringIO()
-            output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+            output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
             cli = PluginCLI(manager, args, output=output)
             manager.find_plugin = Mock(return_value=None)
 
@@ -1117,7 +1117,7 @@ class TestPluginCLIColorOption(PicardTestCase):
 
         # Create output with no_color flag
         color = not getattr(args, 'no_color', False)
-        output = PluginOutput(color=color)
+        output = PluginCliOutput(color=color)
 
         self.assertFalse(output.color)
 

--- a/test/plugins3/test_install.py
+++ b/test/plugins3/test_install.py
@@ -53,7 +53,7 @@ from picard.plugin3.manager.update import (
     UpdateAllResult,
     UpdateResult,
 )
-from picard.plugin3.output import PluginOutput
+from picard.plugin3.output import PluginCliOutput
 from picard.plugin3.plugin import Plugin, PluginState
 from picard.plugin3.ref_item import RefItem
 from picard.plugin3.validator import generate_uuid
@@ -413,7 +413,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='install', source=['https://example.com/plugin.git'], yes=True)
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -438,7 +438,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='install', source=['https://example.com/plugin.git'])
 
         stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+        output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -460,7 +460,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='remove', plugin=['test-plugin'], yes=True)
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -488,7 +488,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='update', plugin=['test-plugin'])
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -516,7 +516,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='update', plugin=['test-plugin'])
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -555,7 +555,7 @@ class TestPluginInstall(PicardTestCase):
         args = MockCliArgs(verb='update', update_all=True)
 
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
         cli = PluginCLI(mock_tagger._pluginmanager3, args, output)
 
         result = cli.run()
@@ -576,7 +576,7 @@ class TestPluginInstall(PicardTestCase):
 
         stdout = StringIO()
         stderr = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=stderr, color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=stderr, color=False)
         # Mock yesno to return False (cancel)
         output.yesno = Mock(return_value=False)
         cli = PluginCLI(mock_manager, args, output)

--- a/test/plugins3/test_output.py
+++ b/test/plugins3/test_output.py
@@ -20,14 +20,14 @@ from io import StringIO
 
 from test.picardtestcase import PicardTestCase
 
-from picard.plugin3.output import PluginOutput
+from picard.plugin3.output import PluginCliOutput
 
 
-class TestPluginOutput(PicardTestCase):
+class TestPluginCliOutput(PicardTestCase):
     def test_print_and_nl(self):
         """Test print and newline methods."""
         stdout = StringIO()
-        output = PluginOutput(stdout=stdout, stderr=StringIO(), color=False)
+        output = PluginCliOutput(stdout=stdout, stderr=StringIO(), color=False)
 
         output.print('test message')
         output.nl()
@@ -40,7 +40,7 @@ class TestPluginOutput(PicardTestCase):
     def test_warning(self):
         """Test warning output."""
         stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+        output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
 
         output.warning('test warning')
 
@@ -51,7 +51,7 @@ class TestPluginOutput(PicardTestCase):
     def test_warning_with_color(self):
         """Test warning output with color."""
         stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=True)
+        output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=True)
 
         output.warning('test warning')
 
@@ -65,20 +65,20 @@ class TestPluginOutput(PicardTestCase):
         mock_stdout = StringIO()
         mock_stdout.isatty = lambda: True
 
-        output = PluginOutput(stdout=mock_stdout, stderr=StringIO())
+        output = PluginCliOutput(stdout=mock_stdout, stderr=StringIO())
         self.assertTrue(output.color)
 
         # Mock stdout without isatty
         mock_stdout_no_tty = StringIO()
         mock_stdout_no_tty.isatty = lambda: False
 
-        output_no_color = PluginOutput(stdout=mock_stdout_no_tty, stderr=StringIO())
+        output_no_color = PluginCliOutput(stdout=mock_stdout_no_tty, stderr=StringIO())
         self.assertFalse(output_no_color.color)
 
     def test_error_without_color(self):
         """Test error output without color."""
         stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=False)
+        output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=False)
 
         output.error('test error')
 
@@ -90,7 +90,7 @@ class TestPluginOutput(PicardTestCase):
     def test_error_with_color(self):
         """Test error output with color."""
         stderr = StringIO()
-        output = PluginOutput(stdout=StringIO(), stderr=stderr, color=True)
+        output = PluginCliOutput(stdout=StringIO(), stderr=stderr, color=True)
 
         output.error('test error')
 


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Close static typing (`ty`) gaps in the plugin3 subsystem — rename `PluginOutput` to `PluginCliOutput` for consistency, and resolve `unresolved-attribute` errors in the plugin CLI and plugin loading code.

## Problem

Running the `ty` type checker over `picard/plugin3/` surfaced a number of `unresolved-attribute` errors, caused by attributes typed against a base class or an over-broad inferred type. This PR closes those gaps.

* JIRA ticket (_optional_): N/A

## Solution

Three focused commits:

1. **Rename `PluginOutput` → `PluginCliOutput`** for naming consistency with its `CliOutput` base class. Pure rename across source, tests, and docs; no behavioural change.

2. **Plugin CLI typing (`picard/plugin3/cli.py`, 29 → 0 errors)**:
   - Annotate `PluginCLI._out` as `PluginCliOutput` (it is inherited from `BaseCLI` as `CliOutput`, but `PluginCLI` always constructs a `PluginCliOutput`, so the plugin/git display methods were unresolved).
   - Guard `QCoreApplication.instance()` against `None` before calling `processEvents()` in the two registry event loops.
   - Use `None` instead of `{}` as the `_get_plugin_metadata()` fallback (it returns `PluginMetadata | None`); the `{}` polluted the inferred type with `dict`. `None` is falsy in the same way and the consumers are already `None`-safe.

3. **Plugin loading typing (`picard/plugin3/plugin.py`)**:
   - Guard `git_ref.ref_type` against `None` before `.value`.
   - Guard the importlib `spec` and its `loader` against `None` before loading a plugin module (raises a clear `ImportError`).
   - Guard `self.manifest` against `None` in `Plugin.name()`.

The remaining `GitRemoteCallbacks._callbacks` errors in `plugin.py` are addressed by a separate change to the git backend abstraction (PICARD-3403 / #3376) and are intentionally left untouched here to keep the changes on disjoint files.

The latent `AttributeError` in `PluginSourceGit.sync()` (`repo.branches.local`) is addressed separately in PICARD-3406 / #3380, which reworks the branch API with a regression test, and is intentionally left untouched here.

Verification: `ruff check`/`ruff format` clean; `ty` introduces no new diagnostics (the plugin CLI is fully clean, plugin.py reduced to the deferred `_callbacks` items); all `test/plugins3/` tests pass.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to run and interpret the `ty` output, identify the root causes, implement the fixes, and draft this description. All changes were reviewed by the author and verified against the test suite.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
