### PR TITLE
PICARD-3404: Fix a rating of 0 being discarded when loading ASF/WMA/WMV files

### DIFF
--- a/picard/formats/asf.py
+++ b/picard/formats/asf.py
@@ -242,8 +242,16 @@ class ASFFile(File):
 
                 continue
             elif name == 'WM/SharedUserRating':
-                # Rating in WMA ranges from 0 to 99, normalize this to the range 0 to 5
-                values[0] = int(round(int(str(values[0])) / 99.0 * (config.setting['rating_steps'] - 1)))
+                # Rating in WMA ranges from 0 to 99, normalize this to the range 0 to 5.
+                # The result is converted to str because the values below are
+                # filtered on truthiness, which would drop a rating of 0.
+                rating_steps = config.setting['rating_steps']
+                try:
+                    rating = int(values[0])
+                except ValueError:
+                    log.warning('Invalid rating value in %r: %s', filename, values[0])
+                else:
+                    values[0] = str(round(rating / 99 * (rating_steps - 1)))
             elif name == 'WM/PartOfSet':
                 disc = str(values[0]).split("/")
                 if len(disc) > 1:

--- a/test/formats/common.py
+++ b/test/formats/common.py
@@ -498,13 +498,15 @@ class CommonTests:
             if not self.supports_ratings:
                 raise unittest.SkipTest("Ratings not supported")
             for rating in range(6):
-                rating = 1
-                metadata = Metadata()
-                metadata['~rating'] = rating
-                loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-                self.assertEqual(
-                    int(loaded_metadata['~rating']), rating, '~rating: %r != %r' % (loaded_metadata['~rating'], rating)
-                )
+                with self.subTest(rating=rating):
+                    metadata = Metadata()
+                    metadata['~rating'] = rating
+                    loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+                    self.assertEqual(
+                        int(loaded_metadata['~rating']),
+                        rating,
+                        '~rating: %r != %r' % (loaded_metadata['~rating'], rating),
+                    )
 
         @skipUnlessTestfile
         def test_invalid_rating_email(self):

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -612,14 +612,16 @@ class CommonId3Tests:
 
         @skipUnlessTestfile
         def test_rating_email_non_latin1(self):
+            config.setting['rating_user_email'] = 'foo€'
             for rating in range(6):
-                config.setting['rating_user_email'] = 'foo€'
-                rating = '3'
-                metadata = Metadata({'~rating': rating})
-                loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-                self.assertEqual(
-                    loaded_metadata['~rating'], rating, '~rating: %r != %r' % (loaded_metadata['~rating'], rating)
-                )
+                with self.subTest(rating=rating):
+                    metadata = Metadata({'~rating': str(rating)})
+                    loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+                    self.assertEqual(
+                        loaded_metadata['~rating'],
+                        str(rating),
+                        '~rating: %r != %r' % (loaded_metadata['~rating'], rating),
+                    )
 
         @skipUnlessTestfile
         def test_unchanged_metadata(self):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  A rating of 0 was written to ASF/WMA/WMV files correctly but silently
  dropped on load, so saving a 0 rating and reloading returned no rating.
  This restores 0 on load, making ASF consistent with every other format.

## Problem

* JIRA ticket: PICARD-3404

`ASFFile._load()` normalizes `WM/SharedUserRating` from the 0-99 WMA scale to
Picard's 0-5 scale and leaves the result as an `int`. A few lines later every
tag value passes through a truthiness filter:

```python
values = [str(value) for value in values if value]
```

The rating is still an `int` at that point, so a value of 0 is falsy and is
silently discarded. The rating is written to the file correctly (verified as
`ASFDWordAttribute(0)`); only reading it back loses it. ID3, Vorbis, MP4 and
APEv2 all preserve a rating of 0, so ASF was the odd one out.

The bug has been latent since ratings were added to ASF in 2009, and became
live with the Python 3 port (commit `8834ec3384`, shipped in Picard 2.0),
which changed the code to filter the still-`int` value on truthiness before
converting it to a string.

## Solution

Normalize the rating to `str` immediately, so 0 becomes `'0'` and survives the
truthiness filter. Empty strings are still filtered out as before.

The first commit is the failing reproduction: `CommonTests.test_ratings` was
only ever testing a single rating value because the loop overwrote its own
loop variable. Fixing the loop to genuinely test all six values (0-5) as
subtests exposes `SUBFAILED(rating=0)` for `ASFTest`, `WMATest` and `WMVTest`.
The second commit applies the one-line fix and the test passes.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Written with Kiro CLI and carefully reviewed by a human. The failing test and
the fix were each verified from tool output during the session: the test fails
with `SUBFAILED(rating=0)` at the first commit and passes at the second.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
