### PR TITLE
PICARD-3405: Keep the biggest image per type in ImageList.get_types_dict()

### DIFF
--- a/picard/util/imagelist.py
+++ b/picard/util/imagelist.py
@@ -199,7 +199,12 @@ class ImageList(MutableSequence['CoverArtImage']):
             image_types = image.normalized_types()
             if image_types in types_dict:
                 previous_image = types_dict[image_types]
-                if image.width > previous_image.width or image.height > previous_image.height:
+                # Keep the biggest image for each set of types. Callers compare a
+                # candidate against this mapping to decide whether it would replace
+                # embedded art with something smaller, so they have to see the
+                # biggest image already present. An image that is smaller in either
+                # dimension does not displace the one already kept.
+                if image.width < previous_image.width or image.height < previous_image.height:
                     continue
             types_dict[image_types] = image
         return types_dict

--- a/test/test_imagelist.py
+++ b/test/test_imagelist.py
@@ -52,6 +52,19 @@ def create_test_files():
     return (test_images, test_files)
 
 
+def create_front_image(name, width, height):
+    """Create a front CoverArtImage with explicit dimensions."""
+    image = CoverArtImage(
+        url='file://' + name,
+        data=create_fake_png(name.encode('utf-8')),
+        types=['front'],
+        support_types=True,
+    )
+    image.width = width
+    image.height = height
+    return image
+
+
 class UpdateMetadataImagesTest(PicardTestCase):
     def setUp(self):
         super().setUp()
@@ -443,40 +456,45 @@ class ImageListTest(PicardTestCase):
         exported to disk instead of being lost, unless a same-or-better
         replacement is already being exported (see PICARD-3380)."""
 
-        def front_image(name, width, height):
-            image = CoverArtImage(
-                url='file://' + name,
-                data=create_fake_png(name.encode('utf-8')),
-                types=['front'],
-                support_types=True,
-            )
-            image.width = width
-            image.height = height
-            return image
-
         settings = {
             "remove_images_from_tags": True,
             "save_images_to_files": True,
             "save_only_one_front_image": False,
         }
-        previous_front = front_image('previous', 1000, 1000)
+        previous_front = create_front_image('previous', 1000, 1000)
         previous_images = ImageList([previous_front])
 
         # no new image at all: the previous (tagged) image is preserved
         self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [previous_front])
 
         # new replacement is smaller: the previous, bigger image is used instead
-        smaller_front = front_image('smaller', 500, 500)
+        smaller_front = create_front_image('smaller', 500, 500)
         self.imagelist.append(smaller_front)
         self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [previous_front])
 
         # new replacement is bigger: it is exported, the previous one is not duplicated
-        bigger_front = front_image('bigger', 2000, 2000)
+        bigger_front = create_front_image('bigger', 2000, 2000)
         self.imagelist = ImageList([bigger_front])
         self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings, previous_images)), [bigger_front])
 
         # without previous_images, nothing extra is added
         self.assertEqual(list(self.imagelist.to_be_saved_to_files(settings)), [bigger_front])
+
+    def test_get_types_dict_keeps_biggest_image_per_type(self):
+        """The biggest image of each type must win.
+
+        `is_bigger_image_filter()` compares a downloaded image against this
+        mapping to avoid replacing embedded art with something smaller, so the
+        mapping has to hold the biggest image already present for a type, not
+        the smallest. The result must not depend on insertion order.
+        """
+        big = create_front_image('big', 1000, 1000)
+        small = create_front_image('small', 200, 200)
+
+        for images in ([big, small], [small, big]):
+            with self.subTest(order=[(image.width, image.height) for image in images]):
+                types_dict = ImageList(images).get_types_dict()
+                self.assertEqual(types_dict[big.normalized_types()], big)
 
     def test_strip_front_images(self):
         self.imagelist.append(self.images['a'])


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  `ImageList.get_types_dict()` kept the smallest image of each type instead of
  the biggest, so "Never replace cover images with smaller ones" could still
  let a download replace a bigger embedded image. This inverts the comparison
  so the biggest image is kept.

## Problem

* JIRA ticket: PICARD-3405

The "Never replace cover images with smaller ones" option
(`dont_replace_with_smaller_cover`) relies on `ImageList.get_types_dict()` to
provide, per image type, the image already embedded. `bigger_previous_image_filter()`
compares a download against that mapping and rejects it only when it is smaller
than the stored image.

The size comparison in `get_types_dict()` is inverted, so it keeps the
*smallest* image of each type. With that as the baseline, a download bigger than
the smallest but smaller than the biggest passes the filter and replaces the
bigger one — the opposite of what the option promises. For example, with front
art embedded at 1000x1000 and 200x200, a 500x500 download is compared against
200x200 and let through.

The bug only surfaces when two or more images of the same type are already
embedded, which is why it went unnoticed.

## Solution

Invert the comparison so an image smaller in either dimension does not displace
the one already kept, i.e. the biggest image per type wins.

The first commit is the failing reproduction: a direct test of
`get_types_dict()` for both insertion orders, which fails without the fix. The
second commit applies the one-line fix and the test passes.

History for reviewers: `get_types_dict()` was added in `4093acc0f7`
(PICARD-1477) as a plain "last image wins" map; the size tie-break arrived in
`c96f0b07e6` ("Move new option to image filters"), whose message does not
mention the comparison, so this looks like an inversion introduced while
relocating the code. The intended "keep the biggest" semantics are backed by
the option label, the consumer `bigger_previous_image_filter()`, PICARD-1477
and the GSoC 2024 proposal ("discard images if too small"). As the tie-break
was written by the feature's author, confirmation of the intended semantics is
welcome.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Written with Kiro CLI and carefully reviewed by a human, including research
into the option's history and intended semantics. The failing test and the fix
were verified from tool output: the test fails for both insertion orders at the
first commit and passes at the second.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
