### PR TITLE
PICARD-3406: Add typed branch API to GitRepository, fix sync() crash

### DIFF
--- a/picard/git/backend.py
+++ b/picard/git/backend.py
@@ -265,8 +265,19 @@ class GitRepository(ABC):
         return False
 
     @abstractmethod
-    def get_branches(self) -> Any:
-        """Get branches object"""
+    def local_branches(self) -> list[str]:
+        """Return the names of local branches."""
+
+    @abstractmethod
+    def create_tracking_branch(self, name: str, commit_id: str, upstream: str) -> None:
+        """Create a local branch at ``commit_id`` tracking ``upstream``.
+
+        Args:
+            name: Local branch name to create (overwritten if it exists).
+            commit_id: Commit the new branch should point at.
+            upstream: Remote-tracking branch name to set as upstream
+                (e.g. ``'origin/main'``).
+        """
 
     @abstractmethod
     def get_commit_date(self, commit_id: str) -> int:

--- a/picard/git/backends/pygit2.py
+++ b/picard/git/backends/pygit2.py
@@ -306,10 +306,16 @@ class Pygit2Repository(GitRepository):
         self._repo.remotes.set_url(name, url)
         _log_git_call("set_remote_url", name, url)
 
-    def get_branches(self) -> Any:
-        ret = self._repo.branches
-        _log_git_call("get_branches", retval=ret)
+    def local_branches(self) -> list[str]:
+        ret = list(self._repo.branches.local)
+        _log_git_call("local_branches", retval=ret)
         return ret
+
+    def create_tracking_branch(self, name: str, commit_id: str, upstream: str) -> None:
+        _log_git_call("create_tracking_branch", name, commit_id, upstream)
+        commit = self._repo.get(commit_id)
+        branch = self._repo.branches.local.create(name, commit, force=True)
+        branch.upstream = self._repo.branches.remote[upstream]
 
     def get_commit_date(self, commit_id: str) -> int:
         commit = self._repo.get(commit_id)

--- a/picard/git/ops.py
+++ b/picard/git/ops.py
@@ -346,10 +346,7 @@ class GitOperations:
         if is_remote_branch:
             # Create local tracking branch
             repo.set_head(commit.id)
-            branches = repo.get_branches()
-            pygit_commit = repo._repo.get(commit.id)
-            branch = branches.local.create(local_ref, pygit_commit, force=True)
-            branch.upstream = branches.remote[f'origin/{local_ref}']
+            repo.create_tracking_branch(local_ref, commit.id, f'origin/{local_ref}')
             repo.set_head(f'refs/heads/{local_ref}')
         else:
             # Switch to existing local branch

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -328,7 +328,7 @@ class PluginSourceGit(PluginSource):
                     self.resolved_ref = 'main'
                 except (KeyError, GitBackendError):
                     # Find first available branch
-                    branches = list(repo.branches.local)
+                    branches = repo.local_branches()
                     if branches:
                         branch_name = branches[0]
                         commit = repo.revparse_to_commit(branch_name)

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -327,6 +327,24 @@ def backend_create_branch(repo_path, branch_name, commit_id=None):
     repo.free()
 
 
+def backend_orphan_head_and_drop_main(repo_path):
+    """Arrange the PluginSourceGit.sync() branch-resolution fallback state.
+
+    Points HEAD at a non-existent branch and deletes ``main`` so that neither
+    ``HEAD`` nor ``main`` resolves, forcing sync() into the "first available
+    branch" fallback that iterates the repository's local branches.
+
+    The public git backend has no branch-delete/orphan-HEAD operation, so this
+    reaches into the underlying pygit2 repository directly. It is test-only
+    scaffolding for the sync() regression test.
+    """
+    backend = git_backend()
+    with backend.create_repository(repo_path) as repo:
+        pygit2_repo = repo._repo
+        pygit2_repo.set_head('refs/heads/__nonexistent__')
+        pygit2_repo.branches.local.delete('main')
+
+
 def backend_add_and_commit(repo_path, message="Commit", author_name="Test", author_email="test@example.com"):
     """Add all files and commit using backend."""
     backend = git_backend()

--- a/test/plugins3/test_git.py
+++ b/test/plugins3/test_git.py
@@ -31,6 +31,7 @@ from test.plugins3.helpers import (
     backend_create_lightweight_tag,
     backend_create_tag,
     backend_init_and_commit,
+    backend_orphan_head_and_drop_main,
     backend_set_detached_head,
     create_git_repo_with_backend,
 )
@@ -70,6 +71,56 @@ class TestCheckRefType(PicardTestCase):
         ref_type, ref_name = GitOperations.check_ref_type(Path('/nonexistent'), 'main')
         self.assertIsNone(ref_type)
         self.assertEqual(ref_name, 'main')
+
+
+@pytest.mark.skipif(not HAS_GIT_BACKEND, reason="git backend not available")
+class TestGitRepositoryBranches(PicardTestCase):
+    """Regression tests for PluginSourceGit.sync() branch resolution.
+
+    PluginSourceGit.sync() previously accessed ``repo.branches.local``, but the
+    GitRepository abstraction had no ``branches`` attribute (it exposed an
+    ``Any``-typed ``get_branches()`` passthrough to pygit2), so that path
+    raised AttributeError. The abstraction now exposes a typed
+    ``local_branches()`` method.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmpdir = tempfile.mkdtemp()
+        # Register cleanup immediately so the temp dir is removed even if the
+        # rest of setUp() fails.
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.repo_dir = Path(self.tmpdir) / "test-repo"
+        backend_init_and_commit(self.repo_dir, {'file.txt': 'content'}, 'Initial commit')
+        backend_create_branch(self.repo_dir, 'feature')
+
+    def test_sync_resolves_ref_without_error(self):
+        """sync() must resolve a branch via local_branches() in the fallback.
+
+        Regression guard for the ``repo.branches.local`` bug. Arranges the
+        error-recovery state sync() hits when HEAD is unset and there is no
+        'main' branch (only 'feature' remains), then syncs against the existing
+        target so sync() runs the branch-listing fallback. Before the fix this
+        raised ``AttributeError: 'Pygit2Repository' object has no attribute
+        'branches'``.
+        """
+        backend_orphan_head_and_drop_main(self.repo_dir)
+        source = PluginSourceGit(str(self.repo_dir))
+        commit_id = source.sync(self.repo_dir)
+        self.assertEqual(source.resolved_ref, 'feature')
+        self.assertEqual(len(commit_id), 40)  # SHA-1 hash
+
+    def test_local_branches_lists_branch_names(self):
+        """local_branches() returns local branch names as a list of str.
+
+        Documents the GitRepository contract that the sync() fallback relies
+        on, independent of sync() itself.
+        """
+        backend = git_backend()
+        with backend.create_repository(self.repo_dir) as repo:
+            branches = repo.local_branches()
+            self.assertIn('main', branches)
+            self.assertIn('feature', branches)
 
 
 @pytest.mark.skipif(not HAS_GIT_BACKEND, reason="git backend not available")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -98,8 +98,11 @@ class MockGitRepository(GitRepository):
     def set_remote_url(self, name, url):
         pass
 
-    def get_branches(self):
-        return Mock()
+    def local_branches(self):
+        return ['main']
+
+    def create_tracking_branch(self, name, commit_id, upstream):
+        pass
 
     def get_commit_date(self, commit_id):
         return 1234567890  # Mock timestamp


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Replace the `Any`-typed `get_branches()` passthrough on the `GitRepository` abstraction with a typed, backend-agnostic branch API, and fix a latent `AttributeError` in `PluginSourceGit.sync()` that used the non-existent `repo.branches.local`.

## Problem

* JIRA ticket (_optional_): PICARD-3406

`PluginSourceGit.sync()` had a latent crash in its branch-resolution fallback — the path taken when HEAD is unset and there is no `main` branch. It accessed `repo.branches.local`, but the `GitRepository` abstraction never exposed a `branches` attribute; it only offered an `Any`-typed `get_branches()` that returned the raw pygit2 `Branches` object.

Two consequences:
* At runtime, that fallback raised `AttributeError: 'Pygit2Repository' object has no attribute 'branches'` instead of resolving a branch.
* Because `get_branches()` was typed `-> Any`, the type checker (`ty`) could not catch the wrong attribute statically — the bug class was invisible until execution.

## Solution

* Replace `get_branches() -> Any` with a typed, backend-agnostic branch API on `GitRepository`:
  * `local_branches() -> list[str]`
  * `create_tracking_branch(name, commit_id, upstream)`
* Migrate both call sites off the raw pygit2 object:
  * `picard/plugin3/plugin.py` fallback now uses `repo.local_branches()`.
  * `picard/git/ops.py` switch-branch now uses `repo.create_tracking_branch(...)` and no longer reaches into `repo._repo`.
* Add a regression test (`test/plugins3/test_git.py`) that arranges the exact fallback state (HEAD orphaned, `main` deleted, only `feature` remaining) and drives `sync()` through the branch-listing fallback. It fails on the pre-fix code with the `AttributeError` above and passes with the fix.

With a concrete return type, a wrong branch attribute is now a static `ty` error rather than a runtime `AttributeError`. `ruff check`/`ruff format` are clean and all `test/plugins3/` tests pass (643 passed, 2 skipped).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to identify the root cause, design the typed branch API, migrate the call sites, and develop the regression test. All changes were reviewed by the author and verified against the test suite.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
