### PR TITLE
Clamp out-of-range numeric config options (bounds support)

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -329,6 +329,35 @@ def enable(api):
 
 When a profile is active and overrides the option, reads from `api.plugin_config['greeting']` automatically return the profile value. Writes go to the profile's storage. The base (non-profile) value is preserved.
 
+#### Numeric bounds
+
+Numeric options (int or float defaults) can declare a valid range with
+`bounds=(minimum, maximum)`. A value read from the configuration that falls
+outside the range is clamped to the nearest bound, and a warning is logged.
+Either element may be `None` to leave that side unbounded.
+
+```python
+def enable(api):
+    # Threads must be at least 1, at most 8
+    api.plugin_config.register_option('threads', 4, bounds=(1, 8))
+
+    # A ratio in the range 0.0..1.0
+    api.plugin_config.register_option('ratio', 0.5, bounds=(0.0, 1.0))
+
+    # Only a lower bound; no upper limit
+    api.plugin_config.register_option('retries', 3, bounds=(0, None))
+```
+
+- `bounds` is only valid for int or float options; passing it for any other
+  type raises `TypeError`.
+- `int` options require `int` bounds; `float` options accept `int` or `float`
+  bounds (coerced to `float`). `bool` bounds are rejected.
+- Declaring `minimum` greater than `maximum` raises `ValueError`.
+
+Clamping happens on read, so an out-of-range value stored by an older version
+of the plugin (or a hand-edited config) is corrected automatically the next
+time the option is read.
+
 **Options page with profile highlighting:**
 
 Declare widgets in the page's `OPTIONS` dict to enable visual highlighting when a profile overrides the option:

--- a/picard/config.py
+++ b/picard/config.py
@@ -186,7 +186,7 @@ class OutOfBoundsError(ValueError):
         )
 
 
-class OptionBounds:
+class NumericOptionBounds:
     """Inclusive numeric bounds for an option.
 
     A bound of ``None`` means unbounded on that side. :meth:`check` detects a
@@ -196,13 +196,9 @@ class OptionBounds:
     Because an out-of-range stored value is unexpected (e.g. from a hand-edited
     configuration file), clamping is reported with a warning so it can be
     diagnosed.
-
-    Subclasses define ``value_type`` to enforce and normalize the bound type.
     """
 
-    value_type: ClassVar[type] = object
-
-    def __init__(self, minimum=None, maximum=None):
+    def __init__(self, minimum: float | None = None, maximum: float | None = None):
         self.minimum = self._check(minimum)
         self.maximum = self._check(maximum)
         if self.minimum is not None and self.maximum is not None and self.minimum > self.maximum:
@@ -212,9 +208,9 @@ class OptionBounds:
         if value is None:
             return None
         # bool is a subclass of int but is never a valid numeric bound.
-        if isinstance(value, bool) or not isinstance(value, self.value_type):
-            raise TypeError(f"Bound {value!r} is not of type {self.value_type.__name__}")
-        return self.value_type(value)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"Bound {value!r} is not a numeric value")
+        return value
 
     def check(self, value, option):
         """Return value unchanged, or raise OutOfBoundsError if out of range.
@@ -251,22 +247,6 @@ class OptionBounds:
             return e.corrected
 
 
-class OptionBoundsInt(OptionBounds):
-    value_type = int
-
-
-class OptionBoundsFloat(OptionBounds):
-    # int is accepted and coerced to float; float bounds are the natural type.
-    value_type = float
-
-    def _check(self, value):
-        if value is None:
-            return None
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(f"Bound {value!r} is not a real number")
-        return float(value)
-
-
 class BoundedNumberOption(Option):
     """Base for numeric options that can be constrained to a range.
 
@@ -275,7 +255,8 @@ class BoundedNumberOption(Option):
     range is clamped to the nearest bound on read.
     """
 
-    bounds_type: ClassVar[type[OptionBounds]] = OptionBounds
+    # Subclasses should set this to int or float
+    _base_type: ClassVar[type[float | int]]
 
     def __init__(
         self,
@@ -285,24 +266,30 @@ class BoundedNumberOption(Option):
         title: str | None = None,
         in_profile: bool = False,
         shareable: bool = True,
-        bounds: tuple = (None, None),
+        bounds: tuple[float | None, float | None] = (None, None),
     ):
         minimum, maximum = bounds
-        self.bounds = self.bounds_type(minimum, maximum)
+        self.bounds = NumericOptionBounds(minimum, maximum)
         super().__init__(section, name, default, title, in_profile, shareable)
 
     def checked_convert(self, value):
         """Convert value, raising OutOfBoundsError if it violates the bounds.
 
         Unlike :meth:`convert` (which auto-corrects and warns), this reports a
-        violation to the caller so it can apply its own policy. Implemented by
-        the concrete numeric subclasses.
+        violation to the caller so it can apply its own policy. Callers that want the
+        default auto-correct policy should use :meth:`convert` instead.
         """
-        raise NotImplementedError
+        value = self.bounds.check(value, self)
+        return self._base_type(value)
+
+    def convert(self, value):
+        # Default policy: clamp to the nearest bound and warn (see
+        # OptionBounds.clamp).
+        return self._base_type(self.bounds.clamp(value, self))
 
 
 class IntOption(BoundedNumberOption):
-    bounds_type = OptionBoundsInt
+    _base_type = int
 
     def checked_convert(self, value):
         """Convert value, raising OutOfBoundsError if it violates the bounds.
@@ -322,17 +309,17 @@ class IntOption(BoundedNumberOption):
                 return enum_type(value)
             except ValueError:
                 raise OutOfBoundsError(self, value, self.default) from None
-        return self.bounds.check(value, self)
+        return super().checked_convert(value)
 
     def convert(self, value):
         # Default policy: an out-of-range value (or an invalid enum member) is
         # corrected to the nearest bound / the option default and reported with
         # a warning, mirroring OptionBounds.clamp. This keeps a stale value
         # (e.g. from a hand-edited config or an outdated profile) usable on read.
-        try:
-            return self.checked_convert(value)
-        except OutOfBoundsError as e:
-            if isinstance(self.default, IntEnum):
+        if isinstance(self.default, IntEnum):
+            try:
+                return self.checked_convert(value)
+            except OutOfBoundsError as e:
                 log.warning(
                     "Option '%s/%s': %r is not a valid %s, using default %r",
                     self.section,
@@ -341,34 +328,13 @@ class IntOption(BoundedNumberOption):
                     type(self.default).__name__,
                     e.corrected,
                 )
-            else:
-                log.warning(
-                    "Option '%s/%s': value %r is out of bounds [%r, %r], clamping to %r",
-                    self.section,
-                    self.name,
-                    e.value,
-                    self.bounds.minimum,
-                    self.bounds.maximum,
-                    e.corrected,
-                )
-            return e.corrected
+                return e.corrected
+        else:
+            return super().convert(value)
 
 
 class FloatOption(BoundedNumberOption):
-    bounds_type = OptionBoundsFloat
-
-    def checked_convert(self, value):
-        """Convert value, raising OutOfBoundsError if it violates the bounds.
-
-        Callers that want the default auto-correct policy should use
-        :meth:`convert` instead.
-        """
-        return self.bounds.check(float(value), self)
-
-    def convert(self, value):
-        # Default policy: clamp to the nearest bound and warn (see
-        # OptionBounds.clamp).
-        return self.bounds.clamp(float(value), self)
+    _base_type = float
 
 
 class ListOption(Option):
@@ -490,7 +456,7 @@ class ConfigSection(QtCore.QObject):
         default: ConfigValueType,
         title: str | None = None,
         in_profile: bool = False,
-        bounds: tuple | None = None,
+        bounds: tuple[float | None, float | None] | None = None,
     ) -> 'Option':
         """Register an option in this config section.
 
@@ -658,7 +624,7 @@ class ProfileConfigSection(ConfigSection):
         default: ConfigValueType,
         title: str | None = None,
         in_profile: bool = False,
-        bounds: tuple | None = None,
+        bounds: tuple[float | None, float | None] | None = None,
     ) -> Option:
         """Register an option in this config section.
 

--- a/picard/config.py
+++ b/picard/config.py
@@ -167,13 +167,35 @@ class BoolOption(Option):
     qtype = bool
 
 
+class OutOfBoundsError(ValueError):
+    """Raised when an option value falls outside its declared bounds.
+
+    Carries the offending ``value`` and the ``corrected`` value (the nearest
+    bound for a numeric option, or the option default for an invalid enum
+    member) so a caller can choose its own policy: clamp to ``corrected``, keep
+    the original, reject it, etc. Subclasses :class:`ValueError` so existing
+    ``except ValueError`` handlers keep working.
+    """
+
+    def __init__(self, option: 'Option', value: Any, corrected: Any):
+        self.option = option
+        self.value = value
+        self.corrected = corrected
+        super().__init__(
+            f"Option '{option.section}/{option.name}': value {value!r} is out of bounds, corrected to {corrected!r}"
+        )
+
+
 class OptionBounds:
     """Inclusive numeric bounds for an option.
 
-    A bound of ``None`` means unbounded on that side. Values outside the range
-    are clamped to the nearest bound by :meth:`clamp`. Because an out-of-range
-    stored value is unexpected (e.g. from a hand-edited configuration file),
-    clamping is reported with a warning so it can be diagnosed.
+    A bound of ``None`` means unbounded on that side. :meth:`check` detects a
+    value outside the range and raises :class:`OutOfBoundsError` carrying the
+    nearest bound; :meth:`clamp` applies the default "auto-correct" policy on
+    top of :meth:`check`, returning the nearest bound and logging a warning.
+    Because an out-of-range stored value is unexpected (e.g. from a hand-edited
+    configuration file), clamping is reported with a warning so it can be
+    diagnosed.
 
     Subclasses define ``value_type`` to enforce and normalize the bound type.
     """
@@ -194,27 +216,39 @@ class OptionBounds:
             raise TypeError(f"Bound {value!r} is not of type {self.value_type.__name__}")
         return self.value_type(value)
 
-    def clamp(self, value, option):
-        """Clamp value to the bounds, warning (via option context) if out of range."""
+    def check(self, value, option):
+        """Return value unchanged, or raise OutOfBoundsError if out of range.
+
+        Pure detection with no side effects. The raised error carries the
+        nearest bound as its ``corrected`` value so a caller can decide what to
+        do about the violation.
+        """
         if self.minimum is not None and value < self.minimum:
-            log.warning(
-                "Option '%s/%s': value %r is below the minimum %r, clamping",
-                option.section,
-                option.name,
-                value,
-                self.minimum,
-            )
-            return self.minimum
+            raise OutOfBoundsError(option, value, self.minimum)
         if self.maximum is not None and value > self.maximum:
+            raise OutOfBoundsError(option, value, self.maximum)
+        return value
+
+    def clamp(self, value, option):
+        """Clamp value to the bounds, warning (via option context) if out of range.
+
+        This is the default "auto-correct" policy used when reading an option:
+        an out-of-range value is corrected to the nearest bound and a warning is
+        logged.
+        """
+        try:
+            return self.check(value, option)
+        except OutOfBoundsError as e:
             log.warning(
-                "Option '%s/%s': value %r is above the maximum %r, clamping",
+                "Option '%s/%s': value %r is out of bounds [%r, %r], clamping to %r",
                 option.section,
                 option.name,
-                value,
+                e.value,
+                self.minimum,
                 self.maximum,
+                e.corrected,
             )
-            return self.maximum
-        return value
+            return e.corrected
 
 
 class OptionBoundsInt(OptionBounds):
@@ -261,34 +295,70 @@ class BoundedNumberOption(Option):
 class IntOption(BoundedNumberOption):
     bounds_type = OptionBoundsInt
 
-    def convert(self, value):
+    def checked_convert(self, value):
+        """Convert value, raising OutOfBoundsError if it violates the bounds.
+
+        For an IntEnum option the value must be a valid member; an invalid
+        member raises OutOfBoundsError whose ``corrected`` value is the option
+        default. For a plain int the numeric bounds are enforced via
+        :meth:`OptionBounds.check`. Callers that want the default auto-correct
+        policy should use :meth:`convert` instead.
+        """
         value = int(value)
-        # If the default is an IntEnum, return an IntEnum. Bounds do not apply
-        # to enum options; instead the value must be a valid member. An invalid
-        # value (e.g. from a hand-edited config or an outdated profile) falls
-        # back to the default, reported with a warning, mirroring how bounds
-        # report clamping.
+        # Bounds do not apply to enum options (an enum is a set of members, not
+        # an ordered range); the value must instead be a valid member.
         if isinstance(self.default, IntEnum):
             enum_type = type(self.default)
             try:
                 return enum_type(value)
             except ValueError:
+                raise OutOfBoundsError(self, value, self.default) from None
+        return self.bounds.check(value, self)
+
+    def convert(self, value):
+        # Default policy: an out-of-range value (or an invalid enum member) is
+        # corrected to the nearest bound / the option default and reported with
+        # a warning, mirroring OptionBounds.clamp. This keeps a stale value
+        # (e.g. from a hand-edited config or an outdated profile) usable on read.
+        try:
+            return self.checked_convert(value)
+        except OutOfBoundsError as e:
+            if isinstance(self.default, IntEnum):
                 log.warning(
                     "Option '%s/%s': %r is not a valid %s, using default %r",
                     self.section,
                     self.name,
-                    value,
-                    enum_type.__name__,
-                    self.default,
+                    e.value,
+                    type(self.default).__name__,
+                    e.corrected,
                 )
-                return self.default
-        return self.bounds.clamp(value, self)
+            else:
+                log.warning(
+                    "Option '%s/%s': value %r is out of bounds [%r, %r], clamping to %r",
+                    self.section,
+                    self.name,
+                    e.value,
+                    self.bounds.minimum,
+                    self.bounds.maximum,
+                    e.corrected,
+                )
+            return e.corrected
 
 
 class FloatOption(BoundedNumberOption):
     bounds_type = OptionBoundsFloat
 
+    def checked_convert(self, value):
+        """Convert value, raising OutOfBoundsError if it violates the bounds.
+
+        Callers that want the default auto-correct policy should use
+        :meth:`convert` instead.
+        """
+        return self.bounds.check(float(value), self)
+
     def convert(self, value):
+        # Default policy: clamp to the nearest bound and warn (see
+        # OptionBounds.clamp).
         return self.bounds.clamp(float(value), self)
 
 

--- a/picard/config.py
+++ b/picard/config.py
@@ -396,6 +396,7 @@ class ConfigSection(QtCore.QObject):
         default: ConfigValueType,
         title: str | None = None,
         in_profile: bool = False,
+        bounds: tuple | None = None,
     ) -> 'Option':
         """Register an option in this config section.
 
@@ -407,12 +408,17 @@ class ConfigSection(QtCore.QObject):
             title: Human-readable title (used by ProfileConfigSection for profiles UI).
             in_profile: If True, the option can be overridden by user profiles
                 (only effective in ProfileConfigSection).
+            bounds: Optional ``(minimum, maximum)`` range for numeric options.
+                Only valid for int or float defaults; either element may be
+                None to leave that side unbounded. A stored value outside the
+                range is clamped on read.
 
         Returns:
             The registered Option instance.
 
         Raises:
-            TypeError: If default is None.
+            TypeError: If default is None, or if bounds is given for a
+                non-numeric option.
         """
         if default is None:
             raise TypeError('Option default value must not be None')
@@ -430,7 +436,13 @@ class ConfigSection(QtCore.QObject):
         else:
             option_type = Option  # type: ignore[assignment]
 
-        return option_type(self.section_name, name, default, title=title, in_profile=in_profile)
+        kwargs: dict[str, Any] = {'title': title, 'in_profile': in_profile}
+        if bounds is not None:
+            if not issubclass(option_type, BoundedNumberOption):
+                raise TypeError('bounds are only valid for int or float options')
+            kwargs['bounds'] = bounds
+
+        return option_type(self.section_name, name, default, **kwargs)
 
 
 class ProfileConfigSection(ConfigSection):
@@ -547,7 +559,12 @@ class ProfileConfigSection(ConfigSection):
         self.__qt_config.profiles._memoization[key].dirty = True
 
     def register_option(
-        self, name: str, default: ConfigValueType, title: str | None = None, in_profile: bool = False
+        self,
+        name: str,
+        default: ConfigValueType,
+        title: str | None = None,
+        in_profile: bool = False,
+        bounds: tuple | None = None,
     ) -> Option:
         """Register an option in this config section.
 
@@ -559,14 +576,17 @@ class ProfileConfigSection(ConfigSection):
             title: Human-readable title for display in profiles and quick menu.
                 Falls back to name if not provided (with a warning for in_profile options).
             in_profile: If True, the option can be overridden by user profiles.
+            bounds: Optional ``(minimum, maximum)`` range for numeric options.
+                See :meth:`ConfigSection.register_option`.
 
         Returns:
             The registered Option instance.
 
         Raises:
-            TypeError: If default is None.
+            TypeError: If default is None, or if bounds is given for a
+                non-numeric option.
         """
-        opt = super().register_option(name, default, title=title, in_profile=in_profile)
+        opt = super().register_option(name, default, title=title, in_profile=in_profile, bounds=bounds)
         if in_profile:
             group_name = self.section_name
             group_title = self.display_name or self.section_name

--- a/picard/config.py
+++ b/picard/config.py
@@ -167,17 +167,114 @@ class BoolOption(Option):
     qtype = bool
 
 
-class IntOption(Option):
-    def convert(self, value):
-        value = int(value)
-        # If the default is an IntEnum, return an IntEnum
-        if isinstance(self.default, IntEnum):
-            return type(self.default)(value)
+class OptionBounds:
+    """Inclusive numeric bounds for an option.
+
+    A bound of ``None`` means unbounded on that side. Values outside the range
+    are clamped to the nearest bound by :meth:`clamp`. Because an out-of-range
+    stored value is unexpected (e.g. from a hand-edited configuration file),
+    clamping is reported with a warning so it can be diagnosed.
+
+    Subclasses define ``value_type`` to enforce and normalize the bound type.
+    """
+
+    value_type: ClassVar[type] = object
+
+    def __init__(self, minimum=None, maximum=None):
+        self.minimum = self._check(minimum)
+        self.maximum = self._check(maximum)
+        if self.minimum is not None and self.maximum is not None and self.minimum > self.maximum:
+            raise ValueError(f"minimum {self.minimum!r} is greater than maximum {self.maximum!r}")
+
+    def _check(self, value):
+        if value is None:
+            return None
+        # bool is a subclass of int but is never a valid numeric bound.
+        if isinstance(value, bool) or not isinstance(value, self.value_type):
+            raise TypeError(f"Bound {value!r} is not of type {self.value_type.__name__}")
+        return self.value_type(value)
+
+    def clamp(self, value, option):
+        """Clamp value to the bounds, warning (via option context) if out of range."""
+        if self.minimum is not None and value < self.minimum:
+            log.warning(
+                "Option '%s/%s': value %r is below the minimum %r, clamping",
+                option.section,
+                option.name,
+                value,
+                self.minimum,
+            )
+            return self.minimum
+        if self.maximum is not None and value > self.maximum:
+            log.warning(
+                "Option '%s/%s': value %r is above the maximum %r, clamping",
+                option.section,
+                option.name,
+                value,
+                self.maximum,
+            )
+            return self.maximum
         return value
 
 
-class FloatOption(Option):
-    convert = float  # type: ignore[assignment]
+class OptionBoundsInt(OptionBounds):
+    value_type = int
+
+
+class OptionBoundsFloat(OptionBounds):
+    # int is accepted and coerced to float; float bounds are the natural type.
+    value_type = float
+
+    def _check(self, value):
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"Bound {value!r} is not a real number")
+        return float(value)
+
+
+class BoundedNumberOption(Option):
+    """Base for numeric options that can be constrained to a range.
+
+    Pass ``bounds=(minimum, maximum)`` to constrain the value; either element
+    may be ``None`` to leave that side unbounded. A stored value outside the
+    range is clamped to the nearest bound on read.
+    """
+
+    bounds_type: ClassVar[type[OptionBounds]] = OptionBounds
+
+    def __init__(
+        self,
+        section: str,
+        name: str,
+        default: ConfigValueType,
+        title: str | None = None,
+        in_profile: bool = False,
+        shareable: bool = True,
+        bounds: tuple = (None, None),
+    ):
+        minimum, maximum = bounds
+        self.bounds = self.bounds_type(minimum, maximum)
+        super().__init__(section, name, default, title, in_profile, shareable)
+
+
+class IntOption(BoundedNumberOption):
+    bounds_type = OptionBoundsInt
+
+    def convert(self, value):
+        value = int(value)
+        # If the default is an IntEnum, return an IntEnum. Bounds do not apply
+        # to enum options.
+        if isinstance(self.default, IntEnum):
+            return type(self.default)(value)
+        return self.bounds.clamp(value, self)
+
+
+class FloatOption(BoundedNumberOption):
+    bounds_type = OptionBoundsFloat
+
+    def convert(self, value):
+        return self.bounds.clamp(float(value), self)
 
 
 class ListOption(Option):

--- a/picard/config.py
+++ b/picard/config.py
@@ -291,6 +291,15 @@ class BoundedNumberOption(Option):
         self.bounds = self.bounds_type(minimum, maximum)
         super().__init__(section, name, default, title, in_profile, shareable)
 
+    def checked_convert(self, value):
+        """Convert value, raising OutOfBoundsError if it violates the bounds.
+
+        Unlike :meth:`convert` (which auto-corrects and warns), this reports a
+        violation to the caller so it can apply its own policy. Implemented by
+        the concrete numeric subclasses.
+        """
+        raise NotImplementedError
+
 
 class IntOption(BoundedNumberOption):
     bounds_type = OptionBoundsInt

--- a/picard/config.py
+++ b/picard/config.py
@@ -279,13 +279,21 @@ class BoundedNumberOption(Option):
         violation to the caller so it can apply its own policy. Callers that want the
         default auto-correct policy should use :meth:`convert` instead.
         """
-        value = self.bounds.check(value, self)
-        return self._base_type(value)
+        # Coerce to the numeric base type first: a value read from an INI config
+        # is a string, and the bounds comparison requires a number.
+        value = self._base_type(value)
+        try:
+            return self._base_type(self.bounds.check(value, self))
+        except OutOfBoundsError as e:
+            # Bounds may be declared as int or float on any option; make the
+            # corrected value match the option type (e.g. int option, float
+            # bound) so callers never see a value of the wrong type.
+            raise OutOfBoundsError(self, e.value, self._base_type(e.corrected)) from None
 
     def convert(self, value):
         # Default policy: clamp to the nearest bound and warn (see
-        # OptionBounds.clamp).
-        return self._base_type(self.bounds.clamp(value, self))
+        # NumericOptionBounds.clamp).
+        return self._base_type(self.bounds.clamp(self._base_type(value), self))
 
 
 class IntOption(BoundedNumberOption):
@@ -297,8 +305,8 @@ class IntOption(BoundedNumberOption):
         For an IntEnum option the value must be a valid member; an invalid
         member raises OutOfBoundsError whose ``corrected`` value is the option
         default. For a plain int the numeric bounds are enforced via
-        :meth:`OptionBounds.check`. Callers that want the default auto-correct
-        policy should use :meth:`convert` instead.
+        :meth:`NumericOptionBounds.check`. Callers that want the default
+        auto-correct policy should use :meth:`convert` instead.
         """
         value = int(value)
         # Bounds do not apply to enum options (an enum is a set of members, not
@@ -314,7 +322,7 @@ class IntOption(BoundedNumberOption):
     def convert(self, value):
         # Default policy: an out-of-range value (or an invalid enum member) is
         # corrected to the nearest bound / the option default and reported with
-        # a warning, mirroring OptionBounds.clamp. This keeps a stale value
+        # a warning, mirroring NumericOptionBounds.clamp. This keeps a stale value
         # (e.g. from a hand-edited config or an outdated profile) usable on read.
         if isinstance(self.default, IntEnum):
             try:

--- a/picard/config.py
+++ b/picard/config.py
@@ -264,9 +264,24 @@ class IntOption(BoundedNumberOption):
     def convert(self, value):
         value = int(value)
         # If the default is an IntEnum, return an IntEnum. Bounds do not apply
-        # to enum options.
+        # to enum options; instead the value must be a valid member. An invalid
+        # value (e.g. from a hand-edited config or an outdated profile) falls
+        # back to the default, reported with a warning, mirroring how bounds
+        # report clamping.
         if isinstance(self.default, IntEnum):
-            return type(self.default)(value)
+            enum_type = type(self.default)
+            try:
+                return enum_type(value)
+            except ValueError:
+                log.warning(
+                    "Option '%s/%s': %r is not a valid %s, using default %r",
+                    self.section,
+                    self.name,
+                    value,
+                    enum_type.__name__,
+                    self.default,
+                )
+                return self.default
         return self.bounds.clamp(value, self)
 
 

--- a/picard/options.py
+++ b/picard/options.py
@@ -698,7 +698,8 @@ IntOption('persist', 'last_update_check', 0)
 BoolOption('setting', 'check_rtd_updates', False, title=N_("Check for documentation updates"), in_profile=True)
 BoolOption('setting', 'check_for_plugin_updates', False, title=N_("Check for plugin updates"), in_profile=True)
 BoolOption('setting', 'check_for_updates', False, title=N_("Check for program updates"), in_profile=True)
-IntOption('setting', 'update_check_days', 7, title=N_("Days between update checks"), in_profile=True)
+# Days between update checks; must be at least 1 (the UI spinbox enforces this).
+IntOption('setting', 'update_check_days', 7, title=N_("Days between update checks"), in_profile=True, bounds=(1, None))
 IntOption('setting', 'update_level', DEFAULT_PROGRAM_UPDATE_LEVEL, title=N_("Update types to check"), in_profile=True)
 IntOption('setting', 'log_verbosity', DEFAULT_LOG_LEVEL, title=N_("Log verbosity level"), in_profile=True)
 

--- a/picard/options.py
+++ b/picard/options.py
@@ -345,7 +345,7 @@ BoolOption('setting', 'analyze_new_files', False, title=N_("Automatically scan a
 BoolOption('setting', 'cluster_new_files', False, title=N_("Automatically cluster all new files"), in_profile=True)
 BoolOption('setting', 'ignore_file_mbids', False, title=N_("Ignore MBIDs when loading new files"), in_profile=True)
 TextOption('setting', 'server_host', MUSICBRAINZ_SERVERS[0], title=N_("Server address"), in_profile=True)
-IntOption('setting', 'server_port', 443, title=N_("Port"), in_profile=True)
+IntOption('setting', 'server_port', 443, title=N_("Port"), in_profile=True, bounds=(1, 65535))
 BoolOption('setting', 'use_server_for_submission', False, title=N_("Submit to configured server"), in_profile=True)
 BoolOption('setting', 'read_isrcs_from_disc', has_isrc_support(), title=N_("Read ISRCs from CD"), in_profile=True)
 BoolOption('setting', 'enable_user_collections', True, title=N_("Enable managing user collections"), in_profile=True)
@@ -555,7 +555,15 @@ IntOption(
 IntOption('setting', 'network_transfer_timeout_seconds', 30, title=N_("Request timeout (seconds)"), in_profile=True)
 TextOption('setting', 'proxy_password', '', title=N_("Proxy password"), in_profile=True, shareable=False)
 TextOption('setting', 'proxy_server_host', '', title=N_("Proxy server address"), in_profile=True, shareable=False)
-IntOption('setting', 'proxy_server_port', 80, title=N_("Proxy server port"), in_profile=True, shareable=False)
+IntOption(
+    'setting',
+    'proxy_server_port',
+    80,
+    title=N_("Proxy server port"),
+    in_profile=True,
+    shareable=False,
+    bounds=(1, 65535),
+)
 TextOption('setting', 'proxy_type', 'http', title=N_("Type of proxy server"), in_profile=True)
 TextOption('setting', 'proxy_username', '', title=N_("Proxy username"), in_profile=True, shareable=False)
 BoolOption('setting', 'use_proxy', False, title=N_("Use a web proxy server"), in_profile=True)

--- a/picard/options.py
+++ b/picard/options.py
@@ -563,7 +563,11 @@ ListOption('persist', 'profile_settings_tree_expanded_list', [])
 # picard/ui/options/ratings.py
 # Ratings
 BoolOption('setting', 'enable_ratings', False, title=N_("Enable track ratings"), in_profile=True)
-IntOption('setting', 'rating_steps', 6)
+# The rating scale has N steps; ratings map onto the range 0..(rating_steps - 1),
+# and that divisor is used when reading and writing ratings in every tag format
+# (asf, id3, vorbis) and by the rating widget. A value below 2 would make the
+# range collapse or divide by zero, so clamp it to a minimum of 2.
+IntOption('setting', 'rating_steps', 6, bounds=(2, None))
 TextOption(
     'setting', 'rating_user_email', 'users@musicbrainz.org', title=N_("Email for saving ratings"), in_profile=True
 )

--- a/picard/options.py
+++ b/picard/options.py
@@ -251,8 +251,25 @@ BoolOption('setting', 'show_cover_art_details_mimetype', True, title=N_("Show co
 # picard/ui/options/cover_processing.py
 # Cover Art Image Processing
 BoolOption('setting', 'filter_cover_by_size', False, title=N_("Discard small images"), in_profile=True)
-IntOption('setting', 'cover_minimum_width', DEFAULT_COVER_MIN_SIZE, title=N_("Minimum image width"), in_profile=True)
-IntOption('setting', 'cover_minimum_height', DEFAULT_COVER_MIN_SIZE, title=N_("Minimum image height"), in_profile=True)
+# Cover image dimensions are pixel counts; a negative or absurd value is
+# meaningless. The UI spinboxes use 0..9999 (minimum size) and 1..9999
+# (resize targets); mirror those ranges here.
+IntOption(
+    'setting',
+    'cover_minimum_width',
+    DEFAULT_COVER_MIN_SIZE,
+    title=N_("Minimum image width"),
+    in_profile=True,
+    bounds=(0, 9999),
+)
+IntOption(
+    'setting',
+    'cover_minimum_height',
+    DEFAULT_COVER_MIN_SIZE,
+    title=N_("Minimum image height"),
+    in_profile=True,
+    bounds=(0, 9999),
+)
 BoolOption('setting', 'cover_tags_enlarge', False, title=N_("Allow enlarging tag images"), in_profile=True)
 BoolOption('setting', 'cover_tags_resize', False, title=N_("Allow resizing tag images"), in_profile=True)
 IntOption(
@@ -261,6 +278,7 @@ IntOption(
     DEFAULT_COVER_MAX_SIZE,
     title=N_("Resized tag image width"),
     in_profile=True,
+    bounds=(1, 9999),
 )
 IntOption(
     'setting',
@@ -268,6 +286,7 @@ IntOption(
     DEFAULT_COVER_MAX_SIZE,
     title=N_("Resized tag image height"),
     in_profile=True,
+    bounds=(1, 9999),
 )
 IntOption(
     'setting', 'cover_tags_resize_mode', DEFAULT_COVER_RESIZE_MODE, title=N_("Tag image resize mode"), in_profile=True
@@ -288,6 +307,7 @@ IntOption(
     DEFAULT_COVER_MAX_SIZE,
     title=N_("Resized file image width"),
     in_profile=True,
+    bounds=(1, 9999),
 )
 IntOption(
     'setting',
@@ -295,6 +315,7 @@ IntOption(
     DEFAULT_COVER_MAX_SIZE,
     title=N_("Resized file image height"),
     in_profile=True,
+    bounds=(1, 9999),
 )
 IntOption(
     'setting', 'cover_file_resize_mode', DEFAULT_COVER_RESIZE_MODE, title=N_("File image resize mode"), in_profile=True
@@ -313,6 +334,7 @@ IntOption(
     DEFAULT_COVER_IMAGE_QUALITY,
     title=N_("Format conversion quality"),
     in_profile=True,
+    bounds=(0, 100),
 )
 
 # picard/ui/options/dialog.py

--- a/picard/options.py
+++ b/picard/options.py
@@ -478,10 +478,19 @@ TextOption(
 
 # picard/ui/options/matching.py
 # Matching
-FloatOption('setting', 'match_min_similarity', 0.25, title=N_("Minimum similarity"), in_profile=True)
-FloatOption('setting', 'match_min_margin', 0.02, title=N_("Minimum margin"), in_profile=True)
+# These are similarity fractions in the range 0.0..1.0, compared directly
+# against computed match scores (see picard/file.py, picard/cluster.py). The UI
+# presents them as 0..100 percent. A stored value outside 0.0..1.0 would make
+# matching always or never succeed, so clamp to that range.
+FloatOption('setting', 'match_min_similarity', 0.25, title=N_("Minimum similarity"), in_profile=True, bounds=(0.0, 1.0))
+FloatOption('setting', 'match_min_margin', 0.02, title=N_("Minimum margin"), in_profile=True, bounds=(0.0, 1.0))
 FloatOption(
-    'setting', 'track_matching_threshold', 0.4, title=N_("Similarity for matching files to tracks"), in_profile=True
+    'setting',
+    'track_matching_threshold',
+    0.4,
+    title=N_("Similarity for matching files to tracks"),
+    in_profile=True,
+    bounds=(0.0, 1.0),
 )
 
 # picard/ui/options/metadata.py

--- a/picard/options.py
+++ b/picard/options.py
@@ -36,6 +36,7 @@ from picard.config import (
     TextOption,
 )
 from picard.const import (
+    BROWSER_INTEGRATION_MAX_PORT,
     BROWSER_INTEGRATION_MIN_PORT,
     MUSICBRAINZ_SERVERS,
 )
@@ -544,6 +545,7 @@ IntOption(
     BROWSER_INTEGRATION_MIN_PORT,
     title=N_("Default listening port"),
     in_profile=True,
+    bounds=(BROWSER_INTEGRATION_MIN_PORT, BROWSER_INTEGRATION_MAX_PORT),
 )
 IntOption(
     'setting',

--- a/picard/options.py
+++ b/picard/options.py
@@ -192,6 +192,7 @@ IntOption(
     2,
     title=N_("Allowed track difference (seconds)"),
     in_profile=True,
+    bounds=(1, 7200),
 )
 IntOption(
     'setting',

--- a/picard/options.py
+++ b/picard/options.py
@@ -769,6 +769,9 @@ IntOption(
     0,
     title=N_("Auto-save interval"),
     in_profile=True,
+    # Interval in minutes; 0 disables autosave (see Tagger.run). A negative
+    # value is meaningless and the UI spinbox caps it at 1440 (24 hours).
+    bounds=(0, 1440),
 )
 BoolOption(
     'setting',

--- a/picard/options.py
+++ b/picard/options.py
@@ -581,7 +581,17 @@ IntOption(
     title=N_("Network cache size (bytes)"),
     in_profile=True,
 )
-IntOption('setting', 'network_transfer_timeout_seconds', 30, title=N_("Request timeout (seconds)"), in_profile=True)
+# Request timeout in seconds, passed to QNetworkAccessManager.setTransferTimeout
+# (which treats 0 as "no timeout"). A negative value is invalid; the UI caps it
+# at 900. Clamp to 0..900.
+IntOption(
+    'setting',
+    'network_transfer_timeout_seconds',
+    30,
+    title=N_("Request timeout (seconds)"),
+    in_profile=True,
+    bounds=(0, 900),
+)
 TextOption('setting', 'proxy_password', '', title=N_("Proxy password"), in_profile=True, shareable=False)
 TextOption('setting', 'proxy_server_host', '', title=N_("Proxy server address"), in_profile=True, shareable=False)
 IntOption(

--- a/picard/options.py
+++ b/picard/options.py
@@ -147,8 +147,11 @@ BoolOption('persist', 'file_view_header_locked', False)
 # picard/ui/mainwindow.py
 #
 TextOption('persist', 'current_directory', "")
-FloatOption('persist', 'mediaplayer_playback_rate', 1.0)
-IntOption('persist', 'mediaplayer_volume', 50)
+# Playback rate is constrained to 0.5..1.5 by the player controls
+# (MIN/MAX_PLAYBACK_RATE in picard/ui/player/player.py); volume is a 0..100
+# percentage (stored as int, divided by 100 on load). Clamp both.
+FloatOption('persist', 'mediaplayer_playback_rate', 1.0, bounds=(0.5, 1.5))
+IntOption('persist', 'mediaplayer_volume', 50, bounds=(0, 100))
 BoolOption('persist', 'view_cover_art', True)
 BoolOption('persist', 'view_file_browser', False)
 BoolOption('persist', 'view_metadata_view', True)

--- a/picard/options.py
+++ b/picard/options.py
@@ -203,6 +203,10 @@ IntOption(
     DEFAULT_QUERY_LIMIT,
     title=N_("Maximum MusicBrainz query items"),
     in_profile=True,
+    # Sent as the MusicBrainz API "limit" parameter, which accepts at most 100
+    # items per request; a value below 1 would request nothing. The options
+    # page offers 25/50/75/100 via a combobox, so clamp to 1..100.
+    bounds=(1, 100),
 )
 BoolOption('setting', 'recursively_add_files', True, title=N_("Include sub-folders when adding files"), in_profile=True)
 

--- a/picard/options.py
+++ b/picard/options.py
@@ -348,7 +348,9 @@ ListOption('persist', 'options_pages_tree_state', [])
 TextOption('setting', 'acoustid_apikey', '')
 TextOption('setting', 'acoustid_fpcalc', '')
 TextOption('setting', 'fingerprinting_system', 'acoustid', title=N_('Use AcoustID fingerprinting'), in_profile=True)
-IntOption('setting', 'fpcalc_threads', DEFAULT_FPCALC_THREADS)
+# Number of threads fpcalc uses; must be at least 1. The UI spinbox caps it at
+# 9, so use the same range.
+IntOption('setting', 'fpcalc_threads', DEFAULT_FPCALC_THREADS, bounds=(1, 9))
 BoolOption(
     'setting',
     'ignore_existing_acoustid_fingerprints',

--- a/picard/options.py
+++ b/picard/options.py
@@ -392,8 +392,10 @@ TextOption(
     in_profile=True,
 )
 TextOption('setting', 'join_genres', '', title=N_("Join multiple genres with"), in_profile=True)
-IntOption('setting', 'max_genres', 5, title=N_("Maximum number of genres"), in_profile=True)
-IntOption('setting', 'min_genre_usage', 90, title=N_("Minimal genre usage"), in_profile=True)
+# max_genres is a count and min_genre_usage is a percentage; the UI caps both
+# at 100. A negative value would be meaningless, so clamp to 0..100.
+IntOption('setting', 'max_genres', 5, title=N_("Maximum number of genres"), in_profile=True, bounds=(0, 100))
+IntOption('setting', 'min_genre_usage', 90, title=N_("Minimal genre usage"), in_profile=True, bounds=(0, 100))
 BoolOption('setting', 'only_my_genres', False, title=N_("Use only my genres"), in_profile=True)
 BoolOption('setting', 'use_genres', False, title=N_("Use genres from MusicBrainz"), in_profile=True)
 

--- a/picard/profiles/importer.py
+++ b/picard/profiles/importer.py
@@ -33,6 +33,7 @@ else:
 
 from picard import log
 from picard.config import (
+    BoundedNumberOption,
     Config,
     Option,
 )
@@ -234,6 +235,14 @@ def _import_value(value, opt: Option):
         if opt.default and isinstance(opt.default[0] if opt.default else None, tuple):
             return [tuple(item) if isinstance(item, list) else item for item in value]
         return value
+    # Normalize numeric values against their bounds at import time, so an
+    # out-of-range value is corrected (and warned about) when the profile is
+    # imported rather than silently clamped on every later read.
+    if isinstance(opt, BoundedNumberOption):
+        try:
+            return opt.convert(value)
+        except (ValueError, TypeError):
+            return value
     return value
 
 

--- a/picard/profiles/importer.py
+++ b/picard/profiles/importer.py
@@ -36,6 +36,7 @@ from picard.config import (
     BoundedNumberOption,
     Config,
     Option,
+    OutOfBoundsError,
 )
 from picard.config_upgrade import apply_settings_upgrades_for_import
 from picard.i18n import (
@@ -49,6 +50,22 @@ class ProfileImportError(Exception):
     """Raised when profile import fails due to invalid data."""
 
 
+class OutOfBoundsSetting:
+    """An imported setting whose value was outside the option's declared bounds.
+
+    Attributes:
+        name: The option name.
+        value: The out-of-range value found in the imported profile.
+        corrected: The value it would be corrected to (the nearest bound, or
+            the option default for an invalid enum member).
+    """
+
+    def __init__(self, name: str, value, corrected):
+        self.name = name
+        self.value = value
+        self.corrected = corrected
+
+
 class ProfileImportResult:
     """Result of a profile import operation.
 
@@ -57,6 +74,8 @@ class ProfileImportResult:
         title: Title of the imported profile.
         skipped_options: List of option names that were not recognized.
         upgraded_settings: List of descriptions of settings upgrades applied.
+        out_of_bounds: List of OutOfBoundsSetting for imported values that were
+            outside their option's declared bounds.
         warnings: List of warning messages for the user.
     """
 
@@ -65,6 +84,7 @@ class ProfileImportResult:
         self.title = title
         self.skipped_options: list[str] = []
         self.upgraded_settings: list[str] = []
+        self.out_of_bounds: list[OutOfBoundsSetting] = []
         self.warnings: list[str] = []
 
 
@@ -171,7 +191,14 @@ def import_profile(
         if not opt.in_profile:
             result.skipped_options.append(key)
             continue
-        profile_settings[key] = _import_value(value, opt)
+        try:
+            profile_settings[key] = _import_value(value, opt)
+        except OutOfBoundsError as e:
+            # The imported value is outside the option's declared bounds. Record
+            # it so the user can be told, and store the corrected value as the
+            # default policy (callers/UI may override this decision).
+            result.out_of_bounds.append(OutOfBoundsSetting(key, e.value, e.corrected))
+            profile_settings[key] = e.corrected
 
     # Process [scripts.naming] section
     scripts_section = data.get('scripts', {})
@@ -201,6 +228,19 @@ def import_profile(
             % (count, ', '.join(result.skipped_options))
         )
 
+    # Report out-of-bounds options (corrected to the nearest valid value)
+    if result.out_of_bounds:
+        count = len(result.out_of_bounds)
+        details = ', '.join(f"{s.name} ({s.value!r} -> {s.corrected!r})" for s in result.out_of_bounds)
+        result.warnings.append(
+            ngettext(
+                "%d setting had an out-of-range value and was corrected: %s",
+                "%d settings had out-of-range values and were corrected: %s",
+                count,
+            )
+            % (count, details)
+        )
+
     # Report upgraded settings
     if result.upgraded_settings:
         count = len(result.upgraded_settings)
@@ -228,19 +268,30 @@ def _make_unique_title(config: Config, title: str) -> str:
 
 
 def _import_value(value, opt: Option):
-    """Convert a TOML value back to the internal representation expected by an option."""
+    """Convert a TOML value back to the internal representation expected by an option.
+
+    For a bounded numeric option this validates the value against the option's
+    bounds and raises OutOfBoundsError (carrying the corrected value) if it is
+    out of range, so the caller can decide what to do about it. Other option
+    types are returned as-is (with TOML list/tuple normalization).
+    """
     # TOML arrays become lists; if the option default is a list of tuples,
     # convert inner lists to tuples
     if isinstance(value, list) and isinstance(opt.default, (list, tuple)):
         if opt.default and isinstance(opt.default[0] if opt.default else None, tuple):
             return [tuple(item) if isinstance(item, list) else item for item in value]
         return value
-    # Normalize numeric values against their bounds at import time, so an
-    # out-of-range value is corrected (and warned about) when the profile is
-    # imported rather than silently clamped on every later read.
+    # Validate numeric values against their bounds at import time. An
+    # out-of-range value raises OutOfBoundsError so the import can report it to
+    # the user instead of silently clamping it on every later read. A value
+    # that cannot even be converted to the option type (TypeError/ValueError
+    # that is not an OutOfBoundsError) is left untouched here and handled by the
+    # normal read path later.
     if isinstance(opt, BoundedNumberOption):
         try:
-            return opt.convert(value)
+            return opt.checked_convert(value)
+        except OutOfBoundsError:
+            raise
         except (ValueError, TypeError):
             return value
     return value

--- a/picard/ui/options/__init__.py
+++ b/picard/ui/options/__init__.py
@@ -22,6 +22,7 @@
 
 
 from collections import defaultdict
+import math
 import re
 from typing import (
     ClassVar,
@@ -36,6 +37,7 @@ from picard import (
     tagger_instance,
 )
 from picard.config import (
+    BoundedNumberOption,
     Option,
     ProfileConfigSection,
     get_config,
@@ -121,6 +123,34 @@ class OptionsPage(QtWidgets.QWidget, HasDisplayTitle):
         if api:
             return api.plugin_config
         return ProfileConfigSection(config, self.OPTION_SECTION)
+
+    def apply_option_bounds(self, widget, option_name, scale=1):
+        """Apply a numeric option's bounds to a spinbox-like widget.
+
+        Reads the minimum/maximum declared on the option so the option
+        definition is the single source of truth for the valid range, keeping
+        the UI in sync with the value clamping done on read.
+
+        Args:
+            widget: A spinbox-like widget with setMinimum/setMaximum.
+            option_name: Name of the option in this page's section.
+            scale: Multiplier applied to each bound before setting it on the
+                widget, for spinboxes that display a scaled value (e.g. a
+                0.0..1.0 option shown as a 0..100 percentage uses scale=100).
+
+        Bounds left as None are not applied. Does nothing if the option is
+        unregistered or not a bounded numeric option.
+        """
+        option = Option.get(self.OPTION_SECTION, option_name)
+        if not isinstance(option, BoundedNumberOption):
+            return
+        # Round the minimum up and the maximum down so the widget range can
+        # never exceed the option's true bounds (a value the spinbox allows is
+        # therefore never clamped afterwards on read).
+        if option.bounds.minimum is not None:
+            widget.setMinimum(math.ceil(option.bounds.minimum * scale))
+        if option.bounds.maximum is not None:
+            widget.setMaximum(math.floor(option.bounds.maximum * scale))
 
     def restore_defaults(self):
         config = get_config()

--- a/picard/ui/options/cover_processing.py
+++ b/picard/ui/options/cover_processing.py
@@ -80,6 +80,14 @@ class CoverProcessingOptionsPage(OptionsPage):
         self.ui = Ui_CoverProcessingOptionsPage()
         self.ui.setupUi(self)
 
+        self.apply_option_bounds(self.ui.filtering_width_value, 'cover_minimum_width')
+        self.apply_option_bounds(self.ui.filtering_height_value, 'cover_minimum_height')
+        self.apply_option_bounds(self.ui.tags_resize_width_value, 'cover_tags_resize_target_width')
+        self.apply_option_bounds(self.ui.tags_resize_height_value, 'cover_tags_resize_target_height')
+        self.apply_option_bounds(self.ui.file_resize_width_value, 'cover_file_resize_target_width')
+        self.apply_option_bounds(self.ui.file_resize_height_value, 'cover_file_resize_target_height')
+        self.apply_option_bounds(self.ui.cover_image_quality_value, 'cover_image_quality')
+
         for resize_mode in COVER_RESIZE_MODES:
             self.ui.tags_resize_mode.addItem(resize_mode.title, resize_mode.mode.value)
             self.ui.file_resize_mode.addItem(resize_mode.title, resize_mode.mode.value)

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -87,6 +87,7 @@ class FingerprintingOptionsPage(OptionsPage):
         self._fpcalc_checking = False
         self.ui = Ui_FingerprintingOptionsPage()
         self.ui.setupUi(self)
+        self.apply_option_bounds(self.ui.fpcalc_threads, 'fpcalc_threads')
 
         # Set open directory icon on folder browse button
         icon = self.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DirOpenIcon)

--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -68,6 +68,7 @@ class GeneralOptionsPage(OptionsPage):
         super().__init__(parent=parent)
         self.ui = Ui_GeneralOptionsPage()
         self.ui.setupUi(self)
+        self.apply_option_bounds(self.ui.server_port, 'server_port')
         self.ui.server_host.addItems(MUSICBRAINZ_SERVERS)
         self.ui.server_host.currentTextChanged.connect(self.update_server_host)
         self.ui.login.clicked.connect(self.login)

--- a/picard/ui/options/genres.py
+++ b/picard/ui/options/genres.py
@@ -89,6 +89,8 @@ class GenresOptionsPage(OptionsPage):
         super().__init__(parent=parent)
         self.ui = Ui_GenresOptionsPage()
         self.ui.setupUi(self)
+        self.apply_option_bounds(self.ui.min_genre_usage, 'min_genre_usage')
+        self.apply_option_bounds(self.ui.max_genres, 'max_genres')
 
         self.ui.genres_filter.setToolTip(_(TOOLTIP_GENRES_FILTER))
         self.ui.genres_filter.textChanged.connect(self.update_test_genres_filter)

--- a/picard/ui/options/matching.py
+++ b/picard/ui/options/matching.py
@@ -57,6 +57,13 @@ class MatchingOptionsPage(OptionsPage):
         super().__init__(parent=parent)
         self.ui = Ui_MatchingOptionsPage()
         self.ui.setupUi(self)
+        # Similarity values are stored as 0.0..1.0 but shown as 0..100 percent.
+        self.apply_option_bounds(self.ui.match_min_similarity, 'match_min_similarity', scale=100)
+        self.apply_option_bounds(self.ui.match_min_margin, 'match_min_margin', scale=100)
+        self.apply_option_bounds(self.ui.track_matching_threshold, 'track_matching_threshold', scale=100)
+        self.apply_option_bounds(
+            self.ui.ignore_track_duration_difference_under, 'ignore_track_duration_difference_under'
+        )
 
     def load(self):
         config = get_config()

--- a/picard/ui/options/network.py
+++ b/picard/ui/options/network.py
@@ -22,11 +22,7 @@
 from typing import ClassVar
 
 from picard.config import get_config
-from picard.const import (
-    BROWSER_INTEGRATION_MAX_PORT,
-    BROWSER_INTEGRATION_MIN_PORT,
-    CACHE_SIZE_DISPLAY_UNIT,
-)
+from picard.const import CACHE_SIZE_DISPLAY_UNIT
 from picard.const.defaults import DEFAULT_CACHE_SIZE_IN_BYTES
 from picard.extension_points.options_pages import register_options_page
 from picard.i18n import (
@@ -81,8 +77,11 @@ class NetworkOptionsPage(OptionsPage):
         self.ui.network_cache_size.setToolTip(max_cache_tooltip)
         self.ui.label_cache_size.setToolTip(max_cache_tooltip)
         self.ui.label_cache_max_unit.setToolTip(max_cache_tooltip)
-        self.ui.browser_integration_port.setMinimum(BROWSER_INTEGRATION_MIN_PORT)
-        self.ui.browser_integration_port.setMaximum(BROWSER_INTEGRATION_MAX_PORT)
+        # Keep the spinbox ranges in sync with the option bounds (single source
+        # of truth). The proxy port reuses the server_port spinbox widget.
+        self.apply_option_bounds(self.ui.server_port, 'proxy_server_port')
+        self.apply_option_bounds(self.ui.transfer_timeout, 'network_transfer_timeout_seconds')
+        self.apply_option_bounds(self.ui.browser_integration_port, 'browser_integration_port')
         self.update_cache_size()
 
     def load(self):

--- a/picard/ui/options/sessions.py
+++ b/picard/ui/options/sessions.py
@@ -63,6 +63,8 @@ class SessionsOptionsPage(OptionsPage):
         self.ui = Ui_SessionsOptionsPage()
         self.ui.setupUi(self)
 
+        self.apply_option_bounds(self.ui.autosave_spin, 'session_autosave_interval_min')
+
         # Set open directory icon on folder browse button
         style = self.style()
         assert style is not None

--- a/picard/ui/options/startup.py
+++ b/picard/ui/options/startup.py
@@ -71,6 +71,7 @@ class StartupOptionsPage(OptionsPage):
         super().__init__(parent=parent)
         self.ui = Ui_StartupOptionsPage()
         self.ui.setupUi(self)
+        self.apply_option_bounds(self.ui.update_check_days, 'update_check_days')
 
         # Populate log verbosity selector
         for level, feat in log.levels_features.items():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -464,8 +464,8 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         opt = IntOption("setting", "int_option", TestIntEnum.A)
         self.assertEqual(opt.convert(2), TestIntEnum.B)
         self.assertIsInstance(opt.convert("2"), TestIntEnum)
-        with self.assertRaises(ValueError):
-            opt.convert(3)
+        # An invalid enum member falls back to the default rather than raising.
+        self.assertEqual(opt.convert(3), TestIntEnum.A)
 
     def test_int_opt_no_config(self):
         IntOption("setting", "int_option", 666)
@@ -564,6 +564,39 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         # bounds are accepted but do not apply to enum options.
         opt = IntOption("setting", "int_option", TestIntEnum.A, bounds=(5, 6))
         self.assertEqual(opt.convert(2), TestIntEnum.B)
+
+    def test_int_opt_invalid_intenum_falls_back_to_default(self):
+        class TestIntEnum(IntEnum):
+            A = 1
+            B = 2
+
+        opt = IntOption("setting", "int_option", TestIntEnum.B)
+        # An invalid enum member falls back to the default instead of raising.
+        self.assertEqual(opt.convert(99), TestIntEnum.B)
+
+    def test_int_opt_invalid_intenum_warns(self):
+        class TestIntEnum(IntEnum):
+            A = 1
+            B = 2
+
+        opt = IntOption("setting", "int_option", TestIntEnum.A)
+        logging.disable(logging.NOTSET)
+        try:
+            with self.assertLogs('main', level='WARNING') as cm:
+                self.assertEqual(opt.convert(99), TestIntEnum.A)
+            self.assertIn('not a valid TestIntEnum', ''.join(cm.output))
+        finally:
+            logging.disable(logging.ERROR)
+
+    def test_int_opt_invalid_intenum_via_stored_value(self):
+        class TestIntEnum(IntEnum):
+            A = 1
+            B = 2
+
+        IntOption("setting", "int_option", TestIntEnum.A)
+        # A stored value that is not a valid member falls back to the default.
+        self.config.setValue('setting/int_option', 99)
+        self.assertEqual(self.config.setting["int_option"], TestIntEnum.A)
 
     @subtest_cases(
         "bounds,exception",

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,6 +41,7 @@ from picard.config import (
     ListOption,
     Option,
     OptionError,
+    OutOfBoundsError,
     TextOption,
     get_quick_menu_items,
     register_quick_menu_item,
@@ -543,10 +544,12 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         try:
             with self.assertLogs('main', level='WARNING') as cm:
                 self.assertEqual(opt.convert(1), 2)
-            self.assertIn('below the minimum', ''.join(cm.output))
+            self.assertIn('out of bounds', ''.join(cm.output))
+            self.assertIn('clamping to 2', ''.join(cm.output))
             with self.assertLogs('main', level='WARNING') as cm:
                 self.assertEqual(opt.convert(99), 10)
-            self.assertIn('above the maximum', ''.join(cm.output))
+            self.assertIn('out of bounds', ''.join(cm.output))
+            self.assertIn('clamping to 10', ''.join(cm.output))
         finally:
             logging.disable(logging.ERROR)
 
@@ -597,6 +600,44 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         # A stored value that is not a valid member falls back to the default.
         self.config.setValue('setting/int_option', 99)
         self.assertEqual(self.config.setting["int_option"], TestIntEnum.A)
+
+    def test_int_opt_checked_convert_raises_out_of_bounds(self):
+        opt = IntOption("setting", "int_option", 5, bounds=(2, 10))
+        # In range: returns the value unchanged, no raise.
+        self.assertEqual(opt.checked_convert(5), 5)
+        with self.assertRaises(OutOfBoundsError) as ctx:
+            opt.checked_convert(99)
+        self.assertEqual(ctx.exception.value, 99)
+        self.assertEqual(ctx.exception.corrected, 10)
+        self.assertIs(ctx.exception.option, opt)
+        # OutOfBoundsError is a ValueError so existing handlers keep working.
+        self.assertIsInstance(ctx.exception, ValueError)
+        with self.assertRaises(OutOfBoundsError) as ctx:
+            opt.checked_convert(0)
+        self.assertEqual(ctx.exception.corrected, 2)
+
+    def test_int_opt_checked_convert_does_not_log(self):
+        opt = IntOption("setting", "int_option", 5, bounds=(2, 10))
+        logging.disable(logging.NOTSET)
+        try:
+            # Pure detection: checked_convert must not log; only convert() does.
+            with self.assertNoLogs('main', level='WARNING'):
+                with self.assertRaises(OutOfBoundsError):
+                    opt.checked_convert(99)
+        finally:
+            logging.disable(logging.ERROR)
+
+    def test_int_opt_checked_convert_invalid_intenum_raises(self):
+        class TestIntEnum(IntEnum):
+            A = 1
+            B = 2
+
+        opt = IntOption("setting", "int_option", TestIntEnum.A)
+        self.assertEqual(opt.checked_convert(2), TestIntEnum.B)
+        with self.assertRaises(OutOfBoundsError) as ctx:
+            opt.checked_convert(99)
+        self.assertEqual(ctx.exception.value, 99)
+        self.assertEqual(ctx.exception.corrected, TestIntEnum.A)
 
     @subtest_cases(
         "bounds,exception",
@@ -689,10 +730,12 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
         try:
             with self.assertLogs('main', level='WARNING') as cm:
                 self.assertEqual(opt.convert(-1.0), 0.0)
-            self.assertIn('below the minimum', ''.join(cm.output))
+            self.assertIn('out of bounds', ''.join(cm.output))
+            self.assertIn('clamping to 0.0', ''.join(cm.output))
             with self.assertLogs('main', level='WARNING') as cm:
                 self.assertEqual(opt.convert(2.0), 1.0)
-            self.assertIn('above the maximum', ''.join(cm.output))
+            self.assertIn('out of bounds', ''.join(cm.output))
+            self.assertIn('clamping to 1.0', ''.join(cm.output))
         finally:
             logging.disable(logging.ERROR)
 
@@ -700,6 +743,14 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
         FloatOption("setting", "float_option", 0.5, bounds=(0.0, 1.0))
         self.config.setValue('setting/float_option', 2.5)
         self.assertEqual(self.config.setting["float_option"], 1.0)
+
+    def test_float_opt_checked_convert_raises_out_of_bounds(self):
+        opt = FloatOption("setting", "float_option", 0.5, bounds=(0.0, 1.0))
+        self.assertEqual(opt.checked_convert(0.5), 0.5)
+        with self.assertRaises(OutOfBoundsError) as ctx:
+            opt.checked_convert(2.5)
+        self.assertEqual(ctx.exception.corrected, 1.0)
+        self.assertIsInstance(ctx.exception, ValueError)
 
     def test_float_opt_bounds_accepts_int(self):
         # int bounds are accepted for a float option and coerced to float.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -27,7 +27,10 @@ import os
 import shutil
 from typing import ClassVar
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    subtest_cases,
+)
 
 from picard import config
 from picard.config import (
@@ -465,6 +468,73 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         self.config.setValue('setting/int_option', '333')
         self.assertEqual(self.config.setting["int_option"], 333)
 
+    def test_int_opt_no_bounds_by_default(self):
+        opt = IntOption("setting", "int_option", 5)
+        self.assertIsNone(opt.bounds.minimum)
+        self.assertIsNone(opt.bounds.maximum)
+        # Without bounds any value passes through unchanged.
+        self.assertEqual(opt.convert(-1000), -1000)
+        self.assertEqual(opt.convert(1000), 1000)
+
+    @subtest_cases(
+        "bounds,value,expected",
+        [
+            # In range: unchanged.
+            ((2, 10), 2, 2),
+            ((2, 10), 5, 5),
+            ((2, 10), 10, 10),
+            # Below minimum: clamped up.
+            ((2, None), 1, 2),
+            ((2, None), -100, 2),
+            # Above maximum: clamped down.
+            ((None, 10), 11, 10),
+            ((None, 10), 100, 10),
+        ],
+    )
+    def test_int_opt_clamp(self, bounds, value, expected):
+        opt = IntOption("setting", "int_option", 5, bounds=bounds)
+        self.assertEqual(opt.convert(value), expected)
+
+    def test_int_opt_clamp_warns(self):
+        opt = IntOption("setting", "int_option", 5, bounds=(2, 10))
+        logging.disable(logging.NOTSET)
+        try:
+            with self.assertLogs('main', level='WARNING') as cm:
+                self.assertEqual(opt.convert(1), 2)
+            self.assertIn('below the minimum', ''.join(cm.output))
+            with self.assertLogs('main', level='WARNING') as cm:
+                self.assertEqual(opt.convert(99), 10)
+            self.assertIn('above the maximum', ''.join(cm.output))
+        finally:
+            logging.disable(logging.ERROR)
+
+    def test_int_opt_bounds_via_stored_value(self):
+        IntOption("setting", "int_option", 5, bounds=(2, 10))
+        # A stored value outside the range is clamped on read.
+        self.config.setValue('setting/int_option', 1)
+        self.assertEqual(self.config.setting["int_option"], 2)
+
+    def test_int_opt_bounds_ignored_for_intenum(self):
+        class TestIntEnum(IntEnum):
+            A = 1
+            B = 2
+
+        # bounds are accepted but do not apply to enum options.
+        opt = IntOption("setting", "int_option", TestIntEnum.A, bounds=(5, 6))
+        self.assertEqual(opt.convert(2), TestIntEnum.B)
+
+    @subtest_cases(
+        "bounds,exception",
+        {
+            'float bound': ((2.5, None), TypeError),
+            'bool bound': ((True, None), TypeError),
+            'minimum greater than maximum': ((10, 2), ValueError),
+        },
+    )
+    def test_int_opt_bounds_rejected(self, bounds, exception):
+        with self.assertRaises(exception):
+            IntOption("setting", "int_option", 5, bounds=bounds)
+
 
 class TestPicardConfigFloatOption(TestPicardConfigCommon):
     # FloatOption
@@ -514,6 +584,66 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
         # store float as string directly, it should be ok, due to conversion
         self.config.setValue('setting/float_option', '333.3')
         self.assertEqual(self.config.setting["float_option"], 333.3)
+
+    def test_float_opt_no_bounds_by_default(self):
+        opt = FloatOption("setting", "float_option", 0.5)
+        self.assertIsNone(opt.bounds.minimum)
+        self.assertIsNone(opt.bounds.maximum)
+        self.assertEqual(opt.convert(-10.0), -10.0)
+        self.assertEqual(opt.convert(10.0), 10.0)
+
+    @subtest_cases(
+        "bounds,value,expected",
+        [
+            # In range: unchanged.
+            ((0.0, 1.0), 0.0, 0.0),
+            ((0.0, 1.0), 0.5, 0.5),
+            ((0.0, 1.0), 1.0, 1.0),
+            # Below minimum / above maximum: clamped.
+            ((0.0, None), -0.5, 0.0),
+            ((None, 1.0), 1.5, 1.0),
+        ],
+    )
+    def test_float_opt_clamp(self, bounds, value, expected):
+        opt = FloatOption("setting", "float_option", 0.5, bounds=bounds)
+        self.assertEqual(opt.convert(value), expected)
+
+    def test_float_opt_clamp_warns(self):
+        opt = FloatOption("setting", "float_option", 0.5, bounds=(0.0, 1.0))
+        logging.disable(logging.NOTSET)
+        try:
+            with self.assertLogs('main', level='WARNING') as cm:
+                self.assertEqual(opt.convert(-1.0), 0.0)
+            self.assertIn('below the minimum', ''.join(cm.output))
+            with self.assertLogs('main', level='WARNING') as cm:
+                self.assertEqual(opt.convert(2.0), 1.0)
+            self.assertIn('above the maximum', ''.join(cm.output))
+        finally:
+            logging.disable(logging.ERROR)
+
+    def test_float_opt_bounds_via_stored_value(self):
+        FloatOption("setting", "float_option", 0.5, bounds=(0.0, 1.0))
+        self.config.setValue('setting/float_option', 2.5)
+        self.assertEqual(self.config.setting["float_option"], 1.0)
+
+    def test_float_opt_bounds_accepts_int(self):
+        # int bounds are accepted for a float option and coerced to float.
+        opt = FloatOption("setting", "float_option", 0.5, bounds=(0, 1))
+        self.assertIsInstance(opt.bounds.minimum, float)
+        self.assertIsInstance(opt.bounds.maximum, float)
+        self.assertEqual(opt.convert(-1.0), 0.0)
+        self.assertEqual(opt.convert(2.0), 1.0)
+
+    @subtest_cases(
+        "bounds,exception",
+        {
+            'bool bound': ((True, None), TypeError),
+            'minimum greater than maximum': ((1.0, 0.0), ValueError),
+        },
+    )
+    def test_float_opt_bounds_rejected(self, bounds, exception):
+        with self.assertRaises(exception):
+            FloatOption("setting", "float_option", 0.5, bounds=bounds)
 
 
 class TestPicardConfigListOption(TestPicardConfigCommon):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -642,7 +642,6 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
     @subtest_cases(
         "bounds,exception",
         {
-            'float bound': ((2.5, None), TypeError),
             'bool bound': ((True, None), TypeError),
             'minimum greater than maximum': ((10, 2), ValueError),
         },
@@ -650,6 +649,15 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
     def test_int_opt_bounds_rejected(self, bounds, exception):
         with self.assertRaises(exception):
             IntOption("setting", "int_option", 5, bounds=bounds)
+
+    def test_int_opt_bounds_accepts_float(self):
+        # float bounds are accepted for an int option, but convert returns int
+        # for clamped values.
+        opt = IntOption("setting", "float_option", 1, bounds=(0.0, 2.0))
+        self.assertIsInstance(opt.bounds.minimum, float)
+        self.assertIsInstance(opt.bounds.maximum, float)
+        self.assertEqual(opt.convert(-1), 0)
+        self.assertEqual(opt.convert(3), 2)
 
 
 class TestPicardConfigFloatOption(TestPicardConfigCommon):
@@ -753,10 +761,11 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
         self.assertIsInstance(ctx.exception, ValueError)
 
     def test_float_opt_bounds_accepts_int(self):
-        # int bounds are accepted for a float option and coerced to float.
+        # int bounds are accepted for an float option, but convert returns float
+        # for clamped values.
         opt = FloatOption("setting", "float_option", 0.5, bounds=(0, 1))
-        self.assertIsInstance(opt.bounds.minimum, float)
-        self.assertIsInstance(opt.bounds.maximum, float)
+        self.assertIsInstance(opt.bounds.minimum, int)
+        self.assertIsInstance(opt.bounds.maximum, int)
         self.assertEqual(opt.convert(-1.0), 0.0)
         self.assertEqual(opt.convert(2.0), 1.0)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -213,6 +213,48 @@ class TestPicardConfigSection(TestPicardConfigCommon):
         with self.assertRaises(TypeError, msg='Option default value must not be None'):
             self.config.setting.register_option("invalid_option", None)
 
+    def test_register_option_int_bounds(self):
+        opt = self.config.setting.register_option("int_option", 5, bounds=(2, 10))
+        self.assertIsInstance(opt, IntOption)
+        self.assertEqual(opt.bounds.minimum, 2)
+        self.assertEqual(opt.bounds.maximum, 10)
+        # Clamping applies to a stored out-of-range value.
+        self.config.setting["int_option"] = 100
+        self.assertEqual(self.config.setting["int_option"], 10)
+
+    def test_register_option_float_bounds(self):
+        opt = self.config.setting.register_option("float_option", 0.5, bounds=(0.0, 1.0))
+        self.assertIsInstance(opt, FloatOption)
+        self.assertEqual(opt.bounds.minimum, 0.0)
+        self.assertEqual(opt.bounds.maximum, 1.0)
+        self.config.setting["float_option"] = 2.0
+        self.assertEqual(self.config.setting["float_option"], 1.0)
+
+    @subtest_cases(
+        "name,default",
+        {
+            'text option': ("text_option", "x"),
+            'bool option': ("bool_option", True),
+            'list option': ("list_option", [1]),
+        },
+    )
+    def test_register_option_bounds_rejected_for_non_numeric(self, name, default):
+        with self.assertRaises(TypeError):
+            self.config.setting.register_option(name, default, bounds=(0, 1))
+
+    def test_register_option_bounds_forwarded_in_profile_section(self):
+        from picard.config import ProfileConfigSection
+
+        section = ProfileConfigSection(self.config, 'test_plugin')
+        opt = section.register_option('threads', 4, bounds=(1, 9))
+        self.assertIsInstance(opt, IntOption)
+        self.assertEqual(opt.bounds.minimum, 1)
+        self.assertEqual(opt.bounds.maximum, 9)
+        # A stored out-of-range value is clamped when read back through the
+        # plugin config section.
+        section['threads'] = 100
+        self.assertEqual(section['threads'], 9)
+
     def test_profile_override_on_config_section(self):
         from picard.config import (
             ProfileConfigSection,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -650,14 +650,29 @@ class TestPicardConfigIntOption(TestPicardConfigCommon):
         with self.assertRaises(exception):
             IntOption("setting", "int_option", 5, bounds=bounds)
 
-    def test_int_opt_bounds_accepts_float(self):
-        # float bounds are accepted for an int option, but convert returns int
-        # for clamped values.
-        opt = IntOption("setting", "float_option", 1, bounds=(0.0, 2.0))
-        self.assertIsInstance(opt.bounds.minimum, float)
-        self.assertIsInstance(opt.bounds.maximum, float)
-        self.assertEqual(opt.convert(-1), 0)
-        self.assertEqual(opt.convert(3), 2)
+    def test_int_opt_float_bounds_yield_int_values(self):
+        # A float bound literal may be declared for an int option. The bound is
+        # kept as declared for the comparison, but the converted/clamped value
+        # (and the reported corrected value) is always int.
+        opt = IntOption("setting", "int_option", 1, bounds=(0, 2.5))
+        self.assertEqual(opt.bounds.maximum, 2.5)  # bound kept as declared
+        self.assertEqual(opt.convert(2), 2)
+        self.assertEqual(opt.convert(3), 2)  # clamped to 2.5, coerced to int 2
+        self.assertIsInstance(opt.convert(3), int)
+        with self.assertRaises(OutOfBoundsError) as ctx:
+            opt.checked_convert(3)
+        self.assertEqual(ctx.exception.corrected, 2)
+        self.assertIsInstance(ctx.exception.corrected, int)
+
+    def test_int_opt_bounds_convert_string(self):
+        # Values read from an INI config arrive as strings; a bounded option
+        # must coerce before comparing against its bounds (regression test).
+        opt = IntOption("setting", "int_option", 5, bounds=(2, 10))
+        self.assertEqual(opt.convert("5"), 5)
+        self.assertEqual(opt.convert("99"), 10)
+        self.assertEqual(opt.checked_convert("7"), 7)
+        with self.assertRaises(OutOfBoundsError):
+            opt.checked_convert("99")
 
 
 class TestPicardConfigFloatOption(TestPicardConfigCommon):
@@ -761,13 +776,14 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
         self.assertIsInstance(ctx.exception, ValueError)
 
     def test_float_opt_bounds_accepts_int(self):
-        # int bounds are accepted for an float option, but convert returns float
-        # for clamped values.
+        # int bound literals are accepted for a float option and kept as
+        # declared for the comparison, but convert returns float values.
         opt = FloatOption("setting", "float_option", 0.5, bounds=(0, 1))
         self.assertIsInstance(opt.bounds.minimum, int)
         self.assertIsInstance(opt.bounds.maximum, int)
         self.assertEqual(opt.convert(-1.0), 0.0)
         self.assertEqual(opt.convert(2.0), 1.0)
+        self.assertIsInstance(opt.convert(2.0), float)
 
     @subtest_cases(
         "bounds,exception",
@@ -779,6 +795,16 @@ class TestPicardConfigFloatOption(TestPicardConfigCommon):
     def test_float_opt_bounds_rejected(self, bounds, exception):
         with self.assertRaises(exception):
             FloatOption("setting", "float_option", 0.5, bounds=bounds)
+
+    def test_float_opt_bounds_convert_string(self):
+        # Values read from an INI config arrive as strings; a bounded option
+        # must coerce before comparing against its bounds (regression test).
+        opt = FloatOption("setting", "float_option", 0.5, bounds=(0.0, 1.0))
+        self.assertEqual(opt.convert("0.5"), 0.5)
+        self.assertEqual(opt.convert("2.5"), 1.0)
+        self.assertEqual(opt.checked_convert("0.5"), 0.5)
+        with self.assertRaises(OutOfBoundsError):
+            opt.checked_convert("2.5")
 
 
 class TestPicardConfigListOption(TestPicardConfigCommon):

--- a/test/test_profile_import.py
+++ b/test/test_profile_import.py
@@ -20,6 +20,7 @@ from test.test_config import TestPicardConfigCommon
 
 from picard.config import (
     BoolOption,
+    IntOption,
     ListOption,
     Option,
     TextOption,
@@ -45,6 +46,15 @@ picard_version = "3.0.0"
 [settings]
 standardize_artists = true
 write_id3v23 = false
+"""
+
+PROFILE_WITH_OUT_OF_RANGE_SETTING = """\
+[profile]
+title = "Out Of Range"
+picard_version = "3.0.0"
+
+[settings]
+bounded_int = 999
 """
 
 PROFILE_WITH_SCRIPTS = """\
@@ -123,6 +133,15 @@ class TestProfileImport(TestPicardConfigCommon):
         settings = self.config.profiles['user_profile_settings'][result.profile_id]
         self.assertTrue(settings['standardize_artists'])
         self.assertFalse(settings['write_id3v23'])
+
+    def test_import_clamps_out_of_range_numeric_setting(self):
+        IntOption('setting', 'bounded_int', 5, title="Bounded", in_profile=True, bounds=(0, 10))
+
+        result = import_profile(self.config, PROFILE_WITH_OUT_OF_RANGE_SETTING)
+
+        # The stored profile value is normalized to the option's maximum.
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertEqual(settings['bounded_int'], 10)
 
     def test_import_unknown_options_skipped(self):
         BoolOption('setting', 'standardize_artists', False, title="Standardize", in_profile=True)

--- a/test/test_profile_import.py
+++ b/test/test_profile_import.py
@@ -57,6 +57,15 @@ picard_version = "3.0.0"
 bounded_int = 999
 """
 
+PROFILE_WITH_IN_RANGE_SETTING = """\
+[profile]
+title = "In Range"
+picard_version = "3.0.0"
+
+[settings]
+bounded_int = 7
+"""
+
 PROFILE_WITH_SCRIPTS = """\
 [profile]
 title = "Scripted Profile"
@@ -142,6 +151,29 @@ class TestProfileImport(TestPicardConfigCommon):
         # The stored profile value is normalized to the option's maximum.
         settings = self.config.profiles['user_profile_settings'][result.profile_id]
         self.assertEqual(settings['bounded_int'], 10)
+
+    def test_import_records_out_of_bounds_setting(self):
+        IntOption('setting', 'bounded_int', 5, title="Bounded", in_profile=True, bounds=(0, 10))
+
+        result = import_profile(self.config, PROFILE_WITH_OUT_OF_RANGE_SETTING)
+
+        # The out-of-range value is reported so the user can be informed.
+        self.assertEqual(len(result.out_of_bounds), 1)
+        oob = result.out_of_bounds[0]
+        self.assertEqual(oob.name, 'bounded_int')
+        self.assertEqual(oob.value, 999)
+        self.assertEqual(oob.corrected, 10)
+        # A human-readable warning is emitted for the import summary.
+        self.assertTrue(any('out-of-range' in w for w in result.warnings))
+
+    def test_import_in_range_numeric_setting_not_reported(self):
+        IntOption('setting', 'bounded_int', 5, title="Bounded", in_profile=True, bounds=(0, 10))
+
+        result = import_profile(self.config, PROFILE_WITH_IN_RANGE_SETTING)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertEqual(settings['bounded_int'], 7)
+        self.assertEqual(result.out_of_bounds, [])
 
     def test_import_unknown_options_skipped(self):
         BoolOption('setting', 'standardize_artists', False, title="Standardize", in_profile=True)

--- a/test/test_ui_options_apply_bounds.py
+++ b/test/test_ui_options_apply_bounds.py
@@ -1,0 +1,99 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from PyQt6 import QtWidgets
+
+from picard.config import (
+    FloatOption,
+    IntOption,
+    Option,
+    TextOption,
+)
+
+import pytest
+
+from picard.ui.options import OptionsPage
+
+
+@pytest.fixture()
+def page(qapp):
+    return OptionsPage.__new__(OptionsPage)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    saved = dict(Option.registry)
+    Option.registry = {}
+    try:
+        yield
+    finally:
+        Option.registry = saved
+
+
+def test_apply_bounds_int(page):
+    IntOption('setting', 'opt', 5, bounds=(2, 10))
+    spinbox = QtWidgets.QSpinBox()
+    page.apply_option_bounds(spinbox, 'opt')
+    assert spinbox.minimum() == 2
+    assert spinbox.maximum() == 10
+
+
+def test_apply_bounds_scale(page):
+    # A 0.0..1.0 float option shown as a 0..100 percentage.
+    FloatOption('setting', 'opt', 0.5, bounds=(0.0, 1.0))
+    spinbox = QtWidgets.QSpinBox()
+    page.apply_option_bounds(spinbox, 'opt', scale=100)
+    assert spinbox.minimum() == 0
+    assert spinbox.maximum() == 100
+
+
+def test_apply_bounds_rounds_min_up_max_down(page):
+    # Scaling fractional bounds: minimum rounds up, maximum rounds down, so the
+    # widget range never exceeds the option's true bounds.
+    FloatOption('setting', 'opt', 0.5, bounds=(0.005, 0.995))
+    spinbox = QtWidgets.QSpinBox()
+    page.apply_option_bounds(spinbox, 'opt', scale=100)
+    assert spinbox.minimum() == 1  # ceil(0.5)
+    assert spinbox.maximum() == 99  # floor(99.5)
+
+
+def test_apply_bounds_only_minimum(page):
+    IntOption('setting', 'opt', 5, bounds=(2, None))
+    spinbox = QtWidgets.QSpinBox()
+    spinbox.setMaximum(12345)
+    page.apply_option_bounds(spinbox, 'opt')
+    assert spinbox.minimum() == 2
+    # Maximum is left untouched when the option has no upper bound.
+    assert spinbox.maximum() == 12345
+
+
+@pytest.mark.parametrize(
+    "register",
+    [
+        pytest.param(lambda: TextOption('setting', 'opt', 'x'), id="non-numeric option"),
+        pytest.param(lambda: None, id="unregistered option"),
+    ],
+)
+def test_apply_bounds_noop(page, register):
+    register()
+    spinbox = QtWidgets.QSpinBox()
+    spinbox.setMinimum(3)
+    spinbox.setMaximum(7)
+    page.apply_option_bounds(spinbox, 'opt')
+    assert spinbox.minimum() == 3
+    assert spinbox.maximum() == 7


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Adds optional `bounds=(minimum, maximum)` support to `IntOption`/`FloatOption`
  so numeric settings declare their valid range once, and out-of-range values
  are clamped (with a warning) instead of silently reaching code that assumes a
  sane range. The valid range is then reused by the options UI and by profile
  import.

## Problem

* JIRA ticket (_optional_): none yet

Several numeric settings are used in ways that assume a sane range, but nothing
enforced it. `IntOption`/`FloatOption` only coerced the *type* of a stored
value; the *range* was only ever constrained by the UI spinboxes. Any value
that reaches the config without going through those widgets was trusted blindly.

Concrete failure modes:

* `rating_steps` is used as `rating_steps - 1`, a divisor/multiplier in every
  tag format (asf, id3, vorbis) and in the rating widget. A stored value below
  2 collapses the rating scale or divides by zero.
* `match_min_similarity` / `match_min_margin` / `track_matching_threshold` are
  compared directly against computed match scores; a value outside `0.0..1.0`
  makes matching always or never succeed.
* Ports, timeouts, thread counts, image dimensions, etc. have obvious valid
  ranges that were only enforced in the UI.

These values can reach the config without passing through the UI in several
ways: a hand-edited configuration file, a settings value carried over from an
older Picard release, and — increasingly relevant — an **imported shareable
profile** (the new profile import feature reads settings from an external TOML
file authored elsewhere).

## Solution

A small, self-contained mechanism plus its application to individual options,
one option (or coherent group) per commit with the rationale in each message.

**Mechanism** (`picard/config.py`)

* `IntOption`/`FloatOption` accept `bounds=(minimum, maximum)`; either side may
  be `None` for "unbounded".
* Bounds are held in an `OptionBounds` value object (`OptionBoundsInt` /
  `OptionBoundsFloat`) that enforces and normalizes the bound type: `int`
  bounds for `IntOption`, real-number bounds (coerced to `float`) for
  `FloatOption`. Invalid declarations raise at construction time (wrong type,
  `bool`, or `minimum > maximum`), so mistakes surface immediately.
* Detection is separated from policy. `OptionBounds.check()` (and the
  `IntOption`/`FloatOption.checked_convert()` wrappers) purely *detect* a
  violation and raise `OutOfBoundsError` — a `ValueError` subclass carrying the
  offending value and the `corrected` value (the nearest bound, or the option
  default for an invalid enum member). `OptionBounds.clamp()` / `convert()`
  layer the default "auto-correct and warn" policy on top. This split lets
  callers that should *not* silently correct (profile import) choose their own
  behaviour without changing how options are normally read.
* Clamping happens in `convert()`, i.e. **on read**, and logs a `warning` so an
  out-of-range value is diagnosable. Options without bounds behave exactly as
  before.
* `IntEnum`-backed options: bounds do not apply (an enum is a set of members,
  not an ordered range), but an invalid stored member now falls back to the
  option default with a targeted warning instead of raising a `ValueError` that
  was previously caught generically and logged as an error with a traceback.

**Applied to the numeric options** that have a meaningful range (rating_steps,
matching thresholds, server/proxy/browser ports, network timeout, fpcalc
threads, genre count/usage, track-duration tolerance, cover dimensions/quality,
media player volume/rate, update interval, session autosave interval, query
limit).

**Single source of truth for the UI** — `OptionsPage.apply_option_bounds()`
reads a spinbox's range from the option's bounds (rounding the minimum up and
the maximum down so the widget can never exceed the true range), replacing the
hardcoded ranges in the option pages. A `scale` argument covers the similarity
spinboxes that display `0.0..1.0` values as `0..100` percent.

**Plugin API** — `ConfigSection.register_option()` (used by plugins via
`api.plugin_config`) accepts `bounds=` and forwards it, so plugin authors get
the same protection. Documented in `docs/PLUGINSV3/API.md`.

### Safety, especially for profile import

Because clamping lives in `convert()`, the guarantee holds for **every** path
that produces an effective value:

* base configuration reads,
* active **profile overrides** (resolved through `opt.convert()`), and
* the options dialog preview (also routed through `opt.convert()`).

For **profile import** specifically, out-of-range values are *detected* at
import time using `checked_convert()` and recorded on the import result
(`ProfileImportResult.out_of_bounds`, with the offending and corrected values),
plus a human-readable summary warning. The current default policy still stores
the corrected (clamped) value so the imported profile stays usable, but the
correction is now **surfaced** rather than hidden — the information a caller
needs to let the user decide is available. This matters because imported
profiles come from external files that Picard did not produce and cannot assume
are well-formed.

### How upgrades are handled

Clamping is applied **on read, not as a one-time migration**, so upgrades are
safe and non-destructive:

* An existing out-of-range value (from an older release, a hand-edited config,
  or a shared profile) is clamped to the nearest bound the next time it is read,
  and a warning is logged. The application never sees an out-of-range value.
* The stored value on disk is left untouched until the option is next written
  (e.g. the user opens and saves the relevant options page), at which point it
  is persisted normalized. Nothing is rewritten behind the user's back.
* Tightening a range in a future release therefore requires no migration hook:
  a value that was valid before and is now out of range simply starts being
  clamped on read. (If a hard, persisted migration is ever needed for a
  specific option, the existing `config_upgrade_hooks` remain the right tool.)

### Testing

* Full unit coverage of the bounds mechanism (in-range, below/above, clamp
  warnings, `bool`/`float`/`min > max` rejection, `IntEnum` bypass and invalid
  member fallback, stored-value path) in `test/test_config.py`.
* Detection vs. policy: `checked_convert()` raises `OutOfBoundsError` (carrying
  `value`/`corrected`) without logging; `convert()` clamps and warns.
* `register_option(bounds=...)` forwarding and end-to-end clamping through a
  plugin config section.
* `OptionsPage.apply_option_bounds()` including the `scale` and ceil/floor
  rounding behavior.
* Profile import: out-of-range values are recorded on
  `ProfileImportResult.out_of_bounds` and reported, in-range values are not, in
  `test/test_profile_import.py`.

### Future work (not in this PR)

Now that out-of-range values are *detected and reported* at import time rather
than silently corrected, a natural follow-up is to let the user **decide** what
to do about them (clamp to the nearest bound / keep the original value / skip
the option / cancel the import). This was intentionally left out of this PR:
the policy needs to work for both the GUI importer (an interactive dialog) and
the CLI importer (a non-interactive flag such as
`--on-out-of-bounds=clamp|keep|skip|fail`), so it deserves its own design and
change rather than a GUI-only prompt. The config/importer layers here already
expose everything that follow-up needs (`OutOfBoundsError.corrected`,
`checked_convert()`, and `ProfileImportResult.out_of_bounds`).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Developed with Kiro CLI under human direction and review. Design decisions
(the `bounds=(min, max)` API, the `OptionBounds` value objects, clamp-on-read
semantics, the detection/policy split via `OutOfBoundsError`/`checked_convert`,
UI single-source-of-truth wiring, invalid-enum fallback, and import-time
detection/reporting) were driven and reviewed by a human; each option's bound
was cross-checked against its real usage and existing UI range. All tests were
run and pass.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

This is a draft pending a `PICARD-XXXX` ticket, which will be added to the PR
title before it is marked ready for review.
