### PR TITLE
Convert remaining test loops to subtest_cases

### DIFF
--- a/test/formats/test_mp4.py
+++ b/test/formats/test_mp4.py
@@ -23,6 +23,8 @@ from types import MappingProxyType
 
 import mutagen
 
+from test.picardtestcase import subtest_cases
+
 from picard.metadata import Metadata
 
 from .common import (
@@ -139,12 +141,19 @@ class CommonMP4Tests:
             self.assertEqual('', loaded_metadata['totaltracks'])
 
         @skipUnlessTestfile
-        def test_invalid_int_tag(self):
-            for tag in ('bpm', 'movementnumber', 'movementtotal', 'showmovement'):
-                with self.subTest(tag=tag):
-                    metadata = Metadata({tag: 'notanumber'})
-                    loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
-                    self.assertNotIn(tag, loaded_metadata)
+        @subtest_cases(
+            "tag",
+            [
+                'bpm',
+                'movementnumber',
+                'movementtotal',
+                'showmovement',
+            ],
+        )
+        def test_invalid_int_tag(self, tag):
+            metadata = Metadata({tag: 'notanumber'})
+            loaded_metadata = save_and_load_metadata(self.format_registry, self.filename, metadata)
+            self.assertNotIn(tag, loaded_metadata)
 
 
 class M4ATest(CommonMP4Tests.MP4TestCase):

--- a/test/formats/test_vorbis.py
+++ b/test/formats/test_vorbis.py
@@ -36,6 +36,7 @@ from mutagen.flac import (
 from test.picardtestcase import (
     PicardTestCase,
     create_fake_png,
+    subtest_cases,
 )
 
 from picard import config
@@ -479,20 +480,22 @@ class VorbisUtilTest(PicardTestCase):
 class FlacCoverArtTest(CommonCoverArtTests.CoverArtTestCase):
     testfile = 'test.flac'
 
-    def test_set_picture_dimensions(self):
-        tests = [
-            CoverArtImage(data=self.jpegdata),
-            CoverArtImage(data=self.pngdata),
-        ]
-        for test in tests:
-            with self.subTest(image=test.mimetype):
-                file_save_image(self.format_registry, self.filename, test)
-                raw_metadata = load_raw(self.filename)
-                pic = raw_metadata.pictures[0]
-                self.assertNotEqual(pic.width, 0)
-                self.assertEqual(pic.width, test.width)
-                self.assertNotEqual(pic.height, 0)
-                self.assertEqual(pic.height, test.height)
+    @subtest_cases(
+        "image_data_attr",
+        [
+            'jpegdata',
+            'pngdata',
+        ],
+    )
+    def test_set_picture_dimensions(self, image_data_attr):
+        test = CoverArtImage(data=getattr(self, image_data_attr))
+        file_save_image(self.format_registry, self.filename, test)
+        raw_metadata = load_raw(self.filename)
+        pic = raw_metadata.pictures[0]
+        self.assertNotEqual(pic.width, 0)
+        self.assertEqual(pic.width, test.width)
+        self.assertNotEqual(pic.height, 0)
+        self.assertEqual(pic.height, test.height)
 
     def test_save_large_pics(self):
         # 16 MB image

--- a/test/plugins3/test_validator.py
+++ b/test/plugins3/test_validator.py
@@ -153,7 +153,7 @@ class TestManifestValidator(PicardTestCase):
 
     @subtest_cases(
         "locale",
-        ['en', 'de', 'fr', 'pt', 'en_US', 'pt_BR', 'zh_CN'],
+        ['en', 'de', 'fr', 'pt', 'en_US', 'pt_BR', 'zh_CN', 'haw', 'haw_US'],
     )
     def test_validate_source_locale_valid(self, locale):
         manifest = _valid_manifest()
@@ -163,7 +163,18 @@ class TestManifestValidator(PicardTestCase):
 
     @subtest_cases(
         "locale",
-        ['', 'e', 'english', 'en-US', 'en_us', 'EN', 'en_USA', '123'],
+        {
+            'empty': ('',),
+            'single letter': ('e',),
+            'full word': ('english',),
+            'hyphen separator': ('en-US',),
+            'lowercase region': ('en_us',),
+            'uppercase language': ('EN',),
+            'three-letter region': ('en_USA',),
+            'digits': ('123',),
+            'trailing space': ('en ',),
+            'one-letter region': ('en_U',),
+        },
     )
     def test_validate_source_locale_invalid_format(self, locale):
         manifest = _valid_manifest()

--- a/test/plugins3/test_validator.py
+++ b/test/plugins3/test_validator.py
@@ -17,7 +17,10 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    subtest_cases,
+)
 
 from picard.plugin3.validator import (
     PLACEHOLDER_UUIDS,
@@ -148,25 +151,28 @@ class TestManifestValidator(PicardTestCase):
         errors = validate_manifest_dict(manifest)
         self.assertEqual(errors, [])
 
-    def test_validate_source_locale(self):
-        """Test validation of source_locale field."""
+    @subtest_cases(
+        "locale",
+        ['en', 'de', 'fr', 'pt', 'en_US', 'pt_BR', 'zh_CN'],
+    )
+    def test_validate_source_locale_valid(self, locale):
         manifest = _valid_manifest()
+        manifest['source_locale'] = locale
+        errors = validate_manifest_dict(manifest)
+        self.assertEqual(errors, [])
 
-        # Valid locales
-        for locale in ['en', 'de', 'fr', 'pt', 'en_US', 'pt_BR', 'zh_CN']:
-            with self.subTest(locale=locale):
-                manifest['source_locale'] = locale
-                errors = validate_manifest_dict(manifest)
-                self.assertEqual(errors, [])
+    @subtest_cases(
+        "locale",
+        ['', 'e', 'english', 'en-US', 'en_us', 'EN', 'en_USA', '123'],
+    )
+    def test_validate_source_locale_invalid_format(self, locale):
+        manifest = _valid_manifest()
+        manifest['source_locale'] = locale
+        errors = validate_manifest_dict(manifest)
+        self.assertTrue(any('source_locale' in e for e in errors))
 
-        # Invalid formats
-        for locale in ['', 'e', 'english', 'en-US', 'en_us', 'EN', 'en_USA', '123']:
-            with self.subTest(locale=locale):
-                manifest['source_locale'] = locale
-                errors = validate_manifest_dict(manifest)
-                self.assertTrue(any('source_locale' in e for e in errors))
-
-        # Wrong type
+    def test_validate_source_locale_wrong_type(self):
+        manifest = _valid_manifest()
         manifest['source_locale'] = 123
         errors = validate_manifest_dict(manifest)
         self.assertIn("Field 'source_locale' must be a string", errors)
@@ -356,32 +362,29 @@ code block
         errors = validate_manifest_dict(manifest)
         self.assertEqual(errors, [], "Valid complex markdown should not produce errors")
 
-    def test_validate_placeholder_uuids(self):
+    @subtest_cases("uuid", PLACEHOLDER_UUIDS)
+    def test_validate_placeholder_uuids(self, uuid):
         """Test validation catches various placeholder/test UUIDs."""
-        for uuid in PLACEHOLDER_UUIDS:
-            with self.subTest(uuid=uuid):
-                manifest = _valid_manifest(uuid=uuid)
-                errors = validate_manifest_dict(manifest)
-                self.assertTrue(any('placeholder/test UUID' in e for e in errors))
+        manifest = _valid_manifest(uuid=uuid)
+        errors = validate_manifest_dict(manifest)
+        self.assertTrue(any('placeholder/test UUID' in e for e in errors))
 
-    def test_validate_all_known_placeholders_fail_entropy(self):
+    @subtest_cases("uuid", PLACEHOLDER_UUIDS)
+    def test_validate_all_known_placeholders_fail_entropy(self, uuid):
         """Test that all UUIDs in PLACEHOLDER_UUIDS fail Shannon entropy check."""
-        for placeholder_uuid in PLACEHOLDER_UUIDS:
-            with self.subTest(uuid=placeholder_uuid):
-                self.assertTrue(
-                    _is_placeholder_uuid(placeholder_uuid), f"UUID {placeholder_uuid} should be detected as placeholder"
-                )
+        self.assertTrue(_is_placeholder_uuid(uuid), f"UUID {uuid} should be detected as placeholder")
 
-    def test_validate_real_uuids(self):
-        """Test that real UUIDs are not flagged as placeholders."""
-        real_uuids = [
+    @subtest_cases(
+        "uuid",
+        [
             '74807b76-c451-419f-bbd4-42a78e2444a6',  # ReplayGain plugin
             '550e8400-e29b-41d4-a716-446655440000',
             'f47ac10b-58cc-4372-a567-0e02b2c3d479',
             '3d6f0e4a-8c9b-4f2e-a1d7-5b8c9e0f1a2b',
-        ]
-        for uuid in real_uuids:
-            with self.subTest(uuid=uuid):
-                manifest = _valid_manifest(uuid=uuid)
-                errors = validate_manifest_dict(manifest)
-                self.assertEqual(errors, [])
+        ],
+    )
+    def test_validate_real_uuids(self, uuid):
+        """Test that real UUIDs are not flagged as placeholders."""
+        manifest = _valid_manifest(uuid=uuid)
+        errors = validate_manifest_dict(manifest)
+        self.assertEqual(errors, [])

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -30,7 +30,10 @@ from urllib.parse import (
     urlparse,
 )
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    subtest_cases,
+)
 
 from picard.browser.filelookup import FileLookup
 from picard.browser.server import (
@@ -335,25 +338,27 @@ class RequestHandlerAuthTest(PicardTestCase):
         self.assertIn(b'Authentication successful', response)
         self.assertIn(b'<!doctype html>', response)
 
-    def test_auth_invalid_state(self):
-        """An invalid state should return 400 regardless of code or error."""
-        self.oauth_manager.verify_state.side_effect = OAuthInvalidStateError()
-        for path in (
+    @subtest_cases(
+        "path",
+        [
             '/auth?code=auth_code_123&state=bad',
             '/auth?error=access_denied&state=bad',
-        ):
-            with self.subTest(path=path):
-                self.oauth_manager.verify_state.reset_mock()
-                handler = self._make_handler(path)
+        ],
+    )
+    def test_auth_invalid_state(self, path):
+        """An invalid state should return 400 regardless of code or error."""
+        self.oauth_manager.verify_state.side_effect = OAuthInvalidStateError()
+        self.oauth_manager.verify_state.reset_mock()
+        handler = self._make_handler(path)
 
-                handler._handle_get()
+        handler._handle_get()
 
-                self.oauth_manager.verify_state.assert_called_once_with('bad')
-                self.callback.assert_not_called()
-                response = handler.wfile.getvalue()
-                self.assertIn(b'400', response)
-                self.assertIn(b'<!doctype html>', response)
-                self.assertIn(b'Authentication error', response)
+        self.oauth_manager.verify_state.assert_called_once_with('bad')
+        self.callback.assert_not_called()
+        response = handler.wfile.getvalue()
+        self.assertIn(b'400', response)
+        self.assertIn(b'<!doctype html>', response)
+        self.assertIn(b'Authentication error', response)
 
     def test_auth_no_code_no_error(self):
         """When auth has neither code nor error, return 400 with a styled page."""


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Follow-up to #3375: convert the remaining "cases defined in a list" test loops
  onto the `subtest_cases` decorator, and add a few previously untested locale
  cases now that those checks are table-driven. Test-only, no production code
  changes.

## Problem

* JIRA ticket (_optional_): none (test-only refactor)

In the review of #3375 (@phw on `test/formats/test_vorbis.py`) it was noted that
a test iterating a hardcoded list of cases with a manual
`for … : with self.subTest(): …` loop is the typical case for the new
`subtest_cases` decorator. A few such loops remained across the suite after that
PR merged.

## Solution

Convert the loops that iterate a genuine list of independent cases onto
`subtest_cases`, one file per commit:

* `test/formats/test_vorbis.py` — `test_set_picture_dimensions` (the exact test
  from the review comment). The images are built from instance data
  (`self.jpegdata` / `self.pngdata`), which is not available at decoration time,
  so the decorator parametrizes over the attribute name and the body resolves it.
* `test/formats/test_mp4.py` — `test_invalid_int_tag` (static tuple of tag names).
* `test/plugins3/test_validator.py` — the source_locale valid/invalid lists, the
  placeholder-UUID checks and the real-UUID list. `test_validate_source_locale`
  is split into `_valid`, `_invalid_format` and `_wrong_type`; the first two are
  case lists, the trailing wrong-type check is a single scalar assertion.
* `test/test_browser.py` — `test_auth_invalid_state` (list of request paths).

A final commit uses the now table-driven locale checks to add cases the regex
(`^[a-z]{2,3}(_[A-Z]{2})?$`) supports but no test exercised: three-letter
language codes (`haw`, `haw_US`), and two realistic malformed inputs (a trailing
space, a one-letter region). The invalid table also moves to the labelled-mapping
form so tricky inputs are self-documenting (the trailing-space case is otherwise
easy to misread as the valid `en`).

Loops that iterate fixture, instance or module-derived collections
(`self.replaygain_tags`, `VALID_KEYS`, `range(6)`, `ALL_TAGS`, `metadata.rawitems()`,
locally-constructed lists, …) are intentionally left as manual `subTest` loops:
their values are not available at decoration time, so they are not the pattern
`subtest_cases` is for. The grouped `test_plural_rules` data is also left as-is,
where flattening would reduce readability.

### Verification

* Coverage was compared between `upstream/master` and this branch for the touched
  modules (`picard.formats`, `picard.plugin3.validator`, `picard.browser`): it is
  **identical** — the conversions change only how cases are structured and
  reported, not which code paths run. The added locale cases guard the regex
  behaviorally; they do not change line coverage (the 3-letter branch shares the
  same regex line as the 2-letter path).
* All affected suites pass: `test/formats/`, `test/plugins3/test_validator.py`,
  `test/test_browser.py`.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Written with Kiro CLI, reviewed and directed interactively. Each conversion was
checked to preserve the original cases, and coverage parity with master was
verified from tool output during the session.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
