### PR TITLE
Fix local cover art default types and subdirectory path join

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -105,7 +105,7 @@ class CoverArtProviderLocal(CoverArtProvider):
 
     _types_split_re = re.compile('[^a-z0-9]', re.IGNORECASE)
     _known_types = frozenset(t['name'] for t in CAA_TYPES)
-    _default_types = tuple('front')
+    _default_types = ('front',)
 
     def queue_images(self):
         config = get_config()
@@ -133,7 +133,7 @@ class CoverArtProviderLocal(CoverArtProvider):
                 m = match_re.search(filename)
                 if not m:
                     continue
-                filepath = os.path.join(current_dir, root, filename)
+                filepath = os.path.join(root, filename)
                 if not os.path.exists(filepath):
                     continue
                 try:

--- a/test/test_coverartprovider_local.py
+++ b/test/test_coverartprovider_local.py
@@ -1,0 +1,117 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+import os
+import re
+
+from test.picardtestcase import PicardTestCase
+
+from picard.coverart.providers.local import CoverArtProviderLocal
+
+
+class LocalCoverArtTestBase(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.provider = CoverArtProviderLocal.__new__(CoverArtProviderLocal)
+        self.provider._default_types = ['front']
+        self.provider._types_split_re = CoverArtProviderLocal._types_split_re
+        self.provider._known_types = CoverArtProviderLocal._known_types
+        self.tmpdir = self.mktmpdir()
+
+    def _create_files(self, filenames):
+        for name in filenames:
+            path = os.path.join(self.tmpdir, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            open(path, 'w').close()
+
+    def _filenames(self, results):
+        return sorted(os.path.basename(r.url.toLocalFile()) for r in results)
+
+
+class FindLocalImagesRegexTest(LocalCoverArtTestBase):
+    def _find(self, regex):
+        match_re = re.compile(regex, re.IGNORECASE)
+        return list(self.provider.find_local_images(self.tmpdir, match_re))
+
+    def test_simple_match(self):
+        self._create_files(['cover.jpg', 'back.jpg'])
+        results = self._find(r'cover')
+        self.assertEqual(['cover.jpg'], self._filenames(results))
+
+    def test_case_insensitive(self):
+        self._create_files(['Cover.JPG', 'FRONT.png'])
+        results = self._find(r'front')
+        self.assertEqual(['FRONT.png'], self._filenames(results))
+
+    def test_no_match(self):
+        self._create_files(['song.mp3', 'notes.txt'])
+        results = self._find(r'cover')
+        self.assertEqual([], self._filenames(results))
+
+    def test_type_extraction_from_group(self):
+        self._create_files(['front.jpg'])
+        results = self._find(r'(front)\.jpg')
+        self.assertEqual(['front.jpg'], self._filenames(results))
+        self.assertIn('front', results[0].types)
+
+    def test_type_extraction_back(self):
+        self._create_files(['back.png'])
+        results = self._find(r'(back)\.')
+        self.assertEqual(['back.png'], self._filenames(results))
+        self.assertIn('back', results[0].types)
+
+    def test_no_group_uses_default_types(self):
+        self._create_files(['cover.jpg'])
+        results = self._find(r'cover\.jpg')
+        self.assertEqual(['cover.jpg'], self._filenames(results))
+        self.assertEqual(['front'], results[0].types)
+
+    def test_multiple_matches(self):
+        self._create_files(['cover.jpg', 'cover.png', 'back.jpg'])
+        results = self._find(r'cover\.')
+        self.assertEqual(['cover.jpg', 'cover.png'], self._filenames(results))
+
+    def test_match_in_subdirectory(self):
+        self._create_files([os.path.join('sub', 'cover.jpg')])
+        results = self._find(r'cover')
+        self.assertEqual(['cover.jpg'], self._filenames(results))
+        self.assertTrue(os.path.exists(results[0].url.toLocalFile()))
+
+    def test_match_with_relative_start_dir(self):
+        # Regression: os.walk(current_dir) yields a root that already includes
+        # current_dir. The returned filepath must be os.path.join(root,
+        # filename); joining current_dir + root + filename double-prepends the
+        # base directory when current_dir is relative, producing a path that
+        # never exists (so the image is silently dropped).
+        self._create_files([os.path.join('sub', 'cover.jpg')])
+        match_re = re.compile(r'cover', re.IGNORECASE)
+        cwd = os.getcwd()
+        try:
+            os.chdir(self.tmpdir)
+            results = list(self.provider.find_local_images('sub', match_re))
+        finally:
+            os.chdir(cwd)
+        self.assertEqual(['cover.jpg'], self._filenames(results))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, results[0].url.toLocalFile())))
+
+
+class DefaultTypesTest(PicardTestCase):
+    def test_default_types_is_single_front(self):
+        # Regression: _default_types must be the single-element tuple
+        # ('front',), not tuple('front') which explodes into
+        # ('f', 'r', 'o', 'n', 't').
+        self.assertEqual(('front',), CoverArtProviderLocal._default_types)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes two latent correctness bugs in the Local Files cover art provider — the default cover art type tuple and a double-prepended file path when scanning sub-directories.

## Problem

Two small but real bugs in `picard/coverart/providers/local.py`:

1. `_default_types = tuple('front')` builds `('f', 'r', 'o', 'n', 't')` instead of the intended single `('front',)` type. Any cover art matched without an explicit type would be assigned five bogus one-letter types instead of "front".
2. `find_local_images()` builds the file path as `os.path.join(current_dir, root, filename)`. Since `os.walk(current_dir)` already yields `root` values prefixed with `current_dir`, this double-prepends the base directory when `current_dir` is relative, producing a path that never exists — so matching cover art in sub-directories is silently dropped.

* JIRA ticket (_optional_): none

## Solution

* Use `('front',)` for `_default_types`.
* Use `os.path.join(root, filename)` in `find_local_images()`.
* Add `test/test_coverartprovider_local.py` covering the regular-expression matching path, plus a dedicated regression test for each fix. The sub-directory regression test uses a relative start directory so it actually reproduces the double-prepend bug (with an absolute directory the incorrect join happens to collapse and the bug is hidden).

Verified locally: `pytest test/test_coverartprovider_local.py` passes, `ruff check`/`ruff format` clean, `ty check` clean on the changed file.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The fixes and regression tests were developed with AI assistance (code structure and test development); the changes were reviewed and verified by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
