### PR TITLE
PICARD-3407: Add `is_from_mb` flag to plugin `register_script_variable()` function

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -800,7 +800,7 @@ def enable(api):
 
 ---
 
-#### `register_script_variable(name, documentation=None, title=None, is_multi_value=False)`
+#### `register_script_variable(name, documentation=None, title=None, is_multi_value=False, is_from_mb=False)`
 
 Register a variable name for script autocomplete and tag dropdowns.
 
@@ -847,6 +847,8 @@ def enable(api):
   the UI.
 - `is_multi_value`: Whether this variable can hold multiple values
   (default: `False`).
+- `is_from_mb`: Whether the tag information is provided from the MusicBrainz
+  database (default: `False`).
 
 **Raises**: `ValueError` if:
 - The variable name is invalid (must use only letters, digits, underscores).

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -67,6 +67,7 @@ def register_script_variable(
     api: 'PluginApi | None' = None,
     title: str | None = None,
     is_multi_value: bool = False,
+    is_from_mb: bool = False,
 ) -> None:
     """Register a variable that plugins can provide for script completion.
 
@@ -88,6 +89,8 @@ def register_script_variable(
         If provided, the tag will show this title instead of the raw name.
     is_multi_value : bool, optional
         Whether this variable can hold multiple values. Default: False.
+    is_from_mb : bool, optional
+        Whether the tag information is provided from the MusicBrainz database. Default: False.
 
     Examples
     --------
@@ -140,13 +143,13 @@ def register_script_variable(
             longdesc=documentation,
             is_hidden=is_hidden,
             is_multi_value=is_multi_value,
+            is_from_mb=is_from_mb,
             # Locked attributes for plugin-registered variables
             is_preserved=False,
             is_script_variable=True,
             is_tag=not is_hidden,
             is_calculated=False,
             is_file_info=False,
-            is_from_mb=False,
             is_populated_by_picard=False,
             plugin_id=plugin_id,
             plugin_name=plugin_name,

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -1373,6 +1373,7 @@ class PluginApi:
         documentation: str | None = None,
         title: str | None = None,
         is_multi_value: bool = False,
+        is_from_mb: bool = False,
     ) -> None:
         """Register a variable name for script autocomplete.
 
@@ -1387,6 +1388,8 @@ class PluginApi:
                 instead of the raw name.
             is_multi_value: Whether this variable can hold multiple
                 values. Default: False.
+            is_from_mb: Whether the tag information is provided from the
+                MusicBrainz database. Default: False.
 
         Example:
             def enable(api):
@@ -1408,6 +1411,7 @@ class PluginApi:
             self,
             title=title,
             is_multi_value=is_multi_value,
+            is_from_mb=is_from_mb,
         )
 
     def unregister_script_variable(self, name: str) -> None:

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -253,6 +253,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         self.assertTrue(var.is_tag)
         self.assertFalse(var.is_hidden)
         self.assertFalse(var.is_multi_value)
+        self.assertFalse(var.is_from_mb)
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
@@ -325,6 +326,12 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('multi_var', 'docs', is_multi_value=True)
         var = self._get_tagvar_by_name('multi_var')
         self.assertTrue(var.is_multi_value)
+
+    def test_register_script_variable_is_from_mb(self):
+        """is_from_mb parameter should be passed through to the TagVar."""
+        register_script_variable('from_mb', 'docs', is_from_mb=True)
+        var = self._get_tagvar_by_name('from_mb')
+        self.assertTrue(var.is_from_mb)
 
     def test_register_script_variable_deduplication(self):
         """Registering the same variable twice from the same plugin should update, not duplicate."""


### PR DESCRIPTION

<!-- pyml disable-next-line first-line-heading-->
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Some plugins such as "Additional Artists Variables" register variables with the information coming from MusicBrainz, however the current plugin registration locks the `TagVar.is_from_mb` flag as `False` so that the note on the help shows the message, "not provided from MusicBrainz data".  This is incorrect, and possibly misleading.

* JIRA ticket (_optional_): PICARD-3407


## Solution

Expose the `is_from_mb` flag as an optional argument to the `register_script_variable()` method, with a default value of `False`.


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)


## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
