### PR TITLE
PICARD-3408: Enable debug-level logging when any --debug-opts is set

### DIFF
--- a/picard/cli/_bootstrap.py
+++ b/picard/cli/_bootstrap.py
@@ -84,13 +84,15 @@ def init_logging(args):
     debug = getattr(args, 'debug', False)
     debug_opts = getattr(args, 'debug_opts', None)
 
-    if not debug and not debug_opts:
-        log.set_verbosity(logging.WARNING)
-    else:
-        log.set_verbosity(logging.DEBUG)
-
     if debug_opts:
         DebugOpt.from_string(debug_opts)
+
+    # Enabling any debug option implies debug-level logging, otherwise its
+    # log.debug() output would be silently discarded.
+    if debug or DebugOpt.any_enabled():
+        log.set_verbosity(logging.DEBUG)
+    else:
+        log.set_verbosity(logging.WARNING)
 
 
 def is_color_disabled(args):

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -157,6 +157,16 @@ class DebugOptEnum(int, Enum):
         """Returns current storage for enabled debug options"""
         return cls.__registry__
 
+    @classmethod
+    def any_enabled(cls):
+        """Returns True if at least one debug option is currently enabled.
+
+        Useful to decide whether debug-level logging should be forced on, so
+        that the log.debug() output guarded by these options is actually
+        emitted.
+        """
+        return bool(cls.__registry__)
+
 
 class DebugOpt(DebugOptEnum):
     PLUGIN_FULLPATH = 1, N_('Plugin Fullpath'), N_('Log plugin full paths')

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -302,12 +302,15 @@ class Tagger(QtWidgets.QApplication):
 
     def _init_logging(self, config):
         """Initialize logging & audit"""
-        log.set_verbosity(logging.DEBUG if self._debug else config.setting['log_verbosity'])
-
-        setup_audit(self._audit)
-
+        # Enabling any debug option implies debug-level logging, otherwise its
+        # log.debug() output would be silently discarded at the default
+        # verbosity. This mirrors the CLI behaviour (see picard/cli/_bootstrap.py).
         if self._debug_opts:
             DebugOpt.from_string(self._debug_opts)
+        debug = self._debug or DebugOpt.any_enabled()
+        log.set_verbosity(logging.DEBUG if debug else config.setting['log_verbosity'])
+
+        setup_audit(self._audit)
 
     def _init_threads(self):
         """Initialize threads"""

--- a/test/test_debug_opt.py
+++ b/test/test_debug_opt.py
@@ -53,6 +53,21 @@ class TestDebugOpt(PicardTestCase):
     def test_opt_names(self):
         self.assertEqual(DebugOptTestCase.opt_names(), 'a,b')
 
+    def test_any_enabled(self):
+        self.assertFalse(DebugOptTestCase.any_enabled())
+        DebugOptTestCase.A.enabled = True
+        self.assertTrue(DebugOptTestCase.any_enabled())
+        DebugOptTestCase.A.enabled = False
+        self.assertFalse(DebugOptTestCase.any_enabled())
+
+    def test_any_enabled_after_invalid_from_string(self):
+        # An unknown option string enables nothing, so debug logging must not
+        # be forced on.
+        DebugOptTestCase.from_string('bogus')
+        self.assertFalse(DebugOptTestCase.any_enabled())
+        DebugOptTestCase.from_string('a')
+        self.assertTrue(DebugOptTestCase.any_enabled())
+
     def test_from_string_simple(self):
         DebugOptTestCase.from_string('a')
         self.assertTrue(DebugOptTestCase.A.enabled)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:
  Enable debug-level logging whenever a valid `--debug-opts` option is set, so
  the `log.debug()` output guarded by those options is actually emitted.

## Problem

* JIRA ticket: PICARD-3408

Passing `--debug-opts=<opt>` enabled the debug option but did not raise the log
verbosity to DEBUG unless `--debug` was also given. As a result, the
`log.debug()` output guarded by those options was silently discarded, making
the options appear to do nothing.

## Solution

Add `DebugOptEnum.any_enabled()` and use it in both startup paths — the GUI
(`Tagger._init_logging`) and the CLI (`_bootstrap.init_logging`) — so that
enabling any debug option implies debug-level logging. The verbosity decision
is made *after* parsing the options, so an unknown option string (which enables
nothing) does not force DEBUG.

Adds unit tests for `any_enabled()`, including the invalid-option case.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
