### PR TITLE
PICARD-3409: Store single-valued Metadata tags as bare str to cut memory use

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -85,7 +85,11 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         **kwargs,
     ):
         self._lock = ReadWriteLockContext()
-        self._store: dict[str, list[str]] = dict()
+        # Values are stored either as a bare ``str`` (single value) or a
+        # ``list[str]`` (multiple values) to save memory on the common
+        # single-valued case. Use the accessors (getall/getraw/rawitems), which
+        # always present values as lists.
+        self._store: dict[str, str | list[str]] = dict()
         self.deleted_tags: set[str] = set()
         self.images: ImageList = ImageList()
         self.has_common_images = True
@@ -186,8 +190,22 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
             return m
 
     def _update_from_metadata(self, other, copy_images=True):
-        for k, v in other.rawitems():
-            self._set(k, v[:])
+        other_store = getattr(other, '_store', None)
+        if other_store is not None and type(other) is type(self):
+            # Fast path for Metadata->Metadata: copy the internal store
+            # directly. Bare str values are immutable so can be shared; only
+            # multi-value lists need a shallow copy. This avoids the
+            # list-normalization allocations of rawitems()/_set().
+            store = self._store
+            for k, v in other_store.items():
+                store[k] = v[:] if type(v) is list else v
+            # The tags we just copied are now set, so drop them from the list
+            # of deleted tags (mirrors the deleted_tags.discard() that _set()
+            # does on the slow path below).
+            self.deleted_tags.difference_update(other_store.keys())
+        else:
+            for k, v in other.rawitems():
+                self._set(k, v[:])
 
         for tag in other.deleted_tags:
             self._del(tag)
@@ -211,20 +229,35 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
     def normalize_tag(name: str):
         return name.rstrip(':')
 
+    @staticmethod
+    def _as_list(stored) -> list[str]:
+        """Present a stored entry (bare str or list) as a list of strings.
+
+        For the bare-str case a new 1-element list is returned. For the
+        multi-value case the stored list is returned as-is (not copied),
+        matching the prior behavior of getall()/getraw(); no caller mutates
+        the returned list in place.
+        """
+        if type(stored) is str:
+            return [stored]
+        return stored
+
     def getall(self, name: str) -> list[str]:
         """Return all values for a tag as a list.
 
-        Metadata is always stored internally as a list of strings.
+        Values are presented as a list regardless of the internal storage
+        (a single value is stored as a bare str, multiple as a list).
         Use this method when you need the individual values (e.g., multiple
         artists or labels). Returns an empty list if the tag is not set.
         """
         with self._lock.lock_for_read():
-            return self._store.get(self.normalize_tag(name), [])
+            stored = self._store.get(self.normalize_tag(name))
+            return [] if stored is None else self._as_list(stored)
 
     def getraw(self, name: str):
         """Return the raw stored list for a tag, raising KeyError if missing."""
         with self._lock.lock_for_read():
-            return self._store[self.normalize_tag(name)]
+            return self._as_list(self._store[self.normalize_tag(name)])
 
     def get(self, name: str, default=None) -> str | None:
         """Return all values joined into a single string.
@@ -234,11 +267,15 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         Returns `default` if the tag is not set.
         """
         with self._lock.lock_for_read():
-            values = self._store.get(self.normalize_tag(name), None)
-            if values:
-                return self.multi_valued_joiner.join(values)
-            else:
+            stored = self._store.get(self.normalize_tag(name), None)
+            if stored is None:
                 return default
+            if type(stored) is str:
+                # Single value stored bare; return as-is (do not char-join).
+                return stored or default
+            if stored:
+                return self.multi_valued_joiner.join(stored)
+            return default
 
     def __getitem__(self, name: str) -> str:
         """Return all values joined as a string, or empty string if unset.
@@ -251,17 +288,22 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
     def _set(self, name, values):
         """Store values for a tag.
 
-        Values are always stored as a list internally. A single string is
-        wrapped in a list. To store multiple values, pass a list of strings
-        (do NOT join them with MULTI_VALUED_JOINER).
+        A single value is stored internally as a bare ``str`` and multiple
+        values as a ``list[str]``. This avoids a one-element list wrapper for
+        the common single-valued case, which is a significant per-object memory
+        saving across large collections. All public accessors
+        (:meth:`getall`, :meth:`getraw`, :meth:`rawitems`, :meth:`items`) still
+        present values as lists, so the external contract is unchanged.
         """
         name = self.normalize_tag(name)
         if isinstance(values, str) or not isinstance(values, Iterable):
             values = [values]
         values = [str(value) for value in values if value or value == 0 or value == '']
         # Remove if there is only a single empty or blank element.
-        if values and (len(values) > 1 or values[0]):
-            self._store[name] = values
+        count = len(values)
+        if count and (count > 1 or values[0]):
+            # Store a bare str for the single-value case to save memory.
+            self._store[name] = values if count > 1 else values[0]
             self.deleted_tags.discard(name)
         elif name in self._store:
             self._del(name)
@@ -316,7 +358,15 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         if value or value == 0:
             with self._lock.lock_for_write():
                 name = self.normalize_tag(name)
-                self._store.setdefault(name, []).append(str(value))
+                stored = self._store.get(name)
+                if stored is None:
+                    # First value: store bare str.
+                    self._store[name] = str(value)
+                elif isinstance(stored, str):
+                    # Promote single bare str to a list on second value.
+                    self._store[name] = [stored, str(value)]
+                else:
+                    stored.append(str(value))
                 self.deleted_tags.discard(name)
 
     def add_unique(self, name: str, value: str):
@@ -343,9 +393,12 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
 
     def items(self):
         with self._lock.lock_for_read():
-            for name, values in self._store.items():
-                for value in values:
-                    yield name, value
+            for name, stored in self._store.items():
+                if isinstance(stored, str):
+                    yield name, stored
+                else:
+                    for value in stored:
+                        yield name, value
 
     def rawitems(self):
         """Returns the metadata items.
@@ -353,7 +406,7 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         >>> m.rawitems()
         [("key1", ["value1", "value2"]), ("key2", ["value3"])]
         """
-        return self._store.items()
+        return [(name, self._as_list(stored)) for name, stored in self._store.items()]
 
     def apply_func(self, func: Callable[[str], str]):
         with self._lock.lock_for_write():

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -134,7 +134,12 @@ class CommonTests:
             self.assertEqual([], self.metadata.getall("nonexistent"))
             self.assertRaises(KeyError, self.metadata.getraw, "nonexistent")
 
-            self.assertEqual(self.metadata._store.items(), self.metadata.rawitems())
+            # rawitems() always presents values as lists (its documented
+            # contract), regardless of the internal single-value storage.
+            raw = dict(self.metadata.rawitems())
+            self.assertEqual(raw, {name: self.metadata.getall(name) for name in self.metadata})
+            for _name, values in self.metadata.rawitems():
+                self.assertIsInstance(values, list)
             metadata_items = [(x, z) for (x, y) in self.metadata.rawitems() for z in y]
             self.assertEqual(metadata_items, list(self.metadata.items()))
 
@@ -143,6 +148,41 @@ class CommonTests:
             self.assertNotIn("single1", self.metadata)
             self.assertNotIn("single1", self.metadata.deleted_tags)
             self.metadata.unset('unknown_tag')
+
+        def test_single_value_no_char_join(self):
+            # A multi-character single value must not be split/joined per char.
+            self.metadata['solo'] = 'HelloWorld'
+            self.assertEqual('HelloWorld', self.metadata['solo'])
+            self.assertEqual('HelloWorld', self.metadata.get('solo'))
+            self.assertEqual(['HelloWorld'], self.metadata.getall('solo'))
+            self.assertEqual(['HelloWorld'], self.metadata.getraw('solo'))
+            solo_items = [(k, v) for k, v in self.metadata.items() if k == 'solo']
+            self.assertEqual([('solo', 'HelloWorld')], solo_items)
+
+        def test_add_promotes_single_to_multi(self):
+            self.metadata['g'] = 'Rock'
+            self.assertEqual(['Rock'], self.metadata.getall('g'))
+            self.metadata.add('g', 'Jazz')
+            self.assertEqual(['Rock', 'Jazz'], self.metadata.getall('g'))
+            self.metadata.add('g', 'Blues')
+            self.assertEqual(['Rock', 'Jazz', 'Blues'], self.metadata.getall('g'))
+
+        def test_add_first_value(self):
+            self.metadata.add('newtag', 'OnlyValue')
+            self.assertEqual(['OnlyValue'], self.metadata.getall('newtag'))
+            self.assertEqual('OnlyValue', self.metadata['newtag'])
+
+        def test_copy_preserves_single_and_multi(self):
+            self.metadata['solo'] = 'JustOne'
+            self.metadata['multi'] = ['A', 'B', 'C']
+            other = self.get_metadata_object()
+            other.copy(self.metadata)
+            self.assertEqual('JustOne', other['solo'])
+            self.assertEqual(['JustOne'], other.getall('solo'))
+            self.assertEqual(['A', 'B', 'C'], other.getall('multi'))
+            # Mutating the source multi-value must not affect the copy.
+            self.metadata.add('multi', 'D')
+            self.assertEqual(['A', 'B', 'C'], other.getall('multi'))
 
         def test_metadata_pop(self):
             self.metadata.pop("single1")


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Store single-valued `Metadata` tags as a bare `str` internally instead of a
  one-element list, cutting per-object memory ~36% on real data while keeping
  the public list-based API unchanged.

## Problem

`Metadata` wraps every tag value in a list, even though the vast majority of
tags are single-valued (title, album, date, the MusicBrainz IDs, …). Those
one-element wrapper lists dominate the per-tag overhead, and with 2 `Metadata`
objects per file and 3 per track they add up across large collections — a
contributor to the high memory use behind PICARD-2172.

PICARD-3409

## Solution

Store a single value as a bare `str` internally and multiple values as a
`list[str]`. All public accessors (`getall`, `getraw`, `rawitems`, `items`,
`get`) still present values as lists, so the external contract is unchanged —
only the internal representation differs.

Along the way:
* `get()` returns a bare single value directly instead of joining it.
* `copy()` / `_update_from_metadata` copies the internal store directly,
  sharing immutable bare strings and only shallow-copying multi-value lists,
  which avoids list allocations.

**Measurement.** Built real `Metadata` (album + per-track, via the actual
`release_to_metadata` / `medium_to_metadata` / `recording_to_metadata`
functions) from 40 real MusicBrainz releases in the test fixtures and eval
corpus — 635 `Metadata` objects, 21,810 tag-slots, of which 93% are
single-valued and 7% multi-valued (arity up to 11):

| metric | before | after |
|--------|-------:|------:|
| total store size | 4845.9 KiB | 3093.1 KiB (**-36%**) |
| per-object avg | 7814 B | 4988 B (**-36%**) |

Multi-valued tags remain lists; the saving comes entirely from single-valued
tags shedding their 1-element list wrapper. A build/read/copy microbenchmark
also showed a small CPU improvement on the copy-heavy load path (relevant to
PICARD-2530), as the direct-store copy more than offsets the small `getall`
list-wrapping cost.

Adds tests for bare-str storage, `add()` single→multi promotion, absence of
per-character joining on single values, and copy fidelity. Full test suite
passes.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
