### PR TITLE
Store album release-node cache compressed to cut memory use

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -51,6 +51,8 @@ from collections.abc import (
     Iterable,
 )
 from enum import IntEnum
+import gzip
+import json
 import time
 import traceback
 from typing import Any
@@ -203,6 +205,12 @@ class Album(MetadataItem):
         self._discids = set()
         self._disc_isrcs: dict[int, str] = disc_isrcs or {}
         self._recordings_map = {}
+        # Compressed (gzipped JSON) form of the raw MB release node, retained
+        # only for session export. Access via the _release_node_cache property,
+        # which (de)serializes on demand. Storing it compressed instead of as a
+        # live dict tree cuts its resident size ~24x on real releases, which
+        # matters a lot for large collections (see PICARD-2172).
+        self._release_node_cache_blob: bytes | None = None
         if discid:
             self._discids.add(discid)
         self._after_load_callbacks: list[tuple[Callable[[], Any], bool]] = []
@@ -215,6 +223,25 @@ class Album(MetadataItem):
 
     def __repr__(self):
         return '<Album %s %r>' % (self.id, self.metadata['album'])
+
+    @property
+    def _release_node_cache(self) -> dict[str, Any] | None:
+        """The raw MB release node retained for session export.
+
+        Stored internally as a gzipped-JSON blob to minimize resident memory
+        (a live dict tree is ~24x larger on real releases). Deserialized on
+        access, which only happens when a session is exported.
+        """
+        if self._release_node_cache_blob is None:
+            return None
+        return json.loads(gzip.decompress(self._release_node_cache_blob).decode('utf-8'))
+
+    @_release_node_cache.setter
+    def _release_node_cache(self, node: dict[str, Any] | None):
+        if node is None:
+            self._release_node_cache_blob = None
+        else:
+            self._release_node_cache_blob = gzip.compress(json.dumps(node).encode('utf-8'), compresslevel=6)
 
     def add_task(
         self,

--- a/test/test_album.py
+++ b/test/test_album.py
@@ -17,11 +17,16 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import gzip
+import json
 from unittest.mock import (
     Mock,
 )
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    load_test_json,
+)
 
 from picard.album import (
     Album,
@@ -98,3 +103,39 @@ class TrackTest(PicardTestCase):
         self.album.metadata.images.append(image)
         self.assertEqual(self.album.column('covercount'), '1')
         self.assertEqual(self.album.column('coverdimensions'), '100x100')
+
+    def test_release_node_cache_roundtrip(self):
+        # The property stores the node compressed but returns an equal dict.
+        node = {
+            'id': 'abc',
+            'media': [{'tracks': [{'title': f'T{i}'} for i in range(12)]}],
+            'artist-credit': [{'name': 'X', 'joinphrase': ''}],
+        }
+        self.album._release_node_cache = node
+        self.assertEqual(self.album._release_node_cache, node)
+
+    def test_release_node_cache_none(self):
+        self.album._release_node_cache = None
+        self.assertIsNone(self.album._release_node_cache)
+        self.assertIsNone(self.album._release_node_cache_blob)
+
+    def test_release_node_cache_is_compressed(self):
+        # Stored blob must be smaller than the raw JSON for repetitive data.
+        node = {'media': [{'tracks': [{'title': 'Song', 'length': 210000} for _ in range(30)]}]}
+        self.album._release_node_cache = node
+        blob = self.album._release_node_cache_blob
+        self.assertIsInstance(blob, bytes)
+        raw = json.dumps(node).encode('utf-8')
+        self.assertLess(len(blob), len(raw))
+        # And it round-trips.
+        self.assertEqual(json.loads(gzip.decompress(blob).decode('utf-8')), node)
+
+    def test_release_node_cache_roundtrip_real_release(self):
+        # Round-trip must be exact for a real MB release node (nested
+        # structure, Unicode, artist-credits, relations, etc.) and the stored
+        # blob must be much smaller than the live JSON.
+        node = load_test_json('release.json')
+        self.album._release_node_cache = node
+        self.assertEqual(self.album._release_node_cache, node)
+        raw = json.dumps(node).encode('utf-8')
+        self.assertLess(len(self.album._release_node_cache_blob), len(raw))


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Store the album's retained raw MusicBrainz release node as a compressed
  (gzipped JSON) blob instead of a live dict tree, cutting its resident memory
  ~24x on real releases while keeping the accessor unchanged.

## Problem

`Album` keeps the full raw MusicBrainz release JSON in `_release_node_cache` as
a live dict tree for the whole session, even though it is only read when
exporting a session (and only when `session_include_mb_data` is enabled). It is
never freed, so at collection scale this is a large, growing cost that
contributes to the high memory use reported in PICARD-2172.

## Solution

Store the node compressed (gzipped JSON) in `_release_node_cache_blob` and
expose it via a `_release_node_cache` property that (de)serializes on demand.
Readers (`session_exporter`) are unchanged; deserialization only happens at the
rare session-export time.

**Measurement.** Across 40 real MusicBrainz release nodes from the test
fixtures and eval corpus (595 tracks total):

| metric | value |
|--------|------:|
| live release-node trees | 2537.2 KiB |
| gzipped blobs | 106.3 KiB (**23.9x smaller**) |
| avg per release | 63.4 KiB → 2.66 KiB |

Round-trip is exact for all 40 nodes (verified, including Unicode and nested
artist-credits/relations). At collection scale this turns hundreds of MiB of
retained JSON into a few MiB.

Adds tests for round-trip fidelity (including a real release fixture), `None`
handling, and that the stored blob is smaller than the raw JSON. Full test
suite passes.

A possible follow-up (not in this PR) is to offload the blob to a temp file
(like `coverart.image.DataHash`) to drop the resident cost to zero for users
who never export a session.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
