### PR TITLE
Move DataHash to picard.util for general reuse

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -27,17 +27,10 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
-import gc
-from hashlib import blake2b
 import os
 import shutil
-import tempfile
-from weakref import WeakValueDictionary
 
-from PyQt6.QtCore import (
-    QMutex,
-    QUrl,
-)
+from PyQt6.QtCore import QUrl
 
 from picard import log
 from picard.config import get_config
@@ -56,133 +49,15 @@ from picard.metadata import Metadata
 from picard.util import (
     imageinfo,
     is_absolute_path,
-    periodictouch,
     sanitize_filename,
 )
+from picard.util.datahash import DataHash
 from picard.util.filenaming import (
     make_save_path,
     make_short_filename,
 )
 from picard.util.imageinfo import ImageInfo
 from picard.util.scripttofilename import script_to_filename
-
-
-class DataHash:
-    """Allows to hold binary data backed by temporary files on the file system.
-
-    This class can efficiently handle large binary data. Instead of holding the data
-    in memory it is stored in temporary files. Identical binary data results in the
-    same DataHash instance and hence the same temporary files.
-
-    Temporary files are automatically cleared once the last reference to a DataHash
-    instance gets deleted.
-    """
-
-    __datahashes: WeakValueDictionary[str, 'DataHash'] = WeakValueDictionary()
-    __datafile_mutex = QMutex()
-
-    def __new__(cls, data: bytes, prefix: str = 'picard', suffix: str = ''):
-        """Creates a new instance of DataHash for data.
-
-        If there is already an existing instance with the same data then this instance
-        will be returned. Otherwise a new instance will be created together with a
-        temporary file to hold the data.
-        """
-        if not isinstance(data, bytes):
-            raise TypeError('data must be bytes')
-
-        hash = blake2b(data).hexdigest()
-
-        # prevent garbage collection while lock is acquired
-        gc.disable()
-        DataHash.__datafile_mutex.lock()
-        try:
-            if instance := DataHash.__datahashes.get(hash, None):
-                return instance
-            instance = super().__new__(cls)
-            instance._write_data(hash, data, prefix, suffix)
-            DataHash.__datahashes[hash] = instance
-            return instance
-        finally:
-            DataHash.__datafile_mutex.unlock()
-            gc.enable()
-
-    def __eq__(self, other):
-        if other is None:
-            return False
-        return self._hash == getattr(other, '_hash', None)
-
-    def __lt__(self, other):
-        return self._hash < other._hash
-
-    def __repr__(self):
-        return f'<DataHash {self.shorthash}>'
-
-    def __str__(self):
-        return self._hash
-
-    def __hash__(self):
-        return hash(self._hash)
-
-    def __del__(self):
-        self._delete_file()
-
-    @property
-    def hash(self) -> str:
-        """The hash value of the data."""
-        return self._hash
-
-    @property
-    def shorthash(self) -> str:
-        """A shortened version of the hash for display purposes."""
-        return self._hash[:16]
-
-    def data(self) -> bytes:
-        """Returns the stored data.
-
-        The data is read from the file system. Might raise OSError.
-        """
-        with open(self._filename, 'rb') as imagefile:
-            return imagefile.read()
-
-    @property
-    def filename(self) -> str | None:
-        """The filename of the temporary file."""
-        return self._filename
-
-    def _write_data(self, hash, data, prefix, suffix):
-        self._hash: str = hash
-        (fd, filepath) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
-        self._filename: str = filepath
-        # On some systems (notably macOS) temporary files are removed after
-        # a certain period of time without access.
-        periodictouch.register_file(filepath)
-        with os.fdopen(fd, 'wb') as imagefile:
-            imagefile.write(data)
-        log.debug("Saving image data %s to %r", self.shorthash, filepath)
-
-    def _delete_file(self):
-        if not self._filename:
-            return
-
-        DataHash.__datafile_mutex.lock()
-        try:
-            os.unlink(self._filename)
-            periodictouch.unregister_file(self._filename)
-        except BaseException as e:
-            log.debug("Failed to delete file %r: %s", self._filename, e)
-        finally:
-            DataHash.__datafile_mutex.unlock()
-
-    @staticmethod
-    def remove_all_files():
-        """This removes all temporary DataHash files stored on disk.
-        Warning: This will leave all existing DataHash instance without file data.
-        This method is not meant to be called during normal operation, but might be
-        called as part of the cleanup routine during application shutdown.
-        """
-        for hash in DataHash.__datahashes.values():
-            hash._delete_file()
 
 
 class CoverArtImageError(Exception):

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -118,7 +118,6 @@ from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
-from picard.coverart.image import DataHash
 from picard.debug_opts import DebugOpt
 from picard.disc import (
     Disc,
@@ -183,6 +182,7 @@ from picard.util import (
     webbrowser2,
 )
 from picard.util.checkupdate import UpdateCheckManager
+from picard.util.datahash import DataHash
 from picard.util.readthedocs import ReadTheDocs
 from picard.util.toc import (
     parse_toc_itunes_cddb,

--- a/picard/util/datahash.py
+++ b/picard/util/datahash.py
@@ -55,7 +55,12 @@ class DataHash:
     __datahashes: WeakValueDictionary[str, 'DataHash'] = WeakValueDictionary()
     __datafile_mutex = QMutex()
 
-    def __new__(cls, data: bytes, prefix: str = 'picard', suffix: str = ''):
+    # Set during construction in _write_data(); annotated here so the types are
+    # visible without reading that method.
+    _hash: str
+    _filename: str
+
+    def __new__(cls, data: bytes, prefix: str = 'picard', suffix: str = '') -> 'DataHash':
         """Creates a new instance of DataHash for data.
 
         If there is already an existing instance with the same data then this
@@ -81,24 +86,24 @@ class DataHash:
             DataHash.__datafile_mutex.unlock()
             gc.enable()
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if other is None:
             return False
         return self._hash == getattr(other, '_hash', None)
 
-    def __lt__(self, other):
+    def __lt__(self, other: 'DataHash') -> bool:
         return self._hash < other._hash
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<DataHash {self.shorthash}>'
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._hash
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._hash)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._delete_file()
 
     @property
@@ -124,10 +129,10 @@ class DataHash:
         """The filename of the temporary file."""
         return self._filename
 
-    def _write_data(self, hash, data, prefix, suffix):
-        self._hash: str = hash
+    def _write_data(self, hash: str, data: bytes, prefix: str, suffix: str) -> None:
+        self._hash = hash
         (fd, filepath) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
-        self._filename: str = filepath
+        self._filename = filepath
         # On some systems (notably macOS) temporary files are removed after
         # a certain period of time without access.
         periodictouch.register_file(filepath)
@@ -135,7 +140,7 @@ class DataHash:
             datafile.write(data)
         log.debug("Saving data %s to %r", self.shorthash, filepath)
 
-    def _delete_file(self):
+    def _delete_file(self) -> None:
         if not self._filename:
             return
 
@@ -149,7 +154,7 @@ class DataHash:
             DataHash.__datafile_mutex.unlock()
 
     @staticmethod
-    def remove_all_files():
+    def remove_all_files() -> None:
         """Remove all temporary DataHash files stored on disk.
 
         Warning: This will leave all existing DataHash instances without file

--- a/picard/util/datahash.py
+++ b/picard/util/datahash.py
@@ -1,0 +1,161 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2007-2011, 2014, 2018-2026 Philipp Wolfer
+# Copyright (C) 2013-2015, 2018-2026 Laurent Monin
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""Content-addressed binary data backed by temporary files.
+
+``DataHash`` keeps arbitrary binary data out of RAM by storing it in a
+temporary file and holding only a hash and filename in memory. Identical data
+is deduplicated: constructing a ``DataHash`` for bytes that already have a live
+instance returns that instance (and the same temp file). The temp file is
+removed once the last reference to its ``DataHash`` is dropped.
+
+Originally written for cover-art image data; it is format-agnostic and can back
+any large blob (e.g. serialized JSON) that should not stay resident in memory.
+"""
+
+import gc
+from hashlib import blake2b
+import os
+import tempfile
+from weakref import WeakValueDictionary
+
+from PyQt6.QtCore import QMutex
+
+from picard import log
+from picard.util import periodictouch
+
+
+class DataHash:
+    """Holds binary data backed by a temporary file on the file system.
+
+    This class can efficiently handle large binary data. Instead of holding the
+    data in memory it is stored in a temporary file. Identical binary data
+    results in the same DataHash instance and hence the same temporary file.
+
+    Temporary files are automatically cleared once the last reference to a
+    DataHash instance gets deleted.
+    """
+
+    __datahashes: WeakValueDictionary[str, 'DataHash'] = WeakValueDictionary()
+    __datafile_mutex = QMutex()
+
+    def __new__(cls, data: bytes, prefix: str = 'picard', suffix: str = ''):
+        """Creates a new instance of DataHash for data.
+
+        If there is already an existing instance with the same data then this
+        instance will be returned. Otherwise a new instance will be created
+        together with a temporary file to hold the data.
+        """
+        if not isinstance(data, bytes):
+            raise TypeError('data must be bytes')
+
+        hash = blake2b(data).hexdigest()
+
+        # prevent garbage collection while lock is acquired
+        gc.disable()
+        DataHash.__datafile_mutex.lock()
+        try:
+            if instance := DataHash.__datahashes.get(hash, None):
+                return instance
+            instance = super().__new__(cls)
+            instance._write_data(hash, data, prefix, suffix)
+            DataHash.__datahashes[hash] = instance
+            return instance
+        finally:
+            DataHash.__datafile_mutex.unlock()
+            gc.enable()
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        return self._hash == getattr(other, '_hash', None)
+
+    def __lt__(self, other):
+        return self._hash < other._hash
+
+    def __repr__(self):
+        return f'<DataHash {self.shorthash}>'
+
+    def __str__(self):
+        return self._hash
+
+    def __hash__(self):
+        return hash(self._hash)
+
+    def __del__(self):
+        self._delete_file()
+
+    @property
+    def hash(self) -> str:
+        """The hash value of the data."""
+        return self._hash
+
+    @property
+    def shorthash(self) -> str:
+        """A shortened version of the hash for display purposes."""
+        return self._hash[:16]
+
+    def data(self) -> bytes:
+        """Returns the stored data.
+
+        The data is read from the file system. Might raise OSError.
+        """
+        with open(self._filename, 'rb') as datafile:
+            return datafile.read()
+
+    @property
+    def filename(self) -> str | None:
+        """The filename of the temporary file."""
+        return self._filename
+
+    def _write_data(self, hash, data, prefix, suffix):
+        self._hash: str = hash
+        (fd, filepath) = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+        self._filename: str = filepath
+        # On some systems (notably macOS) temporary files are removed after
+        # a certain period of time without access.
+        periodictouch.register_file(filepath)
+        with os.fdopen(fd, 'wb') as datafile:
+            datafile.write(data)
+        log.debug("Saving data %s to %r", self.shorthash, filepath)
+
+    def _delete_file(self):
+        if not self._filename:
+            return
+
+        DataHash.__datafile_mutex.lock()
+        try:
+            os.unlink(self._filename)
+            periodictouch.unregister_file(self._filename)
+        except BaseException as e:
+            log.debug("Failed to delete file %r: %s", self._filename, e)
+        finally:
+            DataHash.__datafile_mutex.unlock()
+
+    @staticmethod
+    def remove_all_files():
+        """Remove all temporary DataHash files stored on disk.
+
+        Warning: This will leave all existing DataHash instances without file
+        data. This method is not meant to be called during normal operation,
+        but might be called as part of the cleanup routine during application
+        shutdown.
+        """
+        for hash in DataHash.__datahashes.values():
+            hash._delete_file()

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -43,7 +43,6 @@ from picard.coverart.utils import (
 )
 from picard.file import File
 from picard.metadata import Metadata
-from picard.util.datahash import DataHash
 from picard.util.filenaming import WinPathTooLong
 
 
@@ -351,51 +350,6 @@ class CoverArtImageTest(PicardTestCase):
         self.assertEqual(image.external_file_coverart.types, image.types)
         self.assertEqual(image.external_file_coverart.support_types, image.support_types)
         self.assertEqual(image.external_file_coverart.support_multi_types, image.support_multi_types)
-
-
-class DataHashTest(PicardTestCase):
-    def setUp(self):
-        super().setUp()
-        self.patch_tagger_instance('picard.item')
-
-    def test_data_must_be_bytes(self):
-        with self.assertRaises(TypeError):
-            DataHash('foo')
-
-    def test_data(self):
-        h = DataHash(b'a')
-        self.assertEqual(h.data(), b'a')
-
-    def test_shorthash(self):
-        h = DataHash(b'a')
-        self.assertEqual(
-            h.hash,
-            "333fcb4ee1aa7c115355ec66ceac917c8bfd815bf7587d325aec1864edd24e34d5abe2c6b1b5ee3face62fed78dbef802f2a85cb91d455a8f5249d330853cb3c",
-        )
-        self.assertEqual(h.hash, str(h))
-        self.assertEqual(h.shorthash, "333fcb4ee1aa7c11")
-
-    def test_eq(self):
-        # DataHash interns by content, so equal data yields the very same instance
-        self.assertIs(DataHash(b'a'), DataHash(b'a'))
-        self.assertIs(DataHash(b''), DataHash(b''))
-        # Equality itself, rather than the identity that interning guarantees
-        self.assertEqual(DataHash(b'a'), DataHash(b'a'))
-        self.assertNotEqual(DataHash(b'a'), DataHash(b'b'))
-        self.assertNotEqual(DataHash(b'a'), DataHash(b''))
-        self.assertNotEqual(DataHash(b'a'), None)
-
-    def test_tempfiles(self):
-        a = DataHash(b'a')
-        self.assertTrue(os.path.exists(a.filename))
-        b = DataHash(b'a')
-        self.assertTrue(os.path.exists(b.filename))
-        self.assertEqual(a.filename, b.filename)
-        filename = a.filename
-        del a
-        self.assertTrue(os.path.exists(filename))
-        del b
-        self.assertFalse(os.path.exists(filename))
 
 
 class CoverArtImageMakeFilenameTest(PicardTestCase):

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -34,7 +34,6 @@ from picard.const.defaults import DEFAULT_COVER_IMAGE_FILENAME
 from picard.const.sys import IS_WIN
 from picard.coverart.image import (
     CoverArtImage,
-    DataHash,
     LocalFileCoverArtImage,
     TagCoverArtImage,
 )
@@ -44,6 +43,7 @@ from picard.coverart.utils import (
 )
 from picard.file import File
 from picard.metadata import Metadata
+from picard.util.datahash import DataHash
 from picard.util.filenaming import WinPathTooLong
 
 

--- a/test/test_util_datahash.py
+++ b/test/test_util_datahash.py
@@ -1,0 +1,68 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+import os
+
+from test.picardtestcase import PicardTestCase
+
+from picard.util.datahash import DataHash
+
+
+class DataHashTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+
+    def test_data_must_be_bytes(self):
+        with self.assertRaises(TypeError):
+            DataHash('foo')
+
+    def test_data(self):
+        h = DataHash(b'a')
+        self.assertEqual(h.data(), b'a')
+
+    def test_shorthash(self):
+        h = DataHash(b'a')
+        self.assertEqual(
+            h.hash,
+            "333fcb4ee1aa7c115355ec66ceac917c8bfd815bf7587d325aec1864edd24e34d5abe2c6b1b5ee3face62fed78dbef802f2a85cb91d455a8f5249d330853cb3c",
+        )
+        self.assertEqual(h.hash, str(h))
+        self.assertEqual(h.shorthash, "333fcb4ee1aa7c11")
+
+    def test_eq(self):
+        # DataHash interns by content, so equal data yields the very same instance
+        self.assertIs(DataHash(b'a'), DataHash(b'a'))
+        self.assertIs(DataHash(b''), DataHash(b''))
+        # Equality itself, rather than the identity that interning guarantees
+        self.assertEqual(DataHash(b'a'), DataHash(b'a'))
+        self.assertNotEqual(DataHash(b'a'), DataHash(b'b'))
+        self.assertNotEqual(DataHash(b'a'), DataHash(b''))
+        self.assertNotEqual(DataHash(b'a'), None)
+
+    def test_tempfiles(self):
+        a = DataHash(b'a')
+        self.assertTrue(os.path.exists(a.filename))
+        b = DataHash(b'a')
+        self.assertTrue(os.path.exists(b.filename))
+        self.assertEqual(a.filename, b.filename)
+        filename = a.filename
+        del a
+        self.assertTrue(os.path.exists(filename))
+        del b
+        self.assertFalse(os.path.exists(filename))

--- a/test/test_util_datahash.py
+++ b/test/test_util_datahash.py
@@ -66,3 +66,51 @@ class DataHashTest(PicardTestCase):
         self.assertTrue(os.path.exists(filename))
         del b
         self.assertFalse(os.path.exists(filename))
+
+    def test_ordering(self):
+        # __lt__ orders by content hash (used e.g. to sort cover-art images).
+        a = DataHash(b'a')
+        b = DataHash(b'b')
+        ordered = sorted([b, a])
+        self.assertEqual(ordered, sorted([a, b], key=lambda h: h.hash))
+        # Consistent, antisymmetric.
+        self.assertEqual(a < b, not (b < a))
+
+    def test_repr(self):
+        h = DataHash(b'a')
+        self.assertEqual(repr(h), f"<DataHash {h.shorthash}>")
+
+    def test_hashable(self):
+        # __hash__ is based on the content hash, so equal-content instances
+        # (which are also identical due to interning) collapse in a set.
+        h1 = DataHash(b'abc')
+        h2 = DataHash(b'abc')
+        h3 = DataHash(b'def')
+        self.assertEqual(hash(h1), hash(h2))
+        self.assertEqual(len({h1, h2, h3}), 2)
+
+    def test_remove_all_files(self):
+        a = DataHash(b'remove-all-1')
+        b = DataHash(b'remove-all-2')
+        self.assertTrue(os.path.exists(a.filename))
+        self.assertTrue(os.path.exists(b.filename))
+        DataHash.remove_all_files()
+        self.assertFalse(os.path.exists(a.filename))
+        self.assertFalse(os.path.exists(b.filename))
+
+    def test_delete_missing_file_is_safe(self):
+        # Deleting an already-removed file must not raise (the error path is
+        # swallowed and logged). remove_all_files() drives _delete_file, which
+        # is deterministic (unlike relying on __del__ timing).
+        h = DataHash(b'delete-twice')
+        filename = h.filename
+        os.unlink(filename)
+        self.assertFalse(os.path.exists(filename))
+        # Must not raise even though the file is already gone.
+        DataHash.remove_all_files()
+
+    def test_data_missing_file_raises_oserror(self):
+        h = DataHash(b'read-after-delete')
+        os.unlink(h.filename)
+        with self.assertRaises(OSError):
+            h.data()


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Move the format-agnostic `DataHash` (binary data backed by a
  content-deduplicated temporary file) out of `picard.coverart.image` into
  `picard.util.datahash` so it can be reused for any large blob, and give it its
  own tests and complete type annotations.

## Problem

`DataHash` — which keeps large binary data out of RAM by storing it in a
content-deduplicated temporary file — lived in `picard.coverart.image`, but it
is entirely cover-art-agnostic. Keeping it there makes it awkward to reuse for
other large blobs (e.g. serialized JSON) that should not stay resident in
memory.

## Solution

Split into four small, self-contained commits:

1. **Move `DataHash` to `picard.util.datahash`.** Wording is made neutral
   (data instead of image); behavior is unchanged. `picard.coverart.image`
   imports it back for `CoverArtImage`; `tagger.py` and the tests import it
   from the canonical location.
2. **Move the `DataHash` unit tests** into `test/test_util_datahash.py`. The
   `CoverArtImage` ordering test that happens to exercise datahash ordering
   stays with the image tests.
3. **Extend test coverage** (89% → 99%): `__lt__`, `__repr__`, `__hash__`,
   `remove_all_files()`, the `_delete_file` error path on a missing file, and
   `data()` raising `OSError` after the backing file is gone.
4. **Improve type annotations**: `__new__` return type, all dunders, the
   private helpers, and class-level `_hash` / `_filename` attribute
   annotations.

No behavior change. Full test suite passes (5908 passed); `ruff` and `ty` are
clean.

This is groundwork: a follow-up will use `DataHash` to back the retained
MusicBrainz release node on disk instead of in memory.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
