### PR TITLE
PICARD-3409: Store album release-node cache on disk to cut memory use

### DIFF
--- a/picard/album.py
+++ b/picard/album.py
@@ -51,6 +51,8 @@ from collections.abc import (
     Iterable,
 )
 from enum import IntEnum
+import gzip
+import json
 import time
 import traceback
 from typing import Any
@@ -100,6 +102,7 @@ from picard.util import (
     format_time,
     mbid_validate,
 )
+from picard.util.datahash import DataHash
 from picard.util.isrc import normalized_isrcs
 from picard.util.textencoding import asciipunct
 from picard.webservice import PendingRequest
@@ -203,6 +206,12 @@ class Album(MetadataItem):
         self._discids = set()
         self._disc_isrcs: dict[int, str] = disc_isrcs or {}
         self._recordings_map = {}
+        # The raw MB release node is retained only for session export. Rather
+        # than keep the large live dict tree (or even a compressed blob) in RAM
+        # for the whole session, it is stored in a temporary file via DataHash
+        # and read back on demand. Access through the _release_node_cache
+        # property. See PICARD-2172.
+        self._release_node_cache_datahash: DataHash | None = None
         if discid:
             self._discids.add(discid)
         self._after_load_callbacks: list[tuple[Callable[[], Any], bool]] = []
@@ -215,6 +224,33 @@ class Album(MetadataItem):
 
     def __repr__(self):
         return '<Album %s %r>' % (self.id, self.metadata['album'])
+
+    @property
+    def _release_node_cache(self) -> dict[str, Any] | None:
+        """The raw MB release node retained for session export.
+
+        Backed by a temporary file on disk (via DataHash), so it does not stay
+        resident in memory for the whole session. Deserialized on access, which
+        only happens when a session is exported. Returns None if nothing is
+        cached or the backing file is no longer available.
+        """
+        datahash = self._release_node_cache_datahash
+        if datahash is None:
+            return None
+        try:
+            raw = datahash.data()
+        except OSError:
+            # Backing temp file gone (e.g. cleaned up); treat as no cache.
+            return None
+        return json.loads(gzip.decompress(raw).decode('utf-8'))
+
+    @_release_node_cache.setter
+    def _release_node_cache(self, node: dict[str, Any] | None):
+        if node is None:
+            self._release_node_cache_datahash = None
+        else:
+            blob = gzip.compress(json.dumps(node).encode('utf-8'), compresslevel=6)
+            self._release_node_cache_datahash = DataHash(blob, prefix='picard-release-', suffix='.json.gz')
 
     def add_task(
         self,

--- a/test/test_album.py
+++ b/test/test_album.py
@@ -17,11 +17,15 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import os
 from unittest.mock import (
     Mock,
 )
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    load_test_json,
+)
 
 from picard.album import (
     Album,
@@ -98,3 +102,39 @@ class TrackTest(PicardTestCase):
         self.album.metadata.images.append(image)
         self.assertEqual(self.album.column('covercount'), '1')
         self.assertEqual(self.album.column('coverdimensions'), '100x100')
+
+    def test_release_node_cache_none(self):
+        self.assertIsNone(self.album._release_node_cache)
+        self.album._release_node_cache = None
+        self.assertIsNone(self.album._release_node_cache)
+        self.assertIsNone(self.album._release_node_cache_datahash)
+
+    def test_release_node_cache_roundtrip(self):
+        node = {
+            'id': 'abc',
+            'media': [{'tracks': [{'title': f'T{i}'} for i in range(12)]}],
+            'artist-credit': [{'name': 'X', 'joinphrase': ''}],
+        }
+        self.album._release_node_cache = node
+        self.assertEqual(self.album._release_node_cache, node)
+
+    def test_release_node_cache_roundtrip_real_release(self):
+        # Exact round-trip for a real MB release node (nested, Unicode, etc.).
+        node = load_test_json('release.json')
+        self.album._release_node_cache = node
+        self.assertEqual(self.album._release_node_cache, node)
+
+    def test_release_node_cache_is_backed_by_tempfile(self):
+        node = {'media': [{'tracks': [{'title': 'Song'} for _ in range(30)]}]}
+        self.album._release_node_cache = node
+        datahash = self.album._release_node_cache_datahash
+        self.assertIsNotNone(datahash)
+        self.assertTrue(os.path.exists(datahash.filename))
+
+    def test_release_node_cache_missing_file_returns_none(self):
+        # If the backing temp file disappears, the getter degrades to None
+        # rather than raising.
+        node = {'id': 'abc', 'media': []}
+        self.album._release_node_cache = node
+        os.unlink(self.album._release_node_cache_datahash.filename)
+        self.assertIsNone(self.album._release_node_cache)


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Back the album's retained MusicBrainz release node with a temporary file
  (via `DataHash`) instead of keeping it resident in memory, dropping the
  retained cost to ~48 B/album.

## Problem

`Album` keeps the full raw MusicBrainz release JSON for the whole session so a
session can be exported offline, but it is only read at export time. Holding
the live dict tree costs ~63 KiB/album resident, accumulating into hundreds of
MiB for large collections (PICARD-2172).

PICARD-3409

## Solution

Store the node via `DataHash`: the node is serialized to gzipped JSON and
written to a temporary file; the `Album` holds only the small `DataHash` handle
(a hash + filename). It is read back and deserialized on demand (only on
session export). The `_release_node_cache` property keeps the accessor
interface unchanged and degrades to `None` if the backing temp file is gone.
The temp file is removed when the album is released (`DataHash.__del__`) or at
shutdown (`DataHash.remove_all_files`).

`DataHash` is the existing, battle-tested mechanism that has backed cover-art
image data on disk for a long time, so this leans on proven in-production code
(content deduplication, temp-file lifecycle, shutdown cleanup) rather than
introducing a new storage scheme.

## Measurement

Measured across 40 real release nodes (595 tracks):

| approach | retained resident RAM | per album |
|----------|----------------------:|----------:|
| current `master` (live dict) | 2537 KiB | 63.4 KiB |
| this PR (DataHash on disk) | 1.9 KiB | ~48 B |

The compressed JSON (~106 KiB total for the 40 releases) lives on disk, not in
RAM. Round-trip is exact (verified, including a real release fixture).

Note: this reduces the long-term *retained* cost; it does not change the
transient peak during loading (the full dict must exist while the response is
parsed).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
