### PR TITLE
Fix DataHash tests deleting other tests' temp files

### DIFF
--- a/test/test_util_datahash.py
+++ b/test/test_util_datahash.py
@@ -89,25 +89,28 @@ class DataHashTest(PicardTestCase):
         self.assertEqual(hash(h1), hash(h2))
         self.assertEqual(len({h1, h2, h3}), 2)
 
-    def test_remove_all_files(self):
-        a = DataHash(b'remove-all-1')
-        b = DataHash(b'remove-all-2')
-        self.assertTrue(os.path.exists(a.filename))
-        self.assertTrue(os.path.exists(b.filename))
-        DataHash.remove_all_files()
-        self.assertFalse(os.path.exists(a.filename))
-        self.assertFalse(os.path.exists(b.filename))
+    def test_delete_file_on_last_reference(self):
+        # Dropping the last reference removes the backing file. This exercises
+        # the same _delete_file() path that remove_all_files() fans out to, but
+        # per-instance and deterministically -- without touching the
+        # process-global registry, which would delete temp files belonging to
+        # unrelated live DataHash instances (e.g. cover art) in other tests.
+        h = DataHash(b'per-instance-delete')
+        filename = h.filename
+        self.assertTrue(os.path.exists(filename))
+        del h
+        self.assertFalse(os.path.exists(filename))
 
     def test_delete_missing_file_is_safe(self):
         # Deleting an already-removed file must not raise (the error path is
-        # swallowed and logged). remove_all_files() drives _delete_file, which
-        # is deterministic (unlike relying on __del__ timing).
+        # swallowed and logged). Triggered per-instance by dropping the last
+        # reference after the backing file was removed out from under it.
         h = DataHash(b'delete-twice')
         filename = h.filename
         os.unlink(filename)
         self.assertFalse(os.path.exists(filename))
         # Must not raise even though the file is already gone.
-        DataHash.remove_all_files()
+        del h
 
     def test_data_missing_file_raises_oserror(self):
         h = DataHash(b'read-after-delete')


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Fix the `DataHash` unit tests deleting other tests' temporary files by calling
  the process-global `remove_all_files()`; exercise deletion per-instance
  instead.

## Problem

The `DataHash` tests added in #3394 called `DataHash.remove_all_files()`, a
process-global shutdown helper that deletes the backing temp file of **every
live `DataHash` instance** — including cover-art images kept alive by other
tests via the shared `WeakValueDictionary` registry.

Under some test orderings (hit by the macOS/Windows **Package and release**
jobs, though not by the regular "Run tests" workflow) a live cover-art image's
temp file was deleted mid-suite, causing `FileNotFoundError` /
`CoverArtImageIOError` in `test_coverart_image.py` (`test_save`, `test_data`,
`test_set_data`) and `test_asf.py`.

Failing run:
https://github.com/metabrainz/picard/actions/runs/33596125546

## Solution

Trigger the deletion via the per-instance path instead — drop the last
reference so `__del__` → `_delete_file()` runs — which is deterministic and
touches only that instance, never the shared registry. This still covers the
same `_delete_file()` logic that `remove_all_files()` fans out to.

`remove_all_files()` is a shutdown-only global and is no longer invoked from
the test suite.

Verified across multiple `pytest-randomly` seeds on the affected test files and
with the full test suite (5910 passed).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
