### PR TITLE
PICARD-3410: Show busy cursor to acknowledge async lookup/cluster actions

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -154,6 +154,15 @@ PLUGINS_API = {
 
 PLUGINS_BACKGROUND_CHECK_DELAY = 10  # seconds
 
+# Duration of the short "busy" cursor flash used to acknowledge an async
+# action (e.g. a MusicBrainz lookup) whose result is not immediately visible.
+# Kept intentionally short: most such operations run in the background and the
+# user is still expected to interact, so the cursor must restore itself.
+# This is a constant for now; it is read through the flash_busy_cursor() helper
+# in picard.ui.util so it can later be promoted to a user-configurable option
+# without touching call sites.
+BUSY_CURSOR_FLASH_DELAY_MS = 500  # milliseconds
+
 # Maximum number of covers to draw in a stack in CoverArtThumbnail
 MAX_COVERS_TO_STACK = 4
 

--- a/picard/disc/__init__.py
+++ b/picard/disc/__init__.py
@@ -53,6 +53,7 @@ from picard.util.isrc import (
 from picard.util.mbserver import build_submission_url
 
 from picard.ui.cdlookup import CDLookupDialog
+from picard.ui.util import busy_cursor_stop
 
 
 class Disc:
@@ -188,7 +189,7 @@ class Disc:
         self.tagger.mb_api.lookup_toc(toc_string, self._toc_lookup_finished)
 
     def _lookup_finished(self, document, http, error):
-        self.tagger.restore_cursor()
+        busy_cursor_stop()
         releases = []
         if error:
             log.error("%r", http.errorString())
@@ -203,7 +204,7 @@ class Disc:
 
     def _toc_lookup_finished(self, document, http, error):
         """Handle the result of a TOC lookup."""
-        self.tagger.restore_cursor()
+        busy_cursor_stop()
         releases = []
         if error:
             log.error("TOC lookup error: %r", http.errorString())

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -205,6 +205,8 @@ from picard.ui.searchdialog.artist import ArtistSearchDialog
 from picard.ui.searchdialog.track import TrackSearchDialog
 from picard.ui.util import (
     FileDialog,
+    busy_cursor_start,
+    busy_cursor_stop,
     flash_busy_cursor,
     show_session_not_found_dialog,
 )
@@ -1338,7 +1340,7 @@ class Tagger(QtWidgets.QApplication):
             self.window.set_statusbar_message(_('Moved %(count)i files to trash'), {'count': len(files_removed)})
 
     def _lookup_disc(self, disc, result=None, error=None):
-        self.restore_cursor()
+        busy_cursor_stop()
         if error is not None:
             QtWidgets.QMessageBox.critical(
                 self.window, _("CD Lookup Error"), _("Error while reading CD:\n\n%s") % error
@@ -1360,7 +1362,7 @@ class Tagger(QtWidgets.QApplication):
 
     def run_lookup_cd(self, device):
         disc = Disc()
-        self.set_wait_cursor()
+        busy_cursor_start()
         thread.run_task(partial(disc.read, device), partial(self._lookup_disc, disc), traceback=log.is_debug())
 
     def lookup_discid_from_logfile(self):
@@ -1381,7 +1383,7 @@ class Tagger(QtWidgets.QApplication):
 
     def run_lookup_discid_from_logfile(self, filepath):
         disc = Disc()
-        self.set_wait_cursor()
+        busy_cursor_start()
         thread.run_task(
             partial(self._parse_disc_ripping_log, disc, filepath),
             partial(self._lookup_disc, disc),
@@ -1468,7 +1470,7 @@ class Tagger(QtWidgets.QApplication):
             toc_string += f"+{offset}"
 
         self.window.set_statusbar_message(N_('Looking up disc from tags…'))
-        self.set_wait_cursor()
+        busy_cursor_start()
 
         # Skip dialog if exactly one match, and match files to album
         disc = Disc()
@@ -1579,14 +1581,6 @@ class Tagger(QtWidgets.QApplication):
     # =======================================================================
     #  Utils
     # =======================================================================
-
-    def set_wait_cursor(self):
-        """Sets the waiting cursor."""
-        super().setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
-
-    def restore_cursor(self):
-        """Restores the cursor set by ``set_wait_cursor``."""
-        super().restoreOverrideCursor()
 
     def refresh(self, objs):
         for obj in objs:

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -205,6 +205,7 @@ from picard.ui.searchdialog.artist import ArtistSearchDialog
 from picard.ui.searchdialog.track import TrackSearchDialog
 from picard.ui.util import (
     FileDialog,
+    flash_busy_cursor,
     show_session_not_found_dialog,
 )
 
@@ -1108,11 +1109,19 @@ class Tagger(QtWidgets.QApplication):
         lookup = self.get_file_lookup()
         config = get_config()
         if config.setting["builtin_search"] and not force_browser:
-            if not lookup.mbid_lookup(text, search['entity'], mbid_matched_callback=mbid_matched_callback):
+            # mbid_lookup dispatches an async load only when the text is a
+            # known MBID/URL (it returns True in that case). Flash only then;
+            # the fallback below opens a modal dialog, which is its own
+            # immediate feedback and needs no cursor flash.
+            if lookup.mbid_lookup(text, search['entity'], mbid_matched_callback=mbid_matched_callback):
+                flash_busy_cursor()
+            else:
                 dialog = search['dialog'](self.window)
                 dialog.search(text)
                 dialog.exec()
         else:
+            # Opens the browser / dispatches an entity search asynchronously.
+            flash_busy_cursor()
             lookup.search_entity(
                 search['entity'], text, adv, mbid_matched_callback=mbid_matched_callback, force_browser=force_browser
             )
@@ -1121,12 +1130,17 @@ class Tagger(QtWidgets.QApplication):
         """Lookup the users collections on the MusicBrainz website."""
         lookup = self.get_file_lookup()
         config = get_config()
+        # Result appears asynchronously; acknowledge the action immediately.
+        flash_busy_cursor()
         lookup.collection_lookup(config.persist['oauth_username'])
 
     def browser_lookup(self, item):
         """Lookup the object's metadata on the MusicBrainz website."""
         lookup = self.get_file_lookup()
         metadata = item.metadata
+        # Result appears asynchronously (browser opens / network lookup);
+        # acknowledge the action immediately.
+        flash_busy_cursor()
         # Only lookup via MB IDs if matched to a Track or Album;
         # otherwise ignore and search by metadata details
         is_track = isinstance(item, Track)
@@ -1469,8 +1483,13 @@ class Tagger(QtWidgets.QApplication):
         """Analyze the file(s)."""
         if not self.use_acoustid:
             return
+        flashed = False
         for file in iter_files_from_objects(objs):
             if file.can_analyze:
+                if not flashed:
+                    # Result appears asynchronously; acknowledge the action once.
+                    flash_busy_cursor()
+                    flashed = True
                 file.set_pending()
                 self._acoustid.analyze(file, partial(file._lookup_finished, File.LookupType.ACOUSTID))
 
@@ -1491,8 +1510,13 @@ class Tagger(QtWidgets.QApplication):
     # =======================================================================
 
     def autotag(self, objects):
+        flashed = False
         for obj in objects:
             if obj.can_autotag:
+                if not flashed:
+                    # Result appears asynchronously; acknowledge the action once.
+                    flash_busy_cursor()
+                    flashed = True
                 obj.lookup_metadata()
 
     # =======================================================================
@@ -1502,6 +1526,9 @@ class Tagger(QtWidgets.QApplication):
     def cluster(self, objs, callback=None):
         """Group files with similar metadata to 'clusters'."""
         files = tuple(iter_files_from_objects(objs))
+        if files:
+            # Clustering runs on a background thread; acknowledge the action.
+            flash_busy_cursor()
         if log.is_debug():
             limit = 5
             count = len(files)

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -326,6 +326,30 @@ def menu_builder(menu, main_actions, *args):
             log.error('Invalid menu action: %r', arg)
 
 
+def busy_cursor_start() -> None:
+    """Show the application-wide busy (wait) cursor.
+
+    Pushes a wait cursor onto Qt's override-cursor stack. Must be paired with a
+    matching :func:`busy_cursor_stop`. Use this for operations that have a clear
+    completion point (typically an async callback) where the cursor should stay
+    busy for the whole duration; for fire-and-forget actions whose completion is
+    not tracked, use :func:`flash_busy_cursor` instead.
+
+    Qt's override cursor behaves consistently across Linux, macOS and Windows.
+    """
+    tagger = tagger_instance()
+    tagger.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
+
+
+def busy_cursor_stop() -> None:
+    """Restore the cursor after a :func:`busy_cursor_start`.
+
+    Pops the wait cursor previously pushed by :func:`busy_cursor_start`.
+    """
+    tagger = tagger_instance()
+    tagger.restoreOverrideCursor()
+
+
 def flash_busy_cursor(msecs: int | None = None) -> None:
     """Briefly show the busy cursor to acknowledge an asynchronous action.
 
@@ -344,6 +368,5 @@ def flash_busy_cursor(msecs: int | None = None) -> None:
     """
     if msecs is None:
         msecs = BUSY_CURSOR_FLASH_DELAY_MS
-    tagger = tagger_instance()
-    tagger.set_wait_cursor()
-    QtCore.QTimer.singleShot(msecs, tagger.restore_cursor)
+    busy_cursor_start()
+    QtCore.QTimer.singleShot(msecs, busy_cursor_stop)

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -36,8 +36,10 @@ from PyQt6 import (
 from picard import (
     PICARD_DISPLAY_NAME,
     log,
+    tagger_instance,
 )
 from picard.config import get_config
+from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
 from picard.const.sys import IS_LINUX
 from picard.i18n import gettext as _
 from picard.util import find_existing_path
@@ -322,3 +324,26 @@ def menu_builder(menu, main_actions, *args):
             menu.addAction(arg)
         else:
             log.error('Invalid menu action: %r', arg)
+
+
+def flash_busy_cursor(msecs: int | None = None) -> None:
+    """Briefly show the busy cursor to acknowledge an asynchronous action.
+
+    Shows the application busy cursor immediately and schedules its automatic
+    restoration after ``msecs`` milliseconds. This is meant for background
+    operations (e.g. a MusicBrainz lookup) whose completion time is unknown and
+    where the user is still expected to interact: it gives immediate "something
+    happened" feedback without trapping the user under a busy cursor.
+
+    Args:
+        msecs: How long to keep the busy cursor, in milliseconds. Defaults to
+            :data:`picard.const.BUSY_CURSOR_FLASH_DELAY_MS`. This is currently a
+            constant but is read here (rather than at call sites) so it can be
+            promoted to a user-configurable option later without touching
+            callers.
+    """
+    if msecs is None:
+        msecs = BUSY_CURSOR_FLASH_DELAY_MS
+    tagger = tagger_instance()
+    tagger.set_wait_cursor()
+    QtCore.QTimer.singleShot(msecs, tagger.restore_cursor)

--- a/test/test_ui_util_cursor.py
+++ b/test/test_ui_util_cursor.py
@@ -25,7 +25,25 @@ from test.picardtestcase import PicardTestCase
 from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
 from picard.tagger import Tagger
 
-from picard.ui.util import flash_busy_cursor
+from picard.ui.util import (
+    busy_cursor_start,
+    busy_cursor_stop,
+    flash_busy_cursor,
+)
+
+
+class BusyCursorPrimitivesTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.ui.util')
+
+    def test_start_pushes_wait_cursor(self):
+        busy_cursor_start()
+        self.tagger.setOverrideCursor.assert_called_once()
+
+    def test_stop_restores_cursor(self):
+        busy_cursor_stop()
+        self.tagger.restoreOverrideCursor.assert_called_once_with()
 
 
 class FlashBusyCursorTest(PicardTestCase):
@@ -33,18 +51,18 @@ class FlashBusyCursorTest(PicardTestCase):
         super().setUp()
         self.patch_tagger_instance('picard.ui.util')
 
-    def test_shows_cursor_and_schedules_restore_with_default_delay(self):
+    def test_shows_cursor_and_schedules_stop_with_default_delay(self):
         with patch('picard.ui.util.QtCore.QTimer.singleShot') as mock_single_shot:
             flash_busy_cursor()
-        self.tagger.set_wait_cursor.assert_called_once_with()
-        # Restore is scheduled, not called synchronously.
-        self.tagger.restore_cursor.assert_not_called()
-        mock_single_shot.assert_called_once_with(BUSY_CURSOR_FLASH_DELAY_MS, self.tagger.restore_cursor)
+        # The busy cursor is shown immediately (start), and stop is scheduled.
+        self.tagger.setOverrideCursor.assert_called_once()
+        self.tagger.restoreOverrideCursor.assert_not_called()
+        mock_single_shot.assert_called_once_with(BUSY_CURSOR_FLASH_DELAY_MS, busy_cursor_stop)
 
     def test_custom_delay_is_used(self):
         with patch('picard.ui.util.QtCore.QTimer.singleShot') as mock_single_shot:
             flash_busy_cursor(123)
-        mock_single_shot.assert_called_once_with(123, self.tagger.restore_cursor)
+        mock_single_shot.assert_called_once_with(123, busy_cursor_stop)
 
     def test_scheduled_callback_restores_cursor(self):
         # Verify the callback handed to the timer actually restores the cursor.
@@ -56,9 +74,9 @@ class FlashBusyCursorTest(PicardTestCase):
         with patch('picard.ui.util.QtCore.QTimer.singleShot', side_effect=fake_single_shot):
             flash_busy_cursor()
 
-        self.tagger.restore_cursor.assert_not_called()
+        self.tagger.restoreOverrideCursor.assert_not_called()
         captured['callback']()
-        self.tagger.restore_cursor.assert_called_once_with()
+        self.tagger.restoreOverrideCursor.assert_called_once_with()
 
 
 class TaggerClusterActionsFlashTest(PicardTestCase):

--- a/test/test_ui_util_cursor.py
+++ b/test/test_ui_util_cursor.py
@@ -1,0 +1,199 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+from test.picardtestcase import PicardTestCase
+
+from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
+from picard.tagger import Tagger
+
+from picard.ui.util import flash_busy_cursor
+
+
+class FlashBusyCursorTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.ui.util')
+
+    def test_shows_cursor_and_schedules_restore_with_default_delay(self):
+        with patch('picard.ui.util.QtCore.QTimer.singleShot') as mock_single_shot:
+            flash_busy_cursor()
+        self.tagger.set_wait_cursor.assert_called_once_with()
+        # Restore is scheduled, not called synchronously.
+        self.tagger.restore_cursor.assert_not_called()
+        mock_single_shot.assert_called_once_with(BUSY_CURSOR_FLASH_DELAY_MS, self.tagger.restore_cursor)
+
+    def test_custom_delay_is_used(self):
+        with patch('picard.ui.util.QtCore.QTimer.singleShot') as mock_single_shot:
+            flash_busy_cursor(123)
+        mock_single_shot.assert_called_once_with(123, self.tagger.restore_cursor)
+
+    def test_scheduled_callback_restores_cursor(self):
+        # Verify the callback handed to the timer actually restores the cursor.
+        captured = {}
+
+        def fake_single_shot(msecs, callback):
+            captured['callback'] = callback
+
+        with patch('picard.ui.util.QtCore.QTimer.singleShot', side_effect=fake_single_shot):
+            flash_busy_cursor()
+
+        self.tagger.restore_cursor.assert_not_called()
+        captured['callback']()
+        self.tagger.restore_cursor.assert_called_once_with()
+
+
+class TaggerClusterActionsFlashTest(PicardTestCase):
+    """Cluster-panel actions (cluster, lookup/autotag, analyze) should flash the
+    busy cursor once per user action to acknowledge the async work.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # The Tagger methods call the module-level flash_busy_cursor() imported
+        # into picard.tagger; patch it there and assert on the mock.
+        patcher = patch('picard.tagger.flash_busy_cursor')
+        self.mock_flash = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _mock_self(self):
+        # Use a mock in place of a real Tagger so we can call the unbound
+        # methods without constructing the whole application.
+        return MagicMock(spec=Tagger)
+
+    def test_cluster_flashes_when_files_present(self):
+        tagger = self._mock_self()
+        files = (MagicMock(), MagicMock())
+        with (
+            patch('picard.tagger.iter_files_from_objects', return_value=iter(files)),
+            patch('picard.tagger.thread'),
+        ):
+            Tagger.cluster(tagger, object())
+        self.mock_flash.assert_called_once_with()
+
+    def test_cluster_does_not_flash_when_no_files(self):
+        tagger = self._mock_self()
+        with (
+            patch('picard.tagger.iter_files_from_objects', return_value=iter(())),
+            patch('picard.tagger.thread'),
+        ):
+            Tagger.cluster(tagger, object())
+        self.mock_flash.assert_not_called()
+
+    def test_autotag_flashes_once_for_batch(self):
+        tagger = self._mock_self()
+        obj1 = MagicMock(can_autotag=True)
+        obj2 = MagicMock(can_autotag=True)
+        Tagger.autotag(tagger, [obj1, obj2])
+        self.mock_flash.assert_called_once_with()
+        obj1.lookup_metadata.assert_called_once_with()
+        obj2.lookup_metadata.assert_called_once_with()
+
+    def test_autotag_does_not_flash_when_nothing_taggable(self):
+        tagger = self._mock_self()
+        obj = MagicMock(can_autotag=False)
+        Tagger.autotag(tagger, [obj])
+        self.mock_flash.assert_not_called()
+        obj.lookup_metadata.assert_not_called()
+
+    def test_analyze_flashes_once_for_batch(self):
+        tagger = self._mock_self()
+        tagger.use_acoustid = True
+        tagger._acoustid = MagicMock()
+        file1 = MagicMock(can_analyze=True)
+        file2 = MagicMock(can_analyze=True)
+        with patch('picard.tagger.iter_files_from_objects', return_value=iter((file1, file2))):
+            Tagger.analyze(tagger, object())
+        self.mock_flash.assert_called_once_with()
+
+    def test_analyze_does_not_flash_when_acoustid_disabled(self):
+        tagger = self._mock_self()
+        tagger.use_acoustid = False
+        with patch('picard.tagger.iter_files_from_objects', return_value=iter((MagicMock(),))):
+            Tagger.analyze(tagger, object())
+        self.mock_flash.assert_not_called()
+
+    def test_analyze_does_not_flash_when_nothing_analyzable(self):
+        tagger = self._mock_self()
+        tagger.use_acoustid = True
+        file = MagicMock(can_analyze=False)
+        with patch('picard.tagger.iter_files_from_objects', return_value=iter((file,))):
+            Tagger.analyze(tagger, object())
+        self.mock_flash.assert_not_called()
+
+
+class TaggerSearchFlashTest(PicardTestCase):
+    """Tagger.search should flash only when it dispatches async work, not when
+    it falls back to opening a modal search dialog (which is its own feedback).
+    """
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch('picard.tagger.flash_busy_cursor')
+        self.mock_flash = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _mock_self(self, lookup):
+        tagger = MagicMock(spec=Tagger)
+        tagger.get_file_lookup.return_value = lookup
+        tagger.window = MagicMock()
+        return tagger
+
+    def test_builtin_search_flashes_on_mbid_match(self):
+        self.set_config_values({'builtin_search': True})
+        lookup = MagicMock()
+        lookup.mbid_lookup.return_value = True  # dispatched an async load
+        tagger = self._mock_self(lookup)
+        Tagger.search(tagger, 'some-mbid', 'album')
+        self.mock_flash.assert_called_once_with()
+
+    def test_builtin_search_does_not_flash_on_dialog_fallback(self):
+        self.set_config_values({'builtin_search': True})
+        lookup = MagicMock()
+        lookup.mbid_lookup.return_value = False  # falls back to modal dialog
+        tagger = self._mock_self(lookup)
+        with patch('picard.tagger.AlbumSearchDialog') as mock_dialog:
+            Tagger.search(tagger, 'Radiohead', 'album')
+            mock_dialog.assert_called_once_with(tagger.window)
+        self.mock_flash.assert_not_called()
+
+    def test_browser_search_flashes(self):
+        self.set_config_values({'builtin_search': False})
+        lookup = MagicMock()
+        tagger = self._mock_self(lookup)
+        Tagger.search(tagger, 'Radiohead', 'album')
+        self.mock_flash.assert_called_once_with()
+        lookup.search_entity.assert_called_once()
+
+    def test_force_browser_flashes_even_with_builtin_search(self):
+        self.set_config_values({'builtin_search': True})
+        lookup = MagicMock()
+        tagger = self._mock_self(lookup)
+        Tagger.search(tagger, 'Radiohead', 'album', force_browser=True)
+        self.mock_flash.assert_called_once_with()
+        lookup.search_entity.assert_called_once()
+
+    def test_unknown_search_type_does_nothing(self):
+        lookup = MagicMock()
+        tagger = self._mock_self(lookup)
+        Tagger.search(tagger, 'x', 'not-a-type')
+        self.mock_flash.assert_not_called()
+        lookup.mbid_lookup.assert_not_called()


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: When starting async operations
  (MusicBrainz lookups, and the cluster / lookup / analyze actions) the user
  could feel nothing was happening, because only the status bar was updated.
  This briefly shows the busy mouse cursor to acknowledge the action.

## Problem

* JIRA ticket: PICARD-3410

Several user-initiated operations run in the background and their result is not
immediately visible. The only existing feedback was a status-bar message, which
is easy to miss, so the application could feel unresponsive right after a click.

## Solution

Add a multiplatform `flash_busy_cursor()` helper in `picard/ui/util.py`, built
on Qt's application-wide override cursor (which behaves consistently on Linux,
macOS and Windows). It shows the busy cursor immediately and restores it
automatically after a short delay (`BUSY_CURSOR_FLASH_DELAY_MS`, default 500 ms),
giving immediate "something happened" feedback for an async action without
trapping the user under a busy cursor while they are still expected to interact.

The flash delay is a constant, read inside the helper so it can later be
promoted to a user-configurable option without touching call sites.

`flash_busy_cursor()` is wired into the async entry points that previously gave
no cursor feedback:

* `Tagger.search()` — only on the async paths (MBID/URL load and browser search),
  **not** before the modal search dialog fallback, which is its own immediate
  feedback.
* `Tagger.collection_lookup()` and `Tagger.browser_lookup()`.
* The cluster-panel actions `Tagger.cluster()`, `Tagger.autotag()` (Lookup) and
  `Tagger.analyze()` — flashing once per batch and only when there is actually
  work to dispatch.

While here, the busy-cursor helpers are unified in one place. The low-level
primitives previously lived on `Tagger` (`set_wait_cursor()` / `restore_cursor()`)
while the new helper lived in `picard/ui/util.py`. They are now all module-level
functions in `picard/ui/util.py` with consistent naming:

* `busy_cursor_start()` (was `Tagger.set_wait_cursor`)
* `busy_cursor_stop()` (was `Tagger.restore_cursor`)
* `flash_busy_cursor()` builds on the two primitives

`busy_cursor_start()` / `busy_cursor_stop()` remain the right tool for operations
with a clear completion point — the CD/disc lookup flows set the cursor at
dispatch and restore it in the async callback, so the cursor stays busy for the
whole operation. `flash_busy_cursor()` is for fire-and-forget actions whose
completion is not tracked. The two behaviors are intentionally kept distinct.
The CD/disc lookup flows (`tagger.py`, `disc/__init__.py`) are migrated to the
new functions and the now-unused `Tagger` methods are dropped.

Notes:

* The flash lives in the `Tagger` methods rather than the UI handlers, so
  remote-command / CLI-triggered actions on a running GUI instance get the same
  feedback.
* The 500 ms default is a pragmatic value for an *acknowledgment* (not a
  completion indicator): long enough to be perceived, short enough not to feel
  like the app is stuck. Per Nielsen's response-time limits, feedback for delays
  over ~1 s is recommended; since these operations are open-ended and their
  result may not be immediately visible, the flash acknowledges the input right
  away. The value is trivial to tune or make configurable later.

New unit tests in `test/test_ui_util_cursor.py` cover the `busy_cursor_start()` /
`busy_cursor_stop()` primitives, the flash (default/custom delay, scheduled
stop, and that the scheduled callback restores the cursor), and the wiring for
the cluster actions and all `search()` paths (including that the modal-dialog
fallback does not flash).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The design decisions, scope, and review direction were provided by the author;
the implementation of the helpers, the wiring into the async entry points, the
consolidation refactor, and the unit tests were developed with significant AI
assistance.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

