### PR TITLE
Ensure File._file_identity is updated after load and save

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -554,10 +554,15 @@ class File(MetadataItem):
         if config.setting['enable_tag_saving']:
             # Detect source changes before saving (debug only)
             current = FileIdentity(old_filename)
-            if current and current != self._file_identity:
-                log.warning("File externally modified.")
-            elif not current:
-                log.warning("File missing!")
+            try:
+                if current and current != self._file_identity:
+                    log.warning("File externally modified: %r", old_filename)
+                elif not current:
+                    log.warning("File missing: %r", old_filename)
+            except FileIdentityError:
+                # Comparing identities may fail if the file became unreadable.
+                # This is only a diagnostic check and must never abort the save.
+                log.warning("Could not verify whether file was externally modified: %r", old_filename, exc_info=True)
             save = partial(self._save, old_filename, metadata)
             if config.setting['preserve_timestamps']:
                 try:

--- a/picard/file.py
+++ b/picard/file.py
@@ -267,6 +267,7 @@ class File(MetadataItem):
         super().__init__()
         self.filename: str = filename
         self.base_filename: str = os.path.basename(filename)
+        self._file_identity: FileIdentity | None = None
         self._state = File.State.UNDEFINED
         self.state = File.State.PENDING
         self.error_type: File.ErrorType = File.ErrorType.UNKNOWN
@@ -400,11 +401,12 @@ class File(MetadataItem):
         else:
             self.clear_errors()
             self.state = self.State.NORMAL
-            self._loaded_identity = FileIdentity(self.filename)
             postprocessors = []
             if config.setting['guess_tracknumber_and_title']:
                 postprocessors.append(self._guess_tracknumber_and_title)
             self._copy_loaded_metadata(result, postprocessors)
+
+        self._file_identity = FileIdentity(self.filename)
         # use cached fingerprint from file metadata
         if not config.setting['ignore_existing_acoustid_fingerprints']:
             fingerprints = self.metadata.getall('acoustid_fingerprint')
@@ -552,7 +554,7 @@ class File(MetadataItem):
         if config.setting['enable_tag_saving']:
             # Detect source changes before saving (debug only)
             current = FileIdentity(old_filename)
-            if current and current != self._loaded_identity:
+            if current and current != self._file_identity:
                 log.warning("File externally modified.")
             elif not current:
                 log.warning("File missing!")
@@ -644,10 +646,10 @@ class File(MetadataItem):
             self._update_filesystem_metadata(self.orig_metadata)
             if images_changed:
                 self.metadata_images_changed.emit()
-            self._loaded_identity = FileIdentity(self.filename)
             # run post save hook
             run_file_post_save_processors(self)
 
+        self._file_identity = FileIdentity(self.filename)
         # Force update to ensure file status icon changes immediately after save
         self.update()
 

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -38,7 +38,11 @@ from picard.const.sys import (
     IS_MACOS,
     IS_WIN,
 )
-from picard.file import File
+from picard.file import (
+    File,
+    FileIdentity,
+    FileIdentityError,
+)
 from picard.metadata import Metadata
 from picard.tags import (
     calculated_tag_names,
@@ -1108,3 +1112,93 @@ class RetryOnPermissionErrorTest(PicardTestCase):
         ):
             self.file._move_with_retry('/src/file.mp3', '/dst/file.mp3')
         mock_remove.assert_not_called()
+
+
+class FileIdentityLifecycleTest(PicardTestCase):
+    """Regression tests ensuring File._file_identity is always set and that a
+    failing identity comparison never aborts a save.
+
+    Motivated by the fix moving the _file_identity assignment out of the
+    success-only branches of load and save (so it is set even on error) and
+    initializing it in __init__ so the save-time comparison never raises
+    AttributeError.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.patch_tagger_instance('picard.item')
+        self.tagger.acoustidmanager = MagicMock()
+        self.file = FakeMp3File('somepath/somefile.mp3')
+        self.tagger.files[self.file.filename] = self.file
+        self.set_config_values(
+            {
+                'ignore_existing_acoustid_fingerprints': True,
+                'guess_tracknumber_and_title': False,
+                'enable_tag_saving': True,
+                'preserve_timestamps': False,
+                'rename_files': False,
+                'move_files': False,
+                'delete_empty_dirs': False,
+                'save_images_to_files': False,
+                'enabled_plugins': [],
+            }
+        )
+
+    def test_file_identity_none_on_construction(self):
+        """A freshly constructed File has _file_identity set to None."""
+        self.assertIsNone(self.file._file_identity)
+
+    @patch('picard.file.Filter.apply_filters')
+    @patch('picard.file.run_file_post_load_processors')
+    def test_file_identity_set_after_failed_load(self, mock_post_load, mock_filters):
+        """After a failed load, _file_identity must be set (not None) so a
+        later save does not raise AttributeError."""
+        # Prevent the format-guessing retry path from doing anything.
+        self.tagger.format_registry = MagicMock()
+        self.tagger.format_registry.guess_format.return_value = None
+        self.tagger.format_registry.supported_extensions.return_value = ('.mp3',)
+        callback = Mock()
+
+        self.file._loading_finished(callback, error=OSError("boom"))
+
+        self.assertEqual(File.State.ERROR, self.file.state)
+        self.assertIsNotNone(self.file._file_identity)
+        self.assertIsInstance(self.file._file_identity, FileIdentity)
+
+    @patch('picard.file.run_file_post_save_processors')
+    def test_file_identity_set_after_failed_save(self, mock_post_save):
+        """After a failed save, _file_identity must still be updated."""
+        self.file._file_identity = None
+        self.file.update = Mock()
+
+        self.file._saving_finished(error=OSError("boom"))
+
+        self.assertEqual(File.State.ERROR, self.file.state)
+        self.assertIsNotNone(self.file._file_identity)
+        self.assertIsInstance(self.file._file_identity, FileIdentity)
+
+    @patch('picard.file.log')
+    @patch('picard.file.FileIdentity')
+    def test_save_does_not_raise_when_identity_comparison_fails(self, mock_identity_cls, mock_log):
+        """A FileIdentityError raised while comparing identities is a
+        diagnostic-only failure and must never abort the save."""
+        # Make the freshly built "current" identity truthy but raise on compare.
+        current = MagicMock()
+        current.__bool__.return_value = True
+        current.__eq__.side_effect = FileIdentityError("unreadable")
+        current.__ne__.side_effect = FileIdentityError("unreadable")
+        mock_identity_cls.return_value = current
+
+        # Neutralize the actual save/rename/move side effects.
+        self.file._save = Mock()
+        self.file._rename = Mock(return_value=self.file.filename)
+        self.file._move_additional_files = Mock()
+        self.file._retry_on_permission_error = Mock(side_effect=lambda func: func())
+
+        # Must not raise.
+        result = self.file._save_and_rename(self.file.filename, self.file.metadata)
+
+        self.assertEqual(self.file.filename, result)
+        self.file._save.assert_called_once()
+        # The diagnostic warning was logged instead of propagating the error.
+        self.assertTrue(mock_log.warning.called)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

It is possible that `File._loaded_identity` is not set and when saving the file it fails Picard fails with an `AttributeError`.

```
E: 06:47:15,539 picard\util\thread.run:114: Traceback (most recent call last):
File "picard\util\thread.py", line 111, in run
File "picard\file.py", line 555, in _save_and_rename
AttributeError: 'MP4File' object has no attribute '_loaded_identity'
```

See also https://community.metabrainz.org/t/how-to-handle-video-files-proper/815575/


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Rename `_loaded_identity` to `_file_identity` for clarity. Ensure it is always initialized and set after loading or saving a file.

## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
