### PR TITLE
PICARD-3412: Persist rotated OAuth refresh token

### DIFF
--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -332,6 +332,15 @@ class OAuthManager(QObject):
                     log.warning("OAuth: refresh token is no longer valid, logging out")
                     self.forget_refresh_token()
             else:
+                # The authorization server may rotate the refresh token on
+                # every use (single-use refresh tokens). When it returns a new
+                # refresh_token we must persist it, otherwise the next refresh
+                # will send an already-revoked token and the user gets logged
+                # out. A refresh does not change the granted scopes, so keep
+                # the existing ones.
+                new_refresh_token = data.get('refresh_token')
+                if new_refresh_token and new_refresh_token != self.refresh_token:
+                    self.set_refresh_token(new_refresh_token, self.refresh_token_scopes)
                 access_token = data['access_token']
                 self.set_access_token(access_token, data['expires_in'])
         except Exception as e:

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -85,6 +85,51 @@ class OAuthManagerTest(PicardTestCase):
         self.assertEqual(b'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk', encoded)
 
 
+class RefreshAccessTokenTest(PicardTestCase):
+    def _manager(self):
+        self.set_config_values(
+            persist={
+                'oauth_refresh_token': 'old-refresh-token',
+                'oauth_refresh_token_scopes': 'profile tag',
+                'oauth_access_token': '',
+                'oauth_access_token_expires': 0,
+            }
+        )
+        manager = OAuthManager(webservice=None)
+        # on_refresh_access_token_finished expects a pending refresh state
+        manager._refreshing = True
+        manager._refresh_callbacks = []
+        return manager
+
+    def test_refresh_persists_rotated_refresh_token(self):
+        # The authorization server rotates the refresh token on every use.
+        # Picard must persist the new token, otherwise the next refresh will
+        # send an already-revoked token and the user gets logged out.
+        manager = self._manager()
+        data = {
+            'access_token': 'new-access-token',
+            'expires_in': 3600,
+            'refresh_token': 'new-refresh-token',
+        }
+        manager.on_refresh_access_token_finished(data, http=None, error=None)
+        self.assertEqual('new-refresh-token', manager.refresh_token)
+        # Scopes must be preserved across a refresh.
+        self.assertEqual('profile tag', manager.refresh_token_scopes)
+        self.assertEqual('new-access-token', manager.access_token)
+
+    def test_refresh_keeps_existing_token_when_none_returned(self):
+        # A server that does not rotate refresh tokens omits refresh_token in
+        # the response; the existing token must be kept.
+        manager = self._manager()
+        data = {
+            'access_token': 'new-access-token',
+            'expires_in': 3600,
+        }
+        manager.on_refresh_access_token_finished(data, http=None, error=None)
+        self.assertEqual('old-refresh-token', manager.refresh_token)
+        self.assertEqual('new-access-token', manager.access_token)
+
+
 class AuthorizationUrlTest(PicardTestCase):
     def _manager(self):
         manager = OAuthManager(webservice=None)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Persist the rotated OAuth refresh token returned on each token refresh, so users are no longer logged out roughly every hour against the migrated MetaBrainz OAuth server.

## Problem

* JIRA ticket: PICARD-3412

Since the MetaBrainz authentication migration, the OAuth server rotates refresh
tokens: each successful refresh consumes the old refresh token and returns a new
one, revoking the previous token server-side (single-use rotation).

`OAuthManager.on_refresh_access_token_finished()` only stored the new access
token from the refresh response and discarded the returned `refresh_token`. After
the access token expired (`expires_in` is 3600s / 1 hour), the next refresh sent
the now-revoked token, the server replied HTTP 400
(`"'refresh_token' in request was already revoked"`), and Picard called
`forget_refresh_token()` and logged the user out. In practice this meant being
asked to log in again on nearly every startup, with the failure appearing after
a delay matching the ~1-hour access token lifetime.

Observed log excerpt:

```
E: oauth.on_refresh_access_token_finished: OAuth: access_token refresh failed:
   {"error": "invalid_request", "error_description": "'refresh_token' in request was already revoked."}
W: OAuth: refresh token is no longer valid, logging out
```

## Solution

Persist the rotated `refresh_token` whenever the token endpoint returns one on
refresh, keeping the existing granted scopes (a refresh does not change scopes).
Servers that do not rotate refresh tokens simply omit `refresh_token` from the
response, in which case the previously stored token is kept.

A live token response from the migrated server confirms it returns a
`refresh_token` field (`mebr_…`) alongside `access_token` and `expires_in: 3600`.

Adds regression tests covering both the rotating and non-rotating cases.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to investigate the root cause from the debug logs, locate the
affected code, draft the fix, and write the regression tests. All changes were
reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
