### PR TITLE
PICARD-3413: Fix crash in toolbar action options on "Add Action"

### DIFF
--- a/picard/ui/options/interface_toolbar.py
+++ b/picard/ui/options/interface_toolbar.py
@@ -157,7 +157,7 @@ class InterfaceToolbarOptionsPage(OptionsPage):
             'system-search',
         ),
     }
-    ACTION_IDS = frozenset(TOOLBAR_BUTTONS)
+    ACTION_IDS: ClassVar[set[MainAction]] = set(TOOLBAR_BUTTONS)
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3413
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Clicking "Add Action" in User Interface > Toolbar Actions crashes Picard with:

```
Picard terminated unexpectedly
Traceback (most recent call last):
  File "/home/phw/devel/musicbrainz/picard/picard/ui/options/interface_toolbar.py", line 250, in add_to_toolbar
    display_list = sorted(self._make_missing_actions_list())
  File "/home/phw/devel/musicbrainz/picard/picard/ui/options/interface_toolbar.py", line 245, in _make_missing_actions_list
    for action_id in set.difference(self.ACTION_IDS, self._added_actions()):
                     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: descriptor 'difference' for 'set' objects doesn't apply to a 'frozenset' object
```

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
