### PR TITLE
Decouple picard.util from Qt (add picard.util.qt)

### DIFF
--- a/picard/browser/filelookup.py
+++ b/picard/browser/filelookup.py
@@ -38,9 +38,9 @@ from picard.config import get_config
 from picard.const import PICARD_URLS
 from picard.disc import Disc
 from picard.util import (
-    build_qurl,
     webbrowser2,
 )
+from picard.util.qt import build_qurl
 
 from picard.ui.searchdialog.album import AlbumSearchDialog
 

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -47,10 +47,10 @@ from picard.plugin import PluginFunctions
 from picard.similarity import similarity2
 from picard.tags import preserved_tag_names
 from picard.util import (
-    ReadWriteLockContext,
     linear_combination_of_weights,
 )
 from picard.util.imagelist import ImageList
+from picard.util.qt import ReadWriteLockContext
 
 
 if TYPE_CHECKING:

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -48,10 +48,8 @@ from picard.i18n import (
     get_locale_bcp47,
     gettext as _,
 )
-from picard.util import (
-    build_qurl,
-    load_json,
-)
+from picard.util import load_json
+from picard.util.qt import build_qurl
 
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -174,7 +174,6 @@ from picard.util import (
     normpath,
     periodictouch,
     pipe,
-    process_events_iter,
     resolve_fs_path,
     system_supports_long_paths,
     thread,
@@ -183,6 +182,7 @@ from picard.util import (
 )
 from picard.util.checkupdate import UpdateCheckManager
 from picard.util.datahash import DataHash
+from picard.util.qt import process_events_iter
 from picard.util.readthedocs import ReadTheDocs
 from picard.util.toc import (
     parse_toc_itunes_cddb,

--- a/picard/ui/infodialog/dialog.py
+++ b/picard/ui/infodialog/dialog.py
@@ -49,7 +49,6 @@ from picard.i18n import gettext as _
 from picard.track import Track
 from picard.util import (
     bytes2human,
-    open_local_path,
 )
 
 from .utils import text_as_html
@@ -63,6 +62,7 @@ from .widgets import (
 from picard.ui import PicardDialog
 from picard.ui.colors import interface_colors
 from picard.ui.forms.ui_infodialog import Ui_InfoDialog
+from picard.ui.util import open_local_path
 
 
 class ArtworkRow:

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -40,7 +40,7 @@ from PyQt6 import (
 from picard import log
 from picard.debug_opts import DebugOpt
 from picard.i18n import gettext as _
-from picard.util import reconnect
+from picard.util.qt import reconnect
 
 from picard.ui import (
     FONT_FAMILY_MONOSPACE,

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -115,13 +115,10 @@ from picard.util import (
     icontheme,
     iter_files_from_objects,
     iter_unique,
-    open_local_path,
-    reconnect,
     resolve_fs_path,
     restore_method,
     sanitize_filename,
     thread,
-    throttle,
     webbrowser2,
 )
 from picard.util.cdrom import (
@@ -132,6 +129,10 @@ from picard.util.cdrom import (
     has_isrc_support,
 )
 from picard.util.isrc import valid_isrc
+from picard.util.qt import (
+    reconnect,
+    throttle,
+)
 from picard.util.readthedocs import ReadTheDocs
 from picard.webservice.api_helpers import escape_lucene_query
 
@@ -187,6 +188,7 @@ from picard.ui.util import (
     FileDialog,
     find_starting_directory,
     menu_builder,
+    open_local_path,
     show_session_not_found_dialog,
 )
 from picard.ui.widgets.checkboxmenuitem import CheckboxMenuItem

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -69,8 +69,8 @@ from picard.util import (
     icontheme,
     restore_method,
     thread,
-    throttle,
 )
+from picard.util.qt import throttle
 
 from .edittagdialog import (
     EditTagDialog,

--- a/picard/ui/metadatabox/edittagdialog.py
+++ b/picard/ui/metadatabox/edittagdialog.py
@@ -39,7 +39,7 @@ from picard.const import (
 from picard.const.countries import RELEASE_COUNTRIES
 from picard.i18n import gettext as _
 from picard.tags import tag_names
-from picard.util import temporary_disconnect
+from picard.util.qt import temporary_disconnect
 
 from picard.ui import PicardDialog
 from picard.ui.forms.ui_edittagdialog import Ui_EditTagDialog

--- a/picard/ui/options/maintenance.py
+++ b/picard/ui/options/maintenance.py
@@ -42,7 +42,6 @@ from picard.i18n import (
     gettext as _,
 )
 from picard.util import (
-    open_local_path,
     resolve_fs_path,
 )
 
@@ -51,7 +50,10 @@ from picard.ui.options import (
     OptionsPage,
     PageOptionConfigs,
 )
-from picard.ui.util import FileDialog
+from picard.ui.util import (
+    FileDialog,
+    open_local_path,
+)
 
 
 def _safe_autobackup_dir(path):

--- a/picard/ui/player/listenbrainz.py
+++ b/picard/ui/player/listenbrainz.py
@@ -38,7 +38,7 @@ from picard.config import get_config
 from picard.const.appdirs import cache_folder
 from picard.file import File
 from picard.metadata import Metadata
-from picard.util import (
+from picard.util.qt import (
     ReadWriteLockContext,
     throttle,
 )

--- a/picard/ui/tablebaseddialog.py
+++ b/picard/ui/tablebaseddialog.py
@@ -40,8 +40,8 @@ from picard.i18n import (
 )
 from picard.util import (
     restore_method,
-    throttle,
 )
+from picard.util.qt import throttle
 
 from picard.ui import PicardDialog
 from picard.ui.columns import (

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -26,6 +26,7 @@
 
 
 from html import escape as html_escape
+import os
 
 from PyQt6 import (
     QtCore,
@@ -42,10 +43,21 @@ from picard.config import get_config
 from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
 from picard.const.sys import IS_LINUX
 from picard.i18n import gettext as _
-from picard.util import find_existing_path
+from picard.util import (
+    find_existing_path,
+    run_executable,
+)
 
 from picard.ui.colors import interface_colors
 from picard.ui.enums import MainAction
+
+
+def open_local_path(path: str) -> None:
+    url = QtCore.QUrl.fromLocalFile(path)
+    if os.environ.get('SNAP'):
+        run_executable('xdg-open', url.toString())
+    else:
+        QtGui.QDesktopServices.openUrl(url)
 
 
 def find_starting_directory():

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -46,7 +46,7 @@ from picard.plugin3.plugin_metadata import (
     is_local_plugin,
 )
 from picard.plugin3.ref_item import RefItem
-from picard.util import temporary_disconnect
+from picard.util.qt import temporary_disconnect
 
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -44,6 +44,18 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+"""General-purpose utility helpers.
+
+This module must not import PyQt6 (Qt) directly. Keeping it Qt-free at the
+import level means individual helpers can be reused from Qt-free contexts
+(e.g. build tooling, or a potential headless/alternative frontend) as long as
+their own transitive imports stay Qt-free too.
+
+Utility helpers that genuinely depend on Qt live in ``picard.util.qt``
+instead. If you need Qt here, add your helper there rather than importing
+PyQt6 in this module.
+"""
+
 from collections import (
     defaultdict,
     namedtuple,
@@ -74,8 +86,7 @@ import sys
 import tempfile
 from typing import Any
 import unicodedata
-
-from PyQt6 import QtCore
+from urllib.parse import quote
 
 from picard import (
     log,
@@ -700,14 +711,6 @@ def album_artist_from_path(filename: str, album: str, artist: str) -> tuple[str,
     return album, artist
 
 
-def encoded_queryargs(queryargs: Mapping[str, Any]) -> dict[str, str]:
-    """
-    Percent-encode all values from passed dictionary
-    Keys are left unmodified
-    """
-    return {name: QtCore.QUrl.toPercentEncoding(str(value)).data().decode() for name, value in queryargs.items()}
-
-
 def get_url(url_key: str) -> str:
     """Gets the URL from the key, with {language} and {version} substitutions.
     Args:
@@ -777,6 +780,28 @@ def load_json(data: bytes | bytearray | str) -> Any:
         The decoded Python object (typically a ``dict`` or ``list``).
     """
     return json.loads(data)
+
+
+def encoded_queryargs(queryargs: Mapping[str, Any]) -> dict[str, str]:
+    """Percent-encode all values from the passed dictionary.
+
+    Keys are left unmodified.
+
+    ``quote(str(value), safe='')`` reproduces the output of the previous
+    ``QUrl.toPercentEncoding(str(value))`` implementation byte-for-byte for
+    every input reachable in Picard (ASCII, unreserved characters including
+    ``~``, reserved/sub-delims, UTF-8 multi-byte and astral code points,
+    spaces, ``+``, control characters, NUL and empty strings).
+
+    The only behavioral difference is for malformed lone UTF-16 surrogates:
+    ``QUrl`` silently dropped them, whereas ``quote()`` raises
+    ``UnicodeEncodeError``. This is not a concern here because the values come
+    from machine-generated arguments (MBIDs, fingerprints, integers, constant
+    literals) or from the search field, whose text originates from Qt widgets
+    as well-formed Unicode; lone surrogates cannot arise through any of these
+    paths.
+    """
+    return {name: quote(str(value), safe='') for name, value in queryargs.items()}
 
 
 def restore_method(func: Callable) -> Callable:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -131,38 +131,6 @@ WIN_LONGPATH_PREFIX = '\\\\?\\'
 WIN_LONGPATH_PREFIX_UNC = '\\\\?\\UNC\\'
 
 
-class ReadWriteLockContext:
-    """Context manager wrapping a `QReadWriteLock`.
-
-    Multiple threads can obtain a read lock, but only one can obtain a write lock.
-    Read and write locks can be explicitly entered with `lock_for_read` and `lock_for_write`:
-
-        lock = ReadWriteLockContext()
-        with lock.lock_for_read():
-            ...
-    """
-
-    def __init__(self):
-        self.__lock = QtCore.QReadWriteLock()
-
-    def lock_for_read(self):
-        self.__lock.lockForRead()
-        return self
-
-    def lock_for_write(self):
-        self.__lock.lockForWrite()
-        return self
-
-    def unlock(self):
-        self.__lock.unlock()
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, type, value, tb):
-        self.__lock.unlock()
-
-
 def process_events_iter(iterable: Iterable, interval: float = 0.1) -> Iterator:
     """
     Creates an iterator over iterable that calls QCoreApplication.processEvents()

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -50,16 +50,12 @@ from collections import (
 )
 from collections.abc import (
     Callable,
-    Generator,
     Iterable,
     Iterator,
     Mapping,
     Sequence,
 )
-from contextlib import (
-    contextmanager,
-    suppress,
-)
+from contextlib import suppress
 from datetime import (
     date,
     datetime,
@@ -810,42 +806,6 @@ def restore_method(func: Callable) -> Callable:
             return func(*args, **kwargs)
 
     return func_wrapper
-
-
-def reconnect(
-    signal: QtCore.pyqtBoundSignal, newhandler: Callable | None = None, oldhandler: Callable | None = None
-) -> None:
-    """
-    Reconnect an handler to a signal
-
-    It disconnects all previous handlers before connecting new one
-
-    Credits: https://stackoverflow.com/a/21589403
-    """
-    while True:
-        try:
-            if oldhandler is not None:
-                signal.disconnect(oldhandler)
-            else:
-                signal.disconnect()
-        except TypeError:
-            break
-    if newhandler is not None:
-        signal.connect(newhandler)
-
-
-@contextmanager
-def temporary_disconnect(signal: QtCore.pyqtBoundSignal, *handlers: Callable) -> Generator[None, None, None]:
-    """
-    Create context to temporarly disconnect one or more signal handlers
-    """
-    try:
-        for handler in handlers:
-            signal.disconnect(handler)
-        yield
-    finally:
-        for handler in handlers:
-            signal.connect(handler)
 
 
 def compare_barcodes(barcode1: str, barcode2: str) -> bool:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -76,7 +76,6 @@ import re
 import subprocess  # nosec: B404
 import sys
 import tempfile
-from time import monotonic
 from typing import Any
 import unicodedata
 
@@ -500,48 +499,6 @@ def parse_amazon_url(url: str) -> dict[str, str] | None:
     if match_ is not None:
         return match_.groupdict()
     return None
-
-
-def throttle(interval: float | int) -> Callable:
-    """
-    Throttle a function so that it will only execute once per ``interval``
-    (specified in milliseconds).
-    """
-    mutex = QtCore.QMutex()
-
-    def decorator(func):
-        def later():
-            mutex.lock()
-            func(*decorator.args, **decorator.kwargs)
-            decorator.prev = monotonic()
-            decorator.is_ticking = False
-            mutex.unlock()
-
-        def throttled_func(*args, **kwargs):
-            if decorator.is_ticking:
-                mutex.lock()
-                decorator.args = args
-                decorator.kwargs = kwargs
-                mutex.unlock()
-                return
-            mutex.lock()
-            now = monotonic()
-            r = interval - (now - decorator.prev) * 1000.0
-            if r <= 0:
-                func(*args, **kwargs)
-                decorator.prev = now
-            else:
-                decorator.args = args
-                decorator.kwargs = kwargs
-                QtCore.QTimer.singleShot(int(r), later)
-                decorator.is_ticking = True
-            mutex.unlock()
-
-        return throttled_func
-
-    decorator.prev = 0
-    decorator.is_ticking = False
-    return decorator
 
 
 class IgnoreUpdatesContext:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -80,7 +80,6 @@ from typing import Any
 import unicodedata
 
 from PyQt6 import QtCore
-from PyQt6.QtNetwork import QNetworkReply
 
 from picard import (
     log,
@@ -802,10 +801,6 @@ def load_json(data: bytes | QtCore.QByteArray | str) -> Any:
 
     """
     return json.loads(__convert_to_string(data))
-
-
-def parse_json(reply: QNetworkReply) -> Any:
-    return load_json(reply.readAll())
 
 
 def restore_method(func: Callable) -> Callable:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -131,30 +131,6 @@ WIN_LONGPATH_PREFIX = '\\\\?\\'
 WIN_LONGPATH_PREFIX_UNC = '\\\\?\\UNC\\'
 
 
-def process_events_iter(iterable: Iterable, interval: float = 0.1) -> Iterator:
-    """
-    Creates an iterator over iterable that calls QCoreApplication.processEvents()
-    after certain time intervals.
-
-    This must only be used in the main thread.
-
-    Args:
-        iterable: iterable object to iterate over
-        interval: interval in seconds to call QCoreApplication.processEvents()
-    """
-    if interval:
-        start = monotonic()
-    for item in iterable:
-        if interval:
-            now = monotonic()
-            delta = now - start
-            if delta > interval:
-                start = now
-                QtCore.QCoreApplication.processEvents()
-        yield item
-    QtCore.QCoreApplication.processEvents()
-
-
 def iter_files_from_objects(objects: Iterable, save: bool = False) -> Iterator:
     """Creates an iterator over all unique files from list of albums, clusters, tracks or files."""
     return iter_unique(chain(*(obj.iterfiles(save) for obj in objects)))

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -87,7 +87,6 @@ from picard import (
     tagger_instance,
 )
 from picard.const import (
-    MUSICBRAINZ_SERVERS,
     PICARD_DOCS_URLS,
     PICARD_URLS,
 )
@@ -741,37 +740,6 @@ def get_url(url_key: str) -> str:
 
     # No match in defined Picard URLs
     return url_key
-
-
-def build_qurl(
-    host: str, port: int = 80, path: str | None = None, queryargs: Mapping[str, Any] | None = None
-) -> QtCore.QUrl:
-    """
-    Builds and returns a QUrl object from `host`, `port` and `path` and
-    automatically enables HTTPS if necessary.
-
-    Encoded query arguments can be provided in `queryargs`, a
-    dictionary mapping field names to values.
-    """
-    url = QtCore.QUrl()
-    url.setHost(host)
-
-    if port == 443 or host in MUSICBRAINZ_SERVERS:
-        url.setScheme('https')
-    elif port == 80:
-        url.setScheme('http')
-    else:
-        url.setScheme('http')
-        url.setPort(port)
-
-    if path is not None:
-        url.setPath(path)
-    if queryargs is not None:
-        url_query = QtCore.QUrlQuery()
-        for k, v in queryargs.items():
-            url_query.addQueryItem(k, str(v))
-        url.setQuery(url_query)
-    return url
 
 
 def union_sorted_lists(list1: Sequence, list2: Sequence) -> list:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -767,36 +767,16 @@ def union_sorted_lists(list1: Sequence, list2: Sequence) -> list:
     return union
 
 
-def __convert_to_string(obj: Any) -> str:
-    """Appropriately converts the input `obj` to a string.
+def load_json(data: bytes | bytearray | str) -> Any:
+    """Deserializes a string or bytes-like JSON document to a Python object.
 
     Args:
-        obj (QByteArray, bytes, bytearray, ...): The input object
+        data: The JSON document as ``str``, ``bytes`` or ``bytearray``.
 
     Returns:
-        string: The appropriately decoded string
-
+        The decoded Python object (typically a ``dict`` or ``list``).
     """
-    if isinstance(obj, QtCore.QByteArray):
-        return obj.data().decode()
-    elif isinstance(obj, (bytes, bytearray)):
-        return obj.decode()
-    else:
-        return str(obj)
-
-
-def load_json(data: bytes | QtCore.QByteArray | str) -> Any:
-    """Deserializes a string or bytes like json response and converts
-    it to a python object.
-
-    Args:
-        data (QByteArray, bytes, bytearray, ...): The json response
-
-    Returns:
-        dict: Response data as a python dict
-
-    """
-    return json.loads(__convert_to_string(data))
+    return json.loads(data)
 
 
 def restore_method(func: Callable) -> Callable:

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -81,7 +81,6 @@ from typing import Any
 import unicodedata
 
 from PyQt6 import QtCore
-from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtNetwork import QNetworkReply
 
 from picard import (
@@ -537,14 +536,6 @@ def run_executable(executable: str, *args, timeout: int | float | None = None) -
 
     # Return (error code, stdout and stderr)
     return ret.returncode, ret.stdout.decode(sys.stdout.encoding), ret.stderr.decode(sys.stderr.encoding)
-
-
-def open_local_path(path: str) -> None:
-    url = QtCore.QUrl.fromLocalFile(path)
-    if os.environ.get('SNAP'):
-        run_executable('xdg-open', url.toString())
-    else:
-        QDesktopServices.openUrl(url)
 
 
 _mbid_format = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -21,7 +21,7 @@ from collections import namedtuple
 
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
-from picard.util import build_qurl
+from picard.util.qt import build_qurl
 
 
 ServerTuple = namedtuple('ServerTuple', ('host', 'port'))

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -30,10 +30,14 @@ from collections.abc import (
     Callable,
     Iterable,
     Iterator,
+    Mapping,
 )
 from time import monotonic
+from typing import Any
 
 from PyQt6 import QtCore
+
+from picard.const import MUSICBRAINZ_SERVERS
 
 
 class ReadWriteLockContext:
@@ -132,3 +136,34 @@ def throttle(interval: float | int) -> Callable:
     decorator.prev = 0
     decorator.is_ticking = False
     return decorator
+
+
+def build_qurl(
+    host: str, port: int = 80, path: str | None = None, queryargs: Mapping[str, Any] | None = None
+) -> QtCore.QUrl:
+    """
+    Builds and returns a QUrl object from `host`, `port` and `path` and
+    automatically enables HTTPS if necessary.
+
+    Encoded query arguments can be provided in `queryargs`, a
+    dictionary mapping field names to values.
+    """
+    url = QtCore.QUrl()
+    url.setHost(host)
+
+    if port == 443 or host in MUSICBRAINZ_SERVERS:
+        url.setScheme('https')
+    elif port == 80:
+        url.setScheme('http')
+    else:
+        url.setScheme('http')
+        url.setPort(port)
+
+    if path is not None:
+        url.setPath(path)
+    if queryargs is not None:
+        url_query = QtCore.QUrlQuery()
+        for k, v in queryargs.items():
+            url_query.addQueryItem(k, str(v))
+        url.setQuery(url_query)
+    return url

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -36,8 +36,10 @@ from time import monotonic
 from typing import Any
 
 from PyQt6 import QtCore
+from PyQt6.QtNetwork import QNetworkReply
 
 from picard.const import MUSICBRAINZ_SERVERS
+from picard.util import load_json
 
 
 class ReadWriteLockContext:
@@ -167,3 +169,8 @@ def build_qurl(
             url_query.addQueryItem(k, str(v))
         url.setQuery(url_query)
     return url
+
+
+def parse_json(reply: QNetworkReply) -> Any:
+    """Deserialize the JSON body of a ``QNetworkReply`` to a Python object."""
+    return load_json(reply.readAll().data())

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -27,6 +27,7 @@ tooling or a potential headless/alternative frontend).
 """
 
 from collections.abc import (
+    Callable,
     Iterable,
     Iterator,
 )
@@ -89,3 +90,45 @@ def process_events_iter(iterable: Iterable, interval: float = 0.1) -> Iterator:
                 QtCore.QCoreApplication.processEvents()
         yield item
     QtCore.QCoreApplication.processEvents()
+
+
+def throttle(interval: float | int) -> Callable:
+    """
+    Throttle a function so that it will only execute once per ``interval``
+    (specified in milliseconds).
+    """
+    mutex = QtCore.QMutex()
+
+    def decorator(func):
+        def later():
+            mutex.lock()
+            func(*decorator.args, **decorator.kwargs)
+            decorator.prev = monotonic()
+            decorator.is_ticking = False
+            mutex.unlock()
+
+        def throttled_func(*args, **kwargs):
+            if decorator.is_ticking:
+                mutex.lock()
+                decorator.args = args
+                decorator.kwargs = kwargs
+                mutex.unlock()
+                return
+            mutex.lock()
+            now = monotonic()
+            r = interval - (now - decorator.prev) * 1000.0
+            if r <= 0:
+                func(*args, **kwargs)
+                decorator.prev = now
+            else:
+                decorator.args = args
+                decorator.kwargs = kwargs
+                QtCore.QTimer.singleShot(int(r), later)
+                decorator.is_ticking = True
+            mutex.unlock()
+
+        return throttled_func
+
+    decorator.prev = 0
+    decorator.is_ticking = False
+    return decorator

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -1,0 +1,61 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2004 Robert Kaye
+# Copyright (C) 2006-2009, 2011-2012, 2014 Lukáš Lalinský
+# Copyright (C) 2008-2011, 2014, 2018-2026 Philipp Wolfer
+# Copyright (C) 2013-2014, 2018-2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+"""Qt-dependent utility helpers.
+
+These helpers depend on PyQt6 (QtCore/QtNetwork) and are kept separate from
+``picard.util`` so that importing ``picard.util`` does not pull in Qt. This
+keeps the bulk of the utility helpers usable from Qt-free contexts (e.g. build
+tooling or a potential headless/alternative frontend).
+"""
+
+from PyQt6 import QtCore
+
+
+class ReadWriteLockContext:
+    """Context manager wrapping a `QReadWriteLock`.
+
+    Multiple threads can obtain a read lock, but only one can obtain a write lock.
+    Read and write locks can be explicitly entered with `lock_for_read` and `lock_for_write`:
+
+        lock = ReadWriteLockContext()
+        with lock.lock_for_read():
+            ...
+    """
+
+    def __init__(self):
+        self.__lock = QtCore.QReadWriteLock()
+
+    def lock_for_read(self):
+        self.__lock.lockForRead()
+        return self
+
+    def lock_for_write(self):
+        self.__lock.lockForWrite()
+        return self
+
+    def unlock(self):
+        self.__lock.unlock()
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, tb):
+        self.__lock.unlock()

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -26,6 +26,12 @@ keeps the bulk of the utility helpers usable from Qt-free contexts (e.g. build
 tooling or a potential headless/alternative frontend).
 """
 
+from collections.abc import (
+    Iterable,
+    Iterator,
+)
+from time import monotonic
+
 from PyQt6 import QtCore
 
 
@@ -59,3 +65,27 @@ class ReadWriteLockContext:
 
     def __exit__(self, type, value, tb):
         self.__lock.unlock()
+
+
+def process_events_iter(iterable: Iterable, interval: float = 0.1) -> Iterator:
+    """
+    Creates an iterator over iterable that calls QCoreApplication.processEvents()
+    after certain time intervals.
+
+    This must only be used in the main thread.
+
+    Args:
+        iterable: iterable object to iterate over
+        interval: interval in seconds to call QCoreApplication.processEvents()
+    """
+    if interval:
+        start = monotonic()
+    for item in iterable:
+        if interval:
+            now = monotonic()
+            delta = now - start
+            if delta > interval:
+                start = now
+                QtCore.QCoreApplication.processEvents()
+        yield item
+    QtCore.QCoreApplication.processEvents()

--- a/picard/util/qt.py
+++ b/picard/util/qt.py
@@ -28,10 +28,12 @@ tooling or a potential headless/alternative frontend).
 
 from collections.abc import (
     Callable,
+    Generator,
     Iterable,
     Iterator,
     Mapping,
 )
+from contextlib import contextmanager
 from time import monotonic
 from typing import Any
 
@@ -174,3 +176,39 @@ def build_qurl(
 def parse_json(reply: QNetworkReply) -> Any:
     """Deserialize the JSON body of a ``QNetworkReply`` to a Python object."""
     return load_json(reply.readAll().data())
+
+
+def reconnect(
+    signal: QtCore.pyqtBoundSignal, newhandler: Callable | None = None, oldhandler: Callable | None = None
+) -> None:
+    """
+    Reconnect an handler to a signal
+
+    It disconnects all previous handlers before connecting new one
+
+    Credits: https://stackoverflow.com/a/21589403
+    """
+    while True:
+        try:
+            if oldhandler is not None:
+                signal.disconnect(oldhandler)
+            else:
+                signal.disconnect()
+        except TypeError:
+            break
+    if newhandler is not None:
+        signal.connect(newhandler)
+
+
+@contextmanager
+def temporary_disconnect(signal: QtCore.pyqtBoundSignal, *handlers: Callable) -> Generator[None, None, None]:
+    """
+    Create context to temporarly disconnect one or more signal handlers
+    """
+    try:
+        for handler in handlers:
+            signal.disconnect(handler)
+        yield
+    finally:
+        for handler in handlers:
+            signal.connect(handler)

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -72,6 +72,8 @@ from picard.oauth import OAuthManager
 from picard.util import (
     bytes2human,
     encoded_queryargs,
+)
+from picard.util.qt import (
     parse_json,
 )
 from picard.util.xml import parse_xml

--- a/test/util/test_init.py
+++ b/test/util/test_init.py
@@ -68,7 +68,6 @@ from picard.util import (
     _io_encoding,
     album_artist_from_path,
     any_exception_isinstance,
-    build_qurl,
     detect as charset_detect,
     detect_file_encoding,
     encoded_queryargs,
@@ -86,13 +85,16 @@ from picard.util import (
     pattern_as_regex,
     resolve_fs_path,
     system_supports_long_paths,
-    temporary_disconnect,
     titlecase,
     tracknum_and_title_from_filename,
     tracknum_from_filename,
     uniqify,
     wildcards_to_regex_pattern,
     win_prefix_longpath,
+)
+from picard.util.qt import (
+    build_qurl,
+    temporary_disconnect,
 )
 
 


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Split the Qt-dependent helpers out of `picard.util` into a new `picard.util.qt`, and rewrite the two remaining helpers (`load_json`, `encoded_queryargs`) without Qt, so that `picard.util` no longer imports PyQt6 directly.

## Problem

`picard.util` mixed general-purpose helpers with a handful that depend on PyQt6
(QtCore/QtNetwork). That forced a direct Qt import at the top of the module, so
the whole utility grab-bag could only be used in a Qt context — inconvenient for
Qt-free consumers such as build tooling or a potential headless/alternative
frontend.

## Solution

* Add `picard.util.qt` as the home for genuinely Qt-dependent helpers and move
  them there: `ReadWriteLockContext`, `process_events_iter`, `throttle`,
  `build_qurl`, `parse_json`, `reconnect`, `temporary_disconnect`. Also move
  `open_local_path` to `picard.ui.util` (it uses `QDesktopServices`).
* Rewrite the two helpers that don't actually need Qt so they stay in
  `picard.util`:
  * `load_json` — decode with the standard library instead of `QByteArray`.
    `parse_json` (now in `picard.util.qt`) passes plain bytes via
    `QByteArray.data()`, so `load_json` no longer needs to handle Qt types.
  * `encoded_queryargs` — use `urllib.parse.quote(str(value), safe='')`. This
    reproduces the previous `QUrl.toPercentEncoding` output byte-for-byte for
    every input reachable in Picard; the only difference is for malformed lone
    UTF-16 surrogates (which cannot arise from the actual query-arg sources).
    The equivalence and this caveat are documented in the docstring.
* Add a module docstring to `picard.util` stating that it must not import PyQt6
  directly and that Qt-dependent helpers belong in `picard.util.qt`.
* Update all importers accordingly.

No behavior change is intended; existing tests pass and `ruff`/`ty` are clean.
The history is organized as one commit per moved/rewritten helper for easy
review.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The refactoring, the byte-for-byte equivalence analysis for `encoded_queryargs`,
the commit organization, and the documentation were developed with significant
AI assistance, then reviewed and verified locally (`ruff`, `ty`, and the
affected test suites).

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
