### PR TITLE
Fix crashes in plugin3 from malformed plugin/registry/config data

### DIFF
--- a/picard/git/ops.py
+++ b/picard/git/ops.py
@@ -186,6 +186,8 @@ class GitOperations:
                             return 'tag', ref
                         elif git_ref.ref_type == GitRefType.BRANCH:
                             return 'branch', ref
+                        # Known ref but unrecognized type: treat as unknown.
+                        return None, ref
                     else:
                         # Try as commit hash
                         try:

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -729,6 +729,23 @@ class PluginApi:
         return api
 
     # Translation
+    def _safe_format(self, text: str, kwargs: dict) -> str:
+        """Apply str.format() to a translation string, tolerating bad input.
+
+        Translation strings come from plugin code and translation files, so
+        they may reference placeholders that were not supplied or use malformed
+        format syntax (e.g. a stray brace). Rather than let such errors crash
+        the caller, log a warning identifying the plugin and fall back to the
+        unformatted string.
+        """
+        if not kwargs:
+            return text
+        try:
+            return text.format(**kwargs)
+        except (KeyError, IndexError, ValueError, AttributeError) as e:
+            self._logger.warning("Failed to format translation string %r for plugin '%s': %s", text, self._plugin_id, e)
+            return text
+
     def tr(self, key: str, text: str | None = None, **kwargs) -> str:
         """Translate a string for the plugin.
 
@@ -767,8 +784,7 @@ class PluginApi:
                 self._logger.debug("tr() using fallback: '%s' -> '%s'", key, result)
 
         # Apply placeholder substitution
-        if kwargs:
-            result = result.format(**kwargs)
+        result = self._safe_format(result, kwargs)
 
         return result
 
@@ -833,8 +849,7 @@ class PluginApi:
                 result = key
 
         # Apply placeholder substitution
-        if kwargs:
-            result = result.format(**kwargs)
+        result = self._safe_format(result, kwargs)
 
         return result
 

--- a/picard/plugin3/manager/registry.py
+++ b/picard/plugin3/manager/registry.py
@@ -138,13 +138,25 @@ class PluginRegistryManager:
             min_api = ref.get('min_api_version')
             max_api = ref.get('max_api_version')
 
-            # Skip if below minimum
-            if min_api and current_api < Version.from_string(min_api):
-                continue
+            # min/max_api_version come from unvalidated registry data. If a bound
+            # is present but unparseable, we cannot verify this ref's
+            # compatibility, so skip it and keep looking for one we can verify
+            # (falling back to refs[0] below if none qualify).
+            if min_api:
+                min_version = _parse_version_safely(min_api)
+                if min_version is None:
+                    log.warning("Skipping ref %r: invalid min_api_version %r", ref.get('name'), min_api)
+                    continue
+                if current_api < min_version:
+                    continue
 
-            # Skip if above maximum
-            if max_api and current_api > Version.from_string(max_api):
-                continue
+            if max_api:
+                max_version = _parse_version_safely(max_api)
+                if max_version is None:
+                    log.warning("Skipping ref %r: invalid max_api_version %r", ref.get('name'), max_api)
+                    continue
+                if current_api > max_version:
+                    continue
 
             # Compatible ref found
             return ref['name']

--- a/picard/plugin3/manager/update.py
+++ b/picard/plugin3/manager/update.py
@@ -67,7 +67,7 @@ class UpdateCheck(NamedTuple):
     new_commit: str
     commit_date: int
     old_ref: str
-    new_ref: str
+    new_ref: str | None
     new_ref_type: str | None = None
 
 
@@ -76,8 +76,8 @@ class UpdateAllResult(NamedTuple):
 
     plugin_id: str
     success: bool
-    result: UpdateResult
-    error: str
+    result: UpdateResult | None = None
+    error: str | None = None
 
 
 class PluginUpdater:

--- a/picard/plugin3/manifest.py
+++ b/picard/plugin3/manifest.py
@@ -45,16 +45,29 @@ class PluginManifest:
         self.module_name = module_name
         self._data = tomllib.load(manifest_fp)
 
+    def _localized(self, i18n_field: str, plain_field: str, locale: str) -> str:
+        """Return a localized string field, tolerating malformed manifest data.
+
+        The ``*_i18n`` section and its values come from a plugin-authored
+        MANIFEST.toml and may have the wrong type (the validator only rejects
+        empty sections). Guard that the section is a dict and the resolved
+        value is a string; otherwise fall back to the plain field. Always
+        returns a string.
+        """
+        i18n = self._data.get(i18n_field)
+        if isinstance(i18n, dict):
+            value = i18n.get(locale)
+            if not isinstance(value, str):
+                # Try language without region (e.g., 'de' from 'de_DE')
+                value = i18n.get(locale.split('_')[0])
+            if isinstance(value, str):
+                return value
+        plain = self._data.get(plain_field, '')
+        return plain if isinstance(plain, str) else ''
+
     def name(self, locale: str = 'en') -> str:
         """Get plugin name, optionally translated."""
-        i18n = self._data.get('name_i18n') or {}
-        if locale in i18n:
-            return i18n[locale]
-        # Try language without region (e.g., 'de' from 'de_DE')
-        lang = locale.split('_')[0]
-        if lang in i18n:
-            return i18n[lang]
-        return self._data.get('name', '')
+        return self._localized('name_i18n', 'name', locale)
 
     @property
     def authors(self) -> tuple[str]:
@@ -73,25 +86,11 @@ class PluginManifest:
 
     def description(self, locale: str = 'en') -> str:
         """Get short description, optionally translated."""
-        i18n = self._data.get('description_i18n') or {}
-        if locale in i18n:
-            return i18n[locale]
-        # Try language without region
-        lang = locale.split('_')[0]
-        if lang in i18n:
-            return i18n[lang]
-        return self._data.get('description', '')
+        return self._localized('description_i18n', 'description', locale)
 
     def long_description(self, locale: str = 'en') -> str:
         """Get long description, optionally translated."""
-        i18n = self._data.get('long_description_i18n') or {}
-        if locale in i18n:
-            return i18n[locale]
-        # Try language without region
-        lang = locale.split('_')[0]
-        if lang in i18n:
-            return i18n[lang]
-        return self._data.get('long_description', '')
+        return self._localized('long_description_i18n', 'long_description', locale)
 
     def _get_current_locale(self) -> str:
         """Get current locale from Picard's UI language setting or system locale."""

--- a/picard/plugin3/manifest.py
+++ b/picard/plugin3/manifest.py
@@ -70,12 +70,12 @@ class PluginManifest:
         return self._localized('name_i18n', 'name', locale)
 
     @property
-    def authors(self) -> tuple[str]:
+    def authors(self) -> tuple[str, ...]:
         authors = self._data.get('authors', [])
         return tuple(authors) if authors else tuple()
 
     @property
-    def maintainers(self) -> tuple[str]:
+    def maintainers(self) -> tuple[str, ...]:
         maintainers = self._data.get('maintainers', [])
         return tuple(maintainers) if maintainers else tuple()
 

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -74,6 +74,11 @@ class PluginMetadata:
 
         # Filter unknown fields and create instance
         filtered_data = {k: v for k, v in data.items() if k in cls.__dataclass_fields__}
+        # url/ref/commit are required (no dataclass defaults). Persisted config
+        # may be incomplete (hand-edited or written by a different version), so
+        # default missing required fields to '' rather than crashing.
+        for required in ('url', 'ref', 'commit'):
+            filtered_data.setdefault(required, '')
         instance = cls(**filtered_data)
         instance.git_ref = git_ref
         return instance

--- a/picard/plugin3/validator.py
+++ b/picard/plugin3/validator.py
@@ -306,8 +306,16 @@ def validate_manifest_dict(manifest_data):
     for section in ['name_i18n', 'description_i18n', 'long_description_i18n']:
         if section in manifest_data:
             value = manifest_data[section]
-            if not value or (isinstance(value, dict) and len(value) == 0):
+            if not isinstance(value, dict):
+                errors.append(f"Section '{section}' must be a table of locale -> string")
+            elif len(value) == 0:
                 errors.append(f"Section '{section}' is present but empty")
+            else:
+                for locale, text in value.items():
+                    if not _is_valid_locale(locale):
+                        errors.append(f"Section '{section}' has invalid locale key '{locale}'")
+                    if not isinstance(text, str):
+                        errors.append(f"Section '{section}' value for locale '{locale}' must be a string")
 
     # Validate markdown in long_description_i18n
     if 'long_description_i18n' in manifest_data:

--- a/test/plugins3/test_git.py
+++ b/test/plugins3/test_git.py
@@ -22,6 +22,10 @@ from pathlib import Path
 import shutil
 import sys
 import tempfile
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 from test.picardtestcase import PicardTestCase
 from test.plugins3.helpers import (
@@ -71,6 +75,35 @@ class TestCheckRefType(PicardTestCase):
         ref_type, ref_name = GitOperations.check_ref_type(Path('/nonexistent'), 'main')
         self.assertIsNone(ref_type)
         self.assertEqual(ref_name, 'main')
+
+    def test_check_ref_type_unknown_ref_type_returns_tuple(self):
+        """check_ref_type() must always return a 2-tuple, even for unknown ref types.
+
+        Regression test: when find_git_ref() returned a ref whose ref_type was
+        neither TAG nor BRANCH, the ``if ref:`` branch fell through without an
+        explicit return, so the function implicitly returned None. Callers that
+        unpack the result (``ref_type, ref_name = check_ref_type(...)``) then
+        crashed with ``TypeError: cannot unpack non-iterable NoneType``.
+        """
+        # A git_ref that exists but whose type is neither TAG nor BRANCH.
+        fake_ref = MagicMock()
+        fake_ref.ref_type = object()  # not GitRefType.TAG or .BRANCH
+
+        fake_repo = MagicMock()
+        fake_backend = MagicMock()
+        fake_backend.create_repository.return_value.__enter__.return_value = fake_repo
+
+        with (
+            patch('picard.git.ops.git_backend', return_value=fake_backend),
+            patch('picard.git.ops.find_git_ref', return_value=fake_ref),
+        ):
+            result = GitOperations.check_ref_type(Path('/repo'), 'refs/notes/something')
+
+        # Must be unpackable into (ref_type, ref_name), never None.
+        self.assertIsNotNone(result)
+        ref_type, ref_name = result
+        self.assertIsNone(ref_type)
+        self.assertEqual(ref_name, 'refs/notes/something')
 
 
 @pytest.mark.skipif(not HAS_GIT_BACKEND, reason="git backend not available")

--- a/test/plugins3/test_plugin_metadata.py
+++ b/test/plugins3/test_plugin_metadata.py
@@ -75,6 +75,33 @@ class TestPluginMetadataFromDict(PicardTestCase):
         m = PluginMetadata.from_dict(data)
         self.assertEqual(m.url, 'u')
 
+    def test_missing_required_field_does_not_crash(self):
+        """from_dict() must tolerate stored config missing a required field.
+
+        Regression test: url/ref/commit have no defaults, so a persisted
+        plugins3_metadata entry missing one of them (e.g. hand-edited config or
+        written by a different Picard version) made cls(**data) raise
+        TypeError: missing required positional argument, breaking plugin
+        listing/install/enable. Missing required fields now default to ''.
+        """
+        m = PluginMetadata.from_dict({'url': 'https://x/y', 'ref': 'main'})
+        self.assertEqual(m.url, 'https://x/y')
+        self.assertEqual(m.ref, 'main')
+        self.assertEqual(m.commit, '')
+
+    def test_all_required_fields_missing_does_not_crash(self):
+        m = PluginMetadata.from_dict({'name': 'Foo'})
+        self.assertEqual(m.name, 'Foo')
+        self.assertEqual(m.url, '')
+        self.assertEqual(m.ref, '')
+        self.assertEqual(m.commit, '')
+
+    def test_empty_dict_does_not_crash(self):
+        m = PluginMetadata.from_dict({})
+        self.assertEqual(m.url, '')
+        self.assertEqual(m.ref, '')
+        self.assertEqual(m.commit, '')
+
 
 class TestPluginMetadataGetGitRef(PicardTestCase):
     def test_returns_stored_git_ref(self):

--- a/test/plugins3/test_translations.py
+++ b/test/plugins3/test_translations.py
@@ -17,6 +17,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import io
 import json
 from pathlib import Path
 import tempfile
@@ -58,6 +59,59 @@ class TestPluginManifestSourceLocale(PicardTestCase):
                 self.assertEqual(manifest.source_locale, 'de_DE')
         finally:
             temp_path.unlink(missing_ok=True)
+
+
+class TestPluginManifestMalformedI18n(PicardTestCase):
+    """Regression tests for malformed *_i18n sections in a plugin MANIFEST.toml.
+
+    The i18n accessors (name/description/long_description) previously indexed
+    into whatever value the TOML declared for the section. The manifest
+    validator only rejects *empty* i18n sections, so a section declared with
+    the wrong type still counted as valid. For example ``name_i18n = "enabled"``
+    made ``name('en')`` evaluate ``'en' in "enabled"`` (a substring match) and
+    then ``"enabled"['en']``, raising ``TypeError: string indices must be
+    integers``. Non-string dict values likewise leaked through, breaking the
+    documented ``-> str`` return type.
+
+    The accessors must always return a string, falling back to the plain field.
+    """
+
+    BASE = (
+        b'uuid = "3f9a1b2c-4d5e-4f6a-8b9c-0d1e2f3a4b5c"\n'
+        b'name = "Test Plugin"\n'
+        b'description = "A test plugin for demonstration"\n'
+        b'api = ["3.0"]\n'
+    )
+
+    def _manifest(self, extra: bytes) -> PluginManifest:
+        return PluginManifest('test', io.BytesIO(self.BASE + extra))
+
+    def test_name_i18n_as_string_does_not_crash(self):
+        # 'en' is a substring of 'enabled': the old code indexed into the string.
+        manifest = self._manifest(b'name_i18n = "enabled"\n')
+        self.assertEqual(manifest.name('en'), 'Test Plugin')
+
+    def test_name_i18n_non_string_value_returns_plain_field(self):
+        manifest = self._manifest(b'[name_i18n]\nen = 123\n')
+        self.assertEqual(manifest.name('en'), 'Test Plugin')
+
+    def test_name_i18n_array_value_returns_plain_field(self):
+        manifest = self._manifest(b'[name_i18n]\nen = ["x"]\n')
+        self.assertEqual(manifest.name('en'), 'Test Plugin')
+
+    def test_description_i18n_as_string_does_not_crash(self):
+        manifest = self._manifest(b'description_i18n = "enclosure"\n')
+        self.assertEqual(manifest.description('en'), 'A test plugin for demonstration')
+
+    def test_long_description_i18n_non_string_value_returns_plain_field(self):
+        manifest = self._manifest(b'long_description = "Long desc"\n[long_description_i18n]\nen = 42\n')
+        self.assertEqual(manifest.long_description('en'), 'Long desc')
+
+    def test_valid_i18n_still_translates(self):
+        # Ensure the guard does not break the normal, well-formed case.
+        manifest = self._manifest(b'[name_i18n]\nde = "Test-Erweiterung"\n')
+        self.assertEqual(manifest.name('de'), 'Test-Erweiterung')
+        self.assertEqual(manifest.name('en'), 'Test Plugin')
 
 
 class TestPluginApiLocale(PicardTestCase):

--- a/test/plugins3/test_translations.py
+++ b/test/plugins3/test_translations.py
@@ -22,7 +22,10 @@ from pathlib import Path
 import tempfile
 from unittest.mock import Mock
 
-from test.picardtestcase import PicardTestCase
+from test.picardtestcase import (
+    PicardTestCase,
+    subtest_cases,
+)
 from test.plugins3.helpers import (
     create_test_plugin_api,
     load_plugin_manifest,
@@ -101,6 +104,45 @@ class TestPluginTranslations(PicardTestCase):
 
         result = api.tr('user_info', '{name} has {count} items', name='Alice', count=5)
         self.assertEqual(result, 'Alice has 5 items')
+
+    @subtest_cases(
+        "text,expected",
+        {
+            'missing placeholder kwarg': ('Hello {missing}', 'Hello {missing}'),
+            'malformed opening brace': ('Hello {', 'Hello {'),
+            'malformed closing brace': ('Hello }', 'Hello }'),
+        },
+    )
+    def test_tr_bad_format_falls_back_to_unformatted(self, text, expected):
+        """tr() must not crash on bad format strings from plugins/translations.
+
+        Regression test: a badly written plugin or incorrect translation may
+        reference an unsupplied placeholder ('{missing}') or use malformed
+        format syntax (a stray brace). str.format() raised KeyError/ValueError,
+        which propagated out of the translation call. tr() now logs a warning
+        and falls back to the unformatted string.
+        """
+        manifest = load_plugin_manifest('example')
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
+
+        result = api.tr('greeting', text, name='World')
+        self.assertEqual(result, expected)
+
+    @subtest_cases(
+        "singular,plural,expected",
+        {
+            'missing placeholder kwarg': ('{missing} file', '{missing} files', '{missing} files'),
+            'malformed opening brace': ('{ file', '{ files', '{ files'),
+            'malformed closing brace': ('} file', '} files', '} files'),
+        },
+    )
+    def test_trn_bad_format_falls_back_to_unformatted(self, singular, plural, expected):
+        """trn() must not crash on bad format strings from plugins/translations."""
+        manifest = load_plugin_manifest('example')
+        api = PluginApi(manifest, Mock(), Mock(), Path(''))
+
+        result = api.trn('files', singular, plural, n=5)
+        self.assertEqual(result, expected)
 
 
 def _create_locale_dir(tmpdir):

--- a/test/plugins3/test_validator.py
+++ b/test/plugins3/test_validator.py
@@ -151,6 +151,30 @@ class TestManifestValidator(PicardTestCase):
         errors = validate_manifest_dict(manifest)
         self.assertEqual(errors, [])
 
+    def test_validate_i18n_section_wrong_type(self):
+        """Validation rejects an i18n section that is not a table/dict."""
+        manifest = _valid_manifest(name_i18n='enabled')
+        errors = validate_manifest_dict(manifest)
+        self.assertIn("Section 'name_i18n' must be a table of locale -> string", errors)
+
+    def test_validate_i18n_section_array(self):
+        """Validation rejects an i18n section declared as an array."""
+        manifest = _valid_manifest(name_i18n=['x'])
+        errors = validate_manifest_dict(manifest)
+        self.assertIn("Section 'name_i18n' must be a table of locale -> string", errors)
+
+    def test_validate_i18n_non_string_value(self):
+        """Validation rejects non-string values within an i18n section."""
+        manifest = _valid_manifest(name_i18n={'en': 123})
+        errors = validate_manifest_dict(manifest)
+        self.assertIn("Section 'name_i18n' value for locale 'en' must be a string", errors)
+
+    def test_validate_i18n_invalid_locale_key(self):
+        """Validation rejects invalid locale keys within an i18n section."""
+        manifest = _valid_manifest(name_i18n={'not-a-locale': 'X'})
+        errors = validate_manifest_dict(manifest)
+        self.assertIn("Section 'name_i18n' has invalid locale key 'not-a-locale'", errors)
+
     @subtest_cases(
         "locale",
         ['en', 'de', 'fr', 'pt', 'en_US', 'pt_BR', 'zh_CN', 'haw', 'haw_US'],

--- a/test/plugins3/test_versioning.py
+++ b/test/plugins3/test_versioning.py
@@ -280,6 +280,50 @@ class TestSelectRefForPlugin(PicardTestCase):
         ]
         self.assertEqual(mgr.select_ref_for_plugin(plugin), 'main')
 
+    @patch('picard.plugin3.manager.registry.api_versions_tuple', (Version.from_string('3.0'),))
+    def test_malformed_min_api_version_does_not_crash(self):
+        """Malformed min_api_version from registry data must not crash ref selection.
+
+        Regression test: min_api_version/max_api_version come from raw,
+        unvalidated registry ref data. Version.from_string() raises VersionError
+        on malformed input (e.g. 'abc'), which previously propagated out of
+        select_ref_for_plugin() during install/update. A ref whose bound cannot
+        be parsed is now skipped (its compatibility cannot be verified), and the
+        next verifiable ref is used.
+        """
+        mgr = PluginRegistryManager(Mock())
+        plugin = Mock()
+        plugin.versioning_scheme = None
+        plugin.git_url = 'url'
+        plugin.refs = [
+            {'name': 'broken', 'min_api_version': 'abc'},
+            {'name': 'good', 'min_api_version': '3.0'},
+        ]
+        # 'broken' is skipped (unparseable), 'good' is compatible and selected.
+        self.assertEqual(mgr.select_ref_for_plugin(plugin), 'good')
+
+    @patch('picard.plugin3.manager.registry.api_versions_tuple', (Version.from_string('3.0'),))
+    def test_malformed_max_api_version_does_not_crash(self):
+        mgr = PluginRegistryManager(Mock())
+        plugin = Mock()
+        plugin.versioning_scheme = None
+        plugin.git_url = 'url'
+        plugin.refs = [
+            {'name': 'broken', 'max_api_version': 'not-a-version'},
+            {'name': 'good', 'max_api_version': '99.0'},
+        ]
+        self.assertEqual(mgr.select_ref_for_plugin(plugin), 'good')
+
+    @patch('picard.plugin3.manager.registry.api_versions_tuple', (Version.from_string('3.0'),))
+    def test_all_refs_malformed_falls_back_to_first(self):
+        """If no ref can be verified, fall back to the first ref (unchanged behavior)."""
+        mgr = PluginRegistryManager(Mock())
+        plugin = Mock()
+        plugin.versioning_scheme = None
+        plugin.git_url = 'url'
+        plugin.refs = [{'name': 'main', 'min_api_version': 'abc'}]
+        self.assertEqual(mgr.select_ref_for_plugin(plugin), 'main')
+
     @patch('picard.plugin3.manager.registry.api_versions_tuple', (Version.from_string('10.0'),))
     def test_api_version_multi_digit_comparison(self):
         """Ensure API version 10.0 is correctly compared (not string-based)."""


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Harden `picard/plugin3/` against crashes triggered by malformed or unexpected plugin, registry, and stored‑config data. Each fix turns a latent exception into a graceful fallback or a clear, rejected error.

## Problem

Several code paths in the plugin3 subsystem trusted the shape/type of external
data (plugin manifests, translation files, the plugin registry, and persisted
config) and could raise unhandled exceptions:

* `Plugin.read_manifest()` referenced an unbound `manifest_path` in its
  `except` handler when `local_path` was `None`, masking the real error with an
  `UnboundLocalError`.
* `check_ref_type()` fell through and returned `None` for a known-but-unrecognized
  ref type; callers unpack the result and crashed with `TypeError: cannot unpack
  non-iterable NoneType`.
* `PluginApi.tr()` / `trn()` called `str.format()` directly on plugin-authored
  translation strings; a bad placeholder or malformed syntax raised
  `KeyError`/`ValueError` out of the translation call.
* Malformed `*_i18n` sections in a `MANIFEST.toml` (e.g. `name_i18n = "enabled"`)
  passed validation and then crashed the i18n accessors with `TypeError`.
* `select_ref_for_plugin()` called `Version.from_string()` on unvalidated
  registry `min/max_api_version` values, raising `VersionError` during
  install/update.
* `PluginMetadata.from_dict()` raised `TypeError` when persisted metadata was
  missing a required field (hand-edited config or written by a different Picard
  version).

* JIRA ticket (_optional_): n/a

## Solution

Each fix is small, behavior-preserving on the happy path, and covered by a
regression test that fails before and passes after:

* `read_manifest()`: bind `manifest_path` before the `try` so the handler always
  raises a proper `PluginManifestReadError`.
* `check_ref_type()`: return `(None, ref)` for unrecognized ref types so the
  documented 2-tuple contract always holds.
* `tr()` / `trn()`: add a shared `_safe_format()` helper that catches formatting
  errors, logs a warning identifying the plugin, and falls back to the
  unformatted string.
* Manifest i18n: reject non-table sections / invalid locale keys / non-string
  values in the validator, and add a guarded `_localized()` accessor
  (defense-in-depth) that always returns a string.
* `select_ref_for_plugin()`: parse api-version bounds with
  `_parse_version_safely()`; skip refs whose compatibility cannot be verified,
  falling back to the first ref.
* `from_dict()`: default missing required fields to `''` so incomplete stored
  config no longer crashes plugin listing/install/enable.

A final commit corrects a few type annotations (`Optional`/variadic tuple) to
match runtime values, with no behavior change.

All of `test/plugins3/` passes (`ruff format`, `ruff check`, and `ty check`
clean; no new type diagnostics introduced).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The review of `picard/plugin3/`, the fixes, and the regression tests were
developed with AI assistance (LSP-backed analysis and test-first implementation)
under close human direction: a human set the scope (stability only, near
release), reviewed each change, corrected the fix semantics (e.g. registry
ref selection), enforced project conventions (imports, `subtest_cases`), and
approved each commit. Every fix was verified by running the test suite,
linters, and the type checker.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
