### PR TITLE
Fix crashes importing a malformed profile file

### DIFF
--- a/picard/profiles/importer.py
+++ b/picard/profiles/importer.py
@@ -118,6 +118,8 @@ def import_profile(
     profile_section = data.get('profile')
     if not profile_section:
         raise ProfileImportError(_("Missing required [profile] section"))
+    if not isinstance(profile_section, dict):
+        raise ProfileImportError(_("The [profile] section must be a table"))
 
     title = profile_section.get('title')
     if not title:
@@ -159,6 +161,8 @@ def import_profile(
     profile_settings = {}
 
     settings_section = data.get('settings', {})
+    if not isinstance(settings_section, dict):
+        raise ProfileImportError(_("The [settings] section must be a table"))
 
     # Apply settings upgrades if the profile is from an older version
     picard_version = profile_section.get('picard_version')
@@ -202,8 +206,12 @@ def import_profile(
 
     # Process [scripts.naming] section
     scripts_section = data.get('scripts', {})
+    if not isinstance(scripts_section, dict):
+        raise ProfileImportError(_("The [scripts] section must be a table"))
     naming_section = scripts_section.get('naming')
     if naming_section:
+        if not isinstance(naming_section, dict):
+            raise ProfileImportError(_("The [scripts.naming] section must be a table"))
         script_id = _import_naming_script(config, naming_section, result)
         if script_id:
             profile_settings['active_file_naming_script_id'] = script_id
@@ -211,6 +219,8 @@ def import_profile(
     # Process [[scripts.tagging]] section
     tagging_section = scripts_section.get('tagging', [])
     if tagging_section:
+        if not isinstance(tagging_section, list):
+            raise ProfileImportError(_("The [[scripts.tagging]] section must be an array of tables"))
         _import_tagger_scripts(config, profile_settings, tagging_section, result)
 
     # Register the profile
@@ -353,6 +363,8 @@ def _import_tagger_scripts(
     duplicate_count = 0
 
     for entry in tagging_section:
+        if not isinstance(entry, dict):
+            raise ProfileImportError(_("Each [[scripts.tagging]] entry must be a table"))
         title = entry.get('title', '')
         script = entry.get('script', '')
         enabled = entry.get('enabled', True)

--- a/test/test_profile_import.py
+++ b/test/test_profile_import.py
@@ -16,6 +16,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+from test.picardtestcase import subtest_cases
 from test.test_config import TestPicardConfigCommon
 
 from picard.config import (
@@ -622,3 +623,30 @@ some_option = true
         self.assertTrue(any('failed' in w for w in result.warnings))
         # No upgrades recorded
         self.assertEqual(result.upgraded_settings, [])
+
+    @subtest_cases(
+        "toml",
+        {
+            'profile not a table': 'profile = "hello"\n',
+            'settings not a table': 'settings = 42\n[profile]\ntitle = "T"\n',
+            'scripts not a table': 'scripts = "x"\n[profile]\ntitle = "T"\n',
+            'scripts.naming not a table': '[profile]\ntitle = "T"\n\n[scripts]\nnaming = "x"\n',
+            'scripts.tagging not a list': '[profile]\ntitle = "T"\n\n[scripts]\ntagging = "x"\n',
+            'scripts.tagging entry not a table': '[profile]\ntitle = "T"\n\n[scripts]\ntagging = ["x"]\n',
+        },
+    )
+    def test_import_malformed_section_types_raise_profile_import_error(self, toml):
+        """Type-mismatched (but TOML-valid) sections must raise ProfileImportError.
+
+        Regression test: a profile file could declare a section with the wrong
+        type (e.g. ``profile = "hello"`` instead of a ``[profile]`` table, or
+        ``tagging = "x"`` instead of an array of tables). The importer indexed
+        into these values with ``.get()``/``.items()`` or iterated them,
+        raising ``AttributeError``/``TypeError`` that escaped the documented
+        ``ProfileImportError`` contract and crashed the CLI / produced an
+        uncaught traceback in the UI (callers only catch ProfileImportError).
+        Import is reachable with untrusted input via
+        ``picard-cli profiles import --file <untrusted.toml>``.
+        """
+        with self.assertRaises(ProfileImportError):
+            import_profile(self.config, toml)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Validate the types of the sections in an imported profile so that a malformed (but TOML-valid) profile file raises a `ProfileImportError` instead of an uncaught exception. This prevents `picard-cli profiles import` from crashing and the options dialog from raising an uncaught traceback on untrusted input.

## Problem

`import_profile()` reads a profile from a TOML string and is documented to raise
only `ProfileImportError` on bad input. Both callers rely on that contract and
catch only `ProfileImportError`:

* `picard/cli/profiles.py` (`picard-cli profiles import --file <path>`)
* `picard/ui/options/profiles.py` (the options dialog "Import" button)

However, the importer indexed into the parsed sections with `.get()` / `.items()`
and iterated them without checking their types. A profile file can be perfectly
valid TOML while declaring a section with the wrong type, e.g.:

```toml
profile = "hello"          # not a [profile] table
```
```toml
[profile]
title = "T"
[scripts]
tagging = "x"              # not an array of tables
```

Such input raised `AttributeError` / `TypeError` from inside `import_profile()`,
which escaped the `ProfileImportError` contract: the CLI crashed with an uncaught
traceback and the UI slot raised an uncaught exception. This is reachable with
untrusted input, since the CLI imports an arbitrary user-supplied file.

Confirmed crashing cases (all previously uncaught):

* `profile` not a table
* top-level `settings` not a table
* top-level `scripts` not a table
* `scripts.naming` not a table
* `scripts.tagging` not an array
* a `[[scripts.tagging]]` entry that is not a table

* JIRA ticket (_optional_): n/a

## Solution

Validate the type of each section before using it and raise `ProfileImportError`
with a clear, translatable message otherwise:

* `[profile]`, `[settings]`, `[scripts]`, and `[scripts.naming]` must be tables.
* `[[scripts.tagging]]` must be an array, and each entry must be a table.

This keeps the documented contract intact, so the existing error handling in both
callers reports a friendly message instead of crashing. The happy path and all
existing behavior are unchanged.

Covered by a new table-driven regression test (`subtest_cases`) with one case per
malformed section type; each fails before and passes after. All profile
import/export/CLI tests pass; `ruff format`, `ruff check`, and `ty check` are
clean (no new diagnostics).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The review of the profiles subsystem, the fix, and the regression tests were
developed with AI assistance (LSP-backed analysis and test-first implementation)
under close human direction: a human chose the target, reviewed the change, and
approved the commit. The crashes were reproduced with concrete malformed input,
and the fix was verified by running the test suite, linters, and the type checker.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
