### PR TITLE
Redact OAuth secrets from debug logs

### DIFF
--- a/picard/browser/server.py
+++ b/picard/browser/server.py
@@ -54,6 +54,7 @@ from picard.const import (
     BROWSER_INTEGRATION_MAX_PORT,
     METABRAINZ_OAUTH_SCOPES,
 )
+from picard.debug_opts import DebugOpt
 from picard.oauth import OAuthInvalidStateError
 from picard.util import mbid_validate
 from picard.util.thread import to_main
@@ -205,7 +206,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         self._log(log.error, format, args)
 
     def log_message(self, format, *args):
-        self._log(log.info, format, args)
+        # The access log emits the full request line, including the query
+        # string. For the /auth OAuth callback that query carries the raw
+        # authorization code and state, so this is gated behind an explicit,
+        # dev-facing debug option and stays silent on a normal --debug run.
+        if DebugOpt.BROWSER.enabled:
+            self._log(log.info, format, args)
 
     def _handle_get(self):
         parsed = urlparse(self.path)

--- a/picard/debug_opts.py
+++ b/picard/debug_opts.py
@@ -182,3 +182,4 @@ class DebugOpt(DebugOptEnum):
     ISRC = 11, N_('ISRC'), N_('Log ISRC processing, submission, and lookup details')
     RATECONTROL = 12, N_('Rate Control'), N_('Log request throttling, congestion window, and backoff details')
     THEME = 13, N_('Theme'), N_('Log theme switching diagnostics, palette colors, and color scheme details')
+    BROWSER = 14, N_('Browser Integration'), N_('Log browser integration HTTP requests')

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -55,6 +55,22 @@ from picard.util.qt import build_qurl
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
 
 
+def redact_token(value: str | None) -> str:
+    """Return a non-reversible marker for a secret token, safe to log.
+
+    OAuth tokens and authorization codes are secrets that must never reach the
+    logs (debug logs are routinely attached to bug reports). This returns a
+    short, stable fingerprint — the first 8 hex characters of the SHA-256
+    digest — formatted as ``<token:xxxxxxxx>``. That is enough to tell whether
+    two log lines refer to the same token (e.g. to see a rotation) without
+    exposing anything usable. Empty or missing values return ``<none>``.
+    """
+    if not value:
+        return '<none>'
+    digest = sha256(value.encode('utf-8')).hexdigest()[:8]
+    return f'<token:{digest}>'
+
+
 class OAuthInvalidStateError(Exception):
     pass
 
@@ -278,12 +294,12 @@ class OAuthManager(QObject):
         return bytes(self.url(path="/oauth2/authorize", params=params).toEncoded()).decode()
 
     def set_refresh_token(self, refresh_token, scopes):
-        log.debug("OAuth: got refresh_token %s with scopes %s", refresh_token, scopes)
+        log.debug("OAuth: got refresh_token %s with scopes %s", redact_token(refresh_token), scopes)
         self.refresh_token = refresh_token
         self.refresh_token_scopes = scopes
 
     def set_access_token(self, access_token, expires_in):
-        log.debug("OAuth: got access_token %s that expires in %s seconds", access_token, expires_in)
+        log.debug("OAuth: got access_token %s that expires in %s seconds", redact_token(access_token), expires_in)
         self.access_token = access_token
         self.access_token_expires = int(time.time() + expires_in - 60)
 
@@ -299,7 +315,7 @@ class OAuthManager(QObject):
         self._refreshing = True
         self._refresh_callbacks = [callback]
 
-        log.debug("OAuth: refreshing access_token with a refresh_token %s", self.refresh_token)
+        log.debug("OAuth: refreshing access_token with a refresh_token %s", redact_token(self.refresh_token))
         params = {
             'grant_type': 'refresh_token',
             'refresh_token': self.refresh_token,

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -367,7 +367,7 @@ class OAuthManager(QObject):
                 callback(access_token=access_token)
 
     def exchange_authorization_code(self, authorization_code, scopes, callback):
-        log.debug("OAuth: exchanging authorization_code %s for an access_token", authorization_code)
+        log.debug("OAuth: exchanging authorization_code %s for an access_token", redact_token(authorization_code))
         params = {
             'grant_type': 'authorization_code',
             'code': authorization_code,

--- a/test/test_browser.py
+++ b/test/test_browser.py
@@ -41,6 +41,7 @@ from picard.browser.server import (
     clean_header,
 )
 from picard.const import METABRAINZ_OAUTH_SCOPES
+from picard.debug_opts import DebugOpt
 from picard.oauth import OAuthInvalidStateError
 from picard.util import webbrowser2
 
@@ -381,3 +382,46 @@ class RequestHandlerAuthTest(PicardTestCase):
         self.assertIn(b'200', response)
         self.assertIn(b'image/svg+xml', response)
         self.assertIn(b'<svg', response)
+
+
+class RequestHandlerAccessLogTest(PicardTestCase):
+    """The per-request access log must not leak OAuth callback parameters.
+
+    The stdlib BaseHTTPRequestHandler access log emits the full request line,
+    including the query string. For the /auth callback that query contains the
+    raw OAuth authorization code and state. That access line is now gated behind
+    the opt-in DebugOpt.BROWSER, so it is silent on a normal --debug run and the
+    code never reaches the log by default.
+    """
+
+    def setUp(self):
+        super().setUp()
+        DebugOpt.set_registry(set())
+
+    def _make_handler(self):
+        handler = RequestHandler.__new__(RequestHandler)
+        handler.client_address = ('127.0.0.1', 0)
+        return handler
+
+    def test_access_log_silent_by_default(self):
+        handler = self._make_handler()
+        # assertNoLogs raises if any record is emitted on 'main'.
+        with self.assertNoLogs('main', level='DEBUG'):
+            handler.log_message('%s', 'GET /auth?code=SECRETCODE&state=abc HTTP/1.1')
+
+    def test_access_log_enabled_by_debug_opt(self):
+        DebugOpt.BROWSER.enabled = True
+        handler = self._make_handler()
+        with self.assertLogs('main', level='DEBUG') as cm:
+            handler.log_message('%s', 'GET /auth?code=SECRETCODE&state=abc HTTP/1.1')
+        output = '\n'.join(cm.output)
+        # When the dev explicitly opts in, the full request line is logged.
+        self.assertIn('SECRETCODE', output)
+
+    def test_error_log_always_emitted(self):
+        # Genuine request errors must still surface regardless of the opt; they
+        # do not carry the OAuth code.
+        handler = self._make_handler()
+        with self.assertLogs('main', level='DEBUG') as cm:
+            handler.log_error('%s', 'Bad request')
+        self.assertIn('Bad request', '\n'.join(cm.output))

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -168,6 +168,17 @@ class RefreshAccessTokenTest(PicardTestCase):
         # The redacted marker should be present so the log stays useful.
         self.assertIn('<token:', output)
 
+    def test_authorization_code_is_not_logged_in_cleartext(self):
+        # The authorization code is a short-lived secret; it must not be logged.
+        manager = self._manager()
+        manager.webservice = MagicMock()
+        manager._OAuthManager__code_verifier = 'test-verifier'
+        with self.assertLogs('main', level='DEBUG') as cm:
+            manager.exchange_authorization_code('secret-auth-code', 'profile tag', callback=lambda **k: None)
+        output = '\n'.join(cm.output)
+        self.assertNotIn('secret-auth-code', output)
+        self.assertIn('<token:', output)
+
 
 class AuthorizationUrlTest(PicardTestCase):
     def _manager(self):

--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -17,15 +17,38 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 from test.picardtestcase import PicardTestCase
 
 from picard.oauth import (
     OAuthManager,
     base64url_encode,
+    redact_token,
     s256_encode,
 )
+
+
+class RedactTokenTest(PicardTestCase):
+    def test_redacts_to_stable_partial_hash(self):
+        token = 'super-secret-refresh-token'
+        redacted = redact_token(token)
+        # Never contains the raw token.
+        self.assertNotIn(token, redacted)
+        # Format is <token:xxxxxxxx> with an 8-char hex digest.
+        self.assertRegex(redacted, r'^<token:[0-9a-f]{8}>$')
+        # Stable: the same token always redacts to the same value.
+        self.assertEqual(redacted, redact_token(token))
+
+    def test_different_tokens_redact_differently(self):
+        self.assertNotEqual(redact_token('token-a'), redact_token('token-b'))
+
+    def test_empty_and_none_are_marked_absent(self):
+        self.assertEqual(redact_token(None), '<none>')
+        self.assertEqual(redact_token(''), '<none>')
 
 
 class OAuthManagerTest(PicardTestCase):
@@ -128,6 +151,22 @@ class RefreshAccessTokenTest(PicardTestCase):
         manager.on_refresh_access_token_finished(data, http=None, error=None)
         self.assertEqual('old-refresh-token', manager.refresh_token)
         self.assertEqual('new-access-token', manager.access_token)
+
+    def test_tokens_are_not_logged_in_cleartext(self):
+        # Debug logs are frequently attached to bug reports; token values must
+        # never appear there. Only their redacted partial hash may be logged.
+        manager = self._manager()
+        manager.webservice = MagicMock()
+        with self.assertLogs('main', level='DEBUG') as cm:
+            manager.set_refresh_token('secret-refresh-value', 'profile tag')
+            manager.set_access_token('secret-access-value', 3600)
+            manager._refreshing = False
+            manager.refresh_access_token(callback=lambda **k: None)
+        output = '\n'.join(cm.output)
+        self.assertNotIn('secret-refresh-value', output)
+        self.assertNotIn('secret-access-value', output)
+        # The redacted marker should be present so the log stays useful.
+        self.assertIn('<token:', output)
 
 
 class AuthorizationUrlTest(PicardTestCase):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Stop leaking OAuth secrets (refresh/access tokens, authorization code) into Picard's debug logs. These were written in cleartext on a normal `--debug` run, which is exactly what tends to get attached to bug reports.

## Problem

Several code paths wrote live OAuth credentials to the log at a level visible on
any `--debug` run:

* `OAuthManager.set_refresh_token()`, `set_access_token()` and
  `refresh_access_token()` logged the raw refresh and access token values.
* `OAuthManager.exchange_authorization_code()` logged the raw authorization code.
* The browser integration HTTP server logged the full request line via the
  stdlib access log (`log_request` → `log_message`), including the query string.
  For the `/auth` OAuth callback that query carries the raw authorization `code`
  and `state`, so they ended up in the log at INFO level.

Debug logs are routinely shared in bug reports, so this exposed credentials —
the refresh token in particular, which is long-lived and grants ongoing access.

* JIRA ticket (_optional_): n/a

## Solution

* Add a `redact_token()` helper in `picard/oauth.py` that logs a stable,
  non-reversible partial SHA-256 fingerprint (`<token:xxxxxxxx>`, `<none>` for
  empty) instead of the raw value. It keeps the logs useful for spotting token
  rotation without exposing the secret. Use it for the refresh token, access
  token, and authorization code.
* Gate the browser integration per-request access log (`log_message`) behind a
  new opt-in `DebugOpt.BROWSER` (off by default, dev-facing, same model as the
  existing `WS_POST`). The callback `code` is therefore no longer logged by
  default; a developer debugging browser integration can still enable it
  explicitly. Error logging (`log_error`) is left always-on: the stdlib only
  passes it the status code and reason phrase, not the request line, so it does
  not carry the code.

Each change is covered by a regression test asserting the raw secret never
appears in the log output. All oauth/browser/debug-opt tests pass; `ruff format`,
`ruff check`, and `ty check` are clean (no new diagnostics).

Note: the opt-in `WS_POST` debug option can still log full POST bodies (including
token requests). That is intentional developer-only diagnostics, disabled by
default, and is left unchanged — this PR targets the leaks that occur on a normal
`--debug` run.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The audit of the OAuth code paths, the fixes, and the regression tests were
developed with AI assistance under close human direction: a human chose the
focus area, made the scoping calls (e.g. that the opt-in `WS_POST` diagnostic is
acceptable and that gating `log_message` is the correct and sufficient fix for
the access-log leak), reviewed each change, and approved every commit. The
default-path access-log leak was found by inspecting an actual debug log, and
each fix was verified against the standard library source and by running the
test suite, linters, and type checker.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
