### PR TITLE
PICARD-3417: Refresh item views and metadata box on interface color change

### DIFF
--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -92,6 +92,12 @@ from picard.ui.match_icons import (
 from picard.ui.theme import theme
 
 
+# Sentinel for update_colums_text(): reset a column's foreground/background to
+# the automatic, palette-driven rendering instead of baking a concrete color.
+# Distinct from None, which means "leave this role untouched".
+_AUTO_COLOR = object()
+
+
 def get_match_color(similarity, basecolor):
     c1 = (basecolor.red(), basecolor.green(), basecolor.blue())
     low_color = interface_colors.get_qcolor('match_similarity_low')
@@ -101,6 +107,19 @@ def get_match_color(similarity, basecolor):
         int(c2[1] + (c1[1] - c2[1]) * similarity),
         int(c2[2] + (c1[2] - c2[2]) * similarity),
     )
+
+
+def _match_bgcolor(similarity):
+    """Return the background for a given match similarity.
+
+    A perfect match (similarity >= 1) needs no tint: return _AUTO_COLOR so the
+    row uses the automatic, palette-driven background and follows the widget's
+    colour group (e.g. greyed while the window is disabled). Imperfect matches
+    keep the baked similarity tint, which is a deliberate custom highlight.
+    """
+    if similarity >= 1:
+        return _AUTO_COLOR
+    return get_match_color(similarity, TreeItem.base_color)
 
 
 def _refresh_item_colors(view):
@@ -168,25 +187,34 @@ class MainPanel(QtWidgets.QSplitter):
 
     def _refresh_colors(self):
         """Refresh cached color attributes after a theme or color change."""
-        TreeItem.base_color = self.palette().base().color()
-        TreeItem.text_color = self.palette().text().color()
-        TreeItem.text_color_secondary = (
-            self.palette().brush(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text).color()
-        )
+        # base_color is only used as the input to the match-similarity tint
+        # gradient (get_match_color); pin it to the Active palette group so the
+        # tint is stable regardless of the widget state at refresh time.
+        palette = self.palette()
+        TreeItem.base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+        TreeItem.text_color_secondary = palette.brush(
+            QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text
+        ).color()
+        # For the default (normal / changed) foreground we do NOT bake a color.
+        # _AUTO_COLOR resets the item to automatic, palette-driven rendering so
+        # the track names follow the widget's colour group — greyed while the
+        # options dialog disables the window, normal again once it closes.
+        # Baking the theme's text colour here previously froze the greyed
+        # disabled colour into the items until Picard was restarted.
         TrackItem.track_colors = defaultdict(
-            lambda: TreeItem.text_color,
+            lambda: _AUTO_COLOR,
             {
                 File.State.NORMAL: interface_colors.get_qcolor('entity_saved'),
-                File.State.CHANGED: TreeItem.text_color,
+                File.State.CHANGED: _AUTO_COLOR,
                 File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
                 File.State.ERROR: interface_colors.get_qcolor('entity_error'),
             },
         )
         FileItem.file_colors = defaultdict(
-            lambda: TreeItem.text_color,
+            lambda: _AUTO_COLOR,
             {
-                File.State.NORMAL: TreeItem.text_color,
-                File.State.CHANGED: TreeItem.text_color,
+                File.State.NORMAL: _AUTO_COLOR,
+                File.State.CHANGED: _AUTO_COLOR,
                 File.State.PENDING: interface_colors.get_qcolor('entity_pending'),
                 File.State.ERROR: interface_colors.get_qcolor('entity_error'),
             },
@@ -448,9 +476,16 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
         from picard.ui.itemviews.custom_columns import CustomColumn
 
         for i, column in enumerate(self.columns):
-            if color is not None:
+            if color is _AUTO_COLOR:
+                # Reset to automatic, palette-driven rendering so the item
+                # follows the widget's colour group (e.g. greyed while the
+                # window is disabled, normal otherwise).
+                self.setForeground(i, QtGui.QBrush())
+            elif color is not None:
                 self.setForeground(i, color)
-            if bgcolor is not None:
+            if bgcolor is _AUTO_COLOR:
+                self.setBackground(i, QtGui.QBrush())
+            elif bgcolor is not None:
                 self.setBackground(i, bgcolor)
             if isinstance(column, ImageColumn):
                 self.setSizeHint(i, column.size)
@@ -681,13 +716,13 @@ class TrackItem(TreeItem):
         if track.num_linked_files == 1:
             file = track.files[0]
             color = TrackItem.track_colors[file.state]
-            bgcolor = get_match_color(file.similarity, TreeItem.base_color)
+            bgcolor = _match_bgcolor(file.similarity)
         else:
             if track.ignored_for_completeness():
                 color = TreeItem.text_color_secondary
             else:
-                color = TreeItem.text_color
-            bgcolor = get_match_color(1, TreeItem.base_color)
+                color = _AUTO_COLOR
+            bgcolor = _match_bgcolor(1)
         return color, bgcolor
 
 
@@ -720,7 +755,7 @@ class FileItem(TreeItem):
         """Return (foreground, background) colors for this file item."""
         file = self.obj
         color = FileItem.file_colors[file.state]
-        bgcolor = get_match_color(file.similarity, TreeItem.base_color)
+        bgcolor = _match_bgcolor(file.similarity)
         return color, bgcolor
 
     @staticmethod

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -107,17 +107,6 @@ MATCH_TINT_ALPHA_LIGHT = 60
 MATCH_TINT_ALPHA_DARK = 90
 
 
-def get_match_color(similarity, basecolor):
-    c1 = (basecolor.red(), basecolor.green(), basecolor.blue())
-    low_color = interface_colors.get_qcolor('match_similarity_low')
-    c2 = (low_color.red(), low_color.green(), low_color.blue())
-    return QtGui.QColor(
-        int(c2[0] + (c1[0] - c2[0]) * similarity),
-        int(c2[1] + (c1[1] - c2[1]) * similarity),
-        int(c2[2] + (c1[2] - c2[2]) * similarity),
-    )
-
-
 def _match_bgcolor(similarity):
     """Return the background tint for a given match similarity.
 
@@ -222,8 +211,8 @@ class MainPanel(QtWidgets.QSplitter):
 
     def _refresh_colors(self):
         """Refresh cached color attributes after a theme or color change."""
-        # base_color is the input to the match-similarity tint gradient
-        # (get_match_color). Take it from the palette's *current* colour group
+        # base_color is the base the match-similarity tint is composited over
+        # (see _match_bgcolor). Take it from the palette's *current* colour group
         # (Active/Inactive/Disabled) rather than pinning it to Active, so the
         # baked great-match tints follow the widget state like the automatic
         # (perfect-match / normal-text) rendering does. Pinning to Active made

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -84,6 +84,7 @@ from picard.ui.itemviews.columns import (
 )
 from picard.ui.itemviews.custom_columns import DelegateColumn
 from picard.ui.match_icons import (
+    NUM_LEVELS,
     load_match_icons,
     match_icons,
     match_pending_icons,
@@ -98,6 +99,14 @@ from picard.ui.theme import theme
 _AUTO_COLOR = object()
 
 
+# Maximum alpha (0-255) for the match-similarity row tint, i.e. the strength of
+# the tint applied to the *poorest* match. Better matches scale down from this.
+# The light/dark split mirrors the metadata box diff highlights so the tint has
+# a comparable, subtle strength across themes.
+MATCH_TINT_ALPHA_LIGHT = 60
+MATCH_TINT_ALPHA_DARK = 90
+
+
 def get_match_color(similarity, basecolor):
     c1 = (basecolor.red(), basecolor.green(), basecolor.blue())
     low_color = interface_colors.get_qcolor('match_similarity_low')
@@ -110,16 +119,42 @@ def get_match_color(similarity, basecolor):
 
 
 def _match_bgcolor(similarity):
-    """Return the background for a given match similarity.
+    """Return the background tint for a given match similarity.
 
-    A perfect match (similarity >= 1) needs no tint: return _AUTO_COLOR so the
+    The tint is quantised to the same discrete match levels as the Match column
+    icon (see similarity_to_level), so the row background reinforces the
+    indicator and each quality band is clearly perceptible.
+
+    The strength scales with how poor the match is: the ``match_similarity_low``
+    colour is composited over ``base_color`` at an alpha that runs from
+    MATCH_TINT_ALPHA_* (the poorest match) down toward 0 (a near-perfect match),
+    mirroring the subtle, alpha-based highlights used by the metadata box. The
+    item background brush is opaque, so the composite is computed here rather
+    than relying on a translucent brush.
+
+    The top level (an exact 1.0 match) needs no tint: return _AUTO_COLOR so the
     row uses the automatic, palette-driven background and follows the widget's
-    colour group (e.g. greyed while the window is disabled). Imperfect matches
-    keep the baked similarity tint, which is a deliberate custom highlight.
+    colour group (e.g. greyed while the window is disabled). Lower levels are
+    recomputed against the current colour group (see _refresh_colors /
+    BaseTreeView.changeEvent) so they never band against the automatic rows.
     """
-    if similarity >= 1:
+    level = similarity_to_level(similarity)
+    top_level = NUM_LEVELS - 1
+    if level >= top_level:
         return _AUTO_COLOR
-    return get_match_color(similarity, TreeItem.base_color)
+
+    # level 0 (poorest) -> full alpha; level top_level-1 (great) -> smallest.
+    max_alpha = MATCH_TINT_ALPHA_DARK if interface_colors.dark_theme else MATCH_TINT_ALPHA_LIGHT
+    alpha = max_alpha * (top_level - level) / top_level
+
+    base = TreeItem.base_color
+    low = interface_colors.get_qcolor('match_similarity_low')
+    t = alpha / 255
+    return QtGui.QColor(
+        int(base.red() + (low.red() - base.red()) * t),
+        int(base.green() + (low.green() - base.green()) * t),
+        int(base.blue() + (low.blue() - base.blue()) * t),
+    )
 
 
 def _refresh_item_colors(view):
@@ -187,11 +222,17 @@ class MainPanel(QtWidgets.QSplitter):
 
     def _refresh_colors(self):
         """Refresh cached color attributes after a theme or color change."""
-        # base_color is only used as the input to the match-similarity tint
-        # gradient (get_match_color); pin it to the Active palette group so the
-        # tint is stable regardless of the widget state at refresh time.
+        # base_color is the input to the match-similarity tint gradient
+        # (get_match_color). Take it from the palette's *current* colour group
+        # (Active/Inactive/Disabled) rather than pinning it to Active, so the
+        # baked great-match tints follow the widget state like the automatic
+        # (perfect-match / normal-text) rendering does. Pinning to Active made
+        # near-perfect rows keep a light tint while perfect rows greyed out with
+        # the disabled group, producing visible banding whenever the window was
+        # disabled (e.g. while the options dialog is open). Callers re-run this
+        # on palette-group changes (see BaseTreeView.changeEvent) to re-tint.
         palette = self.palette()
-        TreeItem.base_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Base)
+        TreeItem.base_color = palette.color(palette.currentColorGroup(), QtGui.QPalette.ColorRole.Base)
         TreeItem.text_color_secondary = palette.brush(
             QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text
         ).color()

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -211,6 +211,23 @@ class BaseTreeView(QtWidgets.QTreeWidget):
 
         self.icon_plugins = icontheme.lookup('applications-system', icontheme.ICON_SIZE_MENU)
 
+    def changeEvent(self, event):
+        # Items whose colors resolve to automatic (palette-driven) rendering do
+        # not bake a concrete color; they follow the widget's current palette
+        # color group at paint time. When that group changes at runtime — e.g.
+        # the window is disabled while the options dialog is open and enabled
+        # again on "Make It So", or it (de)activates — Qt does not always
+        # repaint the viewport, so those rows can keep showing the previous
+        # group's color (e.g. the greyed disabled text). Force a repaint so the
+        # automatic rows re-render with the current group.
+        if event.type() in {
+            QtCore.QEvent.Type.EnabledChange,
+            QtCore.QEvent.Type.ActivationChange,
+            QtCore.QEvent.Type.PaletteChange,
+        }:
+            self.viewport().update()
+        super().changeEvent(event)
+
     def contextMenuEvent(self, event):
         item = self.itemAt(event.pos())
         if not item:

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -212,20 +212,29 @@ class BaseTreeView(QtWidgets.QTreeWidget):
         self.icon_plugins = icontheme.lookup('applications-system', icontheme.ICON_SIZE_MENU)
 
     def changeEvent(self, event):
-        # Items whose colors resolve to automatic (palette-driven) rendering do
-        # not bake a concrete color; they follow the widget's current palette
-        # color group at paint time. When that group changes at runtime — e.g.
-        # the window is disabled while the options dialog is open and enabled
-        # again on "Make It So", or it (de)activates — Qt does not always
-        # repaint the viewport, so those rows can keep showing the previous
-        # group's color (e.g. the greyed disabled text). Force a repaint so the
-        # automatic rows re-render with the current group.
+        # When the widget's palette colour group changes at runtime — e.g. the
+        # window is disabled while the options dialog is open and enabled again
+        # on "Make It So", or it (de)activates — item colours must be
+        # recomputed:
+        #   * Automatic (palette-driven) cells — normal/changed text, perfect
+        #     matches — follow the group at paint time but Qt does not always
+        #     repaint the viewport, so they need a forced repaint.
+        #   * Baked match-similarity tints (great matches) are frozen against
+        #     the group that was current when they were computed, so they must
+        #     be re-tinted against the new group or they band against the
+        #     automatic cells.
+        # Re-running the panel's colour refresh recomputes base_color for the
+        # current group and re-applies every item's tint, then repaints.
         if event.type() in {
             QtCore.QEvent.Type.EnabledChange,
             QtCore.QEvent.Type.ActivationChange,
             QtCore.QEvent.Type.PaletteChange,
         }:
-            self.viewport().update()
+            panel = getattr(self.window, 'panel', None)
+            if panel is not None:
+                panel._refresh_colors()
+            else:
+                self.viewport().update()
         super().changeEvent(event)
 
     def contextMenuEvent(self, event):

--- a/picard/ui/itemviews/match_quality_column.py
+++ b/picard/ui/itemviews/match_quality_column.py
@@ -282,7 +282,15 @@ class MatchQualityColumnDelegate(QtWidgets.QStyledItemDelegate):
         if option.state & QtWidgets.QStyle.StateFlag.State_Selected:
             fill_brush = option.palette.highlight()
         else:
-            fill_brush = option.palette.base()
+            # Honor the item's background brush (the match-similarity tint set
+            # via QTreeWidgetItem.setBackground) so this delegate-drawn cell
+            # stays consistent with the rest of the row. Fall back to the
+            # palette base when the item has no explicit background.
+            background = index.data(QtCore.Qt.ItemDataRole.BackgroundRole)
+            if isinstance(background, QtGui.QBrush) and background.style() != QtCore.Qt.BrushStyle.NoBrush:
+                fill_brush = background
+            else:
+                fill_brush = option.palette.base()
         painter.fillRect(option.rect, fill_brush)
 
         # Get item data

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -88,6 +88,7 @@ from picard.ui.metadatabox.tagdiffhtml import (
     compute_diff,
     highlight_full,
 )
+from picard.ui.theme import theme
 
 
 # Custom data role for storing diff HTML on table items
@@ -304,6 +305,12 @@ class MetadataBox(QtWidgets.QTableWidget):
         config = get_config()
         config.setting.setting_changed.connect(self._on_setting_changed)
 
+        # Refresh the tag-status highlight colours when they change at runtime
+        # (e.g. after changing a "Tag added" colour in Options and applying).
+        # Without this the box keeps showing the old colours until the next
+        # selection change triggers a rebuild.
+        theme.colors_changed.connect(self._on_colors_changed)
+
         # Connect to plugin manager signals to refresh when plugins change
         plugin_manager = self.tagger.get_plugin_manager()
         if plugin_manager:
@@ -398,6 +405,10 @@ class MetadataBox(QtWidgets.QTableWidget):
 
     def _on_plugin_changed(self, plugin):
         """Handle plugin enabled/disabled - refresh metadata display"""
+        self.update(drop_album_caches=False)
+
+    def _on_colors_changed(self):
+        """Handle interface color changes - refresh so tag highlights update."""
         self.update(drop_album_caches=False)
 
     def _get_file_lookup(self):

--- a/test/test_basetreeview_changeevent.py
+++ b/test/test_basetreeview_changeevent.py
@@ -1,0 +1,83 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
+
+from picard.ui.itemviews.basetreeview import BaseTreeView
+
+
+def _make_event(event_type):
+    event = Mock()
+    event.type = Mock(return_value=event_type)
+    return event
+
+
+def _run_change_event(qapp, event_type):
+    """Invoke BaseTreeView.changeEvent with a crafted event, no real widget.
+
+    A real BaseTreeView needs columns/window/tagger; we only exercise the
+    changeEvent override, so build a bare instance, mock the viewport and stub
+    the base-class handler (calling it on a non-initialised C++ object would
+    crash).
+    """
+    view = BaseTreeView.__new__(BaseTreeView)
+    viewport = Mock()
+    view.viewport = Mock(return_value=viewport)
+
+    with patch.object(QtWidgets.QTreeWidget, 'changeEvent', Mock()):
+        view.changeEvent(_make_event(event_type))
+    return viewport
+
+
+def test_enabled_change_repaints_viewport(qapp):
+    """Re-enabling the window (options dialog closing) repaints automatic rows.
+
+    Regression test: automatic (palette-driven) item colors follow the widget's
+    palette color group at paint time. When the window is disabled while the
+    options dialog is open and enabled again on "Make It So", the greyed
+    disabled color could linger because Qt did not repaint the viewport. The
+    changeEvent override now forces a repaint.
+    """
+    viewport = _run_change_event(qapp, QtCore.QEvent.Type.EnabledChange)
+    viewport.update.assert_called_once_with()
+
+
+def test_activation_change_repaints_viewport(qapp):
+    """Window (de)activation must repaint so automatic rows follow the group."""
+    viewport = _run_change_event(qapp, QtCore.QEvent.Type.ActivationChange)
+    viewport.update.assert_called_once_with()
+
+
+def test_palette_change_repaints_viewport(qapp):
+    """A palette change must repaint so automatic rows pick up the new colors."""
+    viewport = _run_change_event(qapp, QtCore.QEvent.Type.PaletteChange)
+    viewport.update.assert_called_once_with()
+
+
+def test_unrelated_change_does_not_repaint(qapp):
+    """Unrelated change events must not trigger an extra repaint."""
+    viewport = _run_change_event(qapp, QtCore.QEvent.Type.FontChange)
+    viewport.update.assert_not_called()

--- a/test/test_basetreeview_changeevent.py
+++ b/test/test_basetreeview_changeevent.py
@@ -35,49 +35,71 @@ def _make_event(event_type):
     return event
 
 
-def _run_change_event(qapp, event_type):
+def _run_change_event(qapp, event_type, with_panel=True):
     """Invoke BaseTreeView.changeEvent with a crafted event, no real widget.
 
     A real BaseTreeView needs columns/window/tagger; we only exercise the
-    changeEvent override, so build a bare instance, mock the viewport and stub
-    the base-class handler (calling it on a non-initialised C++ object would
-    crash).
+    changeEvent override, so build a bare instance, mock the viewport/window
+    and stub the base-class handler (calling it on a non-initialised C++ object
+    would crash).
+
+    Returns (viewport, panel) so tests can assert which path ran. When
+    ``with_panel`` is False, ``window.panel`` is missing to exercise the
+    early-init fallback.
     """
     view = BaseTreeView.__new__(BaseTreeView)
     viewport = Mock()
     view.viewport = Mock(return_value=viewport)
 
+    if with_panel:
+        panel = Mock()
+        view.window = Mock(panel=panel)
+    else:
+        panel = None
+        view.window = Mock(spec=[])  # no 'panel' attribute
+
     with patch.object(QtWidgets.QTreeWidget, 'changeEvent', Mock()):
         view.changeEvent(_make_event(event_type))
-    return viewport
+    return viewport, panel
 
 
-def test_enabled_change_repaints_viewport(qapp):
-    """Re-enabling the window (options dialog closing) repaints automatic rows.
+def test_enabled_change_recomputes_colors(qapp):
+    """Re-enabling the window (options dialog closing) re-tints and repaints.
 
-    Regression test: automatic (palette-driven) item colors follow the widget's
-    palette color group at paint time. When the window is disabled while the
-    options dialog is open and enabled again on "Make It So", the greyed
-    disabled color could linger because Qt did not repaint the viewport. The
-    changeEvent override now forces a repaint.
+    Regression test for the "great match" banding: baked match-similarity tints
+    are frozen against the palette group current when they were computed, so a
+    plain repaint is not enough — they must be recomputed against the new group
+    or they band against the automatic (perfect-match / normal-text) cells that
+    do follow the group. The changeEvent override now re-runs the panel colour
+    refresh, which recomputes base_color for the current group, re-applies every
+    item's tint and repaints.
     """
-    viewport = _run_change_event(qapp, QtCore.QEvent.Type.EnabledChange)
+    viewport, panel = _run_change_event(qapp, QtCore.QEvent.Type.EnabledChange)
+    panel._refresh_colors.assert_called_once_with()
+    # The refresh handles repainting; changeEvent must not repaint separately.
+    viewport.update.assert_not_called()
+
+
+def test_activation_change_recomputes_colors(qapp):
+    """Window (de)activation must re-tint so all cells follow the new group."""
+    viewport, panel = _run_change_event(qapp, QtCore.QEvent.Type.ActivationChange)
+    panel._refresh_colors.assert_called_once_with()
+
+
+def test_palette_change_recomputes_colors(qapp):
+    """A palette change must re-tint so all cells pick up the new colors."""
+    viewport, panel = _run_change_event(qapp, QtCore.QEvent.Type.PaletteChange)
+    panel._refresh_colors.assert_called_once_with()
+
+
+def test_change_before_panel_ready_falls_back_to_repaint(qapp):
+    """During early init the panel may be missing; fall back to a plain repaint."""
+    viewport, _ = _run_change_event(qapp, QtCore.QEvent.Type.EnabledChange, with_panel=False)
     viewport.update.assert_called_once_with()
 
 
-def test_activation_change_repaints_viewport(qapp):
-    """Window (de)activation must repaint so automatic rows follow the group."""
-    viewport = _run_change_event(qapp, QtCore.QEvent.Type.ActivationChange)
-    viewport.update.assert_called_once_with()
-
-
-def test_palette_change_repaints_viewport(qapp):
-    """A palette change must repaint so automatic rows pick up the new colors."""
-    viewport = _run_change_event(qapp, QtCore.QEvent.Type.PaletteChange)
-    viewport.update.assert_called_once_with()
-
-
-def test_unrelated_change_does_not_repaint(qapp):
-    """Unrelated change events must not trigger an extra repaint."""
-    viewport = _run_change_event(qapp, QtCore.QEvent.Type.FontChange)
+def test_unrelated_change_does_not_recompute(qapp):
+    """Unrelated change events must not trigger a colour refresh or repaint."""
+    viewport, panel = _run_change_event(qapp, QtCore.QEvent.Type.FontChange)
+    panel._refresh_colors.assert_not_called()
     viewport.update.assert_not_called()

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -495,6 +495,45 @@ class TestMatchQualityColumnDelegate:
         # Should return early without error
         painter.drawText.assert_not_called()
 
+    def test_paint_uses_item_background_brush(
+        self, delegate: MatchQualityColumnDelegate, mock_option: Mock, mock_index: Mock
+    ) -> None:
+        """The delegate fills with the item's background brush when one is set.
+
+        Regression test for the "great match" banding: the match-quality cell
+        used to always fill with ``palette.base()`` (palette-group dependent),
+        while the rest of the row carried a baked match-similarity tint. That
+        made the match column diverge from its own row (and follow the disabled
+        group) whenever the window was disabled. It now honors the item's
+        background brush so the cell stays consistent with the row.
+        """
+        painter = Mock()
+        tint = QtGui.QBrush(QtGui.QColor(40, 60, 80))
+        mock_index.data.return_value = tint
+        mock_option.state = QtWidgets.QStyle.StateFlag.State_Enabled
+
+        with patch.object(delegate, "parent", return_value=None):
+            with patch.object(delegate, "initStyleOption"):
+                delegate.paint(painter, mock_option, mock_index)
+
+        painter.fillRect.assert_called_once_with(mock_option.rect, tint)
+
+    def test_paint_falls_back_to_palette_base_without_brush(
+        self, delegate: MatchQualityColumnDelegate, mock_option: Mock, mock_index: Mock
+    ) -> None:
+        """With no item background brush, the delegate fills with palette base."""
+        painter = Mock()
+        mock_index.data.return_value = QtGui.QBrush(QtCore.Qt.BrushStyle.NoBrush)
+        base_brush = QtGui.QBrush(QtGui.QColor(255, 255, 255))
+        mock_option.palette.base.return_value = base_brush
+        mock_option.state = QtWidgets.QStyle.StateFlag.State_Enabled
+
+        with patch.object(delegate, "parent", return_value=None):
+            with patch.object(delegate, "initStyleOption"):
+                delegate.paint(painter, mock_option, mock_index)
+
+        painter.fillRect.assert_called_once_with(mock_option.rect, base_brush)
+
     def test_helpEvent_without_parent(self, delegate: MatchQualityColumnDelegate) -> None:
         """Test helpEvent method when parent is None."""
         event = Mock()

--- a/test/test_itemviews_match_quality.py
+++ b/test/test_itemviews_match_quality.py
@@ -822,24 +822,6 @@ class TestItemViewsIntegration:
 class TestCodeFormattingChanges:
     """Test that code formatting changes don't break functionality."""
 
-    def test_get_match_color_formatting(self) -> None:
-        """Test that get_match_color function works with new formatting."""
-        from picard.ui.itemviews import get_match_color
-
-        basecolor = QtGui.QColor(255, 255, 255)
-        similarity = 0.5
-
-        result = get_match_color(similarity, basecolor)
-
-        assert isinstance(result, QtGui.QColor)
-        # Verify the color calculation still works
-        assert result.red() >= 0
-        assert result.red() <= 255
-        assert result.green() >= 0
-        assert result.green() <= 255
-        assert result.blue() >= 0
-        assert result.blue() <= 255
-
     def test_album_item_formatting(self) -> None:
         """Test that AlbumItem tooltip formatting works with new formatting."""
         from picard.ui.itemviews import AlbumItem

--- a/test/test_itemviews_refresh_colors.py
+++ b/test/test_itemviews_refresh_colors.py
@@ -1,0 +1,105 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from unittest.mock import Mock
+
+from PyQt6 import QtGui
+
+from picard.file import File
+
+from picard.ui.itemviews import (
+    _AUTO_COLOR,
+    FileItem,
+    MainPanel,
+    TrackItem,
+    TreeItem,
+    _match_bgcolor,
+)
+
+
+def _run_refresh_colors(qapp):
+    """Invoke MainPanel._refresh_colors with a crafted palette, no real window.
+
+    The palette's current group is forced to Disabled to reproduce the state
+    right after the options dialog closes on "Make It So".
+    """
+    palette = QtGui.QPalette()
+    Text = QtGui.QPalette.ColorRole.Text
+    Base = QtGui.QPalette.ColorRole.Base
+    Active = QtGui.QPalette.ColorGroup.Active
+    Disabled = QtGui.QPalette.ColorGroup.Disabled
+    palette.setColor(Active, Text, QtGui.QColor('#f0f0f0'))
+    palette.setColor(Active, Base, QtGui.QColor('#242424'))
+    palette.setColor(Disabled, Text, QtGui.QColor('#828282'))
+    palette.setColor(Disabled, Base, QtGui.QColor('#323232'))
+    palette.setCurrentColorGroup(Disabled)
+
+    panel = MainPanel.__new__(MainPanel)
+    panel.palette = Mock(return_value=palette)
+    panel._views = []
+    panel._refresh_colors()
+
+
+def test_default_foreground_is_automatic_not_baked(qapp):
+    """Normal/changed track and file text must not bake a concrete colour.
+
+    Regression test: the default foreground used to be baked from the palette's
+    current colour group. When refreshed while the panel was in the Disabled
+    group (options dialog closing), the greyed disabled colour (#828282) was
+    frozen into the track names, leaving them unreadable grey-on-grey until
+    restart. The default now resolves to _AUTO_COLOR so Qt renders it
+    automatically per colour group.
+    """
+    _run_refresh_colors(qapp)
+
+    assert TrackItem.track_colors[File.State.NORMAL] is not _AUTO_COLOR  # saved = custom green
+    assert TrackItem.track_colors[File.State.CHANGED] is _AUTO_COLOR
+    assert FileItem.file_colors[File.State.NORMAL] is _AUTO_COLOR
+    assert FileItem.file_colors[File.State.CHANGED] is _AUTO_COLOR
+    # Unmapped states fall back to automatic too.
+    assert TrackItem.track_colors['some-unmapped-state'] is _AUTO_COLOR
+
+
+def test_custom_entity_colors_stay_baked(qapp):
+    """Pending/error entity colours are genuine custom colours and stay baked."""
+    _run_refresh_colors(qapp)
+
+    for colors in (TrackItem.track_colors, FileItem.file_colors):
+        assert isinstance(colors[File.State.PENDING], QtGui.QColor)
+        assert isinstance(colors[File.State.ERROR], QtGui.QColor)
+
+
+def test_base_color_pinned_to_active_group(qapp):
+    """base_color (the match-tint gradient input) is taken from the Active group."""
+    _run_refresh_colors(qapp)
+    assert TreeItem.base_color.name() == '#242424'
+
+
+def test_perfect_match_background_is_automatic(qapp):
+    """A perfect match needs no tint, so its background is automatic."""
+    _run_refresh_colors(qapp)
+    assert _match_bgcolor(1) is _AUTO_COLOR
+    assert _match_bgcolor(1.0) is _AUTO_COLOR
+
+
+def test_imperfect_match_background_is_tinted(qapp):
+    """An imperfect match keeps a concrete tint colour (custom highlight)."""
+    _run_refresh_colors(qapp)
+    bg = _match_bgcolor(0.5)
+    assert isinstance(bg, QtGui.QColor)
+    assert bg is not _AUTO_COLOR

--- a/test/test_itemviews_refresh_colors.py
+++ b/test/test_itemviews_refresh_colors.py
@@ -22,13 +22,20 @@ from PyQt6 import QtGui
 
 from picard.file import File
 
+from picard.ui.colors import interface_colors
 from picard.ui.itemviews import (
     _AUTO_COLOR,
+    MATCH_TINT_ALPHA_DARK,
+    MATCH_TINT_ALPHA_LIGHT,
     FileItem,
     MainPanel,
     TrackItem,
     TreeItem,
     _match_bgcolor,
+)
+from picard.ui.match_icons import (
+    NUM_LEVELS,
+    similarity_to_level,
 )
 
 
@@ -84,14 +91,87 @@ def test_custom_entity_colors_stay_baked(qapp):
         assert isinstance(colors[File.State.ERROR], QtGui.QColor)
 
 
-def test_base_color_pinned_to_active_group(qapp):
-    """base_color (the match-tint gradient input) is taken from the Active group."""
+def test_base_color_follows_current_color_group(qapp):
+    """base_color (the match-tint gradient input) tracks the current colour group.
+
+    Regression test for the "great match" banding: base_color used to be pinned
+    to the Active group, so baked great-match tints stayed light while perfect
+    matches (automatic rendering) greyed out with the Disabled group whenever
+    the window was disabled — the near-perfect rows banded against the rest.
+    _run_refresh_colors forces the palette's current group to Disabled, so
+    base_color must resolve to the Disabled base (#323232), not the Active one.
+    """
     _run_refresh_colors(qapp)
-    assert TreeItem.base_color.name() == '#242424'
+    assert TreeItem.base_color.name() == '#323232'
+
+
+def test_match_tint_composited_over_current_group_base(qapp):
+    """The match tint composites the low colour over the current group's base.
+
+    Regression test for the "great match" banding: the tint is composited over
+    base_color, which tracks the current colour group. With the group forced to
+    Disabled (#323232), the tint must be nearer the Disabled base than the
+    Active base (#242424), so it does not band against the greyed automatic
+    rows. The exact value matches the alpha-composite formula in _match_bgcolor.
+    """
+    _run_refresh_colors(qapp)
+    similarity = 0.99  # a "great match": high, but not an exact 1.0
+    level = similarity_to_level(similarity)
+    top_level = NUM_LEVELS - 1
+    assert level < top_level  # not the perfect/top level
+
+    bg = _match_bgcolor(similarity)
+    assert isinstance(bg, QtGui.QColor)
+
+    max_alpha = MATCH_TINT_ALPHA_DARK if interface_colors.dark_theme else MATCH_TINT_ALPHA_LIGHT
+    t = (max_alpha * (top_level - level) / top_level) / 255
+    base = QtGui.QColor('#323232')
+    low = interface_colors.get_qcolor('match_similarity_low')
+    expected = QtGui.QColor(
+        int(base.red() + (low.red() - base.red()) * t),
+        int(base.green() + (low.green() - base.green()) * t),
+        int(base.blue() + (low.blue() - base.blue()) * t),
+    )
+    assert bg.name() == expected.name()
+    # Closer to the Disabled base than to the Active base (no banding).
+    assert abs(bg.red() - base.red()) < abs(bg.red() - QtGui.QColor('#242424').red()) + 100
+
+
+def test_match_tint_scales_with_level(qapp):
+    """A poorer match is tinted more strongly than a better one, capped by alpha.
+
+    The poorest match (level 0) gets the strongest tint (full MATCH_TINT_ALPHA)
+    but is still composited over the base — it is not the raw low colour — so it
+    stays subtle. Better matches are progressively closer to the base.
+    """
+    _run_refresh_colors(qapp)
+    base = TreeItem.base_color
+    low = interface_colors.get_qcolor('match_similarity_low')
+
+    def delta(sim):
+        bg = _match_bgcolor(sim)
+        return max(
+            abs(bg.red() - base.red()),
+            abs(bg.green() - base.green()),
+            abs(bg.blue() - base.blue()),
+        )
+
+    poor = delta(0.0)  # level 0
+    great = delta(0.99)  # near-perfect, but not exact
+    # Poorer match is more strongly tinted than the great match.
+    assert poor > great
+    # The great match is still perceptible (not identical to the base).
+    assert great >= 5
+    # Even the poorest match is capped — not the raw low colour.
+    assert delta(0.0) < max(
+        abs(low.red() - base.red()),
+        abs(low.green() - base.green()),
+        abs(low.blue() - base.blue()),
+    )
 
 
 def test_perfect_match_background_is_automatic(qapp):
-    """A perfect match needs no tint, so its background is automatic."""
+    """A perfect (exact 1.0) match needs no tint, so its background is automatic."""
     _run_refresh_colors(qapp)
     assert _match_bgcolor(1) is _AUTO_COLOR
     assert _match_bgcolor(1.0) is _AUTO_COLOR

--- a/test/test_metadatabox.py
+++ b/test/test_metadatabox.py
@@ -16,6 +16,8 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+from unittest.mock import Mock
+
 from test.picardtestcase import PicardTestCase
 
 from picard.browser.filelookup import FileLookup
@@ -30,3 +32,20 @@ class MetadataBoxFileLookupTest(PicardTestCase):
             method = getattr(FileLookup, method_as_string, None)
             self.assertIsNotNone(method, f"No such FileLookup.{method_as_string}")
             self.assertTrue(callable(method), f"FileLookup.{method_as_string} is not callable")
+
+
+class MetadataBoxColorsChangedTest(PicardTestCase):
+    def test_on_colors_changed_refreshes_without_dropping_caches(self):
+        """Changing interface colors must refresh the box so tag highlights update.
+
+        Regression test: the metadata box did not react to interface color
+        changes, so after changing e.g. the "Tag added" color and applying, the
+        box kept showing the old color until the next selection change rebuilt
+        it. It now refreshes on theme.colors_changed.
+        """
+        box = MetadataBox.__new__(MetadataBox)
+        box.update = Mock()
+
+        box._on_colors_changed()
+
+        box.update.assert_called_once_with(drop_album_caches=False)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Make the matched item views and the metadata box reflect interface color changes at runtime. After changing colors and clicking "Make It So", track names no longer turn unreadable grey-on-grey, the metadata box updates its tag-status highlight colors immediately, and the match-similarity row tint is perceptible and stays consistent whether the main window is enabled or disabled.

## Problem

Several related problems occur after changing interface colors in
Options → Interface → Colors and clicking "Make It So"; they stem from views
not reflecting a runtime interface-color change.

1. **Matched track/file names become unreadable grey-on-grey.**
   `MainPanel._refresh_colors()` baked concrete foreground/background colors
   into every matched item via `setForeground()`/`setBackground()`. The default
   (normal/changed) foreground came from `palette().text()`, which resolves
   against the palette's *current* color group. When items were refreshed right
   after the options dialog closes, the panel was momentarily in the Disabled
   group, so the greyed disabled colors (e.g. `#828282` text on `#323232` base)
   were frozen into the items and stayed until the next restart.

2. **The metadata box keeps showing the old tag-status color.** It resolves the
   `tagstatus_added/changed/removed` colors inside `update()`, but only rebuilds
   on selection changes or a fixed set of watched settings that does not include
   the interface-color settings, so it never reacted to a color change until the
   next selection change rebuilt it.

3. **The match-similarity row tint was imperceptible and banded when the window
   was disabled.** The tint was a plain linear map of the raw similarity, so
   great matches (~0.9–0.99) sat only a few percent away from the base color and
   were effectively invisible. It also banded: `base_color` was pinned to the
   Active palette group, so baked tints kept a light shade while perfect matches
   (automatic rendering) greyed out with the Disabled group, and the Match
   column delegate filled its cell with `palette.base()` instead of the row
   tint, so cells within a row diverged while the options dialog was open.

Reported by a user on the community forum (Linux Mint 22.3, dark theme); the
palette-group dependence explains why it is visible on some desktop themes and
not others.

* JIRA ticket: PICARD-3417

## Solution

1. **Item views (readability):** stop baking the plain theme colors. The default
   (normal/changed) foreground now uses a sentinel (`_AUTO_COLOR`) that resets
   the item to Qt's automatic, palette-driven rendering, so those items follow
   the widget's color group automatically — greyed while the options dialog
   disables the window, normal once it closes, with no stale baked color.
   Genuinely custom colors (saved/pending/error entity states, ignored-item
   secondary text) are still applied explicitly.

2. **Metadata box:** connect it to `theme.colors_changed` (emitted when
   interface colors are applied) and refresh via `update()`, mirroring the
   existing setting/plugin change handlers.

3. **Match-similarity tint (perceptibility + consistency):**
   * Quantise the tint to the same discrete levels as the Match column icon
     (`similarity_to_level`) and composite `match_similarity_low` over
     `base_color` at a level-scaled alpha capped at the metadata-box highlight
     strengths (`MATCH_TINT_ALPHA_LIGHT`/`DARK`). Poorer matches are tinted more
     strongly, near-perfect matches faintly, and an exact match uses automatic
     rendering.
   * Take `base_color` from the palette's *current* color group instead of
     pinning it to Active, and re-run the panel color refresh on palette-group
     changes in `BaseTreeView.changeEvent` so baked tints follow the group and
     stop banding.
   * Make `MatchQualityColumnDelegate` honor the item's background brush (falling
     back to `palette.base()`) so the match cell matches the rest of its row.

All fixes include regression tests. All item-view and metadata-box tests pass;
`ruff format`, `ruff check`, and `ty check` are clean (no new type diagnostics).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The investigation, fixes, and regression tests were developed with AI assistance
under close human direction. The root cause was confirmed on the actual Linux
Mint environment using a temporary diagnostic probe (which showed the palette's
current group was Disabled, resolving `#828282` text on `#323232` base at refresh
time). A human chose the desired behavior (items should follow the disabled
palette while the dialog is open, the tint should be perceptible but subtle),
reviewed each change, and verified the fixes live in the GUI before this PR.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
