### PR TITLE
PICARD-3418: Allow shrinking metadata box when cover art box is shown

### DIFF
--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -301,11 +301,26 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.metadata_box = MetadataBox(parent=self)
         self.cover_art_box = CoverArtBox(parent=self)
+        # Wrap the cover art box in a scroll area so it can shrink vertically.
+        # Without this, the cover art box's tall minimum height (fixed-size
+        # thumbnail + labels + button) becomes the floor for the whole
+        # metadata view, preventing the main splitter from shrinking it. The
+        # scroll area has a small minimum height and scrolls its content when
+        # clipped, so the separator can be dragged down as it can when the
+        # cover art box is hidden.
+        self.cover_art_scrollarea = QtWidgets.QScrollArea()
+        self.cover_art_scrollarea.setWidget(self.cover_art_box)
+        self.cover_art_scrollarea.setWidgetResizable(True)
+        self.cover_art_scrollarea.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.cover_art_scrollarea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.cover_art_scrollarea.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         metadata_view_layout = QtWidgets.QHBoxLayout()
         metadata_view_layout.setContentsMargins(0, 0, 0, 0)
         metadata_view_layout.setSpacing(0)
         metadata_view_layout.addWidget(self.metadata_box, 1)
-        metadata_view_layout.addWidget(self.cover_art_box, 0)
+        metadata_view_layout.addWidget(self.cover_art_scrollarea, 0)
         self.metadata_view = QtWidgets.QWidget()
         self.metadata_view.setLayout(metadata_view_layout)
 
@@ -2028,6 +2043,11 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def show_cover_art(self):
         """Show/hide the cover art box."""
         show = self.action_is_checked(MainAction.SHOW_COVER_ART)
+        # Toggle the scroll area wrapper so the whole column is removed from
+        # the layout when hidden (hiding only the inner box would leave the
+        # empty scroll area taking space). Also toggle the inner box so its
+        # own isHidden()-based update optimizations keep working.
+        self.cover_art_scrollarea.setVisible(show)
         self.cover_art_box.setVisible(show)
         if show:
             self.update_selection()


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: The horizontal separator above the metadata view could not be dragged down to shrink the metadata box when the cover art box was shown. This fixes that so it behaves the same whether or not the cover art box is visible.

## Problem

* JIRA ticket: PICARD-3418

When the cover art box is displayed, the main window's horizontal separator between the top panel and the metadata view cannot be dragged down to make the metadata box shorter. When the cover art box is hidden (via View > Cover Art), the separator can be dragged down freely.

The metadata view's minimum height is the maximum of its children's minimum heights. The cover art box has a tall minimum height (fixed-size thumbnail + labels + button), which becomes the floor for the whole metadata view. The main splitter uses `setChildrenCollapsible(False)`, so it will not shrink the pane below that floor.

Steps to reproduce:
1. Ensure the cover art box is shown (View > Cover Art).
2. Try to drag the separator above the metadata view downward — it stops at the cover art box height.
3. Hide the cover art box and drag the separator downward — it now moves freely.

## Solution

Wrap the cover art box in a `QScrollArea` inside the metadata view. The scroll area has a small minimum height and scrolls its content when clipped, so the separator can be dragged down as it can when the cover art box is hidden.

- `show_cover_art()` now toggles the scroll area wrapper (so the whole column leaves the layout when hidden) as well as the inner box (so `CoverArtBox`'s `isHidden()`-based update optimizations keep working).
- The scroll area uses `NoFrame`, horizontal scrollbar off, and a `Fixed`/`Preferred` size policy so the cover art column keeps its width. A vertical scrollbar appears only when the pane is shrunk below the artwork height.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to diagnose the root cause (identifying the cover art box minimum height as the splitter floor) and to implement the QScrollArea wrapper. The fix was reviewed and manually confirmed to work by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
