### PR TITLE
test_manager: mock _find_newer_version_tag to prevent hanging

### DIFF
--- a/test/plugins3/test_manager.py
+++ b/test/plugins3/test_manager.py
@@ -630,6 +630,8 @@ uuid = "3fa397ec-0f2a-47dd-9223-e47ce9f2d692"
         mock_repo.get_commit_date.return_value = 1234567890
         mock_git_backend.return_value.create_repository.return_value.__enter__.return_value = mock_repo
 
+        manager._registry_manager._fetch_version_tags = Mock(return_value=[])
+
         # Mock GitOperations
         with (
             patch('picard.plugin3.manager.update.GitOperations.check_dirty_working_dir', return_value=None),


### PR DESCRIPTION
## Summary
Running `uv run pytest -v test/plugins3/test_manager.py` hung because `update_plugin()` calls `_find_newer_version_tag()` which made network requests from the plugin repository.
This PR mocks out that network call.

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

Running tests by `uv run pytest -v test/plugins3/test_manager.py` never finishes on master.
This is not a bug, just a hole in the tests revealed by 8b24f6c56 2025-12-22 extraction, then 2473c258c 2026-03-15, then cc5d346d0 2026-06-29.

* JIRA ticket (_optional_): None.

## Solution

Mock out the parts that are making network calls.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->
I had done a manual bisection of the test suite to isolate which test was causing the hang, then local LLM `qwen3.5-9b-q4_k_m` was used to diagnose the issue originally by adding logging until the hang was discovered and provide a mock in the style of surrounding code.


## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
