### PR TITLE
PICARD-3420: Set proper pygit2 timeouts, reduce the risk of hang

### DIFF
--- a/docs/EnvironmentVariables.md
+++ b/docs/EnvironmentVariables.md
@@ -30,6 +30,8 @@ These affect a running Picard instance.
 | `PICARD_CACHE_DIR` | path | OS cache location | Override the directory used for caches. |
 | `PICARD_PLUGIN_DIR` | path | `<appdata>/plugins3` | Override the directory used for version 3 plugins. |
 | `PICARD_PLUGIN_REGISTRY_URL` | URL | built-in registry list (`DEFAULT_PLUGIN_REGISTRY_URLS`) | Override the plugin registry with a single URL used to discover plugins. |
+| `PICARD_GIT_CONNECT_TIMEOUT` | integer (seconds) | `30` | Maximum time to establish the connection to a remote git server during plugin install/update. `0` uses the libgit2/OS default. Capped by the operating system's own connect timeout, so a lower value only shortens the wait. Values are clamped to `0`–`3600`; unparseable values fall back to the default. |
+| `PICARD_GIT_TIMEOUT` | integer (seconds) | `60` | Per socket read/write (stall) timeout for remote git operations. This is not a total-operation budget: a slow but progressing transfer is unaffected; it only trips when the connection goes silent for longer than the value. Raise it behind flaky proxies, lower it to fail fast. `0` uses the libgit2/OS default (block). Values are clamped to `0`–`3600`; unparseable values fall back to the default. |
 
 ## Build variables
 

--- a/picard/env.py
+++ b/picard/env.py
@@ -60,3 +60,38 @@ def parse_bool_env(name: str, default: bool = False) -> bool:
     if value in _ENV_FALSY_VALUES:
         return False
     return default
+
+
+def parse_int_env(name: str, default: int, minimum: int | None = None, maximum: int | None = None) -> int:
+    """Parse a non-negative integer environment variable.
+
+    Reads the variable, strips surrounding whitespace and parses it as a base-10
+    integer. If the variable is unset, empty, or holds a value that cannot be
+    parsed as an integer, ``default`` is returned. When parsing succeeds the
+    value is clamped to the inclusive ``[minimum, maximum]`` range if those
+    bounds are provided.
+
+    This provides a single, predictable convention for Picard-owned integer
+    environment variables (e.g. timeouts and limits).
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value returned when the variable is unset or unparseable.
+        minimum: Optional inclusive lower bound to clamp the parsed value to.
+        maximum: Optional inclusive upper bound to clamp the parsed value to.
+
+    Returns:
+        The parsed (and optionally clamped) integer value.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value.strip())
+    except (ValueError, TypeError):
+        return default
+    if minimum is not None and parsed < minimum:
+        parsed = minimum
+    if maximum is not None and parsed > maximum:
+        parsed = maximum
+    return parsed

--- a/picard/git/backends/pygit2.py
+++ b/picard/git/backends/pygit2.py
@@ -34,6 +34,7 @@ except ImportError:
     pygit2 = None  # type: ignore[assignment]
 
 from picard import log
+from picard.env import parse_int_env
 from picard.git.backend import (
     GitBackend,
     GitCommitError,
@@ -49,6 +50,30 @@ from picard.git.backend import (
     GitStatusFlag,
     _log_git_call,
 )
+
+
+# Network timeout defaults for git operations, in seconds.
+#
+# These guard against Picard hanging when a remote git server is unreachable or
+# stalls (e.g. during plugin install/update ref fetches). libgit2 exposes two
+# distinct, purely programmatic settings (no env var of its own); we surface
+# them through Picard-owned environment variables.
+#
+# - connect timeout: time allowed to establish the TCP/TLS connection. libgit2
+#   caps this at the operating system default, so a shorter value only ever
+#   shortens the wait. This is bandwidth-independent.
+# - server timeout: a PER socket read/write (stall) timeout, NOT a total
+#   operation budget. A slow but progressing transfer is unaffected; it only
+#   trips when the socket goes silent for longer than the value. This makes it
+#   safe to keep generous without penalizing slow networks or large repos.
+#
+# A value of 0 means "use the libgit2/OS default" (no Picard-imposed timeout).
+GIT_CONNECT_TIMEOUT_ENV = 'PICARD_GIT_CONNECT_TIMEOUT'
+GIT_SERVER_TIMEOUT_ENV = 'PICARD_GIT_TIMEOUT'
+DEFAULT_GIT_CONNECT_TIMEOUT = 30
+DEFAULT_GIT_SERVER_TIMEOUT = 60
+# Upper bound guards against absurd values; one hour is well beyond any sane use.
+MAX_GIT_TIMEOUT = 3600
 
 
 class Pygit2RemoteCallbacks(GitRemoteCallbacks):
@@ -355,6 +380,41 @@ class Pygit2Backend(GitBackend):
     def __init__(self):
         if not HAS_PYGIT2:
             raise ImportError("pygit2 not available")
+        self._apply_network_timeouts()
+
+    @staticmethod
+    def _apply_network_timeouts():
+        """Configure libgit2 network timeouts from Picard environment variables.
+
+        Reads ``PICARD_GIT_CONNECT_TIMEOUT`` and ``PICARD_GIT_TIMEOUT`` (both in
+        seconds) and applies them to the libgit2 global settings, converting to
+        milliseconds. A value of 0 leaves the corresponding libgit2/OS default in
+        place. Each setting is guarded with ``hasattr`` and any failure to apply
+        is logged and ignored rather than preventing the backend from
+        initializing.
+        """
+        connect_timeout = parse_int_env(
+            GIT_CONNECT_TIMEOUT_ENV, DEFAULT_GIT_CONNECT_TIMEOUT, minimum=0, maximum=MAX_GIT_TIMEOUT
+        )
+        server_timeout = parse_int_env(
+            GIT_SERVER_TIMEOUT_ENV, DEFAULT_GIT_SERVER_TIMEOUT, minimum=0, maximum=MAX_GIT_TIMEOUT
+        )
+
+        # (setting attribute name, value in seconds)
+        for attr, seconds in (
+            ('server_connect_timeout', connect_timeout),
+            ('server_timeout', server_timeout),
+        ):
+            if seconds <= 0:
+                continue
+            if not hasattr(pygit2.settings, attr):
+                log.debug('libgit2 build lacks %s; skipping git timeout setup', attr)
+                continue
+            try:
+                setattr(pygit2.settings, attr, seconds * 1000)
+                log.debug('Set libgit2 %s to %d seconds', attr, seconds)
+            except (pygit2.GitError, OSError, ValueError) as e:
+                log.warning('Failed to set libgit2 %s: %s', attr, e)
 
     @staticmethod
     def _raw(repo: GitRepository):

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -23,7 +23,10 @@ from test.picardtestcase import (
     subtest_cases,
 )
 
-from picard.env import parse_bool_env
+from picard.env import (
+    parse_bool_env,
+    parse_int_env,
+)
 
 
 class ParseBoolEnvTest(PicardTestCase):
@@ -86,3 +89,55 @@ class ParseBoolEnvTest(PicardTestCase):
         # Unrecognized values fall back to the provided default.
         self.assertFalse(parse_bool_env(self.ENV_NAME, default=False))
         self.assertTrue(parse_bool_env(self.ENV_NAME, default=True))
+
+
+class ParseIntEnvTest(PicardTestCase):
+    ENV_NAME = 'PICARD_TEST_INT_ENV'
+
+    def _set_env(self, value):
+        if value is None:
+            os.environ.pop(self.ENV_NAME, None)
+        else:
+            os.environ[self.ENV_NAME] = value
+        self.addCleanup(os.environ.pop, self.ENV_NAME, None)
+
+    @subtest_cases(
+        "value,expected",
+        {
+            'plain integer': ('42', 42),
+            'zero': ('0', 0),
+            'surrounding whitespace': ('  17  ', 17),
+            'negative clamped to minimum 0': ('-5', 0),
+        },
+    )
+    def test_valid_values(self, value, expected):
+        self._set_env(value)
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=99, minimum=0), expected)
+
+    def test_unset_returns_default(self):
+        self._set_env(None)
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=30), 30)
+
+    @subtest_cases(
+        "value",
+        {
+            'empty': ('',),
+            'whitespace only': ('   ',),
+            'not a number': ('abc',),
+            'float': ('1.5',),
+            'trailing junk': ('10x',),
+        },
+    )
+    def test_unparseable_returns_default(self, value):
+        self._set_env(value)
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=60), 60)
+
+    def test_clamped_to_bounds(self):
+        self._set_env('5000')
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=60, minimum=0, maximum=3600), 3600)
+        self._set_env('-1')
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=60, minimum=10, maximum=3600), 10)
+
+    def test_no_bounds_allows_any_integer(self):
+        self._set_env('123456')
+        self.assertEqual(parse_int_env(self.ENV_NAME, default=0), 123456)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import os
 from pathlib import Path
 import unittest
 from unittest.mock import (
@@ -36,6 +37,7 @@ from picard.git.backend import (
     GitRepository,
     GitStatusFlag,
 )
+from picard.git.backends import pygit2 as pygit2_backend
 from picard.git.factory import git_backend
 
 
@@ -388,6 +390,84 @@ class TestGitBackend(unittest.TestCase):
             self.assertEqual(name, "Alice")
             self.assertEqual(email, "alice@example.com")
             repo.free()
+
+
+class TestGitNetworkTimeouts(unittest.TestCase):
+    """Tests for libgit2 network timeout configuration from environment variables."""
+
+    def setUp(self):
+        skip_if_no_git_backend()
+
+    def _run_with_env(self, connect=None, server=None):
+        """Run _apply_network_timeouts with a fake pygit2.settings and env vars.
+
+        Returns the dict of values that would be assigned to pygit2.settings
+        (attribute name -> value in milliseconds).
+        """
+        applied = {}
+
+        class FakeSettings:
+            # Present attributes so hasattr() is True, like libgit2 1.7+.
+            server_connect_timeout = 0
+            server_timeout = 0
+
+            def __setattr__(self, name, value):
+                applied[name] = value
+
+        env = {}
+        if connect is not None:
+            env[pygit2_backend.GIT_CONNECT_TIMEOUT_ENV] = connect
+        if server is not None:
+            env[pygit2_backend.GIT_SERVER_TIMEOUT_ENV] = server
+
+        # Start from a clean slate: remove our env vars, then set any provided.
+        with patch.dict(os.environ, env, clear=False):
+            if connect is None:
+                os.environ.pop(pygit2_backend.GIT_CONNECT_TIMEOUT_ENV, None)
+            if server is None:
+                os.environ.pop(pygit2_backend.GIT_SERVER_TIMEOUT_ENV, None)
+            with patch.object(pygit2_backend.pygit2, 'settings', FakeSettings()):
+                pygit2_backend.Pygit2Backend._apply_network_timeouts()
+        return applied
+
+    def test_defaults_applied_when_env_unset(self):
+        applied = self._run_with_env()
+        # Defaults are in seconds; libgit2 wants milliseconds.
+        self.assertEqual(applied.get('server_connect_timeout'), pygit2_backend.DEFAULT_GIT_CONNECT_TIMEOUT * 1000)
+        self.assertEqual(applied.get('server_timeout'), pygit2_backend.DEFAULT_GIT_SERVER_TIMEOUT * 1000)
+
+    def test_env_overrides_in_seconds_converted_to_ms(self):
+        applied = self._run_with_env(connect='5', server='45')
+        self.assertEqual(applied.get('server_connect_timeout'), 5000)
+        self.assertEqual(applied.get('server_timeout'), 45000)
+
+    def test_zero_leaves_libgit2_default(self):
+        # 0 means "do not impose a Picard timeout" -> attribute is not set.
+        applied = self._run_with_env(connect='0', server='0')
+        self.assertNotIn('server_connect_timeout', applied)
+        self.assertNotIn('server_timeout', applied)
+
+    def test_unparseable_falls_back_to_defaults(self):
+        applied = self._run_with_env(connect='abc', server='')
+        self.assertEqual(applied.get('server_connect_timeout'), pygit2_backend.DEFAULT_GIT_CONNECT_TIMEOUT * 1000)
+        self.assertEqual(applied.get('server_timeout'), pygit2_backend.DEFAULT_GIT_SERVER_TIMEOUT * 1000)
+
+    def test_values_clamped_to_maximum(self):
+        applied = self._run_with_env(connect='999999', server='999999')
+        self.assertEqual(applied.get('server_connect_timeout'), pygit2_backend.MAX_GIT_TIMEOUT * 1000)
+        self.assertEqual(applied.get('server_timeout'), pygit2_backend.MAX_GIT_TIMEOUT * 1000)
+
+    def test_missing_libgit2_support_is_ignored(self):
+        class OldSettings:
+            # No server_* attributes -> emulate libgit2 < 1.7.
+            pass
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(pygit2_backend.GIT_CONNECT_TIMEOUT_ENV, None)
+            os.environ.pop(pygit2_backend.GIT_SERVER_TIMEOUT_ENV, None)
+            with patch.object(pygit2_backend.pygit2, 'settings', OldSettings()):
+                # Must not raise even though the settings are unsupported.
+                pygit2_backend.Pygit2Backend._apply_network_timeouts()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Sets libgit2 connect and read/write (stall) timeouts for remote git operations, configurable via two environment variables, so plugin install/update fetches can no longer hang indefinitely against an unreachable or stalled server.

## Problem

* JIRA ticket: PICARD-3420

Without timeouts set, libgit2 (used via pygit2 for plugin install/update ref fetches) imposes no application-level timeout on remote operations. This can hang Picard:

* **Read stall** — a server that connects then goes silent mid-transfer blocks a socket read **indefinitely** (verified: still blocked past a 12s probe cap with no timeout).
* **Dead connect** — connecting to an unreachable host waits for the OS default (measured ~130s locally before it gave up).

Because libgit2 does its networking in native C and the fetch path swallows errors, the only user-visible symptom is a freeze.

## Solution

Apply libgit2's global `server_connect_timeout` and `server_timeout` settings from two new Picard environment variables (values in seconds, converted to milliseconds), read once when the pygit2 backend initializes:

* `PICARD_GIT_CONNECT_TIMEOUT` (default **30**) — connection-establishment timeout. libgit2 caps this at the OS default, so it can only shorten the wait; it is bandwidth-independent.
* `PICARD_GIT_TIMEOUT` (default **60**) — per socket read/write (**stall**) timeout. This is **not** a total-operation budget: a slow but progressing transfer is unaffected and it only trips when the socket goes silent longer than the value. This was verified empirically — an ~8s trickled transfer under a 2s timeout succeeds, while a mid-transfer stall trips at the timeout — so the default is safe on slow networks and for large repos.

A value of `0` leaves the libgit2/OS default in place. Values are clamped to `0`–`3600`; unparseable values fall back to the default.

These settings were introduced in libgit2 1.7. Picard requires libgit2 1.9+ through its pygit2 dependency (pygit2 1.18/1.19 → libgit2 1.9.x), so they are always available in a supported install; a `hasattr()` guard covers only unusual/source builds.

Details:

* Adds `parse_int_env()` to `picard/env.py` alongside the existing `parse_bool_env()`.
* Applies the timeouts in `Pygit2Backend._apply_network_timeouts()`.
* Documents both variables in `docs/EnvironmentVariables.md`.
* Adds tests for the env parsing and the timeout application (defaults, override, `0`, clamping, unparseable, and the missing-support guard).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI assisted with investigating the hang (empirically probing libgit2 timeout semantics against controlled local servers), structuring the implementation, writing the tests, and drafting the documentation. All changes were reviewed and verified by running the test suite, ruff, and ty.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
