### PR TITLE
PICARD-3421: Fix XDG desktop file name / Wayland app-id association

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1818,7 +1818,7 @@ def setup_application():
     # Some libs (ie. Phonon) require those to be set
     QtWidgets.QApplication.setApplicationName(PICARD_APP_NAME)
     QtWidgets.QApplication.setOrganizationName(PICARD_ORG_NAME)
-    QtWidgets.QApplication.setDesktopFileName(PICARD_APP_NAME)
+    QtWidgets.QApplication.setDesktopFileName(PICARD_APP_ID)
 
     # HighDpiScaleFactorRoundingPolicy is available since Qt 5.14. This is
     # required to support fractional scaling on Windows properly.


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Pass `PICARD_APP_ID` (`org.musicbrainz.Picard`) instead of `PICARD_APP_NAME` (`Picard`) to `QApplication.setDesktopFileName()`, so the value matches the installed desktop entry base name.

## Problem

At startup the desktop portal fails to associate the running process with its desktop entry, logging:

```
qt.qpa.services: Failed to register with host portal
("org.freedesktop.portal.Error.Failed",
 "Could not register app ID: App info not found for 'Picard'")
```

`setup_application()` set the desktop file name to `PICARD_APP_NAME` (`Picard`), but the installed desktop entry is `org.musicbrainz.Picard.desktop` (`PICARD_DESKTOP_NAME`, installed to `share/applications`). Per the freedesktop Desktop Entry Specification, the value must be the entry's base name without the `.desktop` suffix, i.e. the reverse-DNS ID `org.musicbrainz.Picard` (`PICARD_APP_ID`) — not `Picard`.

This regressed in ef2fafd (PICARD-2331), which correctly dropped the `.desktop` suffix but switched to `PICARD_APP_NAME` instead of `PICARD_APP_ID`.

* JIRA ticket (_optional_): [PICARD-3421](https://tickets.metabrainz.org/browse/PICARD-3421)

## Solution

Change the single call in `setup_application()`:

```python
-    QtWidgets.QApplication.setDesktopFileName(PICARD_APP_NAME)
+    QtWidgets.QApplication.setDesktopFileName(PICARD_APP_ID)
```

Effect per platform (checked against Qt sources):

* **Wayland**: the surface `app_id` is taken from `desktopFileName` with `.desktop` stripped (`qtwayland` `qwaylandwindow.cpp`). It becomes `org.musicbrainz.Picard`, so compositors resolve the correct `.desktop` for icon/grouping.
* **X11**: Qt sets `_GTK_APPLICATION_ID` and `_KDE_NET_WM_DESKTOP_FILE` from `desktopFileName` (`qtbase` `qxcbwindow.cpp`); these now resolve to the installed entry.
* **Windows / macOS / Haiku**: no effect — `desktopFileName` is an XDG concept not read by the `windows`/`cocoa` QPA plugins; the `.desktop` is only installed on non-`{darwin,haiku,win32}` platforms.

`StartupWMClass=Picard` in the `.desktop` is intentionally left unchanged: on X11 the `WM_CLASS` is derived from `applicationName()` (`Picard`), not from `desktopFileName` (`qtbase` `qxcbintegration.cpp`), so it still maps correctly; Wayland ignores `StartupWMClass`.

Verified by installing into a throwaway prefix: the installed file is `share/applications/org.musicbrainz.Picard.desktop`, whose base name equals `PICARD_APP_ID`. (Running from a source checkout still warns, since no desktop file is installed there.)

References:
* freedesktop Desktop Entry Specification — File naming / Desktop File ID: <https://specifications.freedesktop.org/desktop-entry/latest/file-naming.html>
* `QGuiApplication::desktopFileName`: <https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop>

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [x] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The code change is a one-line identifier substitution. An AI assistant was used to help investigate the root cause and cross-check the behavior against the Qt sources and the freedesktop specification.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

