### PR TITLE
PICARD-3422: Make the "Make It So!" accept button configurable and reusable

### DIFF
--- a/docs/EnvironmentVariables.md
+++ b/docs/EnvironmentVariables.md
@@ -25,6 +25,7 @@ These affect a running Picard instance.
 | `PICARD_DEBUG` | presence | unset | Enable debug logging when set (any value), equivalent to the `--debug` command line option. |
 | `PICARD_MODAL_OPTIONS` | boolean | platform-dependent (modal on macOS, non-modal elsewhere) | Force the Options dialog to be modal (truthy) or non-modal (falsy). |
 | `PICARD_FORCE_FUSION` | boolean | `false` | Force the Qt "Fusion" style on every platform, including macOS and Haiku, which otherwise keep their native style. Mainly useful on macOS; no visible effect where Fusion is already the default. |
+| `PICARD_MAKE_IT_SO` | boolean | `true` | Override the label of dialog accept buttons. When truthy (the default), buttons use the Star Trek themed "Make It So!" label (a long-standing Picard Easter egg); when falsy, they use the conventional native "OK". There is no configuration option, as the reference does not translate well. |
 | `PICARD_COLLATOR` | `qt`, `strxfrm` or `string` | `strxfrm` on Windows, `qt` elsewhere | Select the string collation backend used for sorting. An unrecognized value falls back to the default. |
 | `PICARD_CONFIG_DIR` | path | OS application config location | Override the directory used to store the configuration. |
 | `PICARD_CACHE_DIR` | path | OS cache location | Override the directory used for caches. |

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -114,6 +114,7 @@ from picard.ui.options import (  # noqa: F401 # pylint: disable=unused-import
     tags_compatibility_wave,
 )
 from picard.ui.theme import theme as _theme
+from picard.ui.util import add_accept_button
 
 
 if TYPE_CHECKING:
@@ -312,8 +313,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         self.ui.reset_button.setToolTip(_("Reset all settings for current option page"))
 
         # Buttons
-        ok = QtWidgets.QPushButton(_("Make It So!"))
-        self.ui.buttonbox.addButton(ok, QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
+        add_accept_button(self.ui.buttonbox)
         self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Help)
         self.ui.buttonbox.addButton(self.ui.reset_all_button, QtWidgets.QDialogButtonBox.ButtonRole.ActionRole)

--- a/picard/ui/scripteditor/__init__.py
+++ b/picard/ui/scripteditor/__init__.py
@@ -77,7 +77,10 @@ from picard.ui.options.scripting import (
     OptionsCheckError,
     ScriptCheckError,
 )
-from picard.ui.util import set_widget_fixed_width_for_text
+from picard.ui.util import (
+    add_accept_button,
+    set_widget_fixed_width_for_text,
+)
 from picard.ui.widgets.scriptdocumentation import ScriptingDocumentationWidget
 
 
@@ -160,7 +163,7 @@ class ScriptEditorDialog(PicardDialog, SingletonDialog, HasDisplayTitle):
         self.reset_button.setToolTip(self.reset_action.toolTip())
         self.reset_button.clicked.connect(self.reload_from_config)
 
-        self.save_button = self.ui.buttonbox.addButton(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        self.save_button = add_accept_button(self.ui.buttonbox)
         self.save_button.setToolTip(self.save_action.toolTip())
         self.ui.buttonbox.accepted.connect(self.make_it_so)
 

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -42,6 +42,7 @@ from picard import (
 from picard.config import get_config
 from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
 from picard.const.sys import IS_LINUX
+from picard.env import parse_bool_env
 from picard.i18n import gettext as _
 from picard.util import (
     find_existing_path,
@@ -50,6 +51,42 @@ from picard.util import (
 
 from picard.ui.colors import interface_colors
 from picard.ui.enums import MainAction
+
+
+def _make_it_so_enabled() -> bool:
+    """Return whether dialog accept buttons should use the "Make It So!" label.
+
+    Enabled by default (preserving the long-standing Easter egg) and can be
+    disabled at runtime by setting the ``PICARD_MAKE_IT_SO`` environment
+    variable to a falsy value. There is deliberately no configuration option:
+    the "Make It So!" reference does not translate well, so a user-facing
+    setting would have no effect in many languages.
+    """
+    return parse_bool_env('PICARD_MAKE_IT_SO', default=True)
+
+
+def add_accept_button(
+    buttonbox: QtWidgets.QDialogButtonBox,
+    role: QtWidgets.QDialogButtonBox.StandardButton = QtWidgets.QDialogButtonBox.StandardButton.Ok,
+) -> QtWidgets.QPushButton:
+    """Add the accept button to a dialog button box with Picard's themed label.
+
+    Creates the standard accept button (``Ok`` by default) on ``buttonbox``.
+    When ``role`` is ``Ok`` and the "Make It So!" Easter egg is enabled (see
+    :func:`_make_it_so_enabled`, which is on by default and controlled by the
+    ``PICARD_MAKE_IT_SO`` environment variable), the button is relabeled with
+    the Star Trek themed "Make It So!" text. In any other case the standard
+    button keeps its native, Qt-translated label. Centralizing this here gives
+    every dialog consistent behavior. Returns the created button so callers can
+    set tooltips, connect signals, etc.
+    """
+    button = buttonbox.addButton(role)
+    # addButton() with a standard button always returns a valid button; assert
+    # to satisfy the type checker (the stub types it as Optional) and callers.
+    assert button is not None
+    if role == QtWidgets.QDialogButtonBox.StandardButton.Ok and _make_it_so_enabled():
+        button.setText(_("Make It So!"))
+    return button
 
 
 def open_local_path(path: str) -> None:


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Extend the long-standing "Make It So!" accept-button Easter egg to the Script Editor via a shared helper, and add an environment variable to disable it.

## Problem

* JIRA ticket: [PICARD-3422](https://tickets.metabrainz.org/browse/PICARD-3422)

The "Make It So!" accept button (a Star Trek reference fitting the Picard name, originally an April Fools' joke that stuck) only appears on the Options dialog. The Script Editor uses a plain "OK". Users have asked for the themed label there too — see this request on Reddit:

> Edit: and I miss the "Make it so" button from the script editor........ ;)

<https://www.reddit.com/r/MusicBrainz/comments/1w4qcs2/comment/p7trn3k/>

At the same time, the label was hardcoded in a single dialog with no way for users who prefer a conventional button to opt out.

## Solution

* Add a shared `add_accept_button()` helper in `picard.ui.util` that adds a standard accept button (`Ok` by default) to a `QDialogButtonBox` and applies the themed "Make It So!" label. Centralizing this removes the hardcoded string and gives every dialog consistent behavior.
* Use the helper in both the Options dialog and the Script Editor, so the Script Editor now shows "Make It So!" by default (the requested parity). Switching the Options dialog to a standard `Ok` button also gives it correct per-platform button ordering and default-button behavior.
* Add a `PICARD_MAKE_IT_SO` environment variable (reusing the existing `parse_bool_env()` convention) that disables the themed label when set to a falsy value; it is enabled by default. Documented in `docs/EnvironmentVariables.md` alongside the other boolean runtime variables.
* No configuration option is added. As discussed in review, the "Make It So!" reference does not translate well, so a user-facing setting would have no effect in many languages; the environment variable is the escape hatch for those who prefer a conventional button.
* When disabled (env var falsy), the accept button keeps its native, Qt-translated label.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Code structure, implementation, and documentation were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)


