### PR TITLE
Minor code refactorings: Use sets in membership tests, resolve nested ifs

### DIFF
--- a/picard/acoustid/recordings.py
+++ b/picard/acoustid/recordings.py
@@ -96,20 +96,19 @@ class RecordingResolver:
                         result_score=result_score,
                         sources=sources,
                     )
-                else:
-                    if (
-                        sources / max_sources > SOURCE_THRESHOLD_NO_METADATA
-                        and incomplete_counts[acoustid] < MAX_NO_METADATA_RECORDINGS
-                    ):
-                        self._missing_metadata.append(
-                            IncompleteRecording(
-                                mbid=mbid,
-                                acoustid=acoustid,
-                                result_score=result_score,
-                                sources=sources,
-                            )
+                elif (
+                    sources / max_sources > SOURCE_THRESHOLD_NO_METADATA
+                    and incomplete_counts[acoustid] < MAX_NO_METADATA_RECORDINGS
+                ):
+                    self._missing_metadata.append(
+                        IncompleteRecording(
+                            mbid=mbid,
+                            acoustid=acoustid,
+                            result_score=result_score,
+                            sources=sources,
                         )
-                        incomplete_counts[acoustid] += 1
+                    )
+                    incomplete_counts[acoustid] += 1
 
         self._load_recordings()
 

--- a/picard/cli/output.py
+++ b/picard/cli/output.py
@@ -214,4 +214,4 @@ class CliOutput:
     def yesno(self, question, default='N'):
         """Ask a yes/no question and return True if yes, False otherwise."""
         response = input(self.d_prompt(question, default)).strip().lower()
-        return response in ('y', 'yes')
+        return response in {'y', 'yes'}

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -226,13 +226,12 @@ def upgrade_option_value(
         # Plain dict path
         if name in settings and settings[name] is not None:
             settings[name] = transform(settings[name])
-    else:
-        # ConfigSection path
-        if name in settings:
-            value = settings.raw_value(name)
-            if value is not None:
-                with settings.no_profile():
-                    settings[name] = transform(value)
+    # ConfigSection path
+    elif name in settings:
+        value = settings.raw_value(name)
+        if value is not None:
+            with settings.no_profile():
+                settings[name] = transform(value)
 
 
 def get_option_value(

--- a/picard/file.py
+++ b/picard/file.py
@@ -977,7 +977,7 @@ class File(MetadataItem):
                     break
             else:
                 self.similarity = 1.0
-                if self.state in (File.State.CHANGED, File.State.NORMAL):
+                if self.state in {File.State.CHANGED, File.State.NORMAL}:
                     if self.metadata.images and self.orig_metadata.images != self._expected_embedded_images():
                         self.state = File.State.CHANGED
                     else:

--- a/picard/formats/apev2.py
+++ b/picard/formats/apev2.py
@@ -272,9 +272,8 @@ class APEv2File(File):
                 tagstr = real_name.lower() + 'number'
                 if tagstr in metadata:
                     tags[real_name] = metadata[tagstr]
-            else:
-                if real_name in tags:
-                    del tags[real_name]
+            elif real_name in tags:
+                del tags[real_name]
 
     def _get_tag_name(self, name):
         if name in self.__casemap:

--- a/picard/formats/vorbis.py
+++ b/picard/formats/vorbis.py
@@ -156,7 +156,7 @@ class VCommentFile(File):
                     # YYYY-00-00 => YYYY
                     if self.is_date_sanitization_enabled():
                         value = sanitize_date(value)
-                elif name == 'performer' or name == 'comment':
+                elif name in {'performer', 'comment'}:
                     # transform "performer=Joe Barr (Piano)" to "performer:Piano=Joe Barr"
                     name += ':'
                     if value.endswith(')'):

--- a/picard/git/ops.py
+++ b/picard/git/ops.py
@@ -75,7 +75,7 @@ class GitOperations:
             # Check for any changes (modified, added, deleted, renamed, etc.)
             modified_files = []
             for filepath, flag in status.items():
-                if flag not in (GitStatusFlag.CURRENT, GitStatusFlag.IGNORED):
+                if flag not in {GitStatusFlag.CURRENT, GitStatusFlag.IGNORED}:
                     # Ignore Python cache files
                     if (
                         filepath.endswith(('.pyc', '.pyo'))

--- a/picard/git/ops.py
+++ b/picard/git/ops.py
@@ -195,15 +195,14 @@ class GitOperations:
                             return 'commit', ref
                         except Exception:
                             return None, ref
+                # Check current HEAD state
+                elif repo.is_head_detached():
+                    commit = repo.get_head_target()[:7]
+                    return 'commit', commit
                 else:
-                    # Check current HEAD state
-                    if repo.is_head_detached():
-                        commit = repo.get_head_target()[:7]
-                        return 'commit', commit
-                    else:
-                        # HEAD points to a branch
-                        branch_name = repo.get_head_shorthand()
-                        return 'branch', branch_name
+                    # HEAD points to a branch
+                    branch_name = repo.get_head_shorthand()
+                    return 'branch', branch_name
 
         except GitBackendError:
             return None, ref

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -298,7 +298,7 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         name = self.normalize_tag(name)
         if isinstance(values, str) or not isinstance(values, Iterable):
             values = [values]
-        values = [str(value) for value in values if value or value == 0 or value == '']
+        values = [str(value) for value in values if value or value in {0, ''}]
         # Remove if there is only a single empty or blank element.
         count = len(values)
         if count and (count > 1 or values[0]):

--- a/picard/oauth.py
+++ b/picard/oauth.py
@@ -229,12 +229,11 @@ class OAuthManager(QObject):
     def get_access_token(self, callback):
         if not self.is_authorized():
             callback(access_token=None)
+        elif self.access_token and time.time() < self.access_token_expires:
+            callback(access_token=self.access_token)
         else:
-            if self.access_token and time.time() < self.access_token_expires:
-                callback(access_token=self.access_token)
-            else:
-                self.forget_access_token()
-                self.refresh_access_token(callback)
+            self.forget_access_token()
+            self.refresh_access_token(callback)
 
     def url(self, path=None, params=None):
         return build_qurl(

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -770,12 +770,11 @@ class PluginApi:
                 lang = locale.split('_')[0]
                 if lang in self._translations and key in self._translations[lang]:
                     result = self._translations[lang][key]
-                else:
-                    # Try source locale as fallback
-                    if self._source_locale in self._translations and key in self._translations[self._source_locale]:
-                        result = self._translations[self._source_locale][key]
-                    elif DebugOpt.PLUGIN_TRANSLATIONS.enabled:
-                        self._logger.debug("tr() no translation found for key '%s' in any locale", key)
+                # Try source locale as fallback
+                elif self._source_locale in self._translations and key in self._translations[self._source_locale]:
+                    result = self._translations[self._source_locale][key]
+                elif DebugOpt.PLUGIN_TRANSLATIONS.enabled:
+                    self._logger.debug("tr() no translation found for key '%s' in any locale", key)
 
         # Fall back to text parameter or key
         if result is None:
@@ -830,12 +829,11 @@ class PluginApi:
                 if lang in self._translations and key in self._translations[lang]:
                     trans = self._translations[lang][key]
                     result = get_plural_translation(trans, plural_form)
-                else:
-                    # Try source locale as fallback
-                    if self._source_locale in self._translations and key in self._translations[self._source_locale]:
-                        trans = self._translations[self._source_locale][key]
-                        source_plural_form = get_plural_form(self._source_locale, n)
-                        result = get_plural_translation(trans, source_plural_form)
+                # Try source locale as fallback
+                elif self._source_locale in self._translations and key in self._translations[self._source_locale]:
+                    trans = self._translations[self._source_locale][key]
+                    source_plural_form = get_plural_form(self._source_locale, n)
+                    result = get_plural_translation(trans, source_plural_form)
 
         # Fall back to singular/plural parameters
         if result is None:

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -282,13 +282,12 @@ class PluginCLI(BaseCLI):
             else:
                 self._out.error('Cannot modify plugin with uncommitted changes in non-interactive mode')
                 return False, None
+        elif self._out.yesno('Discard changes and continue?'):
+            result = action_callback(discard_changes=True)
+            return True, result
         else:
-            if self._out.yesno('Discard changes and continue?'):
-                result = action_callback(discard_changes=True)
-                return True, result
-            else:
-                self._out.print('Operation cancelled')
-                return False, None
+            self._out.print('Operation cancelled')
+            return False, None
 
     def _dispatch(self):
         """Dispatch to the appropriate plugin command."""

--- a/picard/plugin3/manager/__init__.py
+++ b/picard/plugin3/manager/__init__.py
@@ -508,7 +508,7 @@ class PluginManager(QObject):
         loaded_uuids = {p.uuid for p in self._plugins if p.uuid}
 
         for uuid, entry in list(metadata_dict.items()):
-            if entry.get('ref_type') not in (REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV):
+            if entry.get('ref_type') not in {REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV}:
                 continue
             # Skip if already loaded (e.g. symlink in plugin dir)
             if uuid in loaded_uuids:

--- a/picard/plugin3/manager/registry.py
+++ b/picard/plugin3/manager/registry.py
@@ -248,7 +248,7 @@ class PluginRegistryManager:
             return None
 
         # Use version parsing for semver/calver, lexicographic for custom regex
-        if versioning_scheme in ('semver', 'calver'):
+        if versioning_scheme in {'semver', 'calver'}:
             try:
                 current_version = _parse_version_safely(current_tag)
                 if not current_version:

--- a/picard/plugin3/manager/update.py
+++ b/picard/plugin3/manager/update.py
@@ -370,7 +370,7 @@ class PluginUpdater:
             )
 
             for r in repo.list_references():
-                if r.ref_type == GitRefType.TAG and (r.shortname == metadata.ref or r.name == metadata.ref):
+                if r.ref_type == GitRefType.TAG and metadata.ref in {r.shortname, r.name}:
                     is_tag_installation = True
                     resolved_ref_info = f"tag {metadata.ref}"
                     break

--- a/picard/plugin3/plugin.py
+++ b/picard/plugin3/plugin.py
@@ -153,7 +153,7 @@ class PluginSourceGit(PluginSource):
         """
         refs = []
         for ref in repo.list_references():
-            if ref.ref_type in (GitRefType.BRANCH, GitRefType.TAG):
+            if ref.ref_type in {GitRefType.BRANCH, GitRefType.TAG}:
                 refs.append(ref.shortname)
 
         if not refs:
@@ -450,7 +450,7 @@ class PluginSourceGit(PluginSource):
                 except (KeyError, GitBackendError):
                     # Fall back to local branch
                     commit = repo.revparse_to_commit(git_ref.name)
-            elif git_ref and git_ref.ref_type in (GitRefType.TAG, GitRefType.BRANCH):
+            elif git_ref and git_ref.ref_type in {GitRefType.TAG, GitRefType.BRANCH}:
                 commit = repo.revparse_to_commit(git_ref.name)
             else:
                 # For commits or unknown refs, try as-is

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -136,7 +136,7 @@ LOCAL_DEV_MARKER = N_('local-dev')
 
 def is_local_plugin(metadata) -> bool:
     """Check if metadata represents a local plugin. Safe with None."""
-    return metadata is not None and getattr(metadata, 'ref_type', None) in (REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV)
+    return metadata is not None and getattr(metadata, 'ref_type', None) in {REF_TYPE_LOCAL, REF_TYPE_LOCAL_DEV}
 
 
 class PluginMetadataManager:

--- a/picard/plugin3/plugin_metadata.py
+++ b/picard/plugin3/plugin_metadata.py
@@ -95,18 +95,16 @@ class PluginMetadata:
                 if self.ref.startswith('refs/'):
                     # Already a full name, use as-is
                     full_name = self.ref
+                # Short name, construct full name based on ref_type
+                elif self.ref_type == 'tag':
+                    full_name = f"refs/tags/{self.ref}"
+                elif self.ref_type == 'branch':
+                    full_name = f"refs/heads/{self.ref}"
+                # Unknown type, assume it's a short name and guess
+                elif self.ref.startswith('v') or '.' in self.ref:
+                    full_name = f"refs/tags/{self.ref}"
                 else:
-                    # Short name, construct full name based on ref_type
-                    if self.ref_type == 'tag':
-                        full_name = f"refs/tags/{self.ref}"
-                    elif self.ref_type == 'branch':
-                        full_name = f"refs/heads/{self.ref}"
-                    else:
-                        # Unknown type, assume it's a short name and guess
-                        if self.ref.startswith('v') or '.' in self.ref:
-                            full_name = f"refs/tags/{self.ref}"
-                        else:
-                            full_name = f"refs/heads/{self.ref}"
+                    full_name = f"refs/heads/{self.ref}"
             else:
                 # Only commit, no ref name
                 full_name = self.commit
@@ -316,33 +314,31 @@ class PluginMetadataManager:
                     git_ref = metadata.get_git_ref()
                     current_ref = git_ref.shortname if git_ref.shortname else None
                     current_commit = metadata.commit
-            else:
-                # Prefer metadata ref over detected ref for consistency
-                if metadata and metadata.ref:
-                    git_ref = metadata.get_git_ref()
-                    current_ref = git_ref.shortname if git_ref.shortname else metadata.ref
+            # Prefer metadata ref over detected ref for consistency
+            elif metadata and metadata.ref:
+                git_ref = metadata.get_git_ref()
+                current_ref = git_ref.shortname if git_ref.shortname else metadata.ref
 
             # Set ref type from metadata
             current_ref_type = metadata.ref_type if metadata else None
 
+        # Not installed - try registry ID, UUID, or URL
+        elif '://' in identifier or '/' in identifier:
+            # Looks like a URL
+            url = identifier
+            registry_id = self._registry.get_registry_id(url=url)
         else:
-            # Not installed - try registry ID, UUID, or URL
-            if '://' in identifier or '/' in identifier:
-                # Looks like a URL
-                url = identifier
-                registry_id = self._registry.get_registry_id(url=url)
-            else:
-                # Try as registry ID or UUID
-                registry_plugin = self._registry.find_plugin(plugin_id=identifier)
-                if not registry_plugin:
-                    # Try as UUID
-                    registry_plugin = self._registry.find_plugin(uuid=identifier)
+            # Try as registry ID or UUID
+            registry_plugin = self._registry.find_plugin(plugin_id=identifier)
+            if not registry_plugin:
+                # Try as UUID
+                registry_plugin = self._registry.find_plugin(uuid=identifier)
 
-                if not registry_plugin:
-                    return None
+            if not registry_plugin:
+                return None
 
-                url = registry_plugin.git_url
-                registry_id = registry_plugin.id or identifier
+            url = registry_plugin.git_url
+            registry_id = registry_plugin.id or identifier
 
         # Get registry data if available
         registry_plugin = self._registry.find_plugin(plugin_id=registry_id) if registry_id else None

--- a/picard/plugin3/ref_item.py
+++ b/picard/plugin3/ref_item.py
@@ -83,7 +83,7 @@ class RefItem:
 
         if self.shortname and short_commit:
             # If ref is the same as commit (commit hash used as ref), just show @commit
-            if self.shortname == self.commit or self.shortname == short_commit:
+            if self.shortname in {self.commit, short_commit}:
                 base = f"@{formatted_commit}"
             else:
                 base = f"{formatted_ref} @{formatted_commit}"

--- a/picard/plugin3/registry.py
+++ b/picard/plugin3/registry.py
@@ -237,15 +237,14 @@ class PluginRegistry:
             if success:
                 if callback:
                     callback(True, None)
+            # Parse errors are fatal - don't try next URL
+            elif isinstance(error, RegistryParseError):
+                if callback:
+                    callback(False, error)
             else:
-                # Parse errors are fatal - don't try next URL
-                if isinstance(error, RegistryParseError):
-                    if callback:
-                        callback(False, error)
-                else:
-                    log.warning('Failed to fetch registry from %s: %s', url, error)
-                    # Try next URL for network errors, passing along the error
-                    self._try_next_url(url_index + 1, callback, last_error=error)
+                log.warning('Failed to fetch registry from %s: %s', url, error)
+                # Try next URL for network errors, passing along the error
+                self._try_next_url(url_index + 1, callback, last_error=error)
 
         self._fetch_remote_registry(url, on_fetch_complete)
 

--- a/picard/script/functions.py
+++ b/picard/script/functions.py
@@ -1570,7 +1570,7 @@ def _type_args(_type, *args):
         _typer = int
     elif _type == 'float':
         _typer = float
-    elif _type in ('text', 'nocase'):
+    elif _type in {'text', 'nocase'}:
         pass
     else:
         # Unknown processing type

--- a/picard/tags/docs.py
+++ b/picard/tags/docs.py
@@ -54,7 +54,7 @@ def _get_tagvar_item(tagname):
         # Inline import to avoid circular dependency: script_variables imports from this module.
         from picard.extension_points.script_variables import ext_point_script_variables
 
-        bare_name = tagname[1:] if tagname[:1] in ('~', '_') else tagname
+        bare_name = tagname[1:] if tagname[:1] in {'~', '_'} else tagname
         item = next((var for var in ext_point_script_variables if var.name == bare_name), None)
 
     if item:

--- a/picard/ui/dialogs/installconfirm.py
+++ b/picard/ui/dialogs/installconfirm.py
@@ -158,7 +158,7 @@ class InstallConfirmDialog(PicardDialog):
 
             # Check trust level
             trust_level = registry.get_trust_level(self.url)
-            if trust_level in ("community", "unregistered"):
+            if trust_level in {"community", "unregistered"}:
                 if trust_level == "community":
                     warning_text = _(
                         "This is a community plugin. Community plugins are not reviewed by the Picard team."

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -502,7 +502,7 @@ class InstallPluginDialog(PicardDialog):
             plugin_data = registry.find_plugin(plugin_id=plugin_id)
             if plugin_data:
                 trust_level = registry.get_trust_level(plugin_data.get('url', ''))
-                if trust_level in ("community", "unregistered"):
+                if trust_level in {"community", "unregistered"}:
                     self._show_trust_warning(trust_level)
                 else:
                     self.warning_label.hide()

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -624,8 +624,9 @@ class InstallPluginDialog(PicardDialog):
 
     def _disable_ui_for_installation(self):
         """Disable UI elements during installation."""
+        print("_disable_ui_for_installation")
         for widget in self.findChildren(QtWidgets.QWidget):
-            if widget != self.progress_bar and widget != self.status_label:
+            if widget not in {self.progress_bar, self.status_label}:
                 widget.setEnabled(False)
 
     def _enable_ui_after_installation(self):

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -643,13 +643,12 @@ class AlbumItem(TreeItem):
             else:
                 self.setIcon(self.columns.status_icon_column, AlbumItem.icon_cd_saved)
                 self.setToolTip(self.columns.status_icon_column, _("Album unchanged and complete"))
+        elif album.is_modified():
+            self.setIcon(self.columns.status_icon_column, AlbumItem.icon_cd_modified)
+            self.setToolTip(self.columns.status_icon_column, _("Album modified"))
         else:
-            if album.is_modified():
-                self.setIcon(self.columns.status_icon_column, AlbumItem.icon_cd_modified)
-                self.setToolTip(self.columns.status_icon_column, _("Album modified"))
-            else:
-                self.setIcon(self.columns.status_icon_column, AlbumItem.icon_cd)
-                self.setToolTip(self.columns.status_icon_column, _("Album unchanged"))
+            self.setIcon(self.columns.status_icon_column, AlbumItem.icon_cd)
+            self.setToolTip(self.columns.status_icon_column, _("Album unchanged"))
         self.update_colums_text()
         if selection_changed and update_selection:
             TreeItem.window.panel.update_current_view()

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -825,9 +825,8 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                     for value in values:
                         if text in str(value).lower():
                             matches.add(tag)
-                else:
-                    if text in str(values).lower():
-                        matches.add(tag)
+                elif text in str(values).lower():
+                    matches.add(tag)
 
         return has_tags, matches
 

--- a/picard/ui/metadatabox/__init__.py
+++ b/picard/ui/metadatabox/__init__.py
@@ -681,7 +681,7 @@ class MetadataBox(QtWidgets.QTableWidget):
         - Ensures actions are only added once per object.
         """
         status = self.tag_diff.status[tag] & TagStatus.CHANGED
-        if status not in (TagStatus.CHANGED, TagStatus.REMOVED):
+        if status not in {TagStatus.CHANGED, TagStatus.REMOVED}:
             return
 
         file_tracks = []

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -397,7 +397,7 @@ class Plugins3OptionsPage(OptionsPage):
         config = get_config()
 
         # Update the updates dict based on the action
-        if action in ("updated", "reloaded", "reinstalled", "ref switched"):
+        if action in {"updated", "reloaded", "reinstalled", "ref switched"}:
             self._check_plugin_update_after_action(plugin, action)
             # Update the plugin list widget with new updates dict
             self.plugin_list.set_updates(config.persist['plugins3_updates'])

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -372,9 +372,9 @@ class ProfilesOptionsPage(OptionsPage):
             return self._get_scripts_list(config.setting[key])
         if key == 'ca_providers':
             return self._get_ca_providers_list(config.setting[key])
-        if key in ('cover_tags_resize_mode', 'cover_file_resize_mode'):
+        if key in {'cover_tags_resize_mode', 'cover_file_resize_mode'}:
             return self._get_ca_resize_mode(config.setting[key])
-        if key in ('cover_tags_convert_to_format', 'cover_file_convert_to_format'):
+        if key in {'cover_tags_convert_to_format', 'cover_file_convert_to_format'}:
             return self._get_ca_convert_format(config.setting[key])
         if isinstance(value, str):
             return '"%s"' % value

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -194,9 +194,8 @@ class FileDialog(QtWidgets.QFileDialog):
                 path = volume.rootPath()
                 if volume.isRoot():
                     root_volume = path
-                else:
-                    if not IS_LINUX or (path.startswith("/media/") or path.startswith("/mnt/")):
-                        volume_paths.append(path)
+                elif not IS_LINUX or (path.startswith("/media/") or path.startswith("/mnt/")):
+                    volume_paths.append(path)
         paths = [
             root_volume,
             QtCore.QDir.homePath(),

--- a/picard/ui/widgets/completion_provider.py
+++ b/picard/ui/widgets/completion_provider.py
@@ -113,7 +113,7 @@ class CompletionChoicesProvider:
         all_variables = list(builtin_variables | user_defined_variables | user_script_variables)
         all_variables.sort(key=lambda x: (-usage_counts.get(x, 0), x))
 
-        if mode in (CompletionMode.DEFAULT, CompletionMode.FUNCTION_NAME):
+        if mode in {CompletionMode.DEFAULT, CompletionMode.FUNCTION_NAME}:
             for name in sorted(script_function_names()):
                 yield f'${name}'
 
@@ -122,6 +122,6 @@ class CompletionChoicesProvider:
                 yield name
             return
 
-        if mode in (CompletionMode.DEFAULT, CompletionMode.VARIABLE):
+        if mode in {CompletionMode.DEFAULT, CompletionMode.VARIABLE}:
             for name in all_variables:
                 yield f'%{name}%'

--- a/picard/ui/widgets/lockableheaderview.py
+++ b/picard/ui/widgets/lockableheaderview.py
@@ -52,10 +52,9 @@ class LockableHeaderView(QtWidgets.QHeaderView):
         if is_locked:
             self.prelock_state = self.saveState()
             self.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Fixed)
-        else:
-            if self.prelock_state is not None:
-                self.restoreState(self.prelock_state)
-                self.prelock_state = None
+        elif self.prelock_state is not None:
+            self.restoreState(self.prelock_state)
+            self.prelock_state = None
 
         self.setSectionsClickable(not is_locked)
         self.setSectionsMovable(not is_locked)

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -496,7 +496,7 @@ class PluginListWidget(QtWidgets.QWidget):
                     target_enabled = False  # Disable it
                 elif plugin.state == PluginState.LOADED:
                     target_enabled = False  # Disable loaded plugins (they're stuck, need to be reset)
-                elif plugin.state in (PluginState.DISABLED, PluginState.DISCOVERED):
+                elif plugin.state in {PluginState.DISABLED, PluginState.DISCOVERED}:
                     # Don't try to enable plugins that have failed before
                     if plugin.plugin_id in self._failed_enables:
                         return

--- a/picard/util/__init__.py
+++ b/picard/util/__init__.py
@@ -1166,7 +1166,7 @@ def iswbound(char: str) -> bool:
     # from https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/titlecase/titlecase.py
     """Checks whether the given character is a word boundary"""
     category = unicodedata.category(char)
-    return 'Zs' == category or 'Sk' == category or 'P' == category[0]
+    return category in {'Zs', 'Sk'} or 'P' == category[0]
 
 
 def titlecase(text: str) -> str:

--- a/picard/util/checkupdate.py
+++ b/picard/util/checkupdate.py
@@ -159,22 +159,21 @@ class UpdateCheckManager:
                 == QMessageBox.StandardButton.Ok
             ):
                 webbrowser2.open(self._available_versions[key]['urls']['download'])
-        else:
-            if self._show_always:
-                if self._update_level in PROGRAM_UPDATE_LEVELS:
-                    update_level = PROGRAM_UPDATE_LEVELS[self._update_level]['title']
-                else:
-                    update_level = N_("unknown")
-                QMessageBox.information(
-                    self.tagger.window,
-                    _("Picard Update"),
-                    _(
-                        "There is no update currently available for your subscribed update level: {update_level}\n\n"
-                        "Your version: {picard_old_version}\n"
-                    ).format(
-                        update_level=gettext_constants(update_level),
-                        picard_old_version=PICARD_FANCY_VERSION_STR,
-                    ),
-                    QMessageBox.StandardButton.Ok,
-                    QMessageBox.StandardButton.Ok,
-                )
+        elif self._show_always:
+            if self._update_level in PROGRAM_UPDATE_LEVELS:
+                update_level = PROGRAM_UPDATE_LEVELS[self._update_level]['title']
+            else:
+                update_level = N_("unknown")
+            QMessageBox.information(
+                self.tagger.window,
+                _("Picard Update"),
+                _(
+                    "There is no update currently available for your subscribed update level: {update_level}\n\n"
+                    "Your version: {picard_old_version}\n"
+                ).format(
+                    update_level=gettext_constants(update_level),
+                    picard_old_version=PICARD_FANCY_VERSION_STR,
+                ),
+                QMessageBox.StandardButton.Ok,
+                QMessageBox.StandardButton.Ok,
+            )

--- a/picard/util/filenaming.py
+++ b/picard/util/filenaming.py
@@ -362,7 +362,7 @@ def make_short_filename(basedir: str, relpath: str, win_shorten_path: bool = Fal
     relpath = os.path.normpath(relpath)
     if win_shorten_path and relative_to:
         relative_to = os.path.abspath(relative_to)
-        assert basedir.startswith(relative_to) and basedir.split(relative_to)[1][:1] in (os.path.sep, ''), (
+        assert basedir.startswith(relative_to) and basedir.split(relative_to)[1][:1] in {os.path.sep, ''}, (
             "`relative_to` must be an ancestor of `basedir`"
         )
     # always strip the relpath parts

--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -653,8 +653,7 @@ class WebService(QtCore.QObject):
                         self.authorization_required.emit()
 
             elif not request.max_retries_reached() and (
-                response_code == 503
-                or response_code == 429
+                response_code in {429, 503}
                 # Sometimes QT returns a http status code of 200 even when there
                 # is a service unavailable error.
                 or error == QNetworkReply.NetworkError.ServiceUnavailableError

--- a/scripts/eval_matching/refresh_corpus.py
+++ b/scripts/eval_matching/refresh_corpus.py
@@ -72,7 +72,7 @@ def fetch_release(release_id, retries=3):
             with urllib.request.urlopen(req) as resp:
                 return json.loads(resp.read())
         except urllib.error.HTTPError as e:
-            if e.code in (429, 500, 502, 503) and attempt < retries - 1:
+            if e.code in {429, 500, 502, 503} and attempt < retries - 1:
                 wait = REQUEST_DELAY * (attempt + 2)
                 print(f"    HTTP {e.code}, retrying in {wait:.0f}s...", file=sys.stderr)
                 time.sleep(wait)

--- a/scripts/extract_plugin_translations.py
+++ b/scripts/extract_plugin_translations.py
@@ -84,7 +84,7 @@ def extract_from_code(plugin_dir, existing_translations):
             for node in ast.walk(tree):
                 if isinstance(node, ast.Call):
                     # Check if it's api.tr(), api.trn(), or t_()
-                    if isinstance(node.func, ast.Attribute) and node.func.attr in ('tr', 'trn'):
+                    if isinstance(node.func, ast.Attribute) and node.func.attr in {'tr', 'trn'}:
                         extract_translation_call(node, translations, py_file, lines, t_variables)
                     elif isinstance(node.func, ast.Name) and node.func.id == 't_':
                         extract_translation_call(node, translations, py_file, lines, t_variables)
@@ -176,7 +176,7 @@ def extract_translation_call(node, translations, py_file, lines, t_variables):
     key = get_string_value(node.args[0])
     if not key:
         # Check if it's a variable from t_() - if so, skip warning
-        if func_name in ('tr', 'trn'):
+        if func_name in {'tr', 'trn'}:
             first_arg = node.args[0]
             # Handle direct variable: api.tr(ERROR_MSG)
             if isinstance(first_arg, ast.Name) and first_arg.id in t_variables:
@@ -189,7 +189,7 @@ def extract_translation_call(node, translations, py_file, lines, t_variables):
         return
 
     # Handle tr() and t_() with single text
-    if func_name in ('tr', 't_'):
+    if func_name in {'tr', 't_'}:
         text = get_string_value(node.args[1]) if len(node.args) > 1 else None
         plural = get_string_value(node.args[2]) if len(node.args) > 2 else None
 

--- a/scripts/migrate_plugin.py
+++ b/scripts/migrate_plugin.py
@@ -143,7 +143,7 @@ def generate_manifest_toml(metadata, module_name):
     # Map v2 API versions to v3
     api_versions = []
     for v in metadata.get('api_versions', []):
-        if v in ['1.0', '2.0']:
+        if v in {'1.0', '2.0'}:
             api_versions.append('3.0')
 
     if not api_versions:
@@ -900,10 +900,10 @@ def convert_plugin_code(content, metadata):
                         nodes_to_remove.add(node)
             elif isinstance(node, (ast.ImportFrom, ast.Import)):
                 if isinstance(node, ast.ImportFrom):
-                    if node.module in ('picard', 'picard.tagger', 'picard.config'):
+                    if node.module in {'picard', 'picard.tagger', 'picard.config'}:
                         if node.module == 'picard':
                             # Only remove if importing log/config
-                            if any(alias.name in ('log', 'config') for alias in node.names):
+                            if any(alias.name in {'log', 'config'} for alias in node.names):
                                 imports_to_remove.add(node)
                         else:
                             imports_to_remove.add(node)
@@ -1447,7 +1447,7 @@ def migrate_plugin(input_file, output_dir=None):
                 or item.name.startswith('.')
                 or item.name in exclude_patterns
                 or item.name in skip_files
-                or item.suffix in ('.pyc', '.pyo', '.pyd', '.so')
+                or item.suffix in {'.pyc', '.pyo', '.pyd', '.so'}
             ):
                 continue
 

--- a/test/script_text_edit/test_completion_choices_provider.py
+++ b/test/script_text_edit/test_completion_choices_provider.py
@@ -181,7 +181,7 @@ class TestCompletionChoicesProviderModes:
             assert 'test_var' in choices
             assert 'builtin_var' in choices
             assert not any(choice.startswith('%') for choice in choices)
-        elif mode in (CompletionMode.DEFAULT, CompletionMode.VARIABLE):
+        elif mode in {CompletionMode.DEFAULT, CompletionMode.VARIABLE}:
             # Variable modes return %name% format
             assert '%test_var%' in choices
             assert '%builtin_var%' in choices

--- a/test/test_matching.py
+++ b/test/test_matching.py
@@ -207,7 +207,7 @@ class CompareToTrackTest(PicardTestCase):
             track_json['score'] = score
             match_ = compare_to_track(track.metadata, track_json, FILE_COMPARISON_WEIGHTS)
             # Score 42 → 0.42 multiplier; 'foo'/None → treated as 1.0
-            if score in (42, '42'):
+            if score in {42, '42'}:
                 self.assertLess(match_.similarity, 0.5)
             else:
                 self.assertGreater(match_.similarity, 0.5)

--- a/test/test_sorting_adapters_key_stabilisation.py
+++ b/test/test_sorting_adapters_key_stabilisation.py
@@ -82,7 +82,7 @@ def test_numeric_sort_adapter_key_shape_and_category(value: str, expect_flag: in
 
     key = adapter.sort_key(Dummy())
     assert isinstance(key, tuple)
-    assert key[0] in (0, 1)
+    assert key[0] in {0, 1}
     assert key[0] == expect_flag
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

We once decided to use sets for membership tests in static sequences, as Python optimizes the ` in {...}` for sets. But in recent code we haven't been consistent with that. 34d0354bbf929d3f5cea4931f5d21571323e1e64 updates affected `if` and `assert` statements.

There is a ruff rule for this (see [literal-membership](https://docs.astral.sh/ruff/rules/literal-membership/)), but it is in preview-mode and hence not generally available. But it can be run with:

```
uv run ruff check --preview --select literal-membership
```

While changing this I also looked for boolean statements that can be changed to membership tests, see e2673e82b885ae880e1489f82166949836863504 .

I also found cases where nested `if` statements could be turned into `elseif` and actively looked for those cases using the ruff  [collapsible-else-if](https://docs.astral.sh/ruff/rules/collapsible-else-if/) check, see 5461a8dd85a001dc81ff5c8634a2d069f6d4d42e

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [x] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
