### PR TITLE
PICARD-3423: Log MPRIS2 interface registration errors and improve snap integration

### DIFF
--- a/picard/const/sys.py
+++ b/picard/const/sys.py
@@ -18,13 +18,18 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+import os
 import sys
 
 
+# Operating system detection
 IS_WIN: bool = sys.platform == 'win32'
 IS_LINUX: bool = sys.platform == 'linux'
 IS_MACOS: bool = sys.platform == 'darwin'
 IS_HAIKU: bool = sys.platform == 'haiku'
+
+# Detect whether running as a Snap package
+IS_SNAP: bool = IS_LINUX and bool(os.getenv('SNAP'))
 
 # These variables are set by pyinstaller if running from a packaged build
 # See http://pyinstaller.readthedocs.io/en/stable/runtime-information.html

--- a/picard/const/sys.py
+++ b/picard/const/sys.py
@@ -29,7 +29,7 @@ IS_MACOS: bool = sys.platform == 'darwin'
 IS_HAIKU: bool = sys.platform == 'haiku'
 
 # Detect whether running as a Snap package
-IS_SNAP: bool = IS_LINUX and bool(os.getenv('SNAP'))
+IS_SNAP: bool = IS_LINUX and os.getenv('SNAP_NAME', '') == 'picard'
 
 # These variables are set by pyinstaller if running from a packaged build
 # See http://pyinstaller.readthedocs.io/en/stable/runtime-information.html

--- a/picard/ui/player/mpris.py
+++ b/picard/ui/player/mpris.py
@@ -51,7 +51,7 @@ from .player import (
 )
 
 
-MPRIS2_DBUS_BUS_NAME = 'org.mpris.MediaPlayer2.picard'
+MPRIS2_DBUS_BUS_NAME = f'org.mpris.MediaPlayer2.{PICARD_APP_ID}'
 MPRIS2_DBUS_OBJECT_PATH = '/org/mpris/MediaPlayer2'
 MPRIS2_DBUS_INTERFACE = 'org.mpris.MediaPlayer2'
 MPRIS2_DBUS_INTERFACE_PLAYER = 'org.mpris.MediaPlayer2.Player'

--- a/picard/ui/player/mpris.py
+++ b/picard/ui/player/mpris.py
@@ -262,7 +262,6 @@ class MediaPlayer2Adaptor(QDBusAbstractAdaptor):
 class MediaPlayer2PlayerAdaptor(QDBusAbstractAdaptor):
     """See https://specifications.freedesktop.org/mpris/latest/Player_Interface.html"""
 
-    # TODO: Actually trigger
     Seeked = pyqtSignal('qlonglong')
 
     def __init__(self, parent: MPRIS2Service, player: Player):

--- a/picard/ui/player/mpris.py
+++ b/picard/ui/player/mpris.py
@@ -39,6 +39,7 @@ from PyQt6.QtDBus import (
 from picard import (
     PICARD_APP_ID,
     PICARD_DISPLAY_NAME,
+    log,
     tagger_instance,
 )
 from picard.file import File
@@ -80,8 +81,16 @@ class MPRIS2NowPlayingService:
 
         dbus = QDBusConnection.sessionBus()
         self._mpris2_service = MPRIS2Service(dbus, self._player)
-        dbus.registerService(MPRIS2_DBUS_BUS_NAME)
-        dbus.registerObject(MPRIS2_DBUS_OBJECT_PATH, self._mpris2_service)
+        if not dbus.registerService(MPRIS2_DBUS_BUS_NAME):
+            log.warning(
+                'Failed to register MPRIS2 DBus service "%s": %s', MPRIS2_DBUS_BUS_NAME, dbus.lastError().message()
+            )
+            return
+        if not dbus.registerObject(MPRIS2_DBUS_OBJECT_PATH, self._mpris2_service):
+            log.warning(
+                'Failed to register MPRIS2 DBus object "%s": %s', MPRIS2_DBUS_OBJECT_PATH, dbus.lastError().message()
+            )
+            return
 
     def disable(self):
         if not self._mpris2_service:

--- a/picard/ui/player/mpris.py
+++ b/picard/ui/player/mpris.py
@@ -42,6 +42,7 @@ from picard import (
     log,
     tagger_instance,
 )
+from picard.const.sys import IS_SNAP
 from picard.file import File
 
 from .player import (
@@ -51,7 +52,8 @@ from .player import (
 )
 
 
-MPRIS2_DBUS_BUS_NAME = f'org.mpris.MediaPlayer2.{PICARD_APP_ID}'
+MPRIS2_PLAYER_ID = 'picard' if IS_SNAP else PICARD_APP_ID
+MPRIS2_DBUS_BUS_NAME = f'org.mpris.MediaPlayer2.{MPRIS2_PLAYER_ID}'
 MPRIS2_DBUS_OBJECT_PATH = '/org/mpris/MediaPlayer2'
 MPRIS2_DBUS_INTERFACE = 'org.mpris.MediaPlayer2'
 MPRIS2_DBUS_INTERFACE_PLAYER = 'org.mpris.MediaPlayer2.Player'

--- a/picard/ui/statusindicator/unity.py
+++ b/picard/ui/statusindicator/unity.py
@@ -19,8 +19,6 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
-import os
-
 from PyQt6.QtCore import (
     QObject,
     pyqtClassInfo,
@@ -34,12 +32,13 @@ from PyQt6.QtDBus import (
 from PyQt6.QtWidgets import QMainWindow
 
 from picard import PICARD_DESKTOP_NAME
+from picard.const.sys import IS_SNAP
 
 from . import AbstractProgressStatusIndicator
 
 
 DBUS_INTERFACE = 'com.canonical.Unity.LauncherEntry'
-APP_ID = PICARD_DESKTOP_NAME if not os.getenv('SNAP') else 'picard_picard.desktop'
+APP_ID = 'picard_picard.desktop' if IS_SNAP else PICARD_DESKTOP_NAME
 
 
 class UnityLauncherEntryService(QObject):

--- a/picard/ui/util.py
+++ b/picard/ui/util.py
@@ -26,7 +26,6 @@
 
 
 from html import escape as html_escape
-import os
 
 from PyQt6 import (
     QtCore,
@@ -41,7 +40,10 @@ from picard import (
 )
 from picard.config import get_config
 from picard.const import BUSY_CURSOR_FLASH_DELAY_MS
-from picard.const.sys import IS_LINUX
+from picard.const.sys import (
+    IS_LINUX,
+    IS_SNAP,
+)
 from picard.env import parse_bool_env
 from picard.i18n import gettext as _
 from picard.util import (
@@ -91,7 +93,7 @@ def add_accept_button(
 
 def open_local_path(path: str) -> None:
     url = QtCore.QUrl.fromLocalFile(path)
-    if os.environ.get('SNAP'):
+    if IS_SNAP:
         run_executable('xdg-open', url.toString())
     else:
         QtGui.QDesktopServices.openUrl(url)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3423
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The MPRIS2 DBus implementation did not log any error if registering the DBus service failed. This made it hard to debug if it wasn't working, such as the snap failing to register the interface, see PICARD-3423.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

On error log the error details as a warning. In the case of the snap package failing to register this service this produces a understandable log entry:

```
W: 09:01:16,824 ui/player/mpris.enable:85: Failed to register MPRIS2 DBus service "org.mpris.MediaPlayer2.picard": Connection ":1.726" is not allowed to own the service "org.mpris.MediaPlayer2.picard" due to AppArmor policy
```

Note: The snap issue itself is fixed in https://github.com/metabrainz/picard-snap/commit/3a56b00d586f5ea4b9c7756c2b95aa05792a09a6



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
