### PR TITLE
PICARD-3424, PICARD-3137: Only authenticate against servers that support a known auth scheme

### DIFF
--- a/picard/webservice/__init__.py
+++ b/picard/webservice/__init__.py
@@ -65,13 +65,20 @@ from picard import (
     log,
 )
 from picard.config import get_config
-from picard.const import appdirs
+from picard.const import (
+    METABRAINZ_OAUTH_HOST,
+    appdirs,
+)
 from picard.const.defaults import DEFAULT_CACHE_SIZE_IN_BYTES
 from picard.debug_opts import DebugOpt
 from picard.oauth import OAuthManager
 from picard.util import (
     bytes2human,
     encoded_queryargs,
+)
+from picard.util.mbserver import (
+    AuthScheme,
+    server_usable_auth_scheme,
 )
 from picard.util.qt import (
     parse_json,
@@ -542,9 +549,41 @@ class WebService(QtCore.QObject):
             return
 
         if request.mblogin:
-            self.oauth_manager.get_access_token(partial(self._send_request, request, task))
-        else:
-            self._send_request(request, task)
+            # Only authenticate against servers that advertise an auth scheme
+            # Picard can perform. Other servers (e.g. an unofficial mirror, or the
+            # official test server which does not accept the production OAuth
+            # login) would reject an authenticated request with HTTP 401, so send
+            # the request unauthenticated and drop any user-specific inc params
+            # instead. This avoids a re-authentication loop against a server that
+            # can never accept our credentials. See PICARD-3424.
+            #
+            # The MetaBrainz OAuth provider host is not a MusicBrainz server (it is
+            # not in the registry) but authenticated OAuth calls such as the
+            # /oauth2/userinfo request made during login target it, so it must
+            # always carry the bearer token.
+            if request.host == METABRAINZ_OAUTH_HOST:
+                scheme = AuthScheme.MEB_OAUTH2
+            else:
+                scheme = server_usable_auth_scheme(request.host)
+            if scheme is None:
+                self._downgrade_to_unauthenticated(request)
+            elif scheme is AuthScheme.MEB_OAUTH2:
+                self.oauth_manager.get_access_token(partial(self._send_request, request, task))
+                return
+        self._send_request(request, task)
+
+    @staticmethod
+    def _downgrade_to_unauthenticated(request: WSRequest):
+        """Turn an mblogin request into an unauthenticated one in place.
+
+        Clears the mblogin flag and strips user-specific (auth-only) inc params,
+        so the request can be sent to a server that does not accept our login.
+        """
+        request.mblogin = False
+        url, modified = WebService._strip_auth_inc_params(request.url())
+        if modified:
+            request.setUrl(url)
+        log.debug("Sending request without authentication: %s", request.url().toString())
 
     @staticmethod
     def urls_equivalent(leftUrl: QUrl, rightUrl: QUrl) -> bool:
@@ -862,6 +901,28 @@ class WebService(QtCore.QObject):
                 if handler is not None:
                     handler(b'', _AuthorizationErrorReply(request), error)
 
+    @staticmethod
+    def _strip_auth_inc_params(url: QUrl) -> tuple[QUrl, bool]:
+        """Return a copy of `url` with user-specific (auth-only) inc params removed.
+
+        Returns a tuple of the (possibly modified) URL and a bool indicating
+        whether any auth-only inc params were actually removed.
+        """
+        url = QUrl(url)
+        query = QtCore.QUrlQuery(url)
+        if not query.hasQueryItem('inc'):
+            return url, False
+        inc_value = query.queryItemValue('inc', QUrl.ComponentFormattingOption.FullyDecoded)
+        inc_params = set(inc_value.split('+'))
+        filtered_params = inc_params - _AUTH_REQUIRED_INC_PARAMS
+        if filtered_params == inc_params:
+            return url, False
+        query.removeQueryItem('inc')
+        if filtered_params:
+            query.addQueryItem('inc', '+'.join(sorted(filtered_params)))
+        url.setQuery(query)
+        return url, True
+
     def _retry_without_auth(self, request: WSRequest):
         """Retry a request without authentication and user-specific inc params.
 
@@ -869,19 +930,7 @@ class WebService(QtCore.QObject):
         If nothing changed, the request is dropped and the handler is called with
         the authentication error.
         """
-        url = QUrl(request.url())
-        query = QtCore.QUrlQuery(url)
-        modified = False
-        if query.hasQueryItem('inc'):
-            inc_value = query.queryItemValue('inc', QUrl.ComponentFormattingOption.FullyDecoded)
-            inc_params = set(inc_value.split('+'))
-            filtered_params = inc_params - _AUTH_REQUIRED_INC_PARAMS
-            if filtered_params != inc_params:
-                modified = True
-                query.removeQueryItem('inc')
-                if filtered_params:
-                    query.addQueryItem('inc', '+'.join(sorted(filtered_params)))
-                url.setQuery(query)
+        url, modified = self._strip_auth_inc_params(request.url())
         if modified:
             request.setUrl(url)
             request.mblogin = False

--- a/test/test_webservice_authorization.py
+++ b/test/test_webservice_authorization.py
@@ -29,6 +29,7 @@ from PyQt6.QtNetwork import (
 
 from test.picardtestcase import PicardTestCase
 
+from picard.const import METABRAINZ_OAUTH_HOST
 from picard.webservice import (
     MAX_PENDING_AUTHORIZATION_REQUESTS,
     WebService,
@@ -375,3 +376,74 @@ class WebServiceAuthorizationTest(PicardTestCase):
         handler.assert_called_once()
         args = handler.call_args[0]
         self.assertEqual(args[2], QNetworkReply.NetworkError.AuthenticationRequiredError)
+
+
+class WebServiceAuthGateTest(PicardTestCase):
+    """Tests for PICARD-3424: only authenticate against servers that advertise a
+    scheme Picard can perform; downgrade to unauthenticated for all others."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmpdir = self.mktmpdir()
+        self.patcher = patch('picard.webservice.appdirs.cache_folder', return_value=self.tmpdir)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+        self.rc_patcher = patch('picard.webservice.ratecontrol')
+        self.rc_patcher.start()
+        self.addCleanup(self.rc_patcher.stop)
+        self.set_config_values(
+            {
+                'use_proxy': False,
+                'server_host': 'musicbrainz.org',
+                'network_transfer_timeout_seconds': 30,
+                'network_cache_size_bytes': 100 * 1000 * 1000,
+            }
+        )
+        self.ws = WebService()
+        self.ws._timer_run_next_task = MagicMock()
+        self.ws._timer_count_pending_requests = MagicMock()
+        self.ws.oauth_manager = MagicMock()
+
+    def _mblogin_request(self, url):
+        return WSRequest(method='GET', url=url, handler=dummy_handler, mblogin=True)
+
+    def test_official_host_fetches_token(self):
+        request = self._mblogin_request('https://musicbrainz.org/ws/2/collection')
+        with patch.object(self.ws, '_send_request') as mock_send:
+            self.ws._start_request(request)
+        # OAuth token is fetched; _send_request is deferred to the token callback.
+        self.ws.oauth_manager.get_access_token.assert_called_once()
+        mock_send.assert_not_called()
+        self.assertTrue(request.mblogin)
+
+    def test_oauth_provider_host_is_authenticated(self):
+        # The OAuth provider host must carry the token, e.g. for the
+        # /oauth2/userinfo request during login; it must not be downgraded.
+        request = self._mblogin_request(f'https://{METABRAINZ_OAUTH_HOST}/oauth2/userinfo')
+        with patch.object(self.ws, '_send_request') as mock_send:
+            self.ws._start_request(request)
+        self.ws.oauth_manager.get_access_token.assert_called_once()
+        mock_send.assert_not_called()
+        self.assertTrue(request.mblogin)
+
+    def test_no_auth_host_downgrades_and_sends_unauthenticated(self):
+        url = 'https://test.musicbrainz.org/ws/2/release/1?inc=artists+user-collections+user-ratings'
+        request = self._mblogin_request(url)
+        with patch.object(self.ws, '_send_request') as mock_send:
+            self.ws._start_request(request)
+        # No token fetched; request sent directly, unauthenticated.
+        self.ws.oauth_manager.get_access_token.assert_not_called()
+        mock_send.assert_called_once_with(request, None)
+        self.assertFalse(request.mblogin)
+        url_str = request.url().toString()
+        self.assertNotIn('user-collections', url_str)
+        self.assertNotIn('user-ratings', url_str)
+        self.assertIn('artists', url_str)
+
+    def test_unknown_host_downgrades(self):
+        request = self._mblogin_request('http://localhost:5000/ws/2/collection')
+        with patch.object(self.ws, '_send_request') as mock_send:
+            self.ws._start_request(request)
+        self.ws.oauth_manager.get_access_token.assert_not_called()
+        mock_send.assert_called_once_with(request, None)
+        self.assertFalse(request.mblogin)


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Stop Picard from re-prompting for authentication in an endless loop when a server keeps rejecting a valid OAuth token, by deciding up front whether a request can be authenticated against the target server.

## Problem

* JIRA ticket: PICARD-3424

When an `mblogin` web service request keeps returning HTTP 401 even after the user successfully (re-)authenticates, Picard re-prompts for login again and again in an endless loop.

This happens when the configured server does not honor Picard's OAuth token. Example: `server_host = test.musicbrainz.org`. OAuth is always performed against the production provider (metabrainz.org), so login "succeeds" and a valid token with the expected scopes is obtained, but `test.musicbrainz.org`'s `/ws/2` rejects that token with 401. Each successful login also re-issues the failing request (e.g. via `load_user_collections()`), so the request that hits the 401 is a brand-new object each time — a per-request guard is not enough to break the cycle.

## Solution

Builds on the server registry introduced in #3420. Before sending an `mblogin` request, the web service now decides how to authenticate based on the target server's usable authentication scheme:

* A server with a usable scheme (`MEB_OAUTH2` — the official servers) authenticates as before.
* A server with **no** usable scheme (an unofficial mirror, or the official `test.musicbrainz.org`, which does not accept the production OAuth login) has the request **downgraded to unauthenticated**: the `mblogin` flag is cleared and user-specific `inc` params (`user-collections`, `user-ratings`, …) are stripped, so the request is sent without credentials instead of being rejected with 401 and looping.

This removes the loop by construction while leaving normal OAuth login against the official servers unchanged.

The MetaBrainz OAuth provider host (`metabrainz.org`) is intentionally not in the server registry (it is not a MusicBrainz database server), but its authenticated calls — notably `/oauth2/userinfo` during login — must carry the bearer token, so the gate treats it as `MEB_OAUTH2`.

The `inc`-param stripping is factored into a shared helper used by both the new pre-send downgrade and the existing "authorization declined" retry path.

Verified against a live reproduction (server set to `test.musicbrainz.org`): the loop no longer occurs — requests to the test server are sent unauthenticated and settle without any login prompt, album loads succeed (degraded), and logging in/out on musicbrainz.org still works (including the `/oauth2/userinfo` call). New tests in `test/test_webservice_authorization.py` cover the gate for official, no-auth, unknown, and OAuth-provider hosts.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Root-cause analysis (from debug logs), the code, and the tests were developed with AI assistance and reviewed and verified by the author, including a live reproduction confirming the loop is resolved and that login still works.

## Action

Additional actions required:
* [x] Other (please specify below)

A follow-up will address logging out on incompatible server changes (PICARD-3137), also building on the server registry.
