### PR TITLE
util/mbserver: introduce a MusicBrainz server registry (preliminary work)

### DIFF
--- a/picard/util/mbserver/__init__.py
+++ b/picard/util/mbserver/__init__.py
@@ -1,0 +1,54 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2021 Philipp Wolfer
+# Copyright (C) 2021, 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+"""MusicBrainz server registry and submission helpers.
+
+Public API for describing MusicBrainz servers (:class:`MBServer`, the registry
+lookups) and for building data submission URLs. Import from this package rather
+than its submodules.
+"""
+
+from picard.util.mbserver.registry import (
+    PICARD_SUPPORTED_AUTH_SCHEMES,
+    AuthScheme,
+    MBServer,
+    get_server,
+    is_official_server,
+    official_servers,
+    server_usable_auth_scheme,
+)
+from picard.util.mbserver.submission import (
+    ServerTuple,
+    build_submission_url,
+    get_submission_server,
+)
+
+
+__all__ = (
+    'AuthScheme',
+    'MBServer',
+    'PICARD_SUPPORTED_AUTH_SCHEMES',
+    'ServerTuple',
+    'build_submission_url',
+    'get_server',
+    'get_submission_server',
+    'is_official_server',
+    'official_servers',
+    'server_usable_auth_scheme',
+)

--- a/picard/util/mbserver/registry.py
+++ b/picard/util/mbserver/registry.py
@@ -1,0 +1,163 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+"""Registry of MusicBrainz servers and their capabilities.
+
+This module is intentionally dependency-light (no config or Qt imports) so it
+can be imported from anywhere without risking circular imports. It describes the
+servers Picard knows about — their host, port, protocol, whether they are
+official MusicBrainz database servers, and which authentication schemes they
+accept.
+
+The registry data introduced here is descriptive; consuming it to drive request
+authentication or logout behavior is done elsewhere.
+"""
+
+from dataclasses import (
+    dataclass,
+    field,
+)
+from enum import Enum
+
+from picard.const import MUSICBRAINZ_SERVERS
+
+
+class AuthScheme(Enum):
+    """An authentication scheme a MusicBrainz server may accept.
+
+    Members identify a *specific* scheme (not just the protocol family), because
+    credentials are only valid for the exact provider that issued them. Only
+    ``MEB_OAUTH2`` (the MetaBrainz OAuth 2 provider) exists today; new schemes
+    (a different OAuth provider, OpenID Connect, HTTP basic auth, an API key, ...)
+    can be added as Picard grows support for authenticating other servers.
+    """
+
+    MEB_OAUTH2 = 'meb_oauth2'
+
+
+# Auth schemes Picard actually knows how to perform. A server's advertised
+# schemes are intersected with this set to decide how (or whether) to log in.
+PICARD_SUPPORTED_AUTH_SCHEMES = frozenset({AuthScheme.MEB_OAUTH2})
+
+
+@dataclass(frozen=True)
+class MBServer:
+    """A known (or, in the future, user-configured) MusicBrainz server.
+
+    Attributes:
+        host: hostname
+        port: TCP port
+        protocol: URL scheme, ``'https'`` or ``'http'``
+        official: True for the official servers backing the primary MusicBrainz
+            database. Used for submission routing and UI hints; note that being
+            official is independent of whether the server accepts a login.
+        auth_schemes: authentication schemes the server accepts. An empty set
+            means the server accepts no authentication Picard can use. A server
+            may advertise more than one scheme.
+    """
+
+    host: str
+    port: int = 443
+    protocol: str = 'https'
+    official: bool = False
+    auth_schemes: frozenset[AuthScheme] = field(default_factory=frozenset)
+
+    def __post_init__(self):
+        # The instance is immutable, but callers (and, later, user configuration)
+        # may pass any iterable of schemes. Normalize to a frozenset so the stored
+        # value is always immutable and hashable, without requiring a factory.
+        if not isinstance(self.auth_schemes, frozenset):
+            object.__setattr__(self, 'auth_schemes', frozenset(self.auth_schemes))
+
+    @property
+    def supports_auth(self) -> bool:
+        """True if the server accepts at least one authentication scheme."""
+        return bool(self.auth_schemes)
+
+    def usable_auth_scheme(self) -> AuthScheme | None:
+        """The auth scheme Picard should use for this server, or None.
+
+        Returns the scheme to use when the server advertises one that Picard can
+        perform; otherwise None, meaning requests must be sent unauthenticated.
+        The choice is deterministic when several schemes match.
+        """
+        candidates = self.auth_schemes & PICARD_SUPPORTED_AUTH_SCHEMES
+        if not candidates:
+            return None
+        return min(candidates, key=lambda scheme: scheme.value)
+
+
+# Built-in registry of well-known servers and their capabilities.
+#
+# The official MusicBrainz database servers are derived from MUSICBRAINZ_SERVERS
+# (the single source of truth for official hostnames) and all use the shared
+# MetaBrainz OAuth 2 provider.
+#
+# Any other host is treated as an unknown, non-official server with no
+# authentication (see get_server()). User-configured servers, when supported,
+# will be layered on top of these built-in defaults.
+def _build_builtin_servers() -> dict[str, MBServer]:
+    return {
+        host: MBServer(
+            host=host,
+            official=True,
+            auth_schemes=frozenset({AuthScheme.MEB_OAUTH2}),
+        )
+        for host in MUSICBRAINZ_SERVERS
+    }
+
+
+_BUILTIN_SERVERS: dict[str, MBServer] = _build_builtin_servers()
+
+
+def get_server(host: str, port: int | None = None) -> MBServer:
+    """Returns the MBServer describing `host`.
+
+    Built-in servers come from the registry with their fixed capabilities. Any
+    other host is an unknown, non-official server with no authentication; its
+    port defaults to the given `port` (typically the configured ``server_port``)
+    or 443.
+    """
+    server = _BUILTIN_SERVERS.get(host)
+    if server is not None:
+        return server
+    return MBServer(host=host, port=port if port is not None else 443)
+
+
+def server_usable_auth_scheme(host: str) -> AuthScheme | None:
+    """Returns the auth scheme Picard should use for `host`, or None for unauthenticated."""
+    return get_server(host).usable_auth_scheme()
+
+
+def official_servers() -> tuple[str, ...]:
+    """Returns the official MusicBrainz database server hostnames, in order.
+
+    The first entry is the primary server.
+    """
+    return tuple(MUSICBRAINZ_SERVERS)
+
+
+def is_official_server(host: str) -> bool:
+    """Returns True if host is an official MusicBrainz server for the primary database.
+
+    Args:
+        host: the hostname
+
+    Returns: True if host is an official MusicBrainz server, False otherwise
+    """
+    return host in MUSICBRAINZ_SERVERS

--- a/picard/util/mbserver/submission.py
+++ b/picard/util/mbserver/submission.py
@@ -17,25 +17,17 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 
+"""Helpers for choosing and building MusicBrainz data submission URLs."""
+
 from collections import namedtuple
 
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
+from picard.util.mbserver.registry import is_official_server
 from picard.util.qt import build_qurl
 
 
 ServerTuple = namedtuple('ServerTuple', ('host', 'port'))
-
-
-def is_official_server(host: str) -> bool:
-    """Returns True, if host is an official MusicBrainz server for the primary database.
-
-    Args:
-        host: the hostname
-
-    Returns: True, if host is an official MusicBrainz server, False otherwise
-    """
-    return host in MUSICBRAINZ_SERVERS
 
 
 def get_submission_server() -> ServerTuple:

--- a/test/test_disc.py
+++ b/test/test_disc.py
@@ -27,6 +27,7 @@ from test.picardtestcase import PicardTestCase
 
 import picard.disc
 from picard.util.mbserver import ServerTuple
+import picard.util.mbserver.submission
 
 
 test_toc = [1, 11, 242457, 150, 44942, 61305, 72755, 96360, 130485, 147315, 164275, 190702, 205412, 220437]
@@ -50,7 +51,7 @@ class DiscTest(PicardTestCase):
 
     def test_static_submission_url_no_config(self):
         with patch.object(
-            picard.util.mbserver, 'get_submission_server', return_value=ServerTuple('example.com', 443)
+            picard.util.mbserver.submission, 'get_submission_server', return_value=ServerTuple('example.com', 443)
         ) as mocked:
             self.assertEqual(
                 picard.disc.Disc._submission_url('A', 2, 'B C'),

--- a/test/util/test_mbserver.py
+++ b/test/util/test_mbserver.py
@@ -21,10 +21,67 @@ from test.picardtestcase import PicardTestCase
 
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.util.mbserver import (
+    AuthScheme,
+    MBServer,
     build_submission_url,
+    get_server,
     get_submission_server,
     is_official_server,
+    official_servers,
+    server_usable_auth_scheme,
 )
+
+
+class GetServerTest(PicardTestCase):
+    def test_official_servers_use_meb_oauth2(self):
+        for host in MUSICBRAINZ_SERVERS:
+            server = get_server(host)
+            self.assertTrue(server.official)
+            self.assertEqual(frozenset({AuthScheme.MEB_OAUTH2}), server.auth_schemes)
+            self.assertTrue(server.supports_auth)
+            self.assertIs(AuthScheme.MEB_OAUTH2, server.usable_auth_scheme())
+
+    def test_unknown_host_defaults_to_non_official_no_auth(self):
+        server = get_server('example.com')
+        self.assertFalse(server.official)
+        self.assertEqual(frozenset(), server.auth_schemes)
+        self.assertIsNone(server.usable_auth_scheme())
+
+    def test_unknown_host_uses_given_port(self):
+        self.assertEqual(8042, get_server('example.com', port=8042).port)
+        # Known servers keep their fixed port regardless of the argument.
+        self.assertEqual(443, get_server('musicbrainz.org', port=8042).port)
+
+    def test_auth_schemes_coerced_to_frozenset(self):
+        # Any iterable passed for auth_schemes is normalized to a frozenset, so
+        # the (immutable) instance always stores a hashable, immutable value.
+        server = MBServer(host='h', auth_schemes=[AuthScheme.MEB_OAUTH2, AuthScheme.MEB_OAUTH2])
+        self.assertEqual(frozenset({AuthScheme.MEB_OAUTH2}), server.auth_schemes)
+        self.assertIsInstance(server.auth_schemes, frozenset)
+
+    def test_default_auth_schemes_is_empty_frozenset(self):
+        server = MBServer(host='h')
+        self.assertEqual(frozenset(), server.auth_schemes)
+        self.assertIsInstance(server.auth_schemes, frozenset)
+
+    def test_official_entries_match_musicbrainz_servers(self):
+        for host in MUSICBRAINZ_SERVERS:
+            self.assertTrue(get_server(host).official)
+
+
+class ServerUsableAuthSchemeTest(PicardTestCase):
+    def test_official_hosts(self):
+        for host in MUSICBRAINZ_SERVERS:
+            self.assertIs(AuthScheme.MEB_OAUTH2, server_usable_auth_scheme(host))
+
+    def test_no_auth_hosts(self):
+        self.assertIsNone(server_usable_auth_scheme('test.musicbrainz.org'))
+        self.assertIsNone(server_usable_auth_scheme('example.com'))
+
+
+class OfficialServersTest(PicardTestCase):
+    def test_returns_musicbrainz_servers(self):
+        self.assertEqual(tuple(MUSICBRAINZ_SERVERS), official_servers())
 
 
 class IsOfficialServerTest(PicardTestCase):


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Introduce a MusicBrainz server registry that describes each server's capabilities (official flag, authentication schemes), as behavior-neutral groundwork for two upcoming bug fixes.

## Problem

This is preliminary, no-behavior-change work that lays the foundation for fixing two related authentication issues, kept separate so it can land safely (including during the release-candidate phase) and be reviewed on its own:

* **PICARD-3424** – Infinite re-authentication loop when a server rejects a valid OAuth token (e.g. a production OAuth token used against `test.musicbrainz.org`, or an unofficial mirror).
* **PICARD-3137** – Picard stays logged in after the user changes the server address, causing failures against servers that cannot use the existing login.

Both problems come from the same root cause: Picard has no single, declarative notion of *which server accepts which kind of authentication*. Auth decisions are currently spread across the code and rely on the ad-hoc assumption "official ⇒ has OAuth", which is not true (`test.musicbrainz.org` is a MetaBrainz server but does not accept the production OAuth login).

## Solution

Turn `picard/util/mbserver` into a package and add a server registry:

* `registry.py` — a dependency-light leaf module (no `config`/Qt imports, so it is safe to import anywhere). It defines:
  * `AuthScheme` — a specific authentication scheme (only `MEB_OAUTH2` today; designed to grow: other OAuth providers, OpenID Connect, HTTP basic, API keys, …).
  * `MBServer` — an immutable dataclass with `host`, `port`, `protocol`, `official`, and `auth_schemes` (a set, so a server may advertise several schemes). A `create()` factory normalizes any iterable of schemes (e.g. from future user configuration).
  * A built-in registry and lookups: `get_server()`, `server_usable_auth_scheme()`, `official_servers()`, `is_official_server()`. Official database servers are derived from `MUSICBRAINZ_SERVERS` (kept as the single source of truth for official hostnames); `test.musicbrainz.org` is known but advertises no usable auth scheme; the MetaBrainz OAuth provider host advertises `MEB_OAUTH2` (its `/oauth2/userinfo` call must be authenticated).
* `submission.py` — the existing config/Qt-dependent submission helpers, moved unchanged.
* `__init__.py` — re-exports the public API, so all existing `from picard.util.mbserver import …` imports keep working.

**How it helps the fixes:**
* PICARD-3424 will gate authentication on `server_usable_auth_scheme(host)`: requests to servers with no usable scheme are sent unauthenticated instead of being rejected with 401 and looping.
* PICARD-3137 will decide whether a server change invalidates the login by comparing the servers' auth schemes, rather than the "official" flag.

This PR is intentionally **additive and behavior-neutral**: the registry data is descriptive and is not yet consumed to drive authentication or logout. `MUSICBRAINZ_SERVERS` and its existing consumers are left unchanged. No plugin-facing API is added at this stage. It is opened as a **draft** because it is preliminary work; the two bug-fix PRs will build on it.

Verified with the existing and new test suites (registry, `MBServer` model, `create()` factory) plus a broad run over the web service, plugins, disc, collection, album and browser tests; ruff and ty checks pass.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The design, code structure, and tests were developed with AI assistance and reviewed and verified by the author.

## Action

Additional actions required:
* [x] Other (please specify below)

Two follow-up PRs will build on this groundwork: one fixing the re-authentication loop (PICARD-3424) and one logging out on incompatible server changes (PICARD-3137).
