### PR TITLE
PICARD-3137: Log out when changing to a server that cannot use the login

### DIFF
--- a/picard/ui/options/general.py
+++ b/picard/ui/options/general.py
@@ -38,7 +38,10 @@ from picard.i18n import (
     N_,
     gettext as _,
 )
-from picard.util.mbserver import is_official_server
+from picard.util.mbserver import (
+    is_official_server,
+    server_change_requires_logout,
+)
 
 from picard.ui.colors import stylesheet_validation_error
 from picard.ui.forms.ui_options_general import Ui_GeneralOptionsPage
@@ -89,11 +92,36 @@ class GeneralOptionsPage(OptionsPage):
 
     def save(self):
         config = get_config()
-        config.setting['server_host'] = self.ui.server_host.currentText().strip()
+        old_server_host = config.setting['server_host']
+        new_server_host = self.ui.server_host.currentText().strip()
+        config.setting['server_host'] = new_server_host
         config.setting['server_port'] = self.ui.server_port.value()
         config.setting['use_server_for_submission'] = self.ui.use_server_for_submission.isChecked()
         config.setting['remove_complete_albums_after_save'] = self.ui.remove_complete_albums_after_save.isChecked()
+        if server_change_requires_logout(old_server_host, new_server_host):
+            self._logout_stale_credentials(old_server_host, new_server_host)
         self._update_user_collections(config, self.ui.enable_user_collections.isChecked())
+
+    def _logout_stale_credentials(self, old_server_host, new_server_host):
+        # The login is only valid on servers that accept the authentication scheme
+        # it was obtained with (see server_change_requires_logout). After switching
+        # to a server with a different scheme — e.g. to or from a server that
+        # accepts no authentication, such as a local replica or the test server —
+        # the stored credentials are no longer usable, and keeping them causes
+        # confusing authentication errors and login prompts against a server that
+        # cannot authenticate the user. Just forget the locally stored credentials;
+        # do not attempt a network token revocation, as the involved servers may be
+        # unreachable or reject the request. See PICARD-3137.
+        oauth_manager = self.tagger.webservice.oauth_manager
+        if not oauth_manager.is_authorized():
+            return
+        log.debug(
+            "Server changed from %r to %r; logging out to invalidate the stale login",
+            old_server_host,
+            new_server_host,
+        )
+        oauth_manager.forget_access_token()
+        oauth_manager.forget_refresh_token()
 
     def _update_user_collections(self, config, new_enable_user_collections):
         old_enable_user_collections = config.setting['enable_user_collections']

--- a/picard/util/mbserver/__init__.py
+++ b/picard/util/mbserver/__init__.py
@@ -31,6 +31,7 @@ from picard.util.mbserver.registry import (
     get_server,
     is_official_server,
     official_servers,
+    server_change_requires_logout,
     server_usable_auth_scheme,
 )
 from picard.util.mbserver.submission import (
@@ -50,5 +51,6 @@ __all__ = (
     'get_submission_server',
     'is_official_server',
     'official_servers',
+    'server_change_requires_logout',
     'server_usable_auth_scheme',
 )

--- a/picard/util/mbserver/registry.py
+++ b/picard/util/mbserver/registry.py
@@ -144,6 +144,30 @@ def server_usable_auth_scheme(host: str) -> AuthScheme | None:
     return get_server(host).usable_auth_scheme()
 
 
+def server_change_requires_logout(old_host: str, new_host: str) -> bool:
+    """Returns True if changing the server from `old_host` to `new_host` invalidates the login.
+
+    A login is obtained against `old_host` using the authentication scheme Picard
+    uses for it. That login stays valid only if `new_host` also accepts that same
+    scheme; otherwise the stored credentials are no longer usable and the user
+    must be logged out.
+
+    If Picard would not authenticate against `old_host` at all (no usable scheme,
+    e.g. a local replica or the test server), there is no login tied to it, so no
+    logout is required.
+
+    Args:
+        old_host: the previously configured hostname
+        new_host: the newly configured hostname
+
+    Returns: True if the change requires a logout, False if the login stays valid
+    """
+    old_scheme = get_server(old_host).usable_auth_scheme()
+    if old_scheme is None:
+        return False
+    return old_scheme not in get_server(new_host).auth_schemes
+
+
 def official_servers() -> tuple[str, ...]:
     """Returns the official MusicBrainz database server hostnames, in order.
 

--- a/test/test_ui_options_general.py
+++ b/test/test_ui_options_general.py
@@ -1,0 +1,93 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from picard.config import get_config
+
+import pytest
+
+from picard.ui.options.general import GeneralOptionsPage
+
+
+@pytest.fixture()
+def general_options_page(qapp, patch_tagger_instance):
+    tagger = patch_tagger_instance('picard.ui.options')
+    oauth_manager = tagger.webservice.oauth_manager
+    oauth_manager.is_authorized.return_value = True
+
+    config = get_config()
+    config.setting['server_host'] = 'musicbrainz.org'
+    config.setting['server_port'] = 443
+    config.setting['use_server_for_submission'] = False
+    config.setting['enable_user_collections'] = False
+    config.setting['remove_complete_albums_after_save'] = False
+
+    page = GeneralOptionsPage()
+    page.load()
+    # Reset any calls made during construction/load.
+    oauth_manager.reset_mock()
+    oauth_manager.is_authorized.return_value = True
+    return page
+
+
+def _save_with_host(page, host):
+    page.ui.server_host.setEditText(host)
+    page.save()
+
+
+def test_no_logout_when_host_unchanged(general_options_page):
+    page = general_options_page
+    oauth_manager = page.tagger.webservice.oauth_manager
+    _save_with_host(page, 'musicbrainz.org')
+    oauth_manager.forget_refresh_token.assert_not_called()
+    oauth_manager.forget_access_token.assert_not_called()
+
+
+def test_no_logout_between_official_servers(general_options_page):
+    page = general_options_page
+    oauth_manager = page.tagger.webservice.oauth_manager
+    _save_with_host(page, 'beta.musicbrainz.org')
+    oauth_manager.forget_refresh_token.assert_not_called()
+    oauth_manager.forget_access_token.assert_not_called()
+
+
+def test_logout_when_switching_to_unauthenticated_server(general_options_page):
+    page = general_options_page
+    oauth_manager = page.tagger.webservice.oauth_manager
+    _save_with_host(page, 'test.musicbrainz.org')
+    oauth_manager.forget_refresh_token.assert_called_once()
+    oauth_manager.forget_access_token.assert_called_once()
+
+
+def test_no_logout_when_switching_from_unauthenticated_server(general_options_page):
+    # No login was tied to the test server, so switching away requires no logout.
+    page = general_options_page
+    config = get_config()
+    config.setting['server_host'] = 'test.musicbrainz.org'
+    oauth_manager = page.tagger.webservice.oauth_manager
+    _save_with_host(page, 'musicbrainz.org')
+    oauth_manager.forget_refresh_token.assert_not_called()
+    oauth_manager.forget_access_token.assert_not_called()
+
+
+def test_no_logout_when_not_authorized(general_options_page):
+    page = general_options_page
+    oauth_manager = page.tagger.webservice.oauth_manager
+    oauth_manager.is_authorized.return_value = False
+    _save_with_host(page, 'test.musicbrainz.org')
+    oauth_manager.forget_refresh_token.assert_not_called()
+    oauth_manager.forget_access_token.assert_not_called()

--- a/test/util/test_mbserver.py
+++ b/test/util/test_mbserver.py
@@ -28,6 +28,7 @@ from picard.util.mbserver import (
     get_submission_server,
     is_official_server,
     official_servers,
+    server_change_requires_logout,
     server_usable_auth_scheme,
 )
 
@@ -82,6 +83,26 @@ class ServerUsableAuthSchemeTest(PicardTestCase):
 class OfficialServersTest(PicardTestCase):
     def test_returns_musicbrainz_servers(self):
         self.assertEqual(tuple(MUSICBRAINZ_SERVERS), official_servers())
+
+
+class ServerChangeRequiresLogoutTest(PicardTestCase):
+    def test_same_host_no_logout(self):
+        self.assertFalse(server_change_requires_logout('musicbrainz.org', 'musicbrainz.org'))
+        self.assertFalse(server_change_requires_logout('localhost', 'localhost'))
+
+    def test_between_official_servers_no_logout(self):
+        self.assertFalse(server_change_requires_logout('musicbrainz.org', 'beta.musicbrainz.org'))
+        self.assertFalse(server_change_requires_logout('beta.musicbrainz.org', 'musicbrainz.org'))
+
+    def test_official_to_unauthenticated_requires_logout(self):
+        self.assertTrue(server_change_requires_logout('musicbrainz.org', 'test.musicbrainz.org'))
+        self.assertTrue(server_change_requires_logout('musicbrainz.org', 'localhost'))
+
+    def test_from_unauthenticated_server_no_logout(self):
+        # No login was tied to a server Picard cannot authenticate against, so
+        # switching away from it never requires a logout.
+        self.assertFalse(server_change_requires_logout('test.musicbrainz.org', 'musicbrainz.org'))
+        self.assertFalse(server_change_requires_logout('localhost', 'example.com'))
 
 
 class IsOfficialServerTest(PicardTestCase):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Log the user out when they change the server address to a server that cannot use the current login, so Picard does not keep sending a login that will be rejected.

## Problem

* JIRA ticket: PICARD-3137

Picard carries the "logged in" state even after the user changes the server address to a server that does not accept that login (e.g. a local MusicBrainz replica, or `test.musicbrainz.org`, which does not accept the production OAuth login). Requests then go out authenticated and are rejected, and Picard prompts to log in against a server that cannot authenticate the user — an action that should be innocuous (e.g. opening a release from the newly configured server) fails with an error.

## Solution

Builds on the server registry (#3420). When the server address changes in the General options, Picard logs out if the new server does not accept the authentication scheme the current login was obtained with.

* `server_change_requires_logout(old_host, new_host)` (in `picard/util/mbserver`) returns True when the scheme Picard uses for `old_host` is not among the schemes accepted by `new_host`. Switching between servers that accept the same scheme (e.g. the official servers, which share the MetaBrainz OAuth provider) keeps the login. If Picard would not authenticate against the old server at all, there is no login to invalidate and no logout happens.
* `GeneralOptionsPage.save()` forgets the locally stored credentials when a logout is required and the user is currently logged in. No network token revocation is attempted, since the involved servers may be unreachable or reject the request.

Verified in a live session: logged in on an official server, then changing the server address to `test.musicbrainz.org` triggers an automatic logout (login state flips to logged-out and the UI updates), while switching between official servers keeps the login and an unchanged server address never logs out. New tests cover the registry decision and the options-page behavior (`test/util/test_mbserver.py`, `test/test_ui_options_general.py`).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The code and tests were developed with AI assistance and reviewed and verified by the author, including a live reproduction confirming the logout fires on an incompatible server change and does not fire otherwise.

## Action

Additional actions required:
* [x] Other (please specify below)

Related to the re-authentication loop fix (PICARD-3424, #3419); both build on the server registry (#3420) but change different code paths.
