### PR TITLE
PICARD-3426: Fix invisible checkmark of the submit-data checkbox in the server warning

### DIFF
--- a/picard/ui/forms/ui_options_general.py
+++ b/picard/ui/forms/ui_options_general.py
@@ -56,7 +56,7 @@ class Ui_GeneralOptionsPage(object):
         self.gridlayout.addWidget(self.server_host, 1, 0, 1, 1)
         self.server_host_primary_warning = QtWidgets.QFrame(parent=self.musicbrainz_server_box)
         self.server_host_primary_warning.setStyleSheet(
-            "QFrame { background-color: #ffc107; color: black }\nQCheckBox { color: black }"
+            "#server_host_primary_warning { border: 2px solid palette(highlight); border-radius: 3px }"
         )
         self.server_host_primary_warning.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
         self.server_host_primary_warning.setObjectName("server_host_primary_warning")

--- a/ui/options_general.ui
+++ b/ui/options_general.ui
@@ -78,8 +78,7 @@
       <item row="3" column="0" colspan="2">
        <widget class="QFrame" name="server_host_primary_warning">
         <property name="styleSheet">
-         <string notr="true">QFrame { background-color: #ffc107; color: black }
-QCheckBox { color: black }</string>
+         <string notr="true">#server_host_primary_warning { border: 2px solid palette(highlight); border-radius: 3px }</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::Shape::NoFrame</enum>


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Make the "Submit data to the configured server" checkbox show a visible checkmark by not styling it with the surrounding warning box.

## Problem

* JIRA ticket: PICARD-3426

In Options > General, when an unofficial MusicBrainz server is configured, the "Submit data to the configured server" checkbox sits inside the warning box. That box styled its whole frame — a filled background plus a `QCheckBox { color: … }` rule — which pulls the checkbox into Qt style-sheet rendering and drops the native check indicator. The result: clicking the checkbox toggles its state, but the checkmark is not visibly drawn (most noticeable with the dark theme), so it is unclear whether the option is enabled.

<img width="549" height="345" alt="image" src="https://github.com/user-attachments/assets/46fb0963-7a5b-4f4a-9a91-a2d70c9f2bc4" />


## Solution

Replace the filled warning banner with a simple border around the note and its checkbox, using the theme highlight/accent color (`palette(highlight)`) so it adapts to light and dark themes. The checkbox itself is left unstyled, so it renders natively with a clearly visible checkmark and correct contrast in every theme, while remaining visually grouped with the note it belongs to.

Only the `.ui` file and its generated form change; no logic changes. Verified visually in both light and dark themes.

<img width="531" height="374" alt="image" src="https://github.com/user-attachments/assets/8327258b-038c-4af6-9ae8-277ee69b5ecf" />


## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The diagnosis and fix were developed with AI assistance and reviewed and verified by the author in both light and dark themes.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
