### PR TITLE
PICARD-3425, PICARD-3427: Use submission server for ISRC and rating submissions, fix rating crash

### DIFF
--- a/picard/ui/ratingwidget.py
+++ b/picard/ui/ratingwidget.py
@@ -26,7 +26,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
-from picard import log
+from picard import log, tagger_instance
 from picard.config import get_config
 from picard.i18n import N_
 
@@ -94,7 +94,7 @@ class RatingWidget(QtWidgets.QWidget):
 
     def _submitted(self, document, http, error):
         if error:
-            self.tagger.window.set_statusbar_message(
+            tagger_instance().window.set_statusbar_message(
                 N_('Failed to submit rating for track "%(track_title)s" due to server error %(error)d'),
                 {'track_title': self._track.metadata['title'], 'error': error},
                 echo=None,
@@ -111,7 +111,7 @@ class RatingWidget(QtWidgets.QWidget):
         if config.setting['submit_ratings']:
             ratings = {('recording', track.id): self._rating}
             try:
-                self.tagger.mb_api.submit_ratings(ratings, self._submitted)
+                tagger_instance().mb_api.submit_ratings(ratings, self._submitted)
             except ValueError:  # This should never happen as self._rating is always an integer
                 log.error("Failed to submit rating for recording %s", track.id, exc_info=True)
 

--- a/picard/webservice/api_helpers/musicbrainz.py
+++ b/picard/webservice/api_helpers/musicbrainz.py
@@ -31,6 +31,7 @@ from PyQt6.QtCore import QUrl
 
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
+from picard.util.mbserver import get_submission_server
 from picard.webservice import (
     CLIENT_STRING,
     PendingRequest,
@@ -68,6 +69,34 @@ class MBAPIHelper(APIHelper):
         self._base_url = host_port_to_url(host, port)
         self._base_url.setPath('/ws/2')
         return self._base_url
+
+    @property
+    def submission_base_url(self) -> QUrl:
+        """Base URL for data submission.
+
+        Data submission should be done against the primary MusicBrainz database
+        rather than the (possibly mirror) server used for fetching data. See
+        :func:`picard.util.mbserver.get_submission_server`.
+        """
+        # Keep it dynamic since host/port can be changed via options.
+        server = get_submission_server()
+        url = host_port_to_url(server.host, server.port)
+        url.setPath('/ws/2')
+        return url
+
+    def submission_url_from_path(self, path: str) -> QUrl:
+        """Build a full submission URL for the given API path."""
+        url = QUrl(self.submission_base_url)
+        url.setPath(url.path() + path)
+        return url
+
+    def _post_submission(self, path: str, data: str | None, handler: ReplyHandler, **kwargs) -> PendingRequest:
+        """POST to the submission server (primary MusicBrainz database)."""
+        kwargs['mblogin'] = kwargs.get('mblogin', True)
+        kwargs['url'] = self.submission_url_from_path(path)
+        kwargs['handler'] = handler
+        kwargs['data'] = data
+        return self._webservice.post_url(**kwargs)
 
     def post(self, path: str, data: str | None, handler: ReplyHandler, **kwargs) -> PendingRequest:
         kwargs['mblogin'] = kwargs.get('mblogin', True)
@@ -225,7 +254,7 @@ class MBAPIHelper(APIHelper):
     def submit_ratings(self, ratings: dict[tuple[str, str], int], handler: ReplyHandler) -> PendingRequest:
         params = {'client': CLIENT_STRING}
         data = self._xml_ratings(ratings)
-        return self.post(
+        return self._post_submission(
             "/rating",
             data,
             handler,
@@ -263,7 +292,7 @@ class MBAPIHelper(APIHelper):
         """
         params = {'client': CLIENT_STRING}
         data = self._xml_isrcs(recordings_isrcs)
-        return self.post(
+        return self._post_submission(
             "/recording",
             data,
             handler,

--- a/test/ui/test_ratingwidget.py
+++ b/test/ui/test_ratingwidget.py
@@ -1,0 +1,65 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from unittest.mock import MagicMock
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.ratingwidget import RatingWidget
+
+
+class RatingWidgetTest(PicardTestCase):
+    def setUp(self):
+        super().setUp()
+        self.set_config_values(
+            setting={
+                'rating_steps': 6,
+                'submit_ratings': True,
+            }
+        )
+        # RatingWidget is a QWidget and accesses the Tagger singleton via
+        # tagger_instance(); patch it to the mock tagger.
+        self.patch_tagger_instance('picard.ui.ratingwidget')
+        self.tagger.mb_api = MagicMock()
+        self.track = MagicMock()
+        self.track.id = 'b9991644-7275-44db-bc43-fff6c6b4ce69'
+        self.track.metadata = {'~rating': '0', 'title': 'Test Track'}
+        self.track.files = []
+
+    def test_update_track_submits_rating(self):
+        # Regression test for PICARD-3425: RatingWidget referenced self.tagger,
+        # which does not exist on a QWidget, so submitting a rating crashed with
+        # AttributeError. It must use the Tagger singleton instead.
+        widget = RatingWidget(self.track)
+        widget._rating = 4
+        widget._update_track()
+        self.tagger.mb_api.submit_ratings.assert_called_once()
+        ratings = self.tagger.mb_api.submit_ratings.call_args[0][0]
+        self.assertEqual({('recording', self.track.id): 4}, ratings)
+
+    def test_update_track_no_submit_when_disabled(self):
+        self.set_config_values(setting={'rating_steps': 6, 'submit_ratings': False})
+        widget = RatingWidget(self.track)
+        widget._rating = 3
+        widget._update_track()
+        self.tagger.mb_api.submit_ratings.assert_not_called()
+
+    def test_submitted_error_reports_via_tagger_window(self):
+        widget = RatingWidget(self.track)
+        widget._submitted(None, None, error=1)
+        self.tagger.window.set_statusbar_message.assert_called_once()

--- a/test/webservice/test_webservice_api_helpers_musicbrainz.py
+++ b/test/webservice/test_webservice_api_helpers_musicbrainz.py
@@ -211,6 +211,78 @@ class MBAPITest(PicardTestCase):
         self.assertEqual(result, expected)
 
 
+class MBAPISubmissionServerTest(PicardTestCase):
+    """Data submission (ISRCs, ratings) must target the submission server.
+
+    Regression test for PICARD-3425: submissions should go to the primary
+    MusicBrainz database (the submission server), not the possibly-mirror
+    server configured for fetching data.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.ws = MagicMock(auto_spec=WebService)
+        self.api = MBAPIHelper(self.ws)
+
+    def _posted_url(self):
+        self.assertGreater(self.ws.post_url.call_count, 0)
+        return self.ws.post_url.call_args[1]['url']
+
+    def test_submit_isrcs_uses_submission_server_for_mirror(self):
+        # A non-official mirror without opt-in must fall back to the primary server.
+        self.set_config_values(
+            setting={
+                'server_host': 'mirror.example.com',
+                'server_port': 8042,
+                'use_server_for_submission': False,
+            }
+        )
+        self.api.submit_isrcs({'aaaa': ['USRC17607839']}, None)
+        url = self._posted_url()
+        self.assertEqual('musicbrainz.org', url.host())
+        self.assertTrue(url.path().startswith('/ws/2/recording'))
+
+    def test_submit_ratings_uses_submission_server_for_mirror(self):
+        self.set_config_values(
+            setting={
+                'server_host': 'mirror.example.com',
+                'server_port': 8042,
+                'use_server_for_submission': False,
+            }
+        )
+        self.api.submit_ratings({('recording', 'a'): 1}, None)
+        url = self._posted_url()
+        self.assertEqual('musicbrainz.org', url.host())
+        self.assertTrue(url.path().startswith('/ws/2/rating'))
+
+    def test_submit_isrcs_uses_official_server(self):
+        # An official server is used directly for submission.
+        self.set_config_values(
+            setting={
+                'server_host': 'beta.musicbrainz.org',
+                'server_port': 80,
+                'use_server_for_submission': False,
+            }
+        )
+        self.api.submit_isrcs({'aaaa': ['USRC17607839']}, None)
+        url = self._posted_url()
+        self.assertEqual('beta.musicbrainz.org', url.host())
+
+    def test_submit_ratings_uses_unofficial_server_when_opted_in(self):
+        # A non-official server is honoured when the user opts in.
+        self.set_config_values(
+            setting={
+                'server_host': 'mirror.example.com',
+                'server_port': 8042,
+                'use_server_for_submission': True,
+            }
+        )
+        self.api.submit_ratings({('recording', 'a'): 1}, None)
+        url = self._posted_url()
+        self.assertEqual('mirror.example.com', url.host())
+        self.assertEqual(8042, url.port())
+
+
 class LuceneHelpersTest(PicardTestCase):
     def test_escape_lucene_query(self):
         self.assertEqual('', escape_lucene_query(''))


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: ISRC and rating submissions now target the submission server (the primary MusicBrainz database) instead of the possibly-mirror fetch server; also fixes a crash that made rating submission unusable.

## Problem

* JIRA ticket: PICARD-3425

Picard can use a different MB server for fetching data, but data submission should by default go to the primary MB database (unless the user opts in via the submission-server option), because mirrors usually do not allow submitting data. The `get_submission_server` utility already handles this and is used for attaching CD TOCs and the addrelease browser integration. However, ISRC and rating submissions bypassed it: `submit_ratings()` and `submit_isrcs()` posted through `MBAPIHelper.base_url`, which is derived from `server_host`/`server_port` (the fetch server). As a result, submissions from a mirror were sent to the mirror instead of the primary database.

While verifying the rating path, a separate pre-existing crash was found: `RatingWidget` (a `QWidget`) referenced `self.tagger`, which does not exist on a `QWidget` (only `MetadataItem` provides that property). Clicking a rating raised `AttributeError: 'RatingWidget' object has no attribute 'tagger'`, so rating submission was effectively broken before it could reach `submit_ratings()`. The matching ticket for the crash is PICARD-3427

## Solution

Two commits:

1. **Route ISRC/rating submissions to the submission server.** Added a `submission_base_url` property on `MBAPIHelper` that resolves host/port via `get_submission_server()`, plus a `submission_url_from_path()` helper and a `_post_submission()` method that POSTs to the submission server (keeping `mblogin=True`). `submit_ratings()` and `submit_isrcs()` now use `_post_submission()` instead of `self.post()`. This reuses the same server-selection logic already used for CD TOC and addrelease: an official server is used directly; a non-official mirror falls back to the primary server unless `use_server_for_submission` is enabled.

2. **Fix the rating submission crash.** `RatingWidget` now uses the `tagger_instance()` helper to reach the `Tagger` singleton instead of the non-existent `self.tagger`.

Note: CD TOC and addrelease intentionally keep using `build_submission_url()` — they generate browser-facing URLs to HTML forms rather than making authenticated `/ws/2` web service POST requests, so they use a different transport but share the same `get_submission_server()` server-selection logic.

Regression tests added:
* `test/test_webservice_api_helpers_musicbrainz.py` (`MBAPISubmissionServerTest`): mirror fallback, official server, and opt-in cases for both submissions. Verified to fail against the previous behaviour and pass with the fix.
* `test/ui/test_ratingwidget.py`: reproduces the `AttributeError` crash and verifies rating submission is dispatched (and suppressed when disabled).

Verified end-to-end in a running Picard configured to fetch from a mirror (`test.musicbrainz.org`): rating a track no longer crashes and the request is POSTed to `https://musicbrainz.org/ws/2/rating` (HTTP 200), i.e. the primary submission server rather than the mirror.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Code and tests were drafted with AI assistance, then reviewed and verified by running the test suite, ruff, ty, and a live Picard session.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
