### PR TITLE
Read modern iTunes grouping/work ID3 layout (GRP1/TIT1) unambiguously

### DIFF
--- a/picard/formats/id3.py
+++ b/picard/formats/id3.py
@@ -362,6 +362,14 @@ class ID3File(File):
             'filename': filename,
             'file_length': file.info.length,
             'itunes_compatible': config.setting['itunes_compatible_grouping'],
+            # A file that has both GRP1 and TIT1 was written using the modern
+            # iTunes convention, where GRP1 holds the grouping and TIT1 holds
+            # the work (mutagen documents GRP1 as "iTunes Grouping" and TIT1 as
+            # "Content group description"). In that case the frame layout is
+            # unambiguous, so TIT1 is always read as work regardless of the
+            # itunes_compatible_grouping option (see _load_tit1_frame). See
+            # https://mutagen.readthedocs.io/en/latest/api/id3_frames.html
+            'has_grp1': 'GRP1' in tags,
             'rating_user_email': id3_rating_user_email(config),
             'rating_steps': config.setting['rating_steps'],
         }
@@ -404,8 +412,18 @@ class ID3File(File):
     def _load_tit1_frame(self, frame, metadata, config_params):
         """Process a TIT1 frame and add it to metadata.
         Handles work/grouping based on iTunes compatibility setting.
+
+        If the file also has a GRP1 frame (always read as grouping), then it was
+        written using the modern iTunes convention where GRP1 holds the grouping
+        and TIT1 holds the work. In that case TIT1 is read as work regardless of
+        the itunes_compatible_grouping option, so that a file tagged by modern
+        iTunes does not lose its work value or duplicate it into grouping.
+        Otherwise the option decides: work when enabled, grouping when disabled.
         """
-        name = 'work' if config_params['itunes_compatible'] else 'grouping'
+        if config_params.get('has_grp1'):
+            name = 'work'
+        else:
+            name = 'work' if config_params['itunes_compatible'] else 'grouping'
         for text in frame.text:
             if text:
                 metadata.add(name, text)

--- a/picard/ui/forms/ui_options_tags_compatibility_id3.py
+++ b/picard/ui/forms/ui_options_tags_compatibility_id3.py
@@ -1,6 +1,6 @@
 # Form implementation generated from reading ui file 'ui/options_tags_compatibility_id3.ui'
 #
-# Created by: PyQt6 UI code generator 6.9.1
+# Created by: PyQt6 UI code generator 6.11.0
 #
 # Automatically generated - do not edit.
 # Use `python setup.py build_ui` to update it.
@@ -128,5 +128,6 @@ class Ui_TagsCompatibilityOptionsPage(object):
         self.enc_iso88591.setText(_("ISO-8859-1"))
         self.label_id3v23_join_with.setText(_("Join multiple ID3v2.3 tags with:"))
         self.id3v23_join_with.setToolTip(_("<html><head/><body><p>Default is \'/\' to maintain compatibility with previous Picard releases.</p><p>New alternatives are \';_\' or \'_/_\' or type your own. </p></body></html>"))
+        self.itunes_compatible_grouping.setToolTip(_("Controls how the grouping and work are saved to ID3 tags. When disabled (the default), the grouping is saved to the standard TIT1 frame and the work to a TXXX:WORK frame. When enabled, the grouping is saved to the iTunes-specific GRP1 frame and the work to the TIT1 frame, as used by newer iTunes versions. Either way, files that contain both a GRP1 and a TIT1 frame are always read with GRP1 as the grouping and TIT1 as the work."))
         self.itunes_compatible_grouping.setText(_("Save iTunes compatible grouping and work"))
         self.write_id3v1.setText(_("Also include ID3v1 tags in the files"))

--- a/test/formats/test_id3.py
+++ b/test/formats/test_id3.py
@@ -253,6 +253,11 @@ class CommonId3Tests:
 
         @skipUnlessTestfile
         def test_always_read_grp1(self):
+            # File written with the iTunes-compatible option enabled has both a
+            # GRP1 frame (grouping) and a TIT1 frame (work). When such a file is
+            # read back with the option disabled, the presence of GRP1 marks it
+            # as using the modern iTunes convention, so TIT1 must be read as work
+            # (not grouping) and neither value is lost or duplicated.
             metadata = self.itunes_grouping_metadata
 
             config.setting['itunes_compatible_grouping'] = True
@@ -260,9 +265,27 @@ class CommonId3Tests:
             config.setting['itunes_compatible_grouping'] = False
             loaded_metadata = load_metadata(self.format_registry, self.filename)
 
-            self.assertIn(metadata['grouping'], loaded_metadata['grouping'])
-            self.assertIn(metadata['work'], loaded_metadata['grouping'])
-            self.assertEqual(loaded_metadata['work'], '')
+            self.assertEqual(loaded_metadata['grouping'], metadata['grouping'])
+            self.assertEqual(loaded_metadata['work'], metadata['work'])
+
+        @skipUnlessTestfile
+        def test_read_modern_itunes_grp1_and_tit1(self):
+            # A file tagged by modern iTunes stores grouping in GRP1 and work in
+            # TIT1. With the option disabled (default), TIT1 would normally be
+            # read as grouping, but the presence of GRP1 disambiguates the layout
+            # so TIT1 is read as work instead.
+            grouping = 'The Grouping'
+            work = 'The Work'
+            tags = mutagen.id3.ID3Tags()
+            tags.add(mutagen.id3.GRP1(encoding=3, text=[grouping]))
+            tags.add(mutagen.id3.TIT1(encoding=3, text=[work]))
+            save_raw(self.filename, tags)
+
+            config.setting['itunes_compatible_grouping'] = False
+            loaded_metadata = load_metadata(self.format_registry, self.filename)
+
+            self.assertEqual(loaded_metadata['grouping'], grouping)
+            self.assertEqual(loaded_metadata['work'], work)
 
         @skipUnlessTestfile
         def test_always_read_txxx_work(self):

--- a/ui/options_tags_compatibility_id3.ui
+++ b/ui/options_tags_compatibility_id3.ui
@@ -199,6 +199,9 @@
       </item>
       <item>
        <widget class="QCheckBox" name="itunes_compatible_grouping">
+        <property name="toolTip">
+         <string>Controls how the grouping and work are saved to ID3 tags. When disabled (the default), the grouping is saved to the standard TIT1 frame and the work to a TXXX:WORK frame. When enabled, the grouping is saved to the iTunes-specific GRP1 frame and the work to the TIT1 frame, as used by newer iTunes versions. Either way, files that contain both a GRP1 and a TIT1 frame are always read with GRP1 as the grouping and TIT1 as the work.</string>
+        </property>
         <property name="text">
          <string>Save iTunes compatible grouping and work</string>
         </property>


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
* **Describe this change in 1-2 sentences**: When an MP3 was tagged by newer
  iTunes versions (which store the grouping in `GRP1` and the work in `TIT1`),
  Picard misread the `TIT1` work value as a second grouping and lost the work,
  unless the *Save iTunes compatible grouping and work* option happened to be
  enabled. Picard now detects this frame layout and always reads `GRP1` as
  grouping and `TIT1` as work, so nothing is lost regardless of the option.

## Problem

* JIRA ticket (_optional_): PICARD-XXX (to be created)
* Originally reported on the community forum:
  <https://community.metabrainz.org/t/grouping-tag-disappearing/815598/>

Two ID3v2 conventions exist for the grouping/work fields:

* The standard convention, also used by MusicBrainz Picard by default: grouping
  is stored in `TIT1` ("Content group description"). Older iTunes versions also
  used `TIT1` for their Grouping field, so the default matches them on the
  grouping side; the work is stored by Picard in `TXXX:WORK`.
* The convention used by newer iTunes versions: grouping is stored in the
  iTunes-specific `GRP1` frame, and `TIT1` is repurposed for the classical
  *Work*.

Sources for the frame semantics:

* mutagen documents `GRP1` as "iTunes Grouping" and `TIT1` as "Content group
  description":
  <https://mutagen.readthedocs.io/en/latest/api/id3_frames.html>
* mutagen added the `GRP1` frame specifically because "iTunes is now writing
  'Grouping' values from its library out to a new ID3 frame 'GRP1'"
  (quodlibet/mutagen#304): <https://github.com/quodlibet/mutagen/issues/304>
* Picard's own tag-mapping documentation already lists grouping as
  `TIT1` / `GRP1` and work as `TXXX:WORK` / `TIT1`, with the `GRP1`/`TIT1`
  behavior gated behind the *Save iTunes compatible grouping and work* option
  (footnote 8, since Picard 2.1.0):
  <https://picard-docs.musicbrainz.org/en/latest/appendices/tag_mapping.html>
* The change in iTunes has been reported by the community to have happened
  around iTunes 12.5.4 (2016). This specific version is a community report
  (mp3tag forum), not Apple-documented, so it is deliberately not asserted as
  fact in the code or UI:
  <https://community.mp3tag.de/t/work-grouping-fields-itunes-12-5/18659>

The concrete bug: with the option **disabled** (the default), Picard reads
every `TIT1` frame as grouping (`_load_tit1_frame`). For a file written by newer
iTunes, that means:

* the grouping is read correctly from `GRP1` (Picard always reads `GRP1` as
  grouping), but
* the *work* stored in `TIT1` is also read as grouping, producing a duplicated
  grouping value and an empty work.

This is what the forum reporter observed: the value was visible in Picard but
appeared under the wrong field, and re-importing into iTunes showed an empty
Grouping. The existing regression test `test_always_read_grp1` actually encoded
this incorrect behavior (asserting the work value ended up in grouping).

## Solution

A file that contains **both** a `GRP1` and a `TIT1` frame is unambiguously using
the newer iTunes layout (grouping in `GRP1`, work in `TIT1`). In that case the
option is irrelevant for reading — the frames describe themselves.

* `picard/formats/id3.py`
  * `_init_load()` records `has_grp1 = 'GRP1' in tags` in the load parameters.
  * `_load_tit1_frame()` reads `TIT1` as `work` whenever `has_grp1` is true;
    otherwise it falls back to the previous option-based behavior (work when the
    option is enabled, grouping when disabled).
  * This is read-only disambiguation. What Picard *writes* is unchanged and
    still controlled by the option, so there is no change for files Picard
    itself wrote with the option disabled (those have `TIT1` grouping and
    `TXXX:WORK` work, no `GRP1`).

  This mirrors the read-priority approach adopted by other players facing the
  same ambiguity, e.g. Mixxx (mixxxdj/mixxx#9315):
  <https://github.com/mixxxdj/mixxx/issues/9315>

* `test/formats/test_id3.py`
  * `test_always_read_grp1` updated to assert the corrected, lossless
    round-trip: saving with the option on (grouping→`GRP1`, work→`TIT1`) and
    reading back with the option off now preserves both grouping and work,
    instead of collapsing work into grouping.
  * Added `test_read_modern_itunes_grp1_and_tit1`, which writes raw `GRP1` +
    `TIT1` frames (simulating a newer-iTunes file) and verifies that, with the
    option disabled, `GRP1` is read as grouping and `TIT1` as work.

* `ui/options_tags_compatibility_id3.ui` (regenerated
  `picard/ui/forms/ui_options_tags_compatibility_id3.py` via
  `python setup.py build_ui`)
  * Added a tooltip to the *Save iTunes compatible grouping and work* checkbox
    explaining which frames each mode writes (`TIT1`/`TXXX:WORK` when disabled
    vs `GRP1`/`TIT1` when enabled) and that files containing both frames are
    read correctly regardless of the setting.

### Verification

* `pytest test/formats/test_id3.py test/formats/test_id3_load.py`:
  478 passed, 2 skipped, 2766 subtests passed.
* `ruff format --check` and `ruff check` clean on the changed non-generated
  files (`picard/ui/forms/ui_*.py` is excluded from ruff per `pyproject.toml`).
* `ty check picard/formats/id3.py`: no new diagnostics (only a pre-existing,
  unrelated `unused-type-ignore` warning).

## AI Usage

* [x] Significant use (e.g. code structure, tests development, etc.)

Code, tests and this description were drafted with AI assistance. Every factual
claim about frame semantics and the iTunes behavior is backed by the cited
sources above, and the behavior was verified by running the test suite, ruff and
ty.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs)
  (please include a reference to this PR) — Appendix A footnote 8 should note
  that files containing both `GRP1` and `TIT1` are read with `GRP1` as grouping
  and `TIT1` as work regardless of the option.

