### PR TITLE
PICARD-3428: Fix Metadata options page greying out on unknown translation locale

### DIFF
--- a/picard/ui/options/metadata.py
+++ b/picard/ui/options/metadata.py
@@ -33,6 +33,7 @@ from PyQt6 import (
     QtWidgets,
 )
 
+from picard import log
 from picard.config import (
     Option,
     get_config,
@@ -136,7 +137,7 @@ class MetadataOptionsPage(OptionsPage):
         self.ui.translate_artist_names.setChecked(config.setting['translate_artist_names'])
         self.ui.translate_album_titles.setChecked(config.setting['translate_album_titles'])
         self.ui.translate_track_titles.setChecked(config.setting['translate_track_titles'])
-        self.current_locales = config.setting['translation_locales']
+        self.current_locales = self._sanitized_locales(config.setting['translation_locales'])
         self.make_locales_text()
         self.current_scripts = config.setting['script_exceptions']
         self.make_scripts_text()
@@ -160,10 +161,35 @@ class MetadataOptionsPage(OptionsPage):
 
         self.set_enabled_states()
 
+    @staticmethod
+    def _sanitized_locales(locales):
+        """Filter out locale codes not present in ALIAS_LOCALES.
+
+        A configuration carried over from an older Picard (or a different CLDR
+        version), or a corrupted value, may reference a locale that no longer
+        exists. Such entries are dropped so they cannot crash the page or be
+        re-persisted. If nothing valid remains, fall back to the option default
+        so the user is never left with an empty locale list.
+        """
+        valid = []
+        for locale in locales:
+            if locale in ALIAS_LOCALES:
+                valid.append(locale)
+            else:
+                log.warning("Ignoring unknown translation locale %r", locale)
+        if not valid:
+            return list(Option.get_default('setting', 'translation_locales'))
+        return valid
+
     def make_locales_text(self):
         def translated_locales():
             for locale in self.current_locales:
-                yield gettext_constants(ALIAS_LOCALES[locale])
+                # current_locales is sanitized in load(), but guard here too so
+                # this method is safe to call with arbitrary input.
+                name = ALIAS_LOCALES.get(locale)
+                if name is None:
+                    continue
+                yield gettext_constants(name)
 
         self.ui.selected_locales.setText('; '.join(translated_locales()))
 
@@ -253,10 +279,15 @@ class MultiLocaleSelector(PicardDialog):
 
     def load(self):
         for locale in self.parent().current_locales:
+            # current_locales is sanitized by MetadataOptionsPage.load(), but
+            # guard defensively so an unknown code can never crash the dialog.
+            name = ALIAS_LOCALES.get(locale)
+            if name is None:
+                continue
             # Note that items in the selected locales list are not indented because
             # the root locale may not be in the list, or may not immediately precede
             # the specific locale.
-            label = gettext_constants(ALIAS_LOCALES[locale])
+            label = gettext_constants(name)
             item = QtWidgets.QListWidgetItem(label)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, locale)
             self.ui.selected_locales.addItem(item)

--- a/test/ui/test_options_metadata.py
+++ b/test/ui/test_options_metadata.py
@@ -1,0 +1,76 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from picard.config import get_config
+
+import pytest
+
+from picard.ui.options.metadata import MetadataOptionsPage
+
+
+@pytest.fixture()
+def metadata_options_page(qapp, patch_tagger_instance):
+    patch_tagger_instance('picard.ui.options')
+    return MetadataOptionsPage()
+
+
+def test_load_with_known_locale(metadata_options_page):
+    config = get_config()
+    config.setting['translation_locales'] = ['en']
+    metadata_options_page.load()
+    assert metadata_options_page.current_locales == ['en']
+
+
+def test_load_with_unknown_locale_does_not_crash(metadata_options_page):
+    # A config carried over from an older Picard/CLDR version (or a corrupted
+    # value) may contain a locale code that no longer exists in ALIAS_LOCALES.
+    # Loading the page must not raise (which would disable the Metadata options
+    # page in the dialog).
+    config = get_config()
+    config.setting['translation_locales'] = ['en', 'zz_DOES_NOT_EXIST', 'de']
+    metadata_options_page.load()
+    # Unknown locales are dropped from the display text but valid ones remain.
+    assert 'zz_DOES_NOT_EXIST' not in metadata_options_page.ui.selected_locales.text()
+
+
+def test_load_drops_unknown_locale_from_current_locales(metadata_options_page):
+    # Invalid entries must be removed from current_locales so a later save()
+    # does not re-persist them; valid entries keep their order.
+    config = get_config()
+    config.setting['translation_locales'] = ['en', 'zz_DOES_NOT_EXIST', 'de']
+    metadata_options_page.load()
+    assert metadata_options_page.current_locales == ['en', 'de']
+
+
+def test_load_falls_back_to_default_when_all_locales_unknown(metadata_options_page):
+    # If no valid locale remains (e.g. a fully corrupted value), fall back to
+    # the option default instead of leaving an empty locale list.
+    config = get_config()
+    config.setting['translation_locales'] = ['\x85n', 'zz_DOES_NOT_EXIST']
+    metadata_options_page.load()
+    assert metadata_options_page.current_locales == ['en']
+
+
+def test_save_after_sanitizing_persists_clean_locales(metadata_options_page):
+    # After load() sanitizes the value, save() must write back only valid
+    # locales, not the original corrupted list.
+    config = get_config()
+    config.setting['translation_locales'] = ['en', 'zz_DOES_NOT_EXIST']
+    metadata_options_page.load()
+    metadata_options_page.save()
+    assert config.setting['translation_locales'] == ['en']


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: The Metadata options page crashed and greyed itself out when `translation_locales` contained a locale code not present in `ALIAS_LOCALES`. Unknown codes are now dropped (with a fallback to the default), so the page always loads.

## Problem

* JIRA ticket: PICARD-3428

When opening Options → Options and selecting the Metadata section, the page could be accessed once and then the "Metadata" tree entry greyed out and could no longer be selected.

Reported by a user upgrading from Picard 2 to Picard 3 RC2 (the installer replaced the Picard 2 install, so the configuration was carried over). The user's interface language was English — note that `ui_language` and `translation_locales` are independent settings, so an English UI does not imply the translation locales are the default `['en']`.

Root cause: the page looked up each configured translation locale directly in `ALIAS_LOCALES`:

```python
gettext_constants(ALIAS_LOCALES[locale])
```

`ALIAS_LOCALES` is derived from CLDR data, which changes between releases. If the carried-over config references a locale code that no longer exists (e.g. `sh`, `zh_CN`, `sr_CS`), or a corrupted value, the lookup raises `KeyError`. That exception propagates out of `load()`; the options dialog catches it and calls `disable_page('metadata')`, which disables the tree item — while still showing the page content that one time. Hence "opens once, then greys out".

## Solution

* Sanitize `translation_locales` in `MetadataOptionsPage.load()`: filter out codes not present in `ALIAS_LOCALES` (logging a warning), so they cannot crash the page or be re-persisted on save.
* Fall back to the option default when no valid locale remains, so the user is never left with an empty locale list.
* `make_locales_text()` and `MultiLocaleSelector.load()` also guard defensively with `ALIAS_LOCALES.get(...)`.

An upgrade hook to scrub the stored value was considered but not added: the runtime now defends itself, the stale value is inert at tag time (an unknown locale simply never matches an alias), and a version-gated hook would not help users already on RC2 with the bad value.

Adds `test/ui/test_options_metadata.py` covering: known locale preserved; unknown locale does not crash and is dropped from the display and from `current_locales`; all-unknown falls back to the default; and save-after-sanitize persists only the clean list.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Root-cause analysis, the fix, and the tests were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
