### PR TITLE
PICARD-3431: Show a bug-report link on plugin error dialogs

### DIFF
--- a/picard/const/__init__.py
+++ b/picard/const/__init__.py
@@ -87,6 +87,7 @@ PICARD_URLS = {
     'doc_cover_art_types': MB_DOCS_BASE_URL + "/Cover_Art/Types",
     'plugins': "https://picard.musicbrainz.org/plugins/",
     'forum': "https://community.metabrainz.org/c/picard",
+    'bugtracker': "https://tickets.metabrainz.org/projects/PICARD",
     'donate': "https://metabrainz.org/donate",
     'translate': "https://wiki.musicbrainz.org/MusicBrainz_Picard/Internationalization",
     'chromaprint': "https://acoustid.org/chromaprint#download",

--- a/picard/plugin3/manifest.py
+++ b/picard/plugin3/manifest.py
@@ -159,6 +159,10 @@ class PluginManifest:
         return self._data.get('report_bugs_to', '')
 
     @property
+    def homepage(self) -> str:
+        return self._data.get('homepage', '')
+
+    @property
     def source_locale(self) -> str:
         """Get source locale for translations, defaults to 'en'."""
         return self._data.get('source_locale', DEFAULT_SOURCE_LOCALE)

--- a/picard/plugin3/registry.py
+++ b/picard/plugin3/registry.py
@@ -684,6 +684,16 @@ class RegistryPlugin(InstallablePlugin):
         return self._data.get('maintainers', [])
 
     @property
+    def report_bugs_to(self):
+        """Get the plugin's bug-reporting URL, if provided by the registry."""
+        return self._data.get('report_bugs_to', '')
+
+    @property
+    def homepage(self):
+        """Get the plugin's homepage URL, if provided by the registry."""
+        return self._data.get('homepage', '')
+
+    @property
     def added_at(self):
         """Get plugin added timestamp."""
         return self._data.get('added_at')

--- a/picard/ui/dialogs/installplugin.py
+++ b/picard/ui/dialogs/installplugin.py
@@ -42,6 +42,7 @@ from picard.plugin3.registry import RegistryPlugin
 from picard.ui import PicardDialog
 from picard.ui.colors import interface_colors
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
+from picard.ui.dialogs.plugin_error import show_plugin_error
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.theme import theme
 from picard.ui.util import font_scaled_size
@@ -704,6 +705,10 @@ class InstallPluginDialog(PicardDialog):
         self.progress_bar.show()
         self.progress_bar.setValue(0)
 
+        # Remember the plugin being installed so a failure dialog can offer a
+        # plugin-specific "report this issue" link when the info is available.
+        self._installing_plugin = plugin
+
         # Start async installation
         async_manager = AsyncPluginManager(self.plugin_manager)
         async_manager.install_plugin(
@@ -727,6 +732,12 @@ class InstallPluginDialog(PicardDialog):
         else:
             self.status_label.setText(_("Installation failed"))
             error_msg = str(result.error) if result.error else _("Unknown error")
-            QtWidgets.QMessageBox.critical(self, _("Installation Failed"), error_msg)
+            show_plugin_error(
+                self,
+                _("Installation Failed"),
+                _("Failed to install the plugin."),
+                error=error_msg,
+                plugin=getattr(self, '_installing_plugin', None),
+            )
             # Re-enable UI
             self._enable_ui_after_installation()

--- a/picard/ui/dialogs/plugin_error.py
+++ b/picard/ui/dialogs/plugin_error.py
@@ -1,0 +1,199 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from html import escape
+
+from PyQt6 import QtCore, QtWidgets
+
+from picard.i18n import gettext as _
+from picard.util import get_url
+
+
+# Schemes we are willing to turn into a clickable link. Mirrors the manifest
+# validator's allowed schemes for ``report_bugs_to``.
+_ALLOWED_LINK_SCHEMES = ('https://', 'http://', 'mailto:')
+
+
+def _valid_link(value: str | None) -> str:
+    """Return a stripped URL if it uses an allowed scheme, else an empty string.
+
+    This guards against injecting arbitrary (or malformed) manifest content
+    into the rich-text dialog as a link target.
+    """
+    if not value:
+        return ''
+    value = value.strip()
+    if value.startswith(_ALLOWED_LINK_SCHEMES):
+        return value
+    return ''
+
+
+def _report_info_holder(plugin: object | None) -> object | None:
+    """Find the object carrying ``report_bugs_to`` / ``homepage`` for a plugin.
+
+    The bug-reporting info can live in different places depending on the
+    plugin's state:
+      - on the plugin's ``manifest`` (installed plugins),
+      - on a registry entry stored as ``_registry_plugin`` (plugins being
+        installed, not yet on disk),
+      - or directly on the object itself (a manifest/registry entry passed in).
+
+    The first candidate that exposes a non-empty ``report_bugs_to`` or
+    ``homepage`` wins; otherwise the object itself is returned so the caller
+    can still fall back to Picard's tracker.
+    """
+    if plugin is None:
+        return None
+    candidates = (
+        plugin,
+        getattr(plugin, 'manifest', None),
+        getattr(plugin, '_registry_plugin', None),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if getattr(candidate, 'report_bugs_to', '') or getattr(candidate, 'homepage', ''):
+            return candidate
+    return plugin
+
+
+def plugin_report_link(plugin: object | None) -> tuple[str, bool]:
+    """Return the best "report this issue" URL for a plugin error.
+
+    Preference order:
+      1. the plugin's ``report_bugs_to``
+      2. the plugin's ``homepage``
+      3. Picard's own bug tracker (fallback)
+
+    ``plugin`` may be an installed plugin, a plugin being installed, a manifest
+    or a registry entry; the report info is extracted from whichever holds it.
+
+    Returns a tuple ``(url, is_plugin_specific)`` where ``is_plugin_specific``
+    is True when the URL came from the plugin, so callers can adjust the
+    wording (report to the plugin author vs. to Picard).
+    """
+    source = _report_info_holder(plugin)
+    if source is not None:
+        report_bugs_to = _valid_link(getattr(source, 'report_bugs_to', ''))
+        if report_bugs_to:
+            return report_bugs_to, True
+        homepage = _valid_link(getattr(source, 'homepage', ''))
+        if homepage:
+            return homepage, True
+    return get_url('bugtracker'), False
+
+
+def _plugin_display_name(plugin: object | None) -> str:
+    """Best-effort display name for a plugin-ish object.
+
+    Handles the different shapes passed to the error dialogs: installed
+    plugins, plugins being installed (installable/registry entries) and
+    manifests. Returns an empty string if no name can be determined.
+    """
+    if plugin is None:
+        return ''
+    # get_display_name(): installable/registry entries.
+    # name_i18n(): manifest / registry (locale-aware).
+    # name(): installed plugin (no-arg) and manifest (defaulted locale).
+    for attr in ('get_display_name', 'name_i18n', 'name'):
+        candidate = getattr(plugin, attr, None)
+        if callable(candidate):
+            try:
+                value = candidate()
+            except Exception:
+                continue
+            if value:
+                return str(value)
+    # Fall back to a plain ``name`` attribute (installable base class).
+    value = getattr(plugin, 'name', None)
+    if isinstance(value, str) and value:
+        return value
+    return ''
+
+
+def show_plugin_error(
+    parent: QtWidgets.QWidget | None,
+    title: str,
+    message: str,
+    error: str | None = None,
+    plugin: object | None = None,
+    name: str | None = None,
+) -> None:
+    """Show a critical plugin error dialog with a "report this issue" link.
+
+    The dialog is laid out as::
+
+        Plugin "<name>":
+        <message>
+
+        Error reported by the plugin:
+            <error>
+
+        <report link>
+
+    where ``<name>`` is derived from ``plugin`` (or the explicit ``name``
+    override), and the raw ``error`` is shown in its own block so it is easy to
+    distinguish and copy when reporting a bug.
+
+    The report link points at the plugin's ``report_bugs_to`` (or
+    ``homepage``) when that info is available, otherwise at Picard's bug
+    tracker.
+
+    Args:
+        parent: Parent widget for the dialog.
+        title: Dialog window title.
+        message: Human-readable context (e.g. 'Failed to enable plugin.').
+        error: The raw error text reported by the plugin, if any.
+        plugin: The offending plugin (installed plugin, plugin being installed,
+            manifest, or registry entry), if known.
+        name: Explicit plugin display name, used when it cannot be derived from
+            ``plugin``.
+    """
+    url, is_plugin_specific = plugin_report_link(plugin)
+    if is_plugin_specific:
+        report_text = _("If this looks like a plugin problem, report it to the plugin author: %s") % (
+            '<a href="%s">%s</a>' % (escape(url, quote=True), escape(url))
+        )
+    else:
+        report_text = _("Please report this issue on the %s.") % (
+            '<a href="%s">%s</a>' % (escape(url, quote=True), _("MusicBrainz bug tracker"))
+        )
+
+    display_name = name or _plugin_display_name(plugin)
+
+    # All caller-supplied text is HTML-escaped before being placed into the
+    # RichText body so it cannot inject markup.
+    if display_name:
+        header = _('Plugin "%s":') % escape(display_name)
+        parts = ['<p><b>%s</b><br>%s</p>' % (header, escape(message))]
+    else:
+        parts = ['<p>%s</p>' % escape(message)]
+    if error:
+        parts.append('<p>%s</p>' % escape(_("Error reported by the plugin:")))
+        # Render the raw error in a monospace block, preserving line breaks.
+        error_html = escape(error).replace('\n', '<br>')
+        parts.append('<pre style="margin-left: 1em; white-space: pre-wrap;">%s</pre>' % error_html)
+    parts.append('<p>%s</p>' % report_text)
+
+    box = QtWidgets.QMessageBox(parent)
+    box.setIcon(QtWidgets.QMessageBox.Icon.Critical)
+    box.setWindowTitle(title)
+    box.setTextFormat(QtCore.Qt.TextFormat.RichText)
+    box.setText(''.join(parts))
+    box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
+    box.exec()

--- a/picard/ui/options/plugins.py
+++ b/picard/ui/options/plugins.py
@@ -47,6 +47,7 @@ from picard.i18n import (
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 
 from picard.ui.dialogs.installplugin import InstallPluginDialog
+from picard.ui.dialogs.plugin_error import show_plugin_error
 from picard.ui.options import OptionsPage
 from picard.ui.widgets.plugindetailswidget import PluginDetailsWidget
 from picard.ui.widgets.pluginlistwidget import PluginListWidget
@@ -529,8 +530,12 @@ class Plugins3OptionsPage(OptionsPage):
             self.plugin_list.set_updates(config.persist['plugins3_updates'])
         else:
             error_msg = str(result.error) if result.error else _("Unknown error")
-            QtWidgets.QMessageBox.warning(
-                self, _("Update Failed"), _("Failed to update plugin: {errmsg}").format(errmsg=error_msg)
+            show_plugin_error(
+                self,
+                _("Update Failed"),
+                _("Failed to update the plugin."),
+                error=error_msg,
+                plugin=plugin,
             )
 
         self.plugin_manager.refresh_updates_available.emit()

--- a/picard/ui/widgets/plugindetailswidget.py
+++ b/picard/ui/widgets/plugindetailswidget.py
@@ -29,6 +29,7 @@ from picard.i18n import gettext as _
 from picard.plugin3.asyncops.manager import AsyncPluginManager
 from picard.plugin3.ref_item import RefItem
 
+from picard.ui.dialogs.plugin_error import show_plugin_error
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.util import font_scaled_size
 from picard.ui.widgets.pluginformat import (
@@ -240,7 +241,13 @@ class PluginDetailsWidget(QtWidgets.QWidget):
             self.plugin_uninstalled.emit()  # Signal that plugin was uninstalled
         else:
             error_msg = str(result.error) if result.error else _("Unknown error")
-            QtWidgets.QMessageBox.critical(self, _("Uninstall Failed"), error_msg)
+            show_plugin_error(
+                self,
+                _("Uninstall Failed"),
+                _("Failed to uninstall the plugin."),
+                error=error_msg,
+                plugin=plugin,
+            )
 
     def _get_authors_display(self, plugin):
         """Get authors display text."""
@@ -361,8 +368,12 @@ class PluginDetailsWidget(QtWidgets.QWidget):
                     callback=partial(self._on_uninstall_complete, self.current_plugin),
                 )
             except Exception as e:
-                QtWidgets.QMessageBox.critical(
-                    self, _("Uninstall Failed"), _("Failed to uninstall plugin: {errmsg}").format(errmsg=str(e))
+                show_plugin_error(
+                    self,
+                    _("Uninstall Failed"),
+                    _("Failed to uninstall the plugin."),
+                    error=str(e),
+                    plugin=self.current_plugin,
                 )
 
     def _perform_update(self):

--- a/picard/ui/widgets/pluginlistwidget.py
+++ b/picard/ui/widgets/pluginlistwidget.py
@@ -49,6 +49,7 @@ from picard.plugin3.ref_item import RefItem
 from picard.util.qt import temporary_disconnect
 
 from picard.ui.dialogs.installconfirm import InstallConfirmDialog
+from picard.ui.dialogs.plugin_error import show_plugin_error
 from picard.ui.dialogs.plugin_order_selector import display_plugin_order_selector
 from picard.ui.dialogs.plugininfo import PluginInfoDialog
 from picard.ui.formattedtextdelegate import FormattedTextDelegate
@@ -671,17 +672,21 @@ class PluginListWidget(QtWidgets.QWidget):
         menu.exec(self.tree_widget.mapToGlobal(position))
 
     def _enable_error_dialog(self, plugin, errmsg):
-        QtWidgets.QMessageBox.critical(
+        show_plugin_error(
             self,
             _("Plugin Error"),
-            _('Failed to enable plugin "{name}":\n{errmsg}').format(name=plugin.name(), errmsg=errmsg),
+            _("Failed to enable the plugin."),
+            error=errmsg,
+            plugin=plugin,
         )
 
     def _disable_error_dialog(self, plugin, errmsg):
-        QtWidgets.QMessageBox.critical(
+        show_plugin_error(
             self,
             _("Plugin Error"),
-            _('Failed to disable plugin "{name}":\n{errmsg}').format(name=plugin.name(), errmsg=errmsg),
+            _("Failed to disable the plugin."),
+            error=errmsg,
+            plugin=plugin,
         )
 
     def _toggle_plugin_from_menu(self, plugin, enabled):
@@ -708,10 +713,12 @@ class PluginListWidget(QtWidgets.QWidget):
         )
 
     def _update_error_dialog(self, plugin, errmsg):
-        QtWidgets.QMessageBox.critical(
+        show_plugin_error(
             self,
             _("Plugin Error"),
-            _('Failed to update plugin "{name}":\n{errmsg}').format(name=plugin.name(), errmsg=errmsg),
+            _("Failed to update the plugin."),
+            error=errmsg,
+            plugin=plugin,
         )
 
     def _on_context_update_complete(self, plugin, result):
@@ -727,10 +734,12 @@ class PluginListWidget(QtWidgets.QWidget):
             self._update_error_dialog(plugin, error_msg)
 
     def _uninstall_error_dialog(self, plugin, errmsg):
-        QtWidgets.QMessageBox.critical(
+        show_plugin_error(
             self,
             _("Plugin Error"),
-            _('Failed to uninstall plugin "{name}":\n{errmsg}').format(name=plugin.name(), errmsg=errmsg),
+            _("Failed to uninstall the plugin."),
+            error=errmsg,
+            plugin=plugin,
         )
 
     def _uninstall_plugin_from_menu(self, plugin):

--- a/test/ui/test_plugin_error.py
+++ b/test/ui/test_plugin_error.py
@@ -1,0 +1,225 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from types import SimpleNamespace
+
+from picard.util import get_url
+
+import pytest
+
+from picard.ui.dialogs.plugin_error import (
+    plugin_report_link,
+    show_plugin_error,
+)
+
+
+def _plugin(report_bugs_to='', homepage=''):
+    """A plugin-like object that exposes the report fields directly."""
+    return SimpleNamespace(report_bugs_to=report_bugs_to, homepage=homepage)
+
+
+def test_report_link_prefers_report_bugs_to():
+    plugin = _plugin(report_bugs_to='https://example.com/issues', homepage='https://example.com')
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == 'https://example.com/issues'
+    assert is_plugin_specific is True
+
+
+def test_report_link_falls_back_to_homepage():
+    plugin = _plugin(report_bugs_to='', homepage='https://example.com')
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == 'https://example.com'
+    assert is_plugin_specific is True
+
+
+def test_report_link_accepts_mailto():
+    plugin = _plugin(report_bugs_to='mailto:dev@example.com')
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == 'mailto:dev@example.com'
+    assert is_plugin_specific is True
+
+
+def test_report_link_extracts_from_manifest():
+    # An installed plugin carries the info on its manifest.
+    plugin = SimpleNamespace(manifest=_plugin(report_bugs_to='https://example.com/issues'))
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == 'https://example.com/issues'
+    assert is_plugin_specific is True
+
+
+def test_report_link_extracts_from_registry_entry():
+    # A plugin being installed carries the info on its registry entry.
+    plugin = SimpleNamespace(_registry_plugin=_plugin(homepage='https://example.com'))
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == 'https://example.com'
+    assert is_plugin_specific is True
+
+
+def test_report_link_falls_back_to_picard_tracker_when_no_plugin():
+    url, is_plugin_specific = plugin_report_link(None)
+    assert url == get_url('bugtracker')
+    assert is_plugin_specific is False
+
+
+def test_report_link_rejects_non_url_scheme():
+    # A field that is not an allowed URL scheme must not be used as a link
+    # target; fall back to Picard's tracker instead.
+    plugin = _plugin(report_bugs_to='javascript:alert(1)', homepage='not a url')
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == get_url('bugtracker')
+    assert is_plugin_specific is False
+
+
+def test_report_link_ignores_empty_and_whitespace():
+    plugin = _plugin(report_bugs_to='   ', homepage='')
+    url, is_plugin_specific = plugin_report_link(plugin)
+    assert url == get_url('bugtracker')
+    assert is_plugin_specific is False
+
+
+@pytest.mark.parametrize(
+    'plugin,expected_snippet',
+    [
+        (_plugin(report_bugs_to='https://example.com/issues'), 'https://example.com/issues'),
+        (None, get_url('bugtracker')),
+    ],
+)
+def test_show_plugin_error_builds_dialog_with_link(qapp, monkeypatch, plugin, expected_snippet):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Test Failure", "boom", plugin=plugin)
+    assert expected_snippet in captured['text']
+    # The raw error message is HTML-escaped and present.
+    assert 'boom' in captured['text']
+
+
+def test_show_plugin_error_separates_message_and_error(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Plugin Error", "Failed to enable the plugin.", error="ImportError: boom", plugin=None)
+    text = captured['text']
+    assert 'Failed to enable the plugin.' in text
+    assert 'Error reported by the plugin:' in text
+    assert 'ImportError: boom' in text
+    # The raw error is rendered in its own <pre> block.
+    assert '<pre' in text
+
+
+def test_show_plugin_error_without_error_has_no_error_block(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Plugin Error", "Something failed.", plugin=None)
+    text = captured['text']
+    assert 'Error reported by the plugin:' not in text
+    assert '<pre' not in text
+
+
+def test_show_plugin_error_uses_explicit_name(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Plugin Error", "Failed to enable the plugin.", name="My Plugin", plugin=None)
+    assert 'My Plugin' in captured['text']
+
+
+def test_show_plugin_error_derives_name_from_plugin(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    # Installed-plugin shape: name() method returns the display name.
+    plugin = SimpleNamespace(name=lambda: "Derived Name", report_bugs_to='', homepage='')
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Plugin Error", "Failed to enable the plugin.", plugin=plugin)
+    assert 'Derived Name' in captured['text']
+
+
+def test_show_plugin_error_derives_name_from_get_display_name(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    # Installable/registry shape: get_display_name() is preferred.
+    plugin = SimpleNamespace(get_display_name=lambda: "Registry Name", report_bugs_to='', homepage='')
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Plugin Error", "Failed to install the plugin.", plugin=plugin)
+    assert 'Registry Name' in captured['text']
+
+
+def test_show_plugin_error_escapes_error_message(qapp, monkeypatch):
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    show_plugin_error(None, "Test", "context", error="<b>evil</b> & stuff", plugin=None)
+    # The raw error must be escaped, not injected as markup.
+    assert '<b>evil</b>' not in captured['text']
+    assert '&lt;b&gt;evil&lt;/b&gt;' in captured['text']
+    assert '&amp; stuff' in captured['text']
+
+
+def test_show_plugin_error_escapes_script_and_name(qapp, monkeypatch):
+    # A malicious plugin name and a hostile raw error must both be escaped.
+    captured = {}
+
+    def fake_exec(self):
+        captured['text'] = self.text()
+        return 0
+
+    monkeypatch.setattr('PyQt6.QtWidgets.QMessageBox.exec', fake_exec)
+    error = "boom <img src=x onerror=alert(2)>"
+    show_plugin_error(
+        None,
+        "Plugin Error",
+        "Failed to enable the plugin.",
+        error=error,
+        name='<script>alert(1)</script>',
+    )
+    text = captured['text']
+    # No raw tags survive.
+    assert '<script>' not in text
+    assert '<img' not in text
+    # They appear escaped instead.
+    assert '&lt;script&gt;alert(1)&lt;/script&gt;' in text
+    assert '&lt;img src=x onerror=alert(2)&gt;' in text


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Plugin error dialogs now show a "report this issue" link pointing at the plugin's own bug tracker (from its manifest/registry `report_bugs_to` or `homepage`), falling back to Picard's tracker, and separate the human-readable context from the raw error reported by the plugin.

## Problem

* JIRA ticket: PICARD-3431

When a plugin fails to install, enable, disable, update or uninstall, the failure is frequently caused by the plugin's own code (e.g. an import that no longer matches the current Picard API), not by Picard itself. The error dialogs showed only the raw exception text with no guidance on where to report it, and mixed the context and the raw error into a single line.


## Solution

<img width="528" height="276" alt="Capture d’écran du 2026-09-10 19-47-10" src="https://github.com/user-attachments/assets/f8d2c40a-d1ac-4bb4-b207-98dddef4ca33" />


* New shared helper `picard/ui/dialogs/plugin_error.py`:
  * `show_plugin_error(parent, title, message, error=None, plugin=None, name=None)` builds a critical dialog laid out as: `Plugin "<name>":` header, the context `message`, the raw `error` in its own monospace block, then a report link.
  * `plugin_report_link(plugin)` resolves the best URL: plugin `report_bugs_to` → plugin `homepage` → Picard bug tracker, returning whether it is plugin-specific so the wording differs.
  * The plugin name is derived from the plugin object (`get_display_name` / `name_i18n` / `name`), with an optional `name=` override.
  * All caller-supplied text (message, error, name) is HTML-escaped before being placed into the RichText body; link targets are restricted to `http(s)`/`mailto` schemes.
* Wired into the install, enable, disable, update and uninstall error dialogs.
* Added `report_bugs_to`/`homepage` accessors to `RegistryPlugin` (so an install failure can use the registry entry's info even before the plugin is on disk; this also fixes a latent gap where the Plugin Info dialog already tried to read these via `getattr`), a `homepage` accessor to `PluginManifest`, and a `bugtracker` entry to `PICARD_URLS`.
* The startup "Plugin Initialization Failed" aggregate dialog is intentionally left unchanged; enriching it (per-plugin report links) requires carrying the plugin/manifest through `_init_failed_plugins` and is tracked as a separate follow-up.

Adds `test/ui/test_plugin_error.py` covering link selection order, URL-scheme validation, name derivation from the different plugin shapes, the message/error separation, and HTML escaping of both the error and a malicious plugin name.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

The helper, wiring and tests were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
