### PR TITLE
PICARD-3433: Fix profile override highlight/warning inconsistency

### DIFF
--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -329,6 +329,49 @@ def enable(api):
 
 When a profile is active and overrides the option, reads from `api.plugin_config['greeting']` automatically return the profile value. Writes go to the profile's storage. The base (non-profile) value is preserved.
 
+**Two things are required for the option to appear in the Profiles editor:**
+
+1. Register it with `in_profile=True` and a `title` (as above).
+2. Surface it through an `OptionsPage` that lists it in its `OPTIONS` dict and
+   is registered with `api.register_options_page(...)`.
+
+Registering the option alone is not enough: an option is only added to the
+profile groups (the "Settings to include in profile" tree on the Option
+Profiles page) when a registered options page declares it. If your plugin
+registers a profile-eligible option but never exposes it on a registered
+options page, it will not show up in the profiles editor.
+
+```python
+from typing import ClassVar
+
+from picard.plugin3.api import OptionsPage, PageOptionConfigs
+
+
+class MyOptionsPage(OptionsPage):
+    NAME = 'my_plugin'
+    TITLE = 'My Plugin'
+    PARENT = 'plugins'
+    OPTIONS: ClassVar[PageOptionConfigs] = {
+        'greeting': {},
+    }
+
+    def load(self):
+        self.greeting_input.setText(self.api.plugin_config['greeting'])
+
+    def save(self):
+        self.api.plugin_config['greeting'] = self.greeting_input.text()
+
+
+def enable(api):
+    api.plugin_config.register_option(
+        'greeting',
+        'Hello World',
+        title='Greeting message',
+        in_profile=True,
+    )
+    api.register_options_page(MyOptionsPage)
+```
+
 #### Numeric bounds
 
 Numeric options (int or float defaults) can declare a valid range with

--- a/docs/PLUGINSV3/API.md
+++ b/docs/PLUGINSV3/API.md
@@ -352,7 +352,7 @@ class MyOptionsPage(OptionsPage):
     TITLE = 'My Plugin'
     PARENT = 'plugins'
     OPTIONS: ClassVar[PageOptionConfigs] = {
-        'greeting': {},
+        'greeting': {'widgets': ['greeting_input']},
     }
 
     def load(self):
@@ -418,7 +418,15 @@ class MyOptionsPage(OptionsPage):
 
 The widget will be highlighted in the options dialog when the option is tracked or overridden by an active profile.
 
-**Note:** Widget highlighting will only work if is accessed from the `OptionsPage` sub-class as `self.ui.{widget}` or `self.{widget}`. The above example would highlight the widget `self.ui.greeting_input` or `self.greeting_input`.
+Each key in `OPTIONS` is an option name; its `'widgets'` entry is a list of the
+widget attribute names on the page that edit that option. A widget name is
+resolved on the `OptionsPage` subclass instance, either via a loaded Qt Designer
+UI object (`self.ui.<name>`) or directly on the page (`self.<name>`). Listing
+more than one widget highlights all of them for the same option.
+
+**Note:** Highlighting only works when the widget is reachable from the
+`OptionsPage` subclass as `self.ui.<name>` or `self.<name>`. The example above
+highlights `self.ui.greeting_input` or `self.greeting_input`.
 
 **Behavior summary:**
 

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -46,6 +46,7 @@ from picard import (
 from picard.config import (
     Option,
     OptionError,
+    ProfileConfigSection,
     get_config,
 )
 from picard.debug_opts import DebugOpt
@@ -191,7 +192,12 @@ def profile_option_is_override(config, option_name, profile_value) -> bool:
     if is_plugin_profile_key(option_name):
         section, name = option_name.split('/', 1)
         opt = Option.get(section, name)
-        base_value = opt.default if opt else None
+        # Read the option's base (non-profile) value from its own plugin
+        # section, not just its default: a plugin may have a stored base value
+        # that differs from the default. no_profile() on config.setting also
+        # disables profile lookup for plugin sections.
+        with config.setting.no_profile():
+            base_value = ProfileConfigSection(config, section)[name]
     else:
         opt = Option.get('setting', option_name)
         with config.setting.no_profile():

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -581,7 +581,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def highlight_enabled_profile_options(self, load_settings=False):
         working_profiles, working_settings = self.get_working_profile_data()
-        bg_tracked = _interface_colors.get_color_css_rgba('profile_hl_bg', alpha=50)
+        bg_tracked = _interface_colors.get_color_css_rgba('profile_hl_bg', alpha=25)
         bg_override = _interface_colors.get_color_css_rgba('profile_hl_bg', alpha=120)
 
         for page in self.loaded_pages:

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -170,6 +170,41 @@ def _is_simple_value(value) -> bool:
     return isinstance(value, (str, int, float, bool))
 
 
+def profile_option_is_override(config, option_name, profile_value) -> bool:
+    """Return True if a profile setting actually overrides the base value.
+
+    A profile may *track* an option (the option key is present in the profile)
+    without changing its effective value.  This is the case when the profile
+    has no value set yet (``None``) or when the stored value is equal to the
+    current base (non-profile) value.  Only when the profile provides a simple
+    scalar value that differs from the base value does it truly *override* the
+    option.
+
+    Both the field highlighting (:meth:`OptionsDialog._check_and_highlight_option`)
+    and the page-level warning message (:meth:`OptionsDialog.update_profile_save_warning`)
+    rely on this single definition so that the two never disagree about what
+    counts as an override.
+    """
+    if profile_value is None:
+        # Tracked but no value set yet.
+        return False
+    if is_plugin_profile_key(option_name):
+        section, name = option_name.split('/', 1)
+        opt = Option.get(section, name)
+        base_value = opt.default if opt else None
+    else:
+        opt = Option.get('setting', option_name)
+        with config.setting.no_profile():
+            base_value = config.setting[option_name]
+    # Convert profile value to same type for comparison
+    if opt:
+        try:
+            profile_value = opt.convert(profile_value)
+        except (ValueError, TypeError):
+            pass
+    return _is_simple_value(profile_value) and profile_value != base_value
+
+
 class _PageScrollArea(QtWidgets.QScrollArea):
     """A scroll area for options pages that only scrolls when content truly
     cannot fit in the available viewport.
@@ -616,32 +651,12 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             if option_name not in profile_settings:
                 continue
             profile_value = profile_settings[option_name]
-            if profile_value is None:
-                # Tracked but no value set yet
+            if profile_option_is_override(config, option_name, profile_value):
+                tooltip_text = _("This option is overridden by profile: %s") % profile_title
+                obj.setStyleSheet(style_override)
+            else:
                 tooltip_text = _("This option is tracked by profile: %s") % profile_title
                 obj.setStyleSheet(style_tracked)
-            else:
-                # Check if value actually differs from base
-                if is_plugin_profile_key(option_name):
-                    section, name = option_name.split('/', 1)
-                    opt = Option.get(section, name)
-                    base_value = opt.default if opt else None
-                else:
-                    opt = Option.get('setting', option_name)
-                    with config.setting.no_profile():
-                        base_value = config.setting[option_name]
-                # Convert profile value to same type for comparison
-                if opt:
-                    try:
-                        profile_value = opt.convert(profile_value)
-                    except (ValueError, TypeError):
-                        pass
-                if _is_simple_value(profile_value) and profile_value != base_value:
-                    tooltip_text = _("This option is overridden by profile: %s") % profile_title
-                    obj.setStyleSheet(style_override)
-                else:
-                    tooltip_text = _("This option is tracked by profile: %s") % profile_title
-                    obj.setStyleSheet(style_tracked)
             # Append to existing tooltip if not already present
             if obj in seen_widgets:
                 break
@@ -700,11 +715,14 @@ class OptionsDialog(PicardDialog, SingletonDialog):
 
     def update_profile_save_warning(self, page):
         working_profiles, working_settings = self.get_working_profile_data()
-        profile_set = set()
+        config = get_config()
+        override_set = set()
+        tracked_set = set()
 
         option_group = profile_groups_group_from_page(page)
         if option_group:
             for opt in option_group['settings']:
+                option_name = setting_profile_key(opt.name, opt.section)
                 for idx, item in enumerate(working_profiles):
                     if not item['enabled']:
                         continue
@@ -712,10 +730,25 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                     if profile_id not in working_settings:
                         continue
                     profile_settings = working_settings[profile_id]
-                    if setting_profile_key(opt.name, opt.section) in profile_settings:
-                        profile_set.add((idx, item['title']))
+                    if option_name not in profile_settings:
+                        continue
+                    profile_value = profile_settings[option_name]
+                    key = (idx, item['title'])
+                    if profile_option_is_override(config, option_name, profile_value):
+                        override_set.add(key)
+                    else:
+                        tracked_set.add(key)
 
-        if not profile_set:
+        # Only profiles that actually override a value (not merely track it)
+        # drive the warning, so the message stays consistent with the field
+        # highlighting.
+        if override_set:
+            profile_set = override_set
+            overridden = True
+        elif tracked_set:
+            profile_set = tracked_set
+            overridden = False
+        else:
             self.ui.profile_warning.setVisible(False)
             return
 
@@ -726,10 +759,16 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             names = ', '.join([f'"{p[1]}"' for p in sorted_profiles[:3]]) + ', …'
 
         has_highlights = option_group and any(opt.highlights for opt in option_group['settings'])
-        if has_highlights:
-            msg = _('The highlighted settings on this page are overridden by %s') % names
+        if overridden:
+            if has_highlights:
+                msg = _('The highlighted settings on this page are overridden by %s') % names
+            else:
+                msg = _('Some settings on this page are overridden by %s') % names
         else:
-            msg = _('Some settings on this page are overridden by %s') % names
+            if has_highlights:
+                msg = _('The highlighted settings on this page are tracked by %s') % names
+            else:
+                msg = _('Some settings on this page are tracked by %s') % names
         self.profile_warning_text.setText(msg)
         self.ui.profile_warning.setVisible(True)
 

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -189,19 +189,24 @@ def profile_option_is_override(config, option_name, profile_value) -> bool:
     if profile_value is None:
         # Tracked but no value set yet.
         return False
+
+    # Determine the section and the config section object to read the base
+    # (non-profile) value from. Plugin options live in their own
+    # 'plugin.<uuid>' section; core options live in 'setting'.
     if is_plugin_profile_key(option_name):
-        section, name = option_name.split('/', 1)
-        opt = Option.get(section, name)
-        # Read the option's base (non-profile) value from its own plugin
-        # section, not just its default: a plugin may have a stored base value
-        # that differs from the default. no_profile() on config.setting also
-        # disables profile lookup for plugin sections.
-        with config.setting.no_profile():
-            base_value = ProfileConfigSection(config, section)[name]
+        section_name, name = option_name.split('/', 1)
+        config_section = ProfileConfigSection(config, section_name)
     else:
-        opt = Option.get('setting', option_name)
-        with config.setting.no_profile():
-            base_value = config.setting[option_name]
+        section_name, name = 'setting', option_name
+        config_section = config.setting
+
+    opt = Option.get(section_name, name)
+    # no_profile() on config.setting disables profile lookup globally, including
+    # for ProfileConfigSection instances (they read the active profiles/override
+    # from config.setting), so it yields the base value for both cases.
+    with config.setting.no_profile():
+        base_value = config_section[name]
+
     # Convert profile value to same type for comparison
     if opt:
         try:

--- a/test/ui/test_options_profile_override.py
+++ b/test/ui/test_options_profile_override.py
@@ -23,6 +23,7 @@ from test.picardtestcase import PicardTestCase
 from picard.config import (
     Config,
     Option,
+    ProfileConfigSection,
     TextOption,
 )
 
@@ -78,3 +79,21 @@ class TestProfileOptionIsOverride(PicardTestCase):
         # A string profile value equal to the base after conversion is tracked.
         TextOption('setting', 'server_host', 'musicbrainz.org', in_profile=True)
         self.assertFalse(profile_option_is_override(self.config, 'server_host', 'musicbrainz.org'))
+
+    def test_plugin_key_uses_stored_base_not_default(self):
+        # A plugin option whose stored base value differs from its default.
+        # A profile tracking it with a value equal to the stored base value
+        # must be classified as tracked, NOT overridden. Regression: the base
+        # value was previously read from opt.default only.
+        TextOption('plugin.abc', 'greeting', 'default_value', in_profile=True)
+        section = ProfileConfigSection(self.config, 'plugin.abc')
+        with self.config.setting.no_profile():
+            section['greeting'] = 'base_value'
+
+        key = 'plugin.abc/greeting'
+        # Equal to the stored base value -> tracked
+        self.assertFalse(profile_option_is_override(self.config, key, 'base_value'))
+        # Equal to the default but different from the stored base -> override
+        self.assertTrue(profile_option_is_override(self.config, key, 'default_value'))
+        # Different from both -> override
+        self.assertTrue(profile_option_is_override(self.config, key, 'other_value'))

--- a/test/ui/test_options_profile_override.py
+++ b/test/ui/test_options_profile_override.py
@@ -1,0 +1,80 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+import os
+import shutil
+
+from test.picardtestcase import PicardTestCase
+
+from picard.config import (
+    Config,
+    Option,
+    TextOption,
+)
+
+from picard.ui.options.dialog import profile_option_is_override
+
+
+class TestProfileOptionIsOverride(PicardTestCase):
+    """The field highlighting and the page-level warning message must share a
+    single definition of what counts as a profile *override* (value differs
+    from base) versus merely *tracked* (present but not changing the value).
+
+    See PICARD: the server address field was highlighted as "overridden" only
+    "sometimes", contradicting the bottom-of-page warning which always claimed
+    an override.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_directory = self.mktmpdir()
+        self.configpath = os.path.join(self.tmp_directory, 'test.ini')
+        shutil.copy(os.path.join('test', 'data', 'test.ini'), self.configpath)
+        self.addCleanup(os.remove, self.configpath)
+        self.config = Config.from_file(None, self.configpath)
+        self.addCleanup(self.cleanup_config_obj)
+        self.old_registry = dict(Option.registry)
+        Option.registry = {}
+        self.addCleanup(self.restore_registry)
+
+        TextOption('setting', 'server_host', 'musicbrainz.org', in_profile=True)
+        with self.config.setting.no_profile():
+            self.config.setting['server_host'] = 'musicbrainz.org'
+
+    def restore_registry(self):
+        Option.registry = self.old_registry
+
+    def cleanup_config_obj(self):
+        self.config.sync()
+        self.config = None
+
+    def test_none_value_is_tracked_not_override(self):
+        # Tracked with no value set yet is never an override.
+        self.assertFalse(profile_option_is_override(self.config, 'server_host', None))
+
+    def test_value_equal_to_base_is_tracked_not_override(self):
+        # This is the "sometimes" case: the profile tracks the option but its
+        # stored value equals the base value, so it must NOT count as override.
+        self.assertFalse(profile_option_is_override(self.config, 'server_host', 'musicbrainz.org'))
+
+    def test_value_differing_from_base_is_override(self):
+        self.assertTrue(profile_option_is_override(self.config, 'server_host', 'beta.musicbrainz.org'))
+
+    def test_value_type_conversion_before_compare(self):
+        # A string profile value equal to the base after conversion is tracked.
+        TextOption('setting', 'server_host', 'musicbrainz.org', in_profile=True)
+        self.assertFalse(profile_option_is_override(self.config, 'server_host', 'musicbrainz.org'))


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: The Options dialog field highlight and the bottom-of-page warning used different definitions of "overridden", so a field (e.g. the server address) was only "sometimes" highlighted as overridden while the warning always claimed an override. This makes the two consistent.

## Problem

* JIRA ticket: PICARD-3433

In the Options dialog, when an enabled profile tracks an option (for example the server address on the General page), the field highlight and the warning message at the bottom of the page can contradict each other.

The field is highlighted as "overridden" only when the profile's stored value actually differs from the base (global) value. When the profile tracks the option but its value equals the base value, the field gets the lighter "tracked" highlight instead. The bottom warning, however, always said the settings are "overridden" as long as the option was present in an enabled profile, regardless of the value. As a result the field was only "sometimes" highlighted as overridden, contradicting the message shown at the bottom of the page.

## Solution

* Extracted the tracked-vs-overridden classification into a single shared helper, `profile_option_is_override(config, option_name, profile_value)`, in `picard/ui/options/dialog.py`.
* `_check_and_highlight_option()` now uses this helper for the field background/tooltip.
* `update_profile_save_warning()` uses the same helper, so the bottom message only reports "overridden" for profiles that actually change a value. When profiles only track options without changing their value, it now shows a distinct "tracked" message instead.
* Added a regression test (`test/ui/test_options_profile_override.py`) covering the None, value-equals-base (the previously inconsistent case), value-differs, and type-conversion cases.

Verification: `ruff format`/`ruff check` clean; `ty check` introduces no new errors; full `test/ui/`, `test/test_config.py`, and `test/test_profiles.py` suites pass.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to locate the inconsistent code paths, implement the shared helper refactor, and develop the regression test. Changes were reviewed and verified by running the test suite and linters.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
