### PR TITLE
PICARD-3432: Bundle picard.plugin3.cli in frozen builds

### DIFF
--- a/picard.spec
+++ b/picard.spec
@@ -94,6 +94,9 @@ if build_portable:
 hiddenimports = [
     'cffi',  # Needed for pygit2
     'dataclasses',  # Provide dataclasses support for plugins
+    # Used by plugins (e.g. "Create Local Plugin"), but not otherwise
+    # referenced, so PyInstaller would not bundle it (PICARD-3432).
+    'picard.plugin3.cli',
 ]
 
 if has_module('opencc'):


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Frozen (PyInstaller) builds did not bundle `picard.plugin3.cli`, so plugins that import it (e.g. "Create Local Plugin") failed at runtime with `No module named 'picard.plugin3.cli'`. This adds it to the spec's `hiddenimports`.

## Problem

* JIRA ticket: PICARD-3432

Plugins may legitimately import from `picard.plugin3.cli` (for example the "Create Local Plugin" plugin does `from picard.plugin3.cli import ExitCode, PluginCLI` at module level). In a packaged (PyInstaller) build this import fails at runtime with `No module named 'picard.plugin3.cli'`.

Because installing a plugin from the GUI enables it right after install (`enable_after_install=True`), the plugin's module is imported during installation, so the failure surfaces in an "Installation Failed" dialog. It can also surface later as a "Plugin Error" when enabling an already-installed plugin. The error only occurs in frozen/packaged builds; running from source is unaffected because `picard.plugin3.cli` is always importable there.

Root cause: within Picard, `picard.plugin3.cli` is referenced in exactly one place — an inline (lazy) import inside `picard/cli/plugins.py:_run_plugins()`, which lives on the `picard-cli` entry path, not the GUI (`tagger.py`) path. That inline import is intentional (lazy-loading the heavy plugin3 + git stack, and allowing graceful `ImportError` handling of the git backend), but it means the module never enters the GUI executable's import graph, so PyInstaller does not bundle it. This is the documented "hidden import" situation: <https://pyinstaller.org/en/stable/when-things-go-wrong.html#listing-hidden-imports>

## Solution

Add `picard.plugin3.cli` to `hiddenimports` in `picard.spec`.

Audit of the rest of the `picard.plugin3` public API (as suggested in the ticket): I checked which `picard.plugin3.*` modules are reachable from the GUI entry point via module-level imports (what PyInstaller follows), ignoring function-body/`TYPE_CHECKING` imports. Findings:

* Without any fix, four modules were unreachable: `picard.plugin3.cli`, `init_templates`, `output`, `project_config`.
* `picard.plugin3.cli` imports `init_templates`, `output`, and `project_config` at module level, so the single hidden import above transitively bundles those three as well.
* `picard.plugin3.asyncops.*` is already reachable from GUI modules (`picard/ui/options/plugins.py`, `pluginlistwidget.py`, `plugindetailswidget.py`, `dialogs/installplugin.py`); the package `__init__` is covered because its submodules are imported.
* `picard.plugin3.api`, `categories`, `constants`, and the remaining modules are already reachable at module level.

Conclusion: the single `hiddenimports` entry is sufficient to make the entire `picard.plugin3` public API available in frozen builds; no further entries are required. This affects packaged builds only.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

AI was used to trace the import graph, identify the root cause, and audit the plugin3 API reachability. The audit was performed with a static module-level import analysis; results were verified against the codebase.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
