### PR TITLE
PICARD-3435: Add "Convert Unicode punctuation to ASCII" question to setup wizard

### DIFF
--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -454,6 +454,19 @@ class MetadataPage(SetupWizardPage):
         )
         layout.addWidget(self.track_ars_checkbox)
 
+        self.convert_punctuation_checkbox = WizardCheckbox(
+            _("Convert Unicode punctuation to ASCII"),
+            _(
+                "Replace typographic Unicode punctuation with plain ASCII equivalents "
+                "in tags — mainly curly apostrophes (\N{RIGHT SINGLE QUOTATION MARK}) "
+                "become straight single quotes ('). Curly double quotes "
+                "(\N{LEFT DOUBLE QUOTATION MARK}\N{RIGHT DOUBLE QUOTATION MARK}) become "
+                "straight quotes (\"), and dashes (\N{EM DASH}) become hyphens (-).\n\n"
+                "Useful if your player or file system does not handle these characters well."
+            ),
+        )
+        layout.addWidget(self.convert_punctuation_checkbox)
+
         layout.addStretch()
         hint = QtWidgets.QLabel(
             _("You can change this later under Options \N{RIGHTWARDS ARROW} Options \N{RIGHTWARDS ARROW} Metadata.")
@@ -464,9 +477,11 @@ class MetadataPage(SetupWizardPage):
     def initializePage(self) -> None:
         config = get_config()
         self.track_ars_checkbox.set_checked(config.setting['track_ars'])
+        self.convert_punctuation_checkbox.set_checked(config.setting['convert_punctuation'])
 
     def save_settings(self, config: Config) -> None:
         config.setting['track_ars'] = self.track_ars_checkbox.is_checked()
+        config.setting['convert_punctuation'] = self.convert_punctuation_checkbox.is_checked()
 
 
 class SetupWizard(QtWidgets.QWizard):

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -460,7 +460,7 @@ class MetadataPage(SetupWizardPage):
                 "Replace typographic Unicode punctuation with plain ASCII equivalents "
                 "in tags — mainly curly apostrophes (\N{RIGHT SINGLE QUOTATION MARK}) "
                 "become straight single quotes ('). Curly double quotes "
-                "(\N{LEFT DOUBLE QUOTATION MARK}\N{RIGHT DOUBLE QUOTATION MARK}) become "
+                "(\N{LEFT DOUBLE QUOTATION MARK} and \N{RIGHT DOUBLE QUOTATION MARK}) become "
                 "straight quotes (\"), and dashes (\N{EM DASH}) become hyphens (-).\n\n"
                 "Useful if your player or file system does not handle these characters well."
             ),

--- a/test/ui/test_setupwizard.py
+++ b/test/ui/test_setupwizard.py
@@ -47,3 +47,23 @@ class TestSetupWizardMetadataPage(PicardTestCase):
             self.assertEqual(config.setting['track_ars'], not initial)
         finally:
             page.deleteLater()
+
+    def test_convert_punctuation_reflects_config_disabled(self, *args):
+        self._check_convert_punctuation_roundtrip(initial=False)
+
+    def test_convert_punctuation_reflects_config_enabled(self, *args):
+        self._check_convert_punctuation_roundtrip(initial=True)
+
+    def _check_convert_punctuation_roundtrip(self, initial):
+        self.set_config_values(setting={'convert_punctuation': initial})
+        config = get_config()
+        page = MetadataPage()
+        try:
+            page.initializePage()
+            self.assertEqual(page.convert_punctuation_checkbox.is_checked(), initial)
+
+            page.convert_punctuation_checkbox.set_checked(not initial)
+            page.save_settings(config)
+            self.assertEqual(config.setting['convert_punctuation'], not initial)
+        finally:
+            page.deleteLater()


### PR DESCRIPTION
## Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Add a "Convert Unicode punctuation to ASCII" question to the first-run setup wizard, wired to the existing `convert_punctuation` setting.

## Problem

* JIRA ticket: PICARD-3435

Curly/typographic apostrophes and quotes from the MusicBrainz database are a recurring source of player/tool compatibility complaints. The long-standing community advice is to enable the existing "Convert Unicode punctuation to ASCII" metadata option, but new users only discover it after their tags (and filenames derived from them) already contain characters their player mishandles. The setup wizard does not currently expose this option.

## Solution

Add a checkbox to the wizard's "Additional Metadata" page, initialized from and saved to `convert_punctuation`:

- When enabled, typographic Unicode punctuation in tags is replaced with ASCII equivalents — mainly curly apostrophes (’) → straight single quotes ('), plus curly double quotes (“”) → straight quotes (") and dashes (—) → hyphens (-).
- Off by default (matching the current default); still changeable later under Options → Options → Metadata.
- Because it converts the metadata itself, the change also flows through to filenames generated from the tags.

The separate "Replace non-ASCII characters" option (`ascii_filenames`) is intentionally not added: it is a filename-only, lossy transliteration (strips Cyrillic/CJK, etc.) that is often best left disabled, and is a poor fit for a first-run wizard. It remains under Options → File Naming → Compatibility.

Includes roundtrip tests mirroring the existing `track_ars` wizard coverage.

<img width="660" height="550" alt="image" src="https://github.com/user-attachments/assets/67e7ee1f-f39b-4f88-be75-6d66f4c74540" />

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
