### PR TITLE
PICARD-3436: Highlight profile options on lazily-loaded pages

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -585,56 +585,67 @@ class OptionsDialog(PicardDialog, SingletonDialog):
         return working_profiles, working_settings
 
     def highlight_enabled_profile_options(self, load_settings=False):
+        for page in self.loaded_pages:
+            self._highlight_page_options(page, load_settings=load_settings)
+
+    def _highlight_page_options(self, page, load_settings=False):
+        """Apply profile highlighting to the widgets of a single loaded page.
+
+        This is called both for every loaded page from
+        :meth:`highlight_enabled_profile_options` and individually from
+        :meth:`switch_page` so that pages loaded lazily (on first visit) get
+        their highlights applied even though they were not loaded when the
+        dialog was first shown.
+        """
+        option_group = profile_groups_group_from_page(page)
+        if not option_group:
+            return
+        if load_settings:
+            page.load()
         working_profiles, working_settings = self.get_working_profile_data()
         bg_tracked = _interface_colors.get_color_css_rgba('profile_hl_bg', alpha=25)
         bg_override = _interface_colors.get_color_css_rgba('profile_hl_bg', alpha=120)
-
-        for page in self.loaded_pages:
-            option_group = profile_groups_group_from_page(page)
-            if option_group:
-                if load_settings:
-                    page.load()
-                seen_widgets = set()
-                for opt in option_group['settings']:
-                    for objname in opt.highlights:
-                        try:
-                            obj = getattr(page.ui, objname)
-                        except AttributeError:
-                            try:
-                                obj = getattr(page, objname)
-                            except AttributeError:
-                                log.warning(
-                                    "Option '%s' references widget '%s' not found on page '%s'",
-                                    opt.name,
-                                    objname,
-                                    page.NAME,
-                                )
-                                continue
-                        if not isinstance(obj, QtWidgets.QWidget):
-                            log.warning(
-                                "Option '%s' references widget '%s', expected QWidget, found '%s' on page '%s'",
-                                opt.name,
-                                objname,
-                                obj.__class__.__name__,
-                                page.NAME,
-                            )
-                            continue
-                        # Skip list/tree views - stylesheets break checkable item rendering
-                        if isinstance(obj, QtWidgets.QAbstractItemView):
-                            continue
-                        style_override = "#%s { background-color: %s; }" % (objname, bg_override)
-                        style_tracked = "#%s { background-color: %s; }" % (objname, bg_tracked)
-                        style_reset = "#%s { }" % (objname)
-                        self._check_and_highlight_option(
-                            obj,
-                            setting_profile_key(opt.name, opt.section),
-                            working_profiles,
-                            working_settings,
-                            style_override,
-                            style_tracked,
-                            style_reset,
-                            seen_widgets,
+        seen_widgets = set()
+        for opt in option_group['settings']:
+            for objname in opt.highlights:
+                try:
+                    obj = getattr(page.ui, objname)
+                except AttributeError:
+                    try:
+                        obj = getattr(page, objname)
+                    except AttributeError:
+                        log.warning(
+                            "Option '%s' references widget '%s' not found on page '%s'",
+                            opt.name,
+                            objname,
+                            page.NAME,
                         )
+                        continue
+                if not isinstance(obj, QtWidgets.QWidget):
+                    log.warning(
+                        "Option '%s' references widget '%s', expected QWidget, found '%s' on page '%s'",
+                        opt.name,
+                        objname,
+                        obj.__class__.__name__,
+                        page.NAME,
+                    )
+                    continue
+                # Skip list/tree views - stylesheets break checkable item rendering
+                if isinstance(obj, QtWidgets.QAbstractItemView):
+                    continue
+                style_override = "#%s { background-color: %s; }" % (objname, bg_override)
+                style_tracked = "#%s { background-color: %s; }" % (objname, bg_tracked)
+                style_reset = "#%s { }" % (objname)
+                self._check_and_highlight_option(
+                    obj,
+                    setting_profile_key(opt.name, opt.section),
+                    working_profiles,
+                    working_settings,
+                    style_override,
+                    style_tracked,
+                    style_reset,
+                    seen_widgets,
+                )
 
     def _check_and_highlight_option(
         self,
@@ -791,6 +802,11 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             self.set_profiles_button_and_highlight(page)
             self.ui.reset_button.setDisabled(not page.loaded)
             self._show_page(page)
+            # Pages are loaded lazily on first visit, so a page shown after the
+            # dialog's initial highlight pass would otherwise never get its
+            # per-widget profile highlights applied. Highlight it now.
+            if page.loaded:
+                self._highlight_page_options(page)
             config = get_config()
             log.debug("switch_page: Saving page '%s' to options_last_active_page", page.NAME)
             config.persist['options_last_active_page'] = page.NAME

--- a/test/ui/test_options_profile_highlight_lazy.py
+++ b/test/ui/test_options_profile_highlight_lazy.py
@@ -1,0 +1,70 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import MagicMock
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.options.dialog import OptionsDialog
+
+
+class TestSwitchPageHighlightsLazyPages(PicardTestCase):
+    """PICARD-3436: options pages are instantiated/loaded lazily on first visit.
+
+    The initial profile-highlight pass runs once from ``showEvent`` and only
+    covers pages already loaded at that moment. A page displayed later via
+    ``switch_page`` must therefore have its per-widget highlights applied when
+    it is first shown, otherwise overridden settings appear highlighted only on
+    the page that happened to be active when the dialog opened.
+
+    These tests exercise ``OptionsDialog.switch_page`` as an unbound method
+    against a lightweight stub so the full dialog widget does not need to be
+    constructed.
+    """
+
+    def _make_dialog_stub(self, loaded=True):
+        dialog = MagicMock()
+        page = MagicMock()
+        page.NAME = 'metadata'
+        page.loaded = loaded
+        item = MagicMock()
+        dialog.ui.pages_tree.selectedItems.return_value = [item]
+        dialog.item_to_page = {item: MagicMock(NAME='metadata')}
+        dialog._load_page.return_value = page
+        # Use the real method under test rather than the mock's auto-attr.
+        dialog._highlight_page_options = MagicMock()
+        return dialog, page
+
+    def test_switch_page_highlights_loaded_page(self):
+        dialog, page = self._make_dialog_stub(loaded=True)
+        OptionsDialog.switch_page(dialog)
+        dialog._highlight_page_options.assert_called_once_with(page)
+
+    def test_switch_page_does_not_highlight_unloaded_page(self):
+        # A page that failed to load must not be highlighted (its widgets are
+        # not populated); highlighting is deferred until it is actually loaded.
+        dialog, page = self._make_dialog_stub(loaded=False)
+        OptionsDialog.switch_page(dialog)
+        dialog._highlight_page_options.assert_not_called()
+
+    def test_switch_page_no_selection_is_noop(self):
+        dialog = MagicMock()
+        dialog.ui.pages_tree.selectedItems.return_value = []
+        dialog._highlight_page_options = MagicMock()
+        OptionsDialog.switch_page(dialog)
+        dialog._highlight_page_options.assert_not_called()
+        dialog._load_page.assert_not_called()


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Profile-overridden settings were highlighted only on the Options page that was active when the dialog opened. They are now highlighted on every page as soon as it is displayed.

## Problem

* JIRA ticket (_optional_): PICARD-3436

Options pages are loaded lazily on first visit. The profile-highlight pass runs once from `showEvent()` and only covers pages already loaded at that moment (the initially shown page plus `maintenance` and `profiles`). Switching to another category loaded the page and refreshed the warning banner but never applied the per-widget field highlighting, so overridden settings appeared highlighted only on the first-shown page.

## Solution

Extract the per-page highlighting into `_highlight_page_options()` and call it from `switch_page()` after a page is loaded and shown, so pages displayed after the initial highlight pass get their highlights on first visit. Adds regression tests that exercise `switch_page` (verified failing without the fix).

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Root-cause investigation, the fix, and the regression tests were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
