### PR TITLE
PICARD-3437: Enable tagger scripts when importing profiles with scripts

### DIFF
--- a/docs/ShareableProfiles.md
+++ b/docs/ShareableProfiles.md
@@ -399,9 +399,16 @@ Imported scripts default to enabled if the field is absent.
 `enable_tagger_scripts` is a per-profile boolean that gates *all* tagger script processing for that profile. It is distinct from the per-script `enabled` flag: even if individual scripts are enabled, none of them run while the master toggle is off. Because it is a script-related option it is never written to `[settings]`; it is handled alongside the scripts:
 
 - Backup mode: the exact value is written as `enable_tagger_scripts` under the `[scripts]` table so a restore reproduces the author's configuration faithfully. A tracked-but-unset (`None`) toggle is skipped, consistent with the handling of other `None`-valued settings.
-- Share mode: the toggle is deliberately omitted from the file. On import, tagger scripts are always enabled when `[[scripts.tagging]]` entries are present. This prevents a shared profile from carrying the author's incidental local on/off state and silently disabling tagger scripting on the recipient's machine (the master toggle is an override, so a `false` value would force the recipient's scripts off, not merely leave them as-is). A profile shared with scripts is meant to have those scripts run, so the "enabled" intent is implied by the presence of the scripts rather than stored as a separate flag.
+- Share mode: the toggle is deliberately omitted from the file. This prevents a shared profile from carrying the author's incidental local on/off state and silently disabling tagger scripting on the recipient's machine (the master toggle is an override, so a `false` value would force the recipient's scripts off, not merely leave them as-is).
 
-On import, an explicit `enable_tagger_scripts` value under `[scripts]` (backup export) is always honored; when it is absent (share export), the toggle is enabled only if at least one new script was actually imported, so a duplicate-only re-import makes no change.
+On import, an explicit `enable_tagger_scripts` value under `[scripts]` (backup export) is always honored silently — a backup is a faithful restore of the user's own configuration.
+
+When the value is absent (share export) and the imported profile contains at least one enabled tagger script, tagger scripting is **never enabled silently**. Instead the user is asked what to do:
+
+- In the GUI, an "Enable Tagger Scripts?" dialog lists the imported scripts (each pre-checked according to its authored `enabled` flag). Accepting with at least one script checked enables `enable_tagger_scripts` for the profile and applies the per-script selection; unchecking everything or cancelling imports the scripts but leaves tagger scripting disabled.
+- In the CLI (`picard-cli profiles import`), the user is prompted the same way. `--yes` enables without prompting; `--no-enable-tagger-scripts` imports the scripts without enabling.
+
+If no imported script is enabled (only possible in backup exports, since share mode omits disabled scripts), there is nothing to run and no prompt is shown. A duplicate-only re-import imports no new scripts and makes no change.
 
 #### `[plugins.<uuid>]` — Plugin Option Overrides (optional)
 
@@ -437,8 +444,9 @@ sections for uninstalled plugins are skipped with a warning.
    - Append to the profile's `list_of_scripts` override
    - Respect the `enabled` field if present (default: `true`)
    - Set the `enable_tagger_scripts` master toggle: honor an explicit value
-     under `[scripts]` (backup export) if present, otherwise enable it (share
-     export) so the imported scripts actually run
+     under `[scripts]` (backup export) silently; when absent (share export) and
+     at least one imported script is enabled, ask the user whether to enable
+     tagger scripting (GUI dialog / CLI prompt) rather than enabling silently
 6. If `[plugins.*]` sections exist:
    - For each plugin UUID, check if the plugin is installed
    - If installed: apply settings as profile overrides (keyed as

--- a/docs/ShareableProfiles.md
+++ b/docs/ShareableProfiles.md
@@ -394,6 +394,15 @@ In share mode: only enabled scripts are exported (no `enabled` field written).
 In backup mode: all scripts are exported with an explicit `enabled` field.
 Imported scripts default to enabled if the field is absent.
 
+##### The `enable_tagger_scripts` master toggle
+
+`enable_tagger_scripts` is a per-profile boolean that gates *all* tagger script processing for that profile. It is distinct from the per-script `enabled` flag: even if individual scripts are enabled, none of them run while the master toggle is off. Because it is a script-related option it is never written to `[settings]`; it is handled alongside the scripts:
+
+- Backup mode: the exact value is written as `enable_tagger_scripts` under the `[scripts]` table so a restore reproduces the author's configuration faithfully. A tracked-but-unset (`None`) toggle is skipped, consistent with the handling of other `None`-valued settings.
+- Share mode: the toggle is deliberately omitted from the file. On import, tagger scripts are always enabled when `[[scripts.tagging]]` entries are present. This prevents a shared profile from carrying the author's incidental local on/off state and silently disabling tagger scripting on the recipient's machine (the master toggle is an override, so a `false` value would force the recipient's scripts off, not merely leave them as-is). A profile shared with scripts is meant to have those scripts run, so the "enabled" intent is implied by the presence of the scripts rather than stored as a separate flag.
+
+On import, an explicit `enable_tagger_scripts` value under `[scripts]` (backup export) is always honored; when it is absent (share export), the toggle is enabled only if at least one new script was actually imported, so a duplicate-only re-import makes no change.
+
 #### `[plugins.<uuid>]` — Plugin Option Overrides (optional)
 
 Each plugin with overridden options gets its own sub-table keyed by UUID:
@@ -427,7 +436,9 @@ sections for uninstalled plugins are skipped with a warning.
 5. If `[[scripts.tagging]]` entries exist:
    - Append to the profile's `list_of_scripts` override
    - Respect the `enabled` field if present (default: `true`)
-   - Set `enable_tagger_scripts = true` in the profile
+   - Set the `enable_tagger_scripts` master toggle: honor an explicit value
+     under `[scripts]` (backup export) if present, otherwise enable it (share
+     export) so the imported scripts actually run
 6. If `[plugins.*]` sections exist:
    - For each plugin UUID, check if the plugin is installed
    - If installed: apply settings as profile overrides (keyed as
@@ -488,10 +499,11 @@ framework design.
    referenced script into `[scripts.naming]` (unless it's a built-in preset,
    in which case keep the ID in `[settings]` and omit `[scripts.naming]`)
 6. If `list_of_scripts` is overridden:
-   - **Share mode:** embed only **enabled** scripts into `[[scripts.tagging]]`
-   - **Backup mode:** embed **all** scripts with an explicit `enabled` field
-7. Remove `active_file_naming_script_id` and `list_of_scripts` from `[settings]`
-   (they're represented in `[scripts]` instead)
+   - **Share mode:** embed only **enabled** scripts into `[[scripts.tagging]]`, and omit the `enable_tagger_scripts` master toggle (import re-enables it)
+   - **Backup mode:** embed **all** scripts with an explicit `enabled` field, and write the `enable_tagger_scripts` master toggle under `[scripts]` to preserve the exact state (a `None`/unset toggle is skipped)
+7. Remove `active_file_naming_script_id`, `list_of_scripts`, and
+   `enable_tagger_scripts` from `[settings]` (they're represented in `[scripts]`
+   instead)
 8. If plugin options are present, resolve plugin names from installed plugins
    and populate `required_plugins` in `[profile]` metadata
 9. Write TOML using `tomlkit` (preserves multiline strings, allows adding comments)

--- a/picard/cli/profiles.py
+++ b/picard/cli/profiles.py
@@ -117,11 +117,18 @@ def setup_parser(profiles_parser):
     p_import.add_argument('file', metavar='FILE', help="TOML file to import")
     p_import.add_argument('--enable', action='store_true', help="enable the profile after import")
     p_import.add_argument(
+        '--no-enable-tagger-scripts',
+        dest='enable_tagger_scripts',
+        action='store_false',
+        help="import tagger scripts from a shared profile without enabling tagger scripting "
+        "(otherwise you are prompted; use --yes to enable without prompting)",
+    )
+    p_import.add_argument(
         '--replace',
         metavar='TITLE_OR_ID',
         help="replace an existing profile (match by title or UUID, partial allowed)",
     )
-    p_import.set_defaults(run_command=_run_profiles)
+    p_import.set_defaults(run_command=_run_profiles, enable_tagger_scripts=True)
 
 
 def cmd_list(output):
@@ -229,10 +236,54 @@ def cmd_import(args, output):
         for warning in result.warnings:
             output.warning(warning)
 
+    # A shared profile carrying enabled tagger scripts does not enable tagger
+    # scripting silently. Match the GUI: ask the user. --no-enable-tagger-
+    # scripts forces "import without enabling" non-interactively; --yes
+    # auto-confirms enabling.
+    if result.tagger_scripts_enable_pending:
+        _apply_cli_tagger_scripts_decision(config, result, args, output)
+
     # Save config to persist the imported profile
     config.sync()
 
     return ExitCode.SUCCESS
+
+
+def _apply_cli_tagger_scripts_decision(config, result, args, output):
+    """Decide and apply whether to enable tagger scripting for a CLI import.
+
+    The importer leaves enable_tagger_scripts undecided for shared profiles
+    with enabled scripts. Resolution order:
+    - ``--no-enable-tagger-scripts`` (args.enable_tagger_scripts is False):
+      import without enabling, no prompt.
+    - ``--yes``: enable without prompting.
+    - otherwise: list the scripts and ask.
+    """
+    count = len(result.pending_tagger_scripts)
+
+    if not args.enable_tagger_scripts:
+        enable = False
+    elif getattr(args, 'yes', False):
+        enable = True
+    else:
+        output.warning(
+            f"The imported profile contains {count} enabled tagger script(s)."
+            " Tagger scripting is currently disabled for this profile:"
+        )
+        for _pos, name, _enabled, _content in result.pending_tagger_scripts:
+            output.print(f"  - {output.d_name(name)}")
+        enable = output.yesno("Enable tagger scripting for this profile?")
+
+    all_settings = config.profiles['user_profile_settings']
+    settings = all_settings.get(result.profile_id, {})
+    settings['enable_tagger_scripts'] = enable
+    all_settings[result.profile_id] = settings
+    config.profiles['user_profile_settings'] = all_settings
+
+    if enable:
+        output.success(f"Tagger scripting enabled for this profile ({count} script(s)).")
+    else:
+        output.print("Tagger scripting left disabled for this profile.")
 
 
 def _run_profiles(args):

--- a/picard/profiles/exporter.py
+++ b/picard/profiles/exporter.py
@@ -208,6 +208,16 @@ def _export_scripts(doc, config, profile_settings, mode):
                     doc.add('scripts', scripts_container)
             doc['scripts'].add('tagging', tagging_array)
 
+            # In backup mode, preserve the master "enable tagger scripts" toggle
+            # so a restore faithfully reproduces the original state. In share
+            # mode the toggle is intentionally omitted: the importer always
+            # enables tagger scripts when scripts are present, so shared scripts
+            # run without the recipient having to flip the switch manually.
+            if mode == 'backup':
+                enable = profile_settings.get('enable_tagger_scripts')
+                if enable is not None:
+                    doc['scripts'].add('enable_tagger_scripts', enable)
+
 
 def _resolve_naming_script(config, script_id: str) -> tuple[dict | None, bool]:
     """Resolve a naming script ID to its content dict.

--- a/picard/profiles/importer.py
+++ b/picard/profiles/importer.py
@@ -221,7 +221,11 @@ def import_profile(
     if tagging_section:
         if not isinstance(tagging_section, list):
             raise ProfileImportError(_("The [[scripts.tagging]] section must be an array of tables"))
-        _import_tagger_scripts(config, profile_settings, tagging_section, result)
+        # A backup export records the master "enable tagger scripts" toggle
+        # under [scripts]; share exports omit it. When present we honour the
+        # exact value, otherwise the toggle is enabled so imported scripts run.
+        explicit_enable = scripts_section.get('enable_tagger_scripts')
+        _import_tagger_scripts(config, profile_settings, tagging_section, result, explicit_enable)
 
     # Register the profile
     _register_profile(config, profile_id, unique_title, enabled, profile_settings, replace=bool(replace_id))
@@ -350,8 +354,16 @@ def _import_tagger_scripts(
     profile_settings: dict,
     tagging_section: list,
     result: ProfileImportResult,
+    explicit_enable: bool | None = None,
 ):
-    """Import tagger scripts into the profile settings."""
+    """Import tagger scripts into the profile settings.
+
+    Args:
+        explicit_enable: The value of the master ``enable_tagger_scripts``
+            toggle as recorded in the profile file (backup exports), or None
+            if absent (share exports). When None, the toggle is enabled so the
+            imported scripts actually run; otherwise the exact value is kept.
+    """
     # Get existing scripts from the profile (if any) or start fresh
     existing_scripts = profile_settings.get('list_of_scripts', [])
 
@@ -394,6 +406,16 @@ def _import_tagger_scripts(
 
     if existing_scripts:
         profile_settings['list_of_scripts'] = existing_scripts
+
+    # Decide the master "enable tagger scripts" toggle:
+    # - An explicit value from the file (backup export) is always honoured.
+    # - Otherwise (share export), only enable when new scripts were actually
+    #   imported, so the shared scripts run without the user flipping the
+    #   switch. Do nothing when everything was a duplicate (no real change).
+    if explicit_enable is not None:
+        profile_settings['enable_tagger_scripts'] = bool(explicit_enable)
+    elif imported_count:
+        profile_settings['enable_tagger_scripts'] = True
 
 
 def _register_profile(

--- a/picard/profiles/importer.py
+++ b/picard/profiles/importer.py
@@ -77,6 +77,16 @@ class ProfileImportResult:
         out_of_bounds: List of OutOfBoundsSetting for imported values that were
             outside their option's declared bounds.
         warnings: List of warning messages for the user.
+        tagger_scripts_enable_pending: True when tagger scripts were imported
+            from a share export (no explicit enable_tagger_scripts value in the
+            file) and at least one is enabled, so enabling tagger scripting is
+            left for the caller to decide (a UI prompt or CLI flag) rather than
+            done silently. When True, the importer has NOT written
+            enable_tagger_scripts into the profile settings.
+        pending_tagger_scripts: The imported tagger scripts awaiting the
+            caller's enable decision, as a list of (position, title, enabled,
+            content) tuples matching the profile's list_of_scripts entries.
+            Populated only when tagger_scripts_enable_pending is True.
     """
 
     def __init__(self, profile_id: str, title: str):
@@ -86,6 +96,8 @@ class ProfileImportResult:
         self.upgraded_settings: list[str] = []
         self.out_of_bounds: list[OutOfBoundsSetting] = []
         self.warnings: list[str] = []
+        self.tagger_scripts_enable_pending: bool = False
+        self.pending_tagger_scripts: list[tuple[int, str, bool, str]] = []
 
 
 def import_profile(
@@ -221,9 +233,9 @@ def import_profile(
     if tagging_section:
         if not isinstance(tagging_section, list):
             raise ProfileImportError(_("The [[scripts.tagging]] section must be an array of tables"))
-        # A backup export records the master "enable tagger scripts" toggle
-        # under [scripts]; share exports omit it. When present we honour the
-        # exact value, otherwise the toggle is enabled so imported scripts run.
+        # A backup export records the enable_tagger_scripts toggle under
+        # [scripts]; share exports omit it. When present we honor the exact
+        # value; otherwise the enable decision is deferred to the caller.
         explicit_enable = scripts_section.get('enable_tagger_scripts')
         _import_tagger_scripts(config, profile_settings, tagging_section, result, explicit_enable)
 
@@ -359,10 +371,10 @@ def _import_tagger_scripts(
     """Import tagger scripts into the profile settings.
 
     Args:
-        explicit_enable: The value of the master ``enable_tagger_scripts``
-            toggle as recorded in the profile file (backup exports), or None
-            if absent (share exports). When None, the toggle is enabled so the
-            imported scripts actually run; otherwise the exact value is kept.
+        explicit_enable: The value of the ``enable_tagger_scripts`` toggle as
+            recorded in the profile file (backup exports), or None if absent
+            (share exports). When set, the exact value is honored silently.
+            When None, the decision is deferred to the caller (see below).
     """
     # Get existing scripts from the profile (if any) or start fresh
     existing_scripts = profile_settings.get('list_of_scripts', [])
@@ -407,15 +419,20 @@ def _import_tagger_scripts(
     if existing_scripts:
         profile_settings['list_of_scripts'] = existing_scripts
 
-    # Decide the master "enable tagger scripts" toggle:
-    # - An explicit value from the file (backup export) is always honoured.
-    # - Otherwise (share export), only enable when new scripts were actually
-    #   imported, so the shared scripts run without the user flipping the
-    #   switch. Do nothing when everything was a duplicate (no real change).
+    # Decide the ``enable_tagger_scripts`` toggle:
+    # - Backup export (explicit value present): honor it verbatim and silently.
+    #   The file is a faithful snapshot of the user's own config.
+    # - Share export (no explicit value): do NOT enable silently. If the profile
+    #   ends up with at least one enabled tagger script, defer the decision to
+    #   the caller (UI prompt or CLI flag) so enabling is never a surprise.
+    #   With no enabled script there is nothing to run, so no decision is needed.
     if explicit_enable is not None:
         profile_settings['enable_tagger_scripts'] = bool(explicit_enable)
     elif imported_count:
-        profile_settings['enable_tagger_scripts'] = True
+        pending = [(pos, name, enabled, content) for pos, name, enabled, content in existing_scripts if enabled]
+        if pending:
+            result.tagger_scripts_enable_pending = True
+            result.pending_tagger_scripts = pending
 
 
 def _register_profile(

--- a/picard/ui/options/profiles.py
+++ b/picard/ui/options/profiles.py
@@ -74,6 +74,7 @@ from picard.util import get_base_title
 from picard.ui.forms.ui_options_profiles import Ui_ProfileEditorDialog
 from picard.ui.moveable_list_view import MoveableListView
 from picard.ui.options import OptionsPage
+from picard.ui.profile_tagger_scripts_dialog import ProfileTaggerScriptsDialog
 from picard.ui.util import qlistwidget_items
 from picard.ui.widgets.profilelistwidget import ProfileListWidgetItem
 
@@ -774,11 +775,45 @@ class ProfilesOptionsPage(OptionsPage):
                 "\n".join(result.warnings),
             )
 
+        # A shared profile carrying enabled tagger scripts does not turn on
+        # tagger scripting silently: ask the user and apply their per-script
+        # choice. A backup import (explicit toggle in the file) is not pending.
+        if result.tagger_scripts_enable_pending:
+            self._resolve_pending_tagger_scripts(config, result)
+
         # Update the dialog's working state
         all_settings = config.profiles['user_profile_settings']
         self.profile_settings[result.profile_id] = all_settings.get(result.profile_id, {})
 
         return result
+
+    def _resolve_pending_tagger_scripts(self, config, result):
+        """Prompt whether to enable tagger scripting for a just-imported profile.
+
+        Enables ``enable_tagger_scripts`` for the profile only if the user
+        accepts with at least one script checked, and applies the per-script
+        selection back into the profile's ``list_of_scripts``.
+        """
+        dialog = ProfileTaggerScriptsDialog(result.title, result.pending_tagger_scripts, parent=self)
+        accepted = dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted
+        selected = dialog.selected_positions() if accepted else set()
+
+        all_settings = config.profiles['user_profile_settings']
+        settings = all_settings.get(result.profile_id, {})
+
+        if accepted and selected:
+            # Apply per-script choices and enable tagger scripting.
+            scripts = settings.get('list_of_scripts', [])
+            settings['list_of_scripts'] = [
+                (pos, name, pos in selected, content) for pos, name, _enabled, content in scripts
+            ]
+            settings['enable_tagger_scripts'] = True
+        else:
+            # Import the scripts but leave tagger scripting disabled.
+            settings['enable_tagger_scripts'] = False
+
+        all_settings[result.profile_id] = settings
+        config.profiles['user_profile_settings'] = all_settings
 
     def import_and_replace_profile(self, item):
         """Import a profile from a TOML file and replace the given profile."""

--- a/picard/ui/profile_tagger_scripts_dialog.py
+++ b/picard/ui/profile_tagger_scripts_dialog.py
@@ -1,0 +1,97 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+"""Dialog asking the user whether to enable tagger scripts on profile import.
+
+Shown when a shared profile is imported that carries one or more enabled
+tagger scripts. Importing must not silently turn on tagger scripting, so the
+user is warned and given a per-script choice. Accepting with at least one
+script checked enables tagger scripting for the profile and applies the
+per-script selection; rejecting (or unchecking everything) imports the
+scripts but leaves tagger scripting disabled.
+"""
+
+from PyQt6 import (
+    QtCore,
+    QtWidgets,
+)
+
+from picard.i18n import gettext as _
+
+
+class ProfileTaggerScriptsDialog(QtWidgets.QDialog):
+    """Ask whether to enable tagger scripting for an imported profile.
+
+    Args:
+        profile_title: Title of the imported profile (for the message).
+        scripts: List of (position, title, enabled, content) tuples for the
+            profile's tagger scripts. All are shown, pre-checked according to
+            their ``enabled`` flag.
+        parent: Parent widget.
+    """
+
+    def __init__(self, profile_title, scripts, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(_("Enable Tagger Scripts?"))
+        self.setModal(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        message = QtWidgets.QLabel(
+            _(
+                "The imported profile \"%s\" contains tagger scripts. Tagger "
+                "scripting is currently disabled for this profile.\n\n"
+                "Enabling it will run the checked scripts when this profile is "
+                "active. Uncheck any script you do not want to run, or cancel "
+                "to import the scripts without enabling tagger scripting."
+            )
+            % profile_title
+        )
+        message.setWordWrap(True)
+        layout.addWidget(message)
+
+        self._list = QtWidgets.QListWidget(self)
+        for pos, title, enabled, _content in scripts:
+            item = QtWidgets.QListWidgetItem(title, self._list)
+            item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, pos)
+        layout.addWidget(self._list)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        ok_button = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if ok_button is not None:
+            ok_button.setText(_("Enable tagger scripts"))
+        cancel_button = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+        if cancel_button is not None:
+            cancel_button.setText(_("Import without enabling"))
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def selected_positions(self) -> set:
+        """Return the set of script positions the user left checked."""
+        selected = set()
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            if item is not None and item.checkState() == QtCore.Qt.CheckState.Checked:
+                selected.add(item.data(QtCore.Qt.ItemDataRole.UserRole))
+        return selected

--- a/picard/ui/profile_tagger_scripts_dialog.py
+++ b/picard/ui/profile_tagger_scripts_dialog.py
@@ -37,6 +37,10 @@ from picard.i18n import gettext as _
 class ProfileTaggerScriptsDialog(QtWidgets.QDialog):
     """Ask whether to enable tagger scripting for an imported profile.
 
+    The accept button ("Enable tagger scripts") is disabled while no script is
+    checked, so accepting always enables at least one script. Cancelling
+    ("Import without enabling") imports the scripts with tagger scripting off.
+
     Args:
         profile_title: Title of the imported profile (for the message).
         scripts: List of (position, title, enabled, content) tuples for the
@@ -71,21 +75,31 @@ class ProfileTaggerScriptsDialog(QtWidgets.QDialog):
             item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
             item.setCheckState(QtCore.Qt.CheckState.Checked if enabled else QtCore.Qt.CheckState.Unchecked)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, pos)
+        self._list.itemChanged.connect(self._update_ok_button)
         layout.addWidget(self._list)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
             parent=self,
         )
-        ok_button = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
-        if ok_button is not None:
-            ok_button.setText(_("Enable tagger scripts"))
+        self._ok_button = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if self._ok_button is not None:
+            self._ok_button.setText(_("Enable tagger scripts"))
         cancel_button = buttons.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
         if cancel_button is not None:
             cancel_button.setText(_("Import without enabling"))
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
+
+        # The OK button enables tagger scripting, which is meaningless with no
+        # script checked; keep it disabled until at least one is selected.
+        self._update_ok_button()
+
+    def _update_ok_button(self):
+        """Enable the OK button only when at least one script is checked."""
+        if self._ok_button is not None:
+            self._ok_button.setEnabled(bool(self.selected_positions()))
 
     def selected_positions(self) -> set:
         """Return the set of script positions the user left checked."""

--- a/test/profiles/test_profile_export.py
+++ b/test/profiles/test_profile_export.py
@@ -160,10 +160,12 @@ class TestProfileExport(TestPicardConfigCommon):
 
     def test_export_tagger_scripts_backup_mode(self):
         ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
 
         self._setup_profile(
             'p1',
             {
+                'enable_tagger_scripts': True,
                 'list_of_scripts': [
                     (0, 'Enabled Script', True, '$set(foo,bar)'),
                     (1, 'Disabled Script', False, '$noop()'),
@@ -179,6 +181,49 @@ class TestProfileExport(TestPicardConfigCommon):
         self.assertEqual(len(scripts), 2)
         self.assertTrue(scripts[0]['enabled'])
         self.assertFalse(scripts[1]['enabled'])
+        # Backup mode preserves the master toggle so a restore is faithful.
+        self.assertTrue(parsed['scripts']['enable_tagger_scripts'])
+
+    def test_export_tagger_scripts_backup_mode_toggle_off(self):
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        self._setup_profile(
+            'p1',
+            {
+                'enable_tagger_scripts': False,
+                'list_of_scripts': [
+                    (0, 'Enabled Script', True, '$set(foo,bar)'),
+                ],
+            },
+        )
+
+        result = export_profile(self.config, 'p1', title='Test', mode='backup')
+        parsed = tomllib.loads(result)
+
+        self.assertFalse(parsed['scripts']['enable_tagger_scripts'])
+
+    def test_export_tagger_scripts_share_mode_omits_toggle(self):
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        self._setup_profile(
+            'p1',
+            {
+                'enable_tagger_scripts': True,
+                'list_of_scripts': [
+                    (0, 'Enabled Script', True, '$set(foo,bar)'),
+                ],
+            },
+        )
+
+        result = export_profile(self.config, 'p1', title='Test', mode='share')
+        parsed = tomllib.loads(result)
+
+        # Share mode omits the master toggle: the importer always enables tagger
+        # scripts when scripts are present, so shared scripts run automatically.
+        self.assertNotIn('enable_tagger_scripts', parsed['scripts'])
+        self.assertNotIn('enable_tagger_scripts', parsed.get('settings', {}))
 
     def test_export_naming_script(self):
         TextOption('setting', 'active_file_naming_script_id', '', title="Active script", in_profile=True)

--- a/test/profiles/test_profile_import.py
+++ b/test/profiles/test_profile_import.py
@@ -276,6 +276,10 @@ standardize_artists = true
         # All imported scripts are enabled by default
         self.assertTrue(scripts[0][2])
         self.assertTrue(scripts[1][2])
+        # The master "enable tagger scripts" toggle must be turned on, otherwise
+        # the imported scripts would never run (PICARD: reported as
+        # "Enable tagger script isn't exported").
+        self.assertTrue(settings['enable_tagger_scripts'])
 
     def test_import_tagger_scripts_deduplication(self):
         ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
@@ -335,6 +339,52 @@ script = "$noop()"
         self.assertEqual(len(scripts), 2)
         self.assertTrue(scripts[0][2])  # enabled
         self.assertFalse(scripts[1][2])  # disabled
+
+    def test_import_respects_explicit_enable_tagger_scripts_false(self):
+        # A backup export records the master toggle under [scripts]. An explicit
+        # value must be preserved rather than force-enabled.
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        toml = """\
+[profile]
+title = "Backup"
+picard_version = "3.0.0"
+
+[scripts]
+enable_tagger_scripts = false
+
+[[scripts.tagging]]
+title = "Some script"
+enabled = false
+script = "$noop()"
+"""
+        result = import_profile(self.config, toml)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertFalse(settings['enable_tagger_scripts'])
+
+    def test_import_respects_explicit_enable_tagger_scripts_true(self):
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        toml = """\
+[profile]
+title = "Backup"
+picard_version = "3.0.0"
+
+[scripts]
+enable_tagger_scripts = true
+
+[[scripts.tagging]]
+title = "Some script"
+enabled = true
+script = "$set(a,b)"
+"""
+        result = import_profile(self.config, toml)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertTrue(settings['enable_tagger_scripts'])
 
     def test_import_duplicate_title_gets_number_suffix(self):
         # Create an existing profile with the same title

--- a/test/profiles/test_profile_import.py
+++ b/test/profiles/test_profile_import.py
@@ -276,10 +276,12 @@ standardize_artists = true
         # All imported scripts are enabled by default
         self.assertTrue(scripts[0][2])
         self.assertTrue(scripts[1][2])
-        # The master "enable tagger scripts" toggle must be turned on, otherwise
-        # the imported scripts would never run (PICARD: reported as
-        # "Enable tagger script isn't exported").
-        self.assertTrue(settings['enable_tagger_scripts'])
+        # A share export omits the enable_tagger_scripts toggle. The importer
+        # must NOT silently enable tagger scripting; instead it defers the
+        # decision to the caller (UI prompt or CLI flag).
+        self.assertTrue(result.tagger_scripts_enable_pending)
+        self.assertEqual(len(result.pending_tagger_scripts), 2)
+        self.assertNotIn('enable_tagger_scripts', settings)
 
     def test_import_tagger_scripts_deduplication(self):
         ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
@@ -339,6 +341,86 @@ script = "$noop()"
         self.assertEqual(len(scripts), 2)
         self.assertTrue(scripts[0][2])  # enabled
         self.assertFalse(scripts[1][2])  # disabled
+
+    def test_import_share_scripts_defers_enable_only_for_enabled(self):
+        # Share export (no explicit enable_tagger_scripts). One script is
+        # enabled, one is not. The decision is deferred and only the enabled
+        # script is offered to the caller. enable_tagger_scripts is not written.
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        toml = """\
+[profile]
+title = "Shared"
+picard_version = "3.0.0"
+
+[[scripts.tagging]]
+title = "Enabled"
+enabled = true
+script = "$set(a,b)"
+
+[[scripts.tagging]]
+title = "Disabled"
+enabled = false
+script = "$noop()"
+"""
+        result = import_profile(self.config, toml)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertNotIn('enable_tagger_scripts', settings)
+        self.assertTrue(result.tagger_scripts_enable_pending)
+        # Only the enabled script is a pending candidate.
+        self.assertEqual(len(result.pending_tagger_scripts), 1)
+        self.assertEqual(result.pending_tagger_scripts[0][1], 'Enabled')
+
+    def test_import_share_scripts_none_enabled_not_pending(self):
+        # Share export where every imported script is disabled: nothing would
+        # run, so there is no enable decision to make.
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        toml = """\
+[profile]
+title = "Shared"
+picard_version = "3.0.0"
+
+[[scripts.tagging]]
+title = "Disabled"
+enabled = false
+script = "$noop()"
+"""
+        result = import_profile(self.config, toml)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertNotIn('enable_tagger_scripts', settings)
+        self.assertFalse(result.tagger_scripts_enable_pending)
+        self.assertEqual(result.pending_tagger_scripts, [])
+
+    def test_import_backup_scripts_not_pending(self):
+        # Backup export carries an explicit enable_tagger_scripts; the decision
+        # is honored verbatim and is never pending.
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable scripts", in_profile=True)
+
+        toml = """\
+[profile]
+title = "Backup"
+picard_version = "3.0.0"
+
+[scripts]
+enable_tagger_scripts = true
+
+[[scripts.tagging]]
+title = "Enabled"
+enabled = true
+script = "$set(a,b)"
+"""
+        result = import_profile(self.config, toml)
+
+        settings = self.config.profiles['user_profile_settings'][result.profile_id]
+        self.assertTrue(settings['enable_tagger_scripts'])
+        self.assertFalse(result.tagger_scripts_enable_pending)
+        self.assertEqual(result.pending_tagger_scripts, [])
 
     def test_import_respects_explicit_enable_tagger_scripts_false(self):
         # A backup export records the master toggle under [scripts]. An explicit

--- a/test/test_profiles_cli.py
+++ b/test/test_profiles_cli.py
@@ -207,6 +207,81 @@ class TestProfileCLI(TestPicardConfigCommon):
         self.assertEqual(exit_code, ExitCode.ERROR)
         self.assertIn('Invalid TOML', stderr.getvalue())
 
+    def _write_shared_scripts_toml(self):
+        toml_file = os.path.join(self.tmp_directory, 'scripts.toml')
+        with open(toml_file, 'w', encoding='utf-8') as f:
+            f.write(
+                '[profile]\ntitle = "Shared"\npicard_version = "3.0.0"\n\n'
+                '[[scripts.tagging]]\ntitle = "S1"\nscript = "$set(a,b)"\n'
+            )
+        return toml_file
+
+    @patch('picard.cli.profiles.get_config')
+    def test_cmd_import_scripts_no_enable_flag(self, mock_get_config):
+        # --no-enable-tagger-scripts imports the scripts but leaves tagger
+        # scripting disabled, without prompting.
+        mock_get_config.return_value = self.config
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable", in_profile=True)
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+
+        args = SimpleNamespace(
+            file=self._write_shared_scripts_toml(),
+            enable=False,
+            replace=None,
+            enable_tagger_scripts=False,
+            yes=False,
+        )
+        output, stdout, stderr = _make_output()
+        exit_code = cmd_import(args, output)
+
+        self.assertEqual(exit_code, ExitCode.SUCCESS)
+        settings = next(iter(self.config.profiles['user_profile_settings'].values()))
+        self.assertFalse(settings['enable_tagger_scripts'])
+
+    @patch('picard.cli.profiles.get_config')
+    def test_cmd_import_scripts_yes_enables(self, mock_get_config):
+        # --yes auto-confirms enabling tagger scripting.
+        mock_get_config.return_value = self.config
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable", in_profile=True)
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+
+        args = SimpleNamespace(
+            file=self._write_shared_scripts_toml(),
+            enable=False,
+            replace=None,
+            enable_tagger_scripts=True,
+            yes=True,
+        )
+        output, stdout, stderr = _make_output()
+        exit_code = cmd_import(args, output)
+
+        self.assertEqual(exit_code, ExitCode.SUCCESS)
+        settings = next(iter(self.config.profiles['user_profile_settings'].values()))
+        self.assertTrue(settings['enable_tagger_scripts'])
+
+    @patch('picard.cli.profiles.get_config')
+    def test_cmd_import_scripts_prompts_by_default(self, mock_get_config):
+        # Without --yes or --no-enable-tagger-scripts, the user is prompted.
+        mock_get_config.return_value = self.config
+        BoolOption('setting', 'enable_tagger_scripts', False, title="Enable", in_profile=True)
+        ListOption('setting', 'list_of_scripts', [], title="Scripts", in_profile=True)
+
+        args = SimpleNamespace(
+            file=self._write_shared_scripts_toml(),
+            enable=False,
+            replace=None,
+            enable_tagger_scripts=True,
+            yes=False,
+        )
+        output, stdout, stderr = _make_output()
+        with patch.object(output, 'yesno', return_value=True) as mock_yesno:
+            exit_code = cmd_import(args, output)
+
+        self.assertEqual(exit_code, ExitCode.SUCCESS)
+        mock_yesno.assert_called_once()
+        settings = next(iter(self.config.profiles['user_profile_settings'].values()))
+        self.assertTrue(settings['enable_tagger_scripts'])
+
     @unittest.skipUnless(export_available, "profile export requires tomlkit")
     @patch('picard.cli.profiles.get_config')
     def test_cmd_export_backup_mode(self, mock_get_config):

--- a/test/ui/test_profile_tagger_scripts_dialog.py
+++ b/test/ui/test_profile_tagger_scripts_dialog.py
@@ -1,0 +1,58 @@
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+
+from PyQt6 import QtCore
+
+from test.picardtestcase import PicardTestCase
+
+from picard.ui.profile_tagger_scripts_dialog import ProfileTaggerScriptsDialog
+
+
+class TestProfileTaggerScriptsDialog(PicardTestCase):
+    def _make_dialog(self):
+        # (position, title, enabled, content)
+        scripts = [
+            (0, "Enabled A", True, "$set(a,b)"),
+            (1, "Disabled B", False, "$noop()"),
+            (2, "Enabled C", True, "$set(c,d)"),
+        ]
+        return ProfileTaggerScriptsDialog("Shared", scripts)
+
+    def test_precheck_follows_enabled_flag(self):
+        dialog = self._make_dialog()
+        # Scripts authored as enabled are pre-checked and thus selected.
+        self.assertEqual(dialog.selected_positions(), {0, 2})
+
+    def test_uncheck_updates_selection(self):
+        dialog = self._make_dialog()
+        # Uncheck the first item (position 0).
+        item = dialog._list.item(0)
+        item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+        self.assertEqual(dialog.selected_positions(), {2})
+
+    def test_check_disabled_updates_selection(self):
+        dialog = self._make_dialog()
+        # Enable the disabled item (position 1).
+        item = dialog._list.item(1)
+        item.setCheckState(QtCore.Qt.CheckState.Checked)
+        self.assertEqual(dialog.selected_positions(), {0, 1, 2})
+
+    def test_position_stored_in_item_data(self):
+        dialog = self._make_dialog()
+        positions = [dialog._list.item(i).data(QtCore.Qt.ItemDataRole.UserRole) for i in range(dialog._list.count())]
+        self.assertEqual(positions, [0, 1, 2])

--- a/test/ui/test_profile_tagger_scripts_dialog.py
+++ b/test/ui/test_profile_tagger_scripts_dialog.py
@@ -56,3 +56,22 @@ class TestProfileTaggerScriptsDialog(PicardTestCase):
         dialog = self._make_dialog()
         positions = [dialog._list.item(i).data(QtCore.Qt.ItemDataRole.UserRole) for i in range(dialog._list.count())]
         self.assertEqual(positions, [0, 1, 2])
+
+    def test_ok_button_enabled_when_any_checked(self):
+        dialog = self._make_dialog()
+        # Two scripts start checked, so OK is enabled.
+        self.assertTrue(dialog._ok_button.isEnabled())
+
+    def test_ok_button_disabled_when_none_checked(self):
+        dialog = self._make_dialog()
+        for i in range(dialog._list.count()):
+            dialog._list.item(i).setCheckState(QtCore.Qt.CheckState.Unchecked)
+        self.assertFalse(dialog._ok_button.isEnabled())
+
+    def test_ok_button_reenabled_after_recheck(self):
+        dialog = self._make_dialog()
+        for i in range(dialog._list.count()):
+            dialog._list.item(i).setCheckState(QtCore.Qt.CheckState.Unchecked)
+        self.assertFalse(dialog._ok_button.isEnabled())
+        dialog._list.item(0).setCheckState(QtCore.Qt.CheckState.Checked)
+        self.assertTrue(dialog._ok_button.isEnabled())


### PR DESCRIPTION
## Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Importing a shareable profile that contains tagger scripts left the scripts disabled so none of them ran. The per-profile `enable_tagger_scripts` toggle is now handled on import and export, and the user is asked before it is enabled.

## Problem

* JIRA ticket (_optional_): PICARD-3437

The per-profile `enable_tagger_scripts` toggle gates all tagger script processing. On import the scripts were added to the profile but this toggle was never set, so it stayed off and the imported scripts never ran. It was also not written on export, so a backup could not restore its state.

## Solution

Handle the toggle together with the scripts, depending on export mode:

* **Import (backup export):** the file carries an explicit `enable_tagger_scripts` value under `[scripts]`; honor it verbatim and silently (a faithful restore of the user's own config).
* **Import (share export):** the file omits the toggle. The importer no longer enables it silently — because the toggle is a profile override, silently turning it on would also run the recipient's own scripts (raised in review). Instead the importer flags the pending scripts on `ProfileImportResult` and the caller decides:
  * **GUI:** a dialog lists the imported scripts (pre-checked per their `enabled` flag). Accepting enables tagger scripting for the profile and applies the per-script selection; cancelling imports the scripts without enabling.
  * **CLI:** prompts by default; `--yes` enables without prompting, `--no-enable-tagger-scripts` imports without enabling.
  * If no imported script is enabled there is nothing to run, so no prompt is shown.
* **Export:** backup mode writes the exact toggle value so a restore is faithful (a `None`/unset value is skipped, like other `None`-valued settings); share mode omits it (an author's incidental "off" would otherwise force the recipient's tagger scripting off, since a profile setting is an override).

`docs/ShareableProfiles.md` is updated to document this behavior. Regression tests cover both export modes and the import paths (share defers the decision, backup honors the explicit value, none-enabled is not pending), plus the CLI flag/prompt paths and the GUI dialog.

## AI Usage

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [x] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

Root-cause investigation, the fix, the documentation clarification, and the regression tests were developed with AI assistance and reviewed by the author.

## Action

Additional actions required:
* [x] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)
