### PR TITLE
Specify FunctionRegistryItem.argcount as Bound | None

### DIFF
--- a/picard/extension_points/script_functions.py
+++ b/picard/extension_points/script_functions.py
@@ -64,7 +64,7 @@ class FunctionRegistryItem:
         self,
         function: Callable,
         eval_args: bool,
-        argcount: Bound | bool,
+        argcount: Bound | None,
         documentation: str | None = None,
         name: str | None = None,
         module: str | None = None,
@@ -140,7 +140,10 @@ def register_script_function(
     varargs = argspec.varargs is not None
     defaults = len(argspec.defaults) if argspec.defaults else 0
 
-    argcount = Bound(args - defaults, args if not varargs else None)
+    if check_argcount:
+        argcount = Bound(args - defaults, args if not varargs else None)
+    else:
+        argcount = None
 
     if not documentation:
         documentation = function.__doc__
@@ -158,7 +161,7 @@ def register_script_function(
             FunctionRegistryItem(
                 function,
                 eval_args,
-                argcount if argcount and check_argcount else False,
+                argcount,
                 documentation=documentation,
                 name=name,
                 module=function.__module__,

--- a/test/script/test_parser.py
+++ b/test/script/test_parser.py
@@ -45,6 +45,7 @@ from test.picardtestcase import (
 from picard.cluster import Cluster
 from picard.const.defaults import DEFAULT_FILE_NAMING_FORMAT
 from picard.extension_points.script_functions import (
+    Bound,
     FunctionRegistryItem,
     generate_function_signature,
     register_script_function,
@@ -138,10 +139,10 @@ class ScriptParserTest(PicardTestCase):
         def somefunc():
             return 'x'
 
-        item = FunctionRegistryItem(somefunc, 'x', 'y', 'doc', signature='$somefunc()')
+        item = FunctionRegistryItem(somefunc, True, Bound(0, None), 'doc', signature='$somefunc()')
         self.assertEqual(item.function, somefunc)
-        self.assertEqual(item.eval_args, 'x')
-        self.assertEqual(item.argcount, 'y')
+        self.assertEqual(item.eval_args, True)
+        self.assertEqual(item.argcount, Bound(0, None))
         self.assertEqual(item.signature, '$somefunc()')
         self.assertEqual(item.documentation, 'doc')
 
@@ -151,7 +152,7 @@ class ScriptParserTest(PicardTestCase):
             + r'[^ ]+'
             + re.escape(r'.somefunc at ')
             + r'[^>]+'
-            + re.escape(r'>, x, y, $somefunc(), """doc""", None, None)')
+            + re.escape(r'>, True, Bound(lower=0, upper=None), $somefunc(), """doc""", None, None)')
             + r'$'
         )
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Small refactoring of `FunctionRegistryItem.argcount`. It was defined as accepting a boolean, but setting it to True would actually cause an exception when evaluating the function while parsing. Specify it as "Bound | None" instead and set to None if no argcount is needed.

This also fixes a type warning with the previous `argcount if argcount and check_argcount else False,`, as `argcount` was always truthy.

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [ ] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

<!--
    If this PR addresses a PICARD-XXX ticket and requires that the documentation be updated,
    please enter a new ticket as a sub Task to the ticket.  Otherwise, please enter a new
    ticket in the ticket tracker for the required documentation changes, referring to this PR.

    https://tickets.metabrainz.org/projects/PICARD/issues/?filter=allopenissues
-->
Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
