### PR TITLE
PICARD-3430: Fix macOS dark mode colors

### DIFF
--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -191,7 +191,7 @@ from picard.ui.util import (
     open_local_path,
     show_session_not_found_dialog,
 )
-from picard.ui.widgets.checkboxmenuitem import CheckboxMenuItem
+from picard.ui.widgets.checkboxmenuitem import create_checkable_menu_item
 
 
 SuspendWhileLoadingFuncs = namedtuple('SuspendWhileLoadingFuncs', ('on_enter', 'on_exit'))
@@ -2352,12 +2352,8 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         # Use QWidgetAction with a QCheckBox so toggling does not close the menu.
         def _add_menu_item(title, checked, profile_id):
-            menu = self.profile_quick_selector_menu
-            action = QtWidgets.QWidgetAction(menu)
-            action.setChecked(checked)
-            checkbox = CheckboxMenuItem(menu, action, title)
-            checkbox.toggled.connect(partial(self._set_profile_enabled, profile_id))
-            action.setDefaultWidget(checkbox)
+            action = create_checkable_menu_item(self.menuBar(), self.profile_quick_selector_menu, title, checked)
+            action.toggled.connect(partial(self._set_profile_enabled, profile_id))
             self.profile_quick_selector_menu.addAction(action)
 
         if option_profiles:
@@ -2429,11 +2425,10 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
                 ((s, _(get_option_title(s))) for s in quick_settings),
                 key=lambda x: x[1],
             ):
-                action = QtWidgets.QWidgetAction(self.quick_settings_menu)
-                action.setChecked(config.setting[setting_id])
-                checkbox = CheckboxMenuItem(self.quick_settings_menu, action, title)
-                checkbox.toggled.connect(partial(self._toggle_quick_setting, setting_id))
-                action.setDefaultWidget(checkbox)
+                action = create_checkable_menu_item(
+                    self.menuBar(), self.quick_settings_menu, title, bool(config.setting[setting_id])
+                )
+                action.toggled.connect(partial(self._toggle_quick_setting, setting_id))
                 self.quick_settings_menu.addAction(action)
         else:
             placeholder = QtGui.QAction(_("No quick settings configured"), self.quick_settings_menu)

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -234,6 +234,17 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
     # colors to the palette.
     if not palette_is_dark(palette):
         apply_dark_palette_colors(palette)
+    elif IS_MACOS:
+        # On macOS, some inactive text colors of the default dark palette default to black.
+        # Force colors from our palette to avoid this issue.
+        fix_colors = {
+            role: DARK_PALETTE_COLORS[role]
+            for role in (
+                QtGui.QPalette.ColorRole.ButtonText,
+                (QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.ButtonText),
+            )
+        }
+        _apply_palette_colors(palette, fix_colors)
 
 
 def apply_light_theme_to_palette(palette: QtGui.QPalette) -> None:

--- a/picard/ui/widgets/checkboxmenuitem.py
+++ b/picard/ui/widgets/checkboxmenuitem.py
@@ -25,6 +25,14 @@ from PyQt6 import (
 
 
 class CheckboxMenuItem(QtWidgets.QWidget):
+    """Custom checkable menu item.
+
+    This widget provides a custom checkable menu item that can be used in a QMenu.
+    It is similar to a standard QAction checkable item, but the menu does not close
+    when the item is toggled. This is suitable for selectable items, where the user
+    might want to toggle multiple items without closing the menu.
+    """
+
     toggled = QtCore.pyqtSignal(bool)
 
     def __init__(self, menu: QtWidgets.QMenu, action: QtGui.QAction, text: str, parent=None):
@@ -118,3 +126,26 @@ class CheckboxMenuItem(QtWidgets.QWidget):
         else:
             option.state |= QtWidgets.QStyle.StateFlag.State_Raised
         painter.drawControl(QtWidgets.QStyle.ControlElement.CE_MenuItem, option)
+
+
+def create_checkable_menu_item(
+    menu_bar: QtWidgets.QMenuBar | None, menu: QtWidgets.QMenu, title: str, checked: bool
+) -> QtGui.QAction:
+    """Create a checkable menu item for a menu.
+
+    On most platforms this creates a custom checkable menu item using CheckboxMenuItem.
+
+    If the menu bar is a native menu bar (e.g. on macOS), a normal menu action is
+    created, as a custom widget does not integrate well into the global menu and the
+    color scheme of the global menu can differ from the application's color scheme.
+    """
+    if menu_bar and menu_bar.isNativeMenuBar():
+        action = QtGui.QAction(title, menu)
+        action.setCheckable(True)
+    else:
+        action = QtWidgets.QWidgetAction(menu)
+        checkbox = CheckboxMenuItem(menu, action, title)
+        action.setDefaultWidget(checkbox)
+
+    action.setChecked(checked)
+    return action


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-3430
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

On macOS there are several issues with dark mode colors (see also screenshots on the ticket):

- On inactive windows, the menu buttons render completely dark, making them barely visible
- The custom `CheckboxMenuItem` render with dark text (same palette issue as before)
- Even if `CheckboxMenuItem` render with correct color, they look out of place and might render with wrong dark / light mode (using the mode of the application, not the mode of the global menu bar).

## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

- The automatically set palette on macOS does not properly set the `ButtonText` colors. Apply `ButtonText` colors from our default dark palette. Before and after:

    <img width="718" height="249" alt="grafik" src="https://github.com/user-attachments/assets/34646bff-ad90-4a76-9db6-e86260af50ab" />

    <img width="718" height="249" alt="grafik" src="https://github.com/user-attachments/assets/235e3877-d691-4ee4-91c8-169a5f08119e" />

- For global menus (native menu outside the application window) do use a normal checkable `QAction` menu item instead of the custom `CheckboxMenuItem`. While this prevents the special functionality of keeping the menu item open, it avoids the issue of menu items rendered in a non-native look with wrong color mode.

Previously:

<img width="583" height="269" alt="grafik" src="https://github.com/user-attachments/assets/b0e69936-733a-4e66-b7a4-1ce52db436ab" />


Fixed:

<img width="583" height="269" alt="grafik" src="https://github.com/user-attachments/assets/c71b81bc-d697-4b0e-b07d-e1e221d70f16" />


Note on how not only the colors where fixed, also the overall style now uses the native styling.



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

<!--
    If this PR addresses a PICARD-XXX ticket and requires that the documentation be updated,
    please enter a new ticket as a sub Task to the ticket.  Otherwise, please enter a new
    ticket in the ticket tracker for the required documentation changes, referring to this PR.

    https://tickets.metabrainz.org/projects/PICARD/issues/?filter=allopenissues
-->
Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
